### PR TITLE
[docs] Update breakpoint info to be in line with code

### DIFF
--- a/docs/src/pages/layout/basics.md
+++ b/docs/src/pages/layout/basics.md
@@ -8,8 +8,8 @@ For optimal user experience, material design interfaces need to be able to adapt
 Material-UI uses a **simplified** implementation of the original [specification](https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-breakpoints).
 
 Each breakpoint matches with a *fixed* screen width:
-- **xs**, extra-small: 360dp
-- **sm**, small: 600dp
-- **md**, medium: 960dp
-- **lg**, large: 1280dp
-- **xl**, xlarge: 1920dp
+- **xs**, extra-small: 0dp or larger
+- **sm**, small: 600dp or larger
+- **md**, medium: 960dp or larger
+- **lg**, large: 1280dp or larger
+- **xl**, xlarge: 1920dp or larger


### PR DESCRIPTION
The definition of the extra small breakpoint was changed from `360` to `0` [in the code](https://github.com/mui-org/material-ui/blob/e49ce4f7c2df242062fe46a2f3aeb30f78a01ef1/src/styles/createBreakpoints.js#L15), but in [the description](https://github.com/mui-org/material-ui/blob/e49ce4f7c2df242062fe46a2f3aeb30f78a01ef1/docs/src/pages/layout/basics.md) it still says `360dp`.

This PR changes it to `0dp` in the description as well as clarifying that the breakpoints are minimum widths.