### PR TITLE
allow custom prefix for generateClassName

### DIFF
--- a/src/styles/createGenerateClassName.js
+++ b/src/styles/createGenerateClassName.js
@@ -2,7 +2,7 @@
 
 import warning from 'warning';
 import type StyleSheet from 'jss/lib/StyleSheet';
-import type { Rule, generateClassName } from 'jss/lib/types';
+import type {Rule, generateClassName} from 'jss/lib/types';
 
 let generatorCounter = 0;
 
@@ -11,8 +11,10 @@ let generatorCounter = 0;
 // We need to reset the rule counter for SSR for each request.
 //
 // It's an improved version of
-// https://github.com/cssinjs/jss/blob/4e6a05dd3f7b6572fdd3ab216861d9e446c20331/src/utils/createGenerateClassName.js
-export default function createGenerateClassName(): generateClassName {
+// https://github.com/cssinjs/jss/blob/4e6a05dd3f7b657 2fdd3ab216861d9e446c20331/src/utils/createGenerateClassName.js
+
+
+export default function createGenerateClassName(prefix: string = 'c'): generateClassName {
   let ruleCounter = 0;
 
   if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
@@ -41,7 +43,7 @@ export default function createGenerateClassName(): generateClassName {
     );
 
     if (process.env.NODE_ENV === 'production') {
-      return `c${ruleCounter}`;
+      return `${prefix}${ruleCounter}`;
     }
 
     if (sheet && sheet.options.meta) {
@@ -55,4 +57,7 @@ export default function createGenerateClassName(): generateClassName {
 
     return `${rule.key}-${ruleCounter}`;
   };
+}
+export function createGenerateClassNameWithPrefix(prefix: string = 'c'): generateClassName {
+  return createGenerateClassName(prefix);
 }

--- a/src/styles/createGenerateClassName.spec.js
+++ b/src/styles/createGenerateClassName.spec.js
@@ -2,6 +2,8 @@
 
 import { assert } from 'chai';
 import createGenerateClassName from './createGenerateClassName';
+import { createGenerateClassNameWithPrefix } from './createGenerateClassName';
+
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
 
 describe('createGenerateClassName', () => {
@@ -59,10 +61,22 @@ describe('createGenerateClassName', () => {
         consoleErrorMock.reset();
       });
 
-      it('should us a short representation', () => {
+      it('should use a c as prefix', () => {
         const rule = { key: 'root' };
         const generateClassName = createGenerateClassName();
         assert.strictEqual(generateClassName(rule), 'c1');
+      });
+
+      it('should use a c as prefix when none is given', () => {
+        const rule = { key: 'root' };
+        const generateClassName = createGenerateClassNameWithPrefix();
+        assert.strictEqual(generateClassName(rule), 'c1');
+      });
+
+      it('should use the given prefix', () => {
+        const rule = { key: 'root' };
+        const generateClassName = createGenerateClassNameWithPrefix('b');
+        assert.strictEqual(generateClassName(rule), 'b1');
       });
 
       it('should warn', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
We are building websites where every page is a composite of independent React apps.
A typical index.html looks like
```html
<body>
<header id="here renders header.js" />
<navigation id="here renders nav.js" />
<content id="here renders abouts.js />
<script src="https://header.server.com/header.js />
<script src="https://nav.server.org/nav.js" />
<script src"./aboutus.js" />
</body>
```
The fact that every of these apps apply styles for the class `c1` leads to "unexpected" results.
This behavior also contradicts the idea of independent components.
This patch may give others the possibility to add to their own prefixes.
I added some test which pass
Running all Unit tests fail, but they also fail without my changes.

```
> npm run test:unit
...
  1381 passing (5s)
  1 failing

  1) <Tooltip />
       prop: delay
         "before all" hook:
     Uncaught TypeError: Cannot read property 'documentElement' of undefined
      at getOffsetParent (node_modules/popper.js/src/utils/getOffsetParent.js:16:36)
      at findCommonOffsetParent (node_modules/popper.js/src/utils/findCommonOffsetParent.js:42:12)
      at getReferenceOffsets (node_modules/popper.js/src/utils/getReferenceOffsets.js:14:30)
      at Popper.update (node_modules/popper.js/src/methods/update.js:29:28)
      at Popper.update$$1 (node_modules/popper.js/src/index.js:94:19)
      at Timeout._onTimeout (node_modules/popper.js/dist/umd/popper.js:62:9)
```
