### PR TITLE
[BottomNavigationButton] onClick and onChange handler overwritten

### DIFF
--- a/src/BottomNavigation/BottomNavigationButton.js
+++ b/src/BottomNavigation/BottomNavigationButton.js
@@ -158,9 +158,4 @@ BottomNavigationButton.propTypes = {
   value: PropTypes.any,
 };
 
-BottomNavigationButton.defaultProps = {
-  onChange: undefined,
-  onClick: undefined,
-};
-
 export default withStyles(styles, { name: 'MuiBottomNavigationButton' })(BottomNavigationButton);

--- a/src/BottomNavigation/BottomNavigationButton.js
+++ b/src/BottomNavigation/BottomNavigationButton.js
@@ -75,6 +75,7 @@ class BottomNavigationButton extends React.Component {
       icon: iconProp,
       label,
       onChange,
+      onClick,
       selected,
       showLabel: showLabelProp,
       value,
@@ -155,6 +156,11 @@ BottomNavigationButton.propTypes = {
    * You can provide your own value. Otherwise, we fallback to the child position index.
    */
   value: PropTypes.any,
+};
+
+BottomNavigationButton.defaultProps = {
+  onChange: undefined,
+  onClick: undefined,
 };
 
 export default withStyles(styles, { name: 'MuiBottomNavigationButton' })(BottomNavigationButton);

--- a/src/BottomNavigation/BottomNavigationButton.spec.js
+++ b/src/BottomNavigation/BottomNavigationButton.spec.js
@@ -92,7 +92,7 @@ describe('<BottomNavigationButton />', () => {
 
   it('should not render an Icon if icon is not provided', () => {
     const wrapper = shallow(<BottomNavigationButton />);
-    assert.isFalse(wrapper.find(Icon).exists());
+    assert.strictEqual(wrapper.find(Icon).exists(), false);
   });
 
   describe('prop: onClick', () => {

--- a/src/BottomNavigation/BottomNavigationButton.spec.js
+++ b/src/BottomNavigation/BottomNavigationButton.spec.js
@@ -90,14 +90,30 @@ describe('<BottomNavigationButton />', () => {
     assert.strictEqual(iconWrapper.is(Icon), true, 'should be an Icon');
   });
 
+  it('should not render an Icon if icon is not provided', () => {
+    const wrapper = shallow(<BottomNavigationButton />);
+    assert.isFalse(wrapper.find(Icon).exists());
+  });
+
   describe('prop: onClick', () => {
     it('should be called when a click is triggered', () => {
       const handleClick = spy();
       const wrapper = shallow(
-        <BottomNavigationButton icon="book" onClick={handleClick} onChange={() => {}} />,
+        <BottomNavigationButton icon="book" onClick={handleClick} value="foo" />,
       );
-      wrapper.simulate('click');
+      wrapper.simulate('click', 'bar');
       assert.strictEqual(handleClick.callCount, 1, 'it should forward the onClick');
+    });
+  });
+
+  describe('prop: onChange', () => {
+    it('should be called when a click is triggered', () => {
+      const handleChange = spy();
+      const wrapper = shallow(
+        <BottomNavigationButton icon="book" onChange={handleChange} value="foo" />,
+      );
+      wrapper.simulate('click', 'bar');
+      assert.strictEqual(handleChange.callCount, 1, 'it should forward the onChange');
     });
   });
 });


### PR DESCRIPTION
The handler that invokes onChange and onClick will be overwritten if an onClick prop is provided.

We're not pulling the onClick prop out in the destructure, so when we apply other to ButtonBase, we overwrite the onClick handler.  The unit test is evergreen, because it's checking to see if the spy we're passing in is being called when click is simulated, which it is, though not through the handleChange method.

To fix this, I've pulled onClick before destructuring.  If onClick is provided, it will be invoked in the handleChange class method.  I've also added some tests to get BottomNavigationButton to 100% code coverage (part of the effort for #9527).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
