### PR TITLE
[TypeScript] Fix signature of `withMobileDialog`

### DIFF
--- a/src/Dialog/withMobileDialog.d.ts
+++ b/src/Dialog/withMobileDialog.d.ts
@@ -5,8 +5,12 @@ export interface WithMobileDialogOptions {
   breakpoint: Breakpoint;
 }
 
+export interface InjectedProps {
+  fullScreen?: boolean;
+}
+
 export default function withMobileDialog<P = {}>(
-  options: WithMobileDialogOptions
+  options?: WithMobileDialogOptions
 ): (
-  component: React.ComponentType<P & Partial<WithWidthProps>>
-) => React.ComponentClass<P & Partial<WithWidthProps>>;
+  component: React.ComponentType<P & InjectedProps & Partial<WithWidthProps>>
+) => React.ComponentType<P & Partial<WithWidthProps>>;

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -820,16 +820,14 @@ const SelectTest = () => {
 const ResponsiveComponentTest = () => {
   const ResponsiveComponent = withMobileDialog({
     breakpoint: 'sm',
-  })(({ children, width }) =>
-    <div style={{ width }}>
+  })(({ children, width, fullScreen }) =>
+    <div style={{ width, position: fullScreen ? 'fixed' : 'static' }}>
       {children}
     </div>
   );
   <ResponsiveComponent />;
 
-  const ResponsiveDialogComponent = withMobileDialog<DialogProps>({
-    breakpoint: 'sm',
-  })(Dialog);
+  const ResponsiveDialogComponent = withMobileDialog<DialogProps>()(Dialog);
 };
 
 const TooltipComponentTest = () =>


### PR DESCRIPTION
Options argument for `withMobileDialog` should be optional. HOC should include the injected `fullScreen` prop.