### PR TITLE
[EnhancedButton] Fix onClick event being fired twice on "Enter Key" press

### DIFF
--- a/src/internal/EnhancedButton.js
+++ b/src/internal/EnhancedButton.js
@@ -190,9 +190,6 @@ class EnhancedButton extends Component {
 
   handleKeyDown = (event) => {
     if (!this.props.disabled && !this.props.disableKeyboardFocus) {
-      if (keycode(event) === 'enter' && this.state.isKeyboardFocused) {
-        this.handleClick(event);
-      }
       if (keycode(event) === 'esc' && this.state.isKeyboardFocused) {
         this.removeKeyboardFocus(event);
       }
@@ -201,11 +198,6 @@ class EnhancedButton extends Component {
   };
 
   handleKeyUp = (event) => {
-    if (!this.props.disabled && !this.props.disableKeyboardFocus) {
-      if (keycode(event) === 'space' && this.state.isKeyboardFocused) {
-        this.handleClick(event);
-      }
-    }
     this.props.onKeyUp(event);
   };
 


### PR DESCRIPTION
This PR solves this issue: https://github.com/mui-org/material-ui/issues/9344

This is my first PR to this repo, so I'm not quite familiar with the process. The bug doesn't exist on v1x. Only for v0.20.0. I created my branch from that, but I can only create this PR against master or v1-beta. 

The issue was that the event was fired once from the normal `onClick` proc which happens naturally when space/enter is pressed on a focused button, and then once more from the `keyDown` and `keyUp` events in the `EnhancedButton` component manually. That's why the problem showed up in all the buttons. Removing those extra checks and event fires solved the issue.

I wasn't able to write a failing test for the bug, since Enzyme event simulations call the handlers directly and don't actually simulate browser events.
