### PR TITLE
[Portal] Add support for injecting in another document

### DIFF
--- a/src/Modal/Modal.d.ts
+++ b/src/Modal/Modal.d.ts
@@ -13,6 +13,7 @@ export interface ModalProps extends StandardProps<
   BackdropTransitionDuration?: TransitionDuration;
   keepMounted?: boolean;
   disableBackdrop?: boolean;
+  document?: HTMLDocument;
   ignoreBackdropClick?: boolean;
   ignoreEscapeKeyUp?: boolean;
   modalManager?: Object;

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -89,6 +89,10 @@ export type Props = {
    */
   className?: string,
   /**
+   * The document to inject the portal into.
+   */
+  document?: HTMLDocument,
+  /**
    * Always keep the children in the DOM.
    * This property can be useful in SEO situation or
    * when you want to maximize the responsiveness of the Modal.
@@ -374,6 +378,7 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
       children,
       classes,
       className,
+      document,
       keepMounted,
       modalManager: modalManagerProp,
       onBackdropClick,
@@ -432,6 +437,7 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
     return (
       <Portal
         open
+        document={document}
         ref={node => {
           this.mountNode = node ? node.getLayer() : null;
         }}

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -91,7 +91,7 @@ export type Props = {
   /**
    * The document to inject the portal into.
    */
-  document?: HTMLDocument,
+  document?: Document,
   /**
    * Always keep the children in the DOM.
    * This property can be useful in SEO situation or

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -409,7 +409,7 @@ class Popover extends React.Component<ProvidedProps & Props> {
     } = this.props;
 
     return (
-      <Modal show={open} BackdropInvisible {...other}>
+      <Modal document={anchorEl && anchorEl.ownerDocument} show={open} BackdropInvisible {...other}>
         <Grow
           appear
           in={open}

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -408,8 +408,12 @@ class Popover extends React.Component<ProvidedProps & Props> {
       ...other
     } = this.props;
 
+    // Use the ownerDocument of the provided anchorEl to ensure that
+    // we inject the portal into the correct document
+    const document = anchorEl && anchorEl.ownerDocument;
+
     return (
-      <Modal document={anchorEl && anchorEl.ownerDocument} show={open} BackdropInvisible {...other}>
+      <Modal document={document} show={open} BackdropInvisible {...other}>
         <Grow
           appear
           in={open}

--- a/src/internal/Portal.d.ts
+++ b/src/internal/Portal.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 export interface PortalProps {
+  document?: HTMLDocument;
   open?: boolean;
 }
 

--- a/src/internal/Portal.js
+++ b/src/internal/Portal.js
@@ -11,6 +11,10 @@ export type Props = {
    */
   children?: Node,
   /**
+   * The document to inject the portal into.
+   */
+  document?: HTMLDocument,
+  /**
    * If `true` the children will be mounted into the DOM.
    */
   open?: boolean,
@@ -42,12 +46,17 @@ class Portal extends React.Component<Props> {
     this.unrenderLayer();
   }
 
+  getDocument() {
+    return this.props.document || document;
+  }
+
   getLayer() {
     if (!this.layer) {
-      this.layer = document.createElement('div');
+      const doc = this.getDocument();
+      this.layer = doc.createElement('div');
       this.layer.setAttribute('data-mui-portal', 'true');
-      if (document.body && this.layer) {
-        document.body.appendChild(this.layer);
+      if (doc.body && this.layer) {
+        doc.body.appendChild(this.layer);
       }
     }
 
@@ -66,8 +75,10 @@ class Portal extends React.Component<Props> {
       ReactDOM.unmountComponentAtNode(this.layer);
     }
 
-    if (document.body) {
-      document.body.removeChild(this.layer);
+    const doc = this.getDocument();
+
+    if (doc.body) {
+      doc.body.removeChild(this.layer);
     }
     this.layer = null;
   }

--- a/src/internal/Portal.js
+++ b/src/internal/Portal.js
@@ -13,7 +13,7 @@ export type Props = {
   /**
    * The document to inject the portal into.
    */
-  document?: HTMLDocument,
+  document?: Document,
   /**
    * If `true` the children will be mounted into the DOM.
    */
@@ -77,7 +77,7 @@ class Portal extends React.Component<Props> {
 
     const doc = this.getDocument();
 
-    if (doc.body) {
+    if (doc.body && this.layer) {
       doc.body.removeChild(this.layer);
     }
     this.layer = null;


### PR DESCRIPTION
This is a prototype to close #9207. This allows components that rely on Portal (Menu, Modal, Popover, etc), to be rendered in another document outside the main application's document. This supports rendering inside of a new window for example.

Portal now takes an optional document prop, which will be where the portal is injected if provided.

Here's a quick clip showing the new functionality (ignore styling): https://streamable.com/68zk3