### PR TITLE
[slider] Fix margin styling override

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -44,14 +44,16 @@ const getStyles = (props, context, state) => {
   const calcDisabledSpacing = props.disabled ? ` - ${disabledGutter}px` : '';
 
   const styles = {
+    root: {
+      marginTop: 24,
+      marginBottom: 48,
+    },
     slider: {
       touchCallout: 'none',
       userSelect: 'none',
       cursor: 'default',
       height: slider.handleSizeActive,
       position: 'relative',
-      marginTop: 24,
-      marginBottom: 48,
     },
     track: {
       position: 'absolute',
@@ -596,7 +598,7 @@ class Slider extends Component {
     }
 
     return (
-      <div {...other} style={prepareStyles(Object.assign({}, style))}>
+      <div {...other} style={prepareStyles(Object.assign(styles.root, style))}>
         <span>{description}</span>
         <span>{error}</span>
         <div


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Resolves #4258

Currently slider default margin style is being set within an inner div rather than the outer div. Also any overriding option such as `style.slider.marginXXX` is being ignored and replaced by default values.

This fix solves the mentioned issue by moving the default margin styles on the component root and merging user defined option with default values to enable overrides.
