### PR TITLE
[typescript] Add Typography pxToRem

### DIFF
--- a/src/styles/createTypography.d.ts
+++ b/src/styles/createTypography.d.ts
@@ -34,7 +34,11 @@ export interface TypographyStyle {
   textTransform?: React.CSSProperties['textTransform'];
 }
 
-export type Typography = Record<Style, TypographyStyle> & FontStyle;
+export interface TypographyUtils {
+  pxToRem: (px: number) => string
+}
+
+export type Typography = Record<Style, TypographyStyle> & FontStyle & TypographyUtils;
 
 export type TypographyOptions = Partial<Record<Style, Partial<TypographyStyle>> & FontStyle>;
 


### PR DESCRIPTION
Wanted to use `Theme.typography.pxToRem(number)` but wasn't able to because of typings (or at least of course my editor was mad). This fixes that.
