### PR TITLE
Fix typo in TextField doc

### DIFF
--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -242,7 +242,7 @@ let TextFieldsPage = React.createClass({
                 style={styles.textfield}
                 hintText="Hint Text" /><br/>
               <TextField
-                style={styles.textField}
+                style={styles.textfield}
                 hintText="Styled Hint Text"
                 hintStyle={{color: 'red'}} /><br/>
               <TextField

--- a/docs/src/app/components/raw-code/text-fields-code.txt
+++ b/docs/src/app/components/raw-code/text-fields-code.txt
@@ -2,7 +2,6 @@
 <TextField
   hintText="Hint Text" />
 <TextField
-  style={styles.textField}
   hintText="Styled Hint Text"
   hintStyle={{color: 'red'}} />
 <TextField


### PR DESCRIPTION
There is a typo in TextField element documentation: the "Style Hint Text" example is not using the right property of `styles` object.
