### PR TITLE
[autocomplete] Fix handle open prop change

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -233,7 +233,7 @@ class AutoComplete extends Component {
         open: nextProps.open,
         anchorEl: ReactDOM.findDOMNode(this.refs.searchTextField),
       });
-    }    
+    }
   }
 
   componentWillUnmount() {

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -228,6 +228,12 @@ class AutoComplete extends Component {
         searchText: nextProps.searchText,
       });
     }
+    if (this.props.open !== nextProps.open) {
+      this.setState({
+        open: nextProps.open,
+        anchorEl: ReactDOM.findDOMNode(this.refs.searchTextField),
+      });
+    }    
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
This PR fixes #6802

autocomplete didn't handle a scenario when the open prop is changed while the component is mounted (full description+ demo in the issue)

- [x] PR has tests / docs demo, and is linted. though no new tests added
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

