### PR TITLE
add flow usage warning

### DIFF
--- a/docs/src/pages/guides/flow.md
+++ b/docs/src/pages/guides/flow.md
@@ -6,4 +6,6 @@ Have a look at the [Create React App with Flow](https://github.com/mui-org/mater
 ## Warning 
 An [existing bug in flow regarding the use of higher order components (HOC)](https://github.com/facebook/flow/issues/5382) 
 limits the usefulness of flow by an application.  As of November 27, 2017 we cannot recommend the use of flow 
-typing in your application in conjunction with `material-ui`.
+typing in your application in conjunction with `material-ui`.  
+
+This issue is under discussion in [#9312](https://github.com/mui-org/material-ui/issues/9312).

--- a/docs/src/pages/guides/flow.md
+++ b/docs/src/pages/guides/flow.md
@@ -2,3 +2,8 @@
 
 You can add static typing to JavaScript to improve developer productivity and code quality thanks to [Flow](https://github.com/facebook/flow).
 Have a look at the [Create React App with Flow](https://github.com/mui-org/material-ui/tree/v1-beta/examples/create-react-app-with-flow) example.
+
+## Warning 
+An [existing bug in flow regarding the use of higher order components (HOC)](https://github.com/facebook/flow/issues/5382) 
+limits the usefulness of flow by an application.  As of November 27, 2017 we cannot recommend the use of flow 
+typing in your application in conjunction with `material-ui`.

--- a/examples/create-react-app-with-flow/README.md
+++ b/examples/create-react-app-with-flow/README.md
@@ -1,5 +1,10 @@
 # Create React App example with Flow
 
+## Warning 
+An [existing bug in flow regarding the use of higher order components (HOC)](https://github.com/facebook/flow/issues/5382) 
+limits the usefulness of flow by an application.  As of November 27, 2017 we cannot recommend the use of flow 
+typing in your application in conjunction with `material-ui`.
+
 ## How to use
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):

--- a/examples/create-react-app-with-flow/README.md
+++ b/examples/create-react-app-with-flow/README.md
@@ -5,6 +5,8 @@ An [existing bug in flow regarding the use of higher order components (HOC)](htt
 limits the usefulness of flow by an application.  As of November 27, 2017 we cannot recommend the use of flow 
 typing in your application in conjunction with `material-ui`.
 
+This issue is under discussion in [#9312](https://github.com/mui-org/material-ui/issues/9312).
+
 ## How to use
 
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):


### PR DESCRIPTION
Add the following in the guide and example readme:

> ## Warning 
> An [existing bug in flow regarding the use of higher order components (HOC)](https://github.com/facebook/flow/issues/5382) limits the usefulness of flow by an application.  As of November 27, 2017 we cannot at this time recommend the use of flow typing in your application in conjunction with `material-ui` until such time as a resolution is present.

For those getting started, I want to make sure and warn them to avoid any unnecessary effort if possible.