### PR TITLE
[core] Revise theme contrastText approach, remove contrastDefaultColor

### DIFF
--- a/docs/src/pages/style/Color.js
+++ b/docs/src/pages/style/Color.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import * as colors from 'material-ui/colors';
-import { getContrastRatio } from 'material-ui/styles/colorManipulator';
 
 const mainColors = [
   'Red',
@@ -62,13 +61,9 @@ export const styles = theme => ({
   },
 });
 
-function getColorBlock(classes, colorName, colorValue, colorTitle) {
+function getColorBlock(classes, theme, colorName, colorValue, colorTitle) {
   const bgColor = colors[colorName][colorValue];
-
-  let fgColor = colors.common.fullBlack;
-  if (getContrastRatio(bgColor, fgColor) < 7) {
-    fgColor = colors.common.fullWhite;
-  }
+  const fgColor = theme.palette.getContrastText(bgColor);
 
   let blockTitle;
   if (colorTitle) {
@@ -101,20 +96,20 @@ function getColorBlock(classes, colorName, colorValue, colorTitle) {
 }
 
 function getColorGroup(options) {
-  const { classes, color, showAltPalette } = options;
+  const { classes, theme, color, showAltPalette } = options;
   const cssColor = color.replace(' ', '').replace(color.charAt(0), color.charAt(0).toLowerCase());
   let colorsList = [];
-  colorsList = mainPalette.map(mainValue => getColorBlock(classes, cssColor, mainValue));
+  colorsList = mainPalette.map(mainValue => getColorBlock(classes, theme, cssColor, mainValue));
 
   if (showAltPalette) {
     altPalette.forEach(altValue => {
-      colorsList.push(getColorBlock(classes, cssColor, altValue));
+      colorsList.push(getColorBlock(classes, theme, cssColor, altValue));
     });
   }
 
   return (
     <ul className={classes.colorGroup} key={cssColor}>
-      {getColorBlock(classes, cssColor, 500, true)}
+      {getColorBlock(classes, theme, cssColor, 500, true)}
       <div className={classes.blockSpace} />
       {colorsList}
     </ul>
@@ -122,13 +117,14 @@ function getColorGroup(options) {
 }
 
 function Color(props) {
-  const { classes } = props;
+  const { classes, theme } = props;
 
   return (
     <div className={classes.root}>
       {mainColors.map(mainColor =>
         getColorGroup({
           classes,
+          theme,
           color: mainColor,
           showAltPalette: true,
         }),
@@ -136,6 +132,7 @@ function Color(props) {
       {neutralColors.map(neutralColor =>
         getColorGroup({
           classes,
+          theme,
           color: neutralColor,
           showAltPalette: false,
         }),
@@ -146,6 +143,7 @@ function Color(props) {
 
 Color.propTypes = {
   classes: PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(Color);
+export default withStyles(styles, { withTheme: true })(Color);

--- a/src/Reboot/Reboot.js
+++ b/src/Reboot/Reboot.js
@@ -16,9 +16,10 @@ const styles = theme => ({
       boxSizing: 'inherit',
     },
     body: {
-      margin: 0, // Remove the margin in all browsers
+      margin: 0, // Remove the margin in all browsers.
       backgroundColor: theme.palette.background.default,
       '@media print': {
+        // Save printer ink.
         backgroundColor: theme.palette.common.white,
       },
     },

--- a/src/colors/blue.js
+++ b/src/colors/blue.js
@@ -13,7 +13,6 @@ const blue = {
   A200: '#448aff',
   A400: '#2979ff',
   A700: '#2962ff',
-  contrastDefaultColor: 'light',
 };
 
 export default blue;

--- a/src/styles/colorManipulator.js
+++ b/src/styles/colorManipulator.js
@@ -102,25 +102,23 @@ export function decomposeColor(color: string) {
 /**
  * Calculates the contrast ratio between two colors.
  *
- * Formula: http://www.w3.org/TR/2008/REC-WCAG20-20081211/#contrast-ratiodef
+ * Formula: https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
  *
  * @param {string} foreground - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
  * @param {string} background - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
- * @returns {number} A contrast ratio value in the range 0 - 21 with 2 digit precision.
+ * @returns {number} A contrast ratio value in the range 0 - 21.
  */
 export function getContrastRatio(foreground: string, background: string) {
   const lumA = getLuminance(foreground);
   const lumB = getLuminance(background);
-  const contrastRatio = (Math.max(lumA, lumB) + 0.05) / (Math.min(lumA, lumB) + 0.05);
-
-  return Number(contrastRatio.toFixed(2)); // Truncate at two digits
+  return (Math.max(lumA, lumB) + 0.05) / (Math.min(lumA, lumB) + 0.05);
 }
 
 /**
  * The relative brightness of any point in a color space,
  * normalized to 0 for darkest black and 1 for lightest white.
  *
- * Formula: https://www.w3.org/WAI/GL/wiki/Relative_luminance
+ * Formula: https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-tests
  *
  * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
  * @returns {number} The relative brightness of the color in the range 0 - 1

--- a/src/styles/colorManipulator.spec.js
+++ b/src/styles/colorManipulator.spec.js
@@ -91,33 +91,33 @@ describe('utils/colorManipulator', () => {
   });
 
   describe('getContrastRatio', () => {
-    it('returns a ratio of 21 for black : white', () => {
+    it('returns a ratio black : white', () => {
       assert.strictEqual(getContrastRatio('#000', '#FFF'), 21);
     });
 
-    it('returns a ratio of 1 for black : black', () => {
+    it('returns a ratio black : black', () => {
       assert.strictEqual(getContrastRatio('#000', '#000'), 1);
     });
 
-    it('returns a ratio of 1 for white : white', () => {
+    it('returns a ratio white : white', () => {
       assert.strictEqual(getContrastRatio('#FFF', '#FFF'), 1);
     });
 
-    it('returns a ratio of 3.92 for dark-grey : light-grey', () => {
-      assert.strictEqual(getContrastRatio('#707070', '#E5E5E5'), 3.93);
+    it('returns a ratio for dark-grey : light-grey', () => {
+      assert.approximately(getContrastRatio('#707070', '#E5E5E5'), 3.93, 0.01);
     });
 
-    it('returns a ratio of 3.93 for black : light-grey', () => {
-      assert.strictEqual(getContrastRatio('#000', '#888'), 5.92);
+    it('returns a ratio for black : light-grey', () => {
+      assert.approximately(getContrastRatio('#000', '#888'), 5.92, 0.01);
     });
   });
 
   describe('getLuminance', () => {
-    it('returns a luminance of 1 for rgb white', () => {
+    it('returns a valid luminance for rgb white', () => {
       assert.strictEqual(getLuminance('rgb(0, 0, 0)'), 0);
     });
 
-    it('returns a luminance of 1 for rgb white', () => {
+    it('returns a valid luminance for rgb white', () => {
       assert.strictEqual(getLuminance('rgb(255, 255, 255)'), 1);
     });
 
@@ -129,7 +129,7 @@ describe('utils/colorManipulator', () => {
       assert.strictEqual(getLuminance('rgb(255, 127, 0)'), 0.364);
     });
 
-    it('returns a normalized luminance from an hsl color', () => {
+    it('returns a valid luminance from an hsl color', () => {
       assert.strictEqual(getLuminance('hsl(100, 100%, 50%)'), 0.5);
     });
 

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -7,7 +7,7 @@ import pink from '../colors/pink';
 import grey from '../colors/grey';
 import red from '../colors/red';
 import common from '../colors/common';
-import { getContrastRatio } from './colorManipulator';
+import { getLuminance, getContrastRatio } from './colorManipulator';
 
 export const light = {
   text: {
@@ -76,11 +76,21 @@ export const dark = {
   },
 };
 
-function getContrastText(hue) {
-  if (getContrastRatio(hue, common.black) < 7) {
-    return dark.text.primary;
+function getContrastText(color) {
+  const contrastColor = getLuminance(color) <= 0.295 ? dark.text.primary : light.text.primary;
+  const contrastRatio = getContrastRatio(color, contrastColor);
+
+  if (process.env.NODE_ENV !== 'production') {
+    warning(
+      contrastRatio > 3,
+      [
+        `Material-UI: the contrast ratio of ${contrastRatio}:1 for ${contrastColor} on ${color}`,
+        'falls below the WACG recommended absolute minimum contrast ratio of 3:1.',
+        'https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast',
+      ].join('\n'),
+    );
   }
-  return light.text.primary;
+  return contrastColor;
 }
 
 export default function createPalette(palette: Object) {
@@ -103,6 +113,7 @@ export default function createPalette(palette: Object) {
       action: shades[type].action,
       background: shades[type].background,
       line: shades[type].line,
+      contrastThreshold: 0.295,
       getContrastText,
     },
     other,


### PR DESCRIPTION
- Remove `contrastDefaultColor` completely
- Parametrize `getContrastText()` with a `contrastThreshold` option
- Stick closer to the Material specification and material-components-web implementation

Help with #8183.