### PR TITLE
[API] Use onClose over onRequestClose

### DIFF
--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -71,7 +71,7 @@ function reduceChildRoutes(props, activePage, items, childPage, index) {
         key={index}
         title={pageToTitle(childPage)}
         href={childPage.pathname}
-        onClick={props.onRequestClose}
+        onClick={props.onClose}
       />,
     );
   }
@@ -82,13 +82,13 @@ function reduceChildRoutes(props, activePage, items, childPage, index) {
 const GITHUB_RELEASE_BASE_URL = 'https://github.com/mui-org/material-ui/releases/tag/';
 
 function AppDrawer(props, context) {
-  const { classes, className, disablePermanent, mobileOpen, onRequestClose } = props;
+  const { classes, className, disablePermanent, mobileOpen, onClose } = props;
 
   const drawer = (
     <div className={classes.nav}>
       <div className={classes.toolbarIe11}>
         <Toolbar className={classes.toolbar}>
-          <Link className={classes.title} href="/" onClick={onRequestClose}>
+          <Link className={classes.title} href="/" onClick={onClose}>
             <Typography type="title" gutterBottom color="inherit">
               Material-UI
             </Typography>
@@ -117,7 +117,7 @@ function AppDrawer(props, context) {
           }}
           type="temporary"
           open={mobileOpen}
-          onRequestClose={onRequestClose}
+          onClose={onClose}
           ModalProps={{
             keepMounted: true,
           }}
@@ -147,12 +147,12 @@ AppDrawer.propTypes = {
   className: PropTypes.string,
   disablePermanent: PropTypes.bool.isRequired,
   mobileOpen: PropTypes.bool.isRequired,
-  onRequestClose: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
 };
 
 AppDrawer.contextTypes = {
-  pages: PropTypes.array.isRequired,
   activePage: PropTypes.object,
+  pages: PropTypes.array.isRequired,
 };
 
 export default withStyles(styles)(AppDrawer);

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -245,7 +245,7 @@ class AppFrame extends React.Component {
         <AppDrawer
           className={classes.drawer}
           disablePermanent={disablePermanent}
-          onRequestClose={this.handleDrawerToggle}
+          onClose={this.handleDrawerToggle}
           mobileOpen={this.state.mobileOpen}
         />
         {children}

--- a/docs/src/pages/demos/app-bar/MenuAppBar.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.js
@@ -38,7 +38,7 @@ class MenuAppBar extends React.Component {
     this.setState({ anchorEl: event.currentTarget });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ anchorEl: null });
   };
 
@@ -87,10 +87,10 @@ class MenuAppBar extends React.Component {
                     horizontal: 'right',
                   }}
                   open={open}
-                  onRequestClose={this.handleRequestClose}
+                  onClose={this.handleClose}
                 >
-                  <MenuItem onClick={this.handleRequestClose}>Profile</MenuItem>
-                  <MenuItem onClick={this.handleRequestClose}>My account</MenuItem>
+                  <MenuItem onClick={this.handleClose}>Profile</MenuItem>
+                  <MenuItem onClick={this.handleClose}>My account</MenuItem>
                 </Menu>
               </div>
             )}

--- a/docs/src/pages/demos/chips/Chips.js
+++ b/docs/src/pages/demos/chips/Chips.js
@@ -21,7 +21,7 @@ const styles = theme => ({
   },
 });
 
