### PR TITLE
Fix parse error in .codecov.yml

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,5 +4,5 @@ coverage:
   status:
     patch:
       default:
-        threshold: .1%
+        threshold: 0.1%
 comment: false


### PR DESCRIPTION
Since #9323 Codecov has started commenting on PRs again, despite the presence of `comment: false`. It looks like the cause of this might be that the `threshold` was incorrectly formatted:

```
> curl --data-binary @.codecov.yml https://codecov.io/validate
Invalid value {'patch': {'default': {'threshold': '.1%'}}} (dict): must be bool or must be bool or must be bool or must match pattern ^\d{1,45}(\.\d{1,25})?\%?$ (at coverage['status'])
```

With the leading zero it parses correctly:

```
> curl --data-binary @.codecov.yml https://codecov.io/validate
Valid!

{
  "comment": false,
  "coverage": {
    "status": {
      "patch": {
        "default": {
          "threshold": 0.1
        }
      }
    }
  },
  "codecov": {
    "branch": "next"
  }
}
```