### PR TITLE
Continuation of Flow updates 0.57+

### DIFF
--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -4,7 +4,7 @@
 import { mkdir, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import kebabCase from 'lodash/kebabCase';
-import * as reactDocgen from 'react-docgen';
+import * as reactDocgen from '@rosskevin/react-docgen';
 import generateMarkdown from '../src/modules/utils/generateMarkdown';
 import { findPagesMarkdown, findComponents } from '../src/modules/utils/find';
 import { getHeaders } from '../src/modules/utils/parseMarkdown';

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -171,10 +171,7 @@ function generateProps(reactAPI) {
       let defaultValue = '';
 
       if (prop.defaultValue) {
-        defaultValue = prop.defaultValue.value;
-        // remove any flow type casts
-        defaultValue = defaultValue.includes(':') ? defaultValue.split(':')[0] : defaultValue;
-        defaultValue = escapeCell(defaultValue.replace(/\n/g, ''));
+        defaultValue = escapeCell(prop.defaultValue.value.replace(/\n/g, ''));
       }
 
       if (prop.required) {

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -171,7 +171,10 @@ function generateProps(reactAPI) {
       let defaultValue = '';
 
       if (prop.defaultValue) {
-        defaultValue = escapeCell(prop.defaultValue.value.replace(/\n/g, ''));
+        defaultValue = prop.defaultValue.value;
+        // remove any flow type casts
+        defaultValue = defaultValue.includes(':') ? defaultValue.split(':')[0] : defaultValue;
+        defaultValue = escapeCell(defaultValue.replace(/\n/g, ''));
       }
 
       if (prop.required) {

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "raw-loader": "^0.5.1",
     "react": "^16.1.1",
     "react-autosuggest": "^9.3.2",
-    "react-docgen": "^3.0.0-beta9",
+    "@rosskevin/react-docgen": "^3.0.0-beta9",
     "react-dom": "^16.1.1",
     "react-number-format": "^3.0.2",
     "react-redux": "^5.0.6",

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -14,9 +14,8 @@ filename: /src/AppBar/AppBar.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">color *</span> | union:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'accent'&nbsp;&#124;<br>&nbsp;'default'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
-| <span style="color: #31a148">position *</span> | union:&nbsp;'static'&nbsp;&#124;<br>&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'<br> | 'fixed' | The positioning type. |
-| theme | Object |  |  |
+| color | union:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'accent'&nbsp;&#124;<br>&nbsp;'default'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
+| position | union:&nbsp;'static'&nbsp;&#124;<br>&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'<br> | 'fixed' | The positioning type. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -15,12 +15,11 @@ filename: /src/Avatar/Avatar.js
 | alt | string |  | Used in combination with `src` or `srcSet` to provide an alt attribute for the rendered `img` element. |
 | children | union:&nbsp;string&nbsp;&#124;<br>&nbsp;Element&lt;any><br> |  | Used to render icon or text elements inside the Avatar. `src` and `alt` props will not be used and no `img` will be rendered by default.<br>This can be an element, or just a string. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | imgProps | Object |  | Properties applied to the `img` element when the component is used to display an image. |
 | sizes | string |  | The `sizes` attribute for the `img` element. |
 | src | string |  | The `src` attribute for the `img` element. |
 | srcSet | string |  | The `srcSet` attribute for the `img` element. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -15,8 +15,7 @@ filename: /src/Badge/Badge.js
 | <span style="color: #31a148">badgeContent *</span> | Node |  | The content rendered within the badge. |
 | <span style="color: #31a148">children *</span> | Node |  | The badge will be added relative to this node. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">color *</span> | union:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'accent'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
-| theme | Object |  |  |
+| color | union:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'accent'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/bottom-navigation-button.md
+++ b/pages/api/bottom-navigation-button.md
@@ -16,7 +16,6 @@ filename: /src/BottomNavigation/BottomNavigationButton.js
 | icon | union:&nbsp;string&nbsp;&#124;<br>&nbsp;Element&lt;any><br> |  | The icon element. If a string is provided, it will be used as a font ligature. |
 | label | Node |  | The label element. |
 | showLabel | boolean |  | If `true`, the BottomNavigationButton will show its label. |
-| theme | Object |  |  |
 | value | any |  | You can provide your own value. Otherwise, we fallback to the child position index. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -13,10 +13,9 @@ filename: /src/BottomNavigation/BottomNavigation.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Node |  | The content of the component. |
-| classes | Object |  |  |
+| classes | Object |  | Useful to extend the style applied to components. |
 | onChange | Function |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: any) => void`<br>*event:* The event source of the callback<br>*value:* We default to the index of the child |
-| <span style="color: #31a148">showLabels *</span> | boolean | false | If `true`, all `BottomNavigationButton`s will show their labels. By default only the selected `BottomNavigationButton` will show its label. |
-| theme | Object |  |  |
+| showLabels | boolean | false | If `true`, all `BottomNavigationButton`s will show their labels. By default only the selected `BottomNavigationButton` will show its label. |
 | <span style="color: #31a148">value *</span> | any |  | The value of the currently selected `BottomNavigationButton`. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -12,17 +12,16 @@ filename: /src/ButtonBase/ButtonBase.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span style="color: #31a148">centerRipple *</span> | boolean | false | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
+| centerRipple | boolean | false | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
-| <span style="color: #31a148">disableRipple *</span> | boolean | false | If `true`, the ripple effect will be disabled. |
+| disableRipple | boolean | false | If `true`, the ripple effect will be disabled. |
 | disabled | boolean |  | If `true`, the base button will be disabled. |
-| <span style="color: #31a148">focusRipple *</span> | boolean | false | If `true`, the base button will have a keyboard focus ripple. `disableRipple` must also be `false`. |
+| focusRipple | boolean | false | If `true`, the base button will have a keyboard focus ripple. `disableRipple` must also be `false`. |
 | keyboardFocusedClassName | string |  | The CSS class applied while the component is keyboard focused. |
 | onKeyboardFocus | signature |  | Callback fired when the component is focused with a keyboard. We trigger a `onFocus` callback too. |
 | rootRef | Function |  | Use that property to pass a ref callback to the root component. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -14,16 +14,15 @@ filename: /src/Button/Button.js
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Node |  | The content of the button. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">color *</span> | union:&nbsp;'default', 'inherit', 'primary', 'accent', 'contrast'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
+| color | union:&nbsp;'default', 'inherit', 'primary', 'accent', 'contrast'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
 | component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
-| <span style="color: #31a148">dense *</span> | boolean | false | Uses a smaller minWidth, ideal for things like card actions. |
-| <span style="color: #31a148">disableFocusRipple *</span> | boolean | false | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
-| <span style="color: #31a148">disableRipple *</span> | boolean | false | If `true`, the ripple effect will be disabled. |
-| <span style="color: #31a148">disabled *</span> | boolean | false | If `true`, the button will be disabled. |
-| <span style="color: #31a148">fab *</span> | boolean | false | If `true`, will use floating action button styling. |
+| dense | boolean | false | Uses a smaller minWidth, ideal for things like card actions. |
+| disableFocusRipple | boolean | false | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
+| disableRipple | boolean | false | If `true`, the ripple effect will be disabled. |
+| disabled | boolean | false | If `true`, the button will be disabled. |
+| fab | boolean | false | If `true`, will use floating action button styling. |
 | href | string |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
-| <span style="color: #31a148">raised *</span> | boolean | false | If `true`, the button will use raised styling. |
-| theme | Object |  |  |
+| raised | boolean | false | If `true`, the button will use raised styling. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -14,8 +14,7 @@ filename: /src/Card/CardActions.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">disableActionSpacing *</span> | boolean | false | If `true`, the card actions do not have additional margin. |
-| theme | Object |  |  |
+| disableActionSpacing | boolean | false | If `true`, the card actions do not have additional margin. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -13,10 +13,9 @@ filename: /src/Card/CardMedia.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'div' | Component for rendering image. |
+| component | ElementType | 'div' | Component for rendering image. |
 | image | string |  | Image to be displayed as a background image. Either `image` or `src` prop must be specified. Note that caller must specify height otherwise the image will not be visible. |
 | src | string |  | An alias for `image` property. Available only with media components. Media components: `video`, `audio`, `picture`, `iframe`, `img`. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -18,13 +18,12 @@ filename: /src/Checkbox/Checkbox.js
 | disableRipple | boolean |  | If `true`, the ripple effect will be disabled. |
 | disabled | boolean |  | If `true`, the switch will be disabled. |
 | icon | Node |  | The icon to display when the component is unchecked. If a string is provided, it will be used as a font ligature. |
-| <span style="color: #31a148">indeterminate *</span> | boolean | false | If `true`, the component appears indeterminate. |
-| <span style="color: #31a148">indeterminateIcon *</span> | Node | &lt;IndeterminateCheckBoxIcon /> | The icon to display when the component is indeterminate. If a string is provided, it will be used as a font ligature. |
+| indeterminate | boolean | false | If `true`, the component appears indeterminate. |
+| indeterminateIcon | Node | &lt;IndeterminateCheckBoxIcon /> | The icon to display when the component is indeterminate. If a string is provided, it will be used as a font ligature. |
 | inputProps | Object |  | Properties applied to the `input` element. |
 | inputRef | Function |  | Use that property to pass a ref callback to the native input component. |
 | name | string |  |  |
 | onChange | Function |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback<br>*checked:* The `checked` value of the switch |
-| theme | Object |  |  |
 | value | string |  | The value of the component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -13,11 +13,10 @@ Chips represent complex entities in small blocks, such as a contact.
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | avatar | Element |  | Avatar element. |
-| classes | Object |  |  |
+| classes | Object |  | Useful to extend the style applied to components. |
 | deleteIcon | Element |  | Custom delete icon. Will be shown only if `onRequestDelete` is set. |
 | label | Node |  | The content of the label. |
 | onRequestDelete | signature |  | Callback function fired when the delete icon is clicked. If set, the delete icon will be shown. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -13,14 +13,13 @@ filename: /src/Progress/CircularProgress.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">color *</span> | union:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'accent'&nbsp;&#124;<br>&nbsp;'inherit'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
-| <span style="color: #31a148">max *</span> | number | 100 | The max value of progress in determinate mode. |
-| <span style="color: #31a148">min *</span> | number | 0 | The min value of progress in determinate mode. |
+| color | union:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'accent'&nbsp;&#124;<br>&nbsp;'inherit'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
+| max | number | 100 | The max value of progress in determinate mode. |
+| min | number | 0 | The min value of progress in determinate mode. |
 | mode | union:&nbsp;'determinate'&nbsp;&#124;<br>&nbsp;'indeterminate'<br> | 'indeterminate' | The mode of show your progress. Indeterminate for when there is no value for progress. Determinate for controlled progress value. |
 | size | number | 40 | The size of the circle. |
-| theme | Object |  |  |
 | thickness | number | 3.6 | The thickness of the circle. |
-| <span style="color: #31a148">value *</span> | number | 0 | The value of progress in determinate mode. |
+| value | number | 0 | The value of progress in determinate mode. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -14,11 +14,10 @@ filename: /src/transitions/Collapse.js
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Node |  | The content node to be collapsed. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">collapsedHeight *</span> | string | '0px' | The height of the container when collapsed. |
-| <span style="color: #31a148">component *</span> | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
+| collapsedHeight | string | '0px' | The height of the container when collapsed. |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, the component will transition in. |
-| <span style="color: #31a148">timeout *</span> | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;'auto'<br> | duration.standard | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
-| unmountOnExit | boolean |  | /* @ignore |
+| timeout | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;'auto'<br> | duration.standard | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -14,7 +14,6 @@ filename: /src/Dialog/DialogActions.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -14,7 +14,6 @@ filename: /src/Dialog/DialogContentText.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/dialog-title.md
+++ b/pages/api/dialog-title.md
@@ -14,8 +14,7 @@ filename: /src/Dialog/DialogTitle.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">disableTypography *</span> | boolean | false | If `true`, the children won't be wrapped by a typography component. For instance, that can be useful to can render an h4 instead of a |
-| theme | Object |  |  |
+| disableTypography | boolean | false | If `true`, the children won't be wrapped by a typography component. For instance, that can be useful to can render an h4 instead of a |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -29,9 +29,8 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | onExiting | TransitionCallback |  | Callback fired when the dialog is exiting. |
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the Dialog is open. |
-| theme | Object |  |  |
-| <span style="color: #31a148">transition *</span> | ComponentType | Fade | Transition component. |
-| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| transition | ComponentType | Fade | Transition component. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -30,7 +30,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the Dialog is open. |
 | transition | ComponentType | Fade | Transition component. |
-| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -16,7 +16,6 @@ filename: /src/Divider/Divider.js
 | classes | Object |  | Useful to extend the style applied to components. |
 | inset | boolean | false | If `true`, the divider will be indented. |
 | light | boolean | false | If `true`, the divider will have a lighter color. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -14,14 +14,14 @@ filename: /src/Drawer/Drawer.js
 |:-----|:-----|:--------|:------------|
 | ModalProps | Object |  | Properties applied to the `Modal` element. |
 | SlideProps | Object |  | Properties applied to the `Slide` element. |
-| <span style="color: #31a148">anchor *</span> | union:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'top'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'bottom'<br> | 'left' | Side from which the drawer will appear. |
+| anchor | union:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'top'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'bottom'<br> | 'left' | Side from which the drawer will appear. |
 | <span style="color: #31a148">children *</span> | Node |  | The contents of the drawer. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">elevation *</span> | number | 16 | The elevation of the drawer. |
+| elevation | number | 16 | The elevation of the drawer. |
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
-| <span style="color: #31a148">open *</span> | boolean | false | If `true`, the drawer is open. |
-| <span style="color: #31a148">transitionDuration *</span> | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
-| <span style="color: #31a148">type *</span> | union:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | 'temporary' | The type of drawer. |
+| open | boolean | false | If `true`, the drawer is open. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| type | union:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | 'temporary' | The type of drawer. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -20,7 +20,7 @@ filename: /src/Drawer/Drawer.js
 | elevation | number | 16 | The elevation of the drawer. |
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the drawer is open. |
-| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | type | union:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | 'temporary' | The type of drawer. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -20,7 +20,6 @@ filename: /src/Drawer/Drawer.js
 | elevation | number | 16 | The elevation of the drawer. |
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the drawer is open. |
-| <span style="color: #31a148">theme *</span> | Object |  |  |
 | transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | type | union:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | 'temporary' | The type of drawer. |
 

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -15,7 +15,7 @@ It's using [react-transition-group](https://github.com/reactjs/react-transition-
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Element |  | A single child content element. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, the component will transition in. |
-| <span style="color: #31a148">timeout *</span> | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| timeout | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -15,7 +15,7 @@ It's using [react-transition-group](https://github.com/reactjs/react-transition-
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Element |  | A single child content element. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, the component will transition in. |
-| timeout | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| timeout | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -21,7 +21,6 @@ Use this component if you want to display an extra label.
 | <span style="color: #31a148">label *</span> | Node |  | The text to be used in an enclosing label element. |
 | name | string |  |  |
 | onChange | Function |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback<br>*checked:* The `checked` value of the switch |
-| theme | Object |  |  |
 | value | string |  | The value of the component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -27,7 +27,6 @@ This context is used by the following components:
 | fullWidth | boolean | false | If `true`, the component, as well as its children, will take up the full width of its container. |
 | margin | union:&nbsp;'none'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'normal'<br> | 'none' | If `dense` or `normal`, will adjust vertical spacing of this and contained components. |
 | required | boolean | false | If `true`, the label will indicate that the input is required. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/form-group.md
+++ b/pages/api/form-group.md
@@ -17,7 +17,6 @@ For the `Radio`, you should be using the `RadioGroup` component instead of this 
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | row | boolean | false | Display group of elements in a compact row. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -17,7 +17,6 @@ filename: /src/Form/FormHelperText.js
 | disabled | boolean |  | If `true`, the helper text should be displayed in a disabled state. |
 | error | boolean |  | If `true`, helper text should be displayed in an error state. |
 | margin | literal |  | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -14,12 +14,11 @@ filename: /src/Form/FormLabel.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'label' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'label' | The component used for the root node. Either a string to use a DOM element or a component. |
 | disabled | boolean |  | If `true`, the label should be displayed in a disabled state. |
 | error | boolean |  | If `true`, the label should be displayed in an error state. |
 | focused | boolean |  | If `true`, the input of this label is focused (used by `FormGroup` components). |
 | required | boolean |  | If `true`, the label will indicate that the input is required. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -16,7 +16,6 @@ filename: /src/GridList/GridListTileBar.js
 | actionPosition | union:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'<br> | 'right' | Position of secondary action IconButton. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | subtitle | Node |  | String or element serving as subtitle (support text). |
-| theme | Object |  |  |
 | <span style="color: #31a148">title *</span> | Node |  | Title to be displayed on tile. |
 | titlePosition | union:&nbsp;'top'&nbsp;&#124;<br>&nbsp;'bottom'<br> | 'bottom' | Position of the title bar. |
 

--- a/pages/api/grid-list.md
+++ b/pages/api/grid-list.md
@@ -12,13 +12,12 @@ filename: /src/GridList/GridList.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span style="color: #31a148">cellHeight *</span> | union:&nbsp;number&nbsp;&#124;<br>&nbsp;'auto'<br> | 180 | Number of px for one cell height. You can set `'auto'` if you want to let the children determine the height. |
+| cellHeight | union:&nbsp;number&nbsp;&#124;<br>&nbsp;'auto'<br> | 180 | Number of px for one cell height. You can set `'auto'` if you want to let the children determine the height. |
 | <span style="color: #31a148">children *</span> | Node |  | Grid Tiles that will be in Grid List. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">cols *</span> | number | 2 | Number of columns. |
-| <span style="color: #31a148">component *</span> | ElementType | 'ul' | The component used for the root node. Either a string to use a DOM element or a component. By default we map the type to a good default headline component. |
-| <span style="color: #31a148">spacing *</span> | number | 4 | Number of px for the spacing between tiles. |
-| theme | Object |  |  |
+| cols | number | 2 | Number of columns. |
+| component | ElementType | 'ul' | The component used for the root node. Either a string to use a DOM element or a component. By default we map the type to a good default headline component. |
+| spacing | number | 4 | Number of px for the spacing between tiles. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -13,21 +13,20 @@ filename: /src/Grid/Grid.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | alignContent | union:&nbsp;, 'stretch', 'center', 'flex-start', 'flex-end', 'space-between', 'space-around'<br> | 'stretch' | Defines the `align-content` style property. It's applied for all screen sizes. |
-| <span style="color: #31a148">alignItems *</span> | union:&nbsp;'flex-start', 'center', 'flex-end', 'stretch', 'baseline'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
+| alignItems | union:&nbsp;'flex-start', 'center', 'flex-end', 'stretch', 'baseline'<br> | 'stretch' | Defines the `align-items` style property. It's applied for all screen sizes. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span style="color: #31a148">container *</span> | boolean | false | If `true`, the component will have the flex *container* behavior. You should be wrapping *items* with a *container*. |
-| <span style="color: #31a148">direction *</span> | union:&nbsp;'row'&nbsp;&#124;<br>&nbsp;'row-reverse'&nbsp;&#124;<br>&nbsp;'column'&nbsp;&#124;<br>&nbsp;'column-reverse'<br> | 'row' | Defines the `flex-direction` style property. It is applied for all screen sizes. |
-| hidden | [HiddenProps](/layout/hidden) | undefined | If provided, will wrap with [Hidden](/api/hidden) component and given properties. |
-| <span style="color: #31a148">item *</span> | boolean | false | If `true`, the component will have the flex *item* behavior. You should be wrapping *items* with a *container*. |
-| <span style="color: #31a148">justify *</span> | union:&nbsp;'flex-start', 'center', 'flex-end', 'space-between', 'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It is applied for all screen sizes. |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
+| container | boolean | false | If `true`, the component will have the flex *container* behavior. You should be wrapping *items* with a *container*. |
+| direction | union:&nbsp;'row'&nbsp;&#124;<br>&nbsp;'row-reverse'&nbsp;&#124;<br>&nbsp;'column'&nbsp;&#124;<br>&nbsp;'column-reverse'<br> | 'row' | Defines the `flex-direction` style property. It is applied for all screen sizes. |
+| hidden | [HiddenProps](/layout/hidden) |  | If provided, will wrap with [Hidden](/api/hidden) component and given properties. |
+| item | boolean | false | If `true`, the component will have the flex *item* behavior. You should be wrapping *items* with a *container*. |
+| justify | union:&nbsp;'flex-start', 'center', 'flex-end', 'space-between', 'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It is applied for all screen sizes. |
 | lg | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for the `lg` breakpoint and wider screens if not overridden. |
 | md | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for the `md` breakpoint and wider screens if not overridden. |
 | sm | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for the `sm` breakpoint and wider screens if not overridden. |
-| <span style="color: #31a148">spacing *</span> | union:&nbsp;0, 8, 16, 24, 40<br> | 16 | Defines the space between the type `item` component. It can only be used on a type `container` component. |
-| theme | Object |  |  |
-| <span style="color: #31a148">wrap *</span> | union:&nbsp;'nowrap'&nbsp;&#124;<br>&nbsp;'wrap'&nbsp;&#124;<br>&nbsp;'wrap-reverse'<br> | 'wrap' | Defines the `flex-wrap` style property. It's applied for all screen sizes. |
+| spacing | union:&nbsp;0, 8, 16, 24, 40<br> | 16 | Defines the space between the type `item` component. It can only be used on a type `container` component. |
+| wrap | union:&nbsp;'nowrap'&nbsp;&#124;<br>&nbsp;'wrap'&nbsp;&#124;<br>&nbsp;'wrap-reverse'<br> | 'wrap' | Defines the `flex-wrap` style property. It's applied for all screen sizes. |
 | xl | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for the `xl` breakpoint and wider screens. |
 | xs | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for all the screen sizes with the lowest priority. |
 

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -19,7 +19,7 @@ filename: /src/Grid/Grid.js
 | component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | container | boolean | false | If `true`, the component will have the flex *container* behavior. You should be wrapping *items* with a *container*. |
 | direction | union:&nbsp;'row'&nbsp;&#124;<br>&nbsp;'row-reverse'&nbsp;&#124;<br>&nbsp;'column'&nbsp;&#124;<br>&nbsp;'column-reverse'<br> | 'row' | Defines the `flex-direction` style property. It is applied for all screen sizes. |
-| hidden | [HiddenProps](/layout/hidden) | undefined | If provided, will wrap with [Hidden](/api/hidden) component and given properties. |
+| hidden | [HiddenProps](/layout/hidden) |  | If provided, will wrap with [Hidden](/api/hidden) component and given properties. |
 | item | boolean | false | If `true`, the component will have the flex *item* behavior. You should be wrapping *items* with a *container*. |
 | justify | union:&nbsp;'flex-start', 'center', 'flex-end', 'space-between', 'space-around'<br> | 'flex-start' | Defines the `justify-content` style property. It is applied for all screen sizes. |
 | lg | union:&nbsp;boolean, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> |  | Defines the number of grids the component is going to use. It's applied for the `lg` breakpoint and wider screens if not overridden. |

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -16,7 +16,7 @@ It's using [react-transition-group](https://github.com/reactjs/react-transition-
 | <span style="color: #31a148">children *</span> | Element |  | A single child content element. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, show the component; triggers the enter or exit animation. |
 | rootRef | Function |  | Use that property to pass a ref callback to the root component. |
-| <span style="color: #31a148">timeout *</span> | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;'auto'<br> | 'auto' | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
+| timeout | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;'auto'<br> | 'auto' | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 | transitionClasses | TransitionClasses | {} | The animation classNames applied to the component as it enters or exits. This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames). |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -16,11 +16,10 @@ regarding the available icon options.
 | buttonRef | Function |  | Use that property to pass a ref callback to the native button component. |
 | children | Node |  | The icon element. If a string is provided, it will be used as an icon font ligature. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">color *</span> | union:&nbsp;'default', 'inherit', 'primary', 'contrast', 'accent'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
-| <span style="color: #31a148">disableRipple *</span> | boolean | false | If `true`, the ripple will be disabled. |
-| <span style="color: #31a148">disabled *</span> | boolean | false | If `true`, the button will be disabled. |
+| color | union:&nbsp;'default', 'inherit', 'primary', 'contrast', 'accent'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
+| disableRipple | boolean | false | If `true`, the ripple will be disabled. |
+| disabled | boolean | false | If `true`, the button will be disabled. |
 | rootRef | Function |  | Use that property to pass a ref callback to the root component. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -13,9 +13,8 @@ filename: /src/Icon/Icon.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The name of the icon font ligature. |
-| classes | Object |  |  |
-| <span style="color: #31a148">color *</span> | union:&nbsp;'inherit', 'accent', 'action', 'contrast', 'disabled', 'error', 'primary'<br> | 'inherit' | The color of the component. It's using the theme palette when that makes sense. |
-| theme | Object |  |  |
+| classes | Object |  | Useful to extend the style applied to components. |
+| color | union:&nbsp;'inherit', 'accent', 'action', 'contrast', 'disabled', 'error', 'primary'<br> | 'inherit' | The color of the component. It's using the theme palette when that makes sense. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/input-adornment.md
+++ b/pages/api/input-adornment.md
@@ -14,10 +14,9 @@ filename: /src/Input/InputAdornment.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component, normally an `IconButton` or string. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | disableTypography | boolean | false | If children is a string then disable wrapping in a Typography component. |
 | <span style="color: #31a148">position *</span> | union:&nbsp;'start'&nbsp;&#124;<br>&nbsp;'end'<br> |  | The position this adornment should appear relative to the `Input`. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -22,7 +22,6 @@ filename: /src/Input/InputLabel.js
 | margin | literal |  | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
 | required | boolean |  | if `true`, the label will indicate that the input is required. |
 | shrink | boolean |  | If `true`, the label is shrunk. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -36,7 +36,6 @@ filename: /src/Input/Input.js
 | rows | union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | Number of rows to display when multiline option is set to true. |
 | rowsMax | union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | Maximum number of rows to display when multiline option is set to true. |
 | startAdornment | Node |  | Start `InputAdornment` for this component. |
-| theme | Object |  |  |
 | type | string | 'text' | Type of the input element. It should be a valid HTML5 input type. |
 | value | union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;Array&lt;string&nbsp;&#124;<br>&nbsp;number><br> |  | The input value, required for a controlled component. |
 

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -15,7 +15,6 @@ filename: /src/Progress/LinearProgress.js
 | classes | Object |  | Useful to extend the style applied to components. |
 | color | union:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'accent'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
 | mode | union:&nbsp;'determinate'&nbsp;&#124;<br>&nbsp;'indeterminate'&nbsp;&#124;<br>&nbsp;'buffer'&nbsp;&#124;<br>&nbsp;'query'<br> | 'indeterminate' | The mode of show your progress, indeterminate for when there is no value for progress. |
-| theme | Object |  |  |
 | value | number |  | The value of progress, only works in determinate and buffer mode. Value between 0 and 100. |
 | valueBuffer | number |  | The value of buffer, only works in buffer mode. Value between 0 and 100. |
 

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -14,7 +14,6 @@ It's a simple wrapper to apply the `dense` mode styles to `Avatar`.
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Element |  | The content of the component, normally `Avatar`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -14,7 +14,6 @@ A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Element |  | The content of the component, normally `Icon`, `SvgIcon`, or a `material-ui-icons` SVG icon component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -13,11 +13,10 @@ filename: /src/List/ListItemText.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">disableTypography *</span> | boolean | false | If `true`, the children won't be wrapped by a typography component. For instance, that can be useful to can render an h4 instead of a |
-| <span style="color: #31a148">inset *</span> | boolean | false | If `true`, the children will be indented. This should be used if there is no left avatar or left icon. |
-| <span style="color: #31a148">primary *</span> | Node | false |  |
-| <span style="color: #31a148">secondary *</span> | Node | false |  |
-| theme | Object |  |  |
+| disableTypography | boolean | false | If `true`, the children won't be wrapped by a typography component. For instance, that can be useful to can render an h4 instead of a |
+| inset | boolean | false | If `true`, the children will be indented. This should be used if there is no left avatar or left icon. |
+| primary | Node | false |  |
+| secondary | Node | false |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -15,11 +15,10 @@ filename: /src/List/ListItem.js
 | button | boolean | false | If `true`, the ListItem will be a button. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'li' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'li' | The component used for the root node. Either a string to use a DOM element or a component. |
 | dense | boolean | false | If `true`, compact vertical padding designed for keyboard and mouse input will be used. |
 | disableGutters | boolean | false | If `true`, the left and right padding is removed. |
 | divider | boolean | false | If `true`, a 1px light border is added to the bottom of the list item. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -15,10 +15,9 @@ filename: /src/List/ListSubheader.js
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | color | union:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'inherit'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
-| <span style="color: #31a148">component *</span> | ElementType | 'li' | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
+| component | ElementType | 'li' | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
 | disableSticky | boolean | false | If `true`, the List Subheader will not stick to the top during scroll. |
 | inset | boolean | false | If `true`, the List Subheader will be indented. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -14,12 +14,11 @@ filename: /src/List/List.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'ul' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | 'ul' | The component used for the root node. Either a string to use a DOM element or a component. |
 | dense | boolean | false | If `true`, compact vertical padding designed for keyboard and mouse input will be used for the list and list items. The property is available to descendant components as the `dense` context. |
 | disablePadding | boolean | false | If `true`, vertical padding will be removed from the list. |
 | rootRef | Function |  | Use that property to pass a ref callback to the root component. |
 | subheader | Node |  | The content of the component, normally `ListItem`. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -16,7 +16,6 @@ filename: /src/Menu/MenuItem.js
 | classes | Object |  | Useful to extend the style applied to components. |
 | component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. |
 | selected | boolean | false | Use to apply selected styling. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/mobile-stepper.md
+++ b/pages/api/mobile-stepper.md
@@ -18,7 +18,6 @@ filename: /src/MobileStepper/MobileStepper.js
 | <span style="color: #31a148">nextButton *</span> | Element |  | A next button element. For instance, it can be be a `Button` or a `IconButton`. |
 | position | union:&nbsp;'bottom'&nbsp;&#124;<br>&nbsp;'top'&nbsp;&#124;<br>&nbsp;'static'<br> | 'bottom' | Set the positioning type. |
 | <span style="color: #31a148">steps *</span> | number |  | The total steps. |
-| theme | Object |  |  |
 | type | union:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'dots'&nbsp;&#124;<br>&nbsp;'progress'<br> | 'dots' | The type of mobile stepper to use. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -25,7 +25,7 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | BackdropClassName | string |  | The CSS class name of the backdrop element. |
-| <span style="color: #31a148">BackdropComponent *</span> | ElementType | Backdrop | Pass a component class to use as the backdrop. |
+| BackdropComponent | ElementType | Backdrop | Pass a component class to use as the backdrop. |
 | BackdropInvisible | boolean | false | If `true`, the backdrop is invisible. |
 | BackdropTransitionDuration | TransitionDuration | 300 | The duration for the backdrop transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | children | Element |  | A single child content element. |
@@ -44,7 +44,6 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 | onExiting | TransitionCallback |  | Callback fired when the modal is exiting. |
 | onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span style="color: #31a148">show *</span> | boolean |  | If `true`, the Modal is visible. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -13,10 +13,9 @@ filename: /src/Paper/Paper.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span style="color: #31a148">elevation *</span> | number | 2 | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |
-| <span style="color: #31a148">square *</span> | boolean | false | If `true`, rounded corners are disabled. |
-| theme | Object |  |  |
+| component | ElementType | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
+| elevation | number | 2 | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |
+| square | boolean | false | If `true`, rounded corners are disabled. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -14,7 +14,7 @@ filename: /src/Radio/Radio.js
 |:-----|:-----|:--------|:------------|
 | checked | union:&nbsp;boolean&nbsp;&#124;<br>&nbsp;string<br> |  | If `true`, the component is checked. |
 | checkedIcon | Node |  | The icon to display when the component is checked. If a string is provided, it will be used as a font ligature. |
-| children | Node |  | Useful to extend the style applied to components. |
+| classes | Object |  | Useful to extend the style applied to components. |
 | disableRipple | boolean |  | If `true`, the ripple effect will be disabled. |
 | disabled | boolean |  | If `true`, the switch will be disabled. |
 | icon | Node |  | The icon to display when the component is unchecked. If a string is provided, it will be used as a font ligature. |
@@ -22,7 +22,6 @@ filename: /src/Radio/Radio.js
 | inputRef | Function |  | Use that property to pass a ref callback to the native input component. |
 | name | string |  |  |
 | onChange | Function |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback<br>*checked:* The `checked` value of the switch |
-| theme | Object |  |  |
 | value | string |  | The value of the component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -17,11 +17,10 @@ filename: /src/Select/Select.js
 | <span style="color: #31a148">children *</span> | $ReadOnlyArray |  | The option elements to populate the select with. Can be some `MenuItem` when `native` is false and `option` when `native` is true. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | displayEmpty | boolean | false | If `true`, the selected item is displayed even if its value is empty. You can only use it when the `native` property is `false` (default). |
-| <span style="color: #31a148">input *</span> | Element | &lt;Input /> | An `Input` element; does not have to be a material-ui specific `Input`. |
+| input | Element | &lt;Input /> | An `Input` element; does not have to be a material-ui specific `Input`. |
 | multiple | boolean | false | If true, `value` must be an array and the menu will support multiple selections. You can only use it when the `native` property is `false` (default). |
 | native | boolean | false | If `true`, the component will be using a native `select` element. |
 | renderValue | Function |  | Render the selected value. You can only use it when the `native` property is `false` (default). |
-| theme | Object |  |  |
 | value | union:&nbsp;$ReadOnlyArray&lt;string&nbsp;&#124;<br>&nbsp;number>&nbsp;&#124;<br>&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | The input value, required for a controlled component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -15,7 +15,7 @@ filename: /src/transitions/Slide.js
 | <span style="color: #31a148">children *</span> | Element |  | A single child content element. |
 | <span style="color: #31a148">direction *</span> | union:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'up'&nbsp;&#124;<br>&nbsp;'down'<br> |  | Direction the child node will enter from. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, show the component; triggers the enter or exit animation. |
-| <span style="color: #31a148">timeout *</span> | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| timeout | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -15,7 +15,7 @@ filename: /src/transitions/Slide.js
 | <span style="color: #31a148">children *</span> | Element |  | A single child content element. |
 | <span style="color: #31a148">direction *</span> | union:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'up'&nbsp;&#124;<br>&nbsp;'down'<br> |  | Direction the child node will enter from. |
 | <span style="color: #31a148">in *</span> | boolean |  | If `true`, show the component; triggers the enter or exit animation. |
-| timeout | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| timeout | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -14,7 +14,7 @@ filename: /src/Snackbar/Snackbar.js
 |:-----|:-----|:--------|:------------|
 | SnackbarContentProps | Object |  | Properties applied to the `SnackbarContent` element. |
 | action | Node |  | The action to display. |
-| <span style="color: #31a148">anchorOrigin *</span> | signature | { vertical: 'bottom', horizontal: 'center' } | The anchor of the `Snackbar`. |
+| anchorOrigin | signature | {  vertical: 'bottom',  horizontal: 'center'} | The anchor of the `Snackbar`. |
 | autoHideDuration | number |  | The number of milliseconds to wait before automatically dismissing. This behavior is disabled by default with the `null` value. |
 | children | Element |  | If you wish the take control over the children of the component you can use that property. When using it, no `SnackbarContent` component will be rendered. |
 | classes | Object |  | Useful to extend the style applied to components. |
@@ -29,9 +29,8 @@ filename: /src/Snackbar/Snackbar.js
 | onRequestClose | signature |  | Callback fired when the component requests to be closed.<br>Typically `onRequestClose` is used to set state in the parent component, which is used to control the `Snackbar` `open` prop.<br>The `reason` parameter can optionally be used to control the response to `onRequestClose`, for example ignoring `clickaway`.<br><br>**Signature:**<br>`function(event: object, reason: string) => void`<br>*event:* The event source of the callback<br>*reason:* Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"` |
 | <span style="color: #31a148">open *</span> | boolean |  | If true, `Snackbar` is open. |
 | resumeHideDuration | number |  | The number of milliseconds to wait before dismissing after user interaction. If `autoHideDuration` property isn't specified, it does nothing. If `autoHideDuration` property is specified but `resumeHideDuration` isn't, we default to `autoHideDuration / 2` ms. |
-| theme | Object |  |  |
 | transition | ComponentType |  | Transition component. |
-| <span style="color: #31a148">transitionDuration *</span> | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -14,7 +14,7 @@ filename: /src/Snackbar/Snackbar.js
 |:-----|:-----|:--------|:------------|
 | SnackbarContentProps | Object |  | Properties applied to the `SnackbarContent` element. |
 | action | Node |  | The action to display. |
-| anchorOrigin | signature | { vertical: 'bottom', horizontal: 'center' } | The anchor of the `Snackbar`. |
+| anchorOrigin | signature | {  vertical: 'bottom',  horizontal: 'center'} | The anchor of the `Snackbar`. |
 | autoHideDuration | number |  | The number of milliseconds to wait before automatically dismissing. This behavior is disabled by default with the `null` value. |
 | children | Element |  | If you wish the take control over the children of the component you can use that property. When using it, no `SnackbarContent` component will be rendered. |
 | classes | Object |  | Useful to extend the style applied to components. |
@@ -30,7 +30,7 @@ filename: /src/Snackbar/Snackbar.js
 | <span style="color: #31a148">open *</span> | boolean |  | If true, `Snackbar` is open. |
 | resumeHideDuration | number |  | The number of milliseconds to wait before dismissing after user interaction. If `autoHideDuration` property isn't specified, it does nothing. If `autoHideDuration` property is specified but `resumeHideDuration` isn't, we default to `autoHideDuration / 2` ms. |
 | transition | ComponentType |  | Transition component. |
-| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 Any other properties supplied will be [spread to the root element](/customization/api#spread).
 

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -14,7 +14,6 @@ filename: /src/SvgIcon/SvgIcon.js
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | Node |  | Elements passed into the SVG Icon. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| theme | Object |  |  |
 | titleAccess | string |  | Provides a human-readable title for the element that contains it. https://www.w3.org/TR/SVG-access/#Equivalent |
 | viewBox | string | '0 0 24 24' | Allows you to redefine what the coordinates without units mean inside an svg element. For example, if the SVG element is 500 (width) by 200 (height), and you pass viewBox="0 0 50 20", this means that the coordinates inside the svg will go from the top left corner (0,0) to bottom right (50,20) and each unit will be worth 10px. |
 

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -16,7 +16,6 @@ filename: /src/Tabs/Tab.js
 | disabled | boolean | false | If `true`, the tab will be disabled. |
 | icon | union:&nbsp;string&nbsp;&#124;<br>&nbsp;Element&lt;any><br> |  | The icon element. If a string is provided, it will be used as a font ligature. |
 | label | union:&nbsp;string&nbsp;&#124;<br>&nbsp;Element&lt;any><br> |  | The label element. |
-| theme | Object |  |  |
 | value | any |  | You can provide your own value. Otherwise, we fallback to the child position index. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -15,7 +15,6 @@ filename: /src/Table/TableBody.js
 | children | Node |  | The content of the component, normally `TableRow`. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | component | ElementType | 'tbody' | The component used for the root node. Either a string to use a DOM element or a component. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -15,9 +15,8 @@ filename: /src/Table/TableCell.js
 | children | Node |  | The table cell contents. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span style="color: #31a148">numeric *</span> | boolean | false | If `true`, content will align to the right. |
-| <span style="color: #31a148">padding *</span> | union:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'checkbox'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'none'<br> | 'default' | Sets the padding applied to the cell. |
-| theme | Object |  |  |
+| numeric | boolean | false | If `true`, content will align to the right. |
+| padding | union:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'checkbox'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'none'<br> | 'default' | Sets the padding applied to the cell. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -14,8 +14,7 @@ filename: /src/Table/TableFooter.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component, normally `TableRow`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'tfoot' | The component used for the root node. Either a string to use a DOM element or a component. |
-| theme | Object |  |  |
+| component | ElementType | 'tfoot' | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -14,8 +14,7 @@ filename: /src/Table/TableHead.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the component, normally `TableRow`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'thead' | The component used for the root node. Either a string to use a DOM element or a component. |
-| theme | Object |  |  |
+| component | ElementType | 'thead' | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -13,15 +13,15 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | TableCell | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | ElementType | TableCell | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span style="color: #31a148">count *</span> | number |  | The total number of rows. |
-| <span style="color: #31a148">labelDisplayedRows *</span> | signature | ({ from, to, count }) => `${from}-${to} of ${count}` | Useful to customize the displayed rows label. |
+| labelDisplayedRows | signature | ({ from, to, count }) => `${from}-${to} of ${count}` | Useful to customize the displayed rows label. |
 | labelRowsPerPage | Node | 'Rows per page:' | Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }` object. |
 | <span style="color: #31a148">onChangePage *</span> | signature |  | Callback fired when the page is changed.<br><br>**Signature:**<br>`function(event: object, page: number) => void`<br>*event:* The event source of the callback<br>*page:* The page selected |
 | <span style="color: #31a148">onChangeRowsPerPage *</span> | signature |  | Callback fired when the number of rows per page is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span style="color: #31a148">page *</span> | number |  | The zero-based index of the current page. |
 | <span style="color: #31a148">rowsPerPage *</span> | number |  | The number of rows per page. |
-| <span style="color: #31a148">rowsPerPageOptions *</span> | unknown | [5, 10, 25] | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |
+| rowsPerPageOptions | Array | [5, 10, 25] | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -15,10 +15,9 @@ based on the material table element parent (head, body, etc).
 |:-----|:-----|:--------|:------------|
 | children | Node |  | Should be valid `&lt;tr>` children such as `TableCell`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'tr' | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span style="color: #31a148">hover *</span> | boolean | false | If `true`, the table row will shade on hover. |
-| <span style="color: #31a148">selected *</span> | boolean | false | If `true`, the table row will have the selected shading. |
-| theme | Object |  |  |
+| component | ElementType | 'tr' | The component used for the root node. Either a string to use a DOM element or a component. |
+| hover | boolean | false | If `true`, the table row will shade on hover. |
+| selected | boolean | false | If `true`, the table row will have the selected shading. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -16,7 +16,6 @@ A button based label for placing inside `TableCell` for column sorting.
 | children | Node |  | Label contents, the arrow will be appended automatically. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | direction | union:&nbsp;'asc'&nbsp;&#124;<br>&nbsp;'desc'<br> | 'desc' | The current sort direction. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -14,8 +14,7 @@ filename: /src/Table/Table.js
 |:-----|:-----|:--------|:------------|
 | children | Node |  | The content of the table, normally `TableHeader` and `TableBody`. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">component *</span> | ElementType | 'table' | The component used for the root node. Either a string to use a DOM element or a component. |
-| theme | Object |  |  |
+| component | ElementType | 'table' | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -12,14 +12,14 @@ filename: /src/Tabs/Tabs.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span style="color: #31a148">TabScrollButton *</span> | ComponentType | TabScrollButton | The component used to render the scroll buttons. |
+| TabScrollButton | ComponentType | TabScrollButton | The component used to render the scroll buttons. |
 | buttonClassName | string |  | The CSS class name of the scroll button elements. |
 | centered | boolean | false | If `true`, the tabs will be centered. This property is intended for large views. |
 | children | Node |  | The content of the component. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | fullWidth | boolean | false | If `true`, the tabs will grow to use all the available space. This property is intended for small views, like on mobile. |
 | indicatorClassName | string |  | The CSS class name of the indicator element. |
-| <span style="color: #31a148">indicatorColor *</span> | union:&nbsp;'accent'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;string<br> | 'accent' | Determines the color of the indicator. |
+| indicatorColor | union:&nbsp;'accent'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;string<br> | 'accent' | Determines the color of the indicator. |
 | <span style="color: #31a148">onChange *</span> | Function |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: number) => void`<br>*event:* The event source of the callback<br>*value:* We default to the index of the child |
 | scrollButtons | union:&nbsp;'auto'&nbsp;&#124;<br>&nbsp;'on'&nbsp;&#124;<br>&nbsp;'off'<br> | 'auto' | Determine behavior of scroll buttons when tabs are set to scroll `auto` will only present them on medium and larger viewports `on` will always present them `off` will never present them |
 | scrollable | boolean | false | True invokes scrolling properties and allow for horizontally scrolling (or swiping) the tab bar. |

--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -15,7 +15,6 @@ filename: /src/Toolbar/Toolbar.js
 | children | Node |  | Toolbar children, usually a mixture of `IconButton`, `Button` and `Typography`. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | disableGutters | boolean | false | If `true`, disables gutter padding. |
-| theme | Object |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -18,13 +18,13 @@ filename: /src/Tooltip/Tooltip.js
 | disableTriggerFocus | boolean | false | Do not respond to focus events. |
 | disableTriggerHover | boolean | false | Do not respond to hover events. |
 | disableTriggerTouch | boolean | false | Do not respond to long press touch events. |
-| <span style="color: #31a148">enterDelay *</span> | number | 0 | The number of milliseconds to wait before showing the tooltip. |
+| enterDelay | number | 0 | The number of milliseconds to wait before showing the tooltip. |
 | id | string |  | The relationship between the tooltip and the wrapper component is not clear from the DOM. By providing this property, we can use aria-describedby to solve the accessibility issue. |
 | leaveDelay | number | 0 | The number of milliseconds to wait before hidding the tooltip. |
 | onRequestClose | Function |  | Callback fired when the tooltip requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | onRequestOpen | Function |  | Callback fired when the tooltip requests to be open.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean |  | If `true`, the tooltip is shown. |
-| <span style="color: #31a148">placement *</span> | union:&nbsp;, 'bottom-end', 'bottom-start', 'bottom', 'left-end', 'left-start', 'left', 'right-end', 'right-start', 'right', 'top-end', 'top-start', 'top'<br> | 'bottom' | Tooltip placement |
+| placement | union:&nbsp;, 'bottom-end', 'bottom-start', 'bottom', 'left-end', 'left-start', 'left', 'right-end', 'right-start', 'right', 'top-end', 'top-start', 'top'<br> | 'bottom' | Tooltip placement |
 | <span style="color: #31a148">title *</span> | Node |  | Tooltip title. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -12,17 +12,16 @@ filename: /src/Typography/Typography.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span style="color: #31a148">align *</span> | union:&nbsp;'inherit', 'left', 'center', 'right', 'justify'<br> | 'inherit' |  |
+| align | union:&nbsp;'inherit', 'left', 'center', 'right', 'justify'<br> | 'inherit' |  |
 | children | Node |  |  |
 | classes | Object |  | Useful to extend the style applied to components. |
-| <span style="color: #31a148">color *</span> | union:&nbsp;'inherit', 'primary', 'secondary', 'accent', 'error', 'default'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
+| color | union:&nbsp;'inherit', 'primary', 'secondary', 'accent', 'error', 'default'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
 | component | ElementType |  | The component used for the root node. Either a string to use a DOM element or a component. By default we map the type to a good default headline component. |
-| <span style="color: #31a148">gutterBottom *</span> | boolean | false | If `true`, the text will have a bottom margin. |
-| <span style="color: #31a148">headlineMapping *</span> | signature | {  display4: 'h1',  display3: 'h1',  display2: 'h1',  display1: 'h1',  headline: 'h1',  title: 'h2',  subheading: 'h3',  body2: 'aside',  body1: 'p',} | We are empirically mapping the type property to a range of different DOM element type. For instance, h1 to h6. If you wish to change that mapping, you can provide your own. Alternatively, you can use the `component` property. |
-| <span style="color: #31a148">noWrap *</span> | boolean | false | If `true`, the text will not wrap, but instead will truncate with an ellipsis. |
-| <span style="color: #31a148">paragraph *</span> | boolean | false | If `true`, the text will have a bottom margin. |
-| theme | Object |  |  |
-| <span style="color: #31a148">type *</span> | union:&nbsp;, 'display4', 'display3', 'display2', 'display1', 'headline', 'title', 'subheading', 'body2', 'body1', 'caption', 'button'<br> | 'body1' | Applies the theme typography styles. |
+| gutterBottom | boolean | false | If `true`, the text will have a bottom margin. |
+| headlineMapping | signature | {  display4: 'h1',  display3: 'h1',  display2: 'h1',  display1: 'h1',  headline: 'h1',  title: 'h2',  subheading: 'h3',  body2: 'aside',  body1: 'p',} | We are empirically mapping the type property to a range of different DOM element type. For instance, h1 to h6. If you wish to change that mapping, you can provide your own. Alternatively, you can use the `component` property. |
+| noWrap | boolean | false | If `true`, the text will not wrap, but instead will truncate with an ellipsis. |
+| paragraph | boolean | false | If `true`, the text will have a bottom margin. |
+| type | union:&nbsp;, 'display4', 'display3', 'display2', 'display1', 'headline', 'title', 'subheading', 'body2', 'body1', 'caption', 'button'<br> | 'body1' | Applies the theme typography styles. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -55,11 +55,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  color: Color,
-  position: Position,
-};
-
 export type Props = {
   /**
    * The content of the component.
@@ -84,7 +79,7 @@ export type Props = {
 };
 
 class AppBar extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     color: 'primary',
     position: 'fixed',
   };

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -52,6 +52,9 @@ export type Position = 'static' | 'fixed' | 'absolute';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -38,10 +38,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -99,8 +95,8 @@ export type Props = {
 };
 
 class Avatar extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'div',
+  static defaultProps = {
+    component: ('div': ElementType),
   };
 
   render() {

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -35,6 +35,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -47,6 +47,9 @@ type Color = 'default' | 'primary' | 'accent';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -50,10 +50,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  color: Color,
-};
-
 export type Props = {
   /**
    * Other div props.
@@ -82,7 +78,7 @@ export type Props = {
 };
 
 class Badge extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     color: 'default',
   };
 

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -16,6 +16,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -19,10 +19,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  showLabels: boolean,
-};
-
 export type Props = {
   /**
    * The content of the component.
@@ -51,7 +47,7 @@ export type Props = {
 };
 
 class BottomNavigation extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     showLabels: false,
   };
 

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -32,6 +32,10 @@ export type Props = {
    */
   className?: string,
   /**
+   * Useful to extend the style applied to components.
+   */
+  classes?: Object,
+  /**
    * Callback fired when the value changes.
    *
    * @param {object} event The event source of the callback

--- a/src/BottomNavigation/BottomNavigationButton.js
+++ b/src/BottomNavigation/BottomNavigationButton.js
@@ -58,6 +58,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -153,6 +153,9 @@ export type Color = 'default' | 'inherit' | 'primary' | 'accent' | 'contrast';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -156,17 +156,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  color: Color,
-  dense: boolean,
-  disabled: boolean,
-  fab: boolean,
-  disableFocusRipple: boolean,
-  raised: boolean,
-  disableRipple: boolean,
-  type: string,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -231,7 +220,7 @@ export type Props = {
 };
 
 class Button extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     color: 'default',
     dense: false,
     disabled: false,

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -43,14 +43,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  centerRipple: boolean,
-  focusRipple: boolean,
-  disableRipple: boolean,
-  tabIndex: number | string,
-  type: string,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -168,7 +160,7 @@ type State = {
 };
 
 class ButtonBase extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     centerRipple: false,
     focusRipple: false,
     disableRipple: false,

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -40,6 +40,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -23,10 +23,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disableActionSpacing: boolean,
-};
-
 export type Props = {
   /**
    * The content of the component.
@@ -47,7 +43,7 @@ export type Props = {
 };
 
 class CardActions extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     disableActionSpacing: false,
   };
 

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -20,6 +20,9 @@ export const styles = {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -24,10 +24,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -64,8 +60,8 @@ export type Props = {
 };
 
 class CardMedia extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'div',
+  static defaultProps = {
+    component: ('div': ElementType),
   };
 
   render() {

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -21,6 +21,9 @@ const mediaComponents = ['video', 'audio', 'picture', 'iframe', 'img'];
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import type { Node } from 'react';
 import withStyles from '../styles/withStyles';
-import createSwitch from '../internal/SwitchBase';
+import SwitchBase from '../internal/SwitchBase';
 import IndeterminateCheckBoxIcon from '../svg-icons/IndeterminateCheckBox';
 
 export const styles = (theme: Object) => ({
@@ -18,16 +18,9 @@ export const styles = (theme: Object) => ({
   },
 });
 
-const SwitchBase = createSwitch();
-
 type ProvidedProps = {
   classes: Object,
   theme?: Object,
-};
-
-type DefaultProps = {
-  indeterminate: boolean,
-  indeterminateIcon: Node,
 };
 
 export type Props = {
@@ -108,9 +101,9 @@ export type Props = {
 };
 
 class Checkbox extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     indeterminate: false,
-    indeterminateIcon: <IndeterminateCheckBoxIcon />,
+    indeterminateIcon: (<IndeterminateCheckBoxIcon />: Node),
   };
 
   render() {

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -20,6 +20,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -106,6 +106,10 @@ export type Props = {
    */
   className?: string,
   /**
+   * Useful to extend the style applied to components.
+   */
+  classes?: Object,
+  /**
    * Custom delete icon. Will be shown only if `onRequestDelete` is set.
    */
   deleteIcon?: Element<any>,

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -86,6 +86,9 @@ export const styles = (theme: Object) => {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -55,6 +55,9 @@ type MaxWidth = 'xs' | 'sm' | 'md';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -58,17 +58,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  fullScreen?: boolean,
-  ignoreBackdropClick?: boolean,
-  ignoreEscapeKeyUp?: boolean,
-  transitionDuration?: TransitionDuration,
-  maxWidth?: MaxWidth,
-  fullWidth?: boolean,
-  open?: boolean,
-  transition: ComponentType<*>,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -89,31 +78,31 @@ export type Props = {
   /**
    * If `true`, it will be full-screen
    */
-  fullScreen?: boolean,
+  fullScreen: boolean,
   /**
    * If `true`, clicking the backdrop will not fire the `onRequestClose` callback.
    */
-  ignoreBackdropClick?: boolean,
+  ignoreBackdropClick: boolean,
   /**
    * If `true`, hitting escape will not fire the `onRequestClose` callback.
    */
-  ignoreEscapeKeyUp?: boolean,
+  ignoreEscapeKeyUp: boolean,
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    */
-  transitionDuration?: TransitionDuration,
+  transitionDuration: TransitionDuration,
   /**
    * Determine the max width of the dialog.
    * The dialog width grows with the size of the screen, this property is useful
    * on the desktop where you might need some coherent different width size across your
    * application.
    */
-  maxWidth?: MaxWidth,
+  maxWidth: MaxWidth,
   /**
    * If specified, stretches dialog to max width.
    */
-  fullWidth?: boolean,
+  fullWidth: boolean,
   /**
    * Callback fired when the backdrop is clicked.
    */
@@ -155,7 +144,7 @@ export type Props = {
   /**
    * If `true`, the Dialog is open.
    */
-  open?: boolean,
+  open: boolean,
   /**
    * Transition component.
    */
@@ -166,14 +155,14 @@ export type Props = {
  * Dialogs are overlaid modal paper based components with a backdrop.
  */
 class Dialog extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     fullScreen: false,
     ignoreBackdropClick: false,
     ignoreEscapeKeyUp: false,
-    transitionDuration: {
+    transitionDuration: ({
       enter: duration.enteringScreen,
       exit: duration.leavingScreen,
-    },
+    }: TransitionDuration),
     maxWidth: 'sm',
     fullWidth: false,
     open: false,

--- a/src/Dialog/DialogActions.js
+++ b/src/Dialog/DialogActions.js
@@ -24,6 +24,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Dialog/DialogContentText.js
+++ b/src/Dialog/DialogContentText.js
@@ -15,6 +15,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Dialog/DialogTitle.js
+++ b/src/Dialog/DialogTitle.js
@@ -17,6 +17,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Dialog/DialogTitle.js
+++ b/src/Dialog/DialogTitle.js
@@ -20,10 +20,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disableTypography: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -49,7 +45,7 @@ export type Props = {
 };
 
 class DialogTitle extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     disableTypography: false,
   };
 

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -30,6 +30,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -33,14 +33,8 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  absolute?: boolean,
-  inset?: boolean,
-  light?: boolean,
-};
-
 export type Props = {
-  absolute?: boolean,
+  absolute: boolean,
   /**
    * Useful to extend the style applied to components.
    */
@@ -52,15 +46,15 @@ export type Props = {
   /**
    * If `true`, the divider will be indented.
    */
-  inset?: boolean,
+  inset: boolean,
   /**
    * If `true`, the divider will have a lighter color.
    */
-  light?: boolean,
+  light: boolean,
 };
 
 class Divider extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     absolute: false,
     inset: false,
     light: false,

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -91,6 +91,9 @@ export type Type = 'permanent' | 'persistent' | 'temporary';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 
@@ -138,10 +141,6 @@ export type Props = {
    * If `true`, the drawer is open.
    */
   open: boolean,
-  /**
-   * @ignore
-   */
-  theme?: Object,
   /**
    * Properties applied to the `Slide` element.
    */

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -94,14 +94,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  anchor: Anchor,
-  elevation: number,
-  transitionDuration: TransitionDuration,
-  open: boolean,
-  type: Type,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -165,13 +157,13 @@ type State = {
 };
 
 class Drawer extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     anchor: 'left',
     elevation: 16,
-    transitionDuration: {
+    transitionDuration: ({
       enter: duration.enteringScreen,
       exit: duration.leavingScreen,
-    },
+    }: TransitionDuration),
     open: false,
     type: 'temporary', // Mobile first.
   };

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -39,15 +39,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disabled?: boolean,
-  component?: ElementType,
-  error?: boolean,
-  fullWidth?: boolean,
-  margin?: Margin,
-  required?: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -69,20 +60,24 @@ export type Props = {
    * The component used for the root node.
    * Either a string to use a DOM element or a component.
    */
-  component?: ElementType,
+  component: ElementType,
   /**
    * If `true`, the label, input and helper text should be displayed in a disabled state.
    */
-  disabled?: boolean,
+  disabled: boolean,
   /**
    * If `true`, the label should be displayed in an error state.
    */
-  error?: boolean,
+  error: boolean,
   /**
    * If `true`, the component, as well as its children,
    * will take up the full width of its container.
    */
-  fullWidth?: boolean,
+  fullWidth: boolean,
+  /**
+   * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
+   */
+  margin: Margin,
   /**
    * @ignore
    */
@@ -94,11 +89,7 @@ export type Props = {
   /**
    * If `true`, the label will indicate that the input is required.
    */
-  required?: boolean,
-  /**
-   * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
-   */
-  margin?: Margin,
+  required: boolean,
 };
 
 type State = {
@@ -118,8 +109,8 @@ type State = {
  *  - InputLabel
  */
 class FormControl extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
-    component: 'div',
+  static defaultProps = {
+    component: ('div': ElementType),
     disabled: false,
     error: false,
     fullWidth: false,

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -36,6 +36,9 @@ export type Margin = 'none' | 'dense' | 'normal';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -33,6 +33,9 @@ type Context = {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Form/FormGroup.js
+++ b/src/Form/FormGroup.js
@@ -21,10 +21,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  row?: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -45,7 +41,7 @@ export type Props = {
   /**
    * Display group of elements in a compact row.
    */
-  row?: boolean,
+  row: boolean,
 };
 
 /**
@@ -54,7 +50,7 @@ export type Props = {
  * For the `Radio`, you should be using the `RadioGroup` component instead of this one.
  */
 class FormGroup extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     row: false,
   };
 

--- a/src/Form/FormGroup.js
+++ b/src/Form/FormGroup.js
@@ -18,6 +18,9 @@ export const styles = {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Form/FormHelperText.js
+++ b/src/Form/FormHelperText.js
@@ -30,6 +30,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Form/FormLabel.js
+++ b/src/Form/FormLabel.js
@@ -30,6 +30,9 @@ export const styles = (theme: Object) => {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Form/FormLabel.js
+++ b/src/Form/FormLabel.js
@@ -33,10 +33,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-};
-
 export type Props = {
   /**
    * The content of the component.
@@ -78,8 +74,8 @@ class FormLabel extends React.Component<ProvidedProps & Props> {
     muiFormControl: PropTypes.object,
   };
 
-  static defaultProps: DefaultProps = {
-    component: 'label',
+  static defaultProps = {
+    component: ('label': ElementType),
   };
 
   context: { muiFormControl: Object };

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -185,18 +185,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  alignContent?: AlignContent,
-  alignItems: AlignItems,
-  component: ElementType,
-  container: boolean,
-  direction: Direction,
-  item: boolean,
-  justify: Justify,
-  spacing: Spacing,
-  wrap: Wrap,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -233,7 +221,7 @@ export type Props = {
    * Defines the `align-content` style property.
    * It's applied for all screen sizes.
    */
-  alignContent?: AlignContent,
+  alignContent: AlignContent,
   /**
    * Defines the `align-items` style property.
    * It's applied for all screen sizes.
@@ -291,13 +279,12 @@ export type Props = {
 };
 
 class Grid extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     alignContent: 'stretch',
     alignItems: 'stretch',
-    component: 'div',
+    component: ('div': ElementType),
     container: false,
     direction: 'row',
-    hidden: undefined,
     item: false,
     justify: 'flex-start',
     spacing: 16,

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -182,6 +182,9 @@ type Wrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -20,6 +20,9 @@ export type CellHeight = number | 'auto';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -23,13 +23,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  cols: number,
-  spacing: number,
-  cellHeight: CellHeight,
-  component: ElementType,
-};
-
 export type Props = {
   /**
    * Number of px for one cell height.
@@ -69,7 +62,7 @@ export type Props = {
 };
 
 class GridList extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     cols: 2,
     spacing: 4,
     cellHeight: 180,

--- a/src/GridList/GridListTileBar.js
+++ b/src/GridList/GridListTileBar.js
@@ -71,11 +71,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  actionPosition?: ActionPosition,
-  titlePosition?: TitlePosition,
-};
-
 export type Props = {
   /**
    * An IconButton element to be used as secondary action target
@@ -109,7 +104,7 @@ export type Props = {
 };
 
 class GridListTileBar extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     actionPosition: 'right',
     titlePosition: 'bottom',
   };

--- a/src/GridList/GridListTileBar.js
+++ b/src/GridList/GridListTileBar.js
@@ -68,6 +68,9 @@ export type ActionPosition = 'left' | 'right';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -37,10 +37,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  color: Color,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -61,7 +57,7 @@ export type Props = {
 };
 
 class Icon extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     color: 'inherit',
   };
 

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -34,6 +34,9 @@ export type Color = 'inherit' | 'accent' | 'action' | 'contrast' | 'disabled' | 
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -54,6 +54,10 @@ export type Props = {
    */
   className?: string,
   /**
+   * Useful to extend the style applied to components.
+   */
+  classes?: Object,
+  /**
    * The color of the component. It's using the theme palette when that makes sense.
    */
   color: Color,

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -59,6 +59,9 @@ type Color = 'default' | 'inherit' | 'primary' | 'contrast' | 'accent';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -62,12 +62,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  color: Color,
-  disabled: boolean,
-  disableRipple: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -113,7 +107,7 @@ export type Props = {
  * regarding the available icon options.
  */
 class IconButton extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     color: 'default',
     disabled: false,
     disableRipple: false,

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -206,13 +206,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disableUnderline?: boolean,
-  fullWidth?: boolean,
-  multiline?: boolean,
-  type?: string,
-};
-
 export type Props = {
   /**
    * This property helps users to fill forms faster, especially on mobile devices.
@@ -356,7 +349,7 @@ type State = {
 class Input extends React.Component<ProvidedProps & Props, State> {
   static muiName = 'Input';
 
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     disableUnderline: false,
     fullWidth: false,
     multiline: false,

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -203,6 +203,9 @@ export const styles = (theme: Object) => {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Input/InputAdornment.js
+++ b/src/Input/InputAdornment.js
@@ -23,6 +23,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Input/InputAdornment.js
+++ b/src/Input/InputAdornment.js
@@ -26,11 +26,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-  disableTypography?: boolean,
-};
-
 export type Props = {
   /**
    * The content of the component, normally an `IconButton` or string.
@@ -52,7 +47,7 @@ export type Props = {
   /**
    * If children is a string then disable wrapping in a Typography component.
    */
-  disableTypography?: boolean,
+  disableTypography: boolean,
   /**
    * The position this adornment should appear relative to the `Input`.
    */
@@ -60,8 +55,8 @@ export type Props = {
 };
 
 class InputAdornment extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'div',
+  static defaultProps = {
+    component: ('div': ElementType),
     disableTypography: false,
   };
 

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -39,6 +39,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -42,11 +42,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disabled?: boolean,
-  disableAnimation?: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -67,11 +62,11 @@ export type Props = {
   /**
    * If `true`, the transition animation is disabled.
    */
-  disableAnimation?: boolean,
+  disableAnimation: boolean,
   /**
    * If `true`, apply disabled class.
    */
-  disabled?: boolean,
+  disabled: boolean,
   /**
    * If `true`, the label will be displayed in an error state.
    */
@@ -100,7 +95,7 @@ export type Props = {
 };
 
 class InputLabel extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     disabled: false,
     disableAnimation: false,
   };

--- a/src/Input/Textarea.js
+++ b/src/Input/Textarea.js
@@ -41,6 +41,9 @@ export const styles = {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Input/Textarea.js
+++ b/src/Input/Textarea.js
@@ -44,9 +44,7 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  rows?: string | number,
-};
+type Rows = string | number;
 
 export type Props = {
   /**
@@ -76,7 +74,7 @@ export type Props = {
   /**
    * Number of rows to display when multiline option is set to true.
    */
-  rows?: string | number,
+  rows: Rows,
   /**
    * Maximum number of rows to display when multiline option is set to true.
    */
@@ -99,8 +97,8 @@ type State = {
  * @ignore - internal component.
  */
 class Textarea extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
-    rows: 1,
+  static defaultProps = {
+    rows: (1: Rows),
   };
 
   state = {

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -32,12 +32,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-  dense?: boolean,
-  disablePaddin?: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -65,11 +59,11 @@ export type Props = {
    * the list and list items. The property is available to descendant components as the
    * `dense` context.
    */
-  dense?: boolean,
+  dense: boolean,
   /**
    * If `true`, vertical padding will be removed from the list.
    */
-  disablePadding?: boolean,
+  disablePadding: boolean,
   /**
    * Use that property to pass a ref callback to the root component.
    */
@@ -81,8 +75,8 @@ export type Props = {
 };
 
 class List extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'ul',
+  static defaultProps = {
+    component: ('ul': ElementType),
     dense: false,
     disablePadding: false,
   };

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -29,6 +29,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -65,6 +65,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -68,15 +68,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  button?: boolean,
-  component: ElementType,
-  dense?: boolean,
-  disabled?: boolean,
-  disableGutters?: boolean,
-  divider?: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -85,7 +76,7 @@ export type Props = {
   /**
    * If `true`, the ListItem will be a button.
    */
-  button?: boolean,
+  button: boolean,
   /**
    * The content of the component.
    */
@@ -106,25 +97,25 @@ export type Props = {
   /**
    * If `true`, compact vertical padding designed for keyboard and mouse input will be used.
    */
-  dense?: boolean,
+  dense: boolean,
   /**
    * @ignore
    */
-  disabled?: boolean,
+  disabled: boolean,
   /**
    * If `true`, the left and right padding is removed.
    */
-  disableGutters?: boolean,
+  disableGutters: boolean,
   /**
    * If `true`, a 1px light border is added to the bottom of the list item.
    */
-  divider?: boolean,
+  divider: boolean,
 };
 
 class ListItem extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     button: false,
-    component: 'li',
+    component: ('li': ElementType),
     dense: false,
     disabled: false,
     disableGutters: false,

--- a/src/List/ListItemAvatar.js
+++ b/src/List/ListItemAvatar.js
@@ -23,6 +23,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/List/ListItemIcon.js
+++ b/src/List/ListItemIcon.js
@@ -17,6 +17,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -34,13 +34,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disableTypography: boolean,
-  primary: Node,
-  secondary: Node,
-  inset: boolean,
-};
-
 export type Props = {
   /**
    * Useful to extend the style applied to components.
@@ -65,7 +58,7 @@ export type Props = {
 };
 
 class ListItemText extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     disableTypography: false,
     primary: false,
     secondary: false,

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -31,6 +31,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/List/ListSubheader.js
+++ b/src/List/ListSubheader.js
@@ -39,6 +39,9 @@ type Color = 'default' | 'primary' | 'inherit';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/List/ListSubheader.js
+++ b/src/List/ListSubheader.js
@@ -42,13 +42,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  color?: Color,
-  component: ElementType,
-  disableSticky?: boolean,
-  inset?: boolean,
-};
-
 export type Props = {
   /**
    * The content of the component.
@@ -83,7 +76,7 @@ export type Props = {
 };
 
 class ListSubheader extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     component: 'li',
     color: 'default',
     disableSticky: false,

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -15,10 +15,7 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  open?: boolean,
-  transitionDuration?: number | { enter?: number, exit?: number } | 'auto',
-};
+type TransitionDuration = number | { enter?: number, exit?: number } | 'auto';
 
 export type Props = {
   /**
@@ -74,7 +71,7 @@ export type Props = {
   /**
    * If `true`, the menu is visible.
    */
-  open?: boolean,
+  open: boolean,
   /**
    * @ignore
    */
@@ -90,7 +87,7 @@ export type Props = {
   /**
    * The length of the transition in `ms`, or 'auto'
    */
-  transitionDuration?: number | { enter?: number, exit?: number } | 'auto',
+  transitionDuration: TransitionDuration,
 };
 
 const rtlOrigin = {
@@ -115,9 +112,9 @@ export const styles = {
 };
 
 class Menu extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     open: false,
-    transitionDuration: 'auto',
+    transitionDuration: ('auto': TransitionDuration),
   };
 
   componentDidMount() {

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -12,6 +12,9 @@ import type { TransitionCallback } from '../internal/transition';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 
@@ -80,10 +83,6 @@ export type Props = {
    * `classes` property applied to the `Popover` element.
    */
   PopoverClasses?: Object,
-  /**
-   * @ignore
-   */
-  theme?: Object,
   /**
    * The length of the transition in `ms`, or 'auto'
    */

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -30,6 +30,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -33,11 +33,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  role?: string,
-  selected?: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -63,15 +58,15 @@ export type Props = {
   /**
    * @ignore
    */
-  role?: string,
+  role: string,
   /**
    * Use to apply selected styling.
    */
-  selected?: boolean,
+  selected: boolean,
 };
 
 class MenuItem extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     role: 'menuitem',
     selected: false,
   };

--- a/src/MobileStepper/MobileStepper.js
+++ b/src/MobileStepper/MobileStepper.js
@@ -60,12 +60,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  activeStep?: number,
-  position?: Position,
-  type?: Type,
-};
-
 export type Props = {
   /**
    * Set the active step (zero based index).
@@ -103,7 +97,7 @@ export type Props = {
 };
 
 class MobileStepper extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     activeStep: 0,
     position: 'bottom',
     type: 'dots',

--- a/src/MobileStepper/MobileStepper.js
+++ b/src/MobileStepper/MobileStepper.js
@@ -57,6 +57,9 @@ export type Type = 'text' | 'dots' | 'progress';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Modal/Backdrop.js
+++ b/src/Modal/Backdrop.js
@@ -27,6 +27,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Modal/Backdrop.js
+++ b/src/Modal/Backdrop.js
@@ -30,10 +30,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  invisible?: boolean,
-};
-
 export type Props = {
   /**
    * Can be used, for instance, to render a letter inside the avatar.
@@ -50,14 +46,14 @@ export type Props = {
   /**
    * If `true`, the backdrop is invisible.
    */
-  invisible?: boolean,
+  invisible: boolean,
 };
 
 /**
  * @ignore - internal component.
  */
 class Backdrop extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     invisible: false,
   };
 

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -43,17 +43,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  BackdropComponent: ElementType,
-  BackdropTransitionDuration?: TransitionDuration,
-  BackdropInvisible?: boolean,
-  keepMounted?: boolean,
-  disableBackdrop?: boolean,
-  ignoreBackdropClick?: boolean,
-  ignoreEscapeKeyUp?: boolean,
-  modalManager: Object,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -70,12 +59,12 @@ export type Props = {
   /**
    * If `true`, the backdrop is invisible.
    */
-  BackdropInvisible?: boolean,
+  BackdropInvisible: boolean,
   /**
    * The duration for the backdrop transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    */
-  BackdropTransitionDuration?: TransitionDuration,
+  BackdropTransitionDuration: TransitionDuration,
   /**
    * A single child content element.
    */
@@ -93,19 +82,19 @@ export type Props = {
    * This property can be useful in SEO situation or
    * when you want to maximize the responsiveness of the Modal.
    */
-  keepMounted?: boolean,
+  keepMounted: boolean,
   /**
    * If `true`, the backdrop is disabled.
    */
-  disableBackdrop?: boolean,
+  disableBackdrop: boolean,
   /**
    * If `true`, clicking the backdrop will not fire the `onRequestClose` callback.
    */
-  ignoreBackdropClick?: boolean,
+  ignoreBackdropClick: boolean,
   /**
    * If `true`, hitting escape will not fire the `onRequestClose` callback.
    */
-  ignoreEscapeKeyUp?: boolean,
+  ignoreEscapeKeyUp: boolean,
   /**
    * @ignore
    */
@@ -174,9 +163,9 @@ type State = {
  * This component shares many concepts with [react-overlays](https://react-bootstrap.github.io/react-overlays/#modals).
  */
 class Modal extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
-    BackdropComponent: Backdrop,
-    BackdropTransitionDuration: 300,
+  static defaultProps = {
+    BackdropComponent: (Backdrop: ElementType),
+    BackdropTransitionDuration: (300: TransitionDuration),
     BackdropInvisible: false,
     keepMounted: false,
     disableBackdrop: false,

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -40,6 +40,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -28,6 +28,9 @@ export const styles = (theme: Object) => {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -31,12 +31,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-  elevation: number,
-  square: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -71,8 +65,8 @@ export type Props = {
 };
 
 class Paper extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'div',
+  static defaultProps = {
+    component: ('div': ElementType),
     elevation: 2,
     square: false,
   };

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -63,6 +63,9 @@ export type Mode = 'determinate' | 'indeterminate';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -66,15 +66,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  color: Color,
-  size?: number,
-  mode?: Mode,
-  value: number,
-  min: number,
-  max: number,
-};
-
 export type Props = {
   /**
    * Useful to extend the style applied to components.
@@ -101,11 +92,11 @@ export type Props = {
    * for when there is no value for progress.
    * Determinate for controlled progress value.
    */
-  mode?: Mode,
+  mode: Mode,
   /**
    * The size of the circle.
    */
-  size?: number,
+  size: number,
   /**
    * @ignore
    */
@@ -113,7 +104,7 @@ export type Props = {
   /**
    * The thickness of the circle.
    */
-  thickness?: number,
+  thickness: number,
   /**
    * The value of progress in determinate mode.
    */
@@ -121,7 +112,7 @@ export type Props = {
 };
 
 class CircularProgress extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     color: 'primary',
     size: 40,
     thickness: 3.6,

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -151,11 +151,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  color?: Color,
-  mode?: Mode,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -172,12 +167,12 @@ export type Props = {
   /**
    * The color of the component. It's using the theme palette when that makes sense.
    */
-  color?: 'primary' | 'accent',
+  color: Color,
   /**
    * The mode of show your progress, indeterminate
    * for when there is no value for progress.
    */
-  mode?: 'determinate' | 'indeterminate' | 'buffer' | 'query',
+  mode: Mode,
   /**
    * The value of progress, only works in determinate and buffer mode.
    * Value between 0 and 100.
@@ -191,7 +186,7 @@ export type Props = {
 };
 
 class LinearProgress extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     color: 'primary',
     mode: 'indeterminate',
   };

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -148,6 +148,9 @@ type Mode = 'determinate' | 'indeterminate' | 'buffer' | 'query';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import type { Node } from 'react';
 import withStyles from '../styles/withStyles';
-import createSwitch from '../internal/SwitchBase';
+import SwitchBase from '../internal/SwitchBase';
 import RadioButtonCheckedIcon from '../svg-icons/RadioButtonChecked';
 import RadioButtonUncheckedIcon from '../svg-icons/RadioButtonUnchecked';
 
@@ -92,18 +92,16 @@ export type Props = {
   value?: string,
 };
 
-const Switch = createSwitch({
-  inputType: 'radio',
-  defaultIcon: <RadioButtonUncheckedIcon />,
-  defaultCheckedIcon: <RadioButtonCheckedIcon />,
-});
-
-const Radio = withStyles(styles, { name: 'MuiRadio' })(Switch);
+// eslint-disable-next-line no-unused-vars
+const Radio = (props: ProvidedProps & Props) => (
+  <SwitchBase
+    inputType="radio"
+    icon={<RadioButtonUncheckedIcon />}
+    checkedIcon={<RadioButtonCheckedIcon />}
+    {...props}
+  />
+);
 
 Radio.displayName = 'Radio';
 
-export default Radio;
-
-// This is here solely to trigger api doc generation
-// eslint-disable-next-line no-unused-vars
-export const RadioDocs = (props: ProvidedProps & Props) => <span />;
+export default withStyles(styles, { name: 'MuiRadio' })(Radio);

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -21,6 +21,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -38,11 +38,11 @@ export type Props = {
    */
   checkedIcon?: Node,
   /**
-   * Useful to extend the style applied to components.
+   * @ignore
    */
   children?: Node,
   /**
-   * @ignore
+   * Useful to extend the style applied to components.
    */
   classes?: Object,
   /**

--- a/src/Radio/Radio.spec.js
+++ b/src/Radio/Radio.spec.js
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 import { getClasses, createMount } from '../test-utils';
 import Radio from './Radio';
 import RadioButtonCheckedIcon from '../svg-icons/RadioButtonChecked';
+import RadioButtonUncheckedIcon from '../svg-icons/RadioButtonUnchecked';
 
 describe('<Radio />', () => {
   let classes;
@@ -29,7 +30,14 @@ describe('<Radio />', () => {
 
   describe('default Radio export', () => {
     it('should be a SwitchBase with the displayName set for debugging', () => {
-      assert.strictEqual(Radio.displayName, 'Radio');
+      assert.strictEqual(Radio.displayName, 'withStyles(Radio)');
+    });
+  });
+
+  describe('prop: unchecked', () => {
+    it('should render an unchecked icon', () => {
+      const wrapper = mount(<Radio />);
+      assert.strictEqual(wrapper.find(RadioButtonUncheckedIcon).length, 1);
     });
   });
 

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -66,13 +66,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  displayEmpty?: boolean,
-  input: Element<any>,
-  native?: boolean,
-  multiple?: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -82,7 +75,7 @@ export type Props = {
    * If true, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.
    */
-  autoWidth?: boolean,
+  autoWidth: boolean,
   /**
    * The option elements to populate the select with.
    * Can be some `MenuItem` when `native` is false and `option` when `native` is true.
@@ -96,7 +89,7 @@ export type Props = {
    * If `true`, the selected item is displayed even if its value is empty.
    * You can only use it when the `native` property is `false` (default).
    */
-  displayEmpty?: boolean,
+  displayEmpty: boolean,
   /**
    * An `Input` element; does not have to be a material-ui specific `Input`.
    */
@@ -104,12 +97,12 @@ export type Props = {
   /**
    * If `true`, the component will be using a native `select` element.
    */
-  native?: boolean,
+  native: boolean,
   /**
    * If true, `value` must be an array and the menu will support multiple selections.
    * You can only use it when the `native` property is `false` (default).
    */
-  multiple?: boolean,
+  multiple: boolean,
   /**
    * Properties applied to the `Menu` element.
    */
@@ -126,7 +119,7 @@ export type Props = {
 };
 
 class Select extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     autoWidth: false,
     displayEmpty: false,
     input: <Input />,

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -63,6 +63,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -96,6 +96,9 @@ export type Origin = {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -99,11 +99,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  anchorOrigin: Origin,
-  transitionDuration: TransitionDuration,
-};
-
 export type Props = {
   /**
    * The action to display.
@@ -218,12 +213,12 @@ type State = {
 };
 
 class Snackbar extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
-    anchorOrigin: { vertical: 'bottom', horizontal: 'center' },
-    transitionDuration: {
+  static defaultProps = {
+    anchorOrigin: ({ vertical: 'bottom', horizontal: 'center' }: Origin),
+    transitionDuration: ({
       enter: duration.enteringScreen,
       exit: duration.leavingScreen,
-    },
+    }: TransitionDuration),
   };
 
   state = {

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -24,10 +24,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  viewBox?: string,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -57,11 +53,11 @@ export type Props = {
    * this means that the coordinates inside the svg will go from the top left corner (0,0)
    * to bottom right (50,20) and each unit will be worth 10px.
    */
-  viewBox?: string,
+  viewBox: string,
 };
 
 class SvgIcon extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     viewBox: '0 0 24 24',
   };
 

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -21,6 +21,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -4,7 +4,7 @@ import React from 'react';
 import type { Node } from 'react';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import createSwitch from '../internal/SwitchBase';
+import SwitchBase from '../internal/SwitchBase';
 
 export const styles = (theme: Object) => ({
   root: {
@@ -60,8 +60,6 @@ export const styles = (theme: Object) => ({
     },
   },
 });
-
-const SwitchBase = createSwitch();
 
 type ProvidedProps = {
   classes: Object,

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -18,6 +18,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -21,10 +21,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -50,8 +46,8 @@ export type Props = {
 };
 
 class Table extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'table',
+  static defaultProps = {
+    component: ('table': ElementType),
   };
 
   getChildContext() {

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -15,6 +15,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -18,10 +18,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component?: ElementType,
-};
-
 export type Props = {
   /**
    * The content of the component, normally `TableRow`.
@@ -39,12 +35,12 @@ export type Props = {
    * The component used for the root node.
    * Either a string to use a DOM element or a component.
    */
-  component?: ElementType,
+  component: ElementType,
 };
 
 class TableBody extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'tbody',
+  static defaultProps = {
+    component: ('tbody': ElementType),
   };
 
   getChildContext() {

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -18,11 +18,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  padding: Padding,
-  numeric: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -87,7 +82,7 @@ export const styles = (theme: Object) => ({
 });
 
 class TableCell extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     numeric: false,
     padding: 'default',
   };

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -15,6 +15,9 @@ export type Padding = 'default' | 'checkbox' | 'dense' | 'none';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -15,6 +15,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -18,10 +18,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-};
-
 export type Props = {
   /**
    * The content of the component, normally `TableRow`.
@@ -43,8 +39,8 @@ export type Props = {
 };
 
 class TableFooter extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'tfoot',
+  static defaultProps = {
+    component: ('tfoot': ElementType),
   };
 
   getChildContext() {

--- a/src/Table/TableHead.js
+++ b/src/Table/TableHead.js
@@ -16,6 +16,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Table/TableHead.js
+++ b/src/Table/TableHead.js
@@ -19,10 +19,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-};
-
 export type Props = {
   /**
    * The content of the component, normally `TableRow`.
@@ -44,8 +40,8 @@ export type Props = {
 };
 
 class TableHead extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: 'thead',
+  static defaultProps = {
+    component: ('thead': ElementType),
   };
 
   getChildContext() {

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -66,12 +66,7 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-  labelRowsPerPage: Node,
-  labelDisplayedRows: (paginationInfo: LabelDisplayedRowsArgs) => Node,
-  rowsPerPageOptions: number[],
-};
+type LabelDisplayedRows = (paginationInfo: LabelDisplayedRowsArgs) => Node;
 
 export type Props = {
   /**
@@ -98,12 +93,12 @@ export type Props = {
   /**
    * Useful to customize the displayed rows label.
    */
-  labelDisplayedRows: (paginationInfo: LabelDisplayedRowsArgs) => Node,
+  labelDisplayedRows: LabelDisplayedRows,
   /**
    * Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }`
    * object.
    */
-  labelRowsPerPage?: Node,
+  labelRowsPerPage: Node,
   /**
    * Callback fired when the page is changed.
    *
@@ -139,10 +134,10 @@ export type Props = {
  * A `TableCell` based component for placing inside `TableFooter` for pagination.
  */
 class TablePagination extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
-    component: TableCell,
-    labelRowsPerPage: 'Rows per page:',
-    labelDisplayedRows: ({ from, to, count }) => `${from}-${to} of ${count}`,
+  static defaultProps = {
+    component: (TableCell: ElementType),
+    labelRowsPerPage: ('Rows per page:': Node),
+    labelDisplayedRows: (({ from, to, count }) => `${from}-${to} of ${count}`: LabelDisplayedRows),
     rowsPerPageOptions: [5, 10, 25],
   };
 

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -126,7 +126,7 @@ export type Props = {
   /**
    * Customizes the options of the rows per page select field.
    */
-  rowsPerPageOptions: number[],
+  rowsPerPageOptions: Array<number>,
 };
 
 /**

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -63,6 +63,9 @@ export type LabelDisplayedRowsArgs = {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 
@@ -124,10 +127,6 @@ export type Props = {
    * Customizes the options of the rows per page select field.
    */
   rowsPerPageOptions: number[],
-  /**
-   * @ignore
-   */
-  theme?: Object,
 };
 
 /**

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -38,6 +38,9 @@ export type Context = {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -41,12 +41,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  component: ElementType,
-  hover: boolean,
-  selected: boolean,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -84,10 +78,10 @@ export type Props = {
  * based on the material table element parent (head, body, etc).
  */
 class TableRow extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     hover: false,
     selected: false,
-    component: 'tr',
+    component: ('tr': ElementType),
   };
 
   static contextTypes = {

--- a/src/Table/TableSortLabel.js
+++ b/src/Table/TableSortLabel.js
@@ -54,16 +54,11 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  active?: boolean,
-  direction?: Direction,
-};
-
 export type Props = {
   /**
    * If `true`, the label will have the active styling (should be true for the sorted column).
    */
-  active?: boolean,
+  active: boolean,
   /**
    * Label contents, the arrow will be appended automatically.
    */
@@ -79,14 +74,14 @@ export type Props = {
   /**
    * The current sort direction.
    */
-  direction?: Direction,
+  direction: Direction,
 };
 
 /**
  * A button based label for placing inside `TableCell` for column sorting.
  */
 class TableSortLabel extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     active: false,
     direction: 'desc',
   };

--- a/src/Table/TableSortLabel.js
+++ b/src/Table/TableSortLabel.js
@@ -51,6 +51,9 @@ export type Direction = 'asc' | 'desc';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -90,6 +90,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -93,10 +93,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disabled?: boolean,
-};
-
 export type Props = {
   /**
    * Useful to extend the style applied to components.
@@ -109,7 +105,7 @@ export type Props = {
   /**
    * If `true`, the tab will be disabled.
    */
-  disabled?: boolean,
+  disabled: boolean,
   /**
    * @ignore
    */
@@ -159,7 +155,7 @@ type State = {
 };
 
 class Tab extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     disabled: false,
   };
 

--- a/src/Tabs/TabScrollButton.js
+++ b/src/Tabs/TabScrollButton.js
@@ -16,6 +16,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Tabs/TabScrollButton.js
+++ b/src/Tabs/TabScrollButton.js
@@ -19,10 +19,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  visible?: boolean,
-};
-
 export type Props = {
   /**
    * Useful to extend the style applied to components.
@@ -50,7 +46,7 @@ export type Props = {
  * @ignore - internal component.
  */
 class TabScrollButton extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     visible: true,
   };
 

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -55,16 +55,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  centered?: boolean,
-  fullWidth?: boolean,
-  indicatorColor: IndicatorColor,
-  scrollable?: boolean,
-  scrollButtons?: ScrollButtons,
-  textColor?: TextColor,
-  TabScrollButton: ComponentType<*>,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -78,7 +68,7 @@ export type Props = {
    * If `true`, the tabs will be centered.
    * This property is intended for large views.
    */
-  centered?: boolean,
+  centered: boolean,
   /**
    * The content of the component.
    */
@@ -95,7 +85,7 @@ export type Props = {
    * If `true`, the tabs will grow to use all the available space.
    * This property is intended for small views, like on mobile.
    */
-  fullWidth?: boolean,
+  fullWidth: boolean,
   /**
    * The CSS class name of the indicator element.
    */
@@ -103,7 +93,7 @@ export type Props = {
   /**
    * Determines the color of the indicator.
    */
-  indicatorColor: 'accent' | 'primary' | string,
+  indicatorColor: IndicatorColor,
   /**
    * Callback fired when the value changes.
    *
@@ -115,14 +105,14 @@ export type Props = {
    * True invokes scrolling properties and allow for horizontally scrolling
    * (or swiping) the tab bar.
    */
-  scrollable?: boolean,
+  scrollable: boolean,
   /**
    * Determine behavior of scroll buttons when tabs are set to scroll
    * `auto` will only present them on medium and larger viewports
    * `on` will always present them
    * `off` will never present them
    */
-  scrollButtons?: ScrollButtons,
+  scrollButtons: ScrollButtons,
   /**
    * The component used to render the scroll buttons.
    */
@@ -130,7 +120,7 @@ export type Props = {
   /**
    * Determines the color of the `Tab`.
    */
-  textColor?: TextColor,
+  textColor: TextColor,
   /**
    * @ignore
    */
@@ -161,7 +151,7 @@ export type TabsMeta = {
 };
 
 class Tabs extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     centered: false,
     fullWidth: false,
     indicatorColor: 'accent',

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -52,6 +52,9 @@ type TextColor = 'accent' | 'primary' | 'inherit';
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 
@@ -121,10 +124,6 @@ export type Props = {
    * Determines the color of the `Tab`.
    */
   textColor: TextColor,
-  /**
-   * @ignore
-   */
-  theme?: Object,
   /**
    * The value of the currently selected `Tab`.
    * If you don't want any selected `Tab`, you can set this property to `false`.

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -17,6 +17,9 @@ export const styles = (theme: Object) => ({
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -20,10 +20,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disableGutters?: boolean,
-};
-
 export type Props = {
   /**
    * Useful to extend the style applied to components.
@@ -44,7 +40,7 @@ export type Props = {
 };
 
 class Toolbar extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     disableGutters: false,
   };
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -118,6 +118,9 @@ function flipPlacement(placement: Placement): Placement {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 
@@ -187,10 +190,6 @@ export type Props = {
    * Properties applied to the `Popper` element.
    */
   PopperProps?: Object,
-  /**
-   * @ignore
-   */
-  theme?: Object,
 };
 
 type State = {

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -121,15 +121,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  disableTriggerFocus?: boolean,
-  disableTriggerHover?: boolean,
-  disableTriggerTouch?: boolean,
-  enterDelay: number,
-  leaveDelay?: number,
-  placement: Placement,
-};
-
 export type Props = {
   /**
    * Tooltip reference component.
@@ -146,15 +137,15 @@ export type Props = {
   /**
    * Do not respond to focus events.
    */
-  disableTriggerFocus?: boolean,
+  disableTriggerFocus: boolean,
   /**
    * Do not respond to hover events.
    */
-  disableTriggerHover?: boolean,
+  disableTriggerHover: boolean,
   /**
    * Do not respond to long press touch events.
    */
-  disableTriggerTouch?: boolean,
+  disableTriggerTouch: boolean,
   /**
    * The relationship between the tooltip and the wrapper component is not clear from the DOM.
    * By providing this property, we can use aria-describedby to solve the accessibility issue.
@@ -187,7 +178,7 @@ export type Props = {
   /**
    * The number of milliseconds to wait before hidding the tooltip.
    */
-  leaveDelay?: number,
+  leaveDelay: number,
   /**
    * Tooltip placement
    */
@@ -207,7 +198,7 @@ type State = {
 };
 
 class Tooltip extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     disableTriggerFocus: false,
     disableTriggerHover: false,
     disableTriggerTouch: false,

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -78,16 +78,6 @@ export type Type =
 type Align = 'inherit' | 'left' | 'center' | 'right' | 'justify';
 type Color = 'inherit' | 'primary' | 'secondary' | 'accent' | 'error' | 'default';
 
-type DefaultProps = {
-  align: Align,
-  color: Color,
-  gutterBottom: boolean,
-  headlineMapping: { [key: Type]: string },
-  noWrap: boolean,
-  paragraph: boolean,
-  type: Type,
-};
-
 type ProvidedProps = {
   classes: Object,
   theme?: Object,
@@ -143,7 +133,7 @@ export type Props = {
 };
 
 class Typography extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     align: 'inherit',
     color: 'default',
     gutterBottom: false,

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -80,6 +80,9 @@ type Color = 'inherit' | 'primary' | 'secondary' | 'accent' | 'error' | 'default
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import type { Node, Element } from 'react';
+import type { Node } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
@@ -35,12 +35,6 @@ export const styles = {
 type ProvidedProps = {
   classes: Object,
   theme?: Object,
-};
-
-type DefaultProps = {
-  checkedIcon: Node,
-  disableRipple: boolean,
-  icon: Node,
 };
 
 // NB: If changed, please update Checkbox, Switch and Radio
@@ -105,6 +99,10 @@ export type Props = {
    * Use that property to pass a ref callback to the native input component.
    */
   inputRef?: Function,
+  /**
+   * The input component property `type`.
+   */
+  inputType: string,
   /*
    * @ignore
    */
@@ -130,137 +128,125 @@ type State = {
   checked?: boolean,
 };
 
-export type Options = {
-  defaultIcon: Element<*>,
-  defaultCheckedIcon: Element<*>,
-  inputType?: string,
-};
+/**
+ * @ignore - internal component.
+ */
+class SwitchBase extends React.Component<ProvidedProps & Props, State> {
+  static defaultProps = {
+    checkedIcon: (<CheckBoxIcon />: Node), // defaultCheckedIcon
+    disableRipple: false,
+    icon: (<CheckBoxOutlineBlankIcon />: Node), // defaultIcon
+    inputType: 'checkbox',
+  };
 
-export default function createSwitch(
-  {
-    defaultIcon = <CheckBoxOutlineBlankIcon />,
-    defaultCheckedIcon = <CheckBoxIcon />,
-    inputType = 'checkbox',
-  }: Options = {},
-) {
-  /**
-   * @ignore - internal component.
-   */
-  class SwitchBase extends React.Component<ProvidedProps & Props, State> {
-    static defaultProps: DefaultProps = {
-      checkedIcon: defaultCheckedIcon,
-      disableRipple: false,
-      icon: defaultIcon,
-    };
+  static contextTypes = {
+    muiFormControl: PropTypes.object,
+  };
 
-    static contextTypes = {
-      muiFormControl: PropTypes.object,
-    };
+  state = {};
 
-    state = {};
+  componentWillMount() {
+    const { props } = this;
 
-    componentWillMount() {
-      const { props } = this;
+    this.isControlled = props.checked !== undefined;
 
-      this.isControlled = props.checked !== undefined;
-
-      if (!this.isControlled) {
-        // not controlled, use internal state
-        this.setState({
-          checked: props.defaultChecked !== undefined ? props.defaultChecked : false,
-        });
-      }
-    }
-
-    input = null;
-    button = null;
-    isControlled = null;
-
-    handleInputChange = (event: SyntheticInputEvent<*>) => {
-      const checked = event.target.checked;
-
-      if (!this.isControlled) {
-        this.setState({ checked });
-      }
-
-      if (this.props.onChange) {
-        this.props.onChange(event, checked);
-      }
-    };
-
-    render() {
-      const {
-        checked: checkedProp,
-        classes,
-        className: classNameProp,
-        checkedIcon,
-        disabled: disabledProp,
-        icon: iconProp,
-        inputProps,
-        inputRef,
-        name,
-        onChange,
-        tabIndex,
-        value,
-        ...other
-      } = this.props;
-
-      const { muiFormControl } = this.context;
-      let disabled = disabledProp;
-
-      if (muiFormControl) {
-        if (typeof disabled === 'undefined') {
-          disabled = muiFormControl.disabled;
-        }
-      }
-
-      const checked = this.isControlled ? checkedProp : this.state.checked;
-      const className = classNames(classes.root, classes.default, classNameProp, {
-        [classes.checked]: checked,
-        [classes.disabled]: disabled,
+    if (!this.isControlled) {
+      // not controlled, use internal state
+      this.setState({
+        checked: props.defaultChecked !== undefined ? props.defaultChecked : false,
       });
-
-      let icon = checked ? checkedIcon : iconProp;
-
-      if (typeof icon === 'string') {
-        icon = <Icon>{icon}</Icon>;
-      }
-
-      return (
-        <IconButton
-          data-mui-test="SwitchBase"
-          component="span"
-          className={className}
-          disabled={disabled}
-          tabIndex={null}
-          role={undefined}
-          rootRef={node => {
-            this.button = node;
-          }}
-          {...other}
-        >
-          {icon}
-          <input
-            type={inputType}
-            name={name}
-            checked={this.isControlled ? checkedProp : undefined}
-            onChange={this.handleInputChange}
-            className={classes.input}
-            disabled={disabled}
-            tabIndex={tabIndex}
-            value={value}
-            {...inputProps}
-            ref={node => {
-              this.input = node;
-              if (inputRef) {
-                inputRef(node);
-              }
-            }}
-          />
-        </IconButton>
-      );
     }
   }
 
-  return withStyles(styles, { name: 'MuiSwitchBase' })(SwitchBase);
+  input = null;
+  button = null;
+  isControlled = null;
+
+  handleInputChange = (event: SyntheticInputEvent<*>) => {
+    const checked = event.target.checked;
+
+    if (!this.isControlled) {
+      this.setState({ checked });
+    }
+
+    if (this.props.onChange) {
+      this.props.onChange(event, checked);
+    }
+  };
+
+  render() {
+    const {
+      checked: checkedProp,
+      classes,
+      className: classNameProp,
+      checkedIcon,
+      disabled: disabledProp,
+      icon: iconProp,
+      inputProps,
+      inputRef,
+      inputType,
+      name,
+      onChange,
+      tabIndex,
+      value,
+      ...other
+    } = this.props;
+
+    const { muiFormControl } = this.context;
+    let disabled = disabledProp;
+
+    if (muiFormControl) {
+      if (typeof disabled === 'undefined') {
+        disabled = muiFormControl.disabled;
+      }
+    }
+
+    const checked = this.isControlled ? checkedProp : this.state.checked;
+    const className = classNames(classes.root, classes.default, classNameProp, {
+      [classes.checked]: checked,
+      [classes.disabled]: disabled,
+    });
+
+    let icon = checked ? checkedIcon : iconProp;
+
+    if (typeof icon === 'string') {
+      icon = <Icon>{icon}</Icon>;
+    }
+
+    return (
+      <IconButton
+        data-mui-test="SwitchBase"
+        component="span"
+        className={className}
+        disabled={disabled}
+        tabIndex={null}
+        role={undefined}
+        rootRef={node => {
+          this.button = node;
+        }}
+        {...other}
+      >
+        {icon}
+        <input
+          type={inputType}
+          name={name}
+          checked={this.isControlled ? checkedProp : undefined}
+          onChange={this.handleInputChange}
+          className={classes.input}
+          disabled={disabled}
+          tabIndex={tabIndex}
+          value={value}
+          {...inputProps}
+          ref={node => {
+            this.input = node;
+            if (inputRef) {
+              inputRef(node);
+            }
+          }}
+        />
+      </IconButton>
+    );
+  }
 }
+
+export default withStyles(styles, { name: 'MuiSwitchBase' })(SwitchBase);

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -34,6 +34,9 @@ export const styles = {
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
-import createSwitch from './SwitchBase';
+import SwitchBase from './SwitchBase';
 import Icon from '../Icon';
 
 function assertIsChecked(wrapper) {
@@ -49,11 +49,9 @@ describe('<SwitchBase />', () => {
   let shallow;
   let mount;
   let classes;
-  let SwitchBase;
   let SwitchBaseNaked;
 
   before(() => {
-    SwitchBase = createSwitch();
     SwitchBaseNaked = unwrap(SwitchBase);
     shallow = createShallow({ dive: true });
     mount = createMount();

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -34,13 +34,6 @@ type ProvidedProps = {
   theme?: Object,
 };
 
-type DefaultProps = {
-  appear: boolean,
-  component: ElementType,
-  collapsedHeight: string,
-  timeout: TransitionDuration,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -118,11 +111,11 @@ export type Props = {
 };
 
 class Collapse extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     appear: false,
-    component: 'div',
+    component: ('div': ElementType),
     collapsedHeight: '0px',
-    timeout: duration.standard,
+    timeout: (duration.standard: TransitionDuration),
   };
 
   wrapper = null;

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -104,7 +104,7 @@ export type Props = {
    */
   timeout: TransitionDuration,
   /**
-  /* @ignore
+   * @ignore
    */
   unmountOnExit?: boolean,
 };

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -31,6 +31,9 @@ export type TransitionDuration = number | { enter?: number, exit?: number } | 'a
 
 type ProvidedProps = {
   classes: Object,
+  /**
+   * @ignore
+   */
   theme?: Object,
 };
 
@@ -93,10 +96,6 @@ export type Props = {
    * @ignore
    */
   style?: Object,
-  /**
-   * @ignore
-   */
-  theme?: Object,
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -12,11 +12,6 @@ type ProvidedProps = {
   theme: Object,
 };
 
-type DefaultProps = {
-  appear: boolean,
-  timeout: TransitionDuration,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -68,12 +63,12 @@ const reflow = node => node.scrollTop;
  * It's using [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 class Fade extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     appear: true,
-    timeout: {
+    timeout: ({
       enter: duration.enteringScreen,
       exit: duration.leavingScreen,
-    },
+    }: TransitionDuration),
   };
 
   handleEnter = (node: HTMLElement) => {

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -9,6 +9,9 @@ import withTheme from '../styles/withTheme';
 import type { TransitionDuration, TransitionCallback } from '../internal/transition';
 
 type ProvidedProps = {
+  /**
+   * @ignore
+   */
   theme: Object,
 };
 
@@ -41,10 +44,6 @@ export type Props = {
    * @ignore
    */
   onExit?: TransitionCallback,
-  /**
-   * @ignore
-   */
-  theme?: Object,
   /**
    * @ignore
    */

--- a/src/transitions/Grow.js
+++ b/src/transitions/Grow.js
@@ -15,6 +15,9 @@ export function getScale(value: number) {
 export type TransitionDuration = number | { enter?: number, exit?: number } | 'auto';
 
 type ProvidedProps = {
+  /**
+   * @ignore
+   */
   theme: Object,
 };
 
@@ -72,10 +75,6 @@ export type Props = {
    * This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames).
    */
   transitionClasses: TransitionClasses,
-  /**
-   * @ignore
-   */
-  theme?: Object,
   /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.

--- a/src/transitions/Grow.js
+++ b/src/transitions/Grow.js
@@ -18,12 +18,6 @@ type ProvidedProps = {
   theme: Object,
 };
 
-type DefaultProps = {
-  appear?: boolean,
-  timeout: TransitionDuration,
-  transitionClasses?: TransitionClasses,
-};
-
 export type Props = {
   /**
    * Other base element props.
@@ -32,7 +26,7 @@ export type Props = {
   /**
    * @ignore
    */
-  appear?: boolean,
+  appear: boolean,
   /**
    * A single child content element.
    */
@@ -77,7 +71,7 @@ export type Props = {
    * The animation classNames applied to the component as it enters or exits.
    * This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames).
    */
-  transitionClasses?: TransitionClasses,
+  transitionClasses: TransitionClasses,
   /**
    * @ignore
    */
@@ -96,9 +90,9 @@ export type Props = {
  * It's using [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 class Grow extends React.Component<ProvidedProps & Props> {
-  static defaultProps: DefaultProps = {
+  static defaultProps = {
     appear: true,
-    timeout: 'auto',
+    timeout: ('auto': TransitionDuration),
     transitionClasses: {},
   };
 

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -67,6 +67,9 @@ export function setTranslateValue(props: Object, node: HTMLElement | Object) {
 export type Direction = 'left' | 'right' | 'up' | 'down';
 
 type ProvidedProps = {
+  /**
+   * @ignore
+   */
   theme: Object,
 };
 
@@ -120,10 +123,6 @@ export type Props = {
    * You may specify a single timeout for all transitions, or individually with an object.
    */
   timeout: TransitionDuration,
-  /**
-   * @ignore
-   */
-  theme?: Object,
 };
 
 type State = {

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -70,11 +70,6 @@ type ProvidedProps = {
   theme: Object,
 };
 
-type DefaultProps = {
-  direction?: Direction,
-  timeout: TransitionDuration,
-};
-
 export type Props = {
   /**
    * Other Transition element props.
@@ -138,11 +133,11 @@ type State = {
 const reflow = node => node.scrollTop;
 
 class Slide extends React.Component<ProvidedProps & Props, State> {
-  static defaultProps: DefaultProps = {
-    timeout: {
+  static defaultProps = {
+    timeout: ({
       enter: duration.enteringScreen,
       exit: duration.leavingScreen,
-    },
+    }: TransitionDuration),
   };
 
   state = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -55,6 +55,18 @@
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
+"@rosskevin/react-docgen@^3.0.0-beta9":
+  version "3.0.0-beta9"
+  resolved "https://registry.yarnpkg.com/@rosskevin/react-docgen/-/react-docgen-3.0.0-beta9.tgz#af9e50b70360b4954c450ad98819390ea5acfa4a"
+  dependencies:
+    async "^2.6.0"
+    babel-runtime "^6.26.0"
+    babylon "7.0.0-beta.31"
+    commander "^2.11.0"
+    doctrine "^2.0.0"
+    node-dir "^0.1.17"
+    recast "^0.12.9"
+
 "@semantic-release/commit-analyzer@^3.0.1":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@semantic-release/commit-analyzer/-/commit-analyzer-3.0.4.tgz#040bd2b99909f5671063be0c68fd782fd4543997"
@@ -451,10 +463,6 @@ ast-types@0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.10.1.tgz#f52fca9715579a14f841d67d7f8d25432ab6a3dd"
 
-ast-types@0.9.11:
-  version "0.9.11"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.11.tgz#371177bb59232ff5ceaa1d09ee5cad705b1a5aa9"
-
 async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
@@ -473,9 +481,15 @@ async@^1.4.0, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.1, async@^2.1.2, async@^2.1.4:
+async@^2.0.1, async@^2.1.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
+  dependencies:
+    lodash "^4.14.0"
+
+async@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.0.tgz#61a29abb6fcc026fea77e56d1c6ec53a795951f4"
   dependencies:
     lodash "^4.14.0"
 
@@ -1299,7 +1313,7 @@ babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
+babel-runtime@6.26.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -5863,7 +5877,7 @@ nise@^1.2.0:
     path-to-regexp "^1.7.0"
     text-encoding "^0.6.4"
 
-node-dir@^0.1.10:
+node-dir@^0.1.17:
   version "0.1.17"
   resolved "https://registry.yarnpkg.com/node-dir/-/node-dir-0.1.17.tgz#5f5665d93351335caabef8f1c554516cf5f1e4e5"
   dependencies:
@@ -7108,18 +7122,6 @@ react-deep-force-update@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.1.1.tgz#8ea4263cd6455a050b37445b3f08fd839d86e909"
 
-react-docgen@^3.0.0-beta9:
-  version "3.0.0-beta9"
-  resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-3.0.0-beta9.tgz#6be987e640786ecb10ce2dd22157a022c8285e95"
-  dependencies:
-    async "^2.1.4"
-    babel-runtime "^6.9.2"
-    babylon "7.0.0-beta.31"
-    commander "^2.9.0"
-    doctrine "^2.0.0"
-    node-dir "^0.1.10"
-    recast "^0.12.6"
-
 react-dom@^16.1.1:
   version "16.1.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.1.1.tgz#b2e331b6d752faf1a2d31399969399a41d8d45f8"
@@ -7370,16 +7372,6 @@ readdirp@^2.0.0:
     minimatch "^3.0.2"
     readable-stream "^2.0.2"
     set-immediate-shim "^1.0.1"
-
-recast@^0.12.6:
-  version "0.12.6"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.12.6.tgz#4b0fb82feb1d10b3bd62d34943426d9b3ed30d4c"
-  dependencies:
-    ast-types "0.9.11"
-    core-js "^2.4.1"
-    esprima "~4.0.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
 
 recast@^0.12.9:
   version "0.12.9"
@@ -8098,7 +8090,7 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 


### PR DESCRIPTION
Closes #9222

This is a follow-on for #8983 by @rsolomon 

Now that flow's treatment of `defaultProps` changed with flow `0.57.0`, we no longer need to specify `type DefaultProps` separate from `type Props`.

The only quirk is that sometimes when a defaultProp is a union, it needs to be cast to the type specified in `type Props`, as it doesn't seem to be able to resolve it.  Regardless, overall, it's a cut in code and due to reduced duplication.

Also, since `type Props` is the single source of truth, I have fixed the maybe types that were missing in #8983 (due to the difficulty of duplicating these properties in both `Props` and `DefaultProps`)

Regarding `SwitchBase`, it was used as a typical `Component` in all but `Radio`, and even in `Radio`, it was effectively used as a normal component there.  It raised some stateless function flow errors so I simply removed the factory wrapper and exposed the underlying `SwitchBase`, it left usage virtually unchanged.