### PR TITLE
[eslint] enforce import plugin rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       webpack: {
-        config: './docs/webpack.dev.config.js',
+        config: './docs/webpackBaseConfig.js',
       },
     },
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       webpack: {
-        config: 'webpack.config.js',
+        config: './docs/webpack.dev.config.js',
       },
     },
   },
@@ -49,12 +49,9 @@ module.exports = {
 
     'babel/object-curly-spacing': ['error', 'always'],
 
-    'import/unambiguous': 'off',
-    'import/no-unresolved': 'off',
-    'import/no-named-as-default': 'off',
-    'import/extensions': 'off',
+    'import/unambiguous': 'off',  // scripts
+    'import/namespace': ['error', { allowComputed: true }],
     'import/no-extraneous-dependencies': 'off',
-    'import/prefer-default-export': 'off',
 
     'react/jsx-handler-names': ['error', { // airbnb is disabling this rule
       eventHandlerPrefix: 'handle',

--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+  settings: {
+    'import/resolver': {
+      webpack: {
+        config: './webpack.dev.config.js',
+      },
+    },
+  },
+};

--- a/docs/.eslintrc.js
+++ b/docs/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       webpack: {
-        config: './webpack.dev.config.js',
+        config: './webpackBaseConfig.js',
       },
     },
   },

--- a/docs/src/index.js
+++ b/docs/src/index.js
@@ -1,4 +1,5 @@
 // @flow
+/* eslint-disable import/prefer-default-export */
 
 import { AppContainer } from 'react-hot-loader';
 import { createStore } from 'redux';

--- a/docs/webpack.dev.config.js
+++ b/docs/webpack.dev.config.js
@@ -1,4 +1,5 @@
 // @flow weak
+/* eslint-disable import/no-unresolved */
 
 const webpack = require('webpack');
 const webpackBaseConfig = require('./webpackBaseConfig');

--- a/docs/webpack.prod.config.js
+++ b/docs/webpack.prod.config.js
@@ -1,4 +1,6 @@
 // @flow weak
+/* eslint-disable import/no-unresolved */
+
 const webpack = require('webpack');
 const webpackBaseConfig = require('./webpackBaseConfig');
 const dllManifest = require('./build/dll.manifest.json');

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "enzyme": "^2.8.2",
     "eslint": "^3.19.0",
     "eslint-config-airbnb": "^15.0.0",
+    "eslint-import-resolver-webpack": "^0.8.1",
     "eslint-plugin-babel": "^4.1.1",
     "eslint-plugin-flowtype": "^2.33.0",
     "eslint-plugin-import": "^2.2.0",

--- a/packages/material-ui-icons/.eslintrc.js
+++ b/packages/material-ui-icons/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  settings: {
+    'import/resolver': {
+      webpack: {
+        config: '../../docs/webpack.dev.config.js',
+      },
+    },
+  },
+  rules: {
+    // needed for mustache and temp
+    'import/no-unresolved': 'off',
+    'import/extensions': 'off',
+  }
+};

--- a/packages/material-ui-icons/.eslintrc.js
+++ b/packages/material-ui-icons/.eslintrc.js
@@ -2,7 +2,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       webpack: {
-        config: '../../docs/webpack.dev.config.js',
+        config: '../../docs/webpackBaseConfig.js',
       },
     },
   },

