### PR TITLE
[slider] Fix `isRtl` behaviour

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -578,6 +578,11 @@ class Slider extends Component {
     } else {
       position = event.touches[0][mainAxisClientOffsetProperty[axis]] - this.getTrackOffset();
     }
+
+    if (isRtl) {
+      position += this.track[mainAxisClientProperty.x];
+    }
+
     this.setValueFromPosition(event, position);
 
     document.addEventListener('touchmove', this.handleTouchMove);
@@ -629,6 +634,11 @@ class Slider extends Component {
     } else {
       position = event[mainAxisClientOffsetProperty[axis]] - this.getTrackOffset();
     }
+
+    if (isRtl) {
+      position += this.track[mainAxisClientProperty.x];
+    }
+
     this.setValueFromPosition(event, position);
 
     document.addEventListener('mousemove', this.handleDragMouseMove);

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -107,7 +107,7 @@ const reverseMainAxisOffsetProperty = {
   'y-reverse': 'bottom',
 };
 
-const isMouseControlInverted = (axis) => axis === 'x-reverse' || axis === 'y';
+const isMouseControlInverted = (axis, isRtl) => axis === 'x' && isRtl || axis === 'x-reverse' && !isRtl || axis === 'y';
 
 function getPercent(value, min, max) {
   let percent = (value - min) / (max - min);
@@ -562,15 +562,21 @@ class Slider extends Component {
   }
 
   handleTouchStart = (event) => {
-    if (this.props.disabled) {
+    const {
+      axis,
+      disabled,
+    } = this.props;
+    const {isRtl} = this.context.muiTheme;
+
+    if (disabled) {
       return;
     }
 
     let position;
-    if (isMouseControlInverted(this.props.axis)) {
-      position = this.getTrackOffset() - event.touches[0][mainAxisClientOffsetProperty[this.props.axis]];
+    if (isMouseControlInverted(axis, isRtl)) {
+      position = this.getTrackOffset() - event.touches[0][mainAxisClientOffsetProperty[axis]];
     } else {
-      position = event.touches[0][mainAxisClientOffsetProperty[this.props.axis]] - this.getTrackOffset();
+      position = event.touches[0][mainAxisClientOffsetProperty[axis]] - this.getTrackOffset();
     }
     this.setValueFromPosition(event, position);
 
@@ -607,15 +613,21 @@ class Slider extends Component {
   };
 
   handleMouseDown = (event) => {
-    if (this.props.disabled) {
+    const {
+      axis,
+      disabled,
+    } = this.props;
+    const {isRtl} = this.context.muiTheme;
+
+    if (disabled) {
       return;
     }
 
     let position;
-    if (isMouseControlInverted(this.props.axis)) {
-      position = this.getTrackOffset() - event[mainAxisClientOffsetProperty[this.props.axis]];
+    if (isMouseControlInverted(axis, isRtl)) {
+      position = this.getTrackOffset() - event[mainAxisClientOffsetProperty[axis]];
     } else {
-      position = event[mainAxisClientOffsetProperty[this.props.axis]] - this.getTrackOffset();
+      position = event[mainAxisClientOffsetProperty[axis]] - this.getTrackOffset();
     }
     this.setValueFromPosition(event, position);
 
@@ -667,6 +679,12 @@ class Slider extends Component {
   }
 
   onDragUpdate(event, type) {
+    const {
+      axis,
+      disabled,
+    } = this.props;
+    const {isRtl} = this.context.muiTheme;
+
     if (this.dragRunning) {
       return;
     }
@@ -678,13 +696,17 @@ class Slider extends Component {
       const source = type === 'touch' ? event.touches[0] : event;
 
       let position;
-      if (isMouseControlInverted(this.props.axis)) {
-        position = this.getTrackOffset() - source[mainAxisClientOffsetProperty[this.props.axis]];
+      if (isMouseControlInverted(axis, isRtl)) {
+        position = this.getTrackOffset() - source[mainAxisClientOffsetProperty[axis]];
       } else {
-        position = source[mainAxisClientOffsetProperty[this.props.axis]] - this.getTrackOffset();
+        position = source[mainAxisClientOffsetProperty[axis]] - this.getTrackOffset();
       }
 
-      if (!this.props.disabled) {
+      if (isRtl) {
+        position += this.track[mainAxisClientProperty.x];
+      }
+
+      if (!disabled) {
         this.setValueFromPosition(event, position);
       }
     });

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -417,6 +417,8 @@ class Slider extends Component {
       step,
     } = this.props;
 
+    const {isRtl} = this.context.muiTheme;
+
     let action;
 
     switch (keycode(event)) {
@@ -430,9 +432,17 @@ class Slider extends Component {
         break;
       case 'left':
         if (axis === 'x-reverse') {
-          action = 'increase';
+          if (isRtl) {
+            action = 'decrease';
+          } else {
+            action = 'increase';
+          }
         } else {
-          action = 'decrease';
+          if (isRtl) {
+            action = 'increase';
+          } else {
+            action = 'decrease';
+          }
         }
         break;
       case 'page up':
@@ -445,9 +455,17 @@ class Slider extends Component {
         break;
       case 'right':
         if (axis === 'x-reverse') {
-          action = 'decrease';
+          if (isRtl) {
+            action = 'increase';
+          } else {
+            action = 'decrease';
+          }
         } else {
-          action = 'increase';
+          if (isRtl) {
+            action = 'decrease';
+          } else {
+            action = 'increase';
+          }
         }
         break;
       case 'home':

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -336,7 +336,6 @@ describe('<Slider />', () => {
       const wrapper = shallowWithRTLContext(
         <Slider name="slider" onChange={handleChange} />
       );
-      const previousValue = wrapper.state().value;
 
       getTrackContainer(wrapper).simulate('keydown', {
         keyCode: keycode('right'),
@@ -581,7 +580,6 @@ describe('<Slider />', () => {
       const wrapper = shallowWithRTLContext(
         <Slider name="slider" axis="x-reverse" onChange={handleChange} />
       );
-      const previousValue = wrapper.state().value;
 
       getTrackContainer(wrapper).simulate('keydown', {
         keyCode: keycode('left'),

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -10,6 +10,8 @@ import getMuiTheme from '../styles/getMuiTheme';
 describe('<Slider />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+  const muiThemeRtl = getMuiTheme({isRtl: true});
+  const shallowWithRTLContext = (node) => shallow(node, {context: {muiTheme: muiThemeRtl}});
 
   const getThumbElement = function(shallowWrapper) {
     return shallowWrapper.children().at(2).children().at(0).children().at(2);
@@ -256,6 +258,21 @@ describe('<Slider />', () => {
       assert.strictEqual(wrapper.state().value > previousValue, true);
     });
 
+    it('simulates the up arrow key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
+      );
+      const previousValue = wrapper.state().value;
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('up'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(wrapper.state().value > previousValue, true);
+    });
+
     it('simulates the up arrow key on a y axis slider', () => {
       const handleChange = spy();
       const wrapper = shallowWithContext(
@@ -314,6 +331,36 @@ describe('<Slider />', () => {
       assert.strictEqual(wrapper.state().value, 0);
     });
 
+    it('simulates the right arrow key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
+      );
+      const previousValue = wrapper.state().value;
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('right'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 0);
+      assert.strictEqual(wrapper.state().value, 0);
+    });
+
+    it('simulates the right arrow key on an x-reverse rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" axis="x-reverse" onChange={handleChange} />
+      );
+      const previousValue = wrapper.state().value;
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('right'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(wrapper.state().value > previousValue, true);
+    });
+
     it('simulates the right arrow key on an y axis slider', () => {
       const handleChange = spy();
       const wrapper = shallowWithContext(
@@ -362,6 +409,20 @@ describe('<Slider />', () => {
       const handleChange = spy();
       const wrapper = shallowWithContext(
         <Slider name="slider" axis="x-reverse" onChange={handleChange} />
+      );
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('home'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 0);
+      assert.strictEqual(wrapper.state().value, 0);
+    });
+
+    it('simulates the home key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
       );
 
       getTrackContainer(wrapper).simulate('keydown', {
@@ -428,6 +489,20 @@ describe('<Slider />', () => {
       assert.strictEqual(wrapper.state().value, 0);
     });
 
+    it('simulates the down arrow key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
+      );
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('down'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 0);
+      assert.strictEqual(wrapper.state().value, 0);
+    });
+
     it('simulates the down arrow key on a y axis slider', () => {
       const handleChange = spy();
       const wrapper = shallowWithContext(
@@ -484,6 +559,36 @@ describe('<Slider />', () => {
       });
       assert.strictEqual(handleChange.callCount, 1);
       assert.strictEqual(wrapper.state().value > previousValue, true);
+    });
+
+    it('simulates the left arrow key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
+      );
+      const previousValue = wrapper.state().value;
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('left'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(wrapper.state().value > previousValue, true);
+    });
+
+    it('simulates the left arrow key on an x-reverse rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" axis="x-reverse" onChange={handleChange} />
+      );
+      const previousValue = wrapper.state().value;
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('left'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 0);
+      assert.strictEqual(wrapper.state().value, 0);
     });
 
     it('simulates the left arrow key for a y axis slider', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Closes #6736 

The problem is described well in the issue, I started by writing tests that describe the expected functionality when RTL is enabled, then fixed the new tests that were broken.

Since there were no tests written for dragging, I did not write any tests for RTL drag, however, I did test it manually.