### PR TITLE
Provide accurate typings for theme overrides

### DIFF
--- a/src/Card/CardActions.d.ts
+++ b/src/Card/CardActions.d.ts
@@ -3,12 +3,12 @@ import { StandardProps } from '..';
 
 export interface CardActionsProps extends StandardProps<
   React.HTMLAttributes<HTMLDivElement>,
-  CardActionClassKey
+  CardActionsClassKey
 > {
   disableActionSpacing?: boolean;
 }
 
-export type CardActionClassKey =
+export type CardActionsClassKey =
   | 'root'
   | 'actionSpacing'
   ;

--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -18,7 +18,7 @@ export interface SelectProps extends StandardProps<
   value?: Array<string | number> | string | number;
 }
 
-type SelectClassKey =
+export type SelectClassKey =
   | 'root'
   | 'select'
   | 'selectMenu'

--- a/src/Snackbar/SnackbarContent.d.ts
+++ b/src/Snackbar/SnackbarContent.d.ts
@@ -5,13 +5,13 @@ import { PaperClassKey } from '../Paper/Paper';
 
 export interface SnackbarContentProps extends StandardProps<
   PaperProps,
-  SnackbarContentClasskey
+  SnackbarContentClassKey
 > {
   action?: React.ReactElement<any>;
   message: React.ReactElement<any> | string;
 }
 
-export type SnackbarContentClasskey =
+export type SnackbarContentClassKey =
   | PaperClassKey
   | 'message'
   | 'action'

--- a/src/styles/createMuiTheme.d.ts
+++ b/src/styles/createMuiTheme.d.ts
@@ -7,6 +7,7 @@ import { Transitions } from './transitions';
 import { Typography, TypographyOptions } from './createTypography';
 import { ZIndex } from './zIndex';
 import { StyleRules } from './withStyles'
