### PR TITLE
Make Input component more useful (respects error prop declaratively)

### DIFF
--- a/src/js/input.jsx
+++ b/src/js/input.jsx
@@ -49,7 +49,7 @@ var Input = React.createClass({
     var classes = this.getClasses('mui-input', {
       'mui-floating': this.props.inputStyle === 'floating',
       'mui-text': this.props.type === 'text',
-      'mui-error': this.props.error !== undefined
+      'mui-error': this.props.error !== undefined && this.props.error !== null
     }),
     inputElement = this.props.multiline ?
       this.props.valueLink ? 


### PR DESCRIPTION
I've changed the way the and `Input` component decides whether there is an error or not.

`Input` doesn't have any state related to errors any more. Instead the error is hold completely inside props.

Some examples:

```
// this will show an error
<Input name="input" error="this is an error" />
// these will not show an error
<Input name="input" />
<Input name="input" error={undefined} />
<Input name="input" error={null} />
```

This is more declarative than having to call `setError` and `removeError` and allows components to
use the `Input` more concisely.

Additionally I also made `type="text"` default for the `Input` (although this is something debatable).
