### PR TITLE
[autocomplete] Fix onNewRequest documentation

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -135,7 +135,7 @@ class AutoComplete extends Component {
      * Callback function that is fired when a list item is selected, or enter is pressed in the `TextField`.
      *
      * @param {string} chosenRequest Either the `TextField` input value, if enter is pressed in the `TextField`,
-     * or the text value of the corresponding list item that was selected.
+     * or the dataSource object corresponding to the list item that was selected.
      * @param {number} index The index in `dataSource` of the list item selected, or `-1` if enter is pressed in the
      * `TextField`.
      */


### PR DESCRIPTION
onNewRequest documentation needs to be updated to show that when dataSource is not a simple String Array then the object at the dataSource[index] is returned as chosenRequest.

in handleItemTouchTap() 
Line 281 
  dataSource[index];
Line 280 sends the chosenRequest via
  this.props.onNewRequest(chosenRequest, index);

For simple String arrays this is the text value, for Object dataSources the documentation is incorrect.

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [X] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

