### PR TITLE
[flow] Add config lint

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
 codecov:
   branch: next
 comment: false
+
+coverage:
+  ignore:
+    - ".*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,3 @@
 codecov:
   branch: next
 comment: false
-
-coverage:
-  ignore:
-    - ".*"

--- a/.flowconfig
+++ b/.flowconfig
@@ -38,4 +38,10 @@ suppress_comment= \\(.\\|\n\\)*\\$FlowExpectedError
 suppress_type=$FlowToDo
 
 [lints]
+
 all=error
+sketchy-null-bool=off
+sketchy-null-mixed=off
+sketchy-null-number=off
+sketchy-null-string=off
+untyped-type-import=off

--- a/.flowconfig
+++ b/.flowconfig
@@ -19,6 +19,7 @@ flow/interfaces
 
 [options]
 
+include_warnings=true
 esproposal.class_static_fields=enable
 esproposal.class_instance_fields=enable
 module.file_ext=.js
@@ -35,3 +36,6 @@ module.system.node.resolve_dirname=.
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 suppress_comment= \\(.\\|\n\\)*\\$FlowExpectedError
 suppress_type=$FlowToDo
+
+[lints]
+all=error

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -202,9 +202,7 @@ class Chip extends React.Component<ProvidedProps & Props> {
     if (avatarProp && React.isValidElement(avatarProp)) {
       // $FlowFixMe - this looks strictly correct, not sure why it errors.
       avatar = React.cloneElement(avatarProp, {
-        // $FlowFixMe - this looks strictly correct, not sure why it errors.
         className: classNames(classes.avatar, avatarProp.props.className),
-        // $FlowFixMe - this looks strictly correct, not sure why it errors.
         childrenClassName: classNames(classes.avatarChildren, avatarProp.props.childrenClassName),
       });
     }

--- a/src/internal/Portal.js
+++ b/src/internal/Portal.js
@@ -81,7 +81,6 @@ class Portal extends React.Component<Props> {
       // funnels React's hierarchical updates through to a DOM node on an
       // entirely different part of the page.
       const layerElement = React.Children.only(children);
-      // $FlowFixMe
       ReactDOM.unstable_renderSubtreeIntoContainer(this, layerElement, this.getLayer());
     } else {
       this.unrenderLayer();


### PR DESCRIPTION
Warnings recently changed and new type based lints were added.

I have turned off the current `sketchy-null` and `untyped-type-import`, anyone can feel free to turn any of them on and address the extras.

This at least provides information on unused suppressions, which was on before.

@oliviertassinari  It would be nice to turn these on, but we should discuss handling them.  I some value in turning on the sketchy-null-number at least, perhaps all of them.  You might turn them on just to get a quick look at what it raises and we can discuss on gitter.