### PR TITLE
[docs] Fix typo in comparison guide

### DIFF
--- a/docs/src/pages/guides/comparison.md
+++ b/docs/src/pages/guides/comparison.md
@@ -39,7 +39,7 @@ and towards the goal of a canonical Material Design implementation for the entir
 ![npm](https://img.shields.io/npm/dm/material-components-web.svg)
 
 We are very happy to see this project supported by Google and its design team.
-It sends a clear signal that the [Material Design specifiction](https://material.io/guidelines/) is
+It sends a clear signal that the [Material Design specification](https://material.io/guidelines/) is
 here to stay, as they continue to invest in it.
 
 ### Frameworks and libraries


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This fixes a small typo in the documentation (specifiction => specification)