### PR TITLE
Editorconfig change tabs to spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ root = true
 
 # Unix-style newlines with a newline ending every file
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
When I do save according to .editor all space became tabs,
but almost all app using spaces so I do big diff
I change tabs to space works fine
