### PR TITLE
[breakpoints] add back deleted `getWidth` as `width` with a spec

### DIFF
--- a/src/styles/createBreakpoints.d.ts
+++ b/src/styles/createBreakpoints.d.ts
@@ -15,7 +15,7 @@ export interface Breakpoints {
   down: (key: Breakpoint) => string;
   between: (start: Breakpoint, end: Breakpoint) => string;
   only: (key: Breakpoint) => string;
-  getWidth: (key: Breakpoint) => number;
+  width: (key: Breakpoint) => number;
 }
 
 export default function createBreakpoints(

--- a/src/styles/createBreakpoints.d.ts
+++ b/src/styles/createBreakpoints.d.ts
@@ -10,7 +10,7 @@ export interface BreakpointsOptions {
 
 export interface Breakpoints {
   keys: typeof keys;
-  values: number[];
+  values: BreakpointValues;
   up: (key: Breakpoint) => string;
   down: (key: Breakpoint) => string;
   between: (start: Breakpoint, end: Breakpoint) => string;

--- a/src/styles/createBreakpoints.js
+++ b/src/styles/createBreakpoints.js
@@ -54,6 +54,10 @@ export default function createBreakpoints(breakpoints: Object) {
     return between(key, key);
   }
 
+  function width(key) {
+    return values[key];
+  }
+
   return {
     keys,
     values,
@@ -61,6 +65,7 @@ export default function createBreakpoints(breakpoints: Object) {
     down,
     between,
     only,
+    width,
     ...other,
   };
 }

--- a/src/styles/createBreakpoints.spec.js
+++ b/src/styles/createBreakpoints.spec.js
@@ -47,4 +47,10 @@ describe('createBreakpoints', () => {
       assert.strictEqual(breakpoints.only('xl'), '@media (min-width:1920px)');
     });
   });
+
+  describe('width', () => {
+    it('should work', () => {
+      assert.strictEqual(breakpoints.width('md'), 960);
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
@oliviertassinari deleted `getWidth` probably thinking it is unused.  Well it is used and well loved by me ;).

Also updated the typescript, which was still expecting the old named fn. 