### PR TITLE
[Documentation] AppBar examples overlap page header #2393

### DIFF
--- a/docs/src/app/components/master.jsx
+++ b/docs/src/app/components/master.jsx
@@ -142,7 +142,7 @@ const Master = React.createClass({
         height: 64,
         top: 0,
         right: 0,
-        zIndex: 4,
+        zIndex: 6,
         width: '100%',
       },
       container: {


### PR DESCRIPTION
Lowers the z-index on the AppBars from 5 to 3.

<img width="1426" alt="screen shot 2015-12-06 at 1 45 11 pm" src="https://cloud.githubusercontent.com/assets/264547/11615962/4a98f47c-9c23-11e5-9eef-0b150d61f849.png">
