### PR TITLE
Use the general sibling selector for input:focus

### DIFF
--- a/src/less/components/input.less
+++ b/src/less/components/input.less
@@ -106,30 +106,26 @@
     &:focus, &:valid {
       outline: none;
       box-shadow: none;
-      &+.mui-input-placeholder {
+      &~.mui-input-placeholder {
         color: blue;
         font-size: @input-placeholder-size !important;
         font-weight: 300;
         top: -32px;
         .ease-out;
-
-        &+.mui-input-highlight {
+      }
+      &~.mui-input-highlight {
           width: 0;
           background-color: blue;
           .ease-out;
-
-          &+.mui-input-bar {
-
-            &::before, &::after {
-              background-color: blue;
-              width: 50%;
-            }
-
-            &+.mui-input-description {
-              display: block;
-            }
-          }
+      }
+      &~.mui-input-bar {
+        &::before, &::after {
+          background-color: blue;
+          width: 50%;
         }
+      }
+      &~.mui-input-description {
+        display: block;
       }
     }
 


### PR DESCRIPTION
This address the issue #112. It seems that Safari has problems with pseudo selectors and adjacent siblings (I couldn't investigate that much this bug).

Anyway, since you are using class names, you can also use the general sibling selector `~`, which loose that ugly nesting and solve the issue with Safari :-) 

This patch addresses only the `:focus` part, though.