--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import AppBar, { styleSheet } from './AppBar';
 
 describe('<AppBar />', () => {

--- a/src/Avatar/Avatar.spec.js
+++ b/src/Avatar/Avatar.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Avatar, { styleSheet } from './Avatar';
 import CancelIcon from '../svg-icons/cancel';
 

--- a/src/Badge/Badge.spec.js
+++ b/src/Badge/Badge.spec.js
@@ -1,8 +1,8 @@
 // @flow
 
 import React from 'react';
-import { createShallow } from 'src/test-utils';
 import { assert } from 'chai';
+import { createShallow } from '../test-utils';
 import Badge, { styleSheet } from './Badge';
 
 describe('<Badge />', () => {

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import BottomNavigation, { styleSheet } from './BottomNavigation';
 import BottomNavigationButton from './BottomNavigationButton';
 import Icon from '../Icon';

--- a/src/BottomNavigation/BottomNavigationButton.spec.js
+++ b/src/BottomNavigation/BottomNavigationButton.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import BottomNavigationButton, { styleSheet } from './BottomNavigationButton';
 import Icon from '../Icon';
 

--- a/src/Button/Button.spec.js
+++ b/src/Button/Button.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import htmlLooksLike from 'html-looks-like';
-import { createShallow, createRenderToString } from 'src/test-utils';
+import { createShallow, createRenderToString } from '../test-utils';
 import Button, { styleSheet } from './Button';
 
 describe('<Button />', () => {

--- a/src/Card/Card.spec.js
+++ b/src/Card/Card.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Card, { styleSheet } from './Card';
 
 describe('<Card />', () => {

--- a/src/Card/CardActions.spec.js
+++ b/src/Card/CardActions.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import CardActions, { styleSheet } from './CardActions';
 
 describe('<CardActions />', () => {

--- a/src/Card/CardContent.spec.js
+++ b/src/Card/CardContent.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import CardContent, { styleSheet } from './CardContent';
 
 describe('<CardContent />', () => {

--- a/src/Card/CardHeader.spec.js
+++ b/src/Card/CardHeader.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import CardHeader, { styleSheet } from './CardHeader';
 
 describe('<CardHeader />', () => {

--- a/src/Card/CardMedia.spec.js
+++ b/src/Card/CardMedia.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import CardMedia, { styleSheet } from './CardMedia';
 
 describe('<CardMedia />', () => {

--- a/src/Checkbox/Checkbox.spec.js
+++ b/src/Checkbox/Checkbox.spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Checkbox, { LabelCheckbox, styleSheet } from './Checkbox';
 
 describe('<Checkbox />', () => {

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import keycode from 'keycode';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Chip, { styleSheet } from './Chip';
 import Avatar from '../Avatar';
 

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Dialog, { styleSheet } from './Dialog';
 import Paper from '../Paper';
 

--- a/src/Dialog/DialogActions.spec.js
+++ b/src/Dialog/DialogActions.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import DialogActions, { styleSheet } from './DialogActions';
 
 describe('<DialogActions />', () => {

--- a/src/Dialog/DialogContent.spec.js
+++ b/src/Dialog/DialogContent.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import DialogContent, { styleSheet } from './DialogContent';
 
 describe('<DialogContent />', () => {

--- a/src/Dialog/DialogContentText.spec.js
+++ b/src/Dialog/DialogContentText.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import DialogContentText, { styleSheet } from './DialogContentText';
 
 describe('<DialogContentText />', () => {

--- a/src/Dialog/DialogTitle.spec.js
+++ b/src/Dialog/DialogTitle.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import DialogTitle, { styleSheet } from './DialogTitle';
 
 describe('<DialogTitle />', () => {

--- a/src/Dialog/withResponsiveFullScreen.spec.js
+++ b/src/Dialog/withResponsiveFullScreen.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Paper from '../Paper';
 import Dialog, { styleSheet } from './Dialog';
 import withResponsiveFullScreen from './withResponsiveFullScreen';

--- a/src/Divider/Divider.spec.js
+++ b/src/Divider/Divider.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Divider, { styleSheet } from './Divider';
 
 describe('<Divider />', () => {

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Drawer, { styleSheet } from './Drawer';
 import Slide from '../transitions/Slide';
 import Modal from '../internal/Modal';

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import FormControl, { styleSheet } from './FormControl';
 
 describe('<FormControl />', () => {

--- a/src/Form/FormGroup.spec.js
+++ b/src/Form/FormGroup.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import FormGroup, { styleSheet } from './FormGroup';
 
 describe('<FormGroup />', () => {

--- a/src/Form/FormLabel.spec.js
+++ b/src/Form/FormLabel.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import FormLabel, { styleSheet } from './FormLabel';
 
 describe('<FormLabel />', () => {

--- a/src/Grid/Grid.spec.js
+++ b/src/Grid/Grid.spec.js
@@ -2,8 +2,8 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
 import forOwn from 'lodash/forOwn';
+import { createShallow } from '../test-utils';
 import Grid, { styleSheet } from './Grid';
 import Hidden from '../Hidden';
 

--- a/src/Hidden/Hidden.spec.js
+++ b/src/Hidden/Hidden.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Hidden from './Hidden';
 import HiddenJs from './HiddenJs';
 

--- a/src/Hidden/HiddenJs.spec.js
+++ b/src/Hidden/HiddenJs.spec.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import HiddenJs from './HiddenJs';
 import type { Breakpoint } from '../styles/breakpoints';
 import Typography from '../Typography';

--- a/src/Icon/Icon.spec.js
+++ b/src/Icon/Icon.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Icon, { styleSheet } from './Icon';
 
 describe('<Icon />', () => {

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import IconButton, { styleSheet } from './IconButton';
 import Icon from '../Icon';
 

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Textarea from './Textarea';
 import Input, { styleSheet } from './Input';
 

--- a/src/Input/InputLabel.spec.js
+++ b/src/Input/InputLabel.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import InputLabel, { styleSheet } from './InputLabel';
 
 describe('<InputLabel />', () => {

--- a/src/Input/Textarea.spec.js
+++ b/src/Input/Textarea.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Textarea from './Textarea';
 
 describe('<Textarea />', () => {

--- a/src/List/List.spec.js
+++ b/src/List/List.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import List, { styleSheet } from './List';
 import ListSubheader from './ListSubheader';
 

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import ListItem, { styleSheet } from './ListItem';
 
 /**

--- a/src/List/ListItemAvatar.spec.js
+++ b/src/List/ListItemAvatar.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import ListItemAvatar, { styleSheet } from './ListItemAvatar';
 import Avatar from '../Avatar';
 

--- a/src/List/ListItemIcon.spec.js
+++ b/src/List/ListItemIcon.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import ListItemIcon, { styleSheet } from './ListItemIcon';
 
 describe('<ListItemIcon />', () => {

--- a/src/List/ListItemSecondaryAction.spec.js
+++ b/src/List/ListItemSecondaryAction.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import ListItemSecondaryAction, { styleSheet } from './ListItemSecondaryAction';
 
 describe('<ListItemSecondaryAction />', () => {

--- a/src/List/ListItemText.spec.js
+++ b/src/List/ListItemText.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import ListItemText, { styleSheet } from './ListItemText';
 
 describe('<ListItemText />', () => {

--- a/src/List/ListSubheader.spec.js
+++ b/src/List/ListSubheader.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import ListSubheader, { styleSheet } from './ListSubheader';
 
 describe('<ListSubheader />', () => {

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { spy, stub } from 'sinon';
 import { assert } from 'chai';
 import ReactDOM from 'react-dom';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Menu, { styleSheet } from './Menu';
 
 describe('<Menu />', () => {

--- a/src/Menu/MenuItem.spec.js
+++ b/src/Menu/MenuItem.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import MenuItem, { styleSheet } from './MenuItem';
 
 describe('<MenuItem />', () => {

--- a/src/Menu/MenuList.spec.js
+++ b/src/Menu/MenuList.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import MenuList from './MenuList';
 
 describe('<MenuList />', () => {

--- a/src/Paper/Paper.spec.js
+++ b/src/Paper/Paper.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Paper, { styleSheet } from './Paper';
 
 describe('<Paper />', () => {

--- a/src/Progress/CircularProgress.spec.js
+++ b/src/Progress/CircularProgress.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import CircularProgress, { styleSheet } from './CircularProgress';
 
 describe('<CircularProgress />', () => {

--- a/src/Progress/LinearProgress.spec.js
+++ b/src/Progress/LinearProgress.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import LinearProgress, { styleSheet } from './LinearProgress';
 
 describe('<LinearProgress />', () => {

--- a/src/Radio/Radio.spec.js
+++ b/src/Radio/Radio.spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Radio, { LabelRadio, styleSheet } from './Radio';
 
 describe('<Radio />', () => {

--- a/src/Radio/RadioGroup.spec.js
+++ b/src/Radio/RadioGroup.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import RadioGroup from './RadioGroup';
 import Radio from './Radio';
 

--- a/src/SvgIcon/SvgIcon.spec.js
+++ b/src/SvgIcon/SvgIcon.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import SvgIcon, { styleSheet } from './SvgIcon';
 
 describe('<SvgIcon />', () => {

--- a/src/Switch/Switch.spec.js
+++ b/src/Switch/Switch.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Switch, { LabelSwitch } from '../Switch';
 import { styleSheet } from './Switch';
 

--- a/src/Table/Table.spec.js
+++ b/src/Table/Table.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Table, { styleSheet } from './Table';
 
 describe('<Table />', () => {

--- a/src/Table/TableBody.spec.js
+++ b/src/Table/TableBody.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import TableBody, { styleSheet } from './TableBody';
 
 describe('<TableBody />', () => {

--- a/src/Table/TableCell.spec.js
+++ b/src/Table/TableCell.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import TableCell, { styleSheet } from './TableCell';
 
 describe('<TableCell />', () => {

--- a/src/Table/TableHead.spec.js
+++ b/src/Table/TableHead.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import TableHead, { styleSheet } from './TableHead';
 
 describe('<TableHead />', () => {

--- a/src/Table/TableRow.spec.js
+++ b/src/Table/TableRow.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import TableRow, { styleSheet } from './TableRow';
 
 describe('<TableRow />', () => {

--- a/src/Table/TableSortLabel.spec.js
+++ b/src/Table/TableSortLabel.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import TableSortLabel, { styleSheet } from './TableSortLabel';
 
 describe('<TableSortLabel />', () => {

--- a/src/Tabs/Tab.spec.js
+++ b/src/Tabs/Tab.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Tab, { styleSheet } from './Tab';
 import Icon from '../Icon';
 

--- a/src/Tabs/TabIndicator.spec.js
+++ b/src/Tabs/TabIndicator.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import TabIndicator, { styleSheet } from './TabIndicator';
 
 describe('<TabIndicator />', () => {

--- a/src/Tabs/TabScrollButton.spec.js
+++ b/src/Tabs/TabScrollButton.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import TabScrollButton, { styleSheet } from './TabScrollButton';
 import ButtonBase from '../internal/ButtonBase';
 import KeyboardArrowLeft from '../svg-icons/keyboard-arrow-left';

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import scroll from 'scroll';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Tabs, { styleSheet } from './Tabs';
 import TabScrollButton from './TabScrollButton';
 import Tab from './Tab';

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Input, { InputLabel } from '../Input';
 import TextField from './TextField';
 

--- a/src/TextField/TextFieldLabel.spec.js
+++ b/src/TextField/TextFieldLabel.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import TextFieldLabel, { styleSheet } from './TextFieldLabel';
 
 describe('<TextFieldLabel />', () => {

--- a/src/Toolbar/Toolbar.spec.js
+++ b/src/Toolbar/Toolbar.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Toolbar, { styleSheet } from './Toolbar';
 
 /**

--- a/src/Typography/Typography.spec.js
+++ b/src/Typography/Typography.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Typography, { styleSheet } from './Typography';
 
 describe('<Typography />', () => {

--- a/src/internal/Backdrop.spec.js
+++ b/src/internal/Backdrop.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Backdrop, { styleSheet } from './Backdrop';
 
 describe('<Backdrop />', () => {

--- a/src/internal/ButtonBase.spec.js
+++ b/src/internal/ButtonBase.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import keycode from 'keycode';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import TouchRipple from './TouchRipple';
 import ButtonBase, { styleSheet } from './ButtonBase';
 

--- a/src/internal/Modal.js
+++ b/src/internal/Modal.js
@@ -14,7 +14,7 @@ import addEventListener from '../utils/addEventListener';
 import { createChainedFunction } from '../utils/helpers';
 import Fade from '../transitions/Fade';
 import withStyles from '../styles/withStyles';
-import { createModalManager } from './modalManager';
+import createModalManager from './modalManager';
 import Backdrop from './Backdrop';
 import Portal from './Portal';
 

--- a/src/internal/Modal.spec.js
+++ b/src/internal/Modal.spec.js
@@ -5,7 +5,7 @@ import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import keycode from 'keycode';
 import contains from 'dom-helpers/query/contains';
-import { createShallow, createMount, consoleErrorMock } from 'src/test-utils';
+import { createShallow, createMount, consoleErrorMock } from '../test-utils';
 import Backdrop from './Backdrop';
 import Modal, { styleSheet } from './Modal';
 

--- a/src/internal/Popover.spec.js
+++ b/src/internal/Popover.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import css from 'dom-helpers/style';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Popover, { styleSheet } from './Popover';
 
 describe('<Popover />', () => {

--- a/src/internal/Portal.spec.js
+++ b/src/internal/Portal.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createMount } from 'src/test-utils';
+import { createMount } from '../test-utils';
 import Portal from './Portal';
 
 describe('<Portal />', () => {

--- a/src/internal/Ripple.spec.js
+++ b/src/internal/Ripple.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Ripple, { styleSheet } from './Ripple';
 
 describe('<Ripple />', () => {

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import createSwitch, { styleSheet } from './SwitchBase';
 import Icon from '../Icon';
 

--- a/src/internal/TouchRipple.spec.js
+++ b/src/internal/TouchRipple.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import TouchRipple, { styleSheet } from './TouchRipple';
 
 describe('<TouchRipple />', () => {

--- a/src/internal/Transition.spec.js
+++ b/src/internal/Transition.spec.js
@@ -4,7 +4,7 @@ import React, { Component } from 'react';
 import { findDOMNode } from 'react-dom';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createMount } from 'src/test-utils';
+import { createMount } from '../test-utils';
 import Transition, { UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING } from './Transition';
 
 describe('<Transition />', () => {

--- a/src/internal/modalManager.js
+++ b/src/internal/modalManager.js
@@ -26,7 +26,7 @@ const defaultContainer = canUseDom ? window.document.body : {};
  *
  * @internal Used by the Modal to ensure proper focus management.
  */
-export function createModalManager({
+function createModalManager({
   container = defaultContainer,
   hideSiblingNodes = true,
 } = {}) {
@@ -103,3 +103,5 @@ export function createModalManager({
 
   return modalManager;
 }
+
+export default createModalManager;

--- a/src/internal/modalManager.spec.js
+++ b/src/internal/modalManager.spec.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { assert } from 'chai';
-import { createModalManager } from './modalManager';
+import createModalManager from './modalManager';
 
 describe('internal/modalManager', () => {
   let modalManager;

--- a/src/internal/withSwitchLabel.spec.js
+++ b/src/internal/withSwitchLabel.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import withSwitchLabel, { styleSheet } from './withSwitchLabel';
 
 describe('withSwitchLabel', () => {

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -10,9 +10,9 @@ import { createStyleManager } from 'jss-theme-reactor';
 import React from 'react';
 import htmlLooksLike from 'html-looks-like';
 import { renderToString } from 'react-dom/server';
-import { createMount } from 'src/test-utils';
-import { createMuiTheme } from 'src/styles';
-import Button from 'src/Button';
+import { createMount } from '../test-utils';
+import { createMuiTheme } from '../styles';
+import Button from '../Button';
 import MuiThemeProvider from './MuiThemeProvider';
 
 function trim(str) {

--- a/src/styles/theme.spec.js
+++ b/src/styles/theme.spec.js
@@ -2,7 +2,7 @@
 
 import { assert } from 'chai';
 import createMuiTheme from './theme';
-import createPalette, { dark, light } from './palette.js';
+import createPalette, { dark, light } from './palette';
 import {
   indigo,
   pink,

--- a/src/styles/withStyles.spec.js
+++ b/src/styles/withStyles.spec.js
@@ -3,8 +3,8 @@
 import React from 'react';
 import { spy } from 'sinon';
 import { assert } from 'chai';
-import { createShallow, consoleErrorMock, createMount } from 'src/test-utils';
 import { createStyleSheet } from 'jss-theme-reactor';
+import { createShallow, consoleErrorMock, createMount } from '../test-utils';
 import withStyles from './withStyles';
 
 const Empty = () => <div />;

--- a/src/styles/withTheme.spec.js
+++ b/src/styles/withTheme.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import withTheme from './withTheme';
 
 const Empty = () => <div />;

--- a/src/transitions/Collapse.spec.js
+++ b/src/transitions/Collapse.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
-import { createShallow, createMount } from 'src/test-utils';
+import { createShallow, createMount } from '../test-utils';
 import Collapse, { styleSheet } from './Collapse';
 
 describe('<Collapse />', () => {

--- a/src/transitions/Fade.spec.js
+++ b/src/transitions/Fade.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Fade from './Fade';
 
 describe('<Fade />', () => {

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow } from 'src/test-utils';
+import { createShallow } from '../test-utils';
 import Slide from './Slide';
 import transitions, { easing, duration } from '../styles/transitions';
 

--- a/src/utils/reactHelpers.js
+++ b/src/utils/reactHelpers.js
@@ -1,4 +1,5 @@
 // @flow weak
+/* eslint-disable import/prefer-default-export */
 
 import { cloneElement, Children, isValidElement } from 'react';
 

--- a/src/utils/withWidth.spec.js
+++ b/src/utils/withWidth.spec.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createMount, createShallow } from 'src/test-utils';
+import { createMount, createShallow } from '../test-utils';
 import withWidth, { isWidthDown, isWidthUp } from './withWidth';
 
 const Empty = () => <div />;

--- a/test/integration/.eslintrc.js
+++ b/test/integration/.eslintrc.js
@@ -7,5 +7,8 @@ module.exports = {
   },
   rules: {
     'no-unused-expressions': 'off',
+    // needed for src/* resolution off of root
+    'import/no-unresolved': 'off',
+    'import/extensions': 'off',
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,6 +196,10 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
+array-find@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-find/-/array-find-1.0.0.tgz#6c8e286d11ed768327f8e62ecee87353ca3e78b8"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -2083,6 +2087,14 @@ enhanced-resolve@^3.0.0:
     object-assign "^4.0.1"
     tapable "^0.2.5"
 
+enhanced-resolve@~0.9.0:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz#4d6e689b3725f86090927ccc86cd9f1635b89e2e"
+  dependencies:
+    graceful-fs "^4.1.2"
+    memory-fs "^0.2.0"
+    tapable "^0.1.8"
+
 ent@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ent/-/ent-2.2.0.tgz#e964219325a21d05f44466a2f686ed6ce5f5dd1d"
@@ -2240,6 +2252,22 @@ eslint-import-resolver-node@^0.2.0:
     debug "^2.2.0"
     object-assign "^4.0.1"
     resolve "^1.1.6"
+
+eslint-import-resolver-webpack@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-webpack/-/eslint-import-resolver-webpack-0.8.1.tgz#c7f8b4d5bd3c5b489457e5728c5db1c4ffbac9aa"
+  dependencies:
+    array-find "^1.0.0"
+    debug "^2.2.0"
+    enhanced-resolve "~0.9.0"
+    find-root "^0.1.1"
+    has "^1.0.1"
+    interpret "^1.0.0"
+    is-absolute "^0.2.3"
+    lodash.get "^3.7.0"
+    node-libs-browser "^1.0.0"
+    resolve "^1.2.0"
+    semver "^5.3.0"
 
 eslint-module-utils@^2.0.0:
   version "2.0.0"
@@ -2586,6 +2614,10 @@ find-cache-dir@^0.1.1:
     commondir "^1.0.1"
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
+
+find-root@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-0.1.2.tgz#98d2267cff1916ccaf2743b3a0eea81d79d7dcd1"
 
 find-up@^1.0.0, find-up@^1.1.2:
   version "1.1.2"
@@ -3202,6 +3234,13 @@ ipaddr.js@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
 
+is-absolute@^0.2.3:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/is-absolute/-/is-absolute-0.2.6.tgz#20de69f3db942ef2d87b9c2da36f172235b1b5eb"
+  dependencies:
+    is-relative "^0.2.1"
+    is-windows "^0.2.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3339,6 +3378,12 @@ is-regex@^1.0.3:
   dependencies:
     has "^1.0.1"
 
+is-relative@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-relative/-/is-relative-0.2.1.tgz#d27f4c7d516d175fb610db84bbeef23c3bc97aa5"
+  dependencies:
+    is-unc-path "^0.1.1"
+
 is-resolvable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
@@ -3365,9 +3410,19 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
 
+is-unc-path@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/is-unc-path/-/is-unc-path-0.1.2.tgz#6ab053a72573c10250ff416a3814c35178af39b9"
+  dependencies:
+    unc-path-regex "^0.1.0"
+
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-0.2.0.tgz#de1aa6d63ea29dd248737b69f1ff8b8002d2108c"
 
 is-windows@^1.0.0:
   version "1.0.1"
@@ -3846,6 +3901,10 @@ lodash._basecreate@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz#1bc661614daa7fc311b7d03bf16806a0213cf821"
 
+lodash._baseget@^3.0.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/lodash._baseget/-/lodash._baseget-3.7.2.tgz#1b6ae1d5facf3c25532350a13c1197cb8bb674f4"
+
 lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
@@ -3853,6 +3912,12 @@ lodash._getnative@^3.0.0:
 lodash._isiterateecall@^3.0.0:
   version "3.0.9"
   resolved "https://registry.yarnpkg.com/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz#5203ad7ba425fae842460e696db9cf3e6aac057c"
+
+lodash._topath@^3.0.0:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/lodash._topath/-/lodash._topath-3.8.1.tgz#3ec5e2606014f4cb97f755fe6914edd8bfc00eac"
+  dependencies:
+    lodash.isarray "^3.0.0"
 
 lodash.assign@^4.0.3, lodash.assign@^4.0.6:
   version "4.2.0"
@@ -3897,6 +3962,13 @@ lodash.flatten@^4.2.0:
 lodash.foreach@^4.3.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.get@^3.7.0:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-3.7.0.tgz#3ce68ae2c91683b281cc5394128303cbf75e691f"
+  dependencies:
+    lodash._baseget "^3.0.0"
+    lodash._topath "^3.0.0"
 
 lodash.isarguments@^3.0.0:
   version "3.1.0"
@@ -4040,6 +4112,10 @@ md5@^2.1.0:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+memory-fs@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.2.0.tgz#f2bb25368bc121e391c2520de92969caee0a0290"
 
 memory-fs@^0.4.0, memory-fs@~0.4.1:
   version "0.4.1"
@@ -4225,6 +4301,34 @@ node-fetch@^1.0.1, node-fetch@^1.6.3:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-libs-browser@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/node-libs-browser/-/node-libs-browser-1.1.1.tgz#2a38243abedd7dffcd07a97c9aca5668975a6fea"
+  dependencies:
+    assert "^1.1.1"
+    browserify-zlib "^0.1.4"
+    buffer "^4.3.0"
+    console-browserify "^1.1.0"
+    constants-browserify "^1.0.0"
+    crypto-browserify "^3.11.0"
+    domain-browser "^1.1.1"
+    events "^1.0.0"
+    https-browserify "0.0.1"
+    os-browserify "^0.2.0"
+    path-browserify "0.0.0"
+    process "^0.11.0"
+    punycode "^1.2.4"
+    querystring-es3 "^0.2.0"
+    readable-stream "^2.0.5"
+    stream-browserify "^2.0.1"
+    stream-http "^2.3.1"
+    string_decoder "^0.10.25"
+    timers-browserify "^1.4.2"
+    tty-browserify "0.0.0"
+    url "^0.11.0"
+    util "^0.10.3"
+    vm-browserify "0.0.4"
 
 node-libs-browser@^2.0.0:
   version "2.0.0"
@@ -4698,7 +4802,7 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
-process@^0.11.0:
+process@^0.11.0, process@~0.11.0:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
 
@@ -5217,7 +5321,7 @@ resolve-from@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-2.0.0.tgz#9480ab20e94ffa1d9e80a804c7ea147611966b57"
 
-resolve@^1.1.6, resolve@^1.1.7:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
   dependencies:
@@ -5648,6 +5752,10 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
+tapable@^0.1.8:
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.1.10.tgz#29c35707c2b70e50d07482b5d202e8ed446dafd4"
+
 tapable@^0.2.5, tapable@~0.2.5:
   version "0.2.6"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.6.tgz#206be8e188860b514425375e6f1ae89bfb01fd8d"
@@ -5720,6 +5828,12 @@ through@^2.3.6, through@^2.3.8, through@~2.3.4:
 timed-out@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
+timers-browserify@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-1.4.2.tgz#c9c58b575be8407375cb5e2462dacee74359f41d"
+  dependencies:
+    process "~0.11.0"
 
 timers-browserify@^2.0.2:
   version "2.0.2"
@@ -5894,6 +6008,10 @@ uid-number@^0.0.6:
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
+
+unc-path-regex@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
 unique-string@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Most of the eslint-import-plugin rules were disabled.  I added the webpack resolver, pointing it at the docs/webpack.dev.config.js as it had the aliases setup that check most of the code.

I removed disabled rules and configured a few local exceptions using subordinate eslintrc.js files.

Since we make one eslint run, we have to disable import resolution checks in some cases because we are using multiple package.json files, and it is one execution to one package.json.  I focused on hardening the src imports and secondarily docs.  

Aside from setup, I fixed a few import related consistency issues that it exposed.

- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

