### PR TITLE
[docs] Update callemall to mui-org

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -6,7 +6,7 @@
 -->
 
 <!-- Checked checkbox should look like this: [x] -->
-- [ ] I have searched the [issues](https://github.com/callemall/material-ui/issues) of this repository and believe that this is not a duplicate.
+- [ ] I have searched the [issues](https://github.com/mui-org/material-ui/issues) of this repository and believe that this is not a duplicate.
 
 ## Expected Behavior
 <!--- 
@@ -26,7 +26,7 @@
     Include code to reproduce, if relevant (which it most likely is). 
 
     This codesandbox.io template _may_ be a good starting point: 
-    https://codesandbox.io/s/github/callemall/material-ui/tree/v1-beta/examples/create-react-app
+    https://codesandbox.io/s/github/mui-org/material-ui/tree/v1-beta/examples/create-react-app
 
 
     If YOU DO NOT take time to provide a codesandbox.io reproduction, should the COMMUNITY take time to help you? 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,7 +231,7 @@ Big thanks to the 14 contributors who made this release possible.
 
 Here are some highlights ✨:
 - New InputAdornment component (#8504)
-- New [Frequently asked questions](https://github.com/callemall/material-ui/blob/4df547d56448cedf70977d6e2463b38eaf64d1c7/docs/src/pages/getting-started/frequently-asked-questions.md) documentation section
+- New [Frequently asked questions](https://github.com/mui-org/material-ui/blob/4df547d56448cedf70977d6e2463b38eaf64d1c7/docs/src/pages/getting-started/frequently-asked-questions.md) documentation section
 - We have saved 1 KB gzip by removing our internal react-transition-group fork (#8785)
 - We have made one step further in order to upgrade all our development dependencies to react@16 (#8804)
 
@@ -1705,7 +1705,7 @@ Big thanks to the 11 contributors who are pushing the `next` branch forward.
 
 We are continuing investing in the documentation and the test suite.
 
-Visual regression tests are now sent to [argos-ci](https://www.argos-ci.com/callemall/material-ui).
+Visual regression tests are now sent to [argos-ci](https://www.argos-ci.com/mui-org/material-ui).
 Thanks @agamrafaeli for increasing the test coverage of 1% since the last release (95.23%).
 Thanks @mbrookes for fixing the inconsistency of the API and improving the API.
 
@@ -2028,12 +2028,12 @@ We are releasing sooner than we use to for this **special day** :christmas_tree:
 
 2016 has been an exceptional year for Material-UI.
 - We went from 40k to 180k [downloads](https://npm-stat.com/charts.html?package=material-ui&from=2014-12-24&to=2016-12-25) a month. :package:
-- We went from 12k to 22k [stars](http://www.timqian.com/star-history/#callemall/material-ui). :star:
+- We went from 12k to 22k [stars](http://www.timqian.com/star-history/#mui-org/material-ui). :star:
 
 That wouldn't have been possible without this awesome community.
 **Thank you!**
 
-But this's just the beginning, some [exciting stuff](https://github.com/callemall/material-ui/blob/master/ROADMAP.md) is coming in 2017 :sparkles:.
+But this's just the beginning, some [exciting stuff](https://github.com/mui-org/material-ui/blob/master/ROADMAP.md) is coming in 2017 :sparkles:.
 You can preview a **very early** version of the `next` branch following [that link](https://material-ui-next.com).
 
 #### Component Fixes / Enhancements
@@ -2112,7 +2112,7 @@ This is another release improving the stability of `v0.16.x`.
 ## 0.16.3
 ###### _Nov 17, 2016_
 
-This release is intended to solve an [issue](https://github.com/callemall/material-ui/issues/5573) with `react-tap-event-plugin` following the release of React `v15.4.0`.
+This release is intended to solve an [issue](https://github.com/mui-org/material-ui/issues/5573) with `react-tap-event-plugin` following the release of React `v15.4.0`.
 
 #### Component Fixes / Enhancements
 
@@ -2221,7 +2221,7 @@ We are switching in goal so we can release changes more **often**.
 Regarding going forward, this is likely to be the last `minor` release using the **inline-style** approach.
 We are migrating all the components to a **CSS-in-JS** approach on the `next` branch.
 
-For more details, you can have a look a the [next milestone](https://github.com/callemall/material-ui/milestone/14) as well as the [next project](https://github.com/callemall/material-ui/projects/1)
+For more details, you can have a look a the [next milestone](https://github.com/mui-org/material-ui/milestone/14) as well as the [next project](https://github.com/mui-org/material-ui/projects/1)
 
 :warning: New features based on the `master` branch (inline-style) have low priority and will most likely not be reviewed nor merged.
 
@@ -2609,7 +2609,7 @@ documentation page.
 
 Have a ton of imports? almost had a heart attack? worry not, we also made a tool
 to ease your pain. checkout the
-[readme](https://github.com/callemall/material-ui/tree/master/packages/material-ui-codemod/README.md).
+[readme](https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod/README.md).
 
 ##### Breaking Changes
 - [Core] Improve import path for published lib (#3921)
@@ -2799,7 +2799,7 @@ import MUI from 'material-ui'; // no changes here :D
 This release includes huge improvements to the implementation
 of components and utility modules. The most important improvement
 is the removal of mixins from the library, thanks to the
-[great efforts](https://github.com/callemall/material-ui/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+author%3Anewoga+style-propable)
+[great efforts](https://github.com/mui-org/material-ui/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Aclosed+author%3Anewoga+style-propable)
 of @newoga :+1:
 
 There are also improvements to the unit testing infrastructure. We own this
@@ -3693,7 +3693,7 @@ We've cleaned up some of our click/tap events. (#771) Upgrade should be straight
     component specific. In addition to the benefits mentioned in the
     presentation, inline styles allow Material-UI to become CSS preprocessor
     agnostic and make Themeing much more dynamic and simple.
-    [Read our CSS in JS discussion](https://github.com/callemall/material-ui/issues/30)
+    [Read our CSS in JS discussion](https://github.com/mui-org/material-ui/issues/30)
   - Upgrade path:
     - *If you are overriding component CSS classes:* Redefine your overrides as
       an object following [React's inline styles format](https://facebook.github.io/react/tips/inline-styles.html),
@@ -3702,10 +3702,10 @@ We've cleaned up some of our click/tap events. (#771) Upgrade should be straight
       overriding a nested element of the component, check the component's
       documentation and see if there is a style prop available for that nested
       element. If a style prop does not exist for the component's nested element
-      that you are trying to override, [submit an issue](https://github.com/callemall/material-ui/issues/new)
+      that you are trying to override, [submit an issue](https://github.com/mui-org/material-ui/issues/new)
       requesting to have it added.
     - *If you are using any of Material-UI's Less files:* These files have been
-      refactored into their [own javascript files](https://github.com/callemall/material-ui/tree/css-in-js/src/styles)
+      refactored into their [own javascript files](https://github.com/mui-org/material-ui/tree/css-in-js/src/styles)
       and can be accessed like so `var FILENAME = require('material-ui').Styles.FILENAME;`.
       Material-UI has moved away from being a CSS Framework to being simply a
       set of React components.
@@ -3862,7 +3862,7 @@ We've cleaned up some of our click/tap events. (#771) Upgrade should be straight
       For FontIcon, create a custom font file and include it in your project and just pass the Icon
       className into the FontIcon component. For SvgIcon, create a new React component that represents
       that particular icon. This will allow you to package your icons inside your js files. Examples
-      can be found [here](https://github.com/callemall/material-ui/tree/master/src/js/svg-icons).
+      can be found [here](https://github.com/mui-org/material-ui/tree/master/src/js/svg-icons).
     - Additionally, all components that had an icon prop now take an iconClassName prop instead. These
       include FloatingActionButton, IconButton, Menu, MenuItem, and DropDownIcon.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ When in doubt, keep your pull requests small. To give a PR the best chance of ge
 
 As with issues, please begin the title with [ComponentName].
 
-When adding new features or modifying existing, please attempt to include tests to confirm the new behaviour. You can read more about our test setup [here](https://github.com/callemall/material-ui/blob/v1-beta/test/README.md).
+When adding new features or modifying existing, please attempt to include tests to confirm the new behaviour. You can read more about our test setup [here](https://github.com/mui-org/material-ui/blob/v1-beta/test/README.md).
 
 ### Branch Structure
 
-All stable releases are tagged ([view tags](https://github.com/callemall/material-ui/tags)). At any given time, `v1-beta` represents the latest development version of the library.
+All stable releases are tagged ([view tags](https://github.com/mui-org/material-ui/tags)). At any given time, `v1-beta` represents the latest development version of the library.
 Patches or hotfix releases are prepared on an independent branch.
 
 #### `v1-beta` is unsafe
@@ -33,7 +33,7 @@ Please create a new branch from an up to date v1-beta on your fork. (Note, urgen
 
 If you have an existing local repository, please update it before you start, to minimise the chance of merge conflicts.
 ```js
-git remote add upstream git@github.com:callemall/material-ui.git
+git remote add upstream git@github.com:mui-org/material-ui.git
 git checkout v1-beta
 git pull upstream v1-beta
 git checkout -b my-topic-branch
@@ -110,12 +110,12 @@ Then, you will need to add the following code:
 
 #### 4. You are done 🎉!
 
-In case you missed something, [we have a real example that can be used as a summary report]((https://github.com/callemall/material-ui/pull/8922/files)).
+In case you missed something, [we have a real example that can be used as a summary report]((https://github.com/mui-org/material-ui/pull/8922/files)).
 
 ## Roadmap
 
-To get a sense of where Material-UI is heading, or for ideas on where you could contribute, take a look at the [ROADMAP](https://github.com/callemall/material-ui/blob/v1-beta/ROADMAP.md).
+To get a sense of where Material-UI is heading, or for ideas on where you could contribute, take a look at the [ROADMAP](https://github.com/mui-org/material-ui/blob/v1-beta/ROADMAP.md).
 
 ## License
 
-By contributing your code to the callemall/material-ui GitHub repository, you agree to license your contribution under the MIT license.
+By contributing your code to the mui-org/material-ui GitHub repository, you agree to license your contribution under the MIT license.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ that you can use to tag your questions.
 # [Material-UI@v1-beta](https://material-ui-next.com/)
 [![npm package](https://img.shields.io/npm/v/material-ui/next.svg)](https://www.npmjs.org/package/material-ui)
 [![CircleCI](https://img.shields.io/circleci/project/github/mui-org/material-ui/v1-beta.svg)](https://circleci.com/gh/mui-org/material-ui/tree/v1-beta)
-[![Gitter](https://img.shields.io/badge/gitter-join%20chat-f81a65.svg)](https://gitter.im/mui-org/material-ui?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://img.shields.io/badge/gitter-join%20chat-f81a65.svg)](https://gitter.im/callemall/material-ui?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Coverage Status](https://img.shields.io/codecov/c/github/mui-org/material-ui/v1-beta.svg)](https://codecov.io/gh/mui-org/material-ui/branch/v1-beta)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/1320/badge)](https://bestpractices.coreinfrastructure.org/projects/1320)
 
@@ -59,7 +59,7 @@ render(<App />, document.querySelector('#app'));
 ## Examples
 
 Are you looking for an example project to get started?
-[We host some](https://github.com/callemall/material-ui/blob/v1-beta/docs/src/pages/getting-started/example-projects.md).
+[We host some](https://github.com/mui-org/material-ui/blob/v1-beta/docs/src/pages/getting-started/example-projects.md).
 
 ## Documentation
 
@@ -67,16 +67,16 @@ Check out our [documentation website](https://material-ui-next.com/).
 
 ## Contributing
 
-We'd greatly appreciate any [contribution](https://github.com/callemall/material-ui/blob/v1-beta/CONTRIBUTING.md) you make. :)
+We'd greatly appreciate any [contribution](https://github.com/mui-org/material-ui/blob/v1-beta/CONTRIBUTING.md) you make. :)
 
 ## Changelog
 
 Recently Updated?
-Please read the [changelog](https://github.com/callemall/material-ui/releases).
+Please read the [changelog](https://github.com/mui-org/material-ui/releases).
 
 ## Roadmap
 
-The future plans and high priority features and enhancements can be found in the [ROADMAP.md](https://github.com/callemall/material-ui/blob/v1-beta/ROADMAP.md) file.
+The future plans and high priority features and enhancements can be found in the [ROADMAP.md](https://github.com/mui-org/material-ui/blob/v1-beta/ROADMAP.md) file.
 
 ## Thanks
 
@@ -87,4 +87,4 @@ Thank you to [BrowserStack](https://www.browserstack.com/) for providing the inf
 ## License
 
 This project is licensed under the terms of the
-[MIT license](https://github.com/callemall/material-ui/blob/v1-beta/LICENSE).
+[MIT license](https://github.com/mui-org/material-ui/blob/v1-beta/LICENSE).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,16 +9,16 @@ The roadmap is a living document, and it is likely that priorities will change, 
 Version 1 release is going to be huge ✨.
 We host a temporary [documentation site](https://material-ui-next.com) for the pre-releases.
 
-Material-UI was started [3 years ago](https://github.com/callemall/material-ui/commit/28b768913b75752ecf9b6bb32766e27c241dbc46).
+Material-UI was started [3 years ago](https://github.com/mui-org/material-ui/commit/28b768913b75752ecf9b6bb32766e27c241dbc46).
 The ecosystem has evolved a lot since then, we have also learned a lot.
 [@nathanmarks](https://github.com/nathanmarks/) started an ambitious task, rebuilding Material-UI from the **ground-up**
 taking advantage of this knowledge to address long-standing issues.
 Expect various **breaking changes**.
 
-The core team is now helping him in the [v1-beta](https://github.com/callemall/material-ui/tree/v1-beta) branch.
+The core team is now helping him in the [v1-beta](https://github.com/mui-org/material-ui/tree/v1-beta) branch.
 If you are interested in following our progress or if you want to help us reach that goal faster, you can have a look at the following milestones:
-- ~~[v1.0.0-beta](https://github.com/callemall/material-ui/milestone/22)~~ - complete!
-- [v1.0.0-prerelease](https://github.com/callemall/material-ui/milestone/14)
+- ~~[v1.0.0-beta](https://github.com/mui-org/material-ui/milestone/22)~~ - complete!
+- [v1.0.0-prerelease](https://github.com/mui-org/material-ui/milestone/14)
 
 ## Q&A with the v1 version
 
@@ -70,11 +70,11 @@ We should answer the following questions:
 - What trade-offs are we going to make?
 - What features will be implemented?
 
-That conversation could start on one of the following [issues](https://github.com/callemall/material-ui/issues?q=is%3Aissue+is%3Aopen+label%3ARefactoring+label%3Anext).
+That conversation could start on one of the following [issues](https://github.com/mui-org/material-ui/issues?q=is%3Aissue+is%3Aopen+label%3ARefactoring+label%3Anext).
 
 ### How do I know if a component still needs to be migrated `v1-beta`?
 
-We have [some open issues](https://github.com/callemall/material-ui/issues?q=is%3Aopen+is%3Aissue+label%3ARefactoring+label%3Av1) to **coordinate** the work toward the `v1.0.0` release.
+We have [some open issues](https://github.com/mui-org/material-ui/issues?q=is%3Aopen+is%3Aissue+label%3ARefactoring+label%3Av1) to **coordinate** the work toward the `v1.0.0` release.
 
 ### How do I start migrating components to the `v1-beta` branch?
 
@@ -90,7 +90,7 @@ That's really up to you. At least, you going to have to:
 
 We don't have an ETA for the release of the `v1`, however, we are going to try to follow this plan:
 
-1. ~~We completely address the styling issue before moving from *alpha* to [*beta*](https://github.com/callemall/material-ui/milestone/22).~~
+1. ~~We completely address the styling issue before moving from *alpha* to [*beta*](https://github.com/mui-org/material-ui/milestone/22).~~
 2. ~~We publish our first beta releases.~~
 3. We fix the last API inconsistencies (as we can make breaking changes without having to worry much).
 4. We merge the beta branch into master
@@ -120,5 +120,5 @@ On the other hand, using a smart date library for the DatePicker / TimePicker wo
 ## Future
 
 - Add missing components, and missing features from current ones
-- [[#7721](https://github.com/callemall/material-ui/issues/7721)] Preact support
-- [[#593](https://github.com/callemall/material-ui/issues/593)] Support React Native
+- [[#7721](https://github.com/mui-org/material-ui/issues/7721)] Preact support
+- [[#593](https://github.com/mui-org/material-ui/issues/593)] Support React Native

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@ For how-to questions and other non-issues, please use [StackOverflow](http://sta
 
 ## Opening an Issue
 
-If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported or fixed](https://github.com/callemall/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed). You can search through existing issues and PRs to see if someone has reported one similar to yours.
+If you think you have found a bug, or have a new feature idea, please start by making sure it hasn't already been [reported or fixed](https://github.com/mui-org/material-ui/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aclosed). You can search through existing issues and PRs to see if someone has reported one similar to yours.
 
 Next, create a new issue that briefly explains the problem, and provides a bit of background as to the circumstances that triggered it, and steps to reproduce it.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,5 +10,5 @@ npm run docs:dev
 
 ## How can I add a new demo in the documentation?
 
-[You can follow this guide](https://github.com/callemall/material-ui/blob/v1-beta/CONTRIBUTING.md)
+[You can follow this guide](https://github.com/mui-org/material-ui/blob/v1-beta/CONTRIBUTING.md)
 on how to get started contributing to Material-UI.

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -81,7 +81,7 @@ function reduceChildRoutes(props, activePage, items, childPage, index) {
   return items;
 }
 
-const GITHUB_RELEASE_BASE_URL = 'https://github.com/callemall/material-ui/releases/tag/';
+const GITHUB_RELEASE_BASE_URL = 'https://github.com/mui-org/material-ui/releases/tag/';
 
 function AppDrawer(props: Object, context: Object) {
   const { classes, className, disablePermanent, mobileOpen, onRequestClose } = props;

--- a/docs/src/modules/components/AppFooter.js
+++ b/docs/src/modules/components/AppFooter.js
@@ -39,13 +39,13 @@ function AppFooter(props: Object) {
             <Grid item xs={12} sm={6}>
               <ul className={classes.list}>
                 <li className={classes.listItem}>
-                  <Link href="https://github.com/callemall/material-ui/tree/v1-beta">GitHub</Link>
+                  <Link href="https://github.com/mui-org/material-ui/tree/v1-beta">GitHub</Link>
                 </li>
                 <li className={classes.listItem}>
                   <Link href="https://twitter.com/MaterialUI">Twitter</Link>
                 </li>
                 <li className={classes.listItem}>
-                  <Link href="https://github.com/callemall/material-ui/tree/v1-beta/examples">
+                  <Link href="https://github.com/mui-org/material-ui/tree/v1-beta/examples">
                     Examples
                   </Link>
                 </li>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -238,7 +238,7 @@ class AppFrame extends React.Component<any, any> {
               component="a"
               title="GitHub"
               color="contrast"
-              href="https://github.com/callemall/material-ui/tree/v1-beta"
+              href="https://github.com/mui-org/material-ui/tree/v1-beta"
             >
               <Github />
             </IconButton>

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -25,7 +25,7 @@ const styles = {
 };
 
 const demoRegexp = /^demo='(.*)'$/;
-const SOURCE_CODE_ROOT_URL = 'https://github.com/callemall/material-ui/tree/v1-beta';
+const SOURCE_CODE_ROOT_URL = 'https://github.com/mui-org/material-ui/tree/v1-beta';
 
 type InjectedProps = {
   classes: Object,

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -5,7 +5,7 @@ import recast from 'recast';
 import kebabCase from 'lodash/kebabCase';
 import { pageToTitle } from './helpers';
 
-const SOURCE_CODE_ROOT_URL = 'https://github.com/callemall/material-ui/tree/v1-beta';
+const SOURCE_CODE_ROOT_URL = 'https://github.com/mui-org/material-ui/tree/v1-beta';
 
 function generateHeader(reactAPI) {
   return ['---', `filename: ${reactAPI.filename}`, '---'].join('\n');

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -78,7 +78,7 @@ You can make a theme dark by setting `type` to `dark`.
 ### The other variables
 
 We have tried to normalize the implementation by adding many more variables: typography, breakpoints, transitions, etc. You can see below what the theme object looks like with the default values.
-If you want to learn more, we suggesting having a look at [`material-ui/style/createMuiTheme.js`](https://github.com/callemall/material-ui/blob/v1-beta/src/styles/createMuiTheme.js).
+If you want to learn more, we suggesting having a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/v1-beta/src/styles/createMuiTheme.js).
 
 {{demo='pages/customization/ThemeDefault.js'}}
 
@@ -101,7 +101,7 @@ That's a really powerful feature.
 
 The list of these customization points for each component is documented under the **Component API** section.
 For instance, you can have a look at the [Button](/api/button#css-api).
-Alternatively, you can always have a look at the [implementation](https://github.com/callemall/material-ui/blob/v1-beta/src/Button/Button.js).
+Alternatively, you can always have a look at the [implementation](https://github.com/mui-org/material-ui/blob/v1-beta/src/Button/Button.js).
 
 ## Accessing the theme in a component
 

--- a/docs/src/pages/demos/pickers/pickers.md
+++ b/docs/src/pages/demos/pickers/pickers.md
@@ -12,7 +12,7 @@ components: TextField
 #### Notice
 
 We are currently falling back to **native input controls**.
-If you are interested in implementing or have implemented a rich Material Design Picker with an awesome UX, please, let us know on [#4787](https://github.com/callemall/material-ui/issues/4787) and [#4796](https://github.com/callemall/material-ui/issues/4796)! We could add a link to or a demo of your project in the documentation.
+If you are interested in implementing or have implemented a rich Material Design Picker with an awesome UX, please, let us know on [#4787](https://github.com/mui-org/material-ui/issues/4787) and [#4796](https://github.com/mui-org/material-ui/issues/4796)! We could add a link to or a demo of your project in the documentation.
 Here are some components that are promising:
 - [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker)
 - [material-ui-pickers](https://github.com/dmtrKovalenko/material-ui-pickers)

--- a/docs/src/pages/discover-more/showcase.md
+++ b/docs/src/pages/discover-more/showcase.md
@@ -2,7 +2,7 @@
 
 The following is a list of some of the public apps using Material-UI. Not all of them have their interface implemented using 100% Material-UI.
 
-Want to add your app? Found an app that no longer works or no longer uses Material-UI? Please submit a pull request on [GitHub](https://github.com/callemall/material-ui) to update this page!
+Want to add your app? Found an app that no longer works or no longer uses Material-UI? Please submit a pull request on [GitHub](https://github.com/mui-org/material-ui) to update this page!
 
 ## The list
 

--- a/docs/src/pages/discover-more/team.md
+++ b/docs/src/pages/discover-more/team.md
@@ -7,7 +7,7 @@ The development of the project and its ecosystem is guided by an international t
 
 {{demo='pages/discover-more/Team.js'}}
 
-Get involved with Material-UI development by [opening an issue](https://github.com/callemall/material-ui/issues/new) or submitting a pull request.
-Read our [contributing guidelines](https://github.com/callemall/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.
+Get involved with Material-UI development by [opening an issue](https://github.com/mui-org/material-ui/issues/new) or submitting a pull request.
+Read our [contributing guidelines](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.
 
 [Join the Material-UI Community!](/discover-more/community)

--- a/docs/src/pages/getting-started/example-projects.md
+++ b/docs/src/pages/getting-started/example-projects.md
@@ -2,13 +2,13 @@
 
 Are you looking for an example project to get started?
 
-We host some example projects which you can find in the [GitHub repository](https://github.com/callemall/material-ui) under the [`/examples`](https://github.com/callemall/material-ui/tree/v1-beta/examples) folder:
-- [Create React App](https://github.com/callemall/material-ui/tree/v1-beta/examples/create-react-app)
-- [Next.js](https://github.com/callemall/material-ui/tree/v1-beta/examples/nextjs)
-- [Create React App with Flow](https://github.com/callemall/material-ui/tree/v1-beta/examples/create-react-app-with-flow)
-- [Create React App with TypeScript](https://github.com/callemall/material-ui/tree/v1-beta/examples/create-react-app-with-typescript)
+We host some example projects which you can find in the [GitHub repository](https://github.com/mui-org/material-ui) under the [`/examples`](https://github.com/mui-org/material-ui/tree/v1-beta/examples) folder:
+- [Create React App](https://github.com/mui-org/material-ui/tree/v1-beta/examples/create-react-app)
+- [Next.js](https://github.com/mui-org/material-ui/tree/v1-beta/examples/nextjs)
+- [Create React App with Flow](https://github.com/mui-org/material-ui/tree/v1-beta/examples/create-react-app-with-flow)
+- [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/v1-beta/examples/create-react-app-with-typescript)
 
 The source code for this documentation site is also included in the repository.
 This is a slightly more complex project.
-Check out the [`/docs`](https://github.com/callemall/material-ui/tree/v1-beta/docs) folder for
+Check out the [`/docs`](https://github.com/mui-org/material-ui/tree/v1-beta/docs) folder for
 build instructions.

--- a/docs/src/pages/getting-started/frequently-asked-questions.md
+++ b/docs/src/pages/getting-started/frequently-asked-questions.md
@@ -15,7 +15,7 @@ In this situation, you can apply a global `.mui-fixed` class name to tell Materi
 
 The best solution at present is to write wrapping components for all the Material-UI components showing a ripple.
 The ripple effect is exclusively coming from the `BaseButton` component.
-You can find the components using the BaseButton [here](https://github.com/callemall/material-ui/search?utf8=%E2%9C%93&q=%22%2F%2F+%40inheritedComponent+ButtonBase%22).
+You can find the components using the BaseButton [here](https://github.com/mui-org/material-ui/search?utf8=%E2%9C%93&q=%22%2F%2F+%40inheritedComponent+ButtonBase%22).
 Then, all you have to do is to provide the `disableRipple` property.
 
 ## When should I use inline-style vs `withStyles()`?
@@ -56,7 +56,7 @@ export default withTheme()(withStyles(styles)(Modal));
 ## Material-UI is awesome. How can I support the project?
 
 There are a lot of ways to support Material-UI:
-- Improve [the documentation](https://github.com/callemall/material-ui/tree/v1-beta/docs).- Help others to get started.- [Spread the word](https://twitter.com/MaterialUI).- Answer [StackOverflow questions](https://stackoverflow.com/questions/tagged/material-ui).If you use Material-UI in a commercial project and would like to support its continued development by becoming a **Sponsor**,
+- Improve [the documentation](https://github.com/mui-org/material-ui/tree/v1-beta/docs).- Help others to get started.- [Spread the word](https://twitter.com/MaterialUI).- Answer [StackOverflow questions](https://stackoverflow.com/questions/tagged/material-ui).If you use Material-UI in a commercial project and would like to support its continued development by becoming a **Sponsor**,
 or in a side or hobby project and would like to become a backer, you can do so through [OpenCollective](https://opencollective.com/material-ui).
 
 All funds raised are managed transparently, and Sponsors receive recognition in the README and on the Material-UI home page.

--- a/docs/src/pages/getting-started/supported-components.md
+++ b/docs/src/pages/getting-started/supported-components.md
@@ -10,7 +10,7 @@ feature of every component, but rather to provide the building blocks to
 allow developers to create compelling user interfaces and experiences.
 
 If you wish to add support for a component or feature not highlighted
-here, please search for the relevant [GitHub Issue](https://github.com/callemall/material-ui/issues), or create a new one
+here, please search for the relevant [GitHub Issue](https://github.com/mui-org/material-ui/issues), or create a new one
 to discuss the approach before submitting a PR.
 
 - **[App Bar](https://material.io/guidelines/layout/structure.html#structure-app-bar) ✓**

--- a/docs/src/pages/guides/comparison.md
+++ b/docs/src/pages/guides/comparison.md
@@ -7,11 +7,11 @@ That’s what we hope to answer for you here.
 
 We’d like your help keeping this document up-to-date because the JavaScript world moves fast!
 If you notice an inaccuracy or something that doesn’t seem quite right, please let us know by
-[opening an issue](https://github.com/callemall/material-ui/issues/new?title=[Docs]+Inaccuracy+in+comparison+guide).
+[opening an issue](https://github.com/mui-org/material-ui/issues/new?title=[Docs]+Inaccuracy+in+comparison+guide).
 
 ## Material-UI
 
-![stars](https://img.shields.io/github/stars/callemall/material-ui.svg?style=social&label=Star)
+![stars](https://img.shields.io/github/stars/mui-org/material-ui.svg?style=social&label=Star)
 ![npm](https://img.shields.io/npm/dm/material-ui.svg)
 
 We'll try very hard to avoid bias, although as the core team, we obviously like Material-UI a lot ❤️.
@@ -86,7 +86,7 @@ Our vision is to provide an elegant implementation of the Material Design guidel
 We want to see businesses succeeding in taking advantage of Material-UI to ship an awesome UI to their users
 while having it match their brand, so we have invested a lot in the customization capabilities of Material-UI.
 
-The only goal of MDC-Web is to be a Material Design implementation for the web platform. **Nothing more, nothing less**. They will not consider making changes to the components - especially UX changes - that would facilitate additional flexibility at the cost of breaking with the core Material Design system, as that is a non-goal of the project. *[source](https://github.com/callemall/material-ui/issues/6799#issuecomment-299925174)*
+The only goal of MDC-Web is to be a Material Design implementation for the web platform. **Nothing more, nothing less**. They will not consider making changes to the components - especially UX changes - that would facilitate additional flexibility at the cost of breaking with the core Material Design system, as that is a non-goal of the project. *[source](https://github.com/mui-org/material-ui/issues/6799#issuecomment-299925174)*
 
 ### Tests
 
@@ -95,7 +95,7 @@ Both projects invest a lot in tests. At the time of writing, both projects have 
 - MDC-web has 1200+ unit tests running on all the major browsers.
 
 Still, there is one thing that sets Material-UI apart and it's key:
-We have [hundreds of visual regression tests](https://www.argos-ci.com/callemall/material-ui) when MDC-web doesn't have any.
+We have [hundreds of visual regression tests](https://www.argos-ci.com/mui-org/material-ui) when MDC-web doesn't have any.
 With visual regression tests, you don't have to make any trade-off:
 - You can spend less time making sure every contribution doesn't introduce unexpected regressions.
 The **less** time you spend on a single contribution, the **more** contributions you can accept.

--- a/docs/src/pages/guides/flow.md
+++ b/docs/src/pages/guides/flow.md
@@ -1,4 +1,4 @@
 # Flow
 
 You can add static typing to JavaScript to improve developer productivity and code quality thanks to [Flow](https://github.com/facebook/flow).
-Have a look at the [Create React App with Flow](https://github.com/callemall/material-ui/tree/v1-beta/examples/create-react-app-with-flow) example.
+Have a look at the [Create React App with Flow](https://github.com/mui-org/material-ui/tree/v1-beta/examples/create-react-app-with-flow) example.

--- a/docs/src/pages/guides/migration-v0.x.md
+++ b/docs/src/pages/guides/migration-v0.x.md
@@ -10,14 +10,14 @@ We have been making lower-level components, abstracting less complexity.
 
 ### What motivated such large change?
 
-Material-UI was started [3 years ago](https://github.com/callemall/material-ui/commit/28b768913b75752ecf9b6bb32766e27c241dbc46).
+Material-UI was started [3 years ago](https://github.com/mui-org/material-ui/commit/28b768913b75752ecf9b6bb32766e27c241dbc46).
 The ecosystem has evolved a lot since then, we have also learned a lot.
 [@nathanmarks](https://github.com/nathanmarks/) started an ambitious task, rebuilding Material-UI from the **ground-up**
 taking advantage of this knowledge to address long-standing issues. To name some of the major changes:
 - New styling solution using CSS-in-JS (better [customization](/customization/overrides) power, better performance)
 - New [theme handling](/customization/themes) (nesting, self-supporting, etc.)
 - Blazing fast documentation thanks to [Next.js](https://github.com/zeit/next.js)
-- Way better [test coverage](/guides/testing) (99%+, run on all the major browsers, [visual regression tests](https://www.argos-ci.com/callemall/material-ui))
+- Way better [test coverage](/guides/testing) (99%+, run on all the major browsers, [visual regression tests](https://www.argos-ci.com/mui-org/material-ui))
 - Full [server-side rendering](/guides/server-rendering) support
 - Wide range of [supported browsers](/getting-started/supported-platforms)
 
@@ -48,14 +48,14 @@ then
 import FlatButton from 'material-ui/FlatButton'; // v0.x
 import Button from 'material-ui-next/Button'; // v1.x
 ```
-2. Run [the migration helper](https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-codemod) on your project.
+2. Run [the migration helper](https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui-codemod) on your project.
 3. After that, you are free to migrate one component instance at the time.
 
 ## Components
 
 ### Svg Icon
 
-First, run [the migration helper](https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-codemod) on your project.
+First, run [the migration helper](https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui-codemod) on your project.
 
 However, this might not be enough when using the svg icons.
 The `material-ui-icons` package has a dependency on the `masterial-ui/SvgIcon` module.
@@ -95,4 +95,4 @@ global.__MUI_SvgIcon__ = SvgIcon;
 ### To be continued…
 
 You successfully migrated your app and wish to help the community?
-Please help us! We have an open issue in order to finish this migration guide [#7195](https://github.com/callemall/material-ui/issues/7195). Any pull request is welcomed 😊.
+Please help us! We have an open issue in order to finish this migration guide [#7195](https://github.com/mui-org/material-ui/issues/7195). Any pull request is welcomed 😊.

--- a/docs/src/pages/guides/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size.md
@@ -5,8 +5,8 @@
 Material-UI takes the bundle size very seriously.
 We are relying on [size-limit](https://github.com/ai/size-limit) to prevent introducing any regression.
 We monitor the size of the bundle:
-- When importing **all the components**. This lets us spot any [unwanted bundle size increase](https://github.com/callemall/material-ui/tree/v1-beta/.size-limit#L4).
-- When importing **a single component**. This lets us estimate [the overhead of our core dependencies](https://github.com/callemall/material-ui/tree/v1-beta/.size-limit#L8). (styling, theming, etc.: ~20 kB gzipped)
+- When importing **all the components**. This lets us spot any [unwanted bundle size increase](https://github.com/mui-org/material-ui/tree/v1-beta/.size-limit#L4).
+- When importing **a single component**. This lets us estimate [the overhead of our core dependencies](https://github.com/mui-org/material-ui/tree/v1-beta/.size-limit#L8). (styling, theming, etc.: ~20 kB gzipped)
 
 ## How to reduce the bundle size?
 

--- a/docs/src/pages/guides/testing.md
+++ b/docs/src/pages/guides/testing.md
@@ -3,10 +3,10 @@
 ## Internal
 
 We take tests seriously. We have written and maintain **a wide range** of tests so we can
-iterate with confidence on the components, for instance, the visual regression tests provided by [Argos-CI](https://www.argos-ci.com/callemall/material-ui) have proven to be really helpful.
-To learn more about our internal tests, you can have a look at the [README](https://github.com/callemall/material-ui/blob/v1-beta/test/README.md).
+iterate with confidence on the components, for instance, the visual regression tests provided by [Argos-CI](https://www.argos-ci.com/mui-org/material-ui) have proven to be really helpful.
+To learn more about our internal tests, you can have a look at the [README](https://github.com/mui-org/material-ui/blob/v1-beta/test/README.md).
 
-[![Coverage Status](https://img.shields.io/codecov/c/github/callemall/material-ui/v1-beta.svg)](https://codecov.io/gh/callemall/material-ui/branch/v1-beta)
+[![Coverage Status](https://img.shields.io/codecov/c/github/mui-org/material-ui/v1-beta.svg)](https://codecov.io/gh/mui-org/material-ui/branch/v1-beta)
 
 ## Userspace
 

--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -1,7 +1,7 @@
 # TypeScript
 
 You can add static typing to JavaScript to improve developer productivity and code quality thanks to [TypeScript](https://www.typescriptlang.org/).
-Have a look at the [Create React App with TypeScript](https://github.com/callemall/material-ui/tree/v1-beta/examples/create-react-app-with-typescript) example.
+Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/v1-beta/examples/create-react-app-with-typescript) example.
 
 ## Usage of `withStyles`
 

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/callemall/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/callemall/material-ui/issues"
+    "url": "https://github.com/mui-org/material-ui/issues"
   },
   "homepage": "http://material-ui.com/",
   "scripts": {

--- a/packages/eslint-plugin-material-ui/package.json
+++ b/packages/eslint-plugin-material-ui/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "description": "Custom eslint rules for Material-UI",
-  "repository": "https://github.com/callemall/material-ui/packages/eslint-plugin-material-ui",
+  "repository": "https://github.com/mui-org/material-ui/packages/eslint-plugin-material-ui",
   "main": "lib/index.js",
   "scripts": {
     "test": "../../node_modules/mocha/bin/_mocha -- tests/lib/**/*.js",

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -44,7 +44,7 @@ jscodeshift -t <color-imports.js> <path> --importPath='mui/styles/colors' --targ
 
 #### `svg-icon-imports`
 
-Updates the `svg-icons` import paths from `material-ui/svg-icons/<category>/<icon-name>` to `material-ui-icons/<IconName>`, to use the new [`material-ui-icons`](https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-icons) package.
+Updates the `svg-icons` import paths from `material-ui/svg-icons/<category>/<icon-name>` to `material-ui-icons/<IconName>`, to use the new [`material-ui-icons`](https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui-icons) package.
 The diff should look like this:
 
 ```diff

--- a/packages/material-ui-codemod/package.json
+++ b/packages/material-ui-codemod/package.json
@@ -18,13 +18,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/callemall/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git"
   },
   "files": [
     "src",
     "lib"
   ],
-  "homepage": "https://github.com/callemall/material-ui/tree/master/packages/material-ui-codemod",
+  "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod",
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/material-ui-codemod/src/v1.0.0/color-imports.js
+++ b/packages/material-ui-codemod/src/v1.0.0/color-imports.js
@@ -1,5 +1,5 @@
 // This codemod attempts to fix the color imports breaking change introduced in
-// https://github.com/callemall/material-ui/releases/tag/v1.0.0-alpha.21
+// https://github.com/mui-org/material-ui/releases/tag/v1.0.0-alpha.21
 
 // List of colors that are in the `common` module
 const commonColors = [

--- a/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.js
+++ b/packages/material-ui-codemod/src/v1.0.0/svg-icon-imports.js
@@ -22,7 +22,7 @@ function pascalize(iconName) {
  * Update all `svg-icons` import references to use `material-ui-icons` package.
  * Find and replace string literal AST nodes to ensure all svg-icon paths get updated, regardless
  * of being in an import declaration, or a require() call, etc.
- * https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-icons
+ * https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui-icons
  * @param {jscodeshift_api_object} j
  * @param {jscodeshift_ast_object} root
  */

--- a/packages/material-ui-dependents/package.json
+++ b/packages/material-ui-dependents/package.json
@@ -6,6 +6,6 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/callemall/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git"
   }
 }

--- a/packages/material-ui-icons/README.md
+++ b/packages/material-ui-icons/README.md
@@ -49,4 +49,4 @@ Note: Importing named exports in this way will result in the code for *every ico
 If you are upgrading an existing project from Material-UI 0.x.x, you will need to revise the import paths
 from `material-ui/svg-icons/<category>/<icon-name>` to `material-ui-icons/<IconName>`.
 
-[Here](https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-codemod#svg-icon-imports)'s a `jscodeshift` [codemod](https://github.com/facebook/codemod) to help you upgrade.
+[Here](https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui-codemod#svg-icon-imports)'s a `jscodeshift` [codemod](https://github.com/facebook/codemod) to help you upgrade.

--- a/packages/material-ui-icons/builder.md
+++ b/packages/material-ui-icons/builder.md
@@ -35,5 +35,5 @@ through command line options.
   The default and Material Design filters can be found in `filters/rename`.
 
 If you experience any issues building icons or would like a feature added,
-[file an issue](https://github.com/callemall/material-ui/issues) and let us
+[file an issue](https://github.com/mui-org/material-ui/issues) and let us
 know.

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -15,13 +15,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/callemall/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/callemall/material-ui/issues"
+    "url": "https://github.com/mui-org/material-ui/issues"
   },
-  "homepage": "https://github.com/callemall/material-ui/tree/v1-beta/packages/material-ui-icons",
+  "homepage": "https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui-icons",
   "scripts": {
     "prebuild": "rimraf build",
     "build:es2015": "cross-env NODE_ENV=production babel ./src --out-dir ./build",

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -32,7 +32,7 @@ This property accepts the following keys:
 - `colorAccent`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/AppBar/AppBar.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/AppBar/AppBar.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -32,7 +32,7 @@ This property accepts the following keys:
 - `img`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Avatar/Avatar.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Avatar/Avatar.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -29,7 +29,7 @@ This property accepts the following keys:
 - `colorAccent`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Badge/Badge.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Badge/Badge.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/bottom-navigation-button.md
+++ b/pages/api/bottom-navigation-button.md
@@ -34,7 +34,7 @@ This property accepts the following keys:
 - `icon`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/BottomNavigation/BottomNavigationButton.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/BottomNavigation/BottomNavigationButton.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -27,7 +27,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/BottomNavigation/BottomNavigation.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/BottomNavigation/BottomNavigation.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -33,7 +33,7 @@ This property accepts the following keys:
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/ButtonBase/ButtonBase.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/ButtonBase/ButtonBase.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -46,7 +46,7 @@ This property accepts the following keys:
 - `fab`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Button/Button.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Button/Button.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -26,7 +26,7 @@ This property accepts the following keys:
 - `actionSpacing`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Card/CardActions.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Card/CardActions.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/card-content.md
+++ b/pages/api/card-content.md
@@ -23,7 +23,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Card/CardContent.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Card/CardContent.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/card-header.md
+++ b/pages/api/card-header.md
@@ -32,7 +32,7 @@ This property accepts the following keys:
 - `subheader`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Card/CardHeader.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Card/CardHeader.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -27,7 +27,7 @@ This property accepts the following keys:
 - `rootMedia`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Card/CardMedia.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Card/CardMedia.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -37,7 +37,7 @@ This property accepts the following keys:
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Checkbox/Checkbox.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Checkbox/Checkbox.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -33,7 +33,7 @@ This property accepts the following keys:
 - `deleteIcon`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Chip/Chip.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Chip/Chip.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -36,7 +36,7 @@ This property accepts the following keys:
 - `circleIndeterminate`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Progress/CircularProgress.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Progress/CircularProgress.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -31,7 +31,7 @@ This property accepts the following keys:
 - `wrapperInner`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/transitions/Collapse.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/transitions/Collapse.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -26,7 +26,7 @@ This property accepts the following keys:
 - `button`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Dialog/DialogActions.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Dialog/DialogActions.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -24,7 +24,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Dialog/DialogContentText.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Dialog/DialogContentText.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/dialog-content.md
+++ b/pages/api/dialog-content.md
@@ -24,7 +24,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Dialog/DialogContent.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Dialog/DialogContent.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/dialog-title.md
+++ b/pages/api/dialog-title.md
@@ -25,7 +25,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Dialog/DialogTitle.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Dialog/DialogTitle.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -47,7 +47,7 @@ This property accepts the following keys:
 - `fullScreen`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Dialog/Dialog.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Dialog/Dialog.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -30,7 +30,7 @@ This property accepts the following keys:
 - `absolute`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Divider/Divider.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Divider/Divider.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -42,7 +42,7 @@ This property accepts the following keys:
 - `modal`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Drawer/Drawer.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Drawer/Drawer.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -34,7 +34,7 @@ This property accepts the following keys:
 - `label`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Form/FormControlLabel.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Form/FormControlLabel.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -40,7 +40,7 @@ This property accepts the following keys:
 - `fullWidth`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Form/FormControl.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Form/FormControl.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/form-group.md
+++ b/pages/api/form-group.md
@@ -28,7 +28,7 @@ This property accepts the following keys:
 - `row`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Form/FormGroup.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Form/FormGroup.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -30,7 +30,7 @@ This property accepts the following keys:
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Form/FormHelperText.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Form/FormHelperText.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -32,7 +32,7 @@ This property accepts the following keys:
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Form/FormLabel.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Form/FormLabel.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -38,7 +38,7 @@ This property accepts the following keys:
 - `childImg`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/GridList/GridListTileBar.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/GridList/GridListTileBar.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -30,7 +30,7 @@ This property accepts the following keys:
 - `imgFullWidth`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/GridList/GridListTile.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/GridList/GridListTile.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/grid-list.md
+++ b/pages/api/grid-list.md
@@ -28,7 +28,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/GridList/GridList.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/GridList/GridList.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -75,7 +75,7 @@ This property accepts the following keys:
 - `grid-xs-12`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Grid/Grid.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Grid/Grid.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -38,7 +38,7 @@ This property accepts the following keys:
 - `keyboardFocused`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/IconButton/IconButton.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/IconButton/IconButton.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -31,7 +31,7 @@ This property accepts the following keys:
 - `colorPrimary`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Icon/Icon.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Icon/Icon.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/input-adornment.md
+++ b/pages/api/input-adornment.md
@@ -29,7 +29,7 @@ This property accepts the following keys:
 - `positionEnd`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Input/InputAdornment.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Input/InputAdornment.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -37,7 +37,7 @@ This property accepts the following keys:
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Input/InputLabel.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Input/InputLabel.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -62,7 +62,7 @@ This property accepts the following keys:
 - `inputSearch`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Input/Input.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Input/Input.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -44,7 +44,7 @@ This property accepts the following keys:
 - `bufferBar2Accent`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Progress/LinearProgress.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Progress/LinearProgress.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -25,7 +25,7 @@ This property accepts the following keys:
 - `icon`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/List/ListItemAvatar.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/List/ListItemAvatar.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -24,7 +24,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/List/ListItemIcon.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/List/ListItemIcon.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/list-item-secondary-action.md
+++ b/pages/api/list-item-secondary-action.md
@@ -24,7 +24,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/List/ListItemSecondaryAction.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/List/ListItemSecondaryAction.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -31,7 +31,7 @@ This property accepts the following keys:
 - `textDense`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/List/ListItemText.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/List/ListItemText.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -38,7 +38,7 @@ This property accepts the following keys:
 - `secondaryAction`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/List/ListItem.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/List/ListItem.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -32,7 +32,7 @@ This property accepts the following keys:
 - `sticky`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/List/ListSubheader.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/List/ListSubheader.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -32,7 +32,7 @@ This property accepts the following keys:
 - `subheader`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/List/List.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/List/List.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -27,7 +27,7 @@ This property accepts the following keys:
 - `selected`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Menu/MenuItem.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Menu/MenuItem.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -36,7 +36,7 @@ This property accepts the following keys:
 - `paper`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Menu/Menu.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Menu/Menu.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/mobile-stepper.md
+++ b/pages/api/mobile-stepper.md
@@ -36,7 +36,7 @@ This property accepts the following keys:
 - `progress`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/MobileStepper/MobileStepper.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/MobileStepper/MobileStepper.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -55,7 +55,7 @@ This property accepts the following keys:
 - `hidden`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Modal/Modal.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Modal/Modal.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -52,7 +52,7 @@ This property accepts the following keys:
 - `shadow24`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Paper/Paper.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Paper/Paper.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -43,7 +43,7 @@ This property accepts the following keys:
 - `paper`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Popover/Popover.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Popover/Popover.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -35,7 +35,7 @@ This property accepts the following keys:
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Radio/Radio.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Radio/Radio.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -36,7 +36,7 @@ This property accepts the following keys:
 - `icon`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Select/Select.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Select/Select.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/snackbar-content.md
+++ b/pages/api/snackbar-content.md
@@ -27,7 +27,7 @@ This property accepts the following keys:
 - `action`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Snackbar/SnackbarContent.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Snackbar/SnackbarContent.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -47,7 +47,7 @@ This property accepts the following keys:
 - `anchorBottomLeft`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Snackbar/Snackbar.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Snackbar/Snackbar.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -25,7 +25,7 @@ This property accepts the following keys:
 - `alternativeLabel`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Stepper/StepButton.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/StepButton.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -27,7 +27,7 @@ This property accepts the following keys:
 - `transition`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Stepper/StepContent.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/StepContent.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -35,7 +35,7 @@ This property accepts the following keys:
 - `alternativeLabel`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Stepper/StepLabel.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/StepLabel.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -29,7 +29,7 @@ This property accepts the following keys:
 - `alternativeLabel`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Stepper/Step.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/Step.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -31,7 +31,7 @@ This property accepts the following keys:
 - `vertical`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Stepper/Stepper.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/Stepper.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -26,7 +26,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/SvgIcon/SvgIcon.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/SvgIcon/SvgIcon.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -38,7 +38,7 @@ This property accepts the following keys:
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Switch/Switch.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Switch/Switch.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -42,7 +42,7 @@ This property accepts the following keys:
 - `labelWrapped`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Tabs/Tab.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Tabs/Tab.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -25,7 +25,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Table/TableBody.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TableBody.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -33,7 +33,7 @@ This property accepts the following keys:
 - `footer`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Table/TableCell.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TableCell.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -25,7 +25,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Table/TableFooter.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TableFooter.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -25,7 +25,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Table/TableHead.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TableHead.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -39,7 +39,7 @@ This property accepts the following keys:
 - `actions`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Table/TablePagination.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TablePagination.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -32,7 +32,7 @@ This property accepts the following keys:
 - `selected`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Table/TableRow.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TableRow.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -30,7 +30,7 @@ This property accepts the following keys:
 - `asc`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Table/TableSortLabel.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TableSortLabel.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -25,7 +25,7 @@ This property accepts the following keys:
 - `root`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Table/Table.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/Table.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -41,7 +41,7 @@ This property accepts the following keys:
 - `buttonAuto`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Tabs/Tabs.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Tabs/Tabs.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -26,7 +26,7 @@ This property accepts the following keys:
 - `gutters`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Toolbar/Toolbar.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Toolbar/Toolbar.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -44,7 +44,7 @@ This property accepts the following keys:
 - `tooltipOpen`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Tooltip/Tooltip.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Tooltip/Tooltip.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -55,7 +55,7 @@ This property accepts the following keys:
 - `colorError`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/callemall/material-ui/tree/v1-beta/src/Typography/Typography.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Typography/Typography.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented

--- a/test/README.md
+++ b/test/README.md
@@ -33,14 +33,14 @@ If you want to `grep` for certain tests just add `-- -g STRING_TO_GREP` and chan
 First, we have the **unit test** suite.
 It uses [mocha](https://mochajs.org) and the *shallow* API of [enzyme](https://github.com/airbnb/enzyme) to allow testing the components in isolation.
 It's the fastest approach, and is best suited for testing many combinations.
-Here is an [example](https://github.com/callemall/material-ui/blob/a3719a203515b1ad683e62085cb5065318c0c87f/src/Menu/Menu.spec.js#L18) with the `Menu` component.
+Here is an [example](https://github.com/mui-org/material-ui/blob/a3719a203515b1ad683e62085cb5065318c0c87f/src/Menu/Menu.spec.js#L18) with the `Menu` component.
 
 Next, we have the **integration** tests.
 We are using the *mount* API of [enzyme](https://github.com/airbnb/enzyme).
 It allows testing the integration of different components using a virtual DOM.
 This virtual DOM is provided by [jsdom](https://github.com/tmpvar/jsdom).
 It's here to make sure components work together.
-Here is an [example](https://github.com/callemall/material-ui/blob/a3719a203515b1ad683e62085cb5065318c0c87f/test/integration/Menu.spec.js#L29) with the `Menu` component.
+Here is an [example](https://github.com/mui-org/material-ui/blob/a3719a203515b1ad683e62085cb5065318c0c87f/test/integration/Menu.spec.js#L29) with the `Menu` component.
 
 #### Create HTML coverage reports
 `npm run test:coverage:html`
@@ -74,7 +74,7 @@ Next, we are using [docker](https://github.com/docker/docker) to take screenshot
 ![before](/test/docs-regressions-before.png)
 ![diff](/test/docs-regressions-diff.png)
 
-Here is an [example](https://github.com/callemall/material-ui/blob/a3719a203515b1ad683e62085cb5065318c0c87f/test/regressions/tests/Menu/SimpleMenuList.js#L7) with the `Menu` component.
+Here is an [example](https://github.com/mui-org/material-ui/blob/a3719a203515b1ad683e62085cb5065318c0c87f/test/regressions/tests/Menu/SimpleMenuList.js#L7) with the `Menu` component.
 
 #### Installation
 
@@ -104,7 +104,7 @@ testUrl: process.env.DOCKER_TEST_URL || 'http://10.200.10.1:3090',
 
 ## Writing Tests
 
-For all unit tests, please use the [shallow renderer](https://github.com/airbnb/enzyme/blob/master/docs/api/shallow.md) from `enzyme` unless the Component being tested requires a DOM. [Here's](https://github.com/callemall/material-ui/blob/master/src/Avatar/Avatar.spec.js) a small shallow rendered test to get you started.
+For all unit tests, please use the [shallow renderer](https://github.com/airbnb/enzyme/blob/master/docs/api/shallow.md) from `enzyme` unless the Component being tested requires a DOM. [Here's](https://github.com/mui-org/material-ui/blob/master/src/Avatar/Avatar.spec.js) a small shallow rendered test to get you started.
 
 If the Component being unit tested requires a DOM, you can use the [mount api](https://github.com/airbnb/enzyme/blob/master/docs/api/mount.md) from `enzyme`. For some operations, you may still need to use the React test utils, but try to use the `enzyme` API as much as possible.
 


### PR DESCRIPTION
Convert all references to callemall/material-ui to mui-org/material-ui except gitter (waiting to hear if the chat can be transferred).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
