### PR TITLE
Split up docs page for TextField and SelectField

### DIFF
--- a/docs/src/app/app-routes.jsx
+++ b/docs/src/app/app-routes.jsx
@@ -39,6 +39,7 @@ const Paper = require('./components/pages/components/paper');
 const Popover = require('./components/pages/components/popover');
 const Progress = require('./components/pages/components/progress');
 const RefreshIndicator = require('./components/pages/components/refresh-indicator');
+const SelectFields = require('./components/pages/components/select-fields');
 const Sliders = require('./components/pages/components/sliders');
 const Snackbar = require('./components/pages/components/snackbar');
 const Switches = require('./components/pages/components/switches');
@@ -96,6 +97,7 @@ const AppRoutes = (
       <Route path="popover" component={Popover} />
       <Route path="progress" component={Progress} />
       <Route path="refresh-indicator" component={RefreshIndicator} />
+      <Route path="select-fields" component={SelectFields} />
       <Route path="sliders" component={Sliders} />
       <Route path="switches" component={Switches} />
       <Route path="snackbar" component={Snackbar} />

--- a/docs/src/app/components/pages/components.jsx
+++ b/docs/src/app/components/pages/components.jsx
@@ -24,6 +24,7 @@ export default class Components extends React.Component {
       { route: '/components/popover', text: 'Popover'},
       { route: '/components/progress', text: 'Progress'},
       { route: '/components/refresh-indicator', text: 'Refresh Indicator'},
+      { route: '/components/select-fields', text: 'Select Fields'},
       { route: '/components/sliders', text: 'Sliders'},
       { route: '/components/switches', text: 'Switches'},
       { route: '/components/snackbar', text: 'Snackbar'},

--- a/docs/src/app/components/pages/components/select-fields.jsx
+++ b/docs/src/app/components/pages/components/select-fields.jsx
@@ -243,6 +243,10 @@ const SelectFieldsPage = React.createClass({
               disabled={true}
               value={'4'}
               style={styles.textfield}
+              menuItems={menuItems} /><br/>
+            <SelectField
+              value={this.state.selectValue}
+              onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
               menuItems={menuItems} />
           </ClearFix>
         </CodeExample>

--- a/docs/src/app/components/pages/components/select-fields.jsx
+++ b/docs/src/app/components/pages/components/select-fields.jsx
@@ -14,7 +14,7 @@ const SelectFieldsPage = React.createClass({
   getInitialState() {
     return {
       selectValue: undefined,
-      selectValue2: undefined,
+      selectValue2: 1,
       selectValueLinkValue: 4,
       selectValueLinkValue2: 3,
     };
@@ -43,13 +43,14 @@ const SelectFieldsPage = React.createClass({
             name: 'disabled',
             type: 'bool',
             header: 'optional',
-            desc: 'Disables the text field if set to true.',
+            desc: 'Disables the select field if set to true.',
           },
           {
-            name: 'defaultValue',
+            name: 'displayMember',
             type: 'string',
-            header: 'optional',
-            desc: 'The text string to use for the default value.',
+            header: 'default: text',
+            desc: 'SelectField will use text as default value, with this ' +
+              'property you can choose another name.',
           },
           {
             name: 'errorStyle',
@@ -82,113 +83,72 @@ const SelectFieldsPage = React.createClass({
             desc: 'If true, the field receives the property width 100%.',
           },
           {
-            name: 'hintStyle',
-            type: 'object',
-            header: 'optional',
-            desc: 'Override the inline-styles of the TextField\'s hint text element.',
-          },
-          {
             name: 'hintText',
             type: 'string',
             header: 'optional',
             desc: 'The hint text string to display.',
           },
           {
-            name: 'inputStyle',
+            name: 'iconStyle',
             type: 'object',
             header: 'optional',
-            desc: 'Override the inline-styles of the TextField\'s input element.',
+            desc: 'Overrides the styles of SelectField\'s icon element.',
           },
           {
-            name: 'multiLine',
-            type: 'bool',
-            header: 'default: false',
-            desc: 'If true, a textarea element will be rendered. The textarea also grows and shrinks according to the number of lines.',
-          },
-          {
-            name: 'rows',
-            type: 'number',
-            header: 'default: 1',
-            desc: 'Number of rows to display when multiLine option is set to true.',
-          },
-          {
-            name: 'rowsMax',
-            type: 'number',
-            header: 'default: null',
-            desc: 'Maximum number of rows to display when multiLine option is set to true.',
-          },
-          {
-            name: 'onEnterKeyDown',
-            type: 'function',
+            name: 'labelStyle',
+            type: 'object',
             header: 'optional',
-            desc: 'The function to call when the user presses the Enter key.',
+            desc: 'Overrides the styles of SelectField\'s label when the SelectField is inactive.',
+          },
+          {
+            name: 'valueMember',
+            type: 'string',
+            header: 'default: payload',
+            desc: 'SelectField will use payload as default value, with this ' +
+                'property you can choose another name.',
+          },
+          {
+            name: 'menuItemStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Overrides the inline-styles of the MenuItems when the ' +
+                  'SelectField is expanded.',
+          },
+          {
+            name: 'selectedIndex',
+            type: 'number',
+            header: 'default: 0',
+            desc: 'Index of the item selected.',
+          },
+          {
+            name: 'selectFieldRoot',
+            type: 'object',
+            header: 'optional',
+            desc: 'The style object to use to override the drop-down menu',
           },
           {
             name: 'style',
             type: 'object',
             header: 'optional',
-            desc: 'Override the inline-styles of the TextField\'s root element.',
-          },
-          {
-            name: 'underlineStyle',
-            type: 'object',
-            header: 'optional',
-            desc: 'Override the inline-styles of the TextField\'s underline element.',
-          },
-          {
-            name: 'underlineFocusStyle',
-            type: 'object',
-            header: 'optional',
-            desc: 'Override the inline-styles of the TextField\'s underline element when focussed.',
+            desc: 'Override the inline-styles of the SelectField\'s root element.',
           },
           {
             name: 'underlineDisabledStyle',
             type: 'object',
             header: 'optional',
-            desc: 'Override the inline-styles of the TextField\'s underline element when disabled.',
+            desc: 'Override the inline-styles of the SelectField\'s underline element when disabled.',
           },
           {
-            name: 'type',
-            type: 'string',
+            name: 'underlineStyle',
+            type: 'object',
             header: 'optional',
-            desc: 'Specifies the type of input to display such as "password" or "text".',
+            desc: 'Overrides the styles of SelectField\'s underline.',
           },
         ],
       },
       {
         name: 'Methods',
-        infoArray: [
-          {
-            name: 'blur',
-            header: 'TextField.blur()',
-            desc: 'Removes focus on the input element.',
-          },
-          {
-            name: 'clearValue',
-            header: 'TextField.clearValue()',
-            desc: 'Clears the value on the input element.',
-          },
-          {
-            name: 'focus',
-            header: 'TextField.focus()',
-            desc: 'Sets the focus on the input element.',
-          },
-          {
-            name: 'getValue',
-            header: 'TextField.getValue()',
-            desc: 'Returns the value of the input.',
-          },
-          {
-            name: 'setErrorText',
-            header: 'TextField.setErrorText(newErrorText)',
-            desc: 'Sets the error text on the input element.',
-          },
-          {
-            name: 'setValue',
-            header: 'TextField.setValue(newValue)',
-            desc: 'Sets the value of the input element.',
-          },
-        ],
+        infoArray: [],
       },
       {
         name: 'Events',
@@ -196,19 +156,19 @@ const SelectFieldsPage = React.createClass({
           {
             name: 'onBlur',
             header: 'function(event)',
-            desc: 'Callback function that is fired when the textfield loses' +
+            desc: 'Callback function that is fired when the selectfield loses' +
                   'focus.',
           },
           {
             name: 'onChange',
-            header: 'function(event)',
-            desc: 'Callback function that is fired when the textfield\'s value ' +
+            header: 'function(name, event)',
+            desc: 'Callback function that is fired when the selectfield\'s value ' +
                   'changes.',
           },
           {
             name: 'onFocus',
             header: 'function(event)',
-            desc: 'Callback function that is fired when the textfield gains ' +
+            desc: 'Callback function that is fired when the selectfield gains ' +
                   'focus.',
           },
         ],
@@ -230,6 +190,7 @@ const SelectFieldsPage = React.createClass({
       {id:5, name:'Weekly'},
     ];
 
+
     let styles = this.getStyles();
 
     return (
@@ -250,30 +211,39 @@ const SelectFieldsPage = React.createClass({
 
         <CodeExample code={Code}>
           <ClearFix>
-              <SelectField
-                style={styles.textfield}
-                value={this.state.selectValue}
-                onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
-                hintText="Hint Text"
-                menuItems={menuItems} /><br/>
-              <SelectField
-                valueLink={this.linkState('selectValueLinkValue')}
-                floatingLabelText="Float Label Text"
-                valueMember="id"
-                displayMember="name"
-                menuItems={arbitraryArrayMenuItems} /><br/>
-              <SelectField
-                valueLink={this.linkState('selectValueLinkValue2')}
-                floatingLabelText="Float Custom Label Text"
-                floatingLabelStyle={{color: "red"}}
-                valueMember="id"
-                displayMember="name"
-                menuItems={arbitraryArrayMenuItems} /><br/>
-              <SelectField
-                style={styles.textfield}
-                value={this.state.selectValue2}
-                onChange={this._handleSelectValueChange.bind(null, 'selectValue2')}
-                menuItems={arbitraryArrayMenuItems} />
+            <SelectField
+              style={styles.textfield}
+              value={this.state.selectValue}
+              onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
+              hintText="Hint Text"
+              menuItems={menuItems} /><br/>
+            <SelectField
+              valueLink={this.linkState('selectValueLinkValue')}
+              floatingLabelText="Float Label Text"
+              valueMember="id"
+              displayMember="name"
+              menuItems={arbitraryArrayMenuItems} /><br/>
+            <SelectField
+              valueLink={this.linkState('selectValueLinkValue2')}
+              floatingLabelText="Float Custom Label Text"
+              floatingLabelStyle={{color: "red"}}
+              valueMember="id"
+              displayMember="name"
+              menuItems={arbitraryArrayMenuItems} /><br/>
+            <SelectField
+              floatingLabelText="With default value"
+              style={styles.textfield}
+              value={this.state.selectValue2}
+              valueMember="id"
+              displayMember="name"
+              onChange={this._handleSelectValueChange.bind(null, 'selectValue2')}
+              menuItems={arbitraryArrayMenuItems} /><br/>
+            <SelectField
+              floatingLabelText="Disabled"
+              disabled={true}
+              value={'4'}
+              style={styles.textfield}
+              menuItems={menuItems} />
           </ClearFix>
         </CodeExample>
       </ComponentDoc>
@@ -284,7 +254,7 @@ const SelectFieldsPage = React.createClass({
     let change = {};
     change[name] = e.target.value;
     this.setState(change);
-  }
+  },
 });
 
 module.exports = SelectFieldsPage;

--- a/docs/src/app/components/pages/components/select-fields.jsx
+++ b/docs/src/app/components/pages/components/select-fields.jsx
@@ -1,45 +1,31 @@
 const React = require('react');
-const { ClearFix, Mixins, TextField, Styles, Paper } = require('material-ui');
+const { ClearFix, Mixins, SelectField, Styles, Paper } = require('material-ui');
 const ComponentDoc = require('../../component-doc');
-const { Colors } = Styles;
 const { StyleResizable } = Mixins;
-const Code = require('text-fields-code');
+const Code = require('select-fields-code');
 const CodeExample = require('../../code-example/code-example');
 const LinkedStateMixin = require('react-addons-linked-state-mixin');
 const CodeBlock = require('../../code-example/code-block');
 
-const TextFieldsPage = React.createClass({
+const SelectFieldsPage = React.createClass({
 
   mixins: [StyleResizable, LinkedStateMixin],
 
   getInitialState() {
     return {
-      errorText: 'This field is required.',
-      error2Text: 'This field must be numeric.',
-      floatingErrorText: 'This field is required.',
-      floatingError2Text: 'This field must be numeric.',
-      propValue: 'Prop Value',
-      floatingPropValue: 'Prop Value',
-      valueLinkValue: 'Value Link',
-      floatingValueLinkValue: 'Value Link',
+      selectValue: undefined,
+      selectValue2: undefined,
+      selectValueLinkValue: 4,
+      selectValueLinkValue2: 3,
     };
   },
 
   getStyles() {
     let styles = {
-      group: {
-        width: '100%',
-        float: 'left',
-        marginBottom: 32,
-      },
       textfield: {
         marginTop: 24,
       },
     };
-
-    if (this.isDeviceSize(StyleResizable.statics.Sizes.LARGE)) {
-      styles.group.width = '50%';
-    }
 
     return styles;
   },
@@ -229,18 +215,34 @@ const TextFieldsPage = React.createClass({
       },
     ];
 
+    let menuItems = [
+      { payload: '1', text: 'Never' },
+      { payload: '2', text: 'Every Night' },
+      { payload: '3', text: 'Weeknights' },
+      { payload: '4', text: 'Weekends' },
+      { payload: '5', text: 'Weekly' },
+    ];
+    let arbitraryArrayMenuItems = [
+      {id:1, name:'Never'},
+      {id:2, name:'Every Night'},
+      {id:3, name:'Weeknights'},
+      {id:4, name:'Weekends'},
+      {id:5, name:'Weekly'},
+    ];
+
     let styles = this.getStyles();
 
     return (
       <ComponentDoc
-        name="Text Field"
+        name="Select Field"
         desc={desc}
         componentInfo={componentInfo}>
 
         <Paper style = {{marginBottom: '22px'}}>
           <CodeBlock>
           {
-            '//Import statement:\nconst TextField = require(\'material-ui/lib/text-field\');\n\n' +
+            '//Import statement:\n' +
+            'const SelectField = require(\'material-ui/lib/select-field\');\n\n' +
             '//See material-ui/lib/index.js for more\n'
           }
           </CodeBlock>
@@ -248,169 +250,41 @@ const TextFieldsPage = React.createClass({
 
         <CodeExample code={Code}>
           <ClearFix>
-            <div style={styles.group}>
-              <TextField
+              <SelectField
                 style={styles.textfield}
-                hintText="Hint Text" /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="Styled Hint Text"
-                hintStyle={{color: 'red'}} /><br/>
-              <TextField
-                style={styles.textfield}
+                value={this.state.selectValue}
+                onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
                 hintText="Hint Text"
-                defaultValue="Default Value" /><br/>
-              <TextField
+                menuItems={menuItems} /><br/>
+              <SelectField
+                valueLink={this.linkState('selectValueLinkValue')}
+                floatingLabelText="Float Label Text"
+                valueMember="id"
+                displayMember="name"
+                menuItems={arbitraryArrayMenuItems} /><br/>
+              <SelectField
+                valueLink={this.linkState('selectValueLinkValue2')}
+                floatingLabelText="Float Custom Label Text"
+                floatingLabelStyle={{color: "red"}}
+                valueMember="id"
+                displayMember="name"
+                menuItems={arbitraryArrayMenuItems} /><br/>
+              <SelectField
                 style={styles.textfield}
-                hintText="Custom Underline Color"
-                value={this.state.propValue}
-                underlineStyle={{borderColor:Colors.green500}}
-                onChange={this._handleInputChange} /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="Custom Underline Focus Color"
-                underlineFocusStyle={{borderColor: Colors.amber900}} /><br />
-              <TextField
-                style={styles.textfield}
-                disabled={true}
-                hintText="Custom Underline Disabled Style"
-                underlineDisabledStyle={{borderColor:Colors.purple500, borderBottom: 'solid 1px'}} /><br />
-              <TextField
-                style={styles.textfield}
-                hintText="Hint Text"
-                valueLink={this.linkState('valueLinkValue')} /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="Hint Text (MultiLine)"
-                multiLine={true} /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="The hint text can be as long as you want, it will wrap."
-                multiLine={true} /><br/>
-              <TextField
-                style={styles.textfield}
-                rows={2}
-                rowsMax={4}
-                hintText="Hint Text (MultiLine) with rows: 2 and rowsMax: 4."
-                multiLine={true} /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="Hint Text"
-                errorText="The error text can be as long as you want, it will wrap." /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="Hint Text"
-                errorText={this.state.errorText}
-                onChange={this._handleErrorInputChange} /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="Hint Text (custom error color)"
-                errorText={this.state.error2Text}
-                errorStyle={{color:Colors.orange500}}
-                onChange={this._handleError2InputChange}
-                defaultValue="Custom error color" /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="Disabled Hint Text"
-                disabled={true} /><br/>
-              <TextField
-                style={styles.textfield}
-                hintText="Disabled Hint Text"
-                disabled={true}
-                defaultValue="Disabled With Value" />
-            </div>
-            <div style={styles.group}>
-              <TextField
-                hintText="Hint Text"
-                floatingLabelText="Floating Label Text" /><br/>
-              <TextField
-                hintText="Hint Text"
-                defaultValue="Default Value"
-                floatingLabelText="Floating Label Text" /><br/>
-              <TextField
-                hintText="Hint Text"
-                floatingLabelText="Floating Label Text"
-                value={this.state.floatingPropValue}
-                onChange={this._handleFloatingInputChange} /><br/>
-              <TextField
-                hintText="Hint Text"
-                floatingLabelText="Floating Label Text"
-                valueLink={this.linkState('floatingValueLinkValue')} /><br/>
-              <TextField
-                hintText="Hint Text (MultiLine)"
-                floatingLabelText="Floating Label Text"
-                multiLine={true} /><br/>
-              <TextField
-                hintText="Hint Text"
-                errorText={this.state.floatingErrorText}
-                floatingLabelText="Floating Label Text"
-                onChange={this._handleFloatingErrorInputChange} /><br/>
-              <TextField
-                hintText="Hint Text"
-                errorText={this.state.floatingError2Text}
-                defaultValue="abc"
-                floatingLabelText="Floating Label Text"
-                onChange={this._handleFloating2ErrorInputChange} /><br/>
-              <TextField
-                hintText="Disabled Hint Text"
-                disabled={true}
-                floatingLabelText="Floating Label Text" /><br/>
-              <TextField
-                hintText="Disabled Hint Text"
-                disabled={true}
-                defaultValue="Disabled With Value"
-                floatingLabelText="Floating Label Text" /><br/>
-              <TextField
-                hintText="Password Field"
-                floatingLabelText="Password"
-                type="password" /><br/>
-            </div>
+                value={this.state.selectValue2}
+                onChange={this._handleSelectValueChange.bind(null, 'selectValue2')}
+                menuItems={arbitraryArrayMenuItems} />
           </ClearFix>
         </CodeExample>
       </ComponentDoc>
     );
   },
 
-  _handleErrorInputChange(e) {
-    this.setState({
-      errorText: e.target.value ? '' : 'This field is required.',
-    });
-  },
-
-  _handleError2InputChange(e) {
-    let value = e.target.value;
-    let isNumeric = !isNaN(parseFloat(value)) && isFinite(value);
-    this.setState({
-      error2Text: isNumeric ? '' : 'This field must be numeric.',
-    });
-  },
-
-  _handleFloatingErrorInputChange(e) {
-    this.setState({
-      floatingErrorText: e.target.value ? '' : 'This field is required.',
-    });
-  },
-
-  _handleFloating2ErrorInputChange(e) {
-    let value = e.target.value;
-    let isNumeric = !isNaN(parseFloat(value)) && isFinite(value);
-    this.setState({
-      floatingError2Text: isNumeric ? '' : 'This field must be numeric.',
-    });
-  },
-
-  _handleInputChange(e) {
-    this.setState({
-      propValue: e.target.value,
-    });
-  },
-
-  _handleFloatingInputChange(e) {
-    this.setState({
-      floatingPropValue: e.target.value,
-    });
-  },
-
+  _handleSelectValueChange(name, e) {
+    let change = {};
+    change[name] = e.target.value;
+    this.setState(change);
+  }
 });
 
-module.exports = TextFieldsPage;
+module.exports = SelectFieldsPage;

--- a/docs/src/app/components/raw-code/select-fields-code.txt
+++ b/docs/src/app/components/raw-code/select-fields-code.txt
@@ -30,4 +30,8 @@
   disabled={true}
   value={'4'}
   style={styles.textfield}
+  menuItems={menuItems} /><br/>
+<SelectField
+  value={this.state.selectValue}
+  onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
   menuItems={menuItems} />

--- a/docs/src/app/components/raw-code/select-fields-code.txt
+++ b/docs/src/app/components/raw-code/select-fields-code.txt
@@ -1,22 +1,33 @@
 <SelectField
+  style={styles.textfield}
   value={this.state.selectValue}
   onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
   hintText="Hint Text"
-  menuItems={menuItems} />
+  menuItems={menuItems} /><br/>
 <SelectField
   valueLink={this.linkState('selectValueLinkValue')}
   floatingLabelText="Float Label Text"
   valueMember="id"
   displayMember="name"
-  menuItems={arbitraryArrayMenuItems} />
+  menuItems={arbitraryArrayMenuItems} /><br/>
 <SelectField
   valueLink={this.linkState('selectValueLinkValue2')}
   floatingLabelText="Float Custom Label Text"
   floatingLabelStyle={{color: "red"}}
   valueMember="id"
   displayMember="name"
-  menuItems={arbitraryArrayMenuItems} />
+  menuItems={arbitraryArrayMenuItems} /><br/>
 <SelectField
+  floatingLabelText="With default value"
+  style={styles.textfield}
   value={this.state.selectValue2}
+  valueMember="id"
+  displayMember="name"
   onChange={this._handleSelectValueChange.bind(null, 'selectValue2')}
-  menuItems={arbitraryArrayMenuItems} />
+  menuItems={arbitraryArrayMenuItems} /><br/>
+<SelectField
+  floatingLabelText="Disabled"
+  disabled={true}
+  value={'4'}
+  style={styles.textfield}
+  menuItems={menuItems} />

--- a/docs/src/app/components/raw-code/select-fields-code.txt
+++ b/docs/src/app/components/raw-code/select-fields-code.txt
@@ -1,0 +1,22 @@
+<SelectField
+  value={this.state.selectValue}
+  onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
+  hintText="Hint Text"
+  menuItems={menuItems} />
+<SelectField
+  valueLink={this.linkState('selectValueLinkValue')}
+  floatingLabelText="Float Label Text"
+  valueMember="id"
+  displayMember="name"
+  menuItems={arbitraryArrayMenuItems} />
+<SelectField
+  valueLink={this.linkState('selectValueLinkValue2')}
+  floatingLabelText="Float Custom Label Text"
+  floatingLabelStyle={{color: "red"}}
+  valueMember="id"
+  displayMember="name"
+  menuItems={arbitraryArrayMenuItems} />
+<SelectField
+  value={this.state.selectValue2}
+  onChange={this._handleSelectValueChange.bind(null, 'selectValue2')}
+  menuItems={arbitraryArrayMenuItems} />

--- a/docs/src/app/components/raw-code/text-fields-code.txt
+++ b/docs/src/app/components/raw-code/text-fields-code.txt
@@ -45,30 +45,6 @@
   disabled={true}
   defaultValue="Disabled With Value" />
 
-//Select Fields
-<SelectField
-  value={this.state.selectValue}
-  onChange={this._handleSelectValueChange.bind(null, 'selectValue')}
-  hintText="Hint Text"
-  menuItems={menuItems} />
-<SelectField
-  valueLink={this.linkState('selectValueLinkValue')}
-  floatingLabelText="Float Label Text"
-  valueMember="id"
-  displayMember="name"
-  menuItems={arbitraryArrayMenuItems} />
-<SelectField
-  valueLink={this.linkState('selectValueLinkValue2')}
-  floatingLabelText="Float Custom Label Text"
-  floatingLabelStyle={{color: "red"}}
-  valueMember="id"
-  displayMember="name"
-  menuItems={arbitraryArrayMenuItems} />
-<SelectField
-  value={this.state.selectValue2}
-  onChange={this._handleSelectValueChange.bind(null, 'selectValue2')}
-  menuItems={arbitraryArrayMenuItems} />
-
 //Floating Hint Text Labels
 <TextField
   hintText="Hint Text"


### PR DESCRIPTION
The SelectField component deserves it's own page, that's why I extracted all the information that lived under the `TextField` component's docs page, to a separate page.

What I have done:
1. Created a new page called **Select Fields**
2. Moved examples and description from **Text Fields**
3. Cleaned up all the Props
4. Removed the Methods
5. Updated the Events

While doing that, I noticed that some `propTypes` are either missing, or obsolete. This should be addressed in another PR.
