### PR TITLE
[slider] Prevent unnecessary value spread

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -773,6 +773,7 @@ class Slider extends Component {
       sliderStyle,
       step,
       style,
+      value: propValue, // eslint-disable-line no-unused-vars
       ...other
     } = this.props;
 


### PR DESCRIPTION
- [x] PR has tests / docs demo, and is linted.
- [x] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [x] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

**Description**

Destructs one additional prop - `value` in order to prevent passing it to `Slider` container via `other`. Renaming (`value: propValue`) is necessary because of destructing `value` from state below.

Fixes #7190.

**Images / visual description**

before:
![mui-slider-value](https://user-images.githubusercontent.com/2872434/27309883-d2e6c6c2-5556-11e7-8781-3df30daf556b.png)
after:
![mui-slider-value-after](https://user-images.githubusercontent.com/2872434/27309887-d6ec8a04-5556-11e7-8de3-0badbecb5d6f.png)
