### PR TITLE
[docs] Fix typo `masterial-ui` to `material-ui`

### DIFF
--- a/docs/src/pages/guides/migration-v0.x.md
+++ b/docs/src/pages/guides/migration-v0.x.md
@@ -58,7 +58,7 @@ import Button from 'material-ui-next/Button'; // v1.x
 First, run [the migration helper](https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui-codemod) on your project.
 
 However, this might not be enough when using the svg icons.
-The `material-ui-icons` package has a dependency on the `masterial-ui/SvgIcon` module.
+The `material-ui-icons` package has a dependency on the `material-ui/SvgIcon` module.
 The `SvgIcon` component slightly changed between the two versions.
 You might see some missing context errors and wrong colors.
 
@@ -67,8 +67,8 @@ Apply it before all the other imports:
 ```js
 import SvgIcon from 'material-ui-next/SvgIcon';
 
-// Tells `material-ui-icons` to use `masterial-ui-next/SvgIcon` module
-// instead of `masterial-ui/SvgIcon`.
+// Tells `material-ui-icons` to use `material-ui-next/SvgIcon` module
+// instead of `material-ui/SvgIcon`.
 global.__MUI_SvgIcon__ = SvgIcon;
 ```
 


### PR DESCRIPTION
This changes the typo on the v0.x migration page. In some places, it says `masterial-ui`, not `material-ui`, which is the correct package name.