### PR TITLE
Fixes issue #106

### DIFF
--- a/src/less/components/radio-button.less
+++ b/src/less/components/radio-button.less
@@ -9,18 +9,6 @@
   position: relative;
   width: @radio-button-size;
 
-  .mui-radio-button-fill {
-    .ease-out;
-    background-color: @radio-button-background-color;
-    border-radius: 50%;
-    height: @radio-button-size;
-    position: absolute;
-    left: -2px;
-    top: -2px;
-    transform: scale(0);
-    width: @radio-button-size;
-  }
-
   .mui-radio-button-label {
     position: relative;
     left: @radio-button-size;
@@ -39,4 +27,16 @@
       }
     }
   }
+}
+
+.mui-radio-button-fill {
+	.ease-out;
+	background-color: @radio-button-background-color;
+	border-radius: 50%;
+	height: @radio-button-size;
+	position: absolute;
+	left: -2px;
+	top: -2px;
+	transform: scale(0);
+	width: @radio-button-size;
 }

--- a/src/less/components/toggle.less
+++ b/src/less/components/toggle.less
@@ -16,13 +16,6 @@
   .mui-radio-button {
     .mui-radio-button-fill {
       background-color: transparent;
-      border-radius: 50%;
-      height: @radio-button-size;
-      left: -2px;
-      position: absolute;
-      top: -2px;
-      transform: scale(0);
-      width: @radio-button-size;
     }
   }
 


### PR DESCRIPTION
Togglebox copies all css properties from radio-button because .mui-radio-button-fill is nested inside .mui-radio-button. Moving the rather specific .mui-radio-button-fill lets toggle override background-color on its own. And reduces duplicate .less code.

The problem described is caused by positioning being fixed in the radio-button.less and not in toggle.less.
