### PR TITLE
Added PropTypes validation to TextField and SelectField

### DIFF
--- a/docs/src/app/components/pages/components/select-fields.jsx
+++ b/docs/src/app/components/pages/components/select-fields.jsx
@@ -60,9 +60,9 @@ const SelectFieldsPage = React.createClass({
           },
           {
             name: 'errorText',
-            type: 'string',
+            type: 'node',
             header: 'optional',
-            desc: 'The error text string to display.',
+            desc: 'The error content to display.',
           },
           {
             name: 'floatingLabelStyle',
@@ -72,9 +72,9 @@ const SelectFieldsPage = React.createClass({
           },
           {
             name: 'floatingLabelText',
-            type: 'string',
+            type: 'node',
             header: 'optional',
-            desc: 'The text string to use for the floating label element.',
+            desc: 'The content to use for the floating label element.',
           },
           {
             name: 'fullWidth',
@@ -84,9 +84,9 @@ const SelectFieldsPage = React.createClass({
           },
           {
             name: 'hintText',
-            type: 'string',
+            type: 'node',
             header: 'optional',
-            desc: 'The hint text string to display.',
+            desc: 'The hint content to display.',
           },
           {
             name: 'iconStyle',

--- a/docs/src/app/components/pages/components/text-fields.jsx
+++ b/docs/src/app/components/pages/components/text-fields.jsx
@@ -73,9 +73,9 @@ const TextFieldsPage = React.createClass({
           },
           {
             name: 'errorText',
-            type: 'string',
+            type: 'node',
             header: 'optional',
-            desc: 'The error text string to display.',
+            desc: 'The error content to display.',
           },
           {
             name: 'floatingLabelStyle',
@@ -85,9 +85,9 @@ const TextFieldsPage = React.createClass({
           },
           {
             name: 'floatingLabelText',
-            type: 'string',
+            type: 'node',
             header: 'optional',
-            desc: 'The text string to use for the floating label element.',
+            desc: 'The content to use for the floating label element.',
           },
           {
             name: 'fullWidth',
@@ -103,9 +103,9 @@ const TextFieldsPage = React.createClass({
           },
           {
             name: 'hintText',
-            type: 'string',
+            type: 'node',
             header: 'optional',
-            desc: 'The hint text string to display.',
+            desc: 'The hint content to display.',
           },
           {
             name: 'inputStyle',

--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -27,22 +27,13 @@ const SelectField = React.createClass({
   },
 
   propTypes: {
-    errorText: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
-    floatingLabelText: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
+    errorText: React.PropTypes.node,
+    floatingLabelText: React.PropTypes.node,
     selectFieldRoot: React.PropTypes.object,
     underlineStyle: React.PropTypes.object,
     labelStyle: React.PropTypes.object,
     errorStyle: React.PropTypes.object,
-    hintText: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
+    hintText: React.PropTypes.node,
     id: React.PropTypes.string,
     multiLine: React.PropTypes.bool,
     onBlur: React.PropTypes.func,

--- a/src/select-field.jsx
+++ b/src/select-field.jsx
@@ -27,13 +27,22 @@ const SelectField = React.createClass({
   },
 
   propTypes: {
-    errorText: React.PropTypes.string,
-    floatingLabelText: React.PropTypes.string,
+    errorText: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element,
+    ]),
+    floatingLabelText: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element,
+    ]),
     selectFieldRoot: React.PropTypes.object,
     underlineStyle: React.PropTypes.object,
     labelStyle: React.PropTypes.object,
     errorStyle: React.PropTypes.object,
-    hintText: React.PropTypes.string,
+    hintText: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element,
+    ]),
     id: React.PropTypes.string,
     multiLine: React.PropTypes.bool,
     onBlur: React.PropTypes.func,

--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -32,20 +32,11 @@ const TextField = React.createClass({
 
   propTypes: {
     errorStyle: React.PropTypes.object,
-    errorText: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
+    errorText: React.PropTypes.node,
     floatingLabelStyle: React.PropTypes.object,
-    floatingLabelText: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
+    floatingLabelText: React.PropTypes.node,
     fullWidth: React.PropTypes.bool,
-    hintText: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
-    ]),
+    hintText: React.PropTypes.node,
     hintStyle: React.PropTypes.object,
     id: React.PropTypes.string,
     inputStyle: React.PropTypes.object,

--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -32,9 +32,15 @@ const TextField = React.createClass({
 
   propTypes: {
     errorStyle: React.PropTypes.object,
-    errorText: React.PropTypes.string,
+    errorText: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element,
+    ]),
     floatingLabelStyle: React.PropTypes.object,
-    floatingLabelText: React.PropTypes.string,
+    floatingLabelText: React.PropTypes.oneOfType([
+      React.PropTypes.string,
+      React.PropTypes.element,
+    ]),
     fullWidth: React.PropTypes.bool,
     hintText: React.PropTypes.oneOfType([
       React.PropTypes.string,


### PR DESCRIPTION
I noticed we could use React elements in text props, but I was getting warnings. This is to fix the warnings for TextField and SelectField.