+import { Overrides } from './overrides'
 
 export interface ThemeOptions {
   breakpoints?: Partial<BreakpointsOptions> & Partial<Breakpoints>;
@@ -17,7 +18,7 @@ export interface ThemeOptions {
   transitions?: Partial<Transitions>;
   spacing?: Partial<Spacing>;
   zIndex?: Partial<ZIndex>;
-  overrides?: { [name: string]: StyleRules };
+  overrides?: Overrides;
 }
 
 export type Theme = {
@@ -30,7 +31,7 @@ export type Theme = {
   transitions: Transitions;
   spacing: Spacing;
   zIndex: ZIndex;
-  overrides?: { [name: string]: StyleRules; };
+  overrides?: Overrides;
 };
 
 export default function createMuiTheme(

--- a/src/styles/overrides.d.ts
+++ b/src/styles/overrides.d.ts
@@ -1,0 +1,166 @@
+import { AppBarClassKey } from '../AppBar/AppBar';
+import { AvatarClassKey } from '../Avatar/Avatar';
+import { BackdropClassKey } from '../Modal/Backdrop';
+import { BadgeClassKey } from '../Badge/Badge';
+import { BottomNavigationClassKey } from '../BottomNavigation/BottomNavigation';
+import { BottomNavigationButtonClassKey } from '../BottomNavigation/BottomNavigationButton';
+import { ButtonClassKey } from '../Button/Button';
+import { ButtonBaseClassKey } from '../ButtonBase/ButtonBase';
+import { CardClassKey } from '../Card/Card';
+import { CardActionsClassKey } from '../Card/CardActions';
+import { CardContentClassKey } from '../Card/CardContent';
+import { CardHeaderClassKey } from '../Card/CardHeader';
+import { CardMediaClassKey } from '../Card/CardMedia';
+import { CheckboxClassKey } from '../Checkbox/Checkbox';
+import { ChipClassKey } from '../Chip/Chip';
+import { CircularProgressClassKey } from '../Progress/CircularProgress';
+import { CollapseClassKey } from '../transitions/Collapse';
+import { DialogActionsClassKey } from '../Dialog/DialogActions';
+import { DialogClassKey } from '../Dialog/Dialog';
+import { DialogContentClassKey } from '../Dialog/DialogContent';
+import { DialogContentTextClassKey } from '../Dialog/DialogContentText';
+import { DialogTitleClassKey } from '../Dialog/DialogTitle';
+import { DividerClassKey } from '../Divider/Divider';
+import { DrawerClassKey } from '../Drawer/Drawer';
+import { FormControlClassKey } from '../Form/FormControl';
+import { FormControlLabelClassKey } from '../Form/FormControlLabel';
+import { FormGroupClassKey } from '../Form/FormGroup';
+import { FormHelperTextClassKey } from '../Form/FormHelperText';
+import { FormLabelClassKey } from '../Form/FormLabel';
+import { GridClassKey } from '../Grid/Grid';
+import { GridListClassKey } from '../GridList/GridList';
+import { GridListTileBarClassKey } from '../GridList/GridListTileBar';
+import { GridListTileClassKey } from '../GridList/GridListTile';
+import { IconButtonClassKey } from '../IconButton/IconButton';
+import { IconClassKey } from '../Icon/Icon';
+import { InputAdornmentClassKey } from '../Input/InputAdornment';
+import { InputClassKey } from '../Input/Input';
+import { InputLabelClassKey } from '../Input/InputLabel';
+import { LinearProgressClassKey } from '../Progress/LinearProgress';
+import { ListClassKey } from '../List/List';
+import { ListItemAvatarClassKey } from '../List/ListItemAvatar';
+import { ListItemClassKey } from '../List/ListItem';
+import { ListItemIconClassKey } from '../List/ListItemIcon';
+import { ListItemSecondaryActionClassKey } from '../List/ListItemSecondaryAction';
+import { ListItemTextClassKey } from '../List/ListItemText';
+import { ListSubheaderClassKey } from '../List/ListSubheader';
+import { MenuClassKey } from '../Menu/Menu';
+import { MenuItemClassKey } from '../Menu/MenuItem';
+import { MenuListClassKey } from '../Menu/MenuList';
+import { MobileStepperClassKey } from '../MobileStepper/MobileStepper';
+import { ModalClassKey } from '../Modal/Modal';
+import { PaperClassKey } from '../Paper/Paper';
+import { PopoverClassKey } from '../Popover/Popover';
+import { RadioClassKey } from '../Radio/Radio';
+import { RadioGroupClassKey } from '../Radio/RadioGroup';
+import { SelectClassKey } from '../Select/Select';
+import { SelectInputClassKey } from '../Select/SelectInput';
+import { SnackbarClassKey } from '../Snackbar/Snackbar';
+import { SnackbarContentClassKey } from '../Snackbar/SnackbarContent';
+import { StyleRules } from './withStyles';
+import { SvgIconClassKey } from '../SvgIcon/SvgIcon';
+import { SwitchBaseClassKey } from '../internal/SwitchBase';
+import { SwitchClassKey } from '../Switch/Switch';
+import { TabClassKey } from '../Tabs/Tab';
+import { TabIndicatorClassKey } from '../Tabs/TabIndicator';
+import { TableClassKey } from '../Table/Table';
+import { TableBodyClassKey } from '../Table/TableBody';
+import { TableCellClassKey } from '../Table/TableCell';
+import { TableFooterClassKey } from '../Table/TableFooter';
+import { TableHeadClassKey } from '../Table/TableHead';
+import { TablePaginationClassKey } from '../Table/TablePagination';
+import { TableRowClassKey } from '../Table/TableRow';
+import { TableSortLabelClassKey } from '../Table/TableSortLabel';
+import { TabsClassKey } from '../Tabs/Tabs';
+import { TabScrollButtonClassKey } from '../Tabs/TabScrollButton';
+import { TextareaClassKey } from '../Input/Textarea';
+import { TextFieldClassKey } from '../TextField/TextField';
+import { ToolbarClassKey } from '../Toolbar/Toolbar';
+import { TooltipClassKey } from '../Tooltip/Tooltip';
+import { TypographyClassKey } from '../Typography/Typography';
+
+export type Overrides = {
+  [Name in keyof ComponentNameToClassKey]?: Partial<StyleRules<ComponentNameToClassKey[Name]>>
+};
+
+type ComponentNameToClassKey = {
+  MuiAppBar: AppBarClassKey;
+  MuiAvatar: AvatarClassKey;
+  MuiBackdrop: BackdropClassKey;
+  MuiBadge: BadgeClassKey;
+  MuiBottomNavigation: BottomNavigationClassKey;
+  MuiBottomNavigationButton: BottomNavigationButtonClassKey;
+  MuiButton: ButtonClassKey;
+  MuiButtonBase: ButtonBaseClassKey;
+  MuiCard: CardClassKey; // TODO ?
+  MuiCardActions: CardActionsClassKey;
+  MuiCardContent: CardContentClassKey;
+  MuiCardHeader: CardHeaderClassKey;
+  MuiCardMedia: CardMediaClassKey;
+  MuiCheckbox: CheckboxClassKey;
+  MuiChip: ChipClassKey;
+  MuiCircularProgress: CircularProgressClassKey;
+  MuiCollapse: CollapseClassKey; // TODO ?
+  MuiDialog: DialogClassKey;
+  MuiDialogActions: DialogActionsClassKey;
+  MuiDialogContent: DialogContentClassKey;
+  MuiDialogContentText: DialogContentTextClassKey;
+  MuiDialogTitle: DialogTitleClassKey;
+  MuiDivider: DividerClassKey;
+  MuiDrawer: DrawerClassKey; // TODO ?
+  MuiFormControl: FormControlClassKey;
+  MuiFormControlLabel: FormControlLabelClassKey;
+  MuiFormGroup: FormGroupClassKey;
+  MuiFormHelperText: FormHelperTextClassKey;
+  MuiFormLabel: FormLabelClassKey;
+  MuiGrid: GridClassKey;
+  MuiGridList: GridListClassKey;
+  MuiGridListTile: GridListTileClassKey;
+  MuiGridListTileBar: GridListTileBarClassKey;
+  MuiIcon: IconClassKey;
+  MuiIconButton: IconButtonClassKey;
+  MuiInput: InputClassKey;
+  MuiInputAdornment: InputAdornmentClassKey;
+  MuiInputLabel: InputLabelClassKey;
+  MuiLinearProgress: LinearProgressClassKey;
+  MuiList: ListClassKey;
+  MuiListItem: ListItemClassKey;
+  MuiListItemAvatar: ListItemAvatarClassKey;
+  MuiListItemIcon: ListItemIconClassKey;
+  MuiListItemSecondaryAction: ListItemSecondaryActionClassKey;
+  MuiListItemText: ListItemTextClassKey;
+  MuiListSubheader: ListSubheaderClassKey;
+  MuiMenu: MenuClassKey; // TODO ?
+  MuiMenuItem: MenuItemClassKey;
+  MuiMenuList: MenuListClassKey; // TODO ?
+  MuiMobileStepper: MobileStepperClassKey;
+  MuiModal: ModalClassKey; // TODO ?
+  MuiPaper: PaperClassKey;
+  MuiPopover: PopoverClassKey;
+  MuiRadio: RadioClassKey;
+  MuiRadioGroup: RadioGroupClassKey; // TODO ?
+  MuiSelect: SelectClassKey;
+  MuiSelectInput: SelectInputClassKey; // TODO ?
+  MuiSnackbar: SnackbarClassKey; // TODO ?
+  MuiSnackbarContent: SnackbarContentClassKey;
+  MuiSvgIcon: SvgIconClassKey;
+  MuiSwitchBase: SwitchBaseClassKey;
+  MuiSwitch: SwitchClassKey;
+  MuiTab: TabClassKey;
+  MuiTabIndicator: TabIndicatorClassKey;
+  MuiTable: TableClassKey;
+  MuiTableBody: TableBodyClassKey;
+  MuiTableCell: TableCellClassKey;
+  MuiTableFooter: TableFooterClassKey;
+  MuiTableHead: TableHeadClassKey;
+  MuiTablePagination: TablePaginationClassKey; // TODO ?
+  MuiTableRow: TableRowClassKey;
+  MuiTableSortLabel: TableSortLabelClassKey;
+  MuiTabs: TabsClassKey; // TODO ?
+  MuiTabScrollButton: TabScrollButtonClassKey;
+  MuiTextarea: TextareaClassKey;
+  MuiTextField: TextFieldClassKey; // TODO ?
+  MuiToolbar: ToolbarClassKey;
+  MuiTooltip: TooltipClassKey;
+  MuiTypography: TypographyClassKey;
+}

--- a/src/styles/overrides.d.ts
+++ b/src/styles/overrides.d.ts
@@ -92,7 +92,7 @@ type ComponentNameToClassKey = {
   MuiBottomNavigationButton: BottomNavigationButtonClassKey;
   MuiButton: ButtonClassKey;
   MuiButtonBase: ButtonBaseClassKey;
-  MuiCard: CardClassKey; // TODO ?
+  // MuiCard: CardClassKey;
   MuiCardActions: CardActionsClassKey;
   MuiCardContent: CardContentClassKey;
   MuiCardHeader: CardHeaderClassKey;
@@ -132,15 +132,15 @@ type ComponentNameToClassKey = {
   MuiListSubheader: ListSubheaderClassKey;
   MuiMenu: MenuClassKey;
   MuiMenuItem: MenuItemClassKey;
-  MuiMenuList: MenuListClassKey; // TODO ?
+  // MuiMenuList: MenuListClassKey;
   MuiMobileStepper: MobileStepperClassKey;
   MuiModal: ModalClassKey;
   MuiPaper: PaperClassKey;
   MuiPopover: PopoverClassKey;
   MuiRadio: RadioClassKey;
-  MuiRadioGroup: RadioGroupClassKey; // TODO ?
+  // MuiRadioGroup: RadioGroupClassKey;
   MuiSelect: SelectClassKey;
-  MuiSelectInput: SelectInputClassKey; // TODO ?
+  // MuiSelectInput: SelectInputClassKey;
   MuiSnackbar: SnackbarClassKey;
   MuiSnackbarContent: SnackbarContentClassKey;
   MuiSvgIcon: SvgIconClassKey;
@@ -159,7 +159,7 @@ type ComponentNameToClassKey = {
   MuiTabs: TabsClassKey;
   MuiTabScrollButton: TabScrollButtonClassKey;
   MuiTextarea: TextareaClassKey;
-  MuiTextField: TextFieldClassKey; // TODO ?
+  // MuiTextField: TextFieldClassKey;
   MuiToolbar: ToolbarClassKey;
   MuiTooltip: TooltipClassKey;
   MuiTypography: TypographyClassKey;

--- a/src/styles/overrides.d.ts
+++ b/src/styles/overrides.d.ts
@@ -100,14 +100,14 @@ type ComponentNameToClassKey = {
   MuiCheckbox: CheckboxClassKey;
   MuiChip: ChipClassKey;
   MuiCircularProgress: CircularProgressClassKey;
-  MuiCollapse: CollapseClassKey; // TODO ?
+  MuiCollapse: CollapseClassKey;
   MuiDialog: DialogClassKey;
   MuiDialogActions: DialogActionsClassKey;
   MuiDialogContent: DialogContentClassKey;
   MuiDialogContentText: DialogContentTextClassKey;
   MuiDialogTitle: DialogTitleClassKey;
   MuiDivider: DividerClassKey;
-  MuiDrawer: DrawerClassKey; // TODO ?
+  MuiDrawer: DrawerClassKey;
   MuiFormControl: FormControlClassKey;
   MuiFormControlLabel: FormControlLabelClassKey;
   MuiFormGroup: FormGroupClassKey;
@@ -130,18 +130,18 @@ type ComponentNameToClassKey = {
   MuiListItemSecondaryAction: ListItemSecondaryActionClassKey;
   MuiListItemText: ListItemTextClassKey;
   MuiListSubheader: ListSubheaderClassKey;
-  MuiMenu: MenuClassKey; // TODO ?
+  MuiMenu: MenuClassKey;
   MuiMenuItem: MenuItemClassKey;
   MuiMenuList: MenuListClassKey; // TODO ?
   MuiMobileStepper: MobileStepperClassKey;
-  MuiModal: ModalClassKey; // TODO ?
+  MuiModal: ModalClassKey;
   MuiPaper: PaperClassKey;
   MuiPopover: PopoverClassKey;
   MuiRadio: RadioClassKey;
   MuiRadioGroup: RadioGroupClassKey; // TODO ?
   MuiSelect: SelectClassKey;
   MuiSelectInput: SelectInputClassKey; // TODO ?
-  MuiSnackbar: SnackbarClassKey; // TODO ?
+  MuiSnackbar: SnackbarClassKey;
   MuiSnackbarContent: SnackbarContentClassKey;
   MuiSvgIcon: SvgIconClassKey;
   MuiSwitchBase: SwitchBaseClassKey;
@@ -153,10 +153,10 @@ type ComponentNameToClassKey = {
   MuiTableCell: TableCellClassKey;
   MuiTableFooter: TableFooterClassKey;
   MuiTableHead: TableHeadClassKey;
-  MuiTablePagination: TablePaginationClassKey; // TODO ?
+  MuiTablePagination: TablePaginationClassKey;
   MuiTableRow: TableRowClassKey;
   MuiTableSortLabel: TableSortLabelClassKey;
-  MuiTabs: TabsClassKey; // TODO ?
+  MuiTabs: TabsClassKey;
   MuiTabScrollButton: TabScrollButtonClassKey;
   MuiTextarea: TextareaClassKey;
   MuiTextField: TextFieldClassKey; // TODO ?


### PR DESCRIPTION
In doing this I discovered that the following have declared class keys in the typings, but appear not to be overridable since they weren't created with `withStyles`:
- `MuiCard`
- `MuiMenuList`
- `MuiRadioGroup`
- `MuiSelectInput`
- `MuiTextField`

Should these be overridable? (If so, that should probably be a separate PR).