### PR TITLE
[TypeScript] Fix definition mismatching on ColorObject

### DIFF
--- a/src/styles/colorManipulator.d.ts
+++ b/src/styles/colorManipulator.d.ts
@@ -1,7 +1,7 @@
 export type ColorFormat = 'rgb' | 'rgba' | 'hsl' | 'hsla';
 export interface ColorObject {
   type: ColorFormat;
-  color: [number, number, number] | [number, number, number, number];
+  values: [number, number, number] | [number, number, number, number];
 }
 
 export function convertColorToString(color: ColorObject): string;


### PR DESCRIPTION
I guess material-ui have definition mismatching on ColorObject of colorManipulator.d.ts, so both decomposeColor and convertColorToString are not working.
In colorManipulator.js, those functions seems to use "values" but typescript definition says "color" so they never access this property.

I'm a beginner and might be wrong, but I hope my small work will contribute your great project. thanks!