### PR TITLE
[docs] Add more interoperability examples

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -1,10 +1,10 @@
 [
   {
     "path": "build/index.js",
-    "limit": "90.74 KB"
+    "limit": "90.9 KB"
   },
   {
     "path": "test/size/overhead.js",
-    "limit": "24.06 KB"
+    "limit": "24.2 KB"
   }
 ]

--- a/docs/src/modules/styles/getContext.js
+++ b/docs/src/modules/styles/getContext.js
@@ -3,10 +3,9 @@
 import { create, SheetsRegistry } from 'jss';
 import rtl from 'jss-rtl';
 import { preset } from 'material-ui/styles/withStyles';
-import { createMuiTheme } from 'material-ui/styles';
+import { createMuiTheme, createGenerateClassName } from 'material-ui/styles';
 import blue from 'material-ui/colors/blue';
 import pink from 'material-ui/colors/pink';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
 
 export function getTheme(theme) {
   return createMuiTheme({
@@ -26,7 +25,6 @@ const theme = getTheme({
 
 // Configure JSS
 const jss = create({ plugins: [...preset().plugins, rtl()] });
-jss.options.createGenerateClassName = createGenerateClassName;
 jss.options.insertionPoint = 'insertion-point-jss';
 
 function createContext() {
@@ -37,7 +35,7 @@ function createContext() {
     sheetsManager: new Map(),
     // This is needed in order to inject the critical CSS.
     sheetsRegistry: new SheetsRegistry(),
-    generateClassName: jss.options.createGenerateClassName(),
+    generateClassName: createGenerateClassName(),
   };
 }
 

--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -64,6 +64,24 @@ They are easy to debug in development and as short as possible in production:
 - development: `.MuiAppBar-root-12`
 - production: `.c12`
 
+If you don't like this default behavior, you can change it.
+JSS relies on the concept of [class name generator](http://cssinjs.org/js-api/#generate-your-own-class-names).
+
+### Global CSS
+
+We provide a custom implementation of the class name generator for Material-UI needs:
+[`createGenerateClassName()`](#creategenerateclassname-options-class-name-generator).
+As well as the option to make the class names **deterministic** with the `dangerouslyUseGlobalCSS` option. When turned on, the class names will look like this:
+
+- development: `.MuiAppBar-root`
+- production: `.MuiAppBar-root`
+
+⚠️ **Be very cautious when using `dangerouslyUseGlobalCSS`.**
+We provide this option as an escape hatch for quick prototyping.
+Avoid relying on it for code running in production.
+It's very hard to keep track of class name API changes.
+Global CSS is fragile by design.
+
 ## CSS injection order
 
 The CSS injected by Material-UI to style a component has the highest specificity possible as the `<link />` is injected at the bottom of the `<head />`.
@@ -84,17 +102,16 @@ By adjusting the placement of the `insertionPoint` comment within your HTML body
 import JssProvider from 'react-jss/lib/JssProvider';
 import { create } from 'jss';
 import preset from 'jss-preset-default';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
+import { createGenerateClassName } from 'material-ui/styles';
 
+const generateClassName = createGenerateClassName();
 const jss = create(preset());
-// Custom Material-UI class name generator for better debug and performance.
-jss.options.createGenerateClassName = createGenerateClassName;
 // We define a custom insertion point JSS will look for injecting the styles in the DOM.
 jss.options.insertionPoint = 'insertion-point-jss';
 
 function App() {
   return (
-    <JssProvider jss={jss}>
+    <JssProvider jss={jss} generateClassName={generateClassName}>
       ...
     </JssProvider>
   );
@@ -116,15 +133,14 @@ Here is an example:
 import JssProvider from 'react-jss/lib/JssProvider';
 import { create } from 'jss';
 import preset from 'jss-preset-default';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
+import { createGenerateClassName } from 'material-ui/styles';
 
+const generateClassName = createGenerateClassName();
 const jss = create(preset());
-// Custom Material-UI class name generator for better debug and performance.
-jss.options.createGenerateClassName = createGenerateClassName;
 
 function App() {
   return (
-    <JssProvider jss={jss}>
+    <JssProvider jss={jss} generateClassName={generateClassName}>
       ...
     </JssProvider>
   );
@@ -217,4 +233,41 @@ class MyComponent extends React.Component {
 }
 
 export default MyComponent
+```
+
+### `createGenerateClassName([options]) => class name generator`
+
+A function which returns a class name generator function.
+
+#### Arguments
+
+1. `options` (*Object* [optional]):
+  - `options.dangerouslyUseGlobalCSS` (Boolean [optional]): Makes the Material-UI class names deterministic. It's `false` by default.
+
+#### Returns
+
+`class name generator`: The generator should be provided to JSS.
+
+#### Examples
+
+```jsx
+import JssProvider from 'react-jss/lib/JssProvider';
+import { create } from 'jss';
+import preset from 'jss-preset-default';
+import { createGenerateClassName } from 'material-ui/styles';
+
+const generateClassName = createGenerateClassName({
+  dangerouslyUseGlobalCSS: true,
+});
+const jss = create(preset());
+
+function App() {
+  return (
+    <JssProvider jss={jss} generateClassName={generateClassName}>
+      ...
+    </JssProvider>
+  );
+}
+
+export default App;
 ```

--- a/docs/src/pages/guides/interoperability.md
+++ b/docs/src/pages/guides/interoperability.md
@@ -25,6 +25,45 @@ const styles = theme => ({
 
 {{"demo": "pages/guides/ReactJss.js"}}
 
+## CSS Modules
+
+![stars](https://img.shields.io/github/stars/css-modules/css-modules.svg?style=social&label=Star)
+
+It's hard to know the market share of this styling solution as it's dependent on the
+bundling solution people are using.
+
+**CSSModulesButton.css**
+```css
+.button {
+  background-color: grey;
+  color: pink;
+  width: 240px;
+}
+```
+
+**CSSModulesButton.js**
+```jsx
+import React from 'react';
+// webpack or else will inject the CSS into the page
+import styles from './CSSModulesButton.css';
+import Button from 'material-ui/Button';
+
+function CSSModulesButton() {
+  return (
+    <div>
+      <Button color="accent" raised>
+        Material-UI
+      </Button>
+      <Button color="accent" raised className={styles.button}>
+        CSS Modules
+      </Button>
+    </div>
+  );
+}
+
+export default CSSModulesButton;
+```
+
 ## Styled Components
 
 ![stars](https://img.shields.io/github/stars/styled-components/styled-components.svg?style=social&label=Star)
@@ -85,16 +124,16 @@ function GlamorousButton() {
   return (
     <div>
       <Button color="accent" raised>
-        Materialized
+        Material-UI
       </Button>
       <StyledButton color="accent" raised>
-        Glamoroused
+        Glamorous
       </StyledButton>
     </div>
   );
 }
 
-export default GlamorousButton:
+export default GlamorousButton;
 ```
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/n3jmn72wrm)
@@ -147,3 +186,74 @@ export default GlamorButton;
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/ov5l1j2j8z)
 
 **Note:** Both Glamor and JSS inject their styles at the bottom of the `<head />`. If you don't want to mark style attributes with **!important**, you need to change [the CSS injection order](/customization/css-in-js#css-injection-order) as we do in the demo.
+
+## Raw CSS
+
+Nothing fancy, just plain old CSS. Why reinventing the wheel when it has been working for decades?
+
+**RawCSSButton.css**
+```css
+.button {
+  background-color: grey;
+  color: pink;
+  width: 240px;
+}
+```
+
+**RawCSSButton.js**
+```jsx
+import React from 'react';
+import Button from 'material-ui/Button';
+
+function RawCSSButton() {
+  return (
+    <div>
+      <Button color="accent" raised>
+        Material-UI
+      </Button>
+      <Button color="accent" raised className="button">
+        Raw CSS
+      </Button>
+    </div>
+  );
+}
+
+export default RawCSSButton;
+```
+
+[![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/vmv2mz9785)
+
+**Note:** JSS inject their styles at the bottom of the `<head />`. If you don't want to mark style attributes with **!important**, you need to change [the CSS injection order](/customization/css-in-js#css-injection-order) as we do in the demo.
+
+## Global CSS
+
+Explicitly providing the class names to the component is too much effort?
+Rest assured, we provide an option to make the class names **deterministic** for quick
+prototyping: [`dangerouslyUseGlobalCSS`](/customization/css-in-js#creategenerateclassname-options-class-name-generator).
+
+**GlobalCSSButton.css**
+```css
+.MuiButton-root {
+  background-color: grey;
+  color: pink;
+  width: 240px;
+}
+```
+
+**GlobalCSSButton.js**
+```jsx
+import React from 'react';
+import Button from 'material-ui/Button';
+
+function GlobalCSSButton() {
+  return (
+    <div>
+      <Button color="accent" raised>
+        Global CSS
+      </Button>
+    </div>
+  );
+}
+
+export default GlobalCSSButton;
+```

--- a/docs/src/pages/guides/right-to-left.md
+++ b/docs/src/pages/guides/right-to-left.md
@@ -30,15 +30,17 @@ import { create } from 'jss';
 import preset from 'jss-preset-default';
 import rtl from 'jss-rtl';
 import JssProvider from 'react-jss/lib/JssProvider';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
+import { createGenerateClassName } from 'material-ui/styles';
 
 // Configure JSS
 const jss = create({ plugins: [...preset().plugins, rtl()] });
-jss.options.createGenerateClassName = createGenerateClassName;
+
+// Custom Material-UI class name generator.
+const generateClassName = createGenerateClassName();
 
 function RTL(props) {
   return (
-    <JssProvider jss={jss}>
+    <JssProvider jss={jss} generateClassName={generateClassName}>
       {props.children}
     </JssProvider>
   );

--- a/docs/src/pages/guides/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering.md
@@ -71,8 +71,7 @@ import JssProvider from 'react-jss/lib/JssProvider';
 import { create } from 'jss';
 import preset from 'jss-preset-default';
 // import rtl from 'jss-rtl'; // in-case you're supporting rtl
-import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
+import { MuiThemeProvider, createMuiTheme, createGenerateClassName } from 'material-ui/styles';
 import { green, red } from 'material-ui/colors';
 
 function handleRender(req, res) {
@@ -91,12 +90,11 @@ function handleRender(req, res) {
   // Configure JSS
   const jss = create(preset());
   // const jss = create({ plugins: [...preset().plugins, rtl()] }); // in-case you're supporting rtl
-
-  jss.options.createGenerateClassName = createGenerateClassName;
+  const generateClassName = createGenerateClassName();
 
   // Render the component to a string.
   const html = renderToString(
-    <JssProvider registry={sheetsRegistry} jss={jss}>
+    <JssProvider registry={sheetsRegistry} jss={jss} generateClassName={generateClassName}>
       <MuiThemeProvider theme={theme} sheetsManager={new Map()}>
         <App />
       </MuiThemeProvider>

--- a/examples/create-react-app-with-flow/src/components/withRoot.js
+++ b/examples/create-react-app-with-flow/src/components/withRoot.js
@@ -39,7 +39,11 @@ function withRoot(Component: ComponentType<*>) {
 
     render() {
       return (
-        <JssProvider registry={context.sheetsRegistry} jss={context.jss}>
+        <JssProvider
+          registry={context.sheetsRegistry}
+          jss={context.jss}
+          generateClassName={context.generateClassName}
+        >
           <MuiThemeProvider theme={context.theme} sheetsManager={context.sheetsManager}>
             <AppWrapper>
               <Component />

--- a/examples/create-react-app-with-flow/src/styles/createContext.js
+++ b/examples/create-react-app-with-flow/src/styles/createContext.js
@@ -2,9 +2,8 @@
 
 import { create, SheetsRegistry } from 'jss';
 import preset from 'jss-preset-default';
-import { createMuiTheme } from 'material-ui/styles';
+import { createMuiTheme, createGenerateClassName } from 'material-ui/styles';
 import { purple, green } from 'material-ui/colors';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
 
 const theme = createMuiTheme({
   palette: {
@@ -15,7 +14,6 @@ const theme = createMuiTheme({
 
 // Configure JSS
 const jss = create(preset());
-jss.options.createGenerateClassName = createGenerateClassName;
 
 export const sheetsManager: Map<*, *> = new Map();
 
@@ -27,5 +25,6 @@ export default function createContext() {
     sheetsManager,
     // This is needed in order to inject the critical CSS.
     sheetsRegistry: new SheetsRegistry(),
+    generateClassName: createGenerateClassName(),
   };
 }

--- a/examples/create-react-app-with-typescript/src/components/withRoot.tsx
+++ b/examples/create-react-app-with-typescript/src/components/withRoot.tsx
@@ -34,7 +34,11 @@ function withRoot(BaseComponent: React.ComponentType) {
 
     render() {
       return (
-        <JssProvider registry={context.sheetsRegistry} jss={context.jss}>
+        <JssProvider
+          registry={context.sheetsRegistry}
+          jss={context.jss}
+          generateClassName={context.generateClassName}
+         >
           <MuiThemeProvider theme={context.theme} sheetsManager={context.sheetsManager}>
             <AppWrapper>
               <BaseComponent />

--- a/examples/create-react-app-with-typescript/src/styles/createContext.ts
+++ b/examples/create-react-app-with-typescript/src/styles/createContext.ts
@@ -1,8 +1,7 @@
 import { create, SheetsRegistry } from 'jss';
 import preset from 'jss-preset-default';
-import { createMuiTheme } from 'material-ui/styles';
+import { createMuiTheme, createGenerateClassName } from 'material-ui/styles';
 import { purple, green } from 'material-ui/colors';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
 
 const theme = createMuiTheme({
   palette: {
@@ -25,5 +24,6 @@ export default function createContext() {
     sheetsManager,
     // This is needed in order to inject the critical CSS.
     sheetsRegistry: new SheetsRegistry(),
+    generateClassName: createGenerateClassName(),
   };
 }

--- a/examples/create-react-app/src/components/withRoot.js
+++ b/examples/create-react-app/src/components/withRoot.js
@@ -36,7 +36,11 @@ function withRoot(Component) {
 
     render() {
       return (
-        <JssProvider registry={context.sheetsRegistry} jss={context.jss}>
+        <JssProvider
+          registry={context.sheetsRegistry}
+          jss={context.jss}
+          generateClassName={context.generateClassName}
+        >
           <MuiThemeProvider theme={context.theme} sheetsManager={context.sheetsManager}>
             <AppWrapper>
               <Component {...this.props} />

--- a/examples/create-react-app/src/styles/createContext.js
+++ b/examples/create-react-app/src/styles/createContext.js
@@ -1,8 +1,7 @@
 import { create, SheetsRegistry } from 'jss';
 import preset from 'jss-preset-default';
-import { createMuiTheme } from 'material-ui/styles';
+import { createMuiTheme, createGenerateClassName } from 'material-ui/styles';
 import { purple, green } from 'material-ui/colors';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
 
 const theme = createMuiTheme({
   palette: {
@@ -13,7 +12,6 @@ const theme = createMuiTheme({
 
 // Configure JSS
 const jss = create(preset());
-jss.options.createGenerateClassName = createGenerateClassName;
 
 export const sheetsManager = new Map();
 
@@ -25,5 +23,6 @@ export default function createContext() {
     sheetsManager,
     // This is needed in order to inject the critical CSS.
     sheetsRegistry: new SheetsRegistry(),
+    generateClassName: createGenerateClassName(),
   };
 }

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -60,7 +60,11 @@ MyDocument.getInitialProps = ctx => {
   // Get the context to collected side effects.
   const context = getContext();
   const page = ctx.renderPage(Component => props => (
-    <JssProvider registry={context.sheetsRegistry} jss={context.jss}>
+    <JssProvider
+      registry={context.sheetsRegistry}
+      jss={context.jss}
+      generateClassName={context.generateClassName}
+    >
       <Component {...props} />
     </JssProvider>
   ));

--- a/examples/nextjs/styles/getContext.js
+++ b/examples/nextjs/styles/getContext.js
@@ -2,10 +2,9 @@
 
 import { create, SheetsRegistry } from 'jss';
 import preset from 'jss-preset-default';
-import { createMuiTheme } from 'material-ui/styles';
+import { createMuiTheme, createGenerateClassName } from 'material-ui/styles';
 import purple from 'material-ui/colors/purple';
 import green from 'material-ui/colors/green';
-import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
 
 const theme = createMuiTheme({
   palette: {
@@ -16,7 +15,6 @@ const theme = createMuiTheme({
 
 // Configure JSS
 const jss = create(preset());
-jss.options.createGenerateClassName = createGenerateClassName;
 
 function createContext() {
   return {
@@ -26,6 +24,7 @@ function createContext() {
     sheetsManager: new Map(),
     // This is needed in order to inject the critical CSS.
     sheetsRegistry: new SheetsRegistry(),
+    generateClassName: createGenerateClassName(),
   };
 }
 

--- a/src/styles/createGenerateClassName.spec.js
+++ b/src/styles/createGenerateClassName.spec.js
@@ -1,5 +1,3 @@
-// @flow
-
 import { assert } from 'chai';
 import createGenerateClassName from './createGenerateClassName';
 import consoleErrorMock from '../../test/utils/consoleErrorMock';
@@ -16,12 +14,73 @@ describe('createGenerateClassName', () => {
     });
   });
 
+  it('should escape correctly', () => {
+    const generateClassName = createGenerateClassName();
+    assert.strictEqual(
+      generateClassName(
+        { key: 'root' },
+        {
+          options: {
+            meta: 'pure(MuiButton)',
+          },
+        },
+      ),
+      'pure-MuiButton--root-1',
+    );
+  });
+
+  describe('options: dangerouslyUseGlobalCSS', () => {
+    it('should use a global class name', () => {
+      const generateClassName = createGenerateClassName({
+        dangerouslyUseGlobalCSS: true,
+      });
+      assert.strictEqual(
+        generateClassName(
+          {
+            key: 'root',
+          },
+          {
+            options: {
+              meta: 'MuiButton',
+            },
+          },
+        ),
+        'MuiButton-root',
+      );
+      assert.strictEqual(
+        generateClassName(
+          {
+            key: 'root',
+          },
+          {
+            options: {
+              meta: 'Button',
+            },
+          },
+        ),
+        'Button-root-2',
+      );
+    });
+
+    it('should default to a non deterministic name', () => {
+      const generateClassName = createGenerateClassName({
+        dangerouslyUseGlobalCSS: true,
+      });
+      assert.strictEqual(
+        generateClassName({
+          key: 'root',
+        }),
+        'root-1',
+      );
+    });
+  });
+
   describe('formatting', () => {
     it('should take the sheet meta in development if available', () => {
       const rule = { key: 'root' };
-      const sheet = { options: { meta: 'Button' } };
+      const styleSheet = { options: { meta: 'Button' } };
       const generateClassName = createGenerateClassName();
-      assert.strictEqual(generateClassName(rule, sheet), 'Button-root-1');
+      assert.strictEqual(generateClassName(rule, styleSheet), 'Button-root-1');
     });
 
     it('should use a base 10 representation', () => {
@@ -59,9 +118,17 @@ describe('createGenerateClassName', () => {
         consoleErrorMock.reset();
       });
 
-      it('should us a short representation', () => {
+      it('should output a short representation', () => {
         const rule = { key: 'root' };
         const generateClassName = createGenerateClassName();
+        assert.strictEqual(generateClassName(rule), 'c1');
+      });
+
+      it('should work with global CSS', () => {
+        const rule = { key: 'root' };
+        const generateClassName = createGenerateClassName({
+          dangerouslyUseGlobalCSS: true,
+        });
         assert.strictEqual(generateClassName(rule), 'c1');
       });
 

--- a/src/styles/index.d.ts
+++ b/src/styles/index.d.ts
@@ -2,3 +2,4 @@ export { default as MuiThemeProvider } from './MuiThemeProvider';
 export { default as withStyles, WithStyles, StyleRules, StyleRulesCallback, StyledComponentProps } from './withStyles';
 export { default as withTheme } from './withTheme';
 export { default as createMuiTheme, Theme, Direction } from './createMuiTheme';
+export { default as createGenerateClassName } from './createGenerateClassName';

--- a/src/styles/index.js
+++ b/src/styles/index.js
@@ -2,3 +2,4 @@ export { default as MuiThemeProvider } from './MuiThemeProvider';
 export { default as withStyles } from './withStyles';
 export { default as withTheme } from './withTheme';
 export { default as createMuiTheme } from './createMuiTheme';
+export { default as createGenerateClassName } from './createGenerateClassName';

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -179,10 +179,10 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
 
       if (sheetManagerTheme.refs === 0) {
         const styles = stylesCreatorSaved.create(theme, name);
-        let meta;
+        let meta = name;
 
-        if (process.env.NODE_ENV !== 'production') {
-          meta = name || getDisplayName(Component);
+        if (process.env.NODE_ENV !== 'production' && !meta) {
+          meta = getDisplayName(Component);
         }
 
         const sheet = this.jss.createStyleSheet(styles, {

--- a/src/styles/withStyles.spec.js
+++ b/src/styles/withStyles.spec.js
@@ -111,10 +111,11 @@ describe('withStyles', () => {
   describe('mount', () => {
     let sheetsRegistry;
     let jss;
+    let generateClassName;
 
     beforeEach(() => {
       jss = create(preset());
-      jss.options.createGenerateClassName = createGenerateClassName;
+      generateClassName = createGenerateClassName();
       sheetsRegistry = new SheetsRegistry();
     });
 
@@ -124,7 +125,7 @@ describe('withStyles', () => {
 
       const wrapper = mount(
         <MuiThemeProvider theme={createMuiTheme()}>
-          <JssProvider registry={sheetsRegistry} jss={jss}>
+          <JssProvider registry={sheetsRegistry} jss={jss} generateClassName={generateClassName}>
             <StyledComponent />
           </JssProvider>
         </MuiThemeProvider>,
@@ -148,7 +149,7 @@ describe('withStyles', () => {
 
       const wrapper = mount(
         <MuiThemeProvider theme={createMuiTheme()}>
-          <JssProvider registry={sheetsRegistry} jss={jss}>
+          <JssProvider registry={sheetsRegistry} jss={jss} generateClassName={generateClassName}>
             <StyledComponent />
           </JssProvider>
         </MuiThemeProvider>,
@@ -176,7 +177,7 @@ describe('withStyles', () => {
             },
           })}
         >
-          <JssProvider registry={sheetsRegistry} jss={jss}>
+          <JssProvider registry={sheetsRegistry} jss={jss} generateClassName={generateClassName}>
             <StyledComponent />
           </JssProvider>
         </MuiThemeProvider>,
@@ -193,7 +194,7 @@ describe('withStyles', () => {
 
         const wrapper = mount(
           <MuiThemeProvider theme={createMuiTheme()} disableStylesGeneration>
-            <JssProvider registry={sheetsRegistry} jss={jss}>
+            <JssProvider registry={sheetsRegistry} jss={jss} generateClassName={generateClassName}>
               <StyledComponent />
             </JssProvider>
           </MuiThemeProvider>,


### PR DESCRIPTION
I'm tired of people think JSS can't interop with their stack. It can!

- ⚠️  a global CSS option is coming. cc @nathanmarks, @kof 
You know what I mean, bootstrap style...
`#YOLO`
It should be a quick escape hatch for a lot of people (tests, wrong settings, prototyping, etc.).
Also, it should unlock external people building themes on top of Material-UI, like they do with Bootstrap. 
- Add a CSS interoperability example
- Add a CSS modules interoperability example
- Add a global CSS interoperability example

Closes #9433 