### PR TITLE
Unparameterize Theme type

### DIFF
--- a/src/styles/MuiThemeProvider.d.ts
+++ b/src/styles/MuiThemeProvider.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Theme } from './createMuiTheme';
 
 export interface MuiThemeProviderProps {
-  theme?: Theme<any>;
+  theme?: Theme;
   sheetsManager?: Object;
   children: React.ReactNode;
 }

--- a/src/styles/createMuiTheme.d.ts
+++ b/src/styles/createMuiTheme.d.ts
@@ -20,7 +20,7 @@ export interface ThemeOptions {
   overrides?: { [name: string]: StyleRules };
 }
 
-export type Theme<T = {}> = {
+export type Theme = {
   direction: 'ltr' | 'rtl';
   palette: Palette;
   typography: Typography;
@@ -31,8 +31,8 @@ export type Theme<T = {}> = {
   spacing: Spacing;
   zIndex: ZIndex;
   overrides?: { [name: string]: StyleRules; };
-} & T;
+};
 
-export default function createMuiTheme<T = {}>(
-  options?: ThemeOptions & T
-): Theme<T>;
+export default function createMuiTheme(
+  options?: ThemeOptions
+): Theme;

--- a/src/styles/withTheme.d.ts
+++ b/src/styles/withTheme.d.ts
@@ -1,5 +1,7 @@
 import { Theme } from './createMuiTheme';
 
-export default function withTheme<P = {}, T extends Theme = Theme>():
-  (component: React.ComponentType<P & { theme: T }>
-  ) => React.ComponentClass<P>;
+declare const withTheme: <P = {}>() => (
+  component: React.ComponentType<P & { theme: Theme }>
+) => React.ComponentClass<P>;
+
+export default withTheme


### PR DESCRIPTION
I don't think there's a reason for `Theme` to have a type parameter. There's not really any benefit to having it currently (see #9192), and to make it useful would require making things un-type safe. I don't see the point of attaching "business variables" to a theme; one should just export one's business variables from a module, and import them in one's component modules, and everything is type safe. But if you really want to attach arbitrary variables to a theme, it's impossible to make this type safe, so we shouldn't lie and pretend it is. One can just cast the theme, e.g.

```ts
withStyles(theme => ({
  root: {
    lineHeight: (theme as MyTheme).myBusinessVariable
  }
}))
```
