### PR TITLE
[Input] Specify target type for SyntheticInputEvents

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -299,7 +299,7 @@ export type Props = {
    *
    * @param {object} event The event source of the callback
    */
-  onChange?: (event: SyntheticInputEvent<>) => void,
+  onChange?: (event: SyntheticInputEvent<HTMLInputElement>) => void,
   /**
    * TODO
    */
@@ -417,7 +417,7 @@ class Input extends React.Component<ProvidedProps & Props, State> {
     }
   };
 
-  handleChange = (event: SyntheticInputEvent<>) => {
+  handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
     if (!this.isControlled()) {
       this.checkDirty(this.input);
     }

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -299,7 +299,7 @@ export type Props = {
    *
    * @param {object} event The event source of the callback
    */
-  onChange?: (event: SyntheticInputEvent<HTMLInputElement>) => void,
+  onChange?: (event: SyntheticInputEvent<HTMLElement>) => void,
   /**
    * TODO
    */
@@ -417,7 +417,7 @@ class Input extends React.Component<ProvidedProps & Props, State> {
     }
   };
 
-  handleChange = (event: SyntheticInputEvent<HTMLInputElement>) => {
+  handleChange = (event: SyntheticInputEvent<HTMLElement>) => {
     if (!this.isControlled()) {
       this.checkDirty(this.input);
     }

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -108,13 +108,13 @@ export type Props = {
    * @param {object} event The event source of the callback
    * @param {number} page The page selected
    */
-  onChangePage: (event: SyntheticInputEvent<> | null, page: number) => void,
+  onChangePage: (event: SyntheticInputEvent<*> | null, page: number) => void,
   /**
    * Callback fired when the number of rows per page is changed.
    *
    * @param {object} event The event source of the callback
    */
-  onChangeRowsPerPage: (event: SyntheticInputEvent<>) => void,
+  onChangeRowsPerPage: (event: SyntheticInputEvent<*>) => void,
   /**
    * The zero-based index of the current page.
    */

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -98,7 +98,7 @@ export type Props = {
    *
    * @param {object} event The event source of the callback
    */
-  onChange?: (event: SyntheticInputEvent<>) => void,
+  onChange?: (event: SyntheticInputEvent<HTMLInputElement>) => void,
   /**
    * The short hint displayed in the input before the user enters a value.
    */

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -98,7 +98,7 @@ export type Props = {
    *
    * @param {object} event The event source of the callback
    */
-  onChange?: (event: SyntheticInputEvent<HTMLInputElement>) => void,
+  onChange?: (event: SyntheticInputEvent<HTMLElement>) => void,
   /**
    * The short hint displayed in the input before the user enters a value.
    */


### PR DESCRIPTION
 * Use `HTMLInputElement` as the target type whenever the event source is an input element
 * Fixes flow typed event handlers

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
