### PR TITLE
[docs] Update sentence which might be misinterpreted

### DIFF
--- a/docs/src/pages/style/color.md
+++ b/docs/src/pages/style/color.md
@@ -19,7 +19,7 @@ A palette is a collection of hues. By default, Material-UI ships with all palett
 This color palette comprises primary and accent colors that can be used for illustration or to develop your brand colors.
 They’ve been designed to work harmoniously with each other.
 
-For instance, you can use the red color like so:
+For instance, you can refer to a particular hue/shade of the red color from palette like so:
 ```js
 import { red, purple } from 'material-ui/colors';
 


### PR DESCRIPTION
The previous sentence has a chance of being misinterpreted into "overriding the primary **palette**, entirely with a **particular hue**". Reader might confuse the terms Hue, Palette and Colors by this sentence, even though they were explained just above.

References I found that address this issue
- https://stackoverflow.com/questions/47300720/decompose-color-code-in-react-material
- https://github.com/mui-org/material-ui/issues/8075

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
