### PR TITLE
fix issue with button zdepth not being reset correctly

### DIFF
--- a/docs/dist/js/paper-button.jsx
+++ b/docs/dist/js/paper-button.jsx
@@ -49,7 +49,8 @@ var PaperButton = React.createClass({
   },
 
   getInitialState: function() {
-    return { zDepth: this.props.disabled ? 0 : zDepths[this.props.type] }
+    var zDepth = this.props.disabled ? 0 : zDepths[this.props.type];
+    return { zDepth: zDepth, initialZDepth: zDepth };
   },
 
   render: function() {
@@ -87,7 +88,6 @@ var PaperButton = React.createClass({
     var $el = $(this.getDOMNode()),
       $ripple = $(this.refs.ripple.getDOMNode()),
       $offset = $el.offset(),
-      originalZDepth = this.state.zDepth,
       x = e.pageX - $offset.left,
       y = e.pageY - $offset.top;
 
@@ -103,9 +103,9 @@ var PaperButton = React.createClass({
 
     //animate the zdepth change
     if (this.props.type !== Types.FLAT) {
-      this.setState({ zDepth: originalZDepth + 1 });
+      this.setState({ zDepth: this.state.initialZDepth + 1 });
       CssEvent.onTransitionEnd($el, function() {
-        this.setState({ zDepth: originalZDepth });
+        this.setState({ zDepth: this.state.initialZDepth });
       }.bind(this));
     }
   }


### PR DESCRIPTION
Hi! Thanks for making material-ui. Here's a little fix for a bug I noticed.

Currently if you spam a bunch of clicks too quickly on the raised paper buttons, the button's z-index can break by increasing until it goes out of range. This happens because the var `originalZDepth` (paper-button.jsx line 90) is supposed to always represent the initial z-depth of the button - however, it instead gets reset on every render, which means it really represents the current zDepth. If a second button click event happens before the previous click's onTransitionEnd is called, the already-incremented zDepth will be incremented again incorrectly and only decremented once.

This should fix it by keeping an initialZDepth in this.state from the beginning and never touching it after that.
