### PR TITLE
[autocomplete] Disable browser default autocomplete popup

### DIFF
--- a/src/auto-complete.jsx
+++ b/src/auto-complete.jsx
@@ -400,6 +400,7 @@ const AutoComplete = React.createClass({
         <TextField
           {...other}
           ref="searchTextField"
+          autoComplete="off"
           value={searchText}
           onEnterKeyDown={this.handleEnterKeyDown}
           onChange={this.handleChange}


### PR DESCRIPTION
In `AutoComplete` component, `TextField`  `autoComplete` attribute should be `off`. Otherwise it will show browser default autocomplete suggestion popup
