### PR TITLE
[chip] Fix warning when using onRequestDelete

### DIFF
--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -265,7 +265,7 @@ class Chip extends Component {
     const deleteIcon = deletable ? (
       <DeleteIcon
         color={styles.deleteIcon.color}
-        style={prepareStyles(Object.assign(styles.deleteIcon, deleteIconStyle))}
+        style={Object.assign(styles.deleteIcon, deleteIconStyle)}
         onTouchTap={this.handleTouchTapDeleteIcon}
         onMouseEnter={this.handleMouseEnterDeleteIcon}
         onMouseLeave={this.handleMouseLeaveDeleteIcon}


### PR DESCRIPTION
This removes the `prepareStyles` call for the style of a `Chip`'s delete icon. The `SvgIcon` already calls `prepareStyle` itself, resulting in a warning.
It's a regression introduced in v0.18.6 by #7320 

This fixes #7394 and is related to TeamWertarbyte/material-ui-chip-input#123 and erikras/redux-form#3164

- [ ] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [X] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

