### PR TITLE
[SelectField] Show focus style when onFocus prop given

### DIFF
--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -177,8 +177,6 @@ const DropDownMenu = React.createClass({
     const {
       autoWidth,
       className,
-      onFocus,
-      onBlur,
       style,
       displayMember,
       valueMember,
@@ -225,8 +223,6 @@ const DropDownMenu = React.createClass({
         {...other}
         ref="root"
         onKeyDown={this._onKeyDown}
-        onFocus={onFocus}
-        onBlur={onBlur}
         className={className}
         style={this.prepareStyles(
           styles.root,

--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -141,6 +141,8 @@ const SelectField = React.createClass({
       hintText,
       fullWidth,
       errorText,
+      onFocus,
+      onBlur,
       ...other,
     } = this.props;
 
@@ -152,6 +154,8 @@ const SelectField = React.createClass({
       fullWidth: fullWidth,
       errorText: errorText,
       errorStyle: this.mergeAndPrefix(styles.error, errorStyle),
+      onFocus: onFocus,
+      onBlur: onBlur,
     };
     const dropDownMenuProps = {
       menuItems: menuItems,


### PR DESCRIPTION
Pass onFocus and onBlur handlers to the TextField component instead of the DropDownMenu to ensure the visual focus style is shown when the SelectField is focused and blurred.

See https://github.com/callemall/material-ui/issues/2101
