### PR TITLE
Invariant Violation error of ClickAwayable in IE10

### DIFF
--- a/src/mixins/click-awayable.js
+++ b/src/mixins/click-awayable.js
@@ -17,13 +17,15 @@ module.exports = {
   },
 
   _checkClickAway(event) {
-    let el = ReactDOM.findDOMNode(this);
+    if (this.isMounted()) {
+      let el = ReactDOM.findDOMNode(this);
 
-    // Check if the target is inside the current component
-    if (event.target !== el &&
-        !Dom.isDescendant(el, event.target) &&
-        document.documentElement.contains(event.target)) {
-      if (this.componentClickAway) this.componentClickAway(event);
+      // Check if the target is inside the current component
+      if (event.target !== el &&
+          !Dom.isDescendant(el, event.target) &&
+          document.documentElement.contains(event.target)) {
+        if (this.componentClickAway) this.componentClickAway(event);
+      }
     }
   },
 


### PR DESCRIPTION
The up event seems to be called after the re-render of the parent component, causing the child component to not be mounted anymore.

Probably fixes #2017.
Fixes my issue.
