### PR TITLE
[chip] Support overriding Delete Icon Style

### DIFF
--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -67,8 +67,8 @@ class Chip extends Component {
       PropTypes.element,
     ]),
     /**
-    * Override the inline-styles of the delete icon.
-    */
+     * Override the inline-styles of the delete icon.
+     */
     deleteIconStyle: PropTypes.object,
     /**
      * Override the label color.

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -67,6 +67,10 @@ class Chip extends Component {
       PropTypes.element,
     ]),
     /**
+    * Override the inline-styles of the delete icon.
+    */
+    deleteIconStyle: PropTypes.object,
+    /**
      * Override the label color.
      */
     labelColor: PropTypes.string,
@@ -74,7 +78,6 @@ class Chip extends Component {
      * Override the inline-styles of the label.
      */
     labelStyle: PropTypes.object,
-    deleteIconStyle: PropTypes.object,
     /** @ignore */
     onBlur: PropTypes.func,
     /** @ignore */

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -74,6 +74,7 @@ class Chip extends Component {
      * Override the inline-styles of the label.
      */
     labelStyle: PropTypes.object,
+    deleteIconStyle: PropTypes.object,
     /** @ignore */
     onBlur: PropTypes.func,
     /** @ignore */
@@ -247,6 +248,7 @@ class Chip extends Component {
       containerElement,
       style,
       className,
+      deleteIconStyle,
       labelStyle,
       labelColor, // eslint-disable-line no-unused-vars,prefer-const
       backgroundColor, // eslint-disable-line no-unused-vars,prefer-const
@@ -260,7 +262,7 @@ class Chip extends Component {
     const deleteIcon = deletable ? (
       <DeleteIcon
         color={styles.deleteIcon.color}
-        style={styles.deleteIcon}
+        style={prepareStyles(Object.assign(styles.deleteIcon, deleteIconStyle))}
         onTouchTap={this.handleTouchTapDeleteIcon}
         onMouseEnter={this.handleMouseEnterDeleteIcon}
         onMouseLeave={this.handleMouseLeaveDeleteIcon}


### PR DESCRIPTION
If the chip style is overridden and involves changes to padding, the delete icon gets thrown out of whack.

This change uses the same pattern used elsewhere to override the label style to allow the user implenting this control to have full control of its styling.
