### PR TITLE
allow to pass additional props to Menu from drop down icon

### DIFF
--- a/src/js/drop-down-icon.jsx
+++ b/src/js/drop-down-icon.jsx
@@ -31,6 +31,7 @@ var DropDownIcon = React.createClass({
   },
 
   render: function() {
+    var { className, menuItems, ...other } = this.props;
     var classes = this.getClasses('mui-drop-down-icon', {
       'mui-open': this.state.open
     });
@@ -40,7 +41,7 @@ var DropDownIcon = React.createClass({
           <div className="mui-menu-control" onClick={this._onControlClick}>
               <Icon icon={this.props.icon} />
           </div>
-          <Menu ref="menuItems" menuItems={this.props.menuItems} hideable={true} visible={this.state.open} onItemClick={this._onMenuItemClick} />
+          <Menu {...other} ref="menuItems" menuItems={this.props.menuItems} hideable={true} visible={this.state.open} onItemClick={this._onMenuItemClick} />
         </div>
     );
   },


### PR DESCRIPTION
I have a case when I need to pass additional parameters to menu from drop-down-icon conponent - autoWidth:

```
<mui.DropDownIcon style={{width:'auto !important'}} autoWidth={true} className="notifications-dropdown wkd-dropdown-icon" icon="action-announcement" menuItems={this.userNotificationItems()} />
```
