### PR TITLE
[npm] Upgrades 'inline-style-prefixer' to 3.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.23.0",
-    "inline-style-prefixer": "^3.0.2",
+    "inline-style-prefixer": "^3.0.8",
     "keycode": "^2.1.8",
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",


### PR DESCRIPTION
Mentioned in [this comment](https://github.com/mui-org/material-ui/issues/9299#issuecomment-347340479) by @mbrookes in #9299.

This brings the legacy branch current with the `inline-style-prefixer` library.