### PR TITLE
[slider] Fix bug when handle can be moved out of the grid

### DIFF
--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -392,6 +392,7 @@ let Slider = React.createClass({
     if (!this.props.disabled) this.setState({active: false});
     if (!this.state.dragging && Math.abs(this._pos - e.clientX) < 5) {
       let pos = e.clientX - React.findDOMNode(this).getBoundingClientRect().left;
+      pos = this._constrain()({left: pos}).left;
       this._dragX(e, pos);
     }
 


### PR DESCRIPTION
This fixes bug when slider's handle can be moved out of the grid by clicking to the track.
