### PR TITLE
[slider] fix appearance

### DIFF
--- a/src/styles/themes/light-theme.js
+++ b/src/styles/themes/light-theme.js
@@ -131,6 +131,7 @@ let LightTheme = {
         trackColorSelected: Colors.grey500,
         handleSize: 12,
         handleSizeDisabled: 8,
+        handleSizeActive: 18,
         handleColorZero: Colors.grey400,
         handleFillColor: Colors.white,
         selectionColor: palette.primary3Color,
@@ -215,7 +216,6 @@ let LightTheme = {
     obj.floatingActionButton.disabledTextColor = ColorManipulator.fade(palette.textColor, 0.3);
     obj.raisedButton.disabledColor = ColorManipulator.darken(obj.raisedButton.color, 0.1);
     obj.raisedButton.disabledTextColor = ColorManipulator.fade(obj.raisedButton.textColor, 0.3);
-    obj.slider.handleSizeActive = obj.slider.handleSize * 2;
     obj.toggle.trackRequiredColor = ColorManipulator.fade(obj.toggle.thumbRequiredColor, 0.5);
 
     return obj;


### PR DESCRIPTION
I found several issues with Slider appearance:
1. When slider is at 0% the track overflows from the right.
2. After moving slider to 0% sometimes handle has black border because of overlapping border styles.
3. Spacing around disabled handle is relative and equal to 1% of width, but it should be equal to 2px.
4. Incorrect cursor and handle size when 0% and disabled.
5. No FocusRipple at 0%.
6. Incorrect handle size on click, 24px instead of 18px.
7. Transition to 0% when active.

This should fix all of them, but doesn't fix _setRippleSize() bug from #1451.
I used behavior and dimensions of sliders from https://www.google.com/design/spec/components/sliders.html
Tested on the latest stable Chrome, Firefox and Safari on OS X and on Chrome for Android.
