### PR TITLE
[chip] Changed delete handler on the Chip component to set the state to no l…

### DIFF
--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -129,6 +129,10 @@ class Chip extends Component {
     this.props.onBlur(event);
   };
 
+  handleDelete = (event) => {
+    this.setState({clicked: false, deleteHovered: false, focused: false, hovered: false});
+    this.props.onRequestDelete(event);
+  }
   handleFocus = (event) => {
     if (this.props.onTouchTap || this.props.onRequestDelete) {
       this.setState({focused: true});
@@ -151,7 +155,7 @@ class Chip extends Component {
     if (keycode(event) === 'backspace') {
       event.preventDefault();
       if (this.props.onRequestDelete) {
-        this.props.onRequestDelete(event);
+        this.handleDelete(event);
       }
     }
     this.props.onKeyDown(event);
@@ -199,7 +203,7 @@ class Chip extends Component {
   handleTouchTapDeleteIcon = (event) => {
     // Stop the event from bubbling up to the `Chip`
     event.stopPropagation();
-    this.props.onRequestDelete(event);
+    this.handleDelete(event);
   };
 
   handleTouchEnd = (event) => {

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -118,13 +118,28 @@ describe('<Chip />', () => {
   });
 
   describe('callbacks', () => {
-    it('triggers onRequestDelete when the delete icon is clicked', () => {
-      const handleRequestDelete = spy();
-      const wrapper = themedShallow(
-        <Chip onRequestDelete={handleRequestDelete}>Label</Chip>
-      );
-      wrapper.childAt(1).simulate('touchTap', {stopPropagation() {}});
-      assert.ok(handleRequestDelete.calledOnce);
+    describe('delete', () => {
+      let handleRequestDelete;
+      let wrapper;
+
+      beforeEach(() => {
+        handleRequestDelete = spy();
+        wrapper = themedShallow(
+          <Chip onRequestDelete={handleRequestDelete}>Label</Chip>
+        );
+      });
+
+      it('resets the state after delete', () => {
+        wrapper.setState({focused: true, hovered: true, deleteHovered: true});
+        wrapper.childAt(1).simulate('touchTap', {stopPropagation() {}});
+        assert.strictEqual(wrapper.state('deleteHovered'), false);
+        assert.strictEqual(wrapper.state('focused'), false);
+        assert.strictEqual(wrapper.state('hovered'), false);
+      });
+      it('triggers onRequestDelete when the delete icon is clicked', () => {
+        wrapper.childAt(1).simulate('touchTap', {stopPropagation() {}});
+        assert.ok(handleRequestDelete.calledOnce);
+      });
     });
 
     it('bubbles callbacks used internally', () => {

--- a/src/RadioButton/RadioButton.js
+++ b/src/RadioButton/RadioButton.js
@@ -172,14 +172,12 @@ class RadioButton extends Component {
     const uncheckedElement = React.isValidElement(uncheckedIcon) ?
       React.cloneElement(uncheckedIcon, {
         style: Object.assign(uncheckedStyles, uncheckedIcon.props.style),
-      }) :
-        <RadioButtonOff style={uncheckedStyles} />;
+      }) : <RadioButtonOff style={uncheckedStyles} />;
 
     const checkedElement = React.isValidElement(checkedIcon) ?
       React.cloneElement(checkedIcon, {
         style: Object.assign(checkedStyles, checkedIcon.props.style),
-      }) :
-        <RadioButtonOn style={checkedStyles} />;
+      }) : <RadioButtonOn style={checkedStyles} />;
 
     const mergedIconStyle = Object.assign(styles.icon, iconStyle);
     const mergedLabelStyle = Object.assign(styles.label, labelStyle);


### PR DESCRIPTION
…onger hover or focus so that the background color reverts to original color after handling a delete
We noticed that the Chip component didn't clear the hovered state after calling the delete callback.  We're open to discussion on this but it made our app look odd because we had a delete button in a chip but leave the chip visible (we're using it in conjunction with the date picker component)

I also fixed a lint error in RadioButton.