### PR TITLE
[core] Use the same react pattern everywhere

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,7 +1,7 @@
 [
   {
     "path": "build/index.js",
-    "limit": "90.72 KB"
+    "limit": "90.66 KB"
   },
   {
     "path": "test/size/overhead.js",

--- a/docs/src/modules/components/NoSSR.js
+++ b/docs/src/modules/components/NoSSR.js
@@ -1,9 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
 const DefaultOnSSR = () => null;
 
-class NoSSR extends Component {
+class NoSSR extends React.Component {
   state = {
     mounted: false,
   };

--- a/docs/src/modules/scripts/display.js
+++ b/docs/src/modules/scripts/display.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, flowtype/require-valid-file-annotation */
+/* eslint-disable no-console */
 
 import chalk from 'chalk';
 

--- a/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.js
+++ b/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import ExpansionPanel, {
@@ -23,7 +23,7 @@ const styles = theme => ({
   },
 });
 
-class ControlledExpansionPanels extends Component {
+class ControlledExpansionPanels extends React.Component {
   state = {
     expanded: null,
   };

--- a/docs/src/pages/demos/popovers/MouseOverPopover.js
+++ b/docs/src/pages/demos/popovers/MouseOverPopover.js
@@ -1,6 +1,6 @@
-/* eslint-disable flowtype/require-valid-file-annotation, jsx-a11y/mouse-events-have-key-events */
+/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Popover from 'material-ui/Popover';
 import Typography from 'material-ui/Typography';
@@ -21,7 +21,7 @@ const styles = theme => ({
   },
 });
 
-class MouseOverPopover extends Component {
+class MouseOverPopover extends React.Component {
   state = {
     anchorEl: null,
     popperOpen: false,

--- a/docs/src/pages/guides/interoperability.md
+++ b/docs/src/pages/guides/interoperability.md
@@ -33,7 +33,7 @@ const styles = theme => ({
 The `styled()` method works perfectly on all of our components.
 
 ```jsx
-import React, { Component } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import Button from 'material-ui/Button';
 

--- a/examples/create-react-app-with-flow/src/components/withRoot.js
+++ b/examples/create-react-app-with-flow/src/components/withRoot.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component } from 'react';
+import React from 'react';
 import type { ComponentType } from 'react';
 import JssProvider from 'react-jss/lib/JssProvider';
 import { withStyles, MuiThemeProvider } from 'material-ui/styles';
@@ -27,8 +27,8 @@ AppWrapper = withStyles(styles)(AppWrapper);
 
 const context = createContext();
 
-function withRoot(BaseComponent: ComponentType<*>) {
-  class WithRoot extends Component<{}> {
+function withRoot(Component: ComponentType<*>) {
+  class WithRoot extends React.Component<{}> {
     componentDidMount() {
       // Remove the server-side injected CSS.
       const jssStyles = document.querySelector('#jss-server-side');
@@ -42,7 +42,7 @@ function withRoot(BaseComponent: ComponentType<*>) {
         <JssProvider registry={context.sheetsRegistry} jss={context.jss}>
           <MuiThemeProvider theme={context.theme} sheetsManager={context.sheetsManager}>
             <AppWrapper>
-              <BaseComponent />
+              <Component />
             </AppWrapper>
           </MuiThemeProvider>
         </JssProvider>
@@ -51,7 +51,7 @@ function withRoot(BaseComponent: ComponentType<*>) {
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    WithRoot.displayName = wrapDisplayName(BaseComponent, 'withRoot');
+    WithRoot.displayName = wrapDisplayName(Component, 'withRoot');
   }
 
   return WithRoot;

--- a/examples/create-react-app-with-flow/src/pages/index.js
+++ b/examples/create-react-app-with-flow/src/pages/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { Component } from 'react';
+import React from 'react';
 import Button from 'material-ui/Button';
 import Dialog, {
   DialogTitle,
@@ -32,7 +32,7 @@ type State = {
   open: boolean,
 };
 
-class Index extends Component<ProvidedProps & Props, State> {
+class Index extends React.Component<ProvidedProps & Props, State> {
   state = {
     open: false,
   };

--- a/examples/create-react-app/src/components/withRoot.js
+++ b/examples/create-react-app/src/components/withRoot.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import JssProvider from 'react-jss/lib/JssProvider';
 import { withStyles, MuiThemeProvider } from 'material-ui/styles';
 import wrapDisplayName from 'recompose/wrapDisplayName';
@@ -24,8 +24,8 @@ AppWrapper = withStyles(styles)(AppWrapper);
 
 const context = createContext();
 
-function withRoot(BaseComponent) {
-  class WithRoot extends Component {
+function withRoot(Component) {
+  class WithRoot extends React.Component {
     componentDidMount() {
       // Remove the server-side injected CSS.
       const jssStyles = document.querySelector('#jss-server-side');
@@ -39,7 +39,7 @@ function withRoot(BaseComponent) {
         <JssProvider registry={context.sheetsRegistry} jss={context.jss}>
           <MuiThemeProvider theme={context.theme} sheetsManager={context.sheetsManager}>
             <AppWrapper>
-              <BaseComponent {...this.props} />
+              <Component {...this.props} />
             </AppWrapper>
           </MuiThemeProvider>
         </JssProvider>
@@ -48,7 +48,7 @@ function withRoot(BaseComponent) {
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    WithRoot.displayName = wrapDisplayName(BaseComponent, 'withRoot');
+    WithRoot.displayName = wrapDisplayName(Component, 'withRoot');
   }
 
   return WithRoot;

--- a/examples/create-react-app/src/pages/index.js
+++ b/examples/create-react-app/src/pages/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Button from 'material-ui/Button';
 import Dialog, {
@@ -18,7 +18,7 @@ const styles = {
   },
 };
 
-class Index extends Component {
+class Index extends React.Component {
   state = {
     open: false,
   };

--- a/examples/nextjs/components/withRoot.js
+++ b/examples/nextjs/components/withRoot.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { withStyles, MuiThemeProvider } from 'material-ui/styles';
 import wrapDisplayName from 'recompose/wrapDisplayName';
 import getContext from '../styles/getContext';
@@ -21,11 +21,11 @@ let AppWrapper = props => props.children;
 
 AppWrapper = withStyles(styles)(AppWrapper);
 
-function withRoot(BaseComponent) {
-  class WithRoot extends Component {
+function withRoot(Component) {
+  class WithRoot extends React.Component {
     static getInitialProps(ctx) {
-      if (BaseComponent.getInitialProps) {
-        return BaseComponent.getInitialProps(ctx);
+      if (Component.getInitialProps) {
+        return Component.getInitialProps(ctx);
       }
 
       return {};
@@ -50,7 +50,7 @@ function withRoot(BaseComponent) {
           sheetsManager={this.styleContext.sheetsManager}
         >
           <AppWrapper>
-            <BaseComponent {...this.props} />
+            <Component {...this.props} />
           </AppWrapper>
         </MuiThemeProvider>
       );
@@ -58,7 +58,7 @@ function withRoot(BaseComponent) {
   }
 
   if (process.env.NODE_ENV !== 'production') {
-    WithRoot.displayName = wrapDisplayName(BaseComponent, 'withRoot');
+    WithRoot.displayName = wrapDisplayName(Component, 'withRoot');
   }
 
   return WithRoot;

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Button from 'material-ui/Button';
 import Dialog, {
@@ -18,7 +18,7 @@ const styles = {
   },
 };
 
-class Index extends Component {
+class Index extends React.Component {
   state = {
     open: false,
   };

--- a/packages/material-ui-codemod/.eslintrc.js
+++ b/packages/material-ui-codemod/.eslintrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  rules: {
-    'flowtype/require-valid-file-annotation': 'off',
-  },
-};

--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, flowtype/require-valid-file-annotation */
+/* eslint-disable no-console */
 
 import fs from 'fs';
 import yargs from 'yargs';

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-multi-comp, no-underscore-dangle */
 
-import React, { Children } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import EventListener from 'react-event-listener';
@@ -159,7 +159,7 @@ class Tooltip extends React.Component {
   handleRequestOpen = event => {
     const { children } = this.props;
     if (typeof children !== 'string') {
-      const childrenProps = Children.only(children).props;
+      const childrenProps = React.Children.only(children).props;
 
       if (event.type === 'focus' && childrenProps.onFocus) {
         childrenProps.onFocus(event);
@@ -197,7 +197,7 @@ class Tooltip extends React.Component {
   handleClose = event => {
     const { children } = this.props;
     if (typeof children !== 'string') {
-      const childrenProps = Children.only(children).props;
+      const childrenProps = React.Children.only(children).props;
 
       if (event.type === 'blur' && childrenProps.onBlur) {
         childrenProps.onBlur(event);
@@ -234,7 +234,7 @@ class Tooltip extends React.Component {
     this.ignoreNonTouchEvents = true;
     const { children } = this.props;
     if (typeof children !== 'string') {
-      const childrenProps = Children.only(children).props;
+      const childrenProps = React.Children.only(children).props;
 
       if (childrenProps.onTouchStart) {
         childrenProps.onTouchStart(event);
@@ -251,7 +251,7 @@ class Tooltip extends React.Component {
   handleTouchEnd = event => {
     const { children } = this.props;
     if (typeof children !== 'string') {
-      const childrenProps = Children.only(children).props;
+      const childrenProps = React.Children.only(children).props;
 
       if (childrenProps.onTouchEnd) {
         childrenProps.onTouchEnd(event);

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 
@@ -27,7 +27,7 @@ const styles = theme => ({
   },
 });
 
-class TestViewer extends Component {
+class TestViewer extends React.Component {
   getChildContext() {
     return {
       url: {

--- a/test/regressions/tests/Input/Inputs.js
+++ b/test/regressions/tests/Input/Inputs.js
@@ -1,6 +1,5 @@
-// @flow weak
-
-import React, { Component } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { withStyles } from 'material-ui/styles';
 import Input from 'material-ui/Input';
@@ -19,12 +18,7 @@ const styles = {
   },
 };
 
-type Props = {
-  classes: Object,
-  theme?: Object,
-};
-
-class Inputs extends Component<Props> {
+class Inputs extends React.Component {
   componentDidMount() {
     this.focusInput.focus();
   }
@@ -54,5 +48,9 @@ class Inputs extends Component<Props> {
     );
   }
 }
+
+Inputs.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
 
 export default withStyles(styles)(Inputs);

--- a/test/utils/consoleError.js
+++ b/test/utils/consoleError.js
@@ -1,4 +1,4 @@
-/* eslint-disable flowtype/require-valid-file-annotation, no-console */
+/* eslint-disable no-console */
 
 // Makes sure the tests fails when a PropType validation fails.
 function consoleError() {

--- a/test/utils/mockPortal.js
+++ b/test/utils/mockPortal.js
@@ -1,4 +1,4 @@
-/* eslint-disable func-names, flowtype/require-valid-file-annotation */
+/* eslint-disable func-names */
 
 import reactDOM from 'react-dom';
 import Portal from '../../src/internal/Portal';


### PR DESCRIPTION
We were using `import React from 'react';` for 90%+ of the codebase. Now, it's 100%.
The main argument for doing it the other way around is code splitting. But given React needs to be imported for `React.createElement`. It's unlikely we will ever see code splitting working with React.

So, instead, let's improve gzipped efficiency. It's reducing the entropy of the project 🎉 .