### PR TITLE
RenderToLayer: removed touchstart events, to prevent double call for …

### DIFF
--- a/src/internal/RenderToLayer.js
+++ b/src/internal/RenderToLayer.js
@@ -64,10 +64,8 @@ class RenderToLayer extends Component {
 
     if (this.props.useLayerForClickAway) {
       this.layer.style.position = 'relative';
-      this.layer.removeEventListener('touchstart', this.onClickAway);
       this.layer.removeEventListener('click', this.onClickAway);
     } else {
-      window.removeEventListener('touchstart', this.onClickAway);
       window.removeEventListener('click', this.onClickAway);
     }
 
@@ -94,7 +92,6 @@ class RenderToLayer extends Component {
         document.body.appendChild(this.layer);
 
         if (this.props.useLayerForClickAway) {
-          this.layer.addEventListener('touchstart', this.onClickAway);
           this.layer.addEventListener('click', this.onClickAway);
           this.layer.style.position = 'fixed';
           this.layer.style.top = 0;
@@ -104,7 +101,6 @@ class RenderToLayer extends Component {
           this.layer.style.zIndex = this.context.muiTheme.zIndex.layer;
         } else {
           setTimeout(() => {
-            window.addEventListener('touchstart', this.onClickAway);
             window.addEventListener('click', this.onClickAway);
           }, 0);
         }


### PR DESCRIPTION
onRequestClose callback listens for two events, touchstart and click.
On touch device both events actually fired, so the callback called twice, which brings errors in application, so its better to remove it rather handle double call in the application