### PR TITLE
[TypeScript] Add "component" to FormLabelProps

### DIFF
--- a/src/Form/FormLabel.d.ts
+++ b/src/Form/FormLabel.d.ts
@@ -2,15 +2,17 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface FormLabelProps extends StandardProps<
-  React.LabelHTMLAttributes<HTMLLabelElement>,
+  FormLabelBaseProps,
   FormLabelClassKey
 > {
-  component?: string | React.ComponentType<FormLabelProps>;
+  component?: string | React.ComponentType<FormLabelBaseProps>;
   disabled?: boolean;
   error?: boolean;
   focused?: boolean;
   required?: boolean;
 }
+
+export type FormLabelBaseProps = React.LabelHTMLAttributes<HTMLLabelElement>;
 
 export type FormLabelClassKey =
   | 'root'

--- a/src/Form/FormLabel.d.ts
+++ b/src/Form/FormLabel.d.ts
@@ -5,11 +5,11 @@ export interface FormLabelProps extends StandardProps<
   React.LabelHTMLAttributes<HTMLLabelElement>,
   FormLabelClassKey
 > {
+  component?: string | React.ComponentType;
   disabled?: boolean;
   error?: boolean;
   focused?: boolean;
   required?: boolean;
-  component?: string | React.ComponentType;
 }
 
 export type FormLabelClassKey =

--- a/src/Form/FormLabel.d.ts
+++ b/src/Form/FormLabel.d.ts
@@ -9,6 +9,7 @@ export interface FormLabelProps extends StandardProps<
   error?: boolean;
   focused?: boolean;
   required?: boolean;
+  component?: string | React.ComponentType;
 }
 
 export type FormLabelClassKey =

--- a/src/Form/FormLabel.d.ts
+++ b/src/Form/FormLabel.d.ts
@@ -5,7 +5,7 @@ export interface FormLabelProps extends StandardProps<
   React.LabelHTMLAttributes<HTMLLabelElement>,
   FormLabelClassKey
 > {
-  component?: string | React.ComponentType;
+  component?: string | React.ComponentType<FormLabelProps>;
   disabled?: boolean;
   error?: boolean;
   focused?: boolean;


### PR DESCRIPTION
Adding an optional component prop to FormLabel Typescript definition to allow to match implementation and docs.

https://material-ui-next.com/demos/selection-controls/
<FormLabel component="legend">Assign responsibility</FormLabel>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
