### PR TITLE
Add missing proptypes for a bunch of components

### DIFF
--- a/src/before-after-wrapper.jsx
+++ b/src/before-after-wrapper.jsx
@@ -52,6 +52,7 @@ const BeforeAfterWrapper = React.createClass({
     beforeElementType: React.PropTypes.string,
     afterElementType: React.PropTypes.string,
     elementType: React.PropTypes.string,
+    style: React.PropTypes.object,
   },
 
   getDefaultProps() {

--- a/src/card/card-header.jsx
+++ b/src/card/card-header.jsx
@@ -50,6 +50,7 @@ const CardHeader = React.createClass({
     expandable: React.PropTypes.bool,
     actAsExpander: React.PropTypes.bool,
     showExpandableButton: React.PropTypes.bool,
+    avatar: React.PropTypes.node,
   },
 
   getDefaultProps() {

--- a/src/card/card.jsx
+++ b/src/card/card.jsx
@@ -15,6 +15,8 @@ const Card = React.createClass({
     expandable: React.PropTypes.bool,
     initiallyExpanded: React.PropTypes.bool,
     onExpandChange: React.PropTypes.func,
+    actAsExpander: React.PropTypes.bool,
+    showExpandableButton: React.PropTypes.bool,
   },
 
   _onExpandable() {

--- a/src/checkbox.jsx
+++ b/src/checkbox.jsx
@@ -35,6 +35,8 @@ const Checkbox = React.createClass({
     labelStyle: React.PropTypes.object,
     onCheck: React.PropTypes.func,
     unCheckedIcon: React.PropTypes.element,
+    disabled: React.PropTypes.bool,
+    labelPosition: React.PropTypes.oneOf(['left', 'right']),
   },
 
   getInitialState() {

--- a/src/date-picker/date-picker-dialog.jsx
+++ b/src/date-picker/date-picker-dialog.jsx
@@ -54,6 +54,8 @@ const DatePickerDialog = React.createClass({
     style: React.PropTypes.object,
     shouldDisableDate: React.PropTypes.func,
     showYearSelector: React.PropTypes.bool,
+    autoOk: React.PropTypes.bool,
+    mode: React.PropTypes.oneOf(['portrait', 'landscape']),
   },
 
   //for passing default theme context to children

--- a/src/date-picker/date-picker.jsx
+++ b/src/date-picker/date-picker.jsx
@@ -48,6 +48,7 @@ const DatePicker = React.createClass({
     showYearSelector: React.PropTypes.bool,
     style: React.PropTypes.object,
     textFieldStyle: React.PropTypes.object,
+    value: React.PropTypes.object,
   },
 
   windowListeners: {

--- a/src/dialog.jsx
+++ b/src/dialog.jsx
@@ -116,6 +116,12 @@ let Dialog = React.createClass({
     title: React.PropTypes.node,
     defaultOpen: React.PropTypes.bool,
     open: React.PropTypes.bool,
+    modal: React.PropTypes.bool,
+    onDismiss: React.PropTypes.func,
+    onShow: React.PropTypes.func,
+    onRequestClose: React.PropTypes.func,
+    actionFocus: React.PropTypes.string, 
+    titleStyle: React.PropTypes.object,
   },
 
   windowListeners: {

--- a/src/drop-down-menu.jsx
+++ b/src/drop-down-menu.jsx
@@ -48,6 +48,7 @@ const DropDownMenu = React.createClass({
     selectedIndex: React.PropTypes.number,
     openImmediately: React.PropTypes.bool,
     style: React.PropTypes.object,
+    value: React.PropTypes.object,
   },
 
   getDefaultProps() {

--- a/src/enhanced-textarea.jsx
+++ b/src/enhanced-textarea.jsx
@@ -53,6 +53,7 @@ const EnhancedTextarea = React.createClass({
     rows: React.PropTypes.number,
     rowsMax: React.PropTypes.number,
     style: React.PropTypes.object,
+    value: React.PropTypes.string,
   },
 
   getDefaultProps() {

--- a/src/floating-action-button.jsx
+++ b/src/floating-action-button.jsx
@@ -52,6 +52,7 @@ const FloatingActionButton = React.createClass({
     onTouchStart: React.PropTypes.func,
     secondary: React.PropTypes.bool,
     style: React.PropTypes.object,
+    onMouseEnter: React.PropTypes.func,
   },
 
   getInitialState() {

--- a/src/icon-button.jsx
+++ b/src/icon-button.jsx
@@ -66,6 +66,8 @@ const IconButton = React.createClass({
     tooltipPosition: PropTypes.cornersAndCenter,
     touch: React.PropTypes.bool,
     style: React.PropTypes.object,
+    onMouseLeave: React.PropTypes.func,
+    onMouseEnter: React.PropTypes.func,
   },
 
   getInitialState() {

--- a/src/menu/menu-item.jsx
+++ b/src/menu/menu-item.jsx
@@ -37,6 +37,9 @@ const MenuItem = React.createClass({
     selected: React.PropTypes.bool,
     style: React.PropTypes.object,
     active: React.PropTypes.bool,
+    onMouseLeave: React.PropTypes.func,
+    onMouseEnter: React.PropTypes.func,
+    icon: React.PropTypes.node,
   },
 
   //for passing default theme context to children

--- a/src/menu/menu.jsx
+++ b/src/menu/menu.jsx
@@ -34,6 +34,8 @@ const NestedMenuItem = React.createClass({
     onItemTap: React.PropTypes.func,
     menuItemStyle: React.PropTypes.object,
     style: React.PropTypes.object,
+    onMouseOver: React.PropTypes.func,
+    onMouseOut: React.PropTypes.func,
   },
 
   getDefaultProps() {
@@ -233,6 +235,7 @@ const Menu = React.createClass({
     menuItemClassName: React.PropTypes.string,
     menuItemClassNameSubheader: React.PropTypes.string,
     menuItemClassNameLink: React.PropTypes.string,
+    onItemToggle: React.PropTypes.func,
   },
 
   //for passing default theme context to children

--- a/src/radio-button-group.jsx
+++ b/src/radio-button-group.jsx
@@ -30,6 +30,7 @@ const RadioButtonGroup = React.createClass({
     labelPosition: React.PropTypes.oneOf(['left', 'right']),
     onChange: React.PropTypes.func,
     style: React.PropTypes.object,
+    className: React.PropTypes.string,
   },
 
   _hasCheckAttribute(radioButton) {

--- a/src/radio-button.jsx
+++ b/src/radio-button.jsx
@@ -43,6 +43,10 @@ const RadioButton = React.createClass({
     iconStyle: React.PropTypes.object,
     labelStyle: React.PropTypes.object,
     onCheck: React.PropTypes.func,
+    checked: React.PropTypes.bool,
+    labelPosition: React.PropTypes.oneOf(['left', 'right']),
+    disabled: React.PropTypes.bool,
+    value: React.PropTypes.bool,
   },
 
   getTheme() {

--- a/src/raised-button.jsx
+++ b/src/raised-button.jsx
@@ -59,6 +59,7 @@ const RaisedButton = React.createClass({
     disabledLabelColor: React.PropTypes.string,
     fullWidth: React.PropTypes.bool,
     style: React.PropTypes.object,
+    onMouseEnter: React.PropTypes.func,
   },
 
   getDefaultProps: function() {

--- a/src/slider.jsx
+++ b/src/slider.jsx
@@ -66,6 +66,7 @@ const Slider = React.createClass({
     onFocus: React.PropTypes.func,
     value: valueInRangePropType,
     style: React.PropTypes.object,
+    disableFocusRipple: React.PropTypes.bool,
   },
 
   //for passing default theme context to children

--- a/src/text-field.jsx
+++ b/src/text-field.jsx
@@ -53,6 +53,9 @@ const TextField = React.createClass({
     underlineFocusStyle: React.PropTypes.object,
     underlineDisabledStyle: React.PropTypes.object,
     style: React.PropTypes.object,
+    disabled: React.PropTypes.bool,
+    defaultValue: React.PropTypes.string,
+    value: React.PropTypes.string,
   },
 
   //for passing default theme context to children

--- a/src/toggle.jsx
+++ b/src/toggle.jsx
@@ -20,6 +20,12 @@ const Toggle = React.createClass({
     onToggle: React.PropTypes.func,
     toggled: React.PropTypes.bool,
     defaultToggled: React.PropTypes.bool,
+    thumbStyle: React.PropTypes.object,
+    iconStyle: React.PropTypes.object,
+    labelPosition: React.PropTypes.oneOf(['left', 'right']),
+    trackStyle: React.PropTypes.object,
+    disabled: React.PropTypes.bool,
+    rippleStyle: React.PropTypes.object,
   },
 
   //for passing default theme context to children

--- a/src/toolbar/toolbar-group.jsx
+++ b/src/toolbar/toolbar-group.jsx
@@ -16,6 +16,8 @@ const ToolbarGroup = React.createClass({
     className: React.PropTypes.string,
     float: React.PropTypes.string,
     style: React.PropTypes.object,
+    lastChild: React.PropTypes.bool,
+    firstChild: React.PropTypes.bool,
   },
 
   //for passing default theme context to children

--- a/src/toolbar/toolbar-separator.jsx
+++ b/src/toolbar/toolbar-separator.jsx
@@ -13,6 +13,7 @@ const ToolbarSeparator = React.createClass({
 
   propTypes: {
     style: React.PropTypes.object,
+    className: React.PropTypes.string,
   },
   
   //for passing default theme context to children

--- a/src/toolbar/toolbar.jsx
+++ b/src/toolbar/toolbar.jsx
@@ -14,6 +14,7 @@ const Toolbar = React.createClass({
   propTypes: {
     className: React.PropTypes.string,
     style: React.PropTypes.object,
+    noGutter: React.PropTypes.bool,
   },
 
   //for passing default theme context to children


### PR DESCRIPTION
So, the «generate wrappers» man strikes again. Hope you dont mind :)

I'm now using propTypes as the interface to a component, and adding comments from documentation. 

While doing that i discovered a few missing properties. A separate PR with missing documentation fields will be forthcoming - it should really be a standard way to specify them inline in the component and generate documentation!
