### PR TITLE
[typescript] Add typings to reactHelpers

### DIFF
--- a/src/utils/reactHelpers.d.ts
+++ b/src/utils/reactHelpers.d.ts
@@ -1,4 +1,9 @@
+import * as React from 'react';
+
 export function cloneChildrenWithClassName<T>(
   children: React.ReactNode,
   className: string
 ): T[];
+
+export function isMuiElement(element: any, muiNames: Array<string>): boolean;
+export function isMuiComponent(element: any, muiNames: Array<string>): boolean;


### PR DESCRIPTION
Utility functions `isMuiElement` and `isMuiComponent` in `src/utils/reactHelpers.js` had no TypeScript declaration, so I have added the simplest one.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