-function handleRequestDelete() {
+function handleDelete() {
   alert('You clicked the delete icon.'); // eslint-disable-line no-alert
 }
 
@@ -43,7 +43,7 @@ function Chips(props) {
       <Chip
         avatar={<Avatar src="/static/images/uxceo-128.jpg" />}
         label="Deletable Chip"
-        onRequestDelete={handleRequestDelete}
+        onDelete={handleDelete}
         className={classes.chip}
       />
       <Chip
@@ -54,13 +54,13 @@ function Chips(props) {
         }
         label="Clickable Deletable Chip"
         onClick={handleClick}
-        onRequestDelete={handleRequestDelete}
+        onDelete={handleDelete}
         className={classes.chip}
       />
       <Chip
         label="Custom delete icon Chip"
         onClick={handleClick}
-        onRequestDelete={handleRequestDelete}
+        onDelete={handleDelete}
         className={classes.chip}
         deleteIcon={<Done />}
       />

--- a/docs/src/pages/demos/chips/ChipsArray.js
+++ b/docs/src/pages/demos/chips/ChipsArray.js
@@ -35,7 +35,7 @@ class ChipsArray extends React.Component {
     },
   };
 
-  handleRequestDelete = data => () => {
+  handleDelete = data => () => {
     if (data.label === 'ReactJS') {
       alert('Why would you want to delete React?! :)'); // eslint-disable-line no-alert
       return;
@@ -57,7 +57,7 @@ class ChipsArray extends React.Component {
             <Chip
               label={data.label}
               key={data.key}
-              onRequestDelete={this.handleRequestDelete(data)}
+              onDelete={this.handleDelete(data)}
               className={classes.chip}
             />
           );

--- a/docs/src/pages/demos/dialogs/AlertDialog.js
+++ b/docs/src/pages/demos/dialogs/AlertDialog.js
@@ -16,7 +16,7 @@ class AlertDialog extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -24,7 +24,7 @@ class AlertDialog extends React.Component {
     return (
       <div>
         <Button onClick={this.handleClickOpen}>Open alert dialog</Button>
-        <Dialog open={this.state.open} onRequestClose={this.handleRequestClose}>
+        <Dialog open={this.state.open} onClose={this.handleClose}>
           <DialogTitle>{"Use Google's location service?"}</DialogTitle>
           <DialogContent>
             <DialogContentText>
@@ -33,10 +33,10 @@ class AlertDialog extends React.Component {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={this.handleRequestClose} color="primary">
+            <Button onClick={this.handleClose} color="primary">
               Disagree
             </Button>
-            <Button onClick={this.handleRequestClose} color="primary" autoFocus>
+            <Button onClick={this.handleClose} color="primary" autoFocus>
               Agree
             </Button>
           </DialogActions>

--- a/docs/src/pages/demos/dialogs/AlertDialogSlide.js
+++ b/docs/src/pages/demos/dialogs/AlertDialogSlide.js
@@ -22,7 +22,7 @@ class AlertDialogSlide extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -35,7 +35,7 @@ class AlertDialogSlide extends React.Component {
             open={this.state.open}
             transition={Transition}
             keepMounted
-            onRequestClose={this.handleRequestClose}
+            onClose={this.handleClose}
           >
             <DialogTitle>{"Use Google's location service?"}</DialogTitle>
             <DialogContent>
@@ -45,10 +45,10 @@ class AlertDialogSlide extends React.Component {
               </DialogContentText>
             </DialogContent>
             <DialogActions>
-              <Button onClick={this.handleRequestClose} color="primary">
+              <Button onClick={this.handleClose} color="primary">
                 Disagree
               </Button>
-              <Button onClick={this.handleRequestClose} color="primary">
+              <Button onClick={this.handleClose} color="primary">
                 Agree
               </Button>
             </DialogActions>

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.js
@@ -49,11 +49,11 @@ class ConfirmationDialog extends React.Component {
   };
 
   handleCancel = () => {
-    this.props.onRequestClose(this.props.value);
+    this.props.onClose(this.props.value);
   };
 
   handleOk = () => {
-    this.props.onRequestClose(this.state.value);
+    this.props.onClose(this.state.value);
   };
 
   handleChange = (event, value) => {
@@ -101,7 +101,7 @@ class ConfirmationDialog extends React.Component {
 }
 
 ConfirmationDialog.propTypes = {
-  onRequestClose: PropTypes.func,
+  onClose: PropTypes.func,
   value: PropTypes.string,
 };
 
@@ -129,7 +129,7 @@ class ConfirmationDialogDemo extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = value => {
+  handleClose = value => {
     this.setState({ value, open: false });
   };
 
@@ -159,7 +159,7 @@ class ConfirmationDialogDemo extends React.Component {
               paper: classes.dialog,
             }}
             open={this.state.open}
-            onRequestClose={this.handleRequestClose}
+            onClose={this.handleClose}
             value={this.state.value}
           />
         </List>

--- a/docs/src/pages/demos/dialogs/FormDialog.js
+++ b/docs/src/pages/demos/dialogs/FormDialog.js
@@ -17,7 +17,7 @@ export default class FormDialog extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -25,7 +25,7 @@ export default class FormDialog extends React.Component {
     return (
       <div>
         <Button onClick={this.handleClickOpen}>Open form dialog</Button>
-        <Dialog open={this.state.open} onRequestClose={this.handleRequestClose}>
+        <Dialog open={this.state.open} onClose={this.handleClose}>
           <DialogTitle>Subscribe</DialogTitle>
           <DialogContent>
             <DialogContentText>
@@ -42,10 +42,10 @@ export default class FormDialog extends React.Component {
             />
           </DialogContent>
           <DialogActions>
-            <Button onClick={this.handleRequestClose} color="primary">
+            <Button onClick={this.handleClose} color="primary">
               Cancel
             </Button>
-            <Button onClick={this.handleRequestClose} color="primary">
+            <Button onClick={this.handleClose} color="primary">
               Subscribe
             </Button>
           </DialogActions>

--- a/docs/src/pages/demos/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/demos/dialogs/FullScreenDialog.js
@@ -34,7 +34,7 @@ class FullScreenDialog extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -46,18 +46,18 @@ class FullScreenDialog extends React.Component {
         <Dialog
           fullScreen
           open={this.state.open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
           transition={Transition}
         >
           <AppBar className={classes.appBar}>
             <Toolbar>
-              <IconButton color="contrast" onClick={this.handleRequestClose} aria-label="Close">
+              <IconButton color="contrast" onClick={this.handleClose} aria-label="Close">
                 <CloseIcon />
               </IconButton>
               <Typography type="title" color="inherit" className={classes.flex}>
                 Sound
               </Typography>
-              <Button color="contrast" onClick={this.handleRequestClose}>
+              <Button color="contrast" onClick={this.handleClose}>
                 save
               </Button>
             </Toolbar>

--- a/docs/src/pages/demos/dialogs/ResponsiveDialog.js
+++ b/docs/src/pages/demos/dialogs/ResponsiveDialog.js
@@ -18,7 +18,7 @@ class ResponsiveDialog extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -28,11 +28,7 @@ class ResponsiveDialog extends React.Component {
     return (
       <div>
         <Button onClick={this.handleClickOpen}>Open responsive dialog</Button>
-        <Dialog
-          fullScreen={fullScreen}
-          open={this.state.open}
-          onRequestClose={this.handleRequestClose}
-        >
+        <Dialog fullScreen={fullScreen} open={this.state.open} onClose={this.handleClose}>
           <DialogTitle>{"Use Google's location service?"}</DialogTitle>
           <DialogContent>
             <DialogContentText>
@@ -41,10 +37,10 @@ class ResponsiveDialog extends React.Component {
             </DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button onClick={this.handleRequestClose} color="primary">
+            <Button onClick={this.handleClose} color="primary">
               Disagree
             </Button>
-            <Button onClick={this.handleRequestClose} color="primary" autoFocus>
+            <Button onClick={this.handleClose} color="primary" autoFocus>
               Agree
             </Button>
           </DialogActions>

--- a/docs/src/pages/demos/dialogs/SimpleDialog.js
+++ b/docs/src/pages/demos/dialogs/SimpleDialog.js
@@ -21,19 +21,19 @@ const styles = {
 };
 
 class SimpleDialog extends React.Component {
-  handleRequestClose = () => {
-    this.props.onRequestClose(this.props.selectedValue);
+  handleClose = () => {
+    this.props.onClose(this.props.selectedValue);
   };
 
   handleListItemClick = value => {
-    this.props.onRequestClose(value);
+    this.props.onClose(value);
   };
 
   render() {
-    const { classes, onRequestClose, selectedValue, ...other } = this.props;
+    const { classes, onClose, selectedValue, ...other } = this.props;
 
     return (
-      <Dialog onRequestClose={this.handleRequestClose} {...other}>
+      <Dialog onClose={this.handleClose} {...other}>
         <DialogTitle>Set backup account</DialogTitle>
         <div>
           <List>
@@ -64,7 +64,7 @@ class SimpleDialog extends React.Component {
 
 SimpleDialog.propTypes = {
   classes: PropTypes.object.isRequired,
-  onRequestClose: PropTypes.func,
+  onClose: PropTypes.func,
   selectedValue: PropTypes.string,
 };
 
@@ -82,7 +82,7 @@ class SimpleDialogDemo extends React.Component {
     });
   };
 
-  handleRequestClose = value => {
+  handleClose = value => {
     this.setState({ selectedValue: value, open: false });
   };
 
@@ -95,7 +95,7 @@ class SimpleDialogDemo extends React.Component {
         <SimpleDialogWrapped
           selectedValue={this.state.selectedValue}
           open={this.state.open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
         />
       </div>
     );

--- a/docs/src/pages/demos/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/demos/drawers/ResponsiveDrawer.js
@@ -110,7 +110,7 @@ class ResponsiveDrawer extends React.Component {
               classes={{
                 paper: classes.drawerPaper,
               }}
-              onRequestClose={this.handleDrawerToggle}
+              onClose={this.handleDrawerToggle}
               ModalProps={{
                 keepMounted: true, // Better open performance on mobile.
               }}

--- a/docs/src/pages/demos/drawers/TemporaryDrawer.js
+++ b/docs/src/pages/demos/drawers/TemporaryDrawer.js
@@ -55,7 +55,7 @@ class TemporaryDrawer extends React.Component {
         <Button onClick={this.toggleDrawer('right', true)}>Open Right</Button>
         <Button onClick={this.toggleDrawer('top', true)}>Open Top</Button>
         <Button onClick={this.toggleDrawer('bottom', true)}>Open Bottom</Button>
-        <Drawer open={this.state.left} onRequestClose={this.toggleDrawer('left', false)}>
+        <Drawer open={this.state.left} onClose={this.toggleDrawer('left', false)}>
           <div
             tabIndex={0}
             role="button"
@@ -65,7 +65,7 @@ class TemporaryDrawer extends React.Component {
             {sideList}
           </div>
         </Drawer>
-        <Drawer anchor="top" open={this.state.top} onRequestClose={this.toggleDrawer('top', false)}>
+        <Drawer anchor="top" open={this.state.top} onClose={this.toggleDrawer('top', false)}>
           <div
             tabIndex={0}
             role="button"
@@ -78,7 +78,7 @@ class TemporaryDrawer extends React.Component {
         <Drawer
           anchor="bottom"
           open={this.state.bottom}
-          onRequestClose={this.toggleDrawer('bottom', false)}
+          onClose={this.toggleDrawer('bottom', false)}
         >
           <div
             tabIndex={0}
@@ -89,11 +89,7 @@ class TemporaryDrawer extends React.Component {
             {fullList}
           </div>
         </Drawer>
-        <Drawer
-          anchor="right"
-          open={this.state.right}
-          onRequestClose={this.toggleDrawer('right', false)}
-        >
+        <Drawer anchor="right" open={this.state.right} onClose={this.toggleDrawer('right', false)}>
           <div
             tabIndex={0}
             role="button"

--- a/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
@@ -64,7 +64,7 @@ function DetailedExpansionPanel(props) {
         <ExpansionPanelDetails className={classes.details}>
           <div className={classes.column} />
           <div className={classes.column}>
-            <Chip label="Barbados" className={classes.chip} onRequestDelete={() => {}} />
+            <Chip label="Barbados" className={classes.chip} onDelete={() => {}} />
           </div>
           <div className={classNames(classes.column, classes.helper)}>
             <Typography type="caption">

--- a/docs/src/pages/demos/menus/LongMenu.js
+++ b/docs/src/pages/demos/menus/LongMenu.js
@@ -31,7 +31,7 @@ class LongMenu extends React.Component {
     this.setState({ anchorEl: event.currentTarget });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ anchorEl: null });
   };
 
@@ -52,7 +52,7 @@ class LongMenu extends React.Component {
           id="long-menu"
           anchorEl={this.state.anchorEl}
           open={open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
           PaperProps={{
             style: {
               maxHeight: ITEM_HEIGHT * 4.5,
@@ -61,7 +61,7 @@ class LongMenu extends React.Component {
           }}
         >
           {options.map(option => (
-            <MenuItem key={option} selected={option === 'Pyxis'} onClick={this.handleRequestClose}>
+            <MenuItem key={option} selected={option === 'Pyxis'} onClick={this.handleClose}>
               {option}
             </MenuItem>
           ))}

--- a/docs/src/pages/demos/menus/MenuListComposition.js
+++ b/docs/src/pages/demos/menus/MenuListComposition.js
@@ -27,7 +27,7 @@ class MenuListComposition extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -59,13 +59,13 @@ class MenuListComposition extends React.Component {
             eventsEnabled={open}
             className={classNames({ [classes.popperClose]: !open })}
           >
-            <ClickAwayListener onClickAway={this.handleRequestClose}>
+            <ClickAwayListener onClickAway={this.handleClose}>
               <Grow in={open} id="menu-list" style={{ transformOrigin: '0 0 0' }}>
                 <Paper>
                   <MenuList role="menu">
-                    <MenuItem onClick={this.handleRequestClose}>Profile</MenuItem>
-                    <MenuItem onClick={this.handleRequestClose}>My account</MenuItem>
-                    <MenuItem onClick={this.handleRequestClose}>Logout</MenuItem>
+                    <MenuItem onClick={this.handleClose}>Profile</MenuItem>
+                    <MenuItem onClick={this.handleClose}>My account</MenuItem>
+                    <MenuItem onClick={this.handleClose}>Logout</MenuItem>
                   </MenuList>
                 </Paper>
               </Grow>

--- a/docs/src/pages/demos/menus/SimpleListMenu.js
+++ b/docs/src/pages/demos/menus/SimpleListMenu.js
@@ -36,7 +36,7 @@ class SimpleListMenu extends React.Component {
     this.setState({ selectedIndex: index, open: false });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -62,7 +62,7 @@ class SimpleListMenu extends React.Component {
           id="lock-menu"
           anchorEl={this.state.anchorEl}
           open={this.state.open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
         >
           {options.map((option, index) => (
             <MenuItem

--- a/docs/src/pages/demos/menus/SimpleMenu.js
+++ b/docs/src/pages/demos/menus/SimpleMenu.js
@@ -12,7 +12,7 @@ class SimpleMenu extends React.Component {
     this.setState({ open: true, anchorEl: event.currentTarget });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -30,11 +30,11 @@ class SimpleMenu extends React.Component {
           id="simple-menu"
           anchorEl={this.state.anchorEl}
           open={this.state.open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
         >
-          <MenuItem onClick={this.handleRequestClose}>Profile</MenuItem>
-          <MenuItem onClick={this.handleRequestClose}>My account</MenuItem>
-          <MenuItem onClick={this.handleRequestClose}>Logout</MenuItem>
+          <MenuItem onClick={this.handleClose}>Profile</MenuItem>
+          <MenuItem onClick={this.handleClose}>My account</MenuItem>
+          <MenuItem onClick={this.handleClose}>Logout</MenuItem>
         </Menu>
       </div>
     );

--- a/docs/src/pages/demos/popovers/AnchorPlayground.js
+++ b/docs/src/pages/demos/popovers/AnchorPlayground.js
@@ -51,7 +51,7 @@ class AnchorPlayground extends React.Component {
     });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({
       open: false,
     });
@@ -90,7 +90,7 @@ class AnchorPlayground extends React.Component {
           anchorEl={anchorEl}
           anchorReference={anchorReference}
           anchorPosition={{ top: positionTop, left: positionLeft }}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
           anchorOrigin={{
             vertical: anchorOriginVertical,
             horizontal: anchorOriginHorizontal,

--- a/docs/src/pages/demos/popovers/MouseOverPopover.js
+++ b/docs/src/pages/demos/popovers/MouseOverPopover.js
@@ -68,7 +68,7 @@ class MouseOverPopover extends Component {
             vertical: 'top',
             horizontal: 'left',
           }}
-          onRequestClose={this.handlePopoverClose}
+          onClose={this.handlePopoverClose}
         >
           <Typography>I use Popover.</Typography>
         </Popover>

--- a/docs/src/pages/demos/selects/DialogSelect.js
+++ b/docs/src/pages/demos/selects/DialogSelect.js
@@ -33,7 +33,7 @@ class DialogSelect extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -47,7 +47,7 @@ class DialogSelect extends React.Component {
           ignoreBackdropClick
           ignoreEscapeKeyUp
           open={this.state.open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
         >
           <DialogTitle>Fill the form</DialogTitle>
           <DialogContent>
@@ -84,10 +84,10 @@ class DialogSelect extends React.Component {
             </form>
           </DialogContent>
           <DialogActions>
-            <Button onClick={this.handleRequestClose} color="primary">
+            <Button onClick={this.handleClose} color="primary">
               Cancel
             </Button>
-            <Button onClick={this.handleRequestClose} color="primary">
+            <Button onClick={this.handleClose} color="primary">
               Ok
             </Button>
           </DialogActions>

--- a/docs/src/pages/demos/snackbars/DirectionSnackbar.js
+++ b/docs/src/pages/demos/snackbars/DirectionSnackbar.js
@@ -29,7 +29,7 @@ class DirectionSnackbar extends React.Component {
     this.setState({ open: true, transition });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -42,7 +42,7 @@ class DirectionSnackbar extends React.Component {
         <Button onClick={this.handleClick(TransitionDown)}>Down</Button>
         <Snackbar
           open={this.state.open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
           transition={this.state.transition}
           SnackbarContentProps={{
             'aria-describedby': 'message-id',

--- a/docs/src/pages/demos/snackbars/FadeSnackbar.js
+++ b/docs/src/pages/demos/snackbars/FadeSnackbar.js
@@ -12,7 +12,7 @@ class FadeSnackbar extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -22,7 +22,7 @@ class FadeSnackbar extends React.Component {
         <Button onClick={this.handleClick}>Open with Fade Transition</Button>
         <Snackbar
           open={this.state.open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
           transition={Fade}
           SnackbarContentProps={{
             'aria-describedby': 'message-id',

--- a/docs/src/pages/demos/snackbars/PositionedSnackbar.js
+++ b/docs/src/pages/demos/snackbars/PositionedSnackbar.js
@@ -13,7 +13,7 @@ class PositionedSnackbar extends React.Component {
     this.setState({ open: true, ...state });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
@@ -42,7 +42,7 @@ class PositionedSnackbar extends React.Component {
         <Snackbar
           anchorOrigin={{ vertical, horizontal }}
           open={open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
           SnackbarContentProps={{
             'aria-describedby': 'message-id',
           }}

--- a/docs/src/pages/demos/snackbars/SimpleSnackbar.js
+++ b/docs/src/pages/demos/snackbars/SimpleSnackbar.js
@@ -22,7 +22,7 @@ class SimpleSnackbar extends React.Component {
     this.setState({ open: true });
   };
 
-  handleRequestClose = (event, reason) => {
+  handleClose = (event, reason) => {
     if (reason === 'clickaway') {
       return;
     }
@@ -42,13 +42,13 @@ class SimpleSnackbar extends React.Component {
           }}
           open={this.state.open}
           autoHideDuration={6000}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
           SnackbarContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">Note archived</span>}
           action={[
-            <Button key="undo" color="accent" dense onClick={this.handleRequestClose}>
+            <Button key="undo" color="accent" dense onClick={this.handleClose}>
               UNDO
             </Button>,
             <IconButton
@@ -56,7 +56,7 @@ class SimpleSnackbar extends React.Component {
               aria-label="Close"
               color="inherit"
               className={classes.close}
-              onClick={this.handleRequestClose}
+              onClick={this.handleClose}
             >
               <CloseIcon />
             </IconButton>,

--- a/docs/src/pages/demos/tooltips/ControlledTooltips.js
+++ b/docs/src/pages/demos/tooltips/ControlledTooltips.js
@@ -8,11 +8,11 @@ class ControlledTooltips extends React.Component {
     open: false,
   };
 
-  handleIconButtonRequestClose = () => {
+  handleIconButtonClose = () => {
     this.setState({ open: false });
   };
 
-  handleIconButtonRequestOpen = () => {
+  handleIconButtonOpen = () => {
     this.setState({ open: true });
   };
 
@@ -21,10 +21,10 @@ class ControlledTooltips extends React.Component {
       <Tooltip
         id="tooltip-controlled"
         title="Delete"
-        onRequestClose={this.handleIconButtonRequestClose}
+        onClose={this.handleIconButtonClose}
         enterDelay={300}
         leaveDelay={300}
-        onRequestOpen={this.handleIconButtonRequestOpen}
+        onOpen={this.handleIconButtonOpen}
         open={this.state.open}
         placement="bottom"
       >

--- a/docs/src/pages/guides/api.md
+++ b/docs/src/pages/guides/api.md
@@ -62,5 +62,5 @@ For instance, the `disabled` attribute on an input element. This choice allows t
 
 ### Controllable components
 
- Most of the controllable component are controlled via the `value` and the `onChange` properties.
-However, we also use the `open`/`onRequestClose` combination for display relative state.
+Most of the controllable component are controlled via the `value` and the `onChange` properties.
+However, we also use the `open`/`onClose`/`onOpen` combination for display relative state.

--- a/examples/create-react-app-with-flow/src/pages/index.js
+++ b/examples/create-react-app-with-flow/src/pages/index.js
@@ -37,7 +37,7 @@ class Index extends Component<ProvidedProps & Props, State> {
     open: false,
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({
       open: false,
     });
@@ -52,13 +52,13 @@ class Index extends Component<ProvidedProps & Props, State> {
   render() {
     return (
       <div className={this.props.classes.root}>
-        <Dialog open={this.state.open} onRequestClose={this.handleRequestClose}>
+        <Dialog open={this.state.open} onClose={this.handleClose}>
           <DialogTitle>Super Secret Password</DialogTitle>
           <DialogContent>
             <DialogContentText>1-2-3-4-5</DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button color="primary" onClick={this.handleRequestClose}>
+            <Button color="primary" onClick={this.handleClose}>
               OK
             </Button>
           </DialogActions>

--- a/examples/create-react-app/src/pages/index.js
+++ b/examples/create-react-app/src/pages/index.js
@@ -25,7 +25,7 @@ class Index extends Component {
     open: false,
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({
       open: false,
     });
@@ -40,13 +40,13 @@ class Index extends Component {
   render() {
     return (
       <div className={this.props.classes.root}>
-        <Dialog open={this.state.open} onRequestClose={this.handleRequestClose}>
+        <Dialog open={this.state.open} onClose={this.handleClose}>
           <DialogTitle>Super Secret Password</DialogTitle>
           <DialogContent>
             <DialogContentText>1-2-3-4-5</DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button color="primary" onClick={this.handleRequestClose}>
+            <Button color="primary" onClick={this.handleClose}>
               OK
             </Button>
           </DialogActions>

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -25,7 +25,7 @@ class Index extends Component {
     open: false,
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({
       open: false,
     });
@@ -40,13 +40,13 @@ class Index extends Component {
   render() {
     return (
       <div className={this.props.classes.root}>
-        <Dialog open={this.state.open} onRequestClose={this.handleRequestClose}>
+        <Dialog open={this.state.open} onClose={this.handleClose}>
           <DialogTitle>Super Secret Password</DialogTitle>
           <DialogContent>
             <DialogContentText>1-2-3-4-5</DialogContentText>
           </DialogContent>
           <DialogActions>
-            <Button color="primary" onClick={this.handleRequestClose}>
+            <Button color="primary" onClick={this.handleClose}>
               OK
             </Button>
           </DialogActions>

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -14,9 +14,9 @@ Chips represent complex entities in small blocks, such as a contact.
 |:-----|:-----|:--------|:------------|
 | avatar | Element |  | Avatar element. |
 | classes | Object |  | Useful to extend the style applied to components. |
-| deleteIcon | Element |  | Custom delete icon. Will be shown only if `onRequestDelete` is set. |
+| deleteIcon | Element |  | Custom delete icon. Will be shown only if `onDelete` is set. |
 | label | Node |  | The content of the label. |
-| onRequestDelete | signature |  | Callback function fired when the delete icon is clicked. If set, the delete icon will be shown. |
+| onDelete | signature |  | Callback function fired when the delete icon is clicked. If set, the delete icon will be shown. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -16,10 +16,11 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | classes | Object |  | Useful to extend the style applied to components. |
 | fullScreen | boolean | false | If `true`, it will be full-screen |
 | fullWidth | boolean | false | If specified, stretches dialog to max width. |
-| ignoreBackdropClick | boolean | false | If `true`, clicking the backdrop will not fire the `onRequestClose` callback. |
-| ignoreEscapeKeyUp | boolean | false | If `true`, hitting escape will not fire the `onRequestClose` callback. |
+| ignoreBackdropClick | boolean | false | If `true`, clicking the backdrop will not fire the `onClose` callback. |
+| ignoreEscapeKeyUp | boolean | false | If `true`, hitting escape will not fire the `onClose` callback. |
 | maxWidth | union:&nbsp;'xs'&nbsp;&#124;<br>&nbsp;'sm'&nbsp;&#124;<br>&nbsp;'md'<br> | 'sm' | Determine the max width of the dialog. The dialog width grows with the size of the screen, this property is useful on the desktop where you might need some coherent different width size across your application. |
 | onBackdropClick | Function |  | Callback fired when the backdrop is clicked. |
+| onClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | onEnter | TransitionCallback |  | Callback fired before the dialog enters. |
 | onEntered | TransitionCallback |  | Callback fired when the dialog has entered. |
 | onEntering | TransitionCallback |  | Callback fired when the dialog is entering. |
@@ -27,7 +28,6 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | onExit | TransitionCallback |  | Callback fired before the dialog exits. |
 | onExited | TransitionCallback |  | Callback fired when the dialog has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the dialog is exiting. |
-| onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the Dialog is open. |
 | transition | ComponentType | Fade | Transition component. |
 | transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -18,7 +18,7 @@ filename: /src/Drawer/Drawer.js
 | <span style="color: #31a148">children *</span> | Node |  | The contents of the drawer. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | elevation | number | 16 | The elevation of the drawer. |
-| onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
+| onClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the drawer is open. |
 | transitionDuration | TransitionDuration | {  enter: duration.enteringScreen,  exit: duration.leavingScreen} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | type | union:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | 'temporary' | The type of drawer. |

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -17,13 +17,13 @@ filename: /src/Menu/Menu.js
 | anchorEl | HTMLElement |  | The DOM element used to set the position of the menu. |
 | children | Node |  | Menu contents, normally `MenuItem`s. |
 | classes | Object |  | Useful to extend the style applied to components. |
+| onClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | onEnter | TransitionCallback |  | Callback fired before the Menu enters. |
 | onEntered | TransitionCallback |  | Callback fired when the Menu has entered. |
 | onEntering | TransitionCallback |  | Callback fired when the Menu is entering. |
 | onExit | TransitionCallback |  | Callback fired before the Menu exits. |
 | onExited | TransitionCallback |  | Callback fired when the Menu has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the Menu is exiting. |
-| onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean | false | If `true`, the menu is visible. |
 | transitionDuration | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;'auto'<br> | 'auto' | The length of the transition in `ms`, or 'auto' |
 

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -31,10 +31,11 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 | children | Element |  | A single child content element. |
 | classes | Object |  | Useful to extend the style applied to components. |
 | disableBackdrop | boolean | false | If `true`, the backdrop is disabled. |
-| ignoreBackdropClick | boolean | false | If `true`, clicking the backdrop will not fire the `onRequestClose` callback. |
-| ignoreEscapeKeyUp | boolean | false | If `true`, hitting escape will not fire the `onRequestClose` callback. |
+| ignoreBackdropClick | boolean | false | If `true`, clicking the backdrop will not fire the `onClose` callback. |
+| ignoreEscapeKeyUp | boolean | false | If `true`, hitting escape will not fire the `onClose` callback. |
 | keepMounted | boolean | false | Always keep the children in the DOM. This property can be useful in SEO situation or when you want to maximize the responsiveness of the Modal. |
 | onBackdropClick | Function |  | Callback fires when the backdrop is clicked on. |
+| onClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | onEnter | TransitionCallback |  | Callback fired before the modal is entering. |
 | onEntered | TransitionCallback |  | Callback fired when the modal has entered. |
 | onEntering | TransitionCallback |  | Callback fired when the modal is entering. |
@@ -42,7 +43,6 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 | onExit | TransitionCallback |  | Callback fired before the modal is exiting. |
 | onExited | TransitionCallback |  | Callback fired when the modal has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the modal is exiting. |
-| onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span style="color: #31a148">show *</span> | boolean |  | If `true`, the Modal is visible. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -22,13 +22,13 @@ filename: /src/Popover/Popover.js
 | elevation | number | 8 | The elevation of the popover. |
 | getContentAnchorEl | Function |  | This function is called in order to retrieve the content anchor element. It's the opposite of the `anchorEl` property. The content anchor element should be an element inside the popover. It's used to correctly scroll and set the position of the popover. The positioning strategy tries to make the content anchor element just above the anchor element. |
 | marginThreshold | number | 16 | Specifies how close to the edge of the window the popover can appear. |
+| onClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. |
 | onEnter | TransitionCallback |  | Callback fired before the component is entering. |
 | onEntered | TransitionCallback |  | Callback fired when the component has entered. |
 | onEntering | TransitionCallback |  | Callback fired when the component is entering. |
 | onExit | TransitionCallback |  | Callback fired before the component is exiting. |
 | onExited | TransitionCallback |  | Callback fired when the component has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the component is exiting. |
-| onRequestClose | Function |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. |
 | <span style="color: #31a148">open *</span> | boolean |  | If `true`, the popover is visible. |
 | transformOrigin | signature | {  vertical: 'top',  horizontal: 'left',} | This is the point on the popover which will attach to the anchor's origin.<br>Options: vertical: [top, center, bottom, x(px)]; horizontal: [left, center, right, x(px)]. |
 | transitionClasses | TransitionClasses |  | The animation classNames applied to the component as it enters or exits. This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames). |

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -20,13 +20,13 @@ filename: /src/Snackbar/Snackbar.js
 | classes | Object |  | Useful to extend the style applied to components. |
 | key | any |  | When displaying multiple consecutive Snackbars from a parent rendering a single &lt;Snackbar/>, add the key property to ensure independent treatment of each message. e.g. &lt;Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled. |
 | message | Node |  | The message to display. |
+| onClose | signature |  | Callback fired when the component requests to be closed.<br>Typically `onClose` is used to set state in the parent component, which is used to control the `Snackbar` `open` prop.<br>The `reason` parameter can optionally be used to control the response to `onClose`, for example ignoring `clickaway`.<br><br>**Signature:**<br>`function(event: object, reason: string) => void`<br>*event:* The event source of the callback<br>*reason:* Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"` |
 | onEnter | TransitionCallback |  | Callback fired before the transition is entering. |
 | onEntered | TransitionCallback |  | Callback fired when the transition has entered. |
 | onEntering | TransitionCallback |  | Callback fired when the transition is entering. |
 | onExit | TransitionCallback |  | Callback fired before the transition is exiting. |
 | onExited | TransitionCallback |  | Callback fired when the transition has exited. |
 | onExiting | TransitionCallback |  | Callback fired when the transition is exiting. |
-| onRequestClose | signature |  | Callback fired when the component requests to be closed.<br>Typically `onRequestClose` is used to set state in the parent component, which is used to control the `Snackbar` `open` prop.<br>The `reason` parameter can optionally be used to control the response to `onRequestClose`, for example ignoring `clickaway`.<br><br>**Signature:**<br>`function(event: object, reason: string) => void`<br>*event:* The event source of the callback<br>*reason:* Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"` |
 | <span style="color: #31a148">open *</span> | boolean |  | If true, `Snackbar` is open. |
 | resumeHideDuration | number |  | The number of milliseconds to wait before dismissing after user interaction. If `autoHideDuration` property isn't specified, it does nothing. If `autoHideDuration` property is specified but `resumeHideDuration` isn't, we default to `autoHideDuration / 2` ms. |
 | transition | ComponentType |  | Transition component. |

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -21,8 +21,8 @@ filename: /src/Tooltip/Tooltip.js
 | enterDelay | number | 0 | The number of milliseconds to wait before showing the tooltip. |
 | id | string |  | The relationship between the tooltip and the wrapper component is not clear from the DOM. By providing this property, we can use aria-describedby to solve the accessibility issue. |
 | leaveDelay | number | 0 | The number of milliseconds to wait before hidding the tooltip. |
-| onRequestClose | Function |  | Callback fired when the tooltip requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
-| onRequestOpen | Function |  | Callback fired when the tooltip requests to be open.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
+| onClose | Function |  | Callback fired when the tooltip requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
+| onOpen | Function |  | Callback fired when the tooltip requests to be open.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | boolean |  | If `true`, the tooltip is shown. |
 | placement | union:&nbsp;, 'bottom-end', 'bottom-start', 'bottom', 'left-end', 'left-start', 'left', 'right-end', 'right-start', 'right', 'top-end', 'top-start', 'top'<br> | 'bottom' | Tooltip placement |
 | <span style="color: #31a148">title *</span> | Node |  | Tooltip title. |

--- a/src/Card/CardMedia.d.ts
+++ b/src/Card/CardMedia.d.ts
@@ -5,9 +5,9 @@ export interface CardMediaProps extends StandardProps<
   React.HTMLAttributes<HTMLDivElement>,
   CardMediaClassKey
 > {
+  component?: string | React.ComponentType<CardMediaProps>;
   image?: string;
   src?: string;
-  component?: string | React.ComponentType<CardMediaProps>;
 }
 
 export type CardMediaClassKey =

--- a/src/Chip/Chip.d.ts
+++ b/src/Chip/Chip.d.ts
@@ -6,10 +6,10 @@ export interface ChipProps extends StandardProps<
   ChipClassKey
 > {
   avatar?: React.ReactElement<any>;
-  label?: React.ReactNode;
-  onKeyDown?: React.EventHandler<React.KeyboardEvent<any>>;
-  onRequestDelete?: React.EventHandler<any>;
   deleteIcon?: React.ReactElement<any>;
+  label?: React.ReactNode;
+  onDelete?: React.EventHandler<any>;
+  onKeyDown?: React.EventHandler<React.KeyboardEvent<any>>;
 }
 
 export type ChipClassKey =

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -110,7 +110,7 @@ export type Props = {
    */
   classes?: Object,
   /**
-   * Custom delete icon. Will be shown only if `onRequestDelete` is set.
+   * Custom delete icon. Will be shown only if `onDelete` is set.
    */
   deleteIcon?: Element<any>,
   /**
@@ -122,14 +122,14 @@ export type Props = {
    */
   onClick?: Function,
   /**
-   * @ignore
-   */
-  onKeyDown?: Function,
-  /**
    * Callback function fired when the delete icon is clicked.
    * If set, the delete icon will be shown.
    */
-  onRequestDelete?: (event: SyntheticEvent<>) => void,
+  onDelete?: (event: SyntheticEvent<>) => void,
+  /**
+   * @ignore
+   */
+  onKeyDown?: Function,
   /**
    * @ignore
    */
@@ -147,22 +147,22 @@ class Chip extends React.Component<ProvidedProps & Props> {
   handleDeleteIconClick = event => {
     // Stop the event from bubbling up to the `Chip`
     event.stopPropagation();
-    const { onRequestDelete } = this.props;
-    if (onRequestDelete) {
-      onRequestDelete(event);
+    const { onDelete } = this.props;
+    if (onDelete) {
+      onDelete(event);
     }
   };
 
   handleKeyDown = event => {
-    const { onClick, onRequestDelete, onKeyDown } = this.props;
+    const { onClick, onDelete, onKeyDown } = this.props;
     const key = keycode(event);
 
     if (onClick && (key === 'space' || key === 'enter')) {
       event.preventDefault();
       onClick(event);
-    } else if (onRequestDelete && key === 'backspace') {
+    } else if (onDelete && key === 'backspace') {
       event.preventDefault();
-      onRequestDelete(event);
+      onDelete(event);
     } else if (key === 'esc') {
       event.preventDefault();
       if (this.chipRef) {
@@ -183,7 +183,7 @@ class Chip extends React.Component<ProvidedProps & Props> {
       label,
       onClick,
       onKeyDown,
-      onRequestDelete,
+      onDelete,
       deleteIcon: deleteIconProp,
       tabIndex: tabIndexProp,
       ...other
@@ -192,17 +192,17 @@ class Chip extends React.Component<ProvidedProps & Props> {
     const className = classNames(
       classes.root,
       { [classes.clickable]: onClick },
-      { [classes.deletable]: onRequestDelete },
+      { [classes.deletable]: onDelete },
       classNameProp,
     );
 
     let deleteIcon = null;
-    if (onRequestDelete && deleteIconProp && React.isValidElement(deleteIconProp)) {
+    if (onDelete && deleteIconProp && React.isValidElement(deleteIconProp)) {
       deleteIcon = React.cloneElement(deleteIconProp, {
         onClick: this.handleDeleteIconClick,
         className: classNames(classes.deleteIcon, deleteIconProp.props.className),
       });
-    } else if (onRequestDelete) {
+    } else if (onDelete) {
       deleteIcon = (
         <CancelIcon className={classes.deleteIcon} onClick={this.handleDeleteIconClick} />
       );
@@ -219,7 +219,7 @@ class Chip extends React.Component<ProvidedProps & Props> {
     let tabIndex = tabIndexProp;
 
     if (!tabIndex) {
-      tabIndex = onClick || onRequestDelete ? 0 : -1;
+      tabIndex = onClick || onDelete ? 0 : -1;
     }
 
     return (

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -104,7 +104,7 @@ describe('<Chip />', () => {
             </Avatar>
           }
           label="Text Avatar Chip"
-          onRequestDelete={() => {}}
+          onDelete={() => {}}
           className="my-Chip"
           data-my-prop="woofChip"
         />,
@@ -135,21 +135,17 @@ describe('<Chip />', () => {
     });
 
     it('should fire the function given in onDeleteRequest', () => {
-      const onRequestDeleteSpy = spy();
-      wrapper.setProps({ onRequestDelete: onRequestDeleteSpy });
+      const onDeleteSpy = spy();
+      wrapper.setProps({ onDelete: onDeleteSpy });
 
       wrapper.find('pure(Cancel)').simulate('click', { stopPropagation: () => {} });
-      assert.strictEqual(
-        onRequestDeleteSpy.callCount,
-        1,
-        'should have called the onRequestDelete handler',
-      );
+      assert.strictEqual(onDeleteSpy.callCount, 1, 'should have called the onDelete handler');
     });
 
     it('should stop propagation in onDeleteRequest', () => {
-      const onRequestDeleteSpy = spy();
+      const onDeleteSpy = spy();
       const stopPropagationSpy = spy();
-      wrapper.setProps({ onRequestDelete: onRequestDeleteSpy });
+      wrapper.setProps({ onDelete: onDeleteSpy });
 
       wrapper.find('pure(Cancel)').simulate('click', { stopPropagation: stopPropagationSpy });
       assert.strictEqual(
@@ -163,25 +159,17 @@ describe('<Chip />', () => {
   describe('prop: deleteIcon', () => {
     it('should fire the function given in onDeleteRequest', () => {
       const wrapper = shallow(
-        <Chip
-          label="Custom delete icon Chip"
-          onRequestDelete={() => {}}
-          deleteIcon={<CheckBox />}
-        />,
+        <Chip label="Custom delete icon Chip" onDelete={() => {}} deleteIcon={<CheckBox />} />,
       );
-      const onRequestDeleteSpy = spy();
-      wrapper.setProps({ onRequestDelete: onRequestDeleteSpy });
+      const onDeleteSpy = spy();
+      wrapper.setProps({ onDelete: onDeleteSpy });
 
       wrapper.find(CheckBox).simulate('click', { stopPropagation: () => {} });
-      assert.strictEqual(
-        onRequestDeleteSpy.callCount,
-        1,
-        'should have called the onRequestDelete handler',
-      );
+      assert.strictEqual(onDeleteSpy.callCount, 1, 'should have called the onDelete handler');
     });
 
     it('should render a default icon', () => {
-      const wrapper = mount(<Chip label="Custom delete icon Chip" onRequestDelete={() => {}} />);
+      const wrapper = mount(<Chip label="Custom delete icon Chip" onDelete={() => {}} />);
       assert.strictEqual(wrapper.find(CancelIcon).length, 1);
     });
   });
@@ -252,10 +240,10 @@ describe('<Chip />', () => {
       });
     });
 
-    describe('onRequestDelete is defined and `backspace` is pressed', () => {
-      it('should call onRequestDelete', () => {
-        const onRequestDeleteSpy = spy();
-        wrapper.setProps({ onRequestDelete: onRequestDeleteSpy });
+    describe('onDelete is defined and `backspace` is pressed', () => {
+      it('should call onDelete', () => {
+        const onDeleteSpy = spy();
+        wrapper.setProps({ onDelete: onDeleteSpy });
 
         const preventDefaultSpy = spy();
         const backspaceKeydownEvent = {
@@ -265,8 +253,8 @@ describe('<Chip />', () => {
         wrapper.find('div').simulate('keydown', backspaceKeydownEvent);
 
         assert.strictEqual(preventDefaultSpy.callCount, 1, 'should have stopped event propagation');
-        assert.strictEqual(onRequestDeleteSpy.callCount, 1, 'should have called onClick');
-        assert(onRequestDeleteSpy.calledWith(backspaceKeydownEvent));
+        assert.strictEqual(onDeleteSpy.callCount, 1, 'should have called onClick');
+        assert(onDeleteSpy.calledWith(backspaceKeydownEvent));
       });
     });
   });

--- a/src/Dialog/Dialog.d.ts
+++ b/src/Dialog/Dialog.d.ts
@@ -9,16 +9,16 @@ export interface DialogProps extends StandardProps<
   'onBackdropClick' | 'onEscapeKeyUp'
 > {
   fullScreen?: boolean;
+  fullWidth?: boolean;
   ignoreBackdropClick?: boolean;
   ignoreEscapeKeyUp?: boolean;
-  transitionDuration?: TransitionDuration;
   maxWidth?: 'xs' | 'sm' | 'md';
-  fullWidth?: boolean;
   onBackdropClick?: Function;
+  onClose?: React.EventHandler<any>;
   onEscapeKeyUp?: Function;
-  onRequestClose?: React.EventHandler<any>;
   open?: boolean;
   transition?: React.ReactType;
+  transitionDuration?: TransitionDuration;
 }
 
 export type DialogClassKey =

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -83,11 +83,11 @@ export type Props = {
    */
   fullScreen: boolean,
   /**
-   * If `true`, clicking the backdrop will not fire the `onRequestClose` callback.
+   * If `true`, clicking the backdrop will not fire the `onClose` callback.
    */
   ignoreBackdropClick: boolean,
   /**
-   * If `true`, hitting escape will not fire the `onRequestClose` callback.
+   * If `true`, hitting escape will not fire the `onClose` callback.
    */
   ignoreEscapeKeyUp: boolean,
   /**
@@ -110,6 +110,12 @@ export type Props = {
    * Callback fired when the backdrop is clicked.
    */
   onBackdropClick?: Function,
+  /**
+   * Callback fired when the component requests to be closed.
+   *
+   * @param {object} event The event source of the callback
+   */
+  onClose?: Function,
   /**
    * Callback fired before the dialog enters.
    */
@@ -138,12 +144,6 @@ export type Props = {
    * Callback fired when the dialog has exited.
    */
   onExited?: TransitionCallback,
-  /**
-   * Callback fired when the component requests to be closed.
-   *
-   * @param {object} event The event source of the callback
-   */
-  onRequestClose?: Function,
   /**
    * If `true`, the Dialog is open.
    */
@@ -192,7 +192,7 @@ class Dialog extends React.Component<ProvidedProps & Props> {
       onExit,
       onExiting,
       onExited,
-      onRequestClose,
+      onClose,
       transition: TransitionProp,
       ...other
     } = this.props;
@@ -205,7 +205,7 @@ class Dialog extends React.Component<ProvidedProps & Props> {
         ignoreEscapeKeyUp={ignoreEscapeKeyUp}
         onBackdropClick={onBackdropClick}
         onEscapeKeyUp={onEscapeKeyUp}
-        onRequestClose={onRequestClose}
+        onClose={onClose}
         show={open}
         {...other}
       >

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -34,14 +34,14 @@ describe('<Dialog />', () => {
   it('should put Modal specific props on the root Modal node', () => {
     const onBackdropClick = () => {};
     const onEscapeKeyUp = () => {};
-    const onRequestClose = () => {};
+    const onClose = () => {};
     const wrapper = shallow(
       <Dialog
         open
         transitionDuration={100}
         onBackdropClick={onBackdropClick}
         onEscapeKeyUp={onEscapeKeyUp}
-        onRequestClose={onRequestClose}
+        onClose={onClose}
         hideOnBackdropClick={false}
         hideOnEscapeKeyUp={false}
       />,
@@ -50,7 +50,7 @@ describe('<Dialog />', () => {
     assert.strictEqual(wrapper.props().BackdropTransitionDuration, 100);
     assert.strictEqual(wrapper.props().onBackdropClick, onBackdropClick);
     assert.strictEqual(wrapper.props().onEscapeKeyUp, onEscapeKeyUp);
-    assert.strictEqual(wrapper.props().onRequestClose, onRequestClose);
+    assert.strictEqual(wrapper.props().onClose, onClose);
     assert.strictEqual(wrapper.props().hideOnBackdropClick, false);
     assert.strictEqual(wrapper.props().hideOnEscapeKeyUp, false);
   });

--- a/src/Drawer/Drawer.d.ts
+++ b/src/Drawer/Drawer.d.ts
@@ -11,11 +11,11 @@ export interface DrawerProps extends StandardProps<
 > {
   anchor?: 'left' | 'top' | 'right' | 'bottom';
   elevation?: number;
-  transitionDuration?: TransitionDuration;
   ModalProps?: ModalProps
   open?: boolean;
   SlideProps?: SlideProps;
   theme?: Theme;
+  transitionDuration?: TransitionDuration;
   type?: 'permanent' | 'persistent' | 'temporary';
 }
 

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -136,7 +136,7 @@ export type Props = {
    *
    * @param {object} event The event source of the callback
    */
-  onRequestClose?: Function,
+  onClose?: Function,
   /**
    * If `true`, the drawer is open.
    */
@@ -189,7 +189,7 @@ class Drawer extends React.Component<ProvidedProps & Props, State> {
       elevation,
       transitionDuration,
       ModalProps,
-      onRequestClose,
+      onClose,
       open,
       SlideProps,
       theme,
@@ -253,7 +253,7 @@ class Drawer extends React.Component<ProvidedProps & Props, State> {
         BackdropTransitionDuration={transitionDuration}
         className={classNames(classes.modal, className)}
         show={open}
-        onRequestClose={onRequestClose}
+        onClose={onClose}
         {...other}
         {...ModalProps}
       >

--- a/src/Form/FormControl.d.ts
+++ b/src/Form/FormControl.d.ts
@@ -5,6 +5,7 @@ export interface FormControlProps extends StandardProps<
   React.HtmlHTMLAttributes<HTMLDivElement>,
   FormControlClassKey
 > {
+  component?: string | React.ComponentType<FormControlProps>;
   disabled?: boolean;
   error?: boolean;
   fullWidth?: boolean;
@@ -12,7 +13,6 @@ export interface FormControlProps extends StandardProps<
   onBlur?: React.EventHandler<any>;
   onFocus?: React.EventHandler<any>;
   required?: boolean;
-  component?: string | React.ComponentType<FormControlProps>;
 }
 
 export type FormControlClassKey =

--- a/src/Grid/Grid.d.ts
+++ b/src/Grid/Grid.d.ts
@@ -27,15 +27,15 @@ export interface GridProps extends StandardProps<
   GridClassKey,
   'hidden'
 > {
+  alignContent?: GridContentAlignment;
+  alignItems?: GridItemsAlignment;
   component?: string | React.ComponentType<Omit<GridProps, StrippedProps>>;
   container?: boolean;
-  item?: boolean;
-  alignItems?: GridItemsAlignment;
-  alignContent?: GridContentAlignment;
   direction?: GridDirection;
-  spacing?: GridSpacing;
   hidden?: HiddenProps;
+  item?: boolean;
   justify?: GridJustification;
+  spacing?: GridSpacing;
   wrap?: GridWrap;
 }
 

--- a/src/Menu/Menu.d.ts
+++ b/src/Menu/Menu.d.ts
@@ -10,7 +10,7 @@ export interface MenuProps extends StandardProps<
 > {
   anchorEl?: HTMLElement;
   MenuListProps?: MenuListProps;
-  onRequestClose?: React.EventHandler<any>;
+  onClose?: React.EventHandler<any>;
   open?: boolean;
   transitionDuration?: TransitionDuration;
 }

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -42,6 +42,12 @@ export type Props = {
    */
   MenuListProps?: Object,
   /**
+   * Callback fired when the component requests to be closed.
+   *
+   * @param {object} event The event source of the callback
+   */
+  onClose?: Function,
+  /**
    * Callback fired before the Menu enters.
    */
   onEnter?: TransitionCallback,
@@ -65,12 +71,6 @@ export type Props = {
    * Callback fired when the Menu has exited.
    */
   onExited?: TransitionCallback,
-  /**
-   * Callback fired when the component requests to be closed.
-   *
-   * @param {object} event The event source of the callback
-   */
-  onRequestClose?: Function,
   /**
    * If `true`, the menu is visible.
    */
@@ -183,8 +183,8 @@ class Menu extends React.Component<ProvidedProps & Props> {
     if (key === 'tab') {
       event.preventDefault();
 
-      if (this.props.onRequestClose) {
-        this.props.onRequestClose(event);
+      if (this.props.onClose) {
+        this.props.onClose(event);
       }
     }
   };

--- a/src/Menu/Menu.spec.js
+++ b/src/Menu/Menu.spec.js
@@ -68,10 +68,10 @@ describe('<Menu />', () => {
     );
   });
 
-  it('should pass onRequestClose prop to Popover', () => {
+  it('should pass onClose prop to Popover', () => {
     const fn = () => {};
-    const wrapper = shallow(<Menu onRequestClose={fn} />);
-    assert.strictEqual(wrapper.props().onRequestClose, fn, 'should be the same function');
+    const wrapper = shallow(<Menu onClose={fn} />);
+    assert.strictEqual(wrapper.props().onClose, fn, 'should be the same function');
   });
 
   it('should pass anchorEl prop to Popover', () => {

--- a/src/MobileStepper/MobileStepper.d.ts
+++ b/src/MobileStepper/MobileStepper.d.ts
@@ -9,7 +9,7 @@ export interface MobileStepperProps extends StandardProps<
 > {
   activeStep?: number;
   backButton: React.ReactElement<any>;
-  nextButton: React.ReactElement<any>;  
+  nextButton: React.ReactElement<any>;
   position?: 'bottom' | 'top' | 'static';
   steps: number;
   type?: 'text' | 'dots' | 'progress';

--- a/src/Modal/Modal.d.ts
+++ b/src/Modal/Modal.d.ts
@@ -11,14 +11,14 @@ export interface ModalProps extends StandardProps<
   BackdropComponent?: string | React.ComponentType<BackdropProps>;
   BackdropInvisible?: boolean;
   BackdropTransitionDuration?: TransitionDuration;
-  keepMounted?: boolean;
   disableBackdrop?: boolean;
   ignoreBackdropClick?: boolean;
   ignoreEscapeKeyUp?: boolean;
+  keepMounted?: boolean;
   modalManager?: Object;
   onBackdropClick?: React.ReactEventHandler<{}>;
+  onClose?: React.ReactEventHandler<{}>;
   onEscapeKeyUp?: React.ReactEventHandler<{}>;
-  onRequestClose?: React.ReactEventHandler<{}>;
   show?: boolean;
 }
 

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -91,17 +91,23 @@ export type Props = {
    */
   disableBackdrop: boolean,
   /**
-   * If `true`, clicking the backdrop will not fire the `onRequestClose` callback.
+   * If `true`, clicking the backdrop will not fire the `onClose` callback.
    */
   ignoreBackdropClick: boolean,
   /**
-   * If `true`, hitting escape will not fire the `onRequestClose` callback.
+   * If `true`, hitting escape will not fire the `onClose` callback.
    */
   ignoreEscapeKeyUp: boolean,
   /**
    * @ignore
    */
   modalManager: Object,
+  /**
+   * Callback fired when the component requests to be closed.
+   *
+   * @param {object} event The event source of the callback
+   */
+  onClose?: Function,
   /**
    * Callback fires when the backdrop is clicked on.
    */
@@ -134,12 +140,6 @@ export type Props = {
    * Callback fired when the modal has exited.
    */
   onExited?: TransitionCallback,
-  /**
-   * Callback fired when the component requests to be closed.
-   *
-   * @param {object} event The event source of the callback
-   */
-  onRequestClose?: Function,
   /**
    * If `true`, the Modal is visible.
    */
@@ -298,14 +298,14 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
       return;
     }
 
-    const { onEscapeKeyUp, onRequestClose, ignoreEscapeKeyUp } = this.props;
+    const { onEscapeKeyUp, onClose, ignoreEscapeKeyUp } = this.props;
 
     if (onEscapeKeyUp) {
       onEscapeKeyUp(event);
     }
 
-    if (onRequestClose && !ignoreEscapeKeyUp) {
-      onRequestClose(event);
+    if (onClose && !ignoreEscapeKeyUp) {
+      onClose(event);
     }
   };
 
@@ -314,14 +314,14 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
       return;
     }
 
-    const { onBackdropClick, onRequestClose, ignoreBackdropClick } = this.props;
+    const { onBackdropClick, onClose, ignoreBackdropClick } = this.props;
 
     if (onBackdropClick) {
       onBackdropClick(event);
     }
 
-    if (onRequestClose && !ignoreBackdropClick) {
-      onRequestClose(event);
+    if (onClose && !ignoreBackdropClick) {
+      onClose(event);
     }
   };
 
@@ -356,27 +356,27 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
 
   render() {
     const {
-      disableBackdrop,
-      BackdropComponent,
       BackdropClassName,
-      BackdropTransitionDuration,
+      BackdropComponent,
       BackdropInvisible,
-      ignoreBackdropClick,
-      ignoreEscapeKeyUp,
+      BackdropTransitionDuration,
       children,
       classes,
       className,
+      disableBackdrop,
+      ignoreBackdropClick,
+      ignoreEscapeKeyUp,
       keepMounted,
       modalManager: modalManagerProp,
       onBackdropClick,
-      onEscapeKeyUp,
-      onRequestClose,
+      onClose,
       onEnter,
-      onEntering,
       onEntered,
+      onEntering,
+      onEscapeKeyUp,
       onExit,
-      onExiting,
       onExited,
+      onExiting,
       show,
       ...other
     } = this.props;

--- a/src/Modal/Modal.spec.js
+++ b/src/Modal/Modal.spec.js
@@ -157,9 +157,9 @@ describe('<Modal />', () => {
       assert.strictEqual(transition.props().timeout, 200);
     });
 
-    it('should attach a handler to the backdrop that fires onRequestClose', () => {
-      const onRequestClose = spy();
-      wrapper.setProps({ onRequestClose });
+    it('should attach a handler to the backdrop that fires onClose', () => {
+      const onClose = spy();
+      wrapper.setProps({ onClose });
 
       const handler = wrapper.instance().handleBackdropClick;
       const backdrop = wrapper.find(Backdrop);
@@ -170,21 +170,17 @@ describe('<Modal />', () => {
       );
 
       handler({});
-      assert.strictEqual(onRequestClose.callCount, 1, 'should fire the onRequestClose callback');
+      assert.strictEqual(onClose.callCount, 1, 'should fire the onClose callback');
     });
 
-    it('should let the user disable backdrop click triggering onRequestClose', () => {
-      const onRequestClose = spy();
-      wrapper.setProps({ onRequestClose, ignoreBackdropClick: true });
+    it('should let the user disable backdrop click triggering onClose', () => {
+      const onClose = spy();
+      wrapper.setProps({ onClose, ignoreBackdropClick: true });
 
       const handler = wrapper.instance().handleBackdropClick;
 
       handler({});
-      assert.strictEqual(
-        onRequestClose.callCount,
-        0,
-        'should not fire the onRequestClose callback',
-      );
+      assert.strictEqual(onClose.callCount, 0, 'should not fire the onClose callback');
     });
   });
 
@@ -350,32 +346,32 @@ describe('<Modal />', () => {
 
     describe('called', () => {
       let onEscapeKeyUpStub;
-      let onRequestCloseStub;
+      let onCloseStub;
       let topModalStub;
       let event;
 
       before(() => {
         onEscapeKeyUpStub = stub().returns(true);
-        onRequestCloseStub = stub().returns(true);
+        onCloseStub = stub().returns(true);
         topModalStub = stub();
-        wrapper.setProps({ onEscapeKeyUp: onEscapeKeyUpStub, onRequestClose: onRequestCloseStub });
+        wrapper.setProps({ onEscapeKeyUp: onEscapeKeyUpStub, onClose: onCloseStub });
       });
 
       afterEach(() => {
         onEscapeKeyUpStub.reset();
-        onRequestCloseStub.reset();
+        onCloseStub.reset();
         topModalStub.reset();
       });
 
-      it('when not mounted should not call onEscapeKeyUp and onRequestClose', () => {
+      it('when not mounted should not call onEscapeKeyUp and onClose', () => {
         instance = wrapper.instance();
         instance.mounted = false;
         instance.handleDocumentKeyUp(undefined);
         assert.strictEqual(onEscapeKeyUpStub.callCount, 0);
-        assert.strictEqual(onRequestCloseStub.callCount, 0);
+        assert.strictEqual(onCloseStub.callCount, 0);
       });
 
-      it('when mounted and not TopModal should not call onEscapeKeyUp and onRequestClose', () => {
+      it('when mounted and not TopModal should not call onEscapeKeyUp and onClose', () => {
         topModalStub.returns('false');
         wrapper.setProps({ modalManager: { isTopModal: topModalStub } });
         instance = wrapper.instance();
@@ -384,7 +380,7 @@ describe('<Modal />', () => {
         instance.handleDocumentKeyUp(undefined);
         assert.strictEqual(topModalStub.callCount, 1);
         assert.strictEqual(onEscapeKeyUpStub.callCount, 0);
-        assert.strictEqual(onRequestCloseStub.callCount, 0);
+        assert.strictEqual(onCloseStub.callCount, 0);
       });
 
       it('when mounted, TopModal and event not esc should not call given funcs', () => {
@@ -397,10 +393,10 @@ describe('<Modal />', () => {
         instance.handleDocumentKeyUp(event);
         assert.strictEqual(topModalStub.callCount, 1);
         assert.strictEqual(onEscapeKeyUpStub.callCount, 0);
-        assert.strictEqual(onRequestCloseStub.callCount, 0);
+        assert.strictEqual(onCloseStub.callCount, 0);
       });
 
-      it('should call onEscapeKeyUp and onRequestClose', () => {
+      it('should call onEscapeKeyUp and onClose', () => {
         topModalStub.returns(true);
         wrapper.setProps({ modalManager: { isTopModal: topModalStub } });
         event = { keyCode: keycode('esc') };
@@ -411,11 +407,11 @@ describe('<Modal />', () => {
         assert.strictEqual(topModalStub.callCount, 1);
         assert.strictEqual(onEscapeKeyUpStub.callCount, 1);
         assert.strictEqual(onEscapeKeyUpStub.calledWith(event), true);
-        assert.strictEqual(onRequestCloseStub.callCount, 1);
-        assert.strictEqual(onRequestCloseStub.calledWith(event), true);
+        assert.strictEqual(onCloseStub.callCount, 1);
+        assert.strictEqual(onCloseStub.calledWith(event), true);
       });
 
-      it('when ignoreEscapeKeyUp should call only onRequestClose', () => {
+      it('when ignoreEscapeKeyUp should call only onClose', () => {
         topModalStub.returns(true);
         wrapper.setProps({ modalManager: { isTopModal: topModalStub } });
         wrapper.setProps({ ignoreEscapeKeyUp: true });
@@ -427,7 +423,7 @@ describe('<Modal />', () => {
         assert.strictEqual(topModalStub.callCount, 1);
         assert.strictEqual(onEscapeKeyUpStub.callCount, 1);
         assert.strictEqual(onEscapeKeyUpStub.calledWith(event), true);
-        assert.strictEqual(onRequestCloseStub.callCount, 0);
+        assert.strictEqual(onCloseStub.callCount, 0);
       });
     });
   });

--- a/src/Popover/Popover.d.ts
+++ b/src/Popover/Popover.d.ts
@@ -14,12 +14,12 @@ export interface PopoverPosition {
   left: number;
 }
 
-export type PopoverReference = 'anchorEl' | 'anchorPosition'; 
+export type PopoverReference = 'anchorEl' | 'anchorPosition';
 
 export interface PopoverProps extends StandardProps<
   ModalProps & Partial<TransitionHandlers>,
   PopoverClassKey,
-  'onRequestClose'
+  'onClose'
 > {
   anchorEl?: Object;
   anchorOrigin?: PopoverOrigin;
@@ -33,13 +33,13 @@ export interface PopoverProps extends StandardProps<
   getContentAnchorEl?: Function;
   marginThreshold?: number;
   modal?: boolean;
-  onRequestClose?: Function;
+  onClose?: Function;
   open?: boolean;
+  PaperProps?: Partial<PaperProps>;
   role?: string;
+  theme?: Object;
   transformOrigin?: PopoverOrigin;
   transitionDuration?: TransitionDuration;
-  theme?: Object;
-  PaperProps?: Partial<PaperProps>;
 }
 
 export type PopoverClassKey =

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -161,6 +161,12 @@ export type Props = {
    */
   marginThreshold: number,
   /**
+   * Callback fired when the component requests to be closed.
+   *
+   * @param {object} event The event source of the callback.
+   */
+  onClose?: Function,
+  /**
    * Callback fired before the component is entering.
    */
   onEnter?: TransitionCallback,
@@ -184,12 +190,6 @@ export type Props = {
    * Callback fired when the component has exited.
    */
   onExited?: TransitionCallback,
-  /**
-   * Callback fired when the component requests to be closed.
-   *
-   * @param {object} event The event source of the callback.
-   */
-  onRequestClose?: Function,
   /**
    * If `true`, the popover is visible.
    */

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -43,18 +43,14 @@ describe('<Popover />', () => {
       assert.strictEqual(wrapper.props().BackdropInvisible, true);
     });
 
-    it('should pass onRequestClose prop to Modal', () => {
+    it('should pass onClose prop to Modal', () => {
       const fn = () => {};
       const wrapper = shallow(
-        <Popover {...props} onRequestClose={fn}>
+        <Popover {...props} onClose={fn}>
           <div />
         </Popover>,
       );
-      assert.strictEqual(
-        wrapper.props().onRequestClose,
-        fn,
-        'should be the onRequestClose function',
-      );
+      assert.strictEqual(wrapper.props().onClose, fn, 'should be the onClose function');
     });
 
     it('should pass open prop to Modal as `show`', () => {

--- a/src/Progress/CircularProgress.d.ts
+++ b/src/Progress/CircularProgress.d.ts
@@ -10,8 +10,8 @@ export interface CircularProgressProps extends StandardProps<
   min?: number;
   mode?: 'determinate' | 'indeterminate';
   size?: number;
-  value?: number;
   thickness?: number;
+  value?: number;
 }
 
 export type CircularProgressClassKey =

--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -11,9 +11,9 @@ export interface SelectProps extends StandardProps<
   autoWidth?: boolean;
   displayEmpty?: boolean;
   input?: React.ReactNode;
-  native?: boolean;
-  multiple?: boolean;
   MenuProps?: Partial<MenuProps>;
+  multiple?: boolean;
+  native?: boolean;
   renderValue?: Function;
   value?: Array<string | number> | string | number;
 }

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -5,10 +5,10 @@ import { MenuProps } from '../Menu';
 export interface SelectInputProps extends StandardProps<{}, SelectInputClassKey> {
   autoWidth: boolean;
   disabled?: boolean;
-  native: boolean;
-  multiple: boolean;
   MenuProps?: Partial<MenuProps>;
+  multiple: boolean;
   name?: string;
+  native: boolean;
   onBlur?: React.FocusEventHandler<any>;
   onChange?: (event: React.ChangeEvent<{}>, child: React.ReactNode) => void,
   onFocus?: React.FocusEventHandler<any>;

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -119,7 +119,7 @@ class SelectInput extends React.Component<ProvidedProps & Props, State> {
     });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({
       open: false,
     });
@@ -362,7 +362,7 @@ class SelectInput extends React.Component<ProvidedProps & Props, State> {
           id={`menu-${name || ''}`}
           anchorEl={this.state.anchorEl}
           open={this.state.open}
-          onRequestClose={this.handleRequestClose}
+          onClose={this.handleClose}
           {...MenuProps}
           MenuListProps={{
             ...MenuProps.MenuListProps,

--- a/src/Select/SelectInput.spec.js
+++ b/src/Select/SelectInput.spec.js
@@ -156,7 +156,7 @@ describe('<SelectInput />', () => {
         });
       });
 
-      it('should call handleRequestClose', () => {
+      it('should call handleClose', () => {
         wrapper.find(`.${props.classes.select}`).simulate('click');
         assert.strictEqual(wrapper.state().open, true);
 

--- a/src/Snackbar/Snackbar.d.ts
+++ b/src/Snackbar/Snackbar.d.ts
@@ -14,15 +14,15 @@ export interface SnackbarProps extends StandardProps<
   action?: React.ReactElement<any> | React.ReactElement<any>[];
   anchorOrigin?: SnackBarOrigin;
   autoHideDuration?: number;
-  resumeHideDuration?: number;
-  transitionDuration?: TransitionDuration;
   message?: React.ReactElement<any>;
+  onClose?: (event: React.SyntheticEvent<any>, reason: string) => void;
   onMouseEnter?: React.MouseEventHandler<any>;
   onMouseLeave?: React.MouseEventHandler<any>;
-  onRequestClose?: (event: React.SyntheticEvent<any>, reason: string) => void;
   open: boolean;
+  resumeHideDuration?: number;
   SnackbarContentProps?: Object;
   transition?: React.ReactType;
+  transitionDuration?: TransitionDuration;
 }
 
 export type SnackbarClassKey =

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -148,6 +148,19 @@ export type Props = {
    */
   message?: Node,
   /**
+   * Callback fired when the component requests to be closed.
+   *
+   * Typically `onClose` is used to set state in the parent component,
+   * which is used to control the `Snackbar` `open` prop.
+   *
+   * The `reason` parameter can optionally be used to control the response to `onClose`,
+   * for example ignoring `clickaway`.
+   *
+   * @param {object} event The event source of the callback
+   * @param {string} reason Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"`
+   */
+  onClose?: (event: ?Event, reason: string) => void,
+  /**
    * Callback fired before the transition is entering.
    */
   onEnter?: TransitionCallback,
@@ -179,19 +192,6 @@ export type Props = {
    * @ignore
    */
   onMouseLeave?: Function,
-  /**
-   * Callback fired when the component requests to be closed.
-   *
-   * Typically `onRequestClose` is used to set state in the parent component,
-   * which is used to control the `Snackbar` `open` prop.
-   *
-   * The `reason` parameter can optionally be used to control the response to `onRequestClose`,
-   * for example ignoring `clickaway`.
-   *
-   * @param {object} event The event source of the callback
-   * @param {string} reason Can be:`"timeout"` (`autoHideDuration` expired) or: `"clickaway"`
-   */
-  onRequestClose?: (event: ?Event, reason: string) => void,
   /**
    * If true, `Snackbar` is open.
    */
@@ -263,17 +263,17 @@ class Snackbar extends React.Component<ProvidedProps & Props, State> {
 
   // Timer that controls delay before snackbar auto hides
   setAutoHideTimer(autoHideDuration = null) {
-    if (!this.props.onRequestClose || this.props.autoHideDuration == null) {
+    if (!this.props.onClose || this.props.autoHideDuration == null) {
       return;
     }
 
     clearTimeout(this.timerAutoHide);
     this.timerAutoHide = setTimeout(() => {
-      if (!this.props.onRequestClose || this.props.autoHideDuration == null) {
+      if (!this.props.onClose || this.props.autoHideDuration == null) {
         return;
       }
 
-      this.props.onRequestClose(null, 'timeout');
+      this.props.onClose(null, 'timeout');
     }, autoHideDuration || this.props.autoHideDuration || 0);
   }
 
@@ -294,8 +294,8 @@ class Snackbar extends React.Component<ProvidedProps & Props, State> {
   };
 
   handleClickAway = (event: Event) => {
-    if (this.props.onRequestClose) {
-      this.props.onRequestClose(event, 'clickaway');
+    if (this.props.onClose) {
+      this.props.onClose(event, 'clickaway');
     }
   };
 
@@ -340,7 +340,7 @@ class Snackbar extends React.Component<ProvidedProps & Props, State> {
       onExited,
       onMouseEnter,
       onMouseLeave,
-      onRequestClose,
+      onClose,
       open,
       SnackbarContentProps,
       transition: TransitionProp,

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -36,16 +36,16 @@ describe('<Snackbar />', () => {
     assert.strictEqual(wrapper.find(Slide).length, 1, 'should use a Slide by default');
   });
 
-  describe('prop: onRequestClose', () => {
+  describe('prop: onClose', () => {
     it('should be call when clicking away', () => {
-      const handleRequestClose = spy();
-      mount(<Snackbar open onRequestClose={handleRequestClose} message="message" />);
+      const handleClose = spy();
+      mount(<Snackbar open onClose={handleClose} message="message" />);
 
       const event = new window.Event('mouseup', { view: window, bubbles: true, cancelable: true });
       window.document.body.dispatchEvent(event);
 
-      assert.strictEqual(handleRequestClose.callCount, 1);
-      assert.deepEqual(handleRequestClose.args[0], [event, 'clickaway']);
+      assert.strictEqual(handleClose.callCount, 1);
+      assert.deepEqual(handleClose.args[0], [event, 'clickaway']);
     });
   });
 
@@ -60,125 +60,111 @@ describe('<Snackbar />', () => {
       clock.restore();
     });
 
-    it('should call onRequestClose when the timer is done', () => {
-      const handleRequestClose = spy();
+    it('should call onClose when the timer is done', () => {
+      const handleClose = spy();
       const autoHideDuration = 2e3;
       const wrapper = mount(
         <Snackbar
           open={false}
-          onRequestClose={handleRequestClose}
+          onClose={handleClose}
           message="message"
           autoHideDuration={autoHideDuration}
         />,
       );
 
       wrapper.setProps({ open: true });
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleRequestClose.callCount, 1);
-      assert.deepEqual(handleRequestClose.args[0], [null, 'timeout']);
+      assert.strictEqual(handleClose.callCount, 1);
+      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
     });
 
-    it('should not call onRequestClose when the autoHideDuration is reset', () => {
-      const handleRequestClose = spy();
+    it('should not call onClose when the autoHideDuration is reset', () => {
+      const handleClose = spy();
       const autoHideDuration = 2e3;
       const wrapper = mount(
         <Snackbar
           open={false}
-          onRequestClose={handleRequestClose}
+          onClose={handleClose}
           message="message"
           autoHideDuration={autoHideDuration}
         />,
       );
 
       wrapper.setProps({ open: true });
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(autoHideDuration / 2);
       wrapper.setProps({ autoHideDuration: undefined });
       clock.tick(autoHideDuration / 2);
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
     });
 
     it('should be able to interrupt the timer', () => {
       const handleMouseEnter = spy();
       const handleMouseLeave = spy();
-      const handleRequestClose = spy();
+      const handleClose = spy();
       const autoHideDuration = 2e3;
       const wrapper = mount(
         <Snackbar
           open
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
-          onRequestClose={handleRequestClose}
+          onClose={handleClose}
           message="message"
           autoHideDuration={autoHideDuration}
         />,
       );
 
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseEnter');
       assert.strictEqual(handleMouseEnter.callCount, 1, 'should trigger mouse enter callback');
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseLeave');
       assert.strictEqual(handleMouseLeave.callCount, 1, 'should trigger mouse leave callback');
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(2e3);
-      assert.strictEqual(handleRequestClose.callCount, 1);
-      assert.deepEqual(handleRequestClose.args[0], [null, 'timeout']);
+      assert.strictEqual(handleClose.callCount, 1);
+      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
     });
 
-    it('should not call onRequestClose if autoHideDuration is undefined', () => {
-      const handleRequestClose = spy();
+    it('should not call onClose if autoHideDuration is undefined', () => {
+      const handleClose = spy();
       const autoHideDuration = 2e3;
-      mount(
-        <Snackbar
-          open
-          onRequestClose={handleRequestClose}
-          message="message"
-          autoHideDuration={undefined}
-        />,
-      );
+      mount(<Snackbar open onClose={handleClose} message="message" autoHideDuration={undefined} />);
 
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
     });
 
-    it('should not call onRequestClose if autoHideDuration is null', () => {
-      const handleRequestClose = spy();
+    it('should not call onClose if autoHideDuration is null', () => {
+      const handleClose = spy();
       const autoHideDuration = 2e3;
-      mount(
-        <Snackbar
-          open
-          onRequestClose={handleRequestClose}
-          message="message"
-          autoHideDuration={null}
-        />,
-      );
+      mount(<Snackbar open onClose={handleClose} message="message" autoHideDuration={null} />);
 
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
     });
 
-    it('should not call onRequestClose when closed', () => {
-      const handleRequestClose = spy();
+    it('should not call onClose when closed', () => {
+      const handleClose = spy();
       const autoHideDuration = 2e3;
       const wrapper = mount(
         <Snackbar
           open
-          onRequestClose={handleRequestClose}
+          onClose={handleClose}
           message="message"
           autoHideDuration={autoHideDuration}
         />,
       );
 
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(autoHideDuration / 2);
       wrapper.setProps({ open: false });
       clock.tick(autoHideDuration / 2);
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
     });
   });
 
@@ -193,51 +179,51 @@ describe('<Snackbar />', () => {
       clock.restore();
     });
 
-    it('should not call onRequestClose with not timeout after user interaction', () => {
-      const handleRequestClose = spy();
+    it('should not call onClose with not timeout after user interaction', () => {
+      const handleClose = spy();
       const autoHideDuration = 2e3;
       const resumeHideDuration = 3e3;
       const wrapper = mount(
         <Snackbar
           open
-          onRequestClose={handleRequestClose}
+          onClose={handleClose}
           message="message"
           autoHideDuration={autoHideDuration}
           resumeHideDuration={resumeHideDuration}
         />,
       );
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseEnter');
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseLeave');
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(2e3);
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
     });
 
-    it('should call onRequestClose when timer done after user interaction', () => {
-      const handleRequestClose = spy();
+    it('should call onClose when timer done after user interaction', () => {
+      const handleClose = spy();
       const autoHideDuration = 2e3;
       const resumeHideDuration = 3e3;
       const wrapper = mount(
         <Snackbar
           open
-          onRequestClose={handleRequestClose}
+          onClose={handleClose}
           message="message"
           autoHideDuration={autoHideDuration}
           resumeHideDuration={resumeHideDuration}
         />,
       );
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseEnter');
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseLeave');
-      assert.strictEqual(handleRequestClose.callCount, 0);
+      assert.strictEqual(handleClose.callCount, 0);
       clock.tick(resumeHideDuration);
-      assert.strictEqual(handleRequestClose.callCount, 1);
-      assert.deepEqual(handleRequestClose.args[0], [null, 'timeout']);
+      assert.strictEqual(handleClose.callCount, 1);
+      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
     });
   });
 

--- a/src/Tabs/Tabs.d.ts
+++ b/src/Tabs/Tabs.d.ts
@@ -11,7 +11,6 @@ export interface TabsProps extends StandardProps<
   centered?: boolean;
   children?: React.ReactNode;
   fullWidth?: boolean;
-  value: any;
   indicatorClassName?: string;
   indicatorColor?: 'accent' | 'primary' | string;
   onChange: (event: React.ChangeEvent<{}>, value: any) => void;
@@ -19,6 +18,7 @@ export interface TabsProps extends StandardProps<
   scrollButtons?: 'auto' | 'on' | 'off';
   TabScrollButton?: React.ReactType,
   textColor?: 'accent' | 'primary' | 'inherit' | string;
+  value: any;
   width?: string;
 }
 

--- a/src/TextField/TextField.d.ts
+++ b/src/TextField/TextField.d.ts
@@ -27,8 +27,10 @@ export interface TextFieldProps extends StandardProps<
   inputRef?: React.Ref<any>;
   label?: React.ReactNode;
   labelClassName?: string;
+  margin?: PropTypes.Margin;
   multiline?: boolean;
   name?: string;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
   placeholder?: string;
   required?: boolean;
   rootRef?: React.Ref<any>;
@@ -38,8 +40,6 @@ export interface TextFieldProps extends StandardProps<
   SelectProps?: SelectProps;
   type?: string;
   value?: string | number;
-  margin?: PropTypes.Margin;
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
 }
 
 export type TextFieldClassKey =

--- a/src/Tooltip/Tooltip.d.ts
+++ b/src/Tooltip/Tooltip.d.ts
@@ -9,13 +9,12 @@ export interface TooltipProps extends StandardProps<
   disableTriggerFocus?: boolean;
   disableTriggerHover?: boolean;
   disableTriggerTouch?: boolean;
-  id?: string;
-  onRequestClose?: (event: React.ChangeEvent<{}>) => void;
-  onRequestOpen?: (event: React.ChangeEvent<{}>) => void;
-  open?: boolean;
-  title: React.ReactNode;
   enterDelay?: number;
+  id?: string;
   leaveDelay?: number;
+  onClose?: (event: React.ChangeEvent<{}>) => void;
+  onOpen?: (event: React.ChangeEvent<{}>) => void;
+  open?: boolean;
   placement?:
     | 'bottom-end'
     | 'bottom-start'
@@ -30,6 +29,7 @@ export interface TooltipProps extends StandardProps<
     | 'top-start'
     | 'top';
   PopperProps?: object;
+  title: React.ReactNode;
 }
 
 export type TooltipClassKey =

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -159,13 +159,13 @@ export type Props = {
    *
    * @param {object} event The event source of the callback
    */
-  onRequestClose?: Function,
+  onClose?: Function,
   /**
    * Callback fired when the tooltip requests to be open.
    *
    * @param {object} event The event source of the callback
    */
-  onRequestOpen?: Function,
+  onOpen?: Function,
   /**
    * If `true`, the tooltip is shown.
    */
@@ -290,12 +290,12 @@ class Tooltip extends React.Component<ProvidedProps & Props, State> {
       this.setState({ open: true });
     }
 
-    if (this.props.onRequestOpen) {
-      this.props.onRequestOpen(event, true);
+    if (this.props.onOpen) {
+      this.props.onOpen(event, true);
     }
   };
 
-  handleRequestClose = event => {
+  handleClose = event => {
     const { children } = this.props;
     if (typeof children !== 'string') {
       const childrenProps = Children.only(children).props;
@@ -326,8 +326,8 @@ class Tooltip extends React.Component<ProvidedProps & Props, State> {
       this.setState({ open: false });
     }
 
-    if (this.props.onRequestClose) {
-      this.props.onRequestClose(event, false);
+    if (this.props.onClose) {
+      this.props.onClose(event, false);
     }
   };
 
@@ -379,8 +379,8 @@ class Tooltip extends React.Component<ProvidedProps & Props, State> {
       id,
       leaveDelay,
       open: openProp,
-      onRequestClose,
-      onRequestOpen,
+      onClose,
+      onOpen,
       theme,
       title,
       placement: rawPlacement,
@@ -402,12 +402,12 @@ class Tooltip extends React.Component<ProvidedProps & Props, State> {
 
     if (!disableTriggerHover) {
       childrenProps.onMouseOver = this.handleRequestOpen;
-      childrenProps.onMouseLeave = this.handleRequestClose;
+      childrenProps.onMouseLeave = this.handleClose;
     }
 
     if (!disableTriggerFocus) {
       childrenProps.onFocus = this.handleRequestOpen;
-      childrenProps.onBlur = this.handleRequestClose;
+      childrenProps.onBlur = this.handleClose;
     }
 
     if (typeof childrenProp !== 'string' && childrenProp.props) {

--- a/src/Tooltip/Tooltip.spec.js
+++ b/src/Tooltip/Tooltip.spec.js
@@ -129,7 +129,7 @@ describe('<Tooltip />', () => {
     });
   });
 
-  it('should call handleRequestClose & handleRequestOpen', () => {
+  it('should call handleClose & handleRequestOpen', () => {
     const wrapper = shallow(
       <Tooltip placement="top" title="Hello World">
         <button>Hello World</button>
@@ -145,28 +145,28 @@ describe('<Tooltip />', () => {
 
   it('should be controllable', () => {
     const handleRequestOpen = spy();
-    const handleRequestClose = spy();
+    const handleClose = spy();
 
     const wrapper = shallow(
       <Tooltip
         placement="top"
         title="Hello World"
         open
-        onRequestOpen={handleRequestOpen}
-        onRequestClose={handleRequestClose}
+        onOpen={handleRequestOpen}
+        onClose={handleClose}
       >
         <button>Hello World</button>
       </Tooltip>,
     );
     const children = getTargetChildren(wrapper);
     assert.strictEqual(handleRequestOpen.callCount, 0);
-    assert.strictEqual(handleRequestClose.callCount, 0);
+    assert.strictEqual(handleClose.callCount, 0);
     children.simulate('mouseOver', { type: 'mouseover' });
     assert.strictEqual(handleRequestOpen.callCount, 1);
-    assert.strictEqual(handleRequestClose.callCount, 0);
+    assert.strictEqual(handleClose.callCount, 0);
     children.simulate('blur', { type: 'blur' });
     assert.strictEqual(handleRequestOpen.callCount, 1);
-    assert.strictEqual(handleRequestClose.callCount, 1);
+    assert.strictEqual(handleClose.callCount, 1);
   });
 
   describe('touch screen', () => {

--- a/src/Typography/Typography.d.ts
+++ b/src/Typography/Typography.d.ts
@@ -7,8 +7,8 @@ export interface TypographyProps extends StandardProps<
   TypographyClassKey
 > {
   align?: PropTypes.Alignment;
-  component?: string | React.ComponentType<TypographyProps>;
   color?: PropTypes.Color | 'secondary' | 'error';
+  component?: string | React.ComponentType<TypographyProps>;
   gutterBottom?: boolean;
   headlineMapping?: { [type in TextStyle]: string };
   noWrap?: boolean;

--- a/test/integration/fixtures/menus/SimpleMenu.js
+++ b/test/integration/fixtures/menus/SimpleMenu.js
@@ -15,19 +15,14 @@ class SimpleMenu extends React.Component<any, any> {
     this.setState({ selectedIndex: index, open: false });
   };
 
-  handleRequestClose = () => {
+  handleClose = () => {
     this.setState({ open: false });
   };
 
   render() {
     return (
       <div data-mui-test="SimpleMenu">
-        <Menu
-          id="simple-menu"
-          open={this.state.open}
-          onRequestClose={this.handleRequestClose}
-          {...this.props}
-        >
+        <Menu id="simple-menu" open={this.state.open} onClose={this.handleClose} {...this.props}>
           {options.map((label, index) => {
             return (
               <MenuItem

--- a/test/regressions/tests/Chip/DeletableAvatarChip.js
+++ b/test/regressions/tests/Chip/DeletableAvatarChip.js
@@ -5,5 +5,5 @@ import Avatar from 'material-ui/Avatar';
 import Chip from 'material-ui/Chip';
 
 export default function DeletableAvatarChip() {
-  return <Chip avatar={<Avatar>MB</Avatar>} label="SvgIcon Chip" onRequestDelete={() => {}} />;
+  return <Chip avatar={<Avatar>MB</Avatar>} label="SvgIcon Chip" onDelete={() => {}} />;
 }

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -231,7 +231,7 @@ const ChipsTest = () =>
     <Chip
       avatar={<Avatar src={'image.bmp'} />}
       label="Deletable Chip"
-      onRequestDelete={e => log(e)}
+      onDelete={e => log(e)}
     />
     <Chip
       avatar={
@@ -241,14 +241,14 @@ const ChipsTest = () =>
       }
       label="Clickable Deletable Chip"
       onClick={e => log(e)}
-      onRequestDelete={e => log(e)}
+      onDelete={e => log(e)}
     />
   </div>;
 
 const DialogTest = () => {
   const emails = ['username@gmail.com', 'user02@gmail.com'];
   return (
-    <Dialog onRequestClose={this.handleRequestClose}>
+    <Dialog onClose={e => log(e)}>
       <DialogTitle>Set backup account</DialogTitle>
       <div>
         <List>
@@ -298,7 +298,7 @@ const DrawerTest = () => {
       <Drawer
         type="persistent"
         open={open.left}
-        onRequestClose={e => log(e)}
+        onClose={e => log(e)}
         onClick={e => log(e)}
       >
         List
@@ -307,7 +307,7 @@ const DrawerTest = () => {
         type="temporary"
         anchor="top"
         open={open.top}
-        onRequestClose={e => log(e)}
+        onClose={e => log(e)}
         onClick={e => log(e)}
       >
         List
@@ -316,7 +316,7 @@ const DrawerTest = () => {
         anchor="bottom"
         type="temporary"
         open={open.bottom}
-        onRequestClose={e => log(e)}
+        onClose={e => log(e)}
         onClick={e => log(e)}
       >
         List
@@ -325,7 +325,7 @@ const DrawerTest = () => {
         type="persistent"
         anchor="right"
         open={open.right}
-        onRequestClose={e => log(e)}
+        onClose={e => log(e)}
         onClick={e => log(e)}
       >
         List
@@ -409,7 +409,7 @@ const MenuTest = () => {
       id="lock-menu"
       anchorEl={anchorEl}
       open={true}
-      onRequestClose={e => log(e)}
+      onClose={e => log(e)}
     >
       {options.map((option, index) =>
         <MenuItem
@@ -561,7 +561,7 @@ const SnackbarTest = () =>
       }}
       open={true}
       autoHideDuration={6e3}
-      onRequestClose={e => log(e)}
+      onClose={e => log(e)}
       SnackbarContentProps={{
         'aria-describedby': 'message-id',
       }}


### PR DESCRIPTION
- Sort some component properties alphabetically
- Closes #9432

### Breaking change

Most of our components are stateless by default. It wasn't the case with v0.x. Let's translate this default behavior in the property names of v1. 

```diff
-onRequestClose
-onRequestOpen
-onRequestDelete
+onClose
+onOpen
+onDelete
```