### PR TITLE
Better typescript and withstyles decorate

### DIFF
--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -32,7 +32,9 @@ export interface StyledComponentProps<ClassKey extends string = string> {
 
 export default function withStyles<ClassKey extends string>(
   style: StyleRules<ClassKey> | StyleRulesCallback<ClassKey>,
-  options?: WithStylesOptions
-): <P>(
-  component: React.ComponentType<P & WithStyles<ClassKey>>
-) => React.ComponentType<P & StyledComponentProps<ClassKey>>;
+  options?: WithStylesOptions,
+): (<P>(
+  component: React.ComponentType<P & WithStyles<ClassKey>>,
+) => React.ComponentType<P & StyledComponentProps<ClassKey>>) & {
+  PossibleClassesType: { [k in ClassKey]: Record<k, string> };
+};


### PR DESCRIPTION
With this typings change you can do:
```ts
const decorate = withStyles(({ palette, spacing }) => ({
  root: {
    padding: spacing.unit,
    background: palette.background,
    color: palette.primary,
  },
  foo: {
    padding: spacing.unit,
    background: palette.background,
    color: palette.primary,
  }
}));

const DecoratedClass = decorate(
  class extends React.Component<Props & {classes: typeof decorate.PossibleClassesType}> {
    render() {
      const { text, type, color, classes } = this.props
      return (
        <Typography type={type} color={color} classes={classes}>
          {text}
         <span className={classes.foo}></span>
        </Typography>
      )
    }
  }
);
```

