### PR TITLE
[TypeScript] Rename overloaded type "Icon" in StepButton and StepConnector

### DIFF
--- a/src/Stepper/StepButton.d.ts
+++ b/src/Stepper/StepButton.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { Orientation } from './Stepper';
 import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 
-export type Icon = React.ReactElement<any> | string | number;
+export type StepButtonIcon = React.ReactElement<any> | string | number;
 
 export interface StepButtonProps extends StandardProps<
   ButtonBaseProps,
@@ -14,7 +14,7 @@ export interface StepButtonProps extends StandardProps<
   children: React.ReactElement<any>;
   completed?: boolean;
   disabled?: boolean;
-  icon?: Icon;
+  icon?: StepButtonIcon;
   last?: boolean;
   optional?: boolean;
   orientation: Orientation;

--- a/src/Stepper/StepConnector.d.ts
+++ b/src/Stepper/StepConnector.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { Orientation } from './Stepper';
 
-export type Icon = React.ReactElement<any> | string | number;
+export type StepConnectorIcon = React.ReactElement<any> | string | number;
 
 export interface StepConnectorProps extends StandardProps<
   React.HTMLAttributes<HTMLDivElement>,

--- a/src/Stepper/StepLabel.d.ts
+++ b/src/Stepper/StepLabel.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { Orientation } from './Stepper';
-import { Icon } from './StepButton';
+import { StepButtonIcon } from './StepButton';
 
 export interface StepLabelProps extends StandardProps<
   React.HTMLAttributes<HTMLDivElement>,

--- a/src/Stepper/StepLabel.d.ts
+++ b/src/Stepper/StepLabel.d.ts
@@ -12,7 +12,7 @@ export interface StepLabelProps extends StandardProps<
   children: React.ReactNode;
   completed?: boolean;
   disabled?: boolean;
-  icon?: Icon;
+  icon?: StepButtonIcon;
   last?: boolean;
   optional?: boolean;
   orientation?: Orientation;


### PR DESCRIPTION
In my "mui to react-native" effort I need to have all enums, interfaces and types in single ambient d.ts file. StepButton's ```Icon``` is last duplicity.
