### PR TITLE
[Stepper] "Optional" label in StepLabel should be localizable

### DIFF
--- a/docs/src/pages/demos/stepper/HorizontalLinearStepper.js
+++ b/docs/src/pages/demos/stepper/HorizontalLinearStepper.js
@@ -104,15 +104,16 @@ class HorizontalLinearStepper extends React.Component {
         <Stepper activeStep={activeStep}>
           {steps.map((label, index) => {
             const props = {};
+            const labelProps = {};
             if (this.isStepOptional(index)) {
-              props.optional = true;
+              labelProps.optional = <Typography type="caption">Optional</Typography>;
             }
             if (this.isStepSkipped(index)) {
               props.completed = false;
             }
             return (
               <Step key={label} {...props}>
-                <StepLabel>{label}</StepLabel>
+                <StepLabel {...labelProps}>{label}</StepLabel>
               </Step>
             );
           })}

--- a/docs/src/pages/demos/stepper/HorizontalNonLinearAlternativeLabelStepper.js
+++ b/docs/src/pages/demos/stepper/HorizontalNonLinearAlternativeLabelStepper.js
@@ -157,15 +157,20 @@ class HorizontalNonLinearAlternativeLabelStepper extends React.Component {
         <Stepper alternativeLabel nonLinear activeStep={activeStep}>
           {steps.map((label, index) => {
             const props = {};
+            const buttonProps = {};
             if (this.isStepOptional(index)) {
-              props.optional = true;
+              buttonProps.optional = <Typography type="caption">Optional</Typography>;
             }
             if (this.isStepSkipped(index)) {
               props.completed = false;
             }
             return (
               <Step key={label} {...props}>
-                <StepButton onClick={this.handleStep(index)} completed={this.isStepComplete(index)}>
+                <StepButton
+                  onClick={this.handleStep(index)}
+                  completed={this.isStepComplete(index)}
+                  {...buttonProps}
+                >
                   {label}
                 </StepButton>
               </Step>

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -14,6 +14,7 @@ filename: /src/Stepper/StepButton.js
 |:-----|:-----|:--------|:------------|
 | children | node |  | Can be a `StepLabel` or a node to place inside `StepLabel` as children. |
 | icon | node |  | The icon displayed by the step label. |
+| optional | node |  | The optional node to display. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -16,6 +16,7 @@ filename: /src/Stepper/StepLabel.js
 | classes | object |  | Custom styles for component. |
 | disabled | bool | false | Mark the step as disabled, will also disable the button if `StepLabelButton` is a child of `StepLabel`. Is passed to child components. |
 | icon | node |  | The icon displayed by the step label - if not set will be set by Step component. |
+| optional | node |  | The optional node to display. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -16,7 +16,6 @@ filename: /src/Stepper/Step.js
 | children | node |  | Should be `Step` sub-components such as `StepLabel`, `StepContent`. |
 | completed | bool | false | Mark the step as completed. Is passed to child components. |
 | disabled | bool | false | Mark the step as disabled, will also disable the button if `StepButton` is a child of `Step`. Is passed to child components. |
-| optional | bool | false | Define this step as optional. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/Stepper/Step.d.ts
+++ b/src/Stepper/Step.d.ts
@@ -14,7 +14,6 @@ export interface StepProps extends StandardProps<
   disabled?: boolean;
   index?: number;
   last?: boolean;
-  optional?: boolean;
   orientation?: Orientation;
 }
 

--- a/src/Stepper/Step.js
+++ b/src/Stepper/Step.js
@@ -35,7 +35,6 @@ function Step(props) {
     index,
     last,
     orientation,
-    optional,
     ...other
   } = props;
 
@@ -59,7 +58,6 @@ function Step(props) {
           icon: index + 1,
           last,
           orientation,
-          optional,
           ...child.props,
         }),
       )}
@@ -117,10 +115,6 @@ Step.propTypes = {
    */
   last: PropTypes.bool,
   /**
-   * Define this step as optional.
-   */
-  optional: PropTypes.bool,
-  /**
    * @ignore
    */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
@@ -130,7 +124,6 @@ Step.defaultProps = {
   active: false,
   completed: false,
   disabled: false,
-  optional: false,
 };
 
 export default withStyles(styles, { name: 'MuiStep' })(Step);

--- a/src/Stepper/StepButton.d.ts
+++ b/src/Stepper/StepButton.d.ts
@@ -16,7 +16,7 @@ export interface StepButtonProps extends StandardProps<
   disabled?: boolean;
   icon?: StepButtonIcon;
   last?: boolean;
-  optional?: boolean;
+  optional?: React.ReactNode;
   orientation: Orientation;
 }
 

--- a/src/Stepper/StepButton.js
+++ b/src/Stepper/StepButton.js
@@ -108,9 +108,9 @@ StepButton.propTypes = {
    */
   last: PropTypes.bool,
   /**
-   * @ignore
+   * The optional node to display.
    */
-  optional: PropTypes.bool,
+  optional: PropTypes.node,
   /**
    * @ignore
    */

--- a/src/Stepper/StepLabel.d.ts
+++ b/src/Stepper/StepLabel.d.ts
@@ -14,7 +14,7 @@ export interface StepLabelProps extends StandardProps<
   disabled?: boolean;
   icon?: StepButtonIcon;
   last?: boolean;
-  optional?: boolean;
+  optional?: React.ReactNode;
   orientation?: Orientation;
 }
 

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -82,11 +82,7 @@ function StepLabel(props) {
         <Typography type="body1" className={labelClassName}>
           {children}
         </Typography>
-        {optional && (
-          <Typography type="caption" className={classes.optional}>
-            Optional
-          </Typography>
-        )}
+        {optional}
       </div>
     </div>
   );
@@ -134,9 +130,9 @@ StepLabel.propTypes = {
    */
   last: PropTypes.bool,
   /**
-   * @ignore
+   * The optional node to display.
    */
-  optional: PropTypes.bool,
+  optional: PropTypes.node,
   /**
    * @ignore
    */
@@ -149,7 +145,6 @@ StepLabel.defaultProps = {
   completed: false,
   disabled: false,
   last: false,
-  optional: false,
   orientation: 'horizontal',
 };
 

--- a/src/Stepper/StepLabel.spec.js
+++ b/src/Stepper/StepLabel.spec.js
@@ -126,10 +126,10 @@ describe('<StepLabel />', () => {
     });
   });
 
-  describe('prop: optional = true', () => {
-    it('creates a <Typography> component with text "Optional"', () => {
+  describe('prop: optional = Optional Text', () => {
+    it('creates a <Typography> component with text "Optional Text"', () => {
       const wrapper = shallow(
-        <StepLabel icon={1} optional>
+        <StepLabel icon={1} optional={<Typography type="caption">Optional Text</Typography>}>
           Step One
         </StepLabel>,
       );
@@ -137,7 +137,7 @@ describe('<StepLabel />', () => {
         wrapper
           .find(Typography)
           .at(1)
-          .contains('Optional'),
+          .contains('Optional Text'),
         true,
       );
     });


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui/issues/9485

### Breaking change

There is no logic attached to the `optional` boolean property. So, we can reduce the abstraction cost. The property is provided closer to where it's needed, and people have full control over how it should be displayed. By chance, it matches the specification.

```diff
-<Step optional>
-  <StepLabel>
+<Step>
+  <StepLabel optional={<Typography type="caption">Optional Text</Typography>}>
     Label
   </StepLabel>
 </Step>
```

*Edited by @oliviertassinari*