### PR TITLE
[flow] ChildrenArray need to use $ReadOnlyArray<>

### DIFF
--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -46,7 +46,7 @@ export type Props = {
   /**
    * The contents of the form control.
    */
-  children?: ChildrenArray<*>,
+  children?: $ReadOnlyArray<ChildrenArray<*>>,
   /**
    * Useful to extend the style applied to components.
    */

--- a/src/GridList/GridListTile.js
+++ b/src/GridList/GridListTile.js
@@ -42,7 +42,7 @@ export type Props = {
    * in which case GridListTile takes care of making the image "cover" available space
    * (similar to `background-size: cover` or to `object-fit: cover`).
    */
-  children?: ChildrenArray<*>,
+  children?: $ReadOnlyArray<ChildrenArray<*>>,
   /**
    * Useful to extend the style applied to components.
    */

--- a/src/Radio/RadioGroup.js
+++ b/src/Radio/RadioGroup.js
@@ -24,7 +24,7 @@ export type Props = {
   /**
    * The content of the component.
    */
-  children?: ChildrenArray<*>,
+  children?: $ReadOnlyArray<ChildrenArray<*>>,
   /**
    * Useful to extend the style applied to components.
    */

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -56,7 +56,7 @@ export type Props = {
   /**
    * The content of the component.
    */
-  children?: ChildrenArray<*>,
+  children?: $ReadOnlyArray<ChildrenArray<*>>,
   /**
    * Useful to extend the style applied to components.
    */


### PR DESCRIPTION
ChildrenArray need to use $ReadOnlyArray<> to prevent inference errors downstream

<!-- Thanks so much for your PR, your contribution is appreciated! -->

- [ ] PR has tests / docs demo, and is linted.
- [ ] Commit and PR titles begin with [ComponentName], and are in imperative form: "[Component] Fix leaky abstraction".
- [ ] Description explains the issue / use-case resolved, and auto-closes the related issue(s) (http://tr.im/vFqem).

