### PR TITLE
[docs] Fix doc layout when an ad is present

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -15,6 +15,7 @@ const styles = theme => ({
     marginBottom: 40,
     marginLeft: -theme.spacing.unit * 2,
     marginRight: -theme.spacing.unit * 2,
+    overflow: 'auto',
     [theme.breakpoints.up('sm')]: {
       padding: `0 ${theme.spacing.unit}px`,
       marginLeft: 0,


### PR DESCRIPTION
Hello! I noticed a visual bug in the docs site. Currently, the page looks something like this:

<img width="1148" alt="screen shot 2017-12-11 at 4 49 25 pm" src="https://user-images.githubusercontent.com/606237/33858192-65898d4a-de94-11e7-82e1-1058d83f56bb.png">

Notice the `✏️` and `< >` icons under the ad.

This PR adds a wrapper div to the page content and moves the ad outside. It also adds an `overflow: hidden` onto the code examples container in order to force a new CSS block context. 

This is what the page should look like after:

<img width="1154" alt="screen shot 2017-12-11 at 3 31 09 pm" src="https://user-images.githubusercontent.com/606237/33858379-f05f8f8c-de94-11e7-843e-0875ae259e49.png">