### PR TITLE
[docs] Fix dark theme toggle of website home page content

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -54,8 +54,7 @@ const styles = theme => ({
     maxHeight: 200,
   },
   backers: {
-    backgroundColor:
-      theme.palette.type === 'light' ? theme.palette.common.white : theme.palette.grey[800],
+    backgroundColor: theme.palette.background.paper,
     padding: theme.spacing.unit * 2,
     display: 'flex',
     justifyContent: 'center',

--- a/pages/index.js
+++ b/pages/index.js
@@ -54,7 +54,8 @@ const styles = theme => ({
     maxHeight: 200,
   },
   backers: {
-    backgroundColor: theme.palette.common.white,
+    backgroundColor:
+      theme.palette.type === 'light' ? theme.palette.common.white : theme.palette.grey[800],
     padding: theme.spacing.unit * 2,
     display: 'flex',
     justifyContent: 'center',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
On the current version of [material-ui-next.com](https://material-ui-next.com/), if you toggle the dark theme, the content area stays white and it's text stays white so the contrast could be better 😉

I simply verify if it's the dark theme, change the color proportionally differently from the footer (same proportions as the light version)