### PR TITLE
[slider] Fix Slider div style

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -44,7 +44,7 @@ const getStyles = (props, context, state) => {
   const calcDisabledSpacing = props.disabled ? ` - ${disabledGutter}px` : '';
 
   const styles = {
-    root: {
+    slider: {
       touchCallout: 'none',
       userSelect: 'none',
       cursor: 'default',
@@ -542,7 +542,7 @@ class Slider extends Component {
 
     const {prepareStyles} = this.context.muiTheme;
     const styles = getStyles(this.props, this.context, this.state);
-    const sliderStyles = Object.assign({}, styles.root, style);
+    const sliderStyles = styles.slider;
 
     let handleStyles = {};
     let percent = this.state.percent;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Resolves: #3282 

The issue with the current slider style was that it used to apply styles twice because of the prepareStyles including `style` and hence the width % was being applied twice.

I removed the `style` parameter in `object.assign` as that was the reason of including the styles twice. 
So the style will be applied only once to the Slider div. Renamed styles.root to style.slider
