### PR TITLE
[docs] Add a downshift example

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
@@ -4,11 +4,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Autosuggest from 'react-autosuggest';
+import match from 'autosuggest-highlight/match';
+import parse from 'autosuggest-highlight/parse';
 import TextField from 'material-ui/TextField';
 import Paper from 'material-ui/Paper';
 import { MenuItem } from 'material-ui/Menu';
-import match from 'autosuggest-highlight/match';
-import parse from 'autosuggest-highlight/parse';
 import { withStyles } from 'material-ui/styles';
 
 const suggestions = [
@@ -76,11 +76,11 @@ function renderSuggestion(suggestion, { query, isHighlighted }) {
       <div>
         {parts.map((part, index) => {
           return part.highlight ? (
-            <span key={index} style={{ fontWeight: 300 }}>
+            <span key={String(index)} style={{ fontWeight: 300 }}>
               {part.text}
             </span>
           ) : (
-            <strong key={index} style={{ fontWeight: 500 }}>
+            <strong key={String(index)} style={{ fontWeight: 500 }}>
               {part.text}
             </strong>
           );

--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
@@ -1,0 +1,171 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import Downshift from 'downshift';
+import TextField from 'material-ui/TextField';
+import Paper from 'material-ui/Paper';
+import { MenuItem } from 'material-ui/Menu';
+import { withStyles } from 'material-ui/styles';
+
+const suggestions = [
+  { label: 'Afghanistan' },
+  { label: 'Aland Islands' },
+  { label: 'Albania' },
+  { label: 'Algeria' },
+  { label: 'American Samoa' },
+  { label: 'Andorra' },
+  { label: 'Angola' },
+  { label: 'Anguilla' },
+  { label: 'Antarctica' },
+  { label: 'Antigua and Barbuda' },
+  { label: 'Argentina' },
+  { label: 'Armenia' },
+  { label: 'Aruba' },
+  { label: 'Australia' },
+  { label: 'Austria' },
+  { label: 'Azerbaijan' },
+  { label: 'Bahamas' },
+  { label: 'Bahrain' },
+  { label: 'Bangladesh' },
+  { label: 'Barbados' },
+  { label: 'Belarus' },
+  { label: 'Belgium' },
+  { label: 'Belize' },
+  { label: 'Benin' },
+  { label: 'Bermuda' },
+  { label: 'Bhutan' },
+  { label: 'Bolivia, Plurinational State of' },
+  { label: 'Bonaire, Sint Eustatius and Saba' },
+  { label: 'Bosnia and Herzegovina' },
+  { label: 'Botswana' },
+  { label: 'Bouvet Island' },
+  { label: 'Brazil' },
+  { label: 'British Indian Ocean Territory' },
+  { label: 'Brunei Darussalam' },
+];
+
+function renderInput(inputProps) {
+  const { classes, autoFocus, value, ref, ...other } = inputProps;
+
+  return (
+    <TextField
+      autoFocus={autoFocus}
+      className={classes.textField}
+      value={value}
+      inputRef={ref}
+      InputProps={{
+        classes: {
+          input: classes.input,
+        },
+        ...other,
+      }}
+    />
+  );
+}
+
+function renderSuggestion(params) {
+  const { suggestion, index, itemProps, theme, highlightedIndex, selectedItem } = params;
+  const isHighlighted = highlightedIndex === index;
+  const isSelected = selectedItem === suggestion.label;
+
+  return (
+    <MenuItem
+      {...itemProps}
+      key={suggestion.label}
+      selected={isHighlighted}
+      component="div"
+      style={{
+        fontWeight: isSelected
+          ? theme.typography.fontWeightMedium
+          : theme.typography.fontWeightRegular,
+      }}
+    >
+      {suggestion.label}
+    </MenuItem>
+  );
+}
+
+function renderSuggestionsContainer(options) {
+  const { containerProps, children } = options;
+
+  return (
+    <Paper {...containerProps} square>
+      {children}
+    </Paper>
+  );
+}
+
+function getSuggestions(inputValue) {
+  let count = 0;
+
+  return suggestions.filter(suggestion => {
+    const keep =
+      (!inputValue || suggestion.label.toLowerCase().includes(inputValue.toLowerCase())) &&
+      count < 5;
+
+    if (keep) {
+      count += 1;
+    }
+
+    return keep;
+  });
+}
+
+const styles = {
+  container: {
+    flexGrow: 1,
+    height: 200,
+  },
+  textField: {
+    width: '100%',
+  },
+};
+
+function IntegrationAutosuggest(props) {
+  const { classes, theme } = props;
+
+  return (
+    <Downshift
+      render={({
+        getInputProps,
+        getItemProps,
+        isOpen,
+        inputValue,
+        selectedItem,
+        highlightedIndex,
+      }) => (
+        <div className={classes.container}>
+          {renderInput(
+            getInputProps({
+              classes,
+              placeholder: 'Search a country (start with a)',
+              id: 'integration-downshift',
+            }),
+          )}
+          {isOpen
+            ? renderSuggestionsContainer({
+                children: getSuggestions(inputValue).map((suggestion, index) =>
+                  renderSuggestion({
+                    suggestion,
+                    index,
+                    theme,
+                    itemProps: getItemProps({ item: suggestion.label }),
+                    highlightedIndex,
+                    selectedItem,
+                  }),
+                ),
+              })
+            : null}
+        </div>
+      )}
+    />
+  );
+}
+
+IntegrationAutosuggest.propTypes = {
+  classes: PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles, { withTheme: true })(IntegrationAutosuggest);

--- a/docs/src/pages/demos/autocomplete/autocomplete.md
+++ b/docs/src/pages/demos/autocomplete/autocomplete.md
@@ -12,3 +12,9 @@ In the following example, we demonstrate how to use [react-autosuggest](https://
 You should also install [autosuggest-highlight](https://www.npmjs.com/package/autosuggest-highlight).
 
 {{demo='pages/demos/autocomplete/IntegrationAutosuggest.js'}}
+
+## downshift
+
+In the following example, we demonstrate how to use [downshift](https://github.com/paypal/downshift).
+
+{{demo='pages/demos/autocomplete/IntegrationDownshift.js'}}

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "clean-css": "^4.1.9",
     "cross-env": "^5.1.1",
     "doctrine": "^2.0.0",
+    "downshift": "^1.22.1",
     "enzyme": "^3.2.0",
     "enzyme-adapter-react-16": "^1.1.0",
     "eslint": "^4.11.0",

--- a/pages/demos/autocomplete.js
+++ b/pages/demos/autocomplete.js
@@ -17,6 +17,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/autocomplete/IntegrationAutosuggest'), 'utf8')
 `,
         },
+        'pages/demos/autocomplete/IntegrationDownshift.js': {
+          js: require('docs/src/pages/demos/autocomplete/IntegrationDownshift').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/autocomplete/IntegrationDownshift'), 'utf8')
+`,
+        },
       }}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2740,6 +2740,10 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+downshift@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.22.1.tgz#93ba5576f40e9bf83a10bac9806c5b71078776d3"
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
The only last popular autocomplete lib we miss is react-select, but as far as I know, the customizability power if quite low, so not something we can easily target.

![capture d ecran 2017-12-05 a 23 02 14](https://user-images.githubusercontent.com/3165635/33633233-5bba0f20-da10-11e7-9208-63fd24bc3e12.png)


