### PR TITLE
[slider] Add Logarithmic scale

### DIFF
--- a/docs/src/app/components/pages/components/Slider/ExampleLogScale.js
+++ b/docs/src/app/components/pages/components/Slider/ExampleLogScale.js
@@ -1,0 +1,38 @@
+import React, {Component} from 'react';
+import Slider from 'material-ui/Slider';
+
+/**
+ * The `logScale` property can be helpful when the slider covers a large range of values.
+ * On a logarithmic scale, the value will increase by order of magnitude along the slider axis.
+ */
+export default class SliderExampleLogScale extends Component {
+
+  state = {
+    slider: 1000,
+  };
+
+  handleSlider = (event, value) => {
+    this.setState({slider: value});
+  };
+
+  render() {
+    return (
+      <div>
+        <Slider
+          min={0}
+          max={1000000}
+          defaultValue={1000}
+          logScale={true}
+          step={1}
+          value={this.state.slider}
+          onChange={this.handleSlider}
+        />
+        <p>
+          <span>{'Log scale slider value is '}</span>
+          <span>{this.state.slider}</span>
+          <span>{' from a range of 0 to 1,000,000'}</span>
+        </p>
+      </div>
+    );
+  }
+}

--- a/docs/src/app/components/pages/components/Slider/Page.js
+++ b/docs/src/app/components/pages/components/Slider/Page.js
@@ -14,6 +14,8 @@ import SliderExampleStep from './ExampleStep';
 import sliderExampleStepCode from '!raw!./ExampleStep';
 import SliderExampleControlled from './ExampleControlled';
 import sliderExampleControlledCode from '!raw!./ExampleControlled';
+import SliderExampleLogScale from './ExampleLogScale';
+import sliderExampleLogScaleCode from '!raw!./ExampleLogScale';
 import SliderExampleAxis from './ExampleAxis';
 import sliderExampleAxisCode from '!raw!./ExampleAxis';
 import sliderCode from '!raw!material-ui/Slider/Slider';
@@ -45,6 +47,12 @@ const SliderPage = () => (
       code={sliderExampleControlledCode}
     >
       <SliderExampleControlled />
+    </CodeExample>
+    <CodeExample
+      title="Logarithmic Scale Example"
+      code={sliderExampleLogScaleCode}
+    >
+      <SliderExampleLogScale />
     </CodeExample>
     <CodeExample
       title="Alternative Axis Examples"


### PR DESCRIPTION
I've found myself implementing a log scale slider for our project and thought that it might be useful for others as well. Logarithmic scale is a useful way to represent a wide range of values and reduce them to a more manageable range - [Wikipedia Link](https://simple.wikipedia.org/wiki/Logarithmic_scale). 

I've implemented it as a new Boolean property, `logScale`. When `logScale` is set to true, the value of the slider will increase by order of magnitude along the axis of the slider.

![jdttpjyams](https://cloud.githubusercontent.com/assets/5776439/25064033/7ed7a3ce-21fa-11e7-8f5a-d173669f8ef5.gif)

There is some math involved, and it is open for discussion. My inspiration was [this math stackexchange question](https://math.stackexchange.com/questions/297768/how-would-i-create-a-exponential-ramp-function-from-0-0-to-1-1-with-a-single-val), and the function that worked best for me was:
[![math](https://cloud.githubusercontent.com/assets/5776439/25064074/5c65d148-21fb-11e7-8a4b-fb051e0c0874.PNG)](http://www.wolframalpha.com/input/?i=(+e%5E(12x)+-1+)+%2F+(e%5E12+-1+)+between+0+and+1) 
But since I'm not an expert in this area, I would love to hear other ideas for a reversible function to map between linear and log scale.

notes:
-  I've set a fixed value (12) as the `curveFactor` for the function. I didn't extract it as a prop because I didn't want to confuse the user with implementation details, but I might be wrong.
- I wasn't sure how to test it (if at all) and didn't find other tests that validate relation between the slider position and it's value, any suggestions?
- Since this is my first contribution to material-ui, I might have missed some guidelines or unexpected effects that my change might have, so please give your feedback 😄

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).
