### PR TITLE
Avoid rendering <a> element

### DIFF
--- a/src/enhanced-button.jsx
+++ b/src/enhanced-button.jsx
@@ -195,9 +195,12 @@ const EnhancedButton = React.createClass({
     };
     const buttonChildren = this._createButtonChildren();
 
+    // Provides backward compatibity. Added to support wrapping around <a> element.
+    const targetLinkElement = buttonProps.hasOwnProperty('href') ? 'a' : 'span';
+
     return React.isValidElement(containerElement) ?
       React.cloneElement(containerElement, buttonProps, buttonChildren) :
-      React.createElement(linkButton ? 'a' : containerElement, buttonProps, buttonChildren);
+      React.createElement(linkButton ? targetLinkElement : containerElement, buttonProps, buttonChildren);
 
   },
 


### PR DESCRIPTION
This has caused many issues, when an <a> element is created in this component there will be no way to support links, as nested <a> elements is offensive in the eyes of HTML.

Closes #2178, #1979, #1823

@oliviertassinari Take a look at this. I don't think is can be a braeking change since an `href` was never specified on the link. But I'm not sure...
