### PR TITLE
[Button] Document how to use a third-party routing library

### DIFF
--- a/docs/src/pages/demos/buttons/FlatButtons.js
+++ b/docs/src/pages/demos/buttons/FlatButtons.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import Button from 'material-ui/Button';
-import Link from 'docs/src/modules/components/Link';
 
 const styles = theme => ({
   button: {
@@ -35,7 +34,7 @@ function FlatButtons(props) {
       <Button href="#flat-buttons" className={classes.button}>
         Link
       </Button>
-      <Button disabled component={Link} href="/" className={classes.button}>
+      <Button disabled href="/" className={classes.button}>
         Link disabled
       </Button>
       <Button dense className={classes.button}>

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -44,6 +44,7 @@ Icons are also appropriate for toggle buttons that allow a single choice to be s
 {{demo='pages/demos/buttons/IconButtons.js'}}
 
 ### Buttons with icons and label
+
 Sometimes you might want to have icons for certain button to enhance the UX of the application as humans recognize logos more than plain text. For example, if you have a delete button you can label it with a dustbin icon.
 
 {{demo='pages/demos/buttons/IconLabelButtons.js'}}
@@ -54,3 +55,30 @@ The Flat Buttons, Raised Buttons, Floating Action Buttons and Icon Buttons are b
 You can take advantage of this lower level component to build custom interactions.
 
 {{demo='pages/demos/buttons/ButtonBases.js'}}
+
+## Third-party routing library
+
+One common use case is to use the button to trigger a navigation to a new page.
+The `ButtonBase` component provides a property to handle this use case: `component`.
+Given that a lot of our interactive elements rely on `ButtonBase`, you should be
+able to take advantage of it everywhere:
+
+```jsx
+import { Link } from 'react-router-dom'
+import Button from 'material-ui/Button';
+
+<Button component={Link} to="/open-collective">
+  Link
+</Button>
+```
+
+or if you want to avoid properties collisions:
+
+```jsx
+import { Link } from 'react-router-dom'
+import Button from 'material-ui/Button';
+
+<Button component={props => <Link to="/open-collective" {...props} />}>
+  Link
+</Button>
+```


### PR DESCRIPTION
Link is imported for no reason and it breaks [the demo on CodeSandbox](https://codesandbox.io/s/5yn8l2z81p) (DependencyNotFoundError).

Test it out by applying these changes on CodeSandbox to see that it works.