### PR TITLE
Slightly improve how the props table is generated.

### DIFF
--- a/docs/src/app/components/PropTypeDescription.jsx
+++ b/docs/src/app/components/PropTypeDescription.jsx
@@ -14,8 +14,8 @@ function generatePropType(type) {
       return type.raw;
 
     case 'enum':
-      const values = type.value.map(v => v.value).join(', ');
-      return `enum[${values}]`;
+      const values = type.value.map(v => v.value).join('<br>&nbsp;');
+      return `enum:<br>&nbsp;${values}<br>`;
 
     default:
       return type.name;
@@ -42,7 +42,7 @@ const PropTypeDescription = React.createClass({
     } = this.props;
 
     let text = `${header}
-| Name | Type | Default | Description|
+| Name | Type | Default | Description |
 |:-----|:-----|:-----|:-----|\n`;
 
     const componentInfo = parse(code);
@@ -56,11 +56,15 @@ const PropTypeDescription = React.createClass({
         defaultValue = prop.defaultValue.value;
       }
 
-      const description = (prop.required ? '**required**' : '*optional*') +
-        '. ' + prop.description.replace(/\n/g, '<br>');
+      const requirement = `${prop.required ? '**required**' : '*optional*'}.`;
 
-      text += `| ${key} | ${generatePropType(prop.type)} |`;
-      text += `${defaultValue} |${description} |\n`;
+      // two new lines result in a newline in the table. all other new lines
+      // must be eliminated to prevent markdown mayhem.
+      const jsDocText = prop.description.replace(/\n\n/g, '<br>').replace(/\n/g, ' ');
+
+      const description = `${requirement} ${jsDocText}`;
+
+      text += `| ${key} | ${generatePropType(prop.type)} | ${defaultValue} | ${description} |\n`;
     }
 
     return (


### PR DESCRIPTION
@oliviertassinari This makes the enums even prettier. and also one more thing. Before this, each new line in the jsdoc (for code formatting) would result in a new line in the generated props, that made it ugly sometimes. With this, you can freely split jsdoc into any number of lines and still be able to make paragraphs by two consecutive new lines:

Before:

``` js
/**
 * This is
 * a new line
 */
```

=>
This is
a new line

Now:

``` js
/**
 * This is
 * not a new line
 *
 * This is a new paragraph.
 */
```

=>
This is not a new line
This is a new paragraph.

And with enums:

``` js
oneOf('foo','bar','baz');
// turns into:
enum:
 'foo'
 'bar'
 'baz'
```

What do you think?
