### PR TITLE
Set port of dev server with env var MATERIAL_UI_PORT

### DIFF
--- a/docs/webpack.dev.server.js
+++ b/docs/webpack.dev.server.js
@@ -18,7 +18,7 @@ const serverOptions = {
   },
 };
 
-const PORT = 3000;
+const PORT = process.env.MATERIAL_UI_PORT || 3000;
 
 new WebpackDevServer(webpack(webpackConfig), serverOptions)
   .listen(PORT, '0.0.0.0', (err) => {


### PR DESCRIPTION
Makes it so you can set the port of the dev server with the env var MATERIAL_UI_PORT. If that env var isn't set, the server will default to running on 3000. 

¯\_(ツ)_/¯