### PR TITLE
[core] Upgrade to flow 61

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -45,4 +45,6 @@ sketchy-null-bool=off
 sketchy-null-mixed=off
 sketchy-null-number=off
 sketchy-null-string=off
+unclear-type=off
+untyped-import=off
 untyped-type-import=off

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "eventsource-polyfill": "^0.9.6",
     "fg-loadcss": "^1.3.1",
     "file-loader": "^1.1.5",
-    "flow-bin": "^0.59.0",
+    "flow-bin": "^0.61.0",
     "flow-copy-source": "^1.2.1",
     "flow-typed": "^2.2.3",
     "fs-extra": "^4.0.2",

--- a/src/Form/FormLabel.js
+++ b/src/Form/FormLabel.js
@@ -38,6 +38,10 @@ type ProvidedProps = {
 
 export type Props = {
   /**
+   * Other base element props.
+   */
+  [otherProp: string]: any,
+  /**
    * The content of the component.
    */
   children?: Node,

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -498,7 +498,6 @@ class Input extends React.Component<ProvidedProps & Props, State> {
       rowsMax,
       startAdornment,
       type,
-      // $FlowFixMe
       value,
       ...other
     } = this.props;
@@ -593,7 +592,7 @@ class Input extends React.Component<ProvidedProps & Props, State> {
           onKeyDown={onKeyDown}
           disabled={disabled}
           required={required ? true : undefined}
-          value={value}
+          value={(value: any)}
           id={id}
           name={name}
           defaultValue={defaultValue}

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -195,6 +195,7 @@ class Menu extends React.Component<ProvidedProps & Props> {
       classes,
       MenuListProps,
       onEnter,
+      open, // https://github.com/facebook/flow/issues/5253
       PaperProps = {},
       PopoverClasses,
       theme,
@@ -207,6 +208,7 @@ class Menu extends React.Component<ProvidedProps & Props> {
         getContentAnchorEl={this.getContentAnchorEl}
         classes={PopoverClasses}
         onEnter={this.handleEnter}
+        open={open}
         anchorOrigin={themeDirection === 'rtl' ? rtlOrigin : ltrOrigin}
         transformOrigin={themeDirection === 'rtl' ? rtlOrigin : ltrOrigin}
         PaperProps={{

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import type { Element as ReactElement, ElementType } from 'react';
+import type { Element, ElementType } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import warning from 'warning';
@@ -71,7 +71,7 @@ export type Props = {
   /**
    * A single child content element.
    */
-  children?: ReactElement<any>,
+  children?: Element<any>,
   /**
    * Useful to extend the style applied to components.
    */

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import type { Element, ElementType } from 'react';
+import type { Element as ReactElement, ElementType } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import warning from 'warning';
@@ -71,7 +71,7 @@ export type Props = {
   /**
    * A single child content element.
    */
-  children?: Element<any>,
+  children?: ReactElement<any>,
   /**
    * Useful to extend the style applied to components.
    */
@@ -254,9 +254,9 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
     const modalContent = this.modal && this.modal.lastChild;
     const focusInModal = currentFocus && contains(modalContent, currentFocus);
 
-    if (modalContent && !focusInModal) {
+    if (modalContent instanceof HTMLElement && !focusInModal) {
       if (!modalContent.hasAttribute('tabIndex')) {
-        modalContent.setAttribute('tabIndex', -1);
+        modalContent.setAttribute('tabIndex', '-1');
         warning(
           false,
           'Material-UI: the modal content node does not accept focus. ' +
@@ -284,7 +284,11 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
     const currentFocus = activeElement(ownerDocument(ReactDOM.findDOMNode(this)));
     const modalContent = this.modal && this.modal.lastChild;
 
-    if (modalContent && modalContent !== currentFocus && !contains(modalContent, currentFocus)) {
+    if (
+      modalContent instanceof HTMLElement &&
+      modalContent !== currentFocus &&
+      !contains(modalContent, currentFocus)
+    ) {
       modalContent.focus();
     }
   };

--- a/src/Modal/Modal.js
+++ b/src/Modal/Modal.js
@@ -256,7 +256,8 @@ class Modal extends React.Component<ProvidedProps & Props, State> {
 
     if (modalContent instanceof HTMLElement && !focusInModal) {
       if (!modalContent.hasAttribute('tabIndex')) {
-        modalContent.setAttribute('tabIndex', '-1');
+        // $FlowFixMe Flow's `setAttribute` expects the value to be a string.
+        modalContent.setAttribute('tabIndex', -1);
         warning(
           false,
           'Material-UI: the modal content node does not accept focus. ' +

--- a/src/Modal/Modal.spec.js
+++ b/src/Modal/Modal.spec.js
@@ -68,9 +68,9 @@ describe('<Modal />', () => {
       describe('focus', () => {
         before(() => {
           instance.modal = spy();
-          instance.modal.lastChild = spy();
-          instance.modal.lastChild.setAttribute = spy();
-          instance.modal.lastChild.focus = spy();
+
+          // Modal checks for div instance.
+          instance.modal.lastChild = document.createElement('div');
         });
 
         describe('modalContent has tabIndex attribute', () => {

--- a/src/Modal/Modal.spec.js
+++ b/src/Modal/Modal.spec.js
@@ -68,9 +68,9 @@ describe('<Modal />', () => {
       describe('focus', () => {
         before(() => {
           instance.modal = spy();
-
-          // Modal checks for div instance.
           instance.modal.lastChild = document.createElement('div');
+          instance.modal.lastChild.setAttribute = spy();
+          instance.modal.lastChild.focus = spy();
         });
 
         describe('modalContent has tabIndex attribute', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,9 +3650,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.59.0.tgz#8c151ee7f09f1deed9bf0b9d1f2e8ab9d470f1bb"
+flow-bin@^0.61.0:
+  version "0.61.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.61.0.tgz#d0473a8c35dbbf4de573823f4932124397d32d35"
 
 flow-copy-source@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Closes #9448

The latest flow adds new linters, refined built-in types, and more precise error reporting.

This commit:
1. Ignores the new linters
2. Refines Nodes to HTMLElements (they used to be assumed to be HTMLElements)
3. Moves a `$FlowFixMe` to a `any` cast, as it's within jsx
4. Extracts a param from a spread to deal with a new flow bug (comment inline)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
