### PR TITLE
[material-ui-icons] add making index.js

### DIFF
--- a/packages/material-ui-icons/build.js
+++ b/packages/material-ui-icons/build.js
@@ -76,6 +76,8 @@ function main(options, cb) {
     processFile(svgPath, destPath, options);
   });
 
+  processIndex(options);
+
   if (cb) {
     cb();
   }
@@ -159,6 +161,22 @@ function getJsxString(svgPath, destPath, options) {
   );
 }
 
+/**
+ * make index.js, it exports all of SVGIcon classes.
+ * @param {object} options
+ */
+function processIndex(options) {
+  const files = glob.sync(path.join(options.outputDir, "*.js"));
+  let results = [];
+  files.forEach(jsPath => {
+    const typename = path.basename(jsPath).replace('.js', '');
+    results.push(`export {\n  ${typename}\n} from './${typename}';\n`);
+  });
+  const index = results.join('\n');
+  const absDestPath = path.join(options.outputDir, 'index.js');
+  fs.writeFileSync(absDestPath, index);
+}
+
 if (require.main === module) {
   const argv = parseArgs();
   main(argv);
@@ -168,6 +186,7 @@ module.exports = {
   pascalCase: pascalCase,
   getJsxString: getJsxString,
   processFile: processFile,
+  processIndex: processIndex,
   main: main,
   SVG_ICON_RELATIVE_REQUIRE: SVG_ICON_RELATIVE_REQUIRE,
   SVG_ICON_ABSOLUTE_REQUIRE: SVG_ICON_ABSOLUTE_REQUIRE,

--- a/packages/material-ui-icons/src/README.md
+++ b/packages/material-ui-icons/src/README.md
@@ -29,6 +29,21 @@ For example to use the 'access alarm' icon component, import `material-ui-icons/
 
 Note: One exception is '3d rotation', which is named `ThreeDRotation`.
 
+### Examples
+
+* The simplest version of import icon
+```
+import AccessAlarmIcon from 'material-ui-icons/AccessAlarm';
+```
+
+* Import multiple Icons
+```
+import { 
+  AccessAlarm, 
+  ThreeDRotation
+} from 'material-ui-icons';
+```
+
 ## Upgrading
 
 If you are upgrading an existing project from Material-UI 0.x.x, you will need to revise the import paths 

--- a/packages/material-ui-icons/test/index.js
+++ b/packages/material-ui-icons/test/index.js
@@ -73,6 +73,16 @@ describe('builder', function() {
     });
   });
 
+  describe('#processIndex', function() {
+    it('should have processIndex', function() {
+      assert.strictEqual(builder.hasOwnProperty('processIndex'), true);
+    });
+
+    it('should be a function', function() {
+      assert.isFunction(builder.processIndex);
+    });
+  });
+
 });
 
 describe('--output-dir', function() {
@@ -97,6 +107,7 @@ describe('--output-dir', function() {
   it('script outputs to directory', function(done) {
     builder.main(options, function() {
       assert.strictEqual(fs.lstatSync(tempPath).isDirectory(), true);
+      assert.strictEqual(fs.lstatSync(path.join(tempPath, 'index.js')).isFile(), true)
       done();
     });
   });


### PR DESCRIPTION
material-ui-icons module suppports default member imports only.

this PR contains supporting member name imports.

for example,

* now
```
import AddIcon from 'material-ui-icons/Add';
import AllOutIcon from 'material-ui-icons/AllOut';
```

* this PR supports
```
import { Add, AllOut } from 'material-ui-icons';
```