### PR TITLE
[chip] Fix tabIndex

### DIFF
--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -145,7 +145,7 @@ export default function Chip(props, context) {
     });
   }
 
-  const tabIndex = (onClick || onRequestDelete) ? tabIndexProp : undefined;
+  const tabIndex = (onClick || onRequestDelete) ? tabIndexProp : -1;
 
   return (
     <button
@@ -213,5 +213,4 @@ Chip.contextTypes = {
 
 Chip.defaultProps = {
   onKeyDown: () => {},
-  tabIndex: 0,
 };

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -41,8 +41,8 @@ describe('<Chip />', () => {
       assert.strictEqual(wrapper.prop('data-my-prop'), 'woof');
     });
 
-    it('should not have a tabIndex prop', () => {
-      assert.strictEqual(wrapper.prop('tabIndex'), undefined);
+    it('should have a tabIndex prop with value -1', () => {
+      assert.strictEqual(wrapper.prop('tabIndex'), -1);
     });
   });
 
@@ -75,8 +75,8 @@ describe('<Chip />', () => {
       assert.strictEqual(wrapper.prop('onClick'), handleClick);
     });
 
-    it('should have a tabIndex prop with value 0', () => {
-      assert.strictEqual(wrapper.prop('tabIndex'), 0);
+    it('should not have a tabIndex prop', () => {
+      assert.strictEqual(wrapper.prop('tabIndex'), undefined);
     });
 
     it('should apply user value of tabIndex', () => {
@@ -132,8 +132,8 @@ describe('<Chip />', () => {
       assert.strictEqual(wrapper.childAt(0).prop('data-my-prop'), 'woof');
     });
 
-    it('should have a tabIndex prop with value 0', () => {
-      assert.strictEqual(wrapper.prop('tabIndex'), 0);
+    it('should not have a tabIndex prop', () => {
+      assert.strictEqual(wrapper.prop('tabIndex'), undefined);
     });
   });
 });


### PR DESCRIPTION
Switching the container to <button> changed the default tabIndex from -1 to 0
causing a non-clickable / deletable chip to be focusable.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

