### PR TITLE
[slider] Fix step & max issue

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -684,28 +684,23 @@ class Slider extends Component {
   }
 
   setValueFromPosition(event, position) {
-    const positionMax = this.track[mainAxisClientProperty[this.props.axis]];
-    if (position < 0) {
-      position = 0;
-    } else if (position > positionMax) {
-      position = positionMax;
-    }
-
     const {
       step,
       min,
       max,
     } = this.props;
+    const positionMax = this.track[mainAxisClientProperty[this.props.axis]];
 
     let value;
-    value = position / positionMax * (max - min);
-    value = Math.round(value / step) * step + min;
-    value = parseFloat(value.toFixed(5));
 
-    if (value > max) {
-      value = max;
-    } else if (value < min) {
+    if (position <= 0) {
       value = min;
+    } else if (position >= positionMax) {
+      value = max;
+    } else {
+      value = position / positionMax * (max - min);
+      value = Math.round(value / step) * step + min;
+      value = parseFloat(value.toFixed(5));
     }
 
     if (this.state.value !== value) {


### PR DESCRIPTION
Closes #6750, if the last step is less than half the step size, due to the rounding in the formula to calculate the value in `setValueFromPosition` it is impossible to fill the slider. I resolved this issue by setting the `value` to the `min`/`max` if the cursor is past the respective edges.

- [ ] PR has tests/docs demo and is linted.

I did not write new tests because the problem is specifically related to dragging. Currently, the `Slider` unit tests do not cover mouse actions, I am not experienced enough to write such tests. However, I did test it manually.

- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

