### PR TITLE
[TableCell] Add missing aria-sort 

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,7 +1,7 @@
 [
   {
     "path": "build/index.js",
-    "limit": "90.66 KB"
+    "limit": "90.71 KB"
   },
   {
     "path": "test/size/overhead.js",

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -68,6 +68,7 @@ class EnhancedTableHead extends React.Component {
                 key={column.id}
                 numeric={column.numeric}
                 padding={column.disablePadding ? 'none' : 'default'}
+                sortDirection={orderBy === column.id ? order : false}
               >
                 <Tooltip
                   title="Sort"

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -17,6 +17,7 @@ filename: /src/Table/TableCell.js
 | component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> |  | The component used for the root node. Either a string to use a DOM element or a component. |
 | numeric | bool | false | If `true`, content will align to the right. |
 | padding | enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'checkbox'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'none'<br> | 'default' | Sets the padding applied to the cell. |
+| sortDirection | enum:&nbsp;'asc'&nbsp;&#124;<br>&nbsp;'desc'&nbsp;&#124;<br>&nbsp;false<br> |  | Set aria-sort direction. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -49,6 +49,7 @@ function TableCell(props, context) {
     classes,
     className: classNameProp,
     component,
+    sortDirection,
     numeric,
     padding,
     ...other
@@ -74,8 +75,13 @@ function TableCell(props, context) {
     classNameProp,
   );
 
+  let ariaSort = null;
+  if (sortDirection) {
+    ariaSort = sortDirection === 'asc' ? 'ascending' : 'descending';
+  }
+
   return (
-    <Component className={className} {...other}>
+    <Component className={className} aria-sort={ariaSort} {...other}>
       {children}
     </Component>
   );
@@ -107,6 +113,10 @@ TableCell.propTypes = {
    * Sets the padding applied to the cell.
    */
   padding: PropTypes.oneOf(['default', 'checkbox', 'dense', 'none']),
+  /**
+   * Set aria-sort direction.
+   */
+  sortDirection: PropTypes.oneOf(['asc', 'desc', false]),
 };
 
 TableCell.defaultProps = {

--- a/src/Table/TableCell.spec.js
+++ b/src/Table/TableCell.spec.js
@@ -104,4 +104,14 @@ describe('<TableCell />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.numeric), true, 'should have the numeric class');
   });
+
+  it('should render aria-sort="ascending" when prop sortDirection="asc" provided', () => {
+    const wrapper = shallow(<TableCell sortDirection="asc" />);
+    assert.strictEqual(wrapper.props()['aria-sort'], 'ascending');
+  });
+
+  it('should render aria-sort="descending" when prop sortDirection="desc" provided', () => {
+    const wrapper = shallow(<TableCell sortDirection="desc" />);
+    assert.strictEqual(wrapper.props()['aria-sort'], 'descending');
+  });
 });


### PR DESCRIPTION
Now, the way aria-sort works is only the active column in a row can have a status of either "ascending" or "descending". The rest of columns in the row must be have a value of "none". With this in mind and looking at the structure above I realized TableSortLabel could potentially be wrapped in any other component. 

Because of that it's not guaranteed that I can pass on a function all the way down to TableSortLabel to toggle which column in the row should be the active column.  In order to work around this issue I relied on context as I couldn't think of another way.

![accessbility](https://user-images.githubusercontent.com/19170080/34023250-d240d3ec-e111-11e7-98c4-3fad545657a6.gif)

Closes #9487