### PR TITLE
[TablePagination] Make onChangeRowsPerPage optional

### DIFF
--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -18,7 +18,7 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 | labelDisplayedRows | func | ({ from, to, count }) => `${from}-${to} of ${count}` | Useful to customize the displayed rows label. |
 | labelRowsPerPage | node | 'Rows per page:' | Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }` object. |
 | <span style="color: #31a148">onChangePage *</span> | func |  | Callback fired when the page is changed.<br><br>**Signature:**<br>`function(event: object, page: number) => void`<br>*event:* The event source of the callback<br>*page:* The page selected |
-| <span style="color: #31a148">onChangeRowsPerPage *</span> | func |  | Callback fired when the number of rows per page is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
+| onChangeRowsPerPage | func |  | Callback fired when the number of rows per page is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span style="color: #31a148">page *</span> | number |  | The zero-based index of the current page. |
 | <span style="color: #31a148">rowsPerPage *</span> | number |  | The number of rows per page. |
 | rowsPerPageOptions | array | [5, 10, 25] | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |

--- a/src/Table/TablePagination.d.ts
+++ b/src/Table/TablePagination.d.ts
@@ -18,7 +18,7 @@ export interface TablePaginationProps extends StandardProps<
   labelDisplayedRows?: (paginationInfo: LabelDisplayedRowsArgs) => React.ReactNode;
   labelRowsPerPage?: React.ReactNode;
   onChangePage: (event: React.MouseEvent<HTMLButtonElement> | null, page: number) => void;
-  onChangeRowsPerPage: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  onChangeRowsPerPage?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   page: number;
   rowsPerPage: number;
   rowsPerPageOptions?: number[];

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -193,7 +193,7 @@ TablePagination.propTypes = {
    *
    * @param {object} event The event source of the callback
    */
-  onChangeRowsPerPage: PropTypes.func.isRequired,
+  onChangeRowsPerPage: PropTypes.func,
   /**
    * The zero-based index of the current page.
    */


### PR DESCRIPTION
The select field is now hidden if configured with < 2 options, so it seems as though this should also be optional.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
