### PR TITLE
[Legacy] Removes 'TouchTap' in favor of `Click` throughout library and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Please note that `@next` will only point to pre-releases; to get the latest stab
 
 ### React-Tap-Event-Plugin
 
+(not needed for versions 0.19.0 and higher)
+
 Some components use
 [react-tap-event-plugin](https://github.com/zilverline/react-tap-event-plugin) to
 listen for touch events because onClick is not fast enough

--- a/docs/src/app/components/AppNavDrawer.js
+++ b/docs/src/app/components/AppNavDrawer.js
@@ -102,7 +102,7 @@ class AppNavDrawer extends Component {
     window.location = value;
   };
 
-  handleTouchTapHeader = () => {
+  handleClickHeader = () => {
     this.context.router.push('/');
     this.props.onRequestChangeNavDrawer(false);
   };
@@ -126,7 +126,7 @@ class AppNavDrawer extends Component {
         containerStyle={{zIndex: zIndex.drawer - 100}}
       >
         <div style={styles.v1} />
-        <div style={styles.logo} onClick={this.handleTouchTapHeader}>
+        <div style={styles.logo} onClick={this.handleClickHeader}>
           Material-UI
         </div>
         <span style={styles.version}>Version:</span>

--- a/docs/src/app/components/CodeExample/CodeBlock.js
+++ b/docs/src/app/components/CodeExample/CodeBlock.js
@@ -42,7 +42,7 @@ class CodeBlock extends Component {
     expand: false,
   };
 
-  handleTouchTap = () => {
+  handleClick = () => {
     this.setState({
       expand: !this.state.expand,
     });
@@ -64,7 +64,7 @@ ${this.props.children}
 
     return (
       <div style={styles.root}>
-        <div onClick={this.handleTouchTap} style={styles.codeBlockTitle}>
+        <div onClick={this.handleClick} style={styles.codeBlockTitle}>
           <CodeBlockTitle title={this.props.title} tooltip={tooltip} />
         </div>
         <MarkdownElement style={codeStyle} text={text} />

--- a/docs/src/app/components/Master.js
+++ b/docs/src/app/components/Master.js
@@ -132,7 +132,7 @@ class Master extends Component {
     return styles;
   }
 
-  handleTouchTapLeftIconButton = () => {
+  handleClickLeftIconButton = () => {
     this.setState({
       navDrawerOpen: !this.state.navDrawerOpen,
     });
@@ -207,7 +207,7 @@ class Master extends Component {
           </a>
         </div>
         <AppBar
-          onLeftIconButtonTouchTap={this.handleTouchTapLeftIconButton}
+          onLeftIconButtonClick={this.handleClickLeftIconButton}
           title={title}
           zDepth={0}
           iconElementRight={

--- a/docs/src/app/components/pages/Home.js
+++ b/docs/src/app/components/pages/Home.js
@@ -93,7 +93,7 @@ class HomePage extends Component {
           <RaisedButton
             className="demo-button"
             label="Demo"
-            onClick={this.handleTouchTapDemo}
+            onClick={this.handleClickDemo}
             style={styles.demoStyle}
             labelStyle={styles.label}
           />
@@ -199,7 +199,7 @@ class HomePage extends Component {
     );
   }
 
-  handleTouchTapDemo = () => {
+  handleClickDemo = () => {
     this.context.router.push('/components');
   };
 

--- a/docs/src/app/components/pages/components/AppBar/ExampleIconButton.js
+++ b/docs/src/app/components/pages/components/AppBar/ExampleIconButton.js
@@ -4,7 +4,7 @@ import IconButton from 'material-ui/IconButton';
 import NavigationClose from 'material-ui/svg-icons/navigation/close';
 import FlatButton from 'material-ui/FlatButton';
 
-function handleTouchTap() {
+function handleClick() {
   alert('onClick triggered on the title component');
 }
 
@@ -21,7 +21,7 @@ const styles = {
 const AppBarExampleIconButton = () => (
   <AppBar
     title={<span style={styles.title}>Title</span>}
-    onTitleTouchTap={handleTouchTap}
+    onTitleClick={handleClick}
     iconElementLeft={<IconButton><NavigationClose /></IconButton>}
     iconElementRight={<FlatButton label="Save" />}
   />

--- a/docs/src/app/components/pages/components/Chip/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/Chip/ExampleSimple.js
@@ -19,7 +19,7 @@ function handleRequestDelete() {
   alert('You clicked the delete button.');
 }
 
-function handleTouchTap() {
+function handleClick() {
   alert('You clicked the Chip.');
 }
 
@@ -43,14 +43,14 @@ export default class ChipExampleSimple extends React.Component {
 
         <Chip
           onRequestDelete={handleRequestDelete}
-          onClick={handleTouchTap}
+          onClick={handleClick}
           style={styles.chip}
         >
           Deletable Text Chip
         </Chip>
 
         <Chip
-          onClick={handleTouchTap}
+          onClick={handleClick}
           style={styles.chip}
         >
           <Avatar src="images/uxceo-128.jpg" />
@@ -59,7 +59,7 @@ export default class ChipExampleSimple extends React.Component {
 
         <Chip
           onRequestDelete={handleRequestDelete}
-          onClick={handleTouchTap}
+          onClick={handleClick}
           style={styles.chip}
         >
           <Avatar src="images/ok-128.jpg" />
@@ -67,7 +67,7 @@ export default class ChipExampleSimple extends React.Component {
         </Chip>
 
         <Chip
-          onClick={handleTouchTap}
+          onClick={handleClick}
           style={styles.chip}
         >
           <Avatar icon={<FontIcon className="material-icons">perm_identity</FontIcon>} />
@@ -76,14 +76,14 @@ export default class ChipExampleSimple extends React.Component {
 
         <Chip
           onRequestDelete={handleRequestDelete}
-          onClick={handleTouchTap}
+          onClick={handleClick}
           style={styles.chip}
         >
           <Avatar color="#444" icon={<SvgIconFace />} />
           SvgIcon Avatar Chip
         </Chip>
 
-        <Chip onClick={handleTouchTap} style={styles.chip}>
+        <Chip onClick={handleClick} style={styles.chip}>
           <Avatar size={32}>A</Avatar>
           Text Avatar Chip
         </Chip>
@@ -91,7 +91,7 @@ export default class ChipExampleSimple extends React.Component {
         <Chip
           backgroundColor={blue300}
           onRequestDelete={handleRequestDelete}
-          onClick={handleTouchTap}
+          onClick={handleClick}
           style={styles.chip}
         >
           <Avatar size={32} color={blue300} backgroundColor={indigo900}>

--- a/docs/src/app/components/pages/components/Popover/ExampleAnimation.js
+++ b/docs/src/app/components/pages/components/Popover/ExampleAnimation.js
@@ -14,7 +14,7 @@ export default class PopoverExampleAnimation extends React.Component {
     };
   }
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     // This prevents ghost click.
     event.preventDefault();
 
@@ -34,7 +34,7 @@ export default class PopoverExampleAnimation extends React.Component {
     return (
       <div>
         <RaisedButton
-          onClick={this.handleTouchTap}
+          onClick={this.handleClick}
           label="Click me"
         />
         <Popover

--- a/docs/src/app/components/pages/components/Popover/ExampleConfigurable.js
+++ b/docs/src/app/components/pages/components/Popover/ExampleConfigurable.js
@@ -38,7 +38,7 @@ export default class PopoverExampleConfigurable extends React.Component {
     };
   }
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     // This prevents ghost click.
     event.preventDefault();
     this.setState({
@@ -75,7 +75,7 @@ export default class PopoverExampleConfigurable extends React.Component {
     return (
       <div>
         <RaisedButton
-          onClick={this.handleTouchTap}
+          onClick={this.handleClick}
           label="Click me"
         />
         <h3 style={styles.h3}>Current Settings</h3>

--- a/docs/src/app/components/pages/components/Popover/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/Popover/ExampleSimple.js
@@ -14,7 +14,7 @@ export default class PopoverExampleSimple extends React.Component {
     };
   }
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     // This prevents ghost click.
     event.preventDefault();
 
@@ -34,7 +34,7 @@ export default class PopoverExampleSimple extends React.Component {
     return (
       <div>
         <RaisedButton
-          onClick={this.handleTouchTap}
+          onClick={this.handleClick}
           label="Click me"
         />
         <Popover

--- a/docs/src/app/components/pages/components/Popover/NOTE.md
+++ b/docs/src/app/components/pages/components/Popover/NOTE.md
@@ -1,3 +1,3 @@
 ## Note
 
-The `event.preventDefault();` in the examples above is to prevent an effect called [ghost click](http://ariatemplates.com/blog/2014/05/ghost-clicks-in-mobile-browsers/) that happens with touch-devices. It is recommended that you add that call whenever you handle a `TouchTap` event associated with closing/opening `Popover`.
+The `event.preventDefault();` in the examples above is to prevent an effect called [ghost click](http://ariatemplates.com/blog/2014/05/ghost-clicks-in-mobile-browsers/) that happens with touch-devices. It is recommended that you add that call whenever you handle a `click` event associated with closing/opening `Popover`.

--- a/docs/src/app/components/pages/components/Snackbar/ExampleAction.js
+++ b/docs/src/app/components/pages/components/Snackbar/ExampleAction.js
@@ -14,13 +14,13 @@ export default class SnackbarExampleSimple extends React.Component {
     };
   }
 
-  handleTouchTap = () => {
+  handleClick = () => {
     this.setState({
       open: true,
     });
   };
 
-  handleActionTouchTap = () => {
+  handleActionClick = () => {
     this.setState({
       open: false,
     });
@@ -44,7 +44,7 @@ export default class SnackbarExampleSimple extends React.Component {
     return (
       <div>
         <RaisedButton
-          onClick={this.handleTouchTap}
+          onClick={this.handleClick}
           label="Add to my calendar"
         />
         <br />
@@ -58,7 +58,7 @@ export default class SnackbarExampleSimple extends React.Component {
           message={this.state.message}
           action="undo"
           autoHideDuration={this.state.autoHideDuration}
-          onActionTouchTap={this.handleActionTouchTap}
+          onActionClick={this.handleActionClick}
           onRequestClose={this.handleRequestClose}
         />
       </div>

--- a/docs/src/app/components/pages/components/Snackbar/ExampleSimple.js
+++ b/docs/src/app/components/pages/components/Snackbar/ExampleSimple.js
@@ -11,7 +11,7 @@ export default class SnackbarExampleSimple extends React.Component {
     };
   }
 
-  handleTouchTap = () => {
+  handleClick = () => {
     this.setState({
       open: true,
     });
@@ -27,7 +27,7 @@ export default class SnackbarExampleSimple extends React.Component {
     return (
       <div>
         <RaisedButton
-          onClick={this.handleTouchTap}
+          onClick={this.handleClick}
           label="Add to my calendar"
         />
         <Snackbar

--- a/docs/src/app/components/pages/components/Snackbar/ExampleTwice.js
+++ b/docs/src/app/components/pages/components/Snackbar/ExampleTwice.js
@@ -17,7 +17,7 @@ export default class SnackbarExampleTwice extends React.Component {
     clearTimeout(this.timer);
   }
 
-  handleTouchTap = () => {
+  handleClick = () => {
     this.setState({
       open: true,
     });
@@ -39,7 +39,7 @@ export default class SnackbarExampleTwice extends React.Component {
     return (
       <div>
         <RaisedButton
-          onClick={this.handleTouchTap}
+          onClick={this.handleClick}
           label="Add to my calendar two times"
         />
         <Snackbar

--- a/docs/src/app/components/pages/components/Snackbar/Page.js
+++ b/docs/src/app/components/pages/components/Snackbar/Page.js
@@ -17,7 +17,7 @@ import SnackbarCode from '!raw!material-ui/Snackbar/Snackbar';
 const descriptions = {
   simple: '`Snackbar` is a controlled component, and is displayed when `open` is `true`. Click away from the ' +
   'Snackbar to close it, or wait for `autoHideDuration` to expire.',
-  action: 'A single `action` can be added to the Snackbar, and triggers `onActionTouchTap`. Edit the textfield to ' +
+  action: 'A single `action` can be added to the Snackbar, and triggers `onActionClick`. Edit the textfield to ' +
   'change `autoHideDuration`',
   consecutive: 'Changing `message` causes the Snackbar to animate - it isn\'t necessary to close and reopen the ' +
   'Snackbar with the open prop.',

--- a/docs/src/app/components/pages/customization/Themes.js
+++ b/docs/src/app/components/pages/customization/Themes.js
@@ -221,7 +221,7 @@ class ThemesPage extends Component {
         </div>
         <div style={styles.group}>
           <div style={styles.containerCentered}>
-            <FlatButton label="View Dialog" onClick={this.handleTouchTapDialog} />
+            <FlatButton label="View Dialog" onClick={this.handleClickDialog} />
             <Dialog
               open={this.state.dialogOpen}
               title="Dialog With Standard Actions"
@@ -247,7 +247,7 @@ class ThemesPage extends Component {
         <div style={styles.group}>
           <div style={styles.containerCentered}>
             <FlatButton
-              onClick={this.handleTouchTapDrawer}
+              onClick={this.handleClickDrawer}
               label="View Drawer"
             />
             <Drawer
@@ -262,7 +262,7 @@ class ThemesPage extends Component {
         <div style={styles.group}>
           <div style={styles.containerCentered}>
             <FlatButton
-              onClick={this.handleTouchTapSnackbar}
+              onClick={this.handleClickSnackbar}
               label="View Snackbar"
             />
           </div>
@@ -271,7 +271,7 @@ class ThemesPage extends Component {
             onRequestClose={this.handleRequestCloseSnackbar}
             message="This is a snackbar"
             action="Got It!"
-            onActionTouchTap={this.handleRequestCloseSnackbar}
+            onActionClick={this.handleRequestCloseSnackbar}
           />
         </div>
       </ClearFix>
@@ -317,7 +317,7 @@ class ThemesPage extends Component {
     );
   }
 
-  handleTouchTapDrawer = () => {
+  handleClickDrawer = () => {
     this.setState({
       drawerOpen: true,
     });
@@ -329,7 +329,7 @@ class ThemesPage extends Component {
     });
   };
 
-  handleTouchTapDialog = () => {
+  handleClickDialog = () => {
     this.setState({
       dialogOpen: true,
     });
@@ -341,7 +341,7 @@ class ThemesPage extends Component {
     });
   };
 
-  handleTouchTapSnackbar = () => {
+  handleClickSnackbar = () => {
     this.setState({
       snackbarOpen: true,
     });

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -102,23 +102,23 @@ class AppBar extends Component {
      */
     iconStyleRight: PropTypes.object,
     /**
-     * Callback function for when the left icon is selected via a touch tap.
+     * Callback function for when the left icon is selected via a click.
      *
-     * @param {object} event TouchTap event targeting the left `IconButton`.
+     * @param {object} event Click event targeting the left `IconButton`.
      */
-    onLeftIconButtonTouchTap: PropTypes.func,
+    onLeftIconButtonClick: PropTypes.func,
     /**
-     * Callback function for when the right icon is selected via a touch tap.
+     * Callback function for when the right icon is selected via a click.
      *
-     * @param {object} event TouchTap event targeting the right `IconButton`.
+     * @param {object} event Click event targeting the right `IconButton`.
      */
-    onRightIconButtonTouchTap: PropTypes.func,
+    onRightIconButtonClick: PropTypes.func,
     /**
-     * Callback function for when the title text is selected via a touch tap.
+     * Callback function for when the title text is selected via a click.
      *
-     * @param {object} event TouchTap event targeting the `title` node.
+     * @param {object} event Click event targeting the `title` node.
      */
-    onTitleTouchTap: PropTypes.func,
+    onTitleClick: PropTypes.func,
     /**
      * Determines whether or not to display the Menu icon next to the title.
      * Setting this prop to false will hide the icon.
@@ -161,21 +161,21 @@ class AppBar extends Component {
       and iconClassNameRight cannot be simultaneously defined. Please use one or the other.`);
   }
 
-  handleTouchTapLeftIconButton = (event) => {
-    if (this.props.onLeftIconButtonTouchTap) {
-      this.props.onLeftIconButtonTouchTap(event);
+  handleClickLeftIconButton = (event) => {
+    if (this.props.onLeftIconButtonClick) {
+      this.props.onLeftIconButtonClick(event);
     }
   };
 
-  handleTouchTapRightIconButton = (event) => {
-    if (this.props.onRightIconButtonTouchTap) {
-      this.props.onRightIconButtonTouchTap(event);
+  handleClickRightIconButton = (event) => {
+    if (this.props.onRightIconButtonClick) {
+      this.props.onRightIconButtonClick(event);
     }
   };
 
-  handleTitleTouchTap = (event) => {
-    if (this.props.onTitleTouchTap) {
-      this.props.onTitleTouchTap(event);
+  handleTitleClick = (event) => {
+    if (this.props.onTitleClick) {
+      this.props.onTitleClick(event);
     }
   };
 
@@ -185,14 +185,14 @@ class AppBar extends Component {
       titleStyle,
       iconStyleLeft,
       iconStyleRight,
-      onTitleTouchTap, // eslint-disable-line no-unused-vars
+      onTitleClick, // eslint-disable-line no-unused-vars
       showMenuIconButton,
       iconElementLeft,
       iconElementRight,
       iconClassNameLeft,
       iconClassNameRight,
-      onLeftIconButtonTouchTap, // eslint-disable-line no-unused-vars
-      onRightIconButtonTouchTap, // eslint-disable-line no-unused-vars
+      onLeftIconButtonClick, // eslint-disable-line no-unused-vars
+      onRightIconButtonClick, // eslint-disable-line no-unused-vars
       className,
       style,
       zDepth,
@@ -211,7 +211,7 @@ class AppBar extends Component {
     const titleComponent = typeof title === 'string' || title instanceof String ? 'h1' : 'div';
 
     const titleElement = React.createElement(titleComponent, {
-      onClick: this.handleTitleTouchTap,
+      onClick: this.handleTitleClick,
       style: prepareStyles(Object.assign(styles.title, styles.mainElement, titleStyle)),
     }, title);
 
@@ -232,8 +232,8 @@ class AppBar extends Component {
           iconElementLeftProps.iconStyle = Object.assign({}, iconButtonIconStyle, iconElementLeft.props.iconStyle);
         }
 
-        if (!iconElementLeft.props.onClick && this.props.onLeftIconButtonTouchTap) {
-          iconElementLeftProps.onClick = this.handleTouchTapLeftIconButton;
+        if (!iconElementLeft.props.onClick && this.props.onLeftIconButtonClick) {
+          iconElementLeftProps.onClick = this.handleClickLeftIconButton;
         }
 
         menuElementLeft = (
@@ -249,7 +249,7 @@ class AppBar extends Component {
             style={iconLeftStyle}
             iconStyle={styles.iconButtonIconStyle}
             iconClassName={iconClassNameLeft}
-            onClick={this.handleTouchTapLeftIconButton}
+            onClick={this.handleClickLeftIconButton}
           >
             {iconClassNameLeft ?
               '' :
@@ -288,8 +288,8 @@ class AppBar extends Component {
         default:
       }
 
-      if (!iconElementRight.props.onClick && this.props.onRightIconButtonTouchTap) {
-        iconElementRightProps.onClick = this.handleTouchTapRightIconButton;
+      if (!iconElementRight.props.onClick && this.props.onRightIconButtonClick) {
+        iconElementRightProps.onClick = this.handleClickRightIconButton;
       }
 
       menuElementRight = (
@@ -305,7 +305,7 @@ class AppBar extends Component {
           style={iconRightStyle}
           iconStyle={styles.iconButtonIconStyle}
           iconClassName={iconClassNameRight}
-          onClick={this.handleTouchTapRightIconButton}
+          onClick={this.handleClickRightIconButton}
         />
       );
     }

--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -84,12 +84,12 @@ describe('<AppBar />', () => {
     });
 
     it('should triggers the onClick', () => {
-      const handleTouchTap = spy();
+      const handleClick = spy();
       const wrapper = shallowWithContext(
-        <AppBar iconElementLeft={<IconButton onClick={handleTouchTap}><div /></IconButton>} />
+        <AppBar iconElementLeft={<IconButton onClick={handleClick}><div /></IconButton>} />
       );
       wrapper.find(IconButton).simulate('click');
-      assert.strictEqual(handleTouchTap.callCount, 1);
+      assert.strictEqual(handleClick.callCount, 1);
     });
   });
 
@@ -116,65 +116,65 @@ describe('<AppBar />', () => {
     });
   });
 
-  describe('onLeftIconButtonTouchTap', () => {
+  describe('onLeftIconButtonClick', () => {
     it('should trigger the onClick', () => {
-      const onLeftIconButtonTouchTap = spy();
+      const onLeftIconButtonClick = spy();
       const wrapper = shallowWithContext(
-        <AppBar onLeftIconButtonTouchTap={onLeftIconButtonTouchTap} />
+        <AppBar onLeftIconButtonClick={onLeftIconButtonClick} />
       );
 
       wrapper.find(IconButton).simulate('click');
-      assert.strictEqual(onLeftIconButtonTouchTap.callCount, 1,
-        'should have called onLeftIconButtonTouchTap callback function');
+      assert.strictEqual(onLeftIconButtonClick.callCount, 1,
+        'should have called onLeftIconButtonClick callback function');
     });
 
-    it('should forward the onClick to onLeftIconButtonTouchTap', () => {
-      const handleTouchTap = spy();
+    it('should forward the onClick to onLeftIconButtonClick', () => {
+      const handleClick = spy();
       const wrapper = shallowWithContext(
         <AppBar
           iconElementLeft={<IconButton><div /></IconButton>}
-          onLeftIconButtonTouchTap={handleTouchTap}
+          onLeftIconButtonClick={handleClick}
         />
       );
       wrapper.find(IconButton).simulate('click');
-      assert.strictEqual(handleTouchTap.callCount, 1);
+      assert.strictEqual(handleClick.callCount, 1);
     });
   });
 
-  describe('onRightIconButtonTouchTap', () => {
+  describe('onRightIconButtonClick', () => {
     it('should trigger the onClick', () => {
-      const handleRightIconButtonTouchTap = spy();
+      const handleRightIconButtonClick = spy();
       const wrapper = shallowWithContext(
-        <AppBar onRightIconButtonTouchTap={handleRightIconButtonTouchTap} iconClassNameRight="foo" />
+        <AppBar onRightIconButtonClick={handleRightIconButtonClick} iconClassNameRight="foo" />
       );
 
       wrapper.find(IconButton).at(1).simulate('click');
-      assert.strictEqual(handleRightIconButtonTouchTap.callCount, 1,
-        'should have called onRightIconButtonTouchTap callback function');
+      assert.strictEqual(handleRightIconButtonClick.callCount, 1,
+        'should have called onRightIconButtonClick callback function');
     });
 
-    it('should forward the onClick to onRightIconButtonTouchTap', () => {
-      const handleTouchTap = spy();
+    it('should forward the onClick to onRightIconButtonClick', () => {
+      const handleClick = spy();
       const wrapper = shallowWithContext(
         <AppBar
           iconElementRight={<IconButton><div /></IconButton>}
-          onRightIconButtonTouchTap={handleTouchTap}
+          onRightIconButtonClick={handleClick}
         />
       );
       wrapper.find(IconButton).at(1).simulate('click');
-      assert.strictEqual(handleTouchTap.callCount, 1);
+      assert.strictEqual(handleClick.callCount, 1);
     });
   });
 
-  it('call onTitleTouchTap callback', () => {
-    const onTitleTouchTap = spy();
+  it('call onTitleClick callback', () => {
+    const onTitleClick = spy();
     const wrapper = shallowWithContext(
-      <AppBar title="Title" onTitleTouchTap={onTitleTouchTap} />
+      <AppBar title="Title" onTitleClick={onTitleClick} />
     );
 
     wrapper.find('h1').simulate('click');
-    assert.strictEqual(onTitleTouchTap.callCount, 1,
-      'should have called onTitleTouchTap callback function');
+    assert.strictEqual(onTitleClick.callCount, 1,
+      'should have called onTitleClick callback function');
   });
 
   it('hide menu icon when showMenuIconButton is false', () => {

--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -219,7 +219,7 @@ class AutoComplete extends Component {
       open: this.props.open,
       searchText: this.props.searchText || '',
     });
-    this.timerTouchTapCloseId = null;
+    this.timerClickCloseId = null;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -237,7 +237,7 @@ class AutoComplete extends Component {
   }
 
   componentWillUnmount() {
-    clearTimeout(this.timerTouchTapCloseId);
+    clearTimeout(this.timerClickCloseId);
     clearTimeout(this.timerBlurClose);
   }
 
@@ -265,7 +265,7 @@ class AutoComplete extends Component {
     event.preventDefault();
   };
 
-  handleItemTouchTap = (event, child) => {
+  handleItemClick = (event, child) => {
     const dataSource = this.props.dataSource;
     const index = parseInt(child.key, 10);
     const chosenRequest = dataSource[index];
@@ -274,21 +274,21 @@ class AutoComplete extends Component {
     const updateInput = () => this.props.onUpdateInput(searchText, this.props.dataSource, {
       source: 'click',
     });
-    this.timerTouchTapCloseId = () => setTimeout(() => {
-      this.timerTouchTapCloseId = null;
+    this.timerClickCloseId = () => setTimeout(() => {
+      this.timerClickCloseId = null;
       this.close();
       this.props.onNewRequest(chosenRequest, index);
     }, this.props.menuCloseDelay);
 
     if (typeof this.props.searchText !== 'undefined') {
       updateInput();
-      this.timerTouchTapCloseId();
+      this.timerClickCloseId();
     } else {
       this.setState({
         searchText: searchText,
       }, () => {
         updateInput();
-        this.timerTouchTapCloseId();
+        this.timerClickCloseId();
       });
     }
   };
@@ -361,7 +361,7 @@ class AutoComplete extends Component {
   };
 
   handleBlur = (event) => {
-    if (this.state.focusTextField && this.timerTouchTapCloseId === null) {
+    if (this.state.focusTextField && this.timerClickCloseId === null) {
       this.timerBlurClose = setTimeout(() => {
         this.close();
       }, 0);
@@ -511,7 +511,7 @@ class AutoComplete extends Component {
         disableAutoFocus={focusTextField}
         onEscKeyDown={this.handleEscKeyDown}
         initiallyKeyboardFocused={true}
-        onItemTouchTap={this.handleItemTouchTap}
+        onItemClick={this.handleItemClick}
         onMouseDown={this.handleMouseDown}
         style={Object.assign(styles.menu, menuStyle)}
         listStyle={Object.assign(styles.list, listStyle)}

--- a/src/AutoComplete/AutoComplete.spec.js
+++ b/src/AutoComplete/AutoComplete.spec.js
@@ -116,7 +116,7 @@ describe('<AutoComplete />', () => {
       );
 
       wrapper.setState({open: true, searchText: 'f'});
-      wrapper.find(Menu).props().onItemTouchTap({}, {
+      wrapper.find(Menu).props().onItemClick({}, {
         key: 0,
       });
       assert.strictEqual(handleNewRequest.callCount, 0);
@@ -143,7 +143,7 @@ describe('<AutoComplete />', () => {
       );
 
       wrapper.setState({open: true, searchText: 'f'});
-      wrapper.find(Menu).props().onItemTouchTap({}, {
+      wrapper.find(Menu).props().onItemClick({}, {
         key: 0,
       });
 
@@ -195,7 +195,7 @@ describe('<AutoComplete />', () => {
   });
 
   describe('prop: searchText', () => {
-    it('onItemTouchTap should not call setState:searchText when searchText is controlled', () => {
+    it('onItemClick should not call setState:searchText when searchText is controlled', () => {
       const wrapper = shallowWithContext(
         <AutoComplete
           dataSource={['foo', 'bar']}
@@ -204,7 +204,7 @@ describe('<AutoComplete />', () => {
       );
 
       wrapper.setState({open: true});
-      wrapper.find(Menu).props().onItemTouchTap({}, {
+      wrapper.find(Menu).props().onItemClick({}, {
         key: 0,
       });
       assert.strictEqual(wrapper.state().searchText, 'f');

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -81,9 +81,9 @@ class Chip extends Component {
     /** @ignore */
     onBlur: PropTypes.func,
     /**
-     * Callback function fired when the `Chip` element is touch-tapped.
+     * Callback function fired when the `Chip` element is clicked.
      *
-     * @param {object} event TouchTap event targeting the element.
+     * @param {object} event Click event targeting the element.
      */
     onClick: PropTypes.func,
     /** @ignore */
@@ -210,7 +210,7 @@ class Chip extends Component {
     this.props.onMouseUp(event);
   };
 
-  handleTouchTapDeleteIcon = (event) => {
+  handleClickDeleteIcon = (event) => {
     // Stop the event from bubbling up to the `Chip`
     event.stopPropagation();
     this.props.onRequestDelete(event);
@@ -266,7 +266,7 @@ class Chip extends Component {
       <DeleteIcon
         color={styles.deleteIcon.color}
         style={Object.assign(styles.deleteIcon, deleteIconStyle)}
-        onClick={this.handleTouchTapDeleteIcon}
+        onClick={this.handleClickDeleteIcon}
         onMouseEnter={this.handleMouseEnterDeleteIcon}
         onMouseLeave={this.handleMouseLeaveDeleteIcon}
       />

--- a/src/DatePicker/Calendar.js
+++ b/src/DatePicker/Calendar.js
@@ -34,9 +34,9 @@ class Calendar extends Component {
     minDate: PropTypes.object,
     mode: PropTypes.oneOf(['portrait', 'landscape']),
     okLabel: PropTypes.node,
-    onTouchTapCancel: PropTypes.func,
-    onTouchTapDay: PropTypes.func,
-    onTouchTapOk: PropTypes.func,
+    onClickCancel: PropTypes.func,
+    onClickDay: PropTypes.func,
+    onClickOk: PropTypes.func,
     open: PropTypes.bool,
     openToYearSelection: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
@@ -154,9 +154,9 @@ class Calendar extends Component {
     }
   }
 
-  handleTouchTapDay = (event, date) => {
+  handleClickDay = (event, date) => {
     this.setSelectedDate(date);
-    if (this.props.onTouchTapDay) this.props.onTouchTapDay(event, date);
+    if (this.props.onClickDay) this.props.onClickDay(event, date);
   };
 
   handleMonthChange = (months) => {
@@ -169,9 +169,9 @@ class Calendar extends Component {
     });
   };
 
-  handleTouchTapYear = (event, year) => {
+  handleClickYear = (event, year) => {
     this.setSelectedDate(this.props.utils.setYear(this.state.selectedDate, year), event);
-    this.handleTouchTapDateDisplayMonthDay();
+    this.handleClickDateDisplayMonthDay();
   };
 
   getToolbarInteractions() {
@@ -181,13 +181,13 @@ class Calendar extends Component {
     };
   }
 
-  handleTouchTapDateDisplayMonthDay = () => {
+  handleClickDateDisplayMonthDay = () => {
     this.setState({
       displayMonthDay: true,
     });
   };
 
-  handleTouchTapDateDisplayYear = () => {
+  handleClickDateDisplayYear = () => {
     this.setState({
       displayMonthDay: false,
     });
@@ -248,7 +248,7 @@ class Calendar extends Component {
           key="years"
           DateTimeFormat={this.props.DateTimeFormat}
           locale={this.props.locale}
-          onTouchTapYear={this.handleTouchTapYear}
+          onClickYear={this.handleClickYear}
           selectedDate={this.state.selectedDate}
           minDate={this.getMinDate()}
           maxDate={this.getMaxDate()}
@@ -320,8 +320,8 @@ class Calendar extends Component {
       firstDayOfWeek,
       locale,
       okLabel,
-      onTouchTapCancel, // eslint-disable-line no-unused-vars
-      onTouchTapOk, // eslint-disable-line no-unused-vars
+      onClickCancel, // eslint-disable-line no-unused-vars
+      onClickOk, // eslint-disable-line no-unused-vars
       utils,
     } = this.props;
 
@@ -335,8 +335,8 @@ class Calendar extends Component {
           <DateDisplay
             DateTimeFormat={DateTimeFormat}
             disableYearSelection={this.props.disableYearSelection}
-            onTouchTapMonthDay={this.handleTouchTapDateDisplayMonthDay}
-            onTouchTapYear={this.handleTouchTapDateDisplayYear}
+            onClickMonthDay={this.handleClickDateDisplayMonthDay}
+            onClickYear={this.handleClickDateDisplayYear}
             locale={locale}
             monthDaySelected={this.state.displayMonthDay}
             mode={this.props.mode}
@@ -370,7 +370,7 @@ class Calendar extends Component {
                   key={this.state.displayDate.toDateString()}
                   minDate={this.getMinDate()}
                   maxDate={this.getMaxDate()}
-                  onTouchTapDay={this.handleTouchTapDay}
+                  onClickDay={this.handleClickDay}
                   ref={(ref) => this.calendarRefs.calendar = ref}
                   selectedDate={this.state.selectedDate}
                   shouldDisableDate={this.props.shouldDisableDate}
@@ -389,8 +389,8 @@ class Calendar extends Component {
               autoOk={this.props.autoOk}
               cancelLabel={cancelLabel}
               okLabel={okLabel}
-              onTouchTapCancel={onTouchTapCancel}
-              onTouchTapOk={onTouchTapOk}
+              onClickCancel={onClickCancel}
+              onClickOk={onClickOk}
             />
           }
         </div>

--- a/src/DatePicker/CalendarActionButtons.js
+++ b/src/DatePicker/CalendarActionButtons.js
@@ -7,8 +7,8 @@ class CalendarActionButton extends Component {
     autoOk: PropTypes.bool,
     cancelLabel: PropTypes.node,
     okLabel: PropTypes.node,
-    onTouchTapCancel: PropTypes.func,
-    onTouchTapOk: PropTypes.func,
+    onClickCancel: PropTypes.func,
+    onClickOk: PropTypes.func,
   };
 
   render() {
@@ -36,7 +36,7 @@ class CalendarActionButton extends Component {
       <div style={styles.root} >
         <FlatButton
           label={cancelLabel}
-          onClick={this.props.onTouchTapCancel}
+          onClick={this.props.onClickCancel}
           primary={true}
           style={styles.flatButtons}
         />
@@ -44,7 +44,7 @@ class CalendarActionButton extends Component {
           <FlatButton
             disabled={this.refs.calendar !== undefined && this.refs.calendar.isSelectedDateDisabled()}
             label={okLabel}
-            onClick={this.props.onTouchTapOk}
+            onClick={this.props.onClickOk}
             primary={true}
             style={styles.flatButtons}
           />

--- a/src/DatePicker/CalendarMonth.js
+++ b/src/DatePicker/CalendarMonth.js
@@ -33,7 +33,7 @@ class CalendarMonth extends Component {
     locale: PropTypes.string.isRequired,
     maxDate: PropTypes.object,
     minDate: PropTypes.object,
-    onTouchTapDay: PropTypes.func,
+    onClickDay: PropTypes.func,
     selectedDate: PropTypes.object.isRequired,
     shouldDisableDate: PropTypes.func,
     utils: PropTypes.object.isRequired,
@@ -43,9 +43,9 @@ class CalendarMonth extends Component {
     return this.selectedDateDisabled;
   }
 
-  handleTouchTapDay = (event, date) => {
-    if (this.props.onTouchTapDay) {
-      this.props.onTouchTapDay(event, date);
+  handleClickDay = (event, date) => {
+    if (this.props.onClickDay) {
+      this.props.onClickDay(event, date);
     }
   };
 
@@ -92,7 +92,7 @@ class CalendarMonth extends Component {
           date={day}
           disabled={disabled}
           key={`db${(i + j)}`}
-          onClick={this.handleTouchTapDay}
+          onClick={this.handleClickDay}
           selected={selected}
         />
       );

--- a/src/DatePicker/CalendarToolbar.js
+++ b/src/DatePicker/CalendarToolbar.js
@@ -58,13 +58,13 @@ class CalendarToolbar extends Component {
     }
   }
 
-  handleTouchTapPrevMonth = () => {
+  handleClickPrevMonth = () => {
     if (this.props.onMonthChange) {
       this.props.onMonthChange(-1);
     }
   };
 
-  handleTouchTapNextMonth = () => {
+  handleClickNextMonth = () => {
     if (this.props.onMonthChange) {
       this.props.onMonthChange(1);
     }
@@ -86,7 +86,7 @@ class CalendarToolbar extends Component {
       <div style={styles.root}>
         <IconButton
           disabled={!this.props.prevMonth}
-          onClick={this.handleTouchTapPrevMonth}
+          onClick={this.handleClickPrevMonth}
         >
           {prevButtonIcon}
         </IconButton>
@@ -100,7 +100,7 @@ class CalendarToolbar extends Component {
         </SlideInTransitionGroup>
         <IconButton
           disabled={!this.props.nextMonth}
-          onClick={this.handleTouchTapNextMonth}
+          onClick={this.handleClickNextMonth}
         >
           {nextButtonIcon}
         </IconButton>

--- a/src/DatePicker/CalendarYear.js
+++ b/src/DatePicker/CalendarYear.js
@@ -9,7 +9,7 @@ class CalendarYear extends Component {
     locale: PropTypes.string.isRequired,
     maxDate: PropTypes.object.isRequired,
     minDate: PropTypes.object.isRequired,
-    onTouchTapYear: PropTypes.func,
+    onClickYear: PropTypes.func,
     selectedDate: PropTypes.object.isRequired,
     utils: PropTypes.object.isRequired,
     wordings: PropTypes.object,
@@ -55,7 +55,7 @@ class CalendarYear extends Component {
       const yearButton = (
         <YearButton
           key={`yb${year}`}
-          onClick={this.handleTouchTapYear}
+          onClick={this.handleClickYear}
           selected={selected}
           year={year}
           utils={utils}
@@ -86,9 +86,9 @@ class CalendarYear extends Component {
     container.scrollTop = scrollYOffset;
   }
 
-  handleTouchTapYear = (event, year) => {
-    if (this.props.onTouchTapYear) {
-      this.props.onTouchTapYear(event, year);
+  handleClickYear = (event, year) => {
+    if (this.props.onClickYear) {
+      this.props.onClickYear(event, year);
     }
   };
 

--- a/src/DatePicker/DateDisplay.js
+++ b/src/DatePicker/DateDisplay.js
@@ -63,8 +63,8 @@ class DateDisplay extends Component {
     locale: PropTypes.string.isRequired,
     mode: PropTypes.oneOf(['portrait', 'landscape']),
     monthDaySelected: PropTypes.bool,
-    onTouchTapMonthDay: PropTypes.func,
-    onTouchTapYear: PropTypes.func,
+    onClickMonthDay: PropTypes.func,
+    onClickYear: PropTypes.func,
     selectedDate: PropTypes.object.isRequired,
     style: PropTypes.object,
   };
@@ -104,17 +104,17 @@ class DateDisplay extends Component {
     }
   }
 
-  handleTouchTapMonthDay = () => {
-    if (this.props.onTouchTapMonthDay && this.state.selectedYear) {
-      this.props.onTouchTapMonthDay();
+  handleClickMonthDay = () => {
+    if (this.props.onClickMonthDay && this.state.selectedYear) {
+      this.props.onClickMonthDay();
     }
 
     this.setState({selectedYear: false});
   };
 
-  handleTouchTapYear = () => {
-    if (this.props.onTouchTapYear && !this.props.disableYearSelection && !this.state.selectedYear) {
-      this.props.onTouchTapYear();
+  handleClickYear = () => {
+    if (this.props.onClickYear && !this.props.disableYearSelection && !this.state.selectedYear) {
+      this.props.onClickYear();
     }
 
     if (!this.props.disableYearSelection) {
@@ -129,8 +129,8 @@ class DateDisplay extends Component {
       locale,
       mode, // eslint-disable-line no-unused-vars
       monthDaySelected, // eslint-disable-line no-unused-vars
-      onTouchTapMonthDay, // eslint-disable-line no-unused-vars
-      onTouchTapYear, // eslint-disable-line no-unused-vars
+      onClickMonthDay, // eslint-disable-line no-unused-vars
+      onClickYear, // eslint-disable-line no-unused-vars
       selectedDate, // eslint-disable-line no-unused-vars
       style,
       ...other
@@ -152,14 +152,14 @@ class DateDisplay extends Component {
     return (
       <div {...other} style={prepareStyles(styles.root, style)}>
         <SlideInTransitionGroup style={styles.year} direction={this.state.transitionDirection}>
-          <div key={year} style={styles.yearTitle} onClick={this.handleTouchTapYear}>
+          <div key={year} style={styles.yearTitle} onClick={this.handleClickYear}>
             {year}
           </div>
         </SlideInTransitionGroup>
         <SlideInTransitionGroup style={styles.monthDay} direction={this.state.transitionDirection}>
           <div
             key={dateTime}
-            onClick={this.handleTouchTapMonthDay}
+            onClick={this.handleClickMonthDay}
             style={styles.monthDayTitle}
           >
             {dateTime}

--- a/src/DatePicker/DatePicker.js
+++ b/src/DatePicker/DatePicker.js
@@ -102,9 +102,9 @@ class DatePicker extends Component {
      */
     onChange: PropTypes.func,
     /**
-     * Callback function that is fired when a touch tap event occurs on the Date Picker's `TextField`.
+     * Callback function that is fired when a click event occurs on the Date Picker's `TextField`.
      *
-     * @param {object} event TouchTap event targeting the `TextField`.
+     * @param {object} event Click event targeting the `TextField`.
      */
     onClick: PropTypes.func,
     /**
@@ -238,7 +238,7 @@ class DatePicker extends Component {
     }
   };
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     if (this.props.onClick) {
       this.props.onClick(event);
     }
@@ -311,7 +311,7 @@ class DatePicker extends Component {
         <TextField
           {...other}
           onFocus={this.handleFocus}
-          onClick={this.handleTouchTap}
+          onClick={this.handleClick}
           ref="input"
           style={textFieldStyle}
           value={this.state.date ? formatDate(this.state.date) : ''}

--- a/src/DatePicker/DatePickerDialog.js
+++ b/src/DatePicker/DatePickerDialog.js
@@ -72,13 +72,13 @@ class DatePickerDialog extends Component {
     });
   };
 
-  handleTouchTapDay = () => {
+  handleClickDay = () => {
     if (this.props.autoOk) {
-      setTimeout(this.handleTouchTapOk, 300);
+      setTimeout(this.handleClickOk, 300);
     }
   };
 
-  handleTouchTapCancel = () => {
+  handleClickCancel = () => {
     this.dismiss();
   };
 
@@ -86,7 +86,7 @@ class DatePickerDialog extends Component {
     this.dismiss();
   };
 
-  handleTouchTapOk = () => {
+  handleClickOk = () => {
     if (this.props.onAccept && !this.refs.calendar.isSelectedDateDisabled()) {
       this.props.onAccept(this.refs.calendar.getSelectedDate());
     }
@@ -99,7 +99,7 @@ class DatePickerDialog extends Component {
   handleWindowKeyUp = (event) => {
     switch (keycode(event)) {
       case 'enter':
-        this.handleTouchTapOk();
+        this.handleClickOk();
         break;
     }
   };
@@ -171,14 +171,14 @@ class DatePickerDialog extends Component {
             firstDayOfWeek={firstDayOfWeek}
             initialDate={initialDate}
             locale={locale}
-            onTouchTapDay={this.handleTouchTapDay}
+            onClickDay={this.handleClickDay}
             maxDate={maxDate}
             minDate={minDate}
             mode={mode}
             open={open}
             ref="calendar"
-            onTouchTapCancel={this.handleTouchTapCancel}
-            onTouchTapOk={this.handleTouchTapOk}
+            onClickCancel={this.handleClickCancel}
+            onClickOk={this.handleClickOk}
             okLabel={okLabel}
             openToYearSelection={openToYearSelection}
             shouldDisableDate={shouldDisableDate}

--- a/src/DatePicker/DayButton.js
+++ b/src/DatePicker/DayButton.js
@@ -87,7 +87,7 @@ class DayButton extends Component {
     }
   };
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     if (!this.props.disabled && this.props.onClick) {
       this.props.onClick(event, this.props.date);
     }
@@ -122,7 +122,7 @@ class DayButton extends Component {
         onKeyboardFocus={this.handleKeyboardFocus}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
-        onClick={this.handleTouchTap}
+        onClick={this.handleClick}
         style={styles.root}
       >
         <div style={prepareStyles(styles.buttonState)} />

--- a/src/DatePicker/YearButton.js
+++ b/src/DatePicker/YearButton.js
@@ -63,7 +63,7 @@ class YearButton extends Component {
     this.setState({hover: false});
   };
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     if (this.props.onClick) {
       this.props.onClick(event, this.props.year);
     }
@@ -90,7 +90,7 @@ class YearButton extends Component {
         disableTouchRipple={true}
         onMouseEnter={this.handleMouseEnter}
         onMouseLeave={this.handleMouseLeave}
-        onClick={this.handleTouchTap}
+        onClick={this.handleClick}
         style={styles.root}
       >
         <span style={prepareStyles(styles.label)}>

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -252,7 +252,7 @@ class DialogInline extends Component {
     }
   }
 
-  handleTouchTapOverlay = () => {
+  handleClickOverlay = () => {
     this.requestClose(false);
   };
 
@@ -358,7 +358,7 @@ class DialogInline extends Component {
           show={open}
           className={overlayClassName}
           style={styles.overlay}
-          onClick={this.handleTouchTapOverlay}
+          onClick={this.handleClickOverlay}
         />
       </div>
     );

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -192,7 +192,7 @@ class Drawer extends Component {
     return this;
   }
 
-  handleTouchTapOverlay = (event) => {
+  handleClickOverlay = (event) => {
     event.preventDefault();
     this.close('clickaway');
   };
@@ -394,7 +394,7 @@ class Drawer extends Component {
           className={overlayClassName}
           style={Object.assign(styles.overlay, overlayStyle)}
           transitionEnabled={!this.state.swiping}
-          onClick={this.handleTouchTapOverlay}
+          onClick={this.handleClickOverlay}
         />
       );
     }

--- a/src/DropDownMenu/DropDownMenu.js
+++ b/src/DropDownMenu/DropDownMenu.js
@@ -153,7 +153,7 @@ class DropDownMenu extends Component {
     /**
      * Callback function fired when a menu item is clicked, other than the one currently selected.
      *
-     * @param {object} event TouchTap event targeting the menu item that was clicked.
+     * @param {object} event Click event targeting the menu item that was clicked.
      * @param {number} key The index of the clicked menu item in the `children` collection.
      * @param {any} value If `multiple` is true, the menu's `value`
      * array with either the menu item's `value` added (if
@@ -280,7 +280,7 @@ class DropDownMenu extends Component {
     }
   }
 
-  handleTouchTapControl = (event) => {
+  handleClickControl = (event) => {
     event.preventDefault();
     if (!this.props.disabled) {
       this.setState({
@@ -313,7 +313,7 @@ class DropDownMenu extends Component {
     }
   };
 
-  handleItemTouchTap = (event, child, index) => {
+  handleItemClick = (event, child, index) => {
     if (this.props.multiple) {
       if (!this.state.open) {
         this.setState({open: true});
@@ -442,7 +442,7 @@ class DropDownMenu extends Component {
         className={className}
         style={prepareStyles(Object.assign({}, styles.root, open && styles.rootWhenOpen, style))}
       >
-        <ClearFix style={styles.control} onClick={this.handleTouchTapControl}>
+        <ClearFix style={styles.control} onClick={this.handleClickControl}>
           <div style={prepareStyles(Object.assign({}, styles.label, open && styles.labelWhenOpen, labelStyle))}>
             {displayValue}
           </div>
@@ -476,7 +476,7 @@ class DropDownMenu extends Component {
             onEscKeyDown={this.handleEscKeyDownMenu}
             style={menuStyle}
             listStyle={listStyle}
-            onItemTouchTap={this.handleItemTouchTap}
+            onItemClick={this.handleItemClick}
             onChange={this.handleChange}
             menuItemStyle={menuItemStyle}
             selectedMenuItemStyle={selectedMenuItemStyle}

--- a/src/DropDownMenu/DropDownMenu.spec.js
+++ b/src/DropDownMenu/DropDownMenu.spec.js
@@ -84,7 +84,7 @@ describe('<DropDownMenu />', () => {
       wrapper.setState({
         open: true,
       });
-      wrapper.find(Menu).props().onItemTouchTap({
+      wrapper.find(Menu).props().onItemClick({
         persist: () => {},
       });
 
@@ -111,7 +111,7 @@ describe('<DropDownMenu />', () => {
       const event = {
         persist: () => {},
       };
-      wrapper.find(Menu).props().onItemTouchTap(
+      wrapper.find(Menu).props().onItemClick(
         event,
         {
           props: {

--- a/src/FlatButton/FlatButton.js
+++ b/src/FlatButton/FlatButton.js
@@ -86,9 +86,9 @@ class FlatButton extends Component {
      */
     labelStyle: PropTypes.object,
     /**
-     * Callback function fired when the button is touch-tapped.
+     * Callback function fired when the button is clicked.
      *
-     * @param {object} event TouchTap event targeting the button.
+     * @param {object} event Click event targeting the button.
      */
     onClick: PropTypes.func,
     /**

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -109,9 +109,9 @@ class FloatingActionButton extends Component {
      */
     mini: PropTypes.bool,
     /**
-     * Callback function fired when the button is touch-tapped.
+     * Callback function fired when the button is clicked.
      *
-     * @param {object} event TouchTap event targeting the button.
+     * @param {object} event click event targeting the button.
      */
     onClick: PropTypes.func,
     /** @ignore */

--- a/src/FloatingActionButton/FloatingActionButton.js
+++ b/src/FloatingActionButton/FloatingActionButton.js
@@ -111,7 +111,7 @@ class FloatingActionButton extends Component {
     /**
      * Callback function fired when the button is clicked.
      *
-     * @param {object} event click event targeting the button.
+     * @param {object} event Click event targeting the button.
      */
     onClick: PropTypes.func,
     /** @ignore */

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -71,9 +71,9 @@ class IconButton extends Component {
     /** @ignore */
     onBlur: PropTypes.func,
     /**
-     * Callback function fired when the button is touch-tapped.
+     * Callback function fired when the button is clicked.
      *
-     * @param {object} event TouchTap event targeting the button.
+     * @param {object} event Click event targeting the button.
      */
     onClick: PropTypes.func,
     /** @ignore */

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -37,6 +37,13 @@ class IconMenu extends Component {
      */
     className: PropTypes.string,
     /**
+     * Sets the delay in milliseconds before closing the
+     * menu when an item is clicked.
+     * If set to 0 then the auto close functionality
+     * will be disabled.
+     */
+    clickCloseDelay: PropTypes.number,
+    /**
      * This is the `IconButton` to render. This button will open the menu.
      */
     iconButtonElement: PropTypes.element.isRequired,
@@ -109,13 +116,6 @@ class IconMenu extends Component {
      * horizontal: [left, middle, right].
      */
     targetOrigin: propTypes.origin,
-    /**
-     * Sets the delay in milliseconds before closing the
-     * menu when an item is clicked.
-     * If set to 0 then the auto close functionality
-     * will be disabled.
-     */
-    clickCloseDelay: PropTypes.number,
     /**
      * If true, the popover will render on top of an invisible
      * layer, which will prevent clicks to the underlying elements.

--- a/src/IconMenu/IconMenu.js
+++ b/src/IconMenu/IconMenu.js
@@ -57,18 +57,18 @@ class IconMenu extends Component {
      */
     multiple: PropTypes.bool,
     /**
-     * Callback function fired when the `IconButton` element is touch-tapped.
+     * Callback function fired when the `IconButton` element is clicked.
      *
-     * @param {object} event TouchTap event targeting the `IconButton` element.
+     * @param {object} event Click event targeting the `IconButton` element.
      */
     onClick: PropTypes.func,
     /**
-     * Callback function fired when a menu item is selected with a touch-tap.
+     * Callback function fired when a menu item is selected with a click.
      *
-     * @param {object} event TouchTap event targeting the selected menu item element.
+     * @param {object} event Click event targeting the selected menu item element.
      * @param {object} child The selected element.
      */
-    onItemTouchTap: PropTypes.func,
+    onItemClick: PropTypes.func,
     /**
      * Callback function fired when the `IconButton` element is focused or blurred by the keyboard.
      *
@@ -115,7 +115,7 @@ class IconMenu extends Component {
      * If set to 0 then the auto close functionality
      * will be disabled.
      */
-    touchTapCloseDelay: PropTypes.number,
+    clickCloseDelay: PropTypes.number,
     /**
      * If true, the popover will render on top of an invisible
      * layer, which will prevent clicks to the underlying elements.
@@ -131,7 +131,7 @@ class IconMenu extends Component {
     animated: true,
     multiple: false,
     open: null,
-    onItemTouchTap: () => {},
+    onItemClick: () => {},
     onKeyboardFocus: () => {},
     onMouseDown: () => {},
     onMouseLeave: () => {},
@@ -143,7 +143,7 @@ class IconMenu extends Component {
       vertical: 'top',
       horizontal: 'left',
     },
-    touchTapCloseDelay: 200,
+    clickCloseDelay: 200,
     useLayerForClickAway: false,
   };
 
@@ -209,15 +209,15 @@ class IconMenu extends Component {
     });
   }
 
-  handleItemTouchTap = (event, child) => {
-    if (this.props.touchTapCloseDelay !== 0 && !child.props.hasOwnProperty('menuItems')) {
+  handleItemClick = (event, child) => {
+    if (this.props.clickCloseDelay !== 0 && !child.props.hasOwnProperty('menuItems')) {
       const isKeyboard = Events.isKeyboard(event);
       this.timerCloseId = setTimeout(() => {
         this.close(isKeyboard ? 'enter' : 'itemTap', isKeyboard);
-      }, this.props.touchTapCloseDelay);
+      }, this.props.clickCloseDelay);
     }
 
-    this.props.onItemTouchTap(event, child);
+    this.props.onItemClick(event, child);
   };
 
   handleRequestClose = (reason) => {
@@ -236,7 +236,7 @@ class IconMenu extends Component {
       animation,
       iconButtonElement,
       iconStyle,
-      onItemTouchTap, // eslint-disable-line no-unused-vars
+      onItemClick, // eslint-disable-line no-unused-vars
       onKeyboardFocus,
       onMouseDown,
       onMouseLeave,
@@ -248,7 +248,7 @@ class IconMenu extends Component {
       menuStyle,
       style,
       targetOrigin,
-      touchTapCloseDelay, // eslint-disable-line no-unused-vars
+      clickCloseDelay, // eslint-disable-line no-unused-vars
       useLayerForClickAway,
       ...other
     } = this.props;
@@ -295,7 +295,7 @@ You should wrapped it with an <IconButton />.`);
         {...other}
         initiallyKeyboardFocused={this.state.menuInitiallyKeyboardFocused}
         onEscKeyDown={this.handleEscKeyDownMenu}
-        onItemTouchTap={this.handleItemTouchTap}
+        onItemClick={this.handleItemClick}
         style={mergedMenuStyles}
         listStyle={listStyle}
       >

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -234,9 +234,9 @@ class ListItem extends Component {
      */
     nestedListStyle: PropTypes.object,
     /**
-     * Callback function fired when the list item is touch-tapped.
+     * Callback function fired when the list item is clicked.
      *
-     * @param {object} event TouchTap event targeting the list item.
+     * @param {object} event Click event targeting the list item.
      */
     onClick: PropTypes.func,
     /**
@@ -467,7 +467,7 @@ class ListItem extends Component {
     this.props.onMouseLeave(event);
   };
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     if (this.props.onClick) {
       this.props.onClick(event);
     }
@@ -530,7 +530,7 @@ class ListItem extends Component {
     if (iconButton && iconButton.props.onMouseUp) iconButton.props.onMouseUp(event);
   };
 
-  handleRightIconButtonTouchTap = (event) => {
+  handleRightIconButtonClick = (event) => {
     const iconButton = this.props.rightIconButton;
 
     // Stop the event from bubbling up to the list-item
@@ -660,7 +660,7 @@ class ListItem extends Component {
         onKeyboardFocus: this.handleRightIconButtonKeyboardFocus,
         onMouseEnter: this.handleRightIconButtonMouseEnter,
         onMouseLeave: this.handleRightIconButtonMouseLeave,
-        onClick: this.handleRightIconButtonTouchTap,
+        onClick: this.handleRightIconButtonClick,
         onMouseDown: this.handleRightIconButtonMouseUp,
         onMouseUp: this.handleRightIconButtonMouseUp,
       };
@@ -729,7 +729,7 @@ class ListItem extends Component {
               onMouseEnter={this.handleMouseEnter}
               onTouchStart={this.handleTouchStart}
               onTouchEnd={this.handleTouchEnd}
-              onClick={this.handleTouchTap}
+              onClick={this.handleClick}
               disabled={disabled}
               ref={(node) => this.button = node}
               style={Object.assign({}, styles.root, style)}

--- a/src/List/makeSelectable.js
+++ b/src/List/makeSelectable.js
@@ -29,7 +29,7 @@ export const makeSelectable = (MyComponent) => {
 
         return React.cloneElement(child, {
           onClick: (event) => {
-            this.handleItemTouchTap(event, child);
+            this.handleItemClick(event, child);
             if (child.props.onClick) {
               child.props.onClick(event);
             }
@@ -62,7 +62,7 @@ export const makeSelectable = (MyComponent) => {
       return props.value === child.props.value;
     }
 
-    handleItemTouchTap = (event, item) => {
+    handleItemClick = (event, item) => {
       const itemValue = item.props.value;
 
       if (itemValue !== this.props.value) {

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -90,9 +90,9 @@ class Menu extends Component {
     multiple: PropTypes.bool,
     /**
      * Callback function fired when a menu item with `value` not
-     * equal to the current `value` of the menu is touch-tapped.
+     * equal to the current `value` of the menu is clicked.
      *
-     * @param {object} event TouchTap event targeting the menu item.
+     * @param {object} event Click event targeting the menu item.
      * @param {any}  value If `multiple` is true, the menu's `value`
      * array with either the menu item's `value` added (if
      * it wasn't already selected) or omitted (if it was already selected).
@@ -107,13 +107,13 @@ class Menu extends Component {
      */
     onEscKeyDown: PropTypes.func,
     /**
-     * Callback function fired when a menu item is touch-tapped.
+     * Callback function fired when a menu item is clicked.
      *
-     * @param {object} event TouchTap event targeting the menu item.
+     * @param {object} event Click event targeting the menu item.
      * @param {object} menuItem The menu item.
      * @param {number} index The index of the menu item.
      */
-    onItemTouchTap: PropTypes.func,
+    onItemClick: PropTypes.func,
     /** @ignore */
     onKeyDown: PropTypes.func,
     /**
@@ -165,7 +165,7 @@ class Menu extends Component {
     multiple: false,
     onChange: () => {},
     onEscKeyDown: () => {},
-    onItemTouchTap: () => {},
+    onItemClick: () => {},
     onKeyDown: () => {},
   };
 
@@ -301,7 +301,7 @@ class Menu extends Component {
       Object.assign(extraProps, {
         focusState: focusState,
         onClick: (event) => {
-          this.handleMenuItemTouchTap(event, child, index);
+          this.handleMenuItemClick(event, child, index);
           if (child.props.onClick) child.props.onClick(event);
         },
         ref: isFocused ? 'focusedMenuItem' : null,
@@ -395,7 +395,7 @@ class Menu extends Component {
     return false;
   }
 
-  handleMenuItemTouchTap(event, item, index) {
+  handleMenuItemClick(event, item, index) {
     const children = this.props.children;
     const multiple = this.props.multiple;
     const valueLink = this.getValueLink(this.props);
@@ -421,7 +421,7 @@ class Menu extends Component {
       valueLink.requestChange(event, itemValue);
     }
 
-    this.props.onItemTouchTap(event, item, index);
+    this.props.onItemClick(event, item, index);
   }
 
   incrementKeyboardFocusIndex(event, filteredChildren) {
@@ -525,7 +525,7 @@ class Menu extends Component {
       listStyle,
       maxHeight, // eslint-disable-line no-unused-vars
       multiple, // eslint-disable-line no-unused-vars
-      onItemTouchTap, // eslint-disable-line no-unused-vars
+      onItemClick, // eslint-disable-line no-unused-vars
       onEscKeyDown, // eslint-disable-line no-unused-vars
       onMenuItemFocusChange, // eslint-disable-line no-unused-vars
       selectedMenuItemStyle, // eslint-disable-line no-unused-vars

--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -117,9 +117,9 @@ class MenuItem extends Component {
      */
     menuItems: PropTypes.node,
     /**
-     * Callback function fired when the menu item is touch-tapped.
+     * Callback function fired when the menu item is clicked.
      *
-     * @param {object} event TouchTap event targeting the menu item.
+     * @param {object} event Click event targeting the menu item.
      */
     onClick: PropTypes.func,
     /**
@@ -218,7 +218,7 @@ class MenuItem extends Component {
     });
   };
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     event.preventDefault();
 
     this.setState({
@@ -308,7 +308,7 @@ class MenuItem extends Component {
           </Menu>
         </Popover>
       );
-      other.onClick = this.handleTouchTap;
+      other.onClick = this.handleClick;
     }
 
     return (

--- a/src/RaisedButton/RaisedButton.js
+++ b/src/RaisedButton/RaisedButton.js
@@ -195,9 +195,9 @@ class RaisedButton extends Component {
      */
     labelStyle: PropTypes.object,
     /**
-     * Callback function fired when the button is touch-tapped.
+     * Callback function fired when the button is clicked.
      *
-     * @param {object} event TouchTap event targeting the button.
+     * @param {object} event Click event targeting the button.
      */
     onClick: PropTypes.func,
     /** @ignore */

--- a/src/SelectField/SelectField.js
+++ b/src/SelectField/SelectField.js
@@ -114,7 +114,7 @@ class SelectField extends Component {
     /**
      * Callback function fired when a menu item is selected.
      *
-     * @param {object} event TouchTap event targeting the menu item
+     * @param {object} event Click event targeting the menu item
      * that was selected.
      * @param {number} key The index of the selected menu item, or undefined
      * if `multiple` is true.

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -71,11 +71,11 @@ class Snackbar extends Component {
      */
     message: PropTypes.node.isRequired,
     /**
-     * Fired when the action button is touchtapped.
+     * Fired when the action button is clicked.
      *
      * @param {object} event Action button event.
      */
-    onActionTouchTap: PropTypes.func,
+    onActionClick: PropTypes.func,
     /**
      * Fired when the `Snackbar` is requested to be closed by a click outside the `Snackbar`, or after the
      * `autoHideDuration` timer expires.
@@ -204,7 +204,7 @@ class Snackbar extends Component {
       bodyStyle,
       message: messageProp, // eslint-disable-line no-unused-vars
       onRequestClose, // eslint-disable-line no-unused-vars
-      onActionTouchTap,
+      onActionClick,
       style,
       ...other
     } = this.props;
@@ -226,7 +226,7 @@ class Snackbar extends Component {
             contentStyle={contentStyle}
             message={message}
             open={open}
-            onActionTouchTap={onActionTouchTap}
+            onActionClick={onActionClick}
             style={bodyStyle}
           />
         </div>

--- a/src/Snackbar/SnackbarBody.js
+++ b/src/Snackbar/SnackbarBody.js
@@ -70,7 +70,7 @@ export const SnackbarBody = (props, context) => {
     contentStyle,
     message,
     open, // eslint-disable-line no-unused-vars
-    onActionTouchTap,
+    onActionClick,
     style,
     ...other
   } = props;
@@ -82,7 +82,7 @@ export const SnackbarBody = (props, context) => {
     <FlatButton
       style={styles.action}
       label={action}
-      onClick={onActionTouchTap}
+      onClick={onActionClick}
     />
   );
 
@@ -114,11 +114,11 @@ SnackbarBody.propTypes = {
    */
   message: PropTypes.node.isRequired,
   /**
-   * Fired when the action button is touchtapped.
+   * Fired when the action button is clicked.
    *
    * @param {object} event Action button event.
    */
-  onActionTouchTap: PropTypes.func,
+  onActionClick: PropTypes.func,
   /**
    * @ignore
    * Controls whether the `Snackbar` is opened or not.

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -86,7 +86,7 @@ class Tab extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     if (this.props.onClick) {
       this.props.onClick(this.props.value, event, this);
     }
@@ -132,7 +132,7 @@ class Tab extends Component {
         touchRippleColor={rippleColor}
         focusRippleOpacity={rippleOpacity}
         touchRippleOpacity={rippleOpacity}
-        onClick={this.handleTouchTap}
+        onClick={this.handleClick}
       >
         <div style={Object.assign(styles.button, buttonStyle)} >
           {iconElement}

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -146,7 +146,7 @@ class Tabs extends Component {
     return selectedIndex;
   }
 
-  handleTabTouchTap = (value, event, tab) => {
+  handleTabClick = (value, event, tab) => {
     const valueLink = this.getValueLink(this.props);
     const index = tab.props.index;
 
@@ -211,7 +211,7 @@ class Tabs extends Component {
         index: index,
         selected: this.getSelected(tab, index),
         width: `${width}%`,
-        onClick: this.handleTabTouchTap,
+        onClick: this.handleTabClick,
       });
     });
 

--- a/src/TextField/TextFieldLabel.js
+++ b/src/TextField/TextFieldLabel.js
@@ -72,9 +72,9 @@ TextFieldLabel.propTypes = {
    */
   muiTheme: PropTypes.object.isRequired,
   /**
-   * Callback function for when the label is selected via a touch tap.
+   * Callback function for when the label is selected via a click.
    *
-   * @param {object} event TouchTap event targeting the text field label.
+   * @param {object} event Click event targeting the text field label.
    */
   onClick: PropTypes.func,
   /**

--- a/src/TimePicker/TimePicker.js
+++ b/src/TimePicker/TimePicker.js
@@ -156,7 +156,7 @@ class TimePicker extends Component {
     }
   };
 
-  handleTouchTapInput = (event) => {
+  handleClickInput = (event) => {
     event.preventDefault();
 
     if (!this.props.disabled) {
@@ -211,7 +211,7 @@ class TimePicker extends Component {
           ref="input"
           value={time === emptyTime ? null : formatTime(time, format, pedantic)}
           onFocus={this.handleFocusInput}
-          onClick={this.handleTouchTapInput}
+          onClick={this.handleClickInput}
         />
         <TimePickerDialog
           ref="dialogWindow"

--- a/src/TimePicker/TimePickerDialog.js
+++ b/src/TimePicker/TimePickerDialog.js
@@ -52,11 +52,11 @@ class TimePickerDialog extends Component {
     this.dismiss();
   };
 
-  handleTouchTapCancel = () => {
+  handleClickCancel = () => {
     this.dismiss();
   };
 
-  handleTouchTapOK = () => {
+  handleClickOK = () => {
     if (this.props.onAccept) {
       this.props.onAccept(this.refs.clock.getSelectedTime());
     }
@@ -68,7 +68,7 @@ class TimePickerDialog extends Component {
   handleKeyUp = (event) => {
     switch (keycode(event)) {
       case 'enter':
-        this.handleTouchTapOK();
+        this.handleClickOK();
         break;
     }
   };
@@ -105,17 +105,17 @@ class TimePickerDialog extends Component {
         key={0}
         label={cancelLabel}
         primary={true}
-        onClick={this.handleTouchTapCancel}
+        onClick={this.handleClickCancel}
       />,
       <FlatButton
         key={1}
         label={okLabel}
         primary={true}
-        onClick={this.handleTouchTapOK}
+        onClick={this.handleClickOK}
       />,
     ];
 
-    const onClockChangeMinutes = autoOk === true ? this.handleTouchTapOK : undefined;
+    const onClockChangeMinutes = autoOk === true ? this.handleClickOK : undefined;
     const open = this.state.open;
 
     return (

--- a/src/TimePicker/TimePickerDialog.spec.js
+++ b/src/TimePicker/TimePickerDialog.spec.js
@@ -22,7 +22,7 @@ describe('<TimePickerDialog />', () => {
       />
     );
     wrapper.instance().refs = {clock: {getSelectedTime: stub().returns(Date.now())}};
-    wrapper.instance().handleTouchTapOK();
+    wrapper.instance().handleClickOK();
     expect(onDismissCallback).to.have.property('callCount', 0);
     expect(onAcceptCallback).to.have.property('callCount', 1);
     expect(wrapper.state('open')).to.equal(false);

--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -191,7 +191,7 @@ class EnhancedButton extends Component {
   handleKeyDown = (event) => {
     if (!this.props.disabled && !this.props.disableKeyboardFocus) {
       if (keycode(event) === 'enter' && this.state.isKeyboardFocused) {
-        this.handleTouchTap(event);
+        this.handleClick(event);
       }
       if (keycode(event) === 'esc' && this.state.isKeyboardFocused) {
         this.removeKeyboardFocus(event);
@@ -203,7 +203,7 @@ class EnhancedButton extends Component {
   handleKeyUp = (event) => {
     if (!this.props.disabled && !this.props.disableKeyboardFocus) {
       if (keycode(event) === 'space' && this.state.isKeyboardFocused) {
-        this.handleTouchTap(event);
+        this.handleClick(event);
       }
     }
     this.props.onKeyUp(event);
@@ -232,7 +232,7 @@ class EnhancedButton extends Component {
     }
   };
 
-  handleTouchTap = (event) => {
+  handleClick = (event) => {
     this.cancelFocusTimeout();
     if (!this.props.disabled) {
       tabPressed = false;
@@ -316,7 +316,7 @@ class EnhancedButton extends Component {
       onFocus: this.handleFocus,
       onKeyUp: this.handleKeyUp,
       onKeyDown: this.handleKeyDown,
-      onClick: this.handleTouchTap,
+      onClick: this.handleClick,
       tabIndex: disabled || disableKeyboardFocus ? -1 : tabIndex,
     };
 


### PR DESCRIPTION
### This resolves #9052.

We had _most_ of our library covered with regards to using replacing `onTouchTap` with `onClick`, However, we neglected to get the names changed that resemble `onActionTouchTap`.

- Also cleans up several internal component functions that had a funny signature like this:

```
  onClick={onHandleTouchTap}
```

This also updates the docs in all spots necessary
- Props
- Variable names
- PropTypes descriptions

## To Test

Run this locally and double-check that site is usable in the same way as [the real site](http://www.material-ui.com/#/) is usable. 🤓 

**N.B. This will introduce breaking changes.** 😆 