### PR TITLE
[Typescript] Add missing direction to theme

### DIFF
--- a/src/styles/createMuiTheme.d.ts
+++ b/src/styles/createMuiTheme.d.ts
@@ -9,8 +9,10 @@ import { ZIndex } from './zIndex';
 import { StyleRules } from './withStyles'
 import { Overrides } from './overrides'
 
+export type Direction = 'ltr' | 'rtl';
+
 export interface ThemeOptions {
-  direction?: 'ltr' | 'rtl';
+  direction?: Direction;
   palette?: Partial<Palette>;
   typography?: TypographyOptions | ((palette: Palette) => TypographyOptions);
   mixins?: Partial<Mixins>;
@@ -23,7 +25,7 @@ export interface ThemeOptions {
 }
 
 export type Theme = {
-  direction: 'ltr' | 'rtl';
+  direction: Direction;
   palette: Palette;
   typography: Typography;
   mixins: Mixins;

--- a/src/styles/createMuiTheme.d.ts
+++ b/src/styles/createMuiTheme.d.ts
@@ -10,10 +10,11 @@ import { StyleRules } from './withStyles'
 import { Overrides } from './overrides'
 
 export interface ThemeOptions {
-  breakpoints?: Partial<BreakpointsOptions> & Partial<Breakpoints>;
-  mixins?: Partial<Mixins>;
+  direction?: 'ltr' | 'rtl';
   palette?: Partial<Palette>;
   typography?: TypographyOptions | ((palette: Palette) => TypographyOptions);
+  mixins?: Partial<Mixins>;
+  breakpoints?: Partial<BreakpointsOptions> & Partial<Breakpoints>;
   shadows?: Shadows;
   transitions?: Partial<Transitions>;
   spacing?: Partial<Spacing>;

--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -1,4 +1,4 @@
 export { default as MuiThemeProvider } from './MuiThemeProvider';
 export { default as withStyles, WithStyles, StyleRules, StyleRulesCallback, StyledComponentProps } from './withStyles';
 export { default as withTheme } from './withTheme';
-export { default as createMuiTheme, Theme } from './createMuiTheme';
+export { default as createMuiTheme, Theme, Direction } from './createMuiTheme';


### PR DESCRIPTION
`ThemeOptions` was missing `direction` . I also reordered the props so that it matches `Theme`.