### PR TITLE
[Select] placeholder prop

### DIFF
--- a/docs/src/pages/demos/selects/SimpleSelect.js
+++ b/docs/src/pages/demos/selects/SimpleSelect.js
@@ -155,6 +155,23 @@ class SimpleSelect extends React.Component {
           </Select>
           <FormHelperText>Auto width</FormHelperText>
         </FormControl>
+        <FormControl className={classes.formControl}>
+          <InputLabel htmlFor="age-simple">Age</InputLabel>
+          <Select
+            value={this.state.age}
+            onChange={this.handleChange('age')}
+            input={<Input id="age-simple" />}
+            placeholder="t"
+          >
+            <MenuItem value="">
+              <em>None</em>
+            </MenuItem>
+            <MenuItem value={10}>Ten</MenuItem>
+            <MenuItem value={20}>Twenty</MenuItem>
+            <MenuItem value={30}>Thirty</MenuItem>
+          </Select>
+          <FormHelperText>With placeholder</FormHelperText>
+        </FormControl>
       </form>
     );
   }

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -20,6 +20,7 @@ filename: /src/Select/Select.js
 | input | Element | &lt;Input /> | An `Input` element; does not have to be a material-ui specific `Input`. |
 | multiple | boolean | false | If true, `value` must be an array and the menu will support multiple selections. You can only use it when the `native` property is `false` (default). |
 | native | boolean | false | If `true`, the component will be using a native `select` element. |
+| placeholder | string | | Will render a placeholder. You can only use it when the `native` property is `false` (default). |
 | renderValue | Function |  | Render the selected value. You can only use it when the `native` property is `false` (default). |
 | value | union:&nbsp;Array<string<br>&nbsp;number><br>&nbsp;string<br>&nbsp;number<br> |  | The input value, required for a controlled component. |
 

--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -14,6 +14,7 @@ export interface SelectProps extends StandardProps<
   native?: boolean;
   multiple?: boolean;
   MenuProps?: Object;
+  placeholder?: string;
   renderValue?: Function;
   value?: Array<string | number> | string | number;
 }

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -102,7 +102,7 @@ export type Props = {
    */
   MenuProps?: Object,
   /**
-   * Render a placeholder
+   * The short hint displayed in the input before the user enters a value.
    */
   placeholder?: string,
   /**

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -102,6 +102,10 @@ export type Props = {
    */
   MenuProps?: Object,
   /**
+   * Render a placeholder
+   */
+  placeholder?: string,
+  /**
    * Render the selected value.
    * You can only use it when the `native` property is `false` (default).
    */
@@ -123,6 +127,7 @@ function Select(props: ProvidedProps & Props) {
     multiple,
     MenuProps,
     renderValue,
+    placeholder,
     ...other
   } = props;
 
@@ -150,6 +155,7 @@ function Select(props: ProvidedProps & Props) {
       multiple,
       MenuProps,
       renderValue,
+      placeholder,
     },
   });
 }

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -11,6 +11,7 @@ export interface SelectInputProps extends StandardProps<{}, SelectInputClassKey>
   onBlur?: React.FocusEventHandler<any>;
   onChange?: (event: React.ChangeEvent<{}>, child: React.ReactNode) => void,
   onFocus?: React.FocusEventHandler<any>;
+  placeholder: string,
   readOnly?: boolean;
   renderValue?: Function;
   selectRef?: Function;

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -74,6 +74,10 @@ export type Props = {
    */
   onFocus?: Function,
   /**
+   * If set, renders a placeholder when not dirty
+   */
+  placeholder?: string,
+  /**
    * @ignore
    */
   readOnly?: boolean,
@@ -216,6 +220,7 @@ class SelectInput extends React.Component<ProvidedProps & Props, State> {
       onBlur,
       onChange,
       onFocus,
+      placeholder,
       readOnly,
       renderValue,
       selectRef,
@@ -284,6 +289,8 @@ class SelectInput extends React.Component<ProvidedProps & Props, State> {
       } else {
         computeDisplay = true;
       }
+    } else if (placeholder) {
+      display = placeholder;
     }
 
     const items = React.Children.map(children, child => {

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -74,7 +74,7 @@ export type Props = {
    */
   onFocus?: Function,
   /**
-   * If set, renders a placeholder when not dirty
+   * The short hint displayed in the input before the user enters a value.
    */
   placeholder?: string,
   /**

--- a/src/Select/SelectInput.spec.js
+++ b/src/Select/SelectInput.spec.js
@@ -99,6 +99,7 @@ describe('<SelectInput />', () => {
       );
       assert.strictEqual(wrapper.find(`.${props.classes.select}`).props().children, 'Placeholder');
     });
+
     it('should not render the placeholder when value matches a menu item', () => {
       const wrapper = shallow(
         <SelectInput {...props} value={10} placeholder="Placeholder">

--- a/src/Select/SelectInput.spec.js
+++ b/src/Select/SelectInput.spec.js
@@ -90,6 +90,25 @@ describe('<SelectInput />', () => {
     });
   });
 
+  describe('prop: placeholder', () => {
+    it('should render the placeholder when not dirty', () => {
+      const wrapper = shallow(
+        <SelectInput {...props} value="" placeholder="Placeholder">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectInput>,
+      );
+      assert.strictEqual(wrapper.find(`.${props.classes.select}`).props().children, 'Placeholder');
+    });
+    it('should not render the placeholder when value matches a menu item', () => {
+      const wrapper = shallow(
+        <SelectInput {...props} value={10} placeholder="Placeholder">
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectInput>,
+      );
+      assert.strictEqual(wrapper.find(`.${props.classes.select}`).props().children, 'Ten');
+    });
+  });
+
   describe('prop: renderValue', () => {
     it('should use the property to render the value', () => {
       const renderValue = x => String(-x);


### PR DESCRIPTION
placeholder was forwarded to Input via {...other}. This pr explicity destructs it and renders placeholder as displayText as long as the select isn't dirty. This will only work with non native selects.

- closes #8813
- contains tests

---------
Not sure about the design. The placeholder doesn't have any special styling so it looks like an option.
I couldn't find anything regarding placeholders in the guidelines: https://material.io/guidelines/components/menus.html#menus-menu-items