### PR TITLE
install dependencies for the outer project too

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,8 @@ This is the documentation site for [Material-UI](http://callemall.github.io/mate
 ## Development Installation Notes
 After cloning the repository, install dependencies:
 ```
+cd <project folder>/material-ui
+npm install
 cd <project folder>/material-ui/docs
 npm install
 npm install -g gulp


### PR DESCRIPTION
Without the additional `npm install` step, gulp prints several instances of:

```
[16:04:57] gulp-notify: [Compile Error] Cannot find module 'react/addons' from '/Users/tom/src/material-ui/src/js'
```

and the page that opens has no content.
