### PR TITLE
[Input] Fix input shrink issue in Firefox

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -154,6 +154,7 @@ export const styles = (theme: Object) => {
       // Remove grey highlight
       WebkitTapHighlightColor: theme.palette.common.transparent,
       display: 'block',
+      // Make the flex item shrink with Firefox
       minWidth: 0,
       width: '100%',
       '&::-webkit-input-placeholder': placeholder,

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -154,6 +154,7 @@ export const styles = (theme: Object) => {
       // Remove grey highlight
       WebkitTapHighlightColor: theme.palette.common.transparent,
       display: 'block',
+      minWidth: 0,
       width: '100%',
       '&::-webkit-input-placeholder': placeholder,
       '&::-moz-placeholder': placeholder, // Firefox 19+


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR fixes #9304 

From: [CSS Flexible Box Layout Module Level 1 - 7.1.1. Basic Values of flex](https://www.w3.org/TR/css-flexbox-1/#min-size-autol):

> By default, flex items won’t shrink below their minimum content size (the length of the longest word or fixed-size element). To change this, set the min-width or min-height property. (See [§4.5 Automatic Minimum Size of Flex Items](https://www.w3.org/TR/css-flexbox-1/#min-size-auto).)

Therefore, if the browser is matching the specification, the input element won't shrink if `min-width` isn't specified. See https://bugzilla.mozilla.org/show_bug.cgi?id=1108514.

This commit simply adds the min-width attribute.  
