### PR TITLE
[WIP] Bug Fixed: createTypography TypographyOptions type is invalid

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -48,6 +48,11 @@ type Diff<T extends string, U extends string> = (
 /** @internal */
 export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
 
+/** @internal */
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+}
+
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';
   type Color = 'inherit' | 'primary' | 'accent' | 'default';

--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Palette } from './createPalette';
-import { DeepPartial } from './index'
+import { DeepPartial } from 'index'
 
 export type TextStyle =
   | 'display1'

--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -36,7 +36,11 @@ export interface TypographyStyle {
 
 export type Typography = { [type in Style]: TypographyStyle } & FontStyle;
 
-export type TypographyOptions = Partial<FontStyle> & Partial<{ [type in Style]: Partial<TypographyStyle> }>;
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+};
+
+export type TypographyOptions = Partial<FontStyle> & DeepPartial<TypographyStyle>;
 
 export default function createTypography(
   palette: Palette,

--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -37,7 +37,7 @@ export interface TypographyStyle {
 
 export type Typography = { [type in Style]: TypographyStyle } & FontStyle;
 
-export type TypographyOptions = DeepPartial<TypographyStyle>;
+export type TypographyOptions = DeepPartial<Typography>;
 
 export default function createTypography(
   palette: Palette,

--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { Palette } from './createPalette';
-import { DeepPartial } from 'index'
+import { DeepPartial } from '..'
 
 export type TextStyle =
   | 'display1'
@@ -37,7 +37,7 @@ export interface TypographyStyle {
 
 export type Typography = { [type in Style]: TypographyStyle } & FontStyle;
 
-export type TypographyOptions = Partial<FontStyle> | DeepPartial<TypographyStyle>;
+export type TypographyOptions = DeepPartial<TypographyStyle>;
 
 export default function createTypography(
   palette: Palette,

--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -36,7 +36,7 @@ export interface TypographyStyle {
 
 export type Typography = { [type in Style]: TypographyStyle } & FontStyle;
 
-export type TypographyOptions = Partial<FontStyle> & Partial<Typography>;
+export type TypographyOptions = Partial<FontStyle> & Partial<{ [type in Style]: Partial<TypographyStyle> }>;
 
 export default function createTypography(
   palette: Palette,

--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Palette } from './createPalette';
+import { DeepPartial } from './index'
 
 export type TextStyle =
   | 'display1'
@@ -36,11 +37,7 @@ export interface TypographyStyle {
 
 export type Typography = { [type in Style]: TypographyStyle } & FontStyle;
 
-export type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
-};
-
-export type TypographyOptions = Partial<FontStyle> & DeepPartial<TypographyStyle>;
+export type TypographyOptions = Partial<FontStyle> | DeepPartial<TypographyStyle>;
 
 export default function createTypography(
   palette: Palette,

--- a/src/styles/createTypography.spec.js
+++ b/src/styles/createTypography.spec.js
@@ -34,4 +34,10 @@ describe('createTypography', () => {
     const typography = createTypography(palette, { htmlFontSize: 10 });
     assert.strictEqual(typography.display4.fontSize, '11.2rem');
   });
+  
+  it('should create a typography with custom display4', () => {
+    const customFontSize = '18px';
+    const typography = createTypography(palette, { display4: { fontSize: customFontSize } });
+    assert.strictEqual(typography.display4.fontSize, customFontSize);
+  });
 });

--- a/src/styles/createTypography.spec.js
+++ b/src/styles/createTypography.spec.js
@@ -34,7 +34,7 @@ describe('createTypography', () => {
     const typography = createTypography(palette, { htmlFontSize: 10 });
     assert.strictEqual(typography.display4.fontSize, '11.2rem');
   });
-  
+
   it('should create a typography with custom display4', () => {
     const customFontSize = '18px';
     const typography = createTypography(palette, { display4: { fontSize: customFontSize } });

--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -2,3 +2,7 @@ export { default as MuiThemeProvider } from './MuiThemeProvider';
 export { default as withStyles, WithStyles, StyleRules, StyleRulesCallback, StyledComponentProps } from './withStyles';
 export { default as withTheme } from './withTheme';
 export { default as createMuiTheme, Theme, Direction } from './createMuiTheme';
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: DeepPartial<T[P]>;
+}

--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -2,7 +2,3 @@ export { default as MuiThemeProvider } from './MuiThemeProvider';
 export { default as withStyles, WithStyles, StyleRules, StyleRulesCallback, StyledComponentProps } from './withStyles';
 export { default as withTheme } from './withTheme';
 export { default as createMuiTheme, Theme, Direction } from './createMuiTheme';
-
-export type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
-}

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -94,6 +94,15 @@ const customTheme = createMuiTheme({
   },
 });
 
+const customThemeTypographyPartial = createMuiTheme({
+  typography: {
+    display4: {
+      fontSize: '18px'
+    },
+    fontSize: 18
+  },
+});
+
 function OverridesTheme() {
   return (
     <MuiThemeProvider theme={theme}>


### PR DESCRIPTION
Without this fix the following code can not be compiled, but it should since we do deep merge anyway
```ts
const theme = createMuiTheme({
  typography: {
    // Fails here because currently it's TypographyStyle, not Partial<TypographyStyle>, therefore it wants to get complete TypographyStyle object, not a part of it
    display4: {
      fontSize: '18px'
    }
  }
})
```