### PR TITLE
Revert "[SvgIcon] Add themeable color"

### DIFF
--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -79,13 +79,13 @@ class SvgIcon extends Component {
     } = this.props;
 
     const {
-      svgIcon,
+      baseTheme,
       prepareStyles,
     } = this.context.muiTheme;
 
     const offColor = color ? color :
       style && style.fill ? style.fill :
-      svgIcon.color;
+      baseTheme.palette.textColor;
     const onColor = hoverColor ? hoverColor : offColor;
 
     const mergedStyles = Object.assign({

--- a/src/styles/getMuiTheme.js
+++ b/src/styles/getMuiTheme.js
@@ -238,9 +238,6 @@ export default function getMuiTheme(muiTheme, ...more) {
       disabledTextColor: fade(black, 0.26),
       connectorLineColor: grey400,
     },
-    svgIcon: {
-      color: palette.textColor,
-    },
     table: {
       backgroundColor: palette.canvasColor,
     },


### PR DESCRIPTION
This reverts commit 7aaec5eefed693d34ba5c5c32700b70a8670a5d1 ( #4561 ) which was mistakenly applied on `0.15-stable` instead of `master`. 

@oliviertassinari I could also hard reset `0.15-stable` but I'm afraid that would mess up some peoples work leading to me loosing my head :sweat_smile: :sweat_smile: 
