### PR TITLE
[Table] Add some props to patch css only style overrides

### DIFF
--- a/docs/src/app/components/pages/components/table.jsx
+++ b/docs/src/app/components/pages/components/table.jsx
@@ -57,6 +57,12 @@ export default class TablePage extends React.Component {
             desc: 'Set to true to indicate that all rows should be selected.',
           },
           {
+            name: 'bodyStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of the body\'s table element.',
+          },
+          {
             name: 'fixedFooter',
             type: 'bool',
             header: 'optional',
@@ -67,6 +73,18 @@ export default class TablePage extends React.Component {
             type: 'bool',
             header: 'optional',
             desc: 'If true, the header will appear fixed above the table. The default value is true.',
+          },
+          {
+            name: 'footerStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of the footer\'s table element.',
+          },
+          {
+            name: 'headerStyle',
+            type: 'object',
+            header: 'optional',
+            desc: 'Override the inline-styles of the header\'s table element.',
           },
           {
             name: 'height',

--- a/src/table/table.jsx
+++ b/src/table/table.jsx
@@ -27,6 +27,9 @@ const Table = React.createClass({
     selectable: React.PropTypes.bool,
     style: React.PropTypes.object,
     wrapperStyle: React.PropTypes.object,
+    headerStyle: React.PropTypes.object,
+    bodyStyle: React.PropTypes.object,
+    footerStyle: React.PropTypes.object,
   },
 
   getDefaultProps() {
@@ -101,6 +104,9 @@ const Table = React.createClass({
       fixedHeader,
       style,
       wrapperStyle,
+      headerStyle,
+      bodyStyle,
+      footerStyle,
       ...other,
     } = this.props;
     let classes = 'mui-table';
@@ -131,7 +137,7 @@ const Table = React.createClass({
     let inlineHeader, inlineFooter;
     if (fixedHeader) {
       headerTable = (
-        <div className="mui-header-table">
+        <div className="mui-header-table" style={this.prepareStyles(headerStyle)}>
           <table className={className} style={mergedTableStyle}>
             {tHead}
           </table>
@@ -144,7 +150,7 @@ const Table = React.createClass({
     if (tFoot !== undefined) {
       if (fixedFooter) {
         footerTable = (
-          <div className="mui-footer-table">
+          <div className="mui-footer-table" style={this.prepareStyles(footerStyle)}>
             <table className={className} style={mergedTableStyle}>
               {tFoot}
             </table>
@@ -159,7 +165,7 @@ const Table = React.createClass({
     return (
       <div className="mui-table-wrapper" style={this.prepareStyles(styles.tableWrapper, wrapperStyle)}>
         {headerTable}
-        <div className="mui-body-table" style={this.prepareStyles(styles.bodyTable)} ref="tableDiv">
+        <div className="mui-body-table" style={this.prepareStyles(styles.bodyTable, bodyStyle)} ref="tableDiv">
           <table className={classes} style={mergedTableStyle} ref="tableBody">
             {inlineHeader}
             {inlineFooter}


### PR DESCRIPTION
These elements can only be styled through css classes. This PR temporary patches this component until we come up with a better solution than all these nested `div`s and `table`s. I won't add documentation since this is probably only temporary so people can have some way of overriding these elements without having to resort to css classes.
