### PR TITLE
[slider] Fix `isRtl` behaviour `directionInvariant` approach

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -109,6 +109,18 @@ const reverseMainAxisOffsetProperty = {
 
 const isMouseControlInverted = (axis) => axis === 'x-reverse' || axis === 'y';
 
+const calculateAxis = (axis, isRtl) => {
+  if (isRtl) {
+    switch (axis) {
+      case 'x':
+        return 'x-reverse';
+      case 'x-reverse':
+        return 'x';
+    }
+  }
+  return axis;
+};
+
 function getPercent(value, min, max) {
   let percent = (value - min) / (max - min);
   if (isNaN(percent)) {
@@ -127,6 +139,7 @@ const getStyles = (props, context, state) => {
   } = props;
 
   const {
+    isRtl,
     slider: {
       handleColorZero,
       handleFillColor,
@@ -145,45 +158,48 @@ const getStyles = (props, context, state) => {
   const disabledGutter = trackSize + handleSizeDisabled / 2;
   const calcDisabledSpacing = disabled ? ` - ${disabledGutter}px` : '';
   const percent = getPercent(state.value, min, max);
+  const calculatedAxis = calculateAxis(axis, isRtl);
 
   const styles = {
     slider: {
       touchCallout: 'none',
       userSelect: 'none',
       cursor: 'default',
-      [crossAxisProperty[axis]]: handleSizeActive,
-      [mainAxisProperty[axis]]: '100%',
+      [crossAxisProperty[calculatedAxis]]: handleSizeActive,
+      [mainAxisProperty[calculatedAxis]]: '100%',
       position: 'relative',
       marginTop: 24,
       marginBottom: 48,
     },
     track: {
       position: 'absolute',
-      [crossAxisOffsetProperty[axis]]: (handleSizeActive - trackSize) / 2,
-      [mainAxisOffsetProperty[axis]]: 0,
-      [mainAxisProperty[axis]]: '100%',
-      [crossAxisProperty[axis]]: trackSize,
+      [crossAxisOffsetProperty[calculatedAxis]]: (handleSizeActive - trackSize) / 2,
+      [mainAxisOffsetProperty[calculatedAxis]]: 0,
+      [mainAxisProperty[calculatedAxis]]: '100%',
+      [crossAxisProperty[calculatedAxis]]: trackSize,
     },
     filledAndRemaining: {
+      directionInvariant: true,
       position: 'absolute',
       [crossAxisOffsetProperty]: 0,
-      [crossAxisProperty[axis]]: '100%',
+      [crossAxisProperty[calculatedAxis]]: '100%',
       transition: transitions.easeOut(null, 'margin'),
     },
     handle: {
+      directionInvariant: true,
       boxSizing: 'border-box',
       position: 'absolute',
       cursor: 'pointer',
       pointerEvents: 'inherit',
-      [crossAxisOffsetProperty[axis]]: 0,
-      [mainAxisOffsetProperty[axis]]: percent === 0 ? '0%' : `${(percent * 100)}%`,
+      [crossAxisOffsetProperty[calculatedAxis]]: 0,
+      [mainAxisOffsetProperty[calculatedAxis]]: percent === 0 ? '0%' : `${(percent * 100)}%`,
       zIndex: 1,
       margin: ({
         x: `${(trackSize / 2)}px 0 0 0`,
         'x-reverse': `${(trackSize / 2)}px 0 0 0`,
         y: `0 0 0 ${(trackSize / 2)}px`,
         'y-reverse': `0 0 0 ${(trackSize / 2)}px`,
-      })[axis],
+      })[calculatedAxis],
       width: handleSize,
       height: handleSize,
       backgroundColor: selectionColor,
@@ -195,7 +211,7 @@ const getStyles = (props, context, state) => {
         'x-reverse': 'translate(50%, -50%)',
         y: 'translate(-50%, 50%)',
         'y-reverse': 'translate(-50%, -50%)',
-      })[axis],
+      })[calculatedAxis],
       transition:
         `${transitions.easeOut('450ms', 'background')}, ${
         transitions.easeOut('450ms', 'border-color')}, ${
@@ -249,17 +265,17 @@ const getStyles = (props, context, state) => {
     },
   };
   styles.filled = Object.assign({}, styles.filledAndRemaining, {
-    [mainAxisOffsetProperty[axis]]: 0,
+    [mainAxisOffsetProperty[calculatedAxis]]: 0,
     backgroundColor: disabled ? trackColor : selectionColor,
-    [mainAxisMarginFromEnd[axis]]: fillGutter,
-    [mainAxisProperty[axis]]: `calc(${(percent * 100)}%${calcDisabledSpacing})`,
+    [mainAxisMarginFromEnd[calculatedAxis]]: fillGutter,
+    [mainAxisProperty[calculatedAxis]]: `calc(${(percent * 100)}%${calcDisabledSpacing})`,
   });
   styles.remaining = Object.assign({}, styles.filledAndRemaining, {
-    [reverseMainAxisOffsetProperty[axis]]: 0,
+    [reverseMainAxisOffsetProperty[calculatedAxis]]: 0,
     backgroundColor: (state.hovered || state.focused) &&
       !disabled ? trackColorSelected : trackColor,
-    [mainAxisMarginFromStart[axis]]: fillGutter,
-    [mainAxisProperty[axis]]: `calc(${((1 - percent) * 100)}%${calcDisabledSpacing})`,
+    [mainAxisMarginFromStart[calculatedAxis]]: fillGutter,
+    [mainAxisProperty[calculatedAxis]]: `calc(${((1 - percent) * 100)}%${calcDisabledSpacing})`,
   });
 
   return styles;
@@ -416,20 +432,23 @@ class Slider extends Component {
       max,
       step,
     } = this.props;
+    const {isRtl} = this.context.muiTheme;
+
+    const calculatedAxis = calculateAxis(axis, isRtl);
 
     let action;
 
     switch (keycode(event)) {
       case 'page down':
       case 'down':
-        if (axis === 'y-reverse') {
+        if (calculatedAxis === 'y-reverse') {
           action = 'increase';
         } else {
           action = 'decrease';
         }
         break;
       case 'left':
-        if (axis === 'x-reverse') {
+        if (calculatedAxis === 'x-reverse') {
           action = 'increase';
         } else {
           action = 'decrease';
@@ -437,14 +456,14 @@ class Slider extends Component {
         break;
       case 'page up':
       case 'up':
-        if (axis === 'y-reverse') {
+        if (calculatedAxis === 'y-reverse') {
           action = 'decrease';
         } else {
           action = 'increase';
         }
         break;
       case 'right':
-        if (axis === 'x-reverse') {
+        if (calculatedAxis === 'x-reverse') {
           action = 'decrease';
         } else {
           action = 'increase';
@@ -544,15 +563,23 @@ class Slider extends Component {
   }
 
   handleTouchStart = (event) => {
-    if (this.props.disabled) {
+    const {
+      axis,
+      disabled,
+    } = this.props;
+    const {isRtl} = this.context.muiTheme;
+
+    if (disabled) {
       return;
     }
 
+    const calculatedAxis = calculateAxis(axis, isRtl);
+
     let position;
-    if (isMouseControlInverted(this.props.axis)) {
-      position = this.getTrackOffset() - event.touches[0][mainAxisClientOffsetProperty[this.props.axis]];
+    if (isMouseControlInverted(calculatedAxis)) {
+      position = this.getTrackOffset() - event.touches[0][mainAxisClientOffsetProperty[calculatedAxis]];
     } else {
-      position = event.touches[0][mainAxisClientOffsetProperty[this.props.axis]] - this.getTrackOffset();
+      position = event.touches[0][mainAxisClientOffsetProperty[calculatedAxis]] - this.getTrackOffset();
     }
     this.setValueFromPosition(event, position);
 
@@ -589,15 +616,23 @@ class Slider extends Component {
   };
 
   handleMouseDown = (event) => {
-    if (this.props.disabled) {
+    const {
+      axis,
+      disabled,
+    } = this.props;
+    const {isRtl} = this.context.muiTheme;
+
+    if (disabled) {
       return;
     }
 
+    const calculatedAxis = calculateAxis(axis, isRtl);
+
     let position;
-    if (isMouseControlInverted(this.props.axis)) {
-      position = this.getTrackOffset() - event[mainAxisClientOffsetProperty[this.props.axis]];
+    if (isMouseControlInverted(calculatedAxis)) {
+      position = this.getTrackOffset() - event[mainAxisClientOffsetProperty[calculatedAxis]];
     } else {
-      position = event[mainAxisClientOffsetProperty[this.props.axis]] - this.getTrackOffset();
+      position = event[mainAxisClientOffsetProperty[calculatedAxis]] - this.getTrackOffset();
     }
     this.setValueFromPosition(event, position);
 
@@ -634,7 +669,12 @@ class Slider extends Component {
   };
 
   getTrackOffset() {
-    return this.track.getBoundingClientRect()[mainAxisOffsetProperty[this.props.axis]];
+    const {axis} = this.props;
+    const {isRtl} = this.context.muiTheme;
+
+    const calculatedAxis = calculateAxis(axis, isRtl);
+
+    return this.track.getBoundingClientRect()[mainAxisOffsetProperty[calculatedAxis]];
   }
 
   onDragStart(event) {
@@ -649,6 +689,12 @@ class Slider extends Component {
   }
 
   onDragUpdate(event, type) {
+    const {
+      axis,
+      disabled,
+    } = this.props;
+    const {isRtl} = this.context.muiTheme;
+
     if (this.dragRunning) {
       return;
     }
@@ -657,16 +703,17 @@ class Slider extends Component {
     requestAnimationFrame(() => {
       this.dragRunning = false;
 
+      const calculatedAxis = calculateAxis(axis, isRtl);
       const source = type === 'touch' ? event.touches[0] : event;
 
       let position;
-      if (isMouseControlInverted(this.props.axis)) {
-        position = this.getTrackOffset() - source[mainAxisClientOffsetProperty[this.props.axis]];
+      if (isMouseControlInverted(calculatedAxis)) {
+        position = this.getTrackOffset() - source[mainAxisClientOffsetProperty[calculatedAxis]];
       } else {
-        position = source[mainAxisClientOffsetProperty[this.props.axis]] - this.getTrackOffset();
+        position = source[mainAxisClientOffsetProperty[calculatedAxis]] - this.getTrackOffset();
       }
 
-      if (!this.props.disabled) {
+      if (!disabled) {
         this.setValueFromPosition(event, position);
       }
     });
@@ -685,11 +732,15 @@ class Slider extends Component {
 
   setValueFromPosition(event, position) {
     const {
+      axis,
       step,
       min,
       max,
     } = this.props;
-    const positionMax = this.track[mainAxisClientProperty[this.props.axis]];
+    const {isRtl} = this.context.muiTheme;
+
+    const calculatedAxis = calculateAxis(axis, isRtl);
+    const positionMax = this.track[mainAxisClientProperty[calculatedAxis]];
 
     let value;
 

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -10,6 +10,8 @@ import getMuiTheme from '../styles/getMuiTheme';
 describe('<Slider />', () => {
   const muiTheme = getMuiTheme();
   const shallowWithContext = (node) => shallow(node, {context: {muiTheme}});
+  const muiThemeRtl = getMuiTheme({isRtl: true});
+  const shallowWithRTLContext = (node) => shallow(node, {context: {muiTheme: muiThemeRtl}});
 
   const getThumbElement = function(shallowWrapper) {
     return shallowWrapper.children().at(2).children().at(0).children().at(2);
@@ -256,6 +258,21 @@ describe('<Slider />', () => {
       assert.strictEqual(wrapper.state().value > previousValue, true);
     });
 
+    it('simulates the up arrow key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
+      );
+      const previousValue = wrapper.state().value;
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('up'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(wrapper.state().value > previousValue, true);
+    });
+
     it('simulates the up arrow key on a y axis slider', () => {
       const handleChange = spy();
       const wrapper = shallowWithContext(
@@ -314,6 +331,35 @@ describe('<Slider />', () => {
       assert.strictEqual(wrapper.state().value, 0);
     });
 
+    it('simulates the right arrow key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
+      );
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('right'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 0);
+      assert.strictEqual(wrapper.state().value, 0);
+    });
+
+    it('simulates the right arrow key on an x-reverse rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" axis="x-reverse" onChange={handleChange} />
+      );
+      const previousValue = wrapper.state().value;
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('right'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(wrapper.state().value > previousValue, true);
+    });
+
     it('simulates the right arrow key on an y axis slider', () => {
       const handleChange = spy();
       const wrapper = shallowWithContext(
@@ -362,6 +408,20 @@ describe('<Slider />', () => {
       const handleChange = spy();
       const wrapper = shallowWithContext(
         <Slider name="slider" axis="x-reverse" onChange={handleChange} />
+      );
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('home'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 0);
+      assert.strictEqual(wrapper.state().value, 0);
+    });
+
+    it('simulates the home key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
       );
 
       getTrackContainer(wrapper).simulate('keydown', {
@@ -428,6 +488,20 @@ describe('<Slider />', () => {
       assert.strictEqual(wrapper.state().value, 0);
     });
 
+    it('simulates the down arrow key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
+      );
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('down'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 0);
+      assert.strictEqual(wrapper.state().value, 0);
+    });
+
     it('simulates the down arrow key on a y axis slider', () => {
       const handleChange = spy();
       const wrapper = shallowWithContext(
@@ -484,6 +558,35 @@ describe('<Slider />', () => {
       });
       assert.strictEqual(handleChange.callCount, 1);
       assert.strictEqual(wrapper.state().value > previousValue, true);
+    });
+
+    it('simulates the left arrow key on a rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" onChange={handleChange} />
+      );
+      const previousValue = wrapper.state().value;
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('left'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(wrapper.state().value > previousValue, true);
+    });
+
+    it('simulates the left arrow key on an x-reverse rtl slider', () => {
+      const handleChange = spy();
+      const wrapper = shallowWithRTLContext(
+        <Slider name="slider" axis="x-reverse" onChange={handleChange} />
+      );
+
+      getTrackContainer(wrapper).simulate('keydown', {
+        keyCode: keycode('left'),
+        preventDefault: () => {},
+      });
+      assert.strictEqual(handleChange.callCount, 0);
+      assert.strictEqual(wrapper.state().value, 0);
     });
 
     it('simulates the left arrow key for a y axis slider', () => {


### PR DESCRIPTION
Closes #6736, another approach to the issue as suggested by @oliviertassinari on #6744.
If this is approved, then it closes #6744.

* Made `Slider` direction invariant.
* Transformed `axis` props based on `isRtl` 

<img src="https://cloud.githubusercontent.com/assets/12089120/25649265/8edde736-2f80-11e7-9a6f-c784ebd9f5c2.gif" width="300" />

- [X] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

