### PR TITLE
[chip] Fix invalid `labelColor` being passed

### DIFF
--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -237,6 +237,7 @@ class Chip extends Component {
       style,
       className,
       labelStyle,
+      labelColor, // eslint-disable-line no-unused-vars,prefer-const
       backgroundColor, // eslint-disable-line no-unused-vars,prefer-const
       onRequestDelete, // eslint-disable-line no-unused-vars,prefer-const
       ...other,


### PR DESCRIPTION
This PR extracts `labelColor` from the the `other` object preventing it from being passed to `EnhancedButton`.
- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
