### PR TITLE
[docs] Remove extra spacing

### DIFF
--- a/docs/src/pages/demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.js
@@ -10,9 +10,8 @@ import Button from 'material-ui/Button';
 import IconButton from 'material-ui/IconButton';
 import MenuIcon from 'material-ui-icons/Menu';
 
-const styles = theme => ({
+const styles = {
   root: {
-    marginTop: theme.spacing.unit * 3,
     width: '100%',
   },
   flex: {
@@ -22,7 +21,7 @@ const styles = theme => ({
     marginLeft: -12,
     marginRight: 20,
   },
-});
+};
 
 function ButtonAppBar(props) {
   const { classes } = props;

--- a/docs/src/pages/demos/app-bar/MenuAppBar.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.js
@@ -13,9 +13,8 @@ import Switch from 'material-ui/Switch';
 import { FormControlLabel, FormGroup } from 'material-ui/Form';
 import Menu, { MenuItem } from 'material-ui/Menu';
 
-const styles = theme => ({
+const styles = {
   root: {
-    marginTop: theme.spacing.unit * 3,
     width: '100%',
   },
   flex: {
@@ -25,7 +24,7 @@ const styles = theme => ({
     marginLeft: -12,
     marginRight: 20,
   },
-});
+};
 
 class MenuAppBar extends React.Component {
   state = {

--- a/docs/src/pages/demos/app-bar/SimpleAppBar.js
+++ b/docs/src/pages/demos/app-bar/SimpleAppBar.js
@@ -7,12 +7,11 @@ import AppBar from 'material-ui/AppBar';
 import Toolbar from 'material-ui/Toolbar';
 import Typography from 'material-ui/Typography';
 
-const styles = theme => ({
+const styles = {
   root: {
-    marginTop: theme.spacing.unit * 3,
     width: '100%',
   },
-});
+};
 
 function SimpleAppBar(props) {
   const { classes } = props;

--- a/docs/src/pages/demos/buttons/ButtonBases.js
+++ b/docs/src/pages/demos/buttons/ButtonBases.js
@@ -8,7 +8,6 @@ import Typography from 'material-ui/Typography';
 
 const styles = theme => ({
   root: {
-    marginTop: theme.spacing.unit * 3,
     display: 'flex',
     flexWrap: 'wrap',
     minWidth: 300,

--- a/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.js
+++ b/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.js
@@ -12,7 +12,6 @@ import ExpandMoreIcon from 'material-ui-icons/ExpandMore';
 
 const styles = theme => ({
   root: {
-    marginTop: theme.spacing.unit * 3,
     width: '100%',
   },
   heading: {

--- a/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
@@ -17,7 +17,6 @@ import Divider from 'material-ui/Divider';
 
 const styles = theme => ({
   root: {
-    marginTop: theme.spacing.unit * 3,
     width: '100%',
   },
   heading: {

--- a/docs/src/pages/demos/expansion-panels/SimpleExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/SimpleExpansionPanel.js
@@ -12,7 +12,6 @@ import ExpandMoreIcon from 'material-ui-icons/ExpandMore';
 
 const styles = theme => ({
   root: {
-    marginTop: theme.spacing.unit * 3,
     width: '100%',
   },
   heading: {

--- a/docs/src/pages/demos/snackbars/LongTextSnackbar.js
+++ b/docs/src/pages/demos/snackbars/LongTextSnackbar.js
@@ -13,9 +13,6 @@ const action = (
 );
 
 const styles = theme => ({
-  root: {
-    marginTop: theme.spacing.unit * 3,
-  },
   snackbar: {
     margin: theme.spacing.unit,
   },
@@ -25,7 +22,7 @@ function LongTextSnackbar(props) {
   const { classes } = props;
 
   return (
-    <div className={classes.root}>
+    <div>
       <SnackbarContent className={classes.snackbar} message="I love snacks." action={action} />
       <SnackbarContent
         className={classes.snackbar}

--- a/docs/src/pages/style/Color.js
+++ b/docs/src/pages/style/Color.js
@@ -45,8 +45,8 @@ export const styles = theme => ({
     alignItems: 'center',
   },
   colorGroup: {
-    padding: '16px 0',
-    margin: '0 15px 0 0',
+    padding: 0,
+    margin: `0 ${theme.spacing.unit * 2}px ${theme.spacing.unit * 2}px 0`,
     flexGrow: 1,
     [theme.breakpoints.up('sm')]: {
       flexGrow: 0,


### PR DESCRIPTION
The extra margin-top is no longer needed. We have a permanent placeholder at the top.
It's increasing consistency and making our demos simpler.

![capture d ecran 2017-12-06 a 22 57 17](https://user-images.githubusercontent.com/3165635/33687572-d4d0e5aa-dad8-11e7-8037-e52efc5361bf.png)
