### PR TITLE
[docs] Demo options as JSON

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ In this case, the file you need to edit is `docs/src/pages/demos/buttons/buttons
 +
 + Sometimes, you need a super button to make your app looks **superb**. Yea ...
 +
-+ {{demo='pages/demos/buttons/SuperButtons.js'}}
++ {{"demo": "pages/demos/buttons/SuperButtons.js"}}
 ```
 
 #### 3. Edit the Next.js page.

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -126,7 +126,7 @@ if (rootElement) {
   };
 
   render() {
-    const { classes, githubLocation, js: DemoComponent, raw } = this.props;
+    const { classes, demoOptions, githubLocation, js: DemoComponent, raw } = this.props;
     const { codeOpen } = this.state;
 
     return (
@@ -147,11 +147,13 @@ if (rootElement) {
               <Github />
             </IconButton>
           </Tooltip>
-          <Tooltip title="Edit in codesandbox">
-            <IconButton onClick={this.handleClickCodesandbox}>
-              <ModeEditIcon />
-            </IconButton>
-          </Tooltip>
+          {demoOptions.hideEditButton ? null : (
+            <Tooltip title="Edit in codesandbox">
+              <IconButton onClick={this.handleClickCodesandbox}>
+                <ModeEditIcon />
+              </IconButton>
+            </Tooltip>
+          )}
           <Tooltip title={codeOpen ? 'Hide the source' : 'Show the source'}>
             <IconButton onClick={this.handleClickCodeOpen}>
               <CodeIcon />
@@ -171,6 +173,7 @@ if (rootElement) {
 
 Demo.propTypes = {
   classes: PropTypes.object.isRequired,
+  demoOptions: PropTypes.object.isRequired,
   githubLocation: PropTypes.string.isRequired,
   js: PropTypes.func.isRequired,
   raw: PropTypes.string.isRequired,

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -22,7 +22,7 @@ const styles = {
   },
 };
 
-const demoRegexp = /^demo='(.*)'$/;
+const demoRegexp = /^"demo": "(.*)"/;
 const SOURCE_CODE_ROOT_URL = 'https://github.com/mui-org/material-ui/tree/v1-beta';
 
 function MarkdownDocs(props, context) {
@@ -62,13 +62,16 @@ function MarkdownDocs(props, context) {
         const match = content.match(demoRegexp);
 
         if (match && demos) {
-          const name = match[1];
+          const demoOptions = JSON.parse(`{${content}}`);
+
+          const name = demoOptions.demo;
           warning(demos && demos[name], `Missing demo: ${name}.`);
           return (
             <Demo
               key={content}
               js={demos[name].js}
               raw={demos[name].raw}
+              demoOptions={demoOptions}
               githubLocation={`${SOURCE_CODE_ROOT_URL}/docs/src/${name}`}
             />
           );

--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -17,7 +17,7 @@ So, you may have noticed in the demos how this *CSS-in-JS* looks.
 We use the higher-order component created by [`withStyles`](#api)
 to inject an array of styles into the DOM as CSS, using JSS. Here's an example:
 
-{{demo='pages/customization/CssInJs.js'}}
+{{"demo": "pages/customization/CssInJs.js"}}
 
 ## JSS
 
@@ -37,7 +37,7 @@ When rendering on the server, you will need to get all rendered styles as a CSS 
 The `SheetsRegistry` class allows you to manually aggregate and stringify them.
 Read more about [Server Rendering](/guides/server-rendering).
 
-{{demo='pages/customization/JssRegistry.js'}}
+{{"demo": "pages/customization/JssRegistry.js"}}
 
 ## Sheets manager
 

--- a/docs/src/pages/customization/overrides.md
+++ b/docs/src/pages/customization/overrides.md
@@ -23,7 +23,7 @@ consider the [CSS injection order](/customization/css-in-js#css-injection-order)
 by Material-UI to style a component has the highest specificity possible since the `<link />` is injected at the bottom
 of the `<head />` to ensure the components always render correctly.
 
-{{demo='pages/customization/OverridesClassNames.js'}}
+{{"demo": "pages/customization/OverridesClassNames.js"}}
 
 ### Overriding with classes
 
@@ -40,7 +40,7 @@ you wish to add or override.
 
 Notice that in addition to the button styling, the button label's capitalization has been changed:
 
-{{demo='pages/customization/OverridesClasses.js'}}
+{{"demo": "pages/customization/OverridesClasses.js"}}
 
 ### Overriding with inline-style
 
@@ -50,7 +50,7 @@ These properties are always applied to the root element.
 
 You don't have to worry about CSS specificity as the inline-style takes precedence over the regular CSS.
 
-{{demo='pages/customization/OverridesInlineStyle.js'}}
+{{"demo": "pages/customization/OverridesInlineStyle.js"}}
 
 ## 2. Specific variation of a component
 
@@ -58,7 +58,7 @@ You might need to create a variation of a component and use it in different cont
 
 The best approach is to follow option 1 and then take advantage of the composition power of React by exporting your customized component to use wherever you need it.
 
-{{demo='pages/customization/OverridesComponent.js'}}
+{{"demo": "pages/customization/OverridesComponent.js"}}
 
 ## 3. Material Design variations
 

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -36,7 +36,7 @@ If you want to learn more about color, you can check out [the color section](/st
 
 #### Example
 
-{{demo='pages/customization/Palette.js'}}
+{{"demo": "pages/customization/Palette.js"}}
 
 ### Typography
 
@@ -47,7 +47,7 @@ Those sizes are used across our components.
 Have a look at the following example regarding changing the default values, like the font family.
 If you want to learn more about color, you can check out [the typography section](/style/typography).
 
-{{demo='pages/customization/TypographyTheme.js'}}
+{{"demo": "pages/customization/TypographyTheme.js"}}
 
 #### Font size
 
@@ -67,20 +67,20 @@ html {
 
 *You need to apply the above CSS on the html element of this page to see the below demo render correctly*
 
-{{demo='pages/customization/FontSizeTheme.js'}}
+{{"demo": "pages/customization/FontSizeTheme.js"}}
 
 ### Dark/light theme
 
 You can make a theme dark by setting `type` to `dark`.
 
-{{demo='pages/customization/DarkTheme.js'}}
+{{"demo": "pages/customization/DarkTheme.js"}}
 
 ### The other variables
 
 We have tried to normalize the implementation by adding many more variables: typography, breakpoints, transitions, etc. You can see below what the theme object looks like with the default values.
 If you want to learn more, we suggesting having a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/v1-beta/src/styles/createMuiTheme.js).
 
-{{demo='pages/customization/ThemeDefault.js'}}
+{{"demo": "pages/customization/ThemeDefault.js"}}
 
 ### Adding custom styles
 
@@ -89,7 +89,7 @@ you can also take advantage of the theme.
 It can be convenient to add additional variables to the theme so you can use them everywhere.
 For instance:
 
-{{demo='pages/customization/CustomStyles.js'}}
+{{"demo": "pages/customization/CustomStyles.js"}}
 
 ## Customizing all instances of a component type
 
@@ -97,7 +97,7 @@ When the configuration variables aren't powerful enough, you can take advantage 
 `overrides` key of the `theme` to potentially change every single style injected by Material-UI into the DOM.
 That's a really powerful feature.
 
-{{demo='pages/customization/OverridesTheme.js'}}
+{{"demo": "pages/customization/OverridesTheme.js"}}
 
 The list of these customization points for each component is documented under the **Component API** section.
 For instance, you can have a look at the [Button](/api/button#css-api).
@@ -108,14 +108,14 @@ Alternatively, you can always have a look at the [implementation](https://github
 You might need to access the theme variables inside your React components.
 Let's say you want to display the value of the primary color, you can use the `withTheme()` Higher-order Component to do so. Here is an example:
 
-{{demo='pages/customization/WithTheme.js'}}
+{{"demo": "pages/customization/WithTheme.js"}}
 
 ## Nesting the theme
 
 Our theming solution is very flexible, you can nest multiple theme providers.
 That can be really useful when dealing with different area of your application.
 
-{{demo='pages/customization/Nested.js'}}
+{{"demo": "pages/customization/Nested.js"}}
 
 ## API
 

--- a/docs/src/pages/demos/app-bar/app-bar.md
+++ b/docs/src/pages/demos/app-bar/app-bar.md
@@ -8,12 +8,12 @@ The [App bar](https://material.io/guidelines/layout/structure.html#structure-app
 
 ## Simple App bar
 
-{{demo='pages/demos/app-bar/SimpleAppBar.js'}}
+{{"demo": "pages/demos/app-bar/SimpleAppBar.js"}}
 
 ## App bar with buttons
 
-{{demo='pages/demos/app-bar/ButtonAppBar.js'}}
+{{"demo": "pages/demos/app-bar/ButtonAppBar.js"}}
 
 ## App bar with menu
 
-{{demo='pages/demos/app-bar/MenuAppBar.js'}}
+{{"demo": "pages/demos/app-bar/MenuAppBar.js"}}

--- a/docs/src/pages/demos/autocomplete/autocomplete.md
+++ b/docs/src/pages/demos/autocomplete/autocomplete.md
@@ -11,10 +11,10 @@ The autocomplete is a normal text input enhanced by a panel of suggested options
 In the following example, we demonstrate how to use [react-autosuggest](https://github.com/moroshko/react-autosuggest).
 You should also install [autosuggest-highlight](https://www.npmjs.com/package/autosuggest-highlight).
 
-{{demo='pages/demos/autocomplete/IntegrationAutosuggest.js'}}
+{{"demo": "pages/demos/autocomplete/IntegrationAutosuggest.js"}}
 
 ## downshift
 
 In the following example, we demonstrate how to use [downshift](https://github.com/paypal/downshift).
 
-{{demo='pages/demos/autocomplete/IntegrationDownshift.js'}}
+{{"demo": "pages/demos/autocomplete/IntegrationDownshift.js"}}

--- a/docs/src/pages/demos/avatars/avatars.md
+++ b/docs/src/pages/demos/avatars/avatars.md
@@ -10,16 +10,16 @@ Avatars are found throughout material design with uses in everything from tables
 
 Image avatars can be created by passing standard `img` props `src` or `srcSet` into the component.
 
-{{demo='pages/demos/avatars/ImageAvatars.js'}}
+{{"demo": "pages/demos/avatars/ImageAvatars.js"}}
 
 ## Icon avatars
 
 Icon avatars are created by passing an icon as `children`.
 
-{{demo='pages/demos/avatars/IconAvatars.js'}}
+{{"demo": "pages/demos/avatars/IconAvatars.js"}}
 
 ## Letter avatars
 
 Avatars containing simple characters can be created by passing your string as `children`.
 
-{{demo='pages/demos/avatars/LetterAvatars.js'}}
+{{"demo": "pages/demos/avatars/LetterAvatars.js"}}

--- a/docs/src/pages/demos/badges/badges.md
+++ b/docs/src/pages/demos/badges/badges.md
@@ -10,4 +10,4 @@ Badge generates a small badge to the top-right of its child(ren).
 
 Two examples of badges containing text, using primary and accent colors. The badge is applied to its children.
 
-{{demo='pages/demos/badges/SimpleBadge.js'}}
+{{"demo": "pages/demos/badges/SimpleBadge.js"}}

--- a/docs/src/pages/demos/bottom-navigation/bottom-navigation.md
+++ b/docs/src/pages/demos/bottom-navigation/bottom-navigation.md
@@ -9,10 +9,10 @@ components: BottomNavigation, BottomNavigationButton
 ## Bottom Navigation
 When there are only **three** actions, display both icons and text labels at all times.
 
-{{demo='pages/demos/bottom-navigation/SimpleBottomNavigation.js'}}
+{{"demo": "pages/demos/bottom-navigation/SimpleBottomNavigation.js"}}
 
 ## Bottom Navigation with no label
 
 If there are **four** or **five** actions, display inactive views as icons only.
 
-{{demo='pages/demos/bottom-navigation/LabelBottomNavigation.js'}}
+{{"demo": "pages/demos/bottom-navigation/LabelBottomNavigation.js"}}

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -16,14 +16,14 @@ Flat buttons are text-only buttons.
 They may be used in dialogs, toolbars, or inline.
 They do not lift, but fill with color on press.
 
-{{demo='pages/demos/buttons/FlatButtons.js'}}
+{{"demo": "pages/demos/buttons/FlatButtons.js"}}
 
 ## Raised Buttons
 
 Raised buttons are rectangular-shaped buttons.
 They may be used inline. They lift and display ink reactions on press.
 
-{{demo='pages/demos/buttons/RaisedButtons.js'}}
+{{"demo": "pages/demos/buttons/RaisedButtons.js"}}
 
 ## Floating Action Buttons
 
@@ -33,7 +33,7 @@ When pressed, it may contain more related actions.
 
 Only one floating action button is recommended per screen to represent the most common action.
 
-{{demo='pages/demos/buttons/FloatingActionButtons.js'}}
+{{"demo": "pages/demos/buttons/FloatingActionButtons.js"}}
 
 ## Icon Buttons
 
@@ -41,20 +41,20 @@ Icon buttons are commonly found in app bars and toolbars.
 
 Icons are also appropriate for toggle buttons that allow a single choice to be selected or deselected, such as adding or removing a star to an item.
 
-{{demo='pages/demos/buttons/IconButtons.js'}}
+{{"demo": "pages/demos/buttons/IconButtons.js"}}
 
 ### Buttons with icons and label
 
 Sometimes you might want to have icons for certain button to enhance the UX of the application as humans recognize logos more than plain text. For example, if you have a delete button you can label it with a dustbin icon.
 
-{{demo='pages/demos/buttons/IconLabelButtons.js'}}
+{{"demo": "pages/demos/buttons/IconLabelButtons.js"}}
 
 ## Complex Buttons
 
 The Flat Buttons, Raised Buttons, Floating Action Buttons and Icon Buttons are built on top of the same component: the `ButtonBase`.
 You can take advantage of this lower level component to build custom interactions.
 
-{{demo='pages/demos/buttons/ButtonBases.js'}}
+{{"demo": "pages/demos/buttons/ButtonBases.js"}}
 
 ## Third-party routing library
 

--- a/docs/src/pages/demos/cards/cards.md
+++ b/docs/src/pages/demos/cards/cards.md
@@ -14,13 +14,13 @@ Cards are a convenient means of displaying content composed of different element
 
 Although cards can support multiple actions, UI controls, and an overflow menu, use restraint and remember that cards are entry points to more complex and detailed information.
 
-{{demo='pages/demos/cards/SimpleCard.js'}}
+{{"demo": "pages/demos/cards/SimpleCard.js"}}
 
 ## Media
 
 Example of a card using an image to reinforce the content.
 
-{{demo='pages/demos/cards/SimpleMediaCard.js'}}
+{{"demo": "pages/demos/cards/SimpleMediaCard.js"}}
 
 ## UI Controls
 
@@ -28,11 +28,11 @@ Supplemental actions within the card are explicitly called out using icons, text
 
 Here's an example of a media control card.
 
-{{demo='pages/demos/cards/MediaControlCard.js'}}
+{{"demo": "pages/demos/cards/MediaControlCard.js"}}
 
 ## Complex Interaction
 
 On desktop, card content can expand.
 
-{{demo='pages/demos/cards/RecipeReviewCard.js'}}
+{{"demo": "pages/demos/cards/RecipeReviewCard.js"}}
 

--- a/docs/src/pages/demos/chips/chips.md
+++ b/docs/src/pages/demos/chips/chips.md
@@ -20,7 +20,7 @@ hover, and click.
 - Chips with the `onRequestDelete` property defined will display a delete
 icon which changes appearance on hover.
 
-{{demo='pages/demos/chips/Chips.js'}}
+{{"demo": "pages/demos/chips/Chips.js"}}
 
 ## Chip array
 An example of rendering multiple Chips from an array of values.
@@ -28,4 +28,4 @@ Deleting a chip removes it from the array. Note that since no
 `onClick` property is defined, the Chip can be focused, but does not
 gain depth while clicked or touched.
 
-{{demo='pages/demos/chips/ChipsArray.js'}}
+{{"demo": "pages/demos/chips/ChipsArray.js"}}

--- a/docs/src/pages/demos/dialogs/dialogs.md
+++ b/docs/src/pages/demos/dialogs/dialogs.md
@@ -19,7 +19,7 @@ Touch mechanics:
 - Choosing an option immediately commits the option and closes the menu
 - Touching outside of the dialog, or pressing Back, cancels the action and closes the dialog
 
-{{demo='pages/demos/dialogs/SimpleDialog.js'}}
+{{"demo": "pages/demos/dialogs/SimpleDialog.js"}}
 
 ## Alerts
 
@@ -38,11 +38,11 @@ If a title is required:
 - Use a clear question or statement with an explanation in the content area, such as "Erase USB storage?".
 - Avoid apologies, ambiguity, or questions, such as “Warning!” or “Are you sure?”
 
-{{demo='pages/demos/dialogs/AlertDialog.js'}}
+{{"demo": "pages/demos/dialogs/AlertDialog.js"}}
 
 You can also swap out the transition, the next example uses `Slide`.
 
-{{demo='pages/demos/dialogs/AlertDialogSlide.js'}}
+{{"demo": "pages/demos/dialogs/AlertDialogSlide.js"}}
 
 ## Confirmation dialogs
 
@@ -51,24 +51,24 @@ For example, users can listen to multiple ringtones but only make a final select
 
 Touching “Cancel” in a confirmation dialog, or pressing Back, cancels the action, discards any changes, and closes the dialog.
 
-{{demo='pages/demos/dialogs/ConfirmationDialog.js'}}
+{{"demo": "pages/demos/dialogs/ConfirmationDialog.js"}}
 
 ## Full-screen dialogs
 
-{{demo='pages/demos/dialogs/FullScreenDialog.js'}}
+{{"demo": "pages/demos/dialogs/FullScreenDialog.js"}}
 
 ## Form dialogs
 
 Form dialogs allow users to fill out form fields within a dialog.
 For example, if your site prompts for potential subscribers to fill in their email address, they can fill out the email field and touch 'Submit'
 
-{{demo='pages/demos/dialogs/FormDialog.js'}}
+{{"demo": "pages/demos/dialogs/FormDialog.js"}}
 
 ## Responsive full-screen
 
 You may make a `Dialog` responsively full screen the dialog using `withMobileDialog`. By default, `withMobileDialog()(Dialog)` responsively full screens *at or below* the `sm` [screen size](/layout/basics).
 
-{{demo='pages/demos/dialogs/ResponsiveDialog.js'}}
+{{"demo": "pages/demos/dialogs/ResponsiveDialog.js"}}
 
 ## Accessibility
 

--- a/docs/src/pages/demos/dividers/dividers.md
+++ b/docs/src/pages/demos/dividers/dividers.md
@@ -8,8 +8,8 @@ components: Divider
 
 ## List Dividers
 
-{{demo='pages/demos/dividers/ListDividers.js'}}
+{{"demo": "pages/demos/dividers/ListDividers.js"}}
 
 ## Inset Dividers
 
-{{demo='pages/demos/dividers/InsetDividers.js'}}
+{{"demo": "pages/demos/dividers/InsetDividers.js"}}

--- a/docs/src/pages/demos/drawers/drawers.md
+++ b/docs/src/pages/demos/drawers/drawers.md
@@ -14,7 +14,7 @@ Temporary navigation drawers can toggle open or closed. Closed by default, the d
 The Drawer can be cancelled by clicking the overlay or pressing the Esc key.
 It closes when an item is selected, handled by controlling the `open` prop.
 
-{{demo='pages/demos/drawers/TemporaryDrawer.js'}}
+{{"demo": "pages/demos/drawers/TemporaryDrawer.js"}}
 
 ## Permanent drawer
 
@@ -22,7 +22,7 @@ Permanent navigation drawers are always visible and pinned to the left edge, at 
 
 Permanent navigation drawers are the recommended default for desktop.
 
-{{demo='pages/demos/drawers/PermanentDrawer.js'}}
+{{"demo": "pages/demos/drawers/PermanentDrawer.js"}}
 
 ## Persistent drawer
 
@@ -36,7 +36,7 @@ When the drawer is outside of the page grid and opens, the drawer forces other c
 Persistent navigation drawers are acceptable for all sizes larger than mobile.
 They are not recommended for apps with multiple levels of hierarchy that require using an up arrow for navigation.
 
-{{demo='pages/demos/drawers/PersistentDrawer.js'}}
+{{"demo": "pages/demos/drawers/PersistentDrawer.js"}}
 
 ## Mini variant drawer
 
@@ -46,11 +46,11 @@ When expanded, it appears as the standard persistent navigation drawer.
 
 The mini variant is recommended for apps sections that need quick selection access alongside content.
 
-{{demo='pages/demos/drawers/MiniDrawer.js'}}
+{{"demo": "pages/demos/drawers/MiniDrawer.js"}}
 
 ## Responsive drawer
 
 The `Hidden` responsive helper component allows showing different types of drawer depending on the screen width.
 A `temporary` drawer is shown for small screens while a `permanent` drawer is shown for wider screens.
 
-{{demo='pages/demos/drawers/ResponsiveDrawer.js'}}
+{{"demo": "pages/demos/drawers/ResponsiveDrawer.js"}}

--- a/docs/src/pages/demos/expansion-panels/expansion-panels.md
+++ b/docs/src/pages/demos/expansion-panels/expansion-panels.md
@@ -8,16 +8,16 @@ components: ExpansionPanel, ExpansionPanelActions, ExpansionPanelDetails, Expans
 
 ## Simple Expansion Panel
 
-{{demo='pages/demos/expansion-panels/SimpleExpansionPanel.js'}}
+{{"demo": "pages/demos/expansion-panels/SimpleExpansionPanel.js"}}
 
 ## Secondary heading and Columns
 
 Multiple columns can be used to structure the content, and a helper text may be added to the panel to assist the user.
 
-{{demo='pages/demos/expansion-panels/DetailedExpansionPanel.js'}}
+{{"demo": "pages/demos/expansion-panels/DetailedExpansionPanel.js"}}
 
 ## Controlled Accordion
 
 Extend the default panel behavior to create an accordion with the `ExpansionPanel` component.
 
-{{demo='pages/demos/expansion-panels/ControlledExpansionPanels.js'}}
+{{"demo": "pages/demos/expansion-panels/ControlledExpansionPanels.js"}}

--- a/docs/src/pages/demos/grid-list/grid-list.md
+++ b/docs/src/pages/demos/grid-list/grid-list.md
@@ -15,14 +15,14 @@ They help improve the visual comprehension of the content they contain.
 
 A simple example of a scrollable image `GridList`.
 
-{{demo='pages/demos/grid-list/ImageGridList.js'}}
+{{"demo": "pages/demos/grid-list/ImageGridList.js", "hideEditButton": true}}
 
 ## Grid list with titlebars
 
 This example demonstrates the use of the `GridListTileBar` to add an overlay to each `GridListTile`.
 The overlay can accommodate a `title`, `subtitle` and secondary action - in this example an `IconButton`.
 
-{{demo='pages/demos/grid-list/TitlebarGridList.js'}}
+{{"demo": "pages/demos/grid-list/TitlebarGridList.js"}}
 
 ## Advanced Grid list
 
@@ -30,7 +30,7 @@ This example demonstrates "featured" tiles, using the `rows` and `cols` props to
 The tiles have a customised titlebar, positioned at the top and with a custom gradient `titleBackground`.
 The secondary action `IconButton` is positioned on the left.
 
-{{demo='pages/demos/grid-list/AdvancedGridList.js'}}
+{{"demo": "pages/demos/grid-list/AdvancedGridList.js"}}
 
 ## Single line Grid list
 
@@ -38,4 +38,4 @@ This example demonstrates a horizontal scrollable single-line grid list of image
 Horizontally scrolling grid lists are discouraged because the scrolling interferes with typical reading patterns, affecting comprehension.
 One notable exception is a horizontally-scrolling, single-line grid list of images, such as a gallery.
 
-{{demo='pages/demos/grid-list/SingleLineGridList.js'}}
+{{"demo": "pages/demos/grid-list/SingleLineGridList.js"}}

--- a/docs/src/pages/demos/lists/lists.md
+++ b/docs/src/pages/demos/lists/lists.md
@@ -12,19 +12,19 @@ Lists are best suited for similar data types.
 
 ### Simple List
 
-{{demo='pages/demos/lists/SimpleList.js'}}
+{{"demo": "pages/demos/lists/SimpleList.js"}}
 
 ### Folder List
 
-{{demo='pages/demos/lists/FolderList.js'}}
+{{"demo": "pages/demos/lists/FolderList.js"}}
 
 ### Inset List
 
-{{demo='pages/demos/lists/InsetList.js'}}
+{{"demo": "pages/demos/lists/InsetList.js"}}
 
 ### Nested List
 
-{{demo='pages/demos/lists/NestedList.js'}}
+{{"demo": "pages/demos/lists/NestedList.js"}}
 
 ### Pinned Subheader List
 
@@ -33,7 +33,7 @@ Upon scrolling, subheaders remain pinned to the top of the screen until pushed o
 This feature is relying on the CSS sticky positioning.
 Unfortunately it's [not implemented](https://caniuse.com/#search=sticky) by all the browsers we are supporting. We default to `disableSticky` when not supported.
 
-{{demo='pages/demos/lists/PinnedSubheaderList.js'}}
+{{"demo": "pages/demos/lists/PinnedSubheaderList.js"}}
 
 ## List Controls
 
@@ -43,20 +43,20 @@ A checkbox can either be a primary action or a secondary action.
 
 The checkbox is the primary action and the state indicator for the list item. The comment button is a secondary action and a separate target.
 
-{{demo='pages/demos/lists/CheckboxList.js'}}
+{{"demo": "pages/demos/lists/CheckboxList.js"}}
 
 The checkbox is the secondary action for the list item and a separate target.
 
-{{demo='pages/demos/lists/CheckboxListSecondary.js'}}
+{{"demo": "pages/demos/lists/CheckboxListSecondary.js"}}
 
 ### Switch
 
 The switch is the secondary action and a separate target.
 
-{{demo='pages/demos/lists/SwitchListSecondary.js'}}
+{{"demo": "pages/demos/lists/SwitchListSecondary.js"}}
 
 ## Interactive
 
 Below is an interactive demo that lets you explore the visual results of the different settings:
 
-{{demo='pages/demos/lists/InteractiveList.js'}}
+{{"demo": "pages/demos/lists/InteractiveList.js"}}

--- a/docs/src/pages/demos/menus/menus.md
+++ b/docs/src/pages/demos/menus/menus.md
@@ -20,13 +20,13 @@ Choosing an option should immediately ideally commit the option and close the me
 
 **Disambiguation**: In contrast to simple menus, simple dialogs can present additional detail related to the options available for a list item or provide navigational or orthogonal actions related to the primary task. Although they can display the same content, simple menus are preferred over simple dialogs because simple menus are less disruptive to the user’s current context.
 
-{{demo='pages/demos/menus/SimpleMenu.js'}}
+{{"demo": "pages/demos/menus/SimpleMenu.js"}}
 
 ## Selected menus
 
 If used for item selection, when opened, simple menus attempt to vertically align the currently selected menu item with the anchor element. The currently selected menu item is set using the `selected` prop.
 
-{{demo='pages/demos/menus/SimpleListMenu.js'}}
+{{"demo": "pages/demos/menus/SimpleListMenu.js"}}
 
 If text in a simple menu wraps to a second line, use a simple dialog instead. Simple dialogs can have rows with varying heights.
 
@@ -34,7 +34,7 @@ If text in a simple menu wraps to a second line, use a simple dialog instead. Si
 
 If the height of a menu prevents all menu items from being displayed, the menu can scroll internally.
 
-{{demo='pages/demos/menus/LongMenu.js'}}
+{{"demo": "pages/demos/menus/LongMenu.js"}}
 
 ## MenuList composition
 
@@ -44,11 +44,11 @@ For answering those needs, we expose a `MenuList` component that you can compose
 
 The primary responsibility of the `MenuList` component is to handle the focus.
 
-{{demo='pages/demos/menus/MenuListComposition.js'}}
+{{"demo": "pages/demos/menus/MenuListComposition.js"}}
 
 ## ListItem composition
 
 The `MenuItem` is a wrapper around `ListItem` with some additional styles.
 You can use the same list composition features with the `MenuItem` component:
 
-{{demo='pages/demos/menus/ListItemComposition.js'}}
+{{"demo": "pages/demos/menus/ListItemComposition.js"}}

--- a/docs/src/pages/demos/paper/paper.md
+++ b/docs/src/pages/demos/paper/paper.md
@@ -7,4 +7,4 @@ components: Paper
 In material design, the physical properties of [paper](https://material.google.com/layout/principles.html#principles-how-paper-works) are translated to the screen.
 The background of an application resembles the flat, opaque texture of a sheet of paper, and an application’s behavior mimics paper’s ability to be re-sized, shuffled, and bound together in multiple sheets.
 
-{{demo='pages/demos/paper/PaperSheet.js'}}
+{{"demo": "pages/demos/paper/PaperSheet.js"}}

--- a/docs/src/pages/demos/pickers/pickers.md
+++ b/docs/src/pages/demos/pickers/pickers.md
@@ -19,12 +19,12 @@ Here are some components that are promising:
 
 ## Date pickers
 
-{{demo='pages/demos/pickers/DatePickers.js'}}
+{{"demo": "pages/demos/pickers/DatePickers.js"}}
 
 ## Time pickers
 
-{{demo='pages/demos/pickers/TimePickers.js'}}
+{{"demo": "pages/demos/pickers/TimePickers.js"}}
 
 ## Date & Time pickers
 
-{{demo='pages/demos/pickers/DateAndTimePickers.js'}}
+{{"demo": "pages/demos/pickers/DateAndTimePickers.js"}}

--- a/docs/src/pages/demos/popovers/popovers.md
+++ b/docs/src/pages/demos/popovers/popovers.md
@@ -14,10 +14,10 @@ When it is `anchorPosition`, the component will, instead of `anchorEl`,
 refer to the `anchorPosition` prop which you can adjust to set
 the position of the popover.
 
-{{demo='pages/demos/popovers/AnchorPlayground.js'}}
+{{"demo": "pages/demos/popovers/AnchorPlayground.js"}}
 
 ## Mouse over interaction
 
 We demonstrate how to use the `Popover` component as well as the [react-popper](https://github.com/souporserious/react-popper) package to implement a popover behavior based on the mouse over event.
 
-{{demo='pages/demos/popovers/MouseOverPopover.js'}}
+{{"demo": "pages/demos/popovers/MouseOverPopover.js"}}

--- a/docs/src/pages/demos/progress/progress.md
+++ b/docs/src/pages/demos/progress/progress.md
@@ -18,30 +18,30 @@ For example, a refresh operation should display either a refresh bar or an activ
 
 ### Indeterminate
 
-{{demo='pages/demos/progress/CircularIndeterminate.js'}}
+{{"demo": "pages/demos/progress/CircularIndeterminate.js"}}
 
 ### Interactive Integration
 
-{{demo='pages/demos/progress/CircularIntegration.js'}}
+{{"demo": "pages/demos/progress/CircularIntegration.js"}}
 
 ###  Determinate
 
-{{demo='pages/demos/progress/CircularDeterminate.js'}}
+{{"demo": "pages/demos/progress/CircularDeterminate.js"}}
 
 ## Linear
 
 ### Indeterminate
 
-{{demo='pages/demos/progress/LinearIndeterminate.js'}}
+{{"demo": "pages/demos/progress/LinearIndeterminate.js"}}
 
 ### Determinate
 
-{{demo='pages/demos/progress/LinearDeterminate.js'}}
+{{"demo": "pages/demos/progress/LinearDeterminate.js"}}
 
 ### Buffer
 
-{{demo='pages/demos/progress/LinearBuffer.js'}}
+{{"demo": "pages/demos/progress/LinearBuffer.js"}}
 
 ### Query
 
-{{demo='pages/demos/progress/LinearQuery.js'}}
+{{"demo": "pages/demos/progress/LinearQuery.js"}}

--- a/docs/src/pages/demos/selection-controls/selection-controls.md
+++ b/docs/src/pages/demos/selection-controls/selection-controls.md
@@ -20,11 +20,11 @@ If you have multiple options appearing in a list, you can preserve space by usin
 
 If you have a single option, avoid using a checkbox and use an on/off switch instead.
 
-{{demo='pages/demos/selection-controls/Checkboxes.js'}}
+{{"demo": "pages/demos/selection-controls/Checkboxes.js"}}
 
 `FormGroup` is a helpful wrapper used to group selection controls components that provides an easier API.
 
-{{demo='pages/demos/selection-controls/CheckboxesGroup.js'}}
+{{"demo": "pages/demos/selection-controls/CheckboxesGroup.js"}}
 
 ## Radio Buttons
 
@@ -34,18 +34,18 @@ Otherwise, consider a dropdown, which uses less space than displaying all option
 
 `RadioGroup` is a helpful wrapper used to group `Radio` components that provides an easier API, and proper keyboard accessibility to the group.
 
-{{demo='pages/demos/selection-controls/RadioButtonsGroup.js'}}
+{{"demo": "pages/demos/selection-controls/RadioButtonsGroup.js"}}
 
 `Radio` can also be used standalone, without the wrapper.
 
-{{demo='pages/demos/selection-controls/RadioButtons.js'}}
+{{"demo": "pages/demos/selection-controls/RadioButtons.js"}}
 
 ## Switches
 
 On/off switches toggle the state of a single settings option. The option that the switch controls, as well as the state it’s in, should be made clear from the corresponding inline label.
 
-{{demo='pages/demos/selection-controls/Switches.js'}}
+{{"demo": "pages/demos/selection-controls/Switches.js"}}
 
 `Switch` can also be used with a label description thanks to the `FormControlLabel` component.
-{{demo='pages/demos/selection-controls/SwitchLabels.js'}}
+{{"demo": "pages/demos/selection-controls/SwitchLabels.js"}}
 

--- a/docs/src/pages/demos/selects/selects.md
+++ b/docs/src/pages/demos/selects/selects.md
@@ -8,27 +8,27 @@ components: Select
 
 Menus are positioned over their emitting elements such that the currently selected menu item appears on top of the emitting element.
 
-{{demo='pages/demos/selects/SimpleSelect.js'}}
+{{"demo": "pages/demos/selects/SimpleSelect.js"}}
 
 ## Native Select
 
 As the user experience can be improved on mobile using the native select of the platform,
 we allow such pattern.
 
-{{demo='pages/demos/selects/NativeSelect.js'}}
+{{"demo": "pages/demos/selects/NativeSelect.js"}}
 
 ## Multiple Select
 
 The `Select` component can handle multiple selections.
 It's enabled with the `multiple` property.
 
-{{demo='pages/demos/selects/MultipleSelect.js'}}
+{{"demo": "pages/demos/selects/MultipleSelect.js"}}
 
 ## With a Dialog
 
 While it's not encouraged by the Material Design specification, you can use a select inside a dialog.
 
-{{demo='pages/demos/selects/DialogSelect.js'}}
+{{"demo": "pages/demos/selects/DialogSelect.js"}}
 
 ## Text Fields
 

--- a/docs/src/pages/demos/snackbars/snackbars.md
+++ b/docs/src/pages/demos/snackbars/snackbars.md
@@ -15,19 +15,19 @@ Only one snackbar may be displayed at a time.
 
 A basic snackbar that aims to reproduce Google Keep's snackbar behavior.
 
-{{demo='pages/demos/snackbars/SimpleSnackbar.js'}}
+{{"demo": "pages/demos/snackbars/SimpleSnackbar.js"}}
 
 ## Message Length
 
 Some snackbars with varying message length.
 
-{{demo='pages/demos/snackbars/LongTextSnackbar.js'}}
+{{"demo": "pages/demos/snackbars/LongTextSnackbar.js"}}
 
 ## Positioned
 
 There may be circumstances when the placement of the snackbar needs to be more flexible.
 
-{{demo='pages/demos/snackbars/PositionedSnackbar.js'}}
+{{"demo": "pages/demos/snackbars/PositionedSnackbar.js"}}
 
 ## Transitions
 
@@ -35,10 +35,10 @@ There may be circumstances when the placement of the snackbar needs to be more f
 
 Change the direction of the transition. Slide is the default transition.
 
-{{demo='pages/demos/snackbars/DirectionSnackbar.js'}}
+{{"demo": "pages/demos/snackbars/DirectionSnackbar.js"}}
 
 ### Change Transition
 
 Use a different transition all together.
 
-{{demo='pages/demos/snackbars/FadeSnackbar.js'}}
+{{"demo": "pages/demos/snackbars/FadeSnackbar.js"}}

--- a/docs/src/pages/demos/stepper/stepper.md
+++ b/docs/src/pages/demos/stepper/stepper.md
@@ -30,7 +30,7 @@ The `<Stepper>` can be controlled by passing the current step index (zero-based)
 
 This example also shows the use of an optional step by placing the `optional` property on the second `<Step>` component. Note that it's up to you to manage when an optional step is skipped. Once you've determined this for a particular step you must set `completed={false}` to signify that even though the active step index has gone beyond the optional step, it's not actually complete.
 
-{{demo='pages/demos/stepper/HorizontalLinearStepper.js'}}
+{{"demo": "pages/demos/stepper/HorizontalLinearStepper.js"}}
 
 ## Horizontal Non-linear
 
@@ -42,21 +42,21 @@ We've used the `<StepButton>` here to demonstrate clickable step labels as well 
 flag however because steps can be accessed in a non-linear fashion it's up to your own implementation to
 determine when all steps are completed (or even if they need to be completed).
 
-{{demo='pages/demos/stepper/HorizontalNonLinearStepper.js'}}
+{{"demo": "pages/demos/stepper/HorizontalNonLinearStepper.js"}}
 
 ## Horizontal Linear - Alternative Label
 
 Labels can be placed below the step icon by setting the `alternativeLabel` property on the `<Stepper>` component.
 
-{{demo='pages/demos/stepper/HorizontalLinearAlternativeLabelStepper.js'}}
+{{"demo": "pages/demos/stepper/HorizontalLinearAlternativeLabelStepper.js"}}
 
 ## Horizontal Non Linear - Alternative Label
 
-{{demo='pages/demos/stepper/HorizontalNonLinearAlternativeLabelStepper.js'}}
+{{"demo": "pages/demos/stepper/HorizontalNonLinearAlternativeLabelStepper.js"}}
 
 ## Vertical Stepper
 
-{{demo='pages/demos/stepper/VerticalLinearStepper.js'}}
+{{"demo": "pages/demos/stepper/VerticalLinearStepper.js"}}
 
 ## Mobile Stepper
 
@@ -67,16 +67,16 @@ This component implements a compact stepper suitable for a mobile device. See [m
 This is essentially a back/next button positioned correctly.
 You must implement the textual description yourself, however, an example is provided below for reference.
 
-{{demo='pages/demos/stepper/TextMobileStepper.js'}}
+{{"demo": "pages/demos/stepper/TextMobileStepper.js"}}
 
 ### Mobile Stepper - Dots
 
 Use dots when the number of steps isn’t large.
 
-{{demo='pages/demos/stepper/DotsMobileStepper.js'}}
+{{"demo": "pages/demos/stepper/DotsMobileStepper.js"}}
 
 ### Mobile Stepper - Progress
 
 Use a progress bar when there are many steps, or if there are steps that need to be inserted during the process (based on responses to earlier steps).
 
-{{demo='pages/demos/stepper/ProgressMobileStepper.js'}}
+{{"demo": "pages/demos/stepper/ProgressMobileStepper.js"}}

--- a/docs/src/pages/demos/tables/tables.md
+++ b/docs/src/pages/demos/tables/tables.md
@@ -17,7 +17,7 @@ Checkboxes should accompany each row if the user needs to select or manipulate d
 
 A simple example with no frills.
 
-{{demo='pages/demos/tables/BasicTable.js'}}
+{{"demo": "pages/demos/tables/BasicTable.js"}}
 
 ## Sorting & Selecting
 
@@ -25,7 +25,7 @@ This example demonstrates the use `Checkbox` and clickable rows for selection wi
 
 It uses the `TableSortLabel` component to help style column headings.
 
-{{demo='pages/demos/tables/EnhancedTable.js'}}
+{{"demo": "pages/demos/tables/EnhancedTable.js"}}
 
 ## Advanced use cases
 

--- a/docs/src/pages/demos/tabs/tabs.md
+++ b/docs/src/pages/demos/tabs/tabs.md
@@ -10,13 +10,13 @@ components: Tabs, Tab
 
 A simple example with no frills.
 
-{{demo='pages/demos/tabs/BasicTabs.js'}}
+{{"demo": "pages/demos/tabs/BasicTabs.js"}}
 
 ### Wrapped Labels
 
 Long labels will automatically wrap on tabs. If the label is too long for the tab, it will overflow and the text will not be visible.
 
-{{demo='pages/demos/tabs/BasicTabsWrappedLabel.js'}}
+{{"demo": "pages/demos/tabs/BasicTabsWrappedLabel.js"}}
 
 ## Fixed Tabs
 
@@ -27,13 +27,13 @@ Fixed tabs should be used with a limited number of tabs and when consistent plac
 The `fullWidth` property should be used for smaller views.
 This demo also uses [react-swipeable-views](https://github.com/oliviertassinari/react-swipeable-views) to animate the Tab transition, and allowing tabs to be swiped on touch devices.
 
-{{demo='pages/demos/tabs/FullWidthTabs.js'}}
+{{"demo": "pages/demos/tabs/FullWidthTabs.js"}}
 
 ### Centered
 
 The `centered` property should be used for larger views.
 
-{{demo='pages/demos/tabs/CenteredTabs.js'}}
+{{"demo": "pages/demos/tabs/CenteredTabs.js"}}
 
 ## Scrollable Tabs
 
@@ -41,29 +41,29 @@ The `centered` property should be used for larger views.
 
 Left and right scroll buttons will automatically be presented on desktop and hidden on mobile. (based on viewport width)
 
-{{demo='pages/demos/tabs/ScrollableTabsButtonAuto.js'}}
+{{"demo": "pages/demos/tabs/ScrollableTabsButtonAuto.js"}}
 
 ### Forced Scroll Buttons
 
 Left and right scroll buttons will be presented regardless of the viewport width.
 
-{{demo='pages/demos/tabs/ScrollableTabsButtonForce.js'}}
+{{"demo": "pages/demos/tabs/ScrollableTabsButtonForce.js"}}
 
 ### Prevent Scroll Buttons
 
 Left and right scroll buttons will never be presented.  All scrolling must be initiated through user agent scrolling mechanisms (e.g. left/right swipe, shift-mousewheel, etc.)
 
-{{demo='pages/demos/tabs/ScrollableTabsButtonPrevent.js'}}
+{{"demo": "pages/demos/tabs/ScrollableTabsButtonPrevent.js"}}
 
 ## Icon Tabs
 
 Tab labels may be either all icons or all text.
 
-{{demo='pages/demos/tabs/IconTabs.js'}}
-{{demo='pages/demos/tabs/IconLabelTabs.js'}}
+{{"demo": "pages/demos/tabs/IconTabs.js"}}
+{{"demo": "pages/demos/tabs/IconLabelTabs.js"}}
 
 ## Disabled Tab
 
 Tab may be disabled by setting `disabled` property.
 
-{{demo='pages/demos/tabs/DisabledTabs.js'}}
+{{"demo": "pages/demos/tabs/DisabledTabs.js"}}

--- a/docs/src/pages/demos/text-fields/text-fields.md
+++ b/docs/src/pages/demos/text-fields/text-fields.md
@@ -11,7 +11,7 @@ Users may enter text, numbers, or mixed-format types of input.
 
 The `TextField` wrapper component is a complete form control including a label, input and help text.
 
-{{demo='pages/demos/text-fields/TextFields.js'}}
+{{"demo": "pages/demos/text-fields/TextFields.js"}}
 
 ## Components
 
@@ -21,7 +21,7 @@ You might also have noticed that some native HTML input properties are missing f
 This is on purpose.
 The component takes care of the most used properties, then it's up to the user to use the underlying component shown in the following demo. Still, you can use `inputProps` (and `InputProps`, `InputLabelProps` properties) if you want to avoid some boilerplate.
 
-{{demo='pages/demos/text-fields/ComposedTextField.js'}}
+{{"demo": "pages/demos/text-fields/ComposedTextField.js"}}
 
 ## Layout
 
@@ -29,25 +29,25 @@ The component takes care of the most used properties, then it's up to the user t
 `none` (default) will not apply margins to the `FormControl`, whereas `dense` and `normal` will as well as alter
 other styles to meet the specification.
 
-{{demo='pages/demos/text-fields/TextFieldMargins.js'}}
+{{"demo": "pages/demos/text-fields/TextFieldMargins.js"}}
 
 ## Input Adornments
 
 `Input` allows the provision of `InputAdornment`.
 These can be used to add a prefix, a suffix or an action to an input.
 
-{{demo='pages/demos/text-fields/InputAdornments.js'}}
+{{"demo": "pages/demos/text-fields/InputAdornments.js"}}
 
 ## Inputs
 
-{{demo='pages/demos/text-fields/Inputs.js'}}
+{{"demo": "pages/demos/text-fields/Inputs.js"}}
 
 ## Formatted inputs
 
 We demonstrate how you could be using third-party libraries to [format your input](https://material.io/guidelines/components/text-fields.html#text-fields-input-types).
 Here, we are using [react-text-mask](https://github.com/text-mask/text-mask) and [react-number-format](https://github.com/s-yadav/react-number-format) libraries.
 
-{{demo='pages/demos/text-fields/FormattedInputs.js'}}
+{{"demo": "pages/demos/text-fields/FormattedInputs.js"}}
 
 ## Customized inputs
 
@@ -56,4 +56,4 @@ but you are not confident jumping in?
 Here is an example of how you can change the main color of an input from "primary" to purple.
 There is no limit.
 
-{{demo='pages/demos/text-fields/CustomizedInputs.js'}}
+{{"demo": "pages/demos/text-fields/CustomizedInputs.js"}}

--- a/docs/src/pages/demos/tooltips/tooltips.md
+++ b/docs/src/pages/demos/tooltips/tooltips.md
@@ -8,18 +8,18 @@ The [tooltips](https://material.io/guidelines/components/tooltips.html#) are tex
 
 ## Simple Tooltips
 
-{{demo='pages/demos/tooltips/SimpleTooltips.js'}}
+{{"demo": "pages/demos/tooltips/SimpleTooltips.js"}}
 
 ## Positioned Tooltips
 
 The `Tooltip` has 12 placements choice.
 They don’t have directional arrows; instead, they rely on motion emanating from the source to convey direction.
 
-{{demo='pages/demos/tooltips/PositionedTooltips.js'}}
+{{"demo": "pages/demos/tooltips/PositionedTooltips.js"}}
 
 ## Controlled Tooltips
 
-{{demo='pages/demos/tooltips/ControlledTooltips.js'}}
+{{"demo": "pages/demos/tooltips/ControlledTooltips.js"}}
 
 ## Showing and hiding
 

--- a/docs/src/pages/discover-more/team.md
+++ b/docs/src/pages/discover-more/team.md
@@ -5,7 +5,7 @@ An overview of the founding team and core contributors to Material-UI.
 Material-UI is maintained by a small group of invaluable core contributors, with the massive support and involvement of our community.
 The development of the project and its ecosystem is guided by an international team, some of whom have chosen to be featured below.
 
-{{demo='pages/discover-more/Team.js'}}
+{{"demo": "pages/discover-more/Team.js"}}
 
 Get involved with Material-UI development by [opening an issue](https://github.com/mui-org/material-ui/issues/new) or submitting a pull request.
 Read our [contributing guidelines](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.

--- a/docs/src/pages/getting-started/usage.md
+++ b/docs/src/pages/getting-started/usage.md
@@ -28,7 +28,7 @@ render(<App />, document.querySelector('#app'));
 
 Yes, it's really all you need to get started as you can see in this live and interactive demo:
 
-{{demo='pages/getting-started/Usage.js'}}
+{{"demo": "pages/getting-started/Usage.js"}}
 
 ## Next steps
 

--- a/docs/src/pages/guides/composition.md
+++ b/docs/src/pages/guides/composition.md
@@ -17,4 +17,4 @@ If you encounter this issue, you need to:
 
 Let's see an example:
 
-{{demo='pages/guides/Composition.js'}}
+{{"demo": "pages/guides/Composition.js"}}

--- a/docs/src/pages/guides/interoperability.md
+++ b/docs/src/pages/guides/interoperability.md
@@ -23,7 +23,7 @@ const styles = theme => ({
 });
 ```
 
-{{demo='pages/guides/ReactJss.js'}}
+{{"demo": "pages/guides/ReactJss.js"}}
 
 ## Styled Components
 

--- a/docs/src/pages/guides/right-to-left.md
+++ b/docs/src/pages/guides/right-to-left.md
@@ -49,7 +49,7 @@ function RTL(props) {
 
 *Use the direction toggle button on the top left corner to flip the whole documentation*
 
-{{demo='pages/guides/Direction.js'}}
+{{"demo": "pages/guides/Direction.js"}}
 
 
 ## Opting out of rtl transformation
@@ -58,4 +58,4 @@ If you want to prevent a specific rule-set from being affected by the `rtl` tran
 
 *Use the direction toggle button on the top left corner to see the effect*
 
-{{demo='pages/guides/RtlOptOut.js'}}
+{{"demo": "pages/guides/RtlOptOut.js"}}

--- a/docs/src/pages/layout/css-in-js.md
+++ b/docs/src/pages/layout/css-in-js.md
@@ -7,4 +7,4 @@ for the [Grid](/layout/grid) and [Hidden](/layout/hidden) components.
 
 This can be accomplished using [CSS-in-JS](/customization/css-in-js).
 
-{{demo='pages/layout/MediaQuery.js'}}
+{{"demo": "pages/layout/MediaQuery.js"}}

--- a/docs/src/pages/layout/grid.md
+++ b/docs/src/pages/layout/grid.md
@@ -22,30 +22,30 @@ The responsive grid focuses on consistent spacing widths, rather than column wid
 Material design margins and columns follow a **8dp** square baseline grid.
 Spacing can be 8, 16, 24, or 40dp wide.
 
-{{demo='pages/layout/SpacingGrid.js'}}
+{{"demo": "pages/layout/SpacingGrid.js"}}
 
 ## Full-width vs Centered
 
 **Full-width grids**: use fluid columns and breakpoints to determine when a layout needs to change.
 
-{{demo='pages/layout/FullWidthGrid.js'}}
+{{"demo": "pages/layout/FullWidthGrid.js"}}
 
 **Centered grids**: use fixed columns and re-flow the layout when all columns (plus a defined margin) no longer fit on the screen.
 
-{{demo='pages/layout/CenteredGrid.js'}}
+{{"demo": "pages/layout/CenteredGrid.js"}}
 
 ## Interactive
 
 Below is an interactive demo that lets you explore the visual results of the different settings:
 
-{{demo='pages/layout/InteractiveGrid.js'}}
+{{"demo": "pages/layout/InteractiveGrid.js"}}
 
 ## Auto-layout
 
 The Auto-layout makes the *items* equitably share the available space.
 That also means you can set the width of one *item* and the others will automatically resize around it.
 
-{{demo='pages/layout/AutoGrid.js'}}
+{{"demo": "pages/layout/AutoGrid.js"}}
 
 ## Limitations
 

--- a/docs/src/pages/layout/hidden.md
+++ b/docs/src/pages/layout/hidden.md
@@ -40,13 +40,13 @@ If you are using server side rendering, you can set `implementation="css"` if yo
 
 Using any breakpoint `up` property, the given *children* will be hidden *at or above* the breakpoint.
 
-{{demo='pages/layout/BreakpointUp.js'}}
+{{"demo": "pages/layout/BreakpointUp.js"}}
 
 ## Breakpoint down
 
 Using any breakpoint `down` property, the given *children* will be hidden *at or below* the breakpoint.
 
-{{demo='pages/layout/BreakpointDown.js'}}
+{{"demo": "pages/layout/BreakpointDown.js"}}
 
 ## Breakpoint only
 
@@ -56,11 +56,11 @@ The `only` property can be used in two ways:
  - list a single breakpoint
  - list an array of breakpoints
 
-{{demo='pages/layout/BreakpointOnly.js'}}
+{{"demo": "pages/layout/BreakpointOnly.js"}}
 
 ## Integration with Grid
 
 It is quite common to alter `Grid` at different responsive breakpoints, and in many cases, you want to hide some of those elements.
 For brevity, where you are already using `Grid`, you may specify `Hidden` behaviors as the `hidden` property.
 
-{{demo='pages/layout/GridIntegration.js'}}
+{{"demo": "pages/layout/GridIntegration.js"}}

--- a/docs/src/pages/style/color.md
+++ b/docs/src/pages/style/color.md
@@ -27,7 +27,7 @@ const primary = red[500]; // #F44336
 const accent = purple['A200']; // #E040FB
 ```
 
-{{demo='pages/style/Color.js'}}
+{{"demo": "pages/style/Color.js"}}
 
 ## Color system
 

--- a/docs/src/pages/style/icons.md
+++ b/docs/src/pages/style/icons.md
@@ -31,7 +31,7 @@ for example `<Icon>star</Icon>`.
 By default, an Icon will inherit the current text color.
 Optionally, you can set the icon color using one of the theme color properties: `accent`, `action`, `contrast`, `disabled`, `error`, & `primary`.
 
-{{demo='pages/style/Icons.js'}}
+{{"demo": "pages/style/Icons.js"}}
 
 ### SVG Icons
 
@@ -43,7 +43,7 @@ or included as a child for other Material-UI components that use icons.
 By default, an Icon will inherit the current text color.
 Optionally, you can set the icon color using one of the theme color properties: `accent`, `action`, `contrast`, `disabled`, `error`, & `primary`.
 
-{{demo='pages/style/SvgIcons.js'}}
+{{"demo": "pages/style/SvgIcons.js"}}
 
 Looking for SVG icons? There are a lot of projects out there.
 We have found one that provides 2,000+ unofficial Material Design Icons: [https://materialdesignicons.com](https://materialdesignicons.com/).
@@ -62,4 +62,4 @@ Keep in mind that we `PascalCase` the names of the icons, for instance:
 - [`alarm`](https://material.io/icons/#ic_alarm) is exposed as `material-ui-icons/Alarm`
 - [`alarm off`](https://material.io/icons/#ic_alarm_off) is exposed as `material-ui-icons/AlarmOff`
 
-{{demo='pages/style/SvgMaterialIcons.js'}}
+{{"demo": "pages/style/SvgMaterialIcons.js"}}

--- a/docs/src/pages/style/typography.md
+++ b/docs/src/pages/style/typography.md
@@ -34,11 +34,11 @@ For more info check out the [typeface](https://www.npmjs.com/package/typeface-ro
 
 ## Component
 
-{{demo='pages/style/Types.js'}}
+{{"demo": "pages/style/Types.js"}}
 
 ## CSS in JS
 
 In some situation you might not be able to use the `Typography` component.
 Hopefully, you might be able to take advantage of the `typography` keys of the theme.
 
-{{demo='pages/style/TypographyTheme.js'}}
+{{"demo": "pages/style/TypographyTheme.js"}}


### PR DESCRIPTION
It's setting up the infrastructure needed for #9474. For instance:
```md
A simple example of a scrollable image `GridList`.

{{"demo": "pages/demos/grid-list/ImageGridList.js", "hideEditButton": true}}
```

In practice, it's interpreted as JSON.