### PR TITLE
[slider] Remove deprecated error and description props

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -4,7 +4,6 @@ import keycode from 'keycode';
 import warning from 'warning';
 import transitions from '../styles/transitions';
 import FocusRipple from '../internal/FocusRipple';
-import deprecated from '../utils/deprecatedPropType';
 
 /**
  * Verifies min/max range.
@@ -291,10 +290,6 @@ class Slider extends Component {
      * The default value of the slider.
      */
     defaultValue: valueInRangePropType,
-    /**
-     * Describe the slider.
-     */
-    description: deprecated(PropTypes.node, 'Use a sibling node element instead. It will be removed with v0.17.0.'),
     /**
      * Disables focus ripple if set to true.
      */
@@ -764,7 +759,6 @@ class Slider extends Component {
   render() {
     const {
       axis, // eslint-disable-line no-unused-vars
-      description,
       disabled,
       disableFocusRipple,
       max,
@@ -821,7 +815,6 @@ class Slider extends Component {
 
     return (
       <div {...other} style={prepareStyles(Object.assign({}, style))}>
-        <span>{description}</span>
         <div
           style={prepareStyles(Object.assign({}, styles.slider, sliderStyle))}
           onFocus={this.handleFocus}

--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -304,10 +304,6 @@ class Slider extends Component {
      */
     disabled: PropTypes.bool,
     /**
-     * An error message for the slider.
-     */
-    error: deprecated(PropTypes.node, 'Use a sibling node element instead. It will be removed with v0.17.0.'),
-    /**
      * The maximum value the slider can slide to on
      * a scale from 0 to 1 inclusive. Cannot be equal to min.
      */
@@ -771,7 +767,6 @@ class Slider extends Component {
       description,
       disabled,
       disableFocusRipple,
-      error,
       max,
       min,
       name,
@@ -827,7 +822,6 @@ class Slider extends Component {
     return (
       <div {...other} style={prepareStyles(Object.assign({}, style))}>
         <span>{description}</span>
-        <span>{error}</span>
         <div
           style={prepareStyles(Object.assign({}, styles.slider, sliderStyle))}
           onFocus={this.handleFocus}

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -14,11 +14,12 @@ describe('<Slider />', () => {
   const shallowWithRTLContext = (node) => shallow(node, {context: {muiTheme: muiThemeRtl}});
 
   const getThumbElement = function(shallowWrapper) {
-    return shallowWrapper.children().at(2).children().at(0).children().at(2);
+    return shallowWrapper.childAt(0).childAt(0).childAt(2);
   };
 
   const getTrackContainer = function(shallowWrapper) {
-    return shallowWrapper.children().at(2);
+    // console.log('shallowWrapper.children().at(2)', shallowWrapper.children().at(2));
+    return shallowWrapper.childAt(0);
   };
 
   it('renders slider and the hidden input', () => {

--- a/src/Slider/Slider.spec.js
+++ b/src/Slider/Slider.spec.js
@@ -18,7 +18,6 @@ describe('<Slider />', () => {
   };
 
   const getTrackContainer = function(shallowWrapper) {
-    // console.log('shallowWrapper.children().at(2)', shallowWrapper.children().at(2));
     return shallowWrapper.childAt(0);
   };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

Fixes #6361 
Removes the deprecated `description` and `error` props, which were supposed to have been removed in 17.0

Refactored tests as the removal of the description and error elements caused the tests to fail.
