### PR TITLE
[Menu] Better select, hover, focus logic

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -58,7 +58,7 @@ const styles = theme => ({
         '& [class^=ds-dataset-]': {
           border: 0,
           borderRadius: 2,
-          background: theme.palette.background.paper,
+          backgroundColor: theme.palette.background.paper,
         },
       },
     },

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -191,7 +191,7 @@ const styles = theme => ({
     },
     '& blockquote': {
       borderLeft: `5px solid ${theme.palette.text.hint}`,
-      background: theme.palette.background.paper,
+      backgroundColor: theme.palette.background.paper,
       padding: `${theme.spacing.unit / 2}px ${theme.spacing.unit * 3}px`,
       margin: `${theme.spacing.unit * 3}px 0`,
     },

--- a/docs/src/pages/customization/WithTheme.js
+++ b/docs/src/pages/customization/WithTheme.js
@@ -10,12 +10,12 @@ function WithTheme(props) {
 
   const styles = {
     primaryText: {
-      background: theme.palette.background.default,
+      backgroundColor: theme.palette.background.default,
       padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`,
       color: primaryText,
     },
     primaryColor: {
-      background: primaryColor,
+      backgroundColor: primaryColor,
       padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`,
       color: '#fff',
     },

--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -201,7 +201,7 @@ import { withStyles } from 'material-ui/styles';
 
 const styles = {
   root: {
-    background: 'red',
+    backgroundColor: 'red',
   },
 };
 
@@ -221,7 +221,7 @@ import { withStyles } from 'material-ui/styles';
 
 const styles = {
   root: {
-    background: 'red',
+    backgroundColor: 'red',
   },
 };
 

--- a/docs/src/pages/demos/buttons/ButtonBases.js
+++ b/docs/src/pages/demos/buttons/ButtonBases.js
@@ -57,7 +57,7 @@ const styles = theme => ({
     right: 0,
     top: 0,
     bottom: 0,
-    background: theme.palette.common.black,
+    backgroundColor: theme.palette.common.black,
     opacity: 0.4,
     transition: theme.transitions.create('opacity'),
   },
@@ -68,7 +68,7 @@ const styles = theme => ({
   imageMarked: {
     height: 3,
     width: 18,
-    background: theme.palette.common.white,
+    backgroundColor: theme.palette.common.white,
     position: 'absolute',
     bottom: -2,
     left: 'calc(50% - 9px)',

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.js
@@ -110,7 +110,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
   dialog: {
     width: '80%',

--- a/docs/src/pages/demos/dialogs/SimpleDialog.js
+++ b/docs/src/pages/demos/dialogs/SimpleDialog.js
@@ -15,7 +15,7 @@ import blue from 'material-ui/colors/blue';
 const emails = ['username@gmail.com', 'user02@gmail.com'];
 const styles = {
   avatar: {
-    background: blue[100],
+    backgroundColor: blue[100],
     color: blue[600],
   },
 };

--- a/docs/src/pages/demos/dividers/InsetDividers.js
+++ b/docs/src/pages/demos/dividers/InsetDividers.js
@@ -11,7 +11,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: '360px',
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/dividers/ListDividers.js
+++ b/docs/src/pages/demos/dividers/ListDividers.js
@@ -8,7 +8,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: '360px',
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/grid-list/AdvancedGridList.js
+++ b/docs/src/pages/demos/grid-list/AdvancedGridList.js
@@ -12,7 +12,7 @@ const styles = theme => ({
     flexWrap: 'wrap',
     justifyContent: 'space-around',
     overflow: 'hidden',
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
   gridList: {
     width: 500,

--- a/docs/src/pages/demos/grid-list/ImageGridList.js
+++ b/docs/src/pages/demos/grid-list/ImageGridList.js
@@ -10,7 +10,7 @@ const styles = theme => ({
     flexWrap: 'wrap',
     justifyContent: 'space-around',
     overflow: 'hidden',
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
   gridList: {
     width: 500,

--- a/docs/src/pages/demos/grid-list/SingleLineGridList.js
+++ b/docs/src/pages/demos/grid-list/SingleLineGridList.js
@@ -12,7 +12,7 @@ const styles = theme => ({
     flexWrap: 'wrap',
     justifyContent: 'space-around',
     overflow: 'hidden',
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
   gridList: {
     flexWrap: 'nowrap',

--- a/docs/src/pages/demos/grid-list/TitlebarGridList.js
+++ b/docs/src/pages/demos/grid-list/TitlebarGridList.js
@@ -13,7 +13,7 @@ const styles = theme => ({
     flexWrap: 'wrap',
     justifyContent: 'space-around',
     overflow: 'hidden',
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
   gridList: {
     width: 500,

--- a/docs/src/pages/demos/lists/CheckboxList.js
+++ b/docs/src/pages/demos/lists/CheckboxList.js
@@ -10,7 +10,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/lists/CheckboxListSecondary.js
+++ b/docs/src/pages/demos/lists/CheckboxListSecondary.js
@@ -9,7 +9,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/lists/FolderList.js
+++ b/docs/src/pages/demos/lists/FolderList.js
@@ -9,7 +9,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/lists/InsetList.js
+++ b/docs/src/pages/demos/lists/InsetList.js
@@ -8,7 +8,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/lists/InteractiveList.js
+++ b/docs/src/pages/demos/lists/InteractiveList.js
@@ -23,7 +23,7 @@ const styles = theme => ({
     maxWidth: 752,
   },
   demo: {
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
   title: {
     margin: `${theme.spacing.unit * 4}px 0 ${theme.spacing.unit * 2}px`,

--- a/docs/src/pages/demos/lists/NestedList.js
+++ b/docs/src/pages/demos/lists/NestedList.js
@@ -15,7 +15,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
   nested: {
     paddingLeft: theme.spacing.unit * 4,

--- a/docs/src/pages/demos/lists/PinnedSubheaderList.js
+++ b/docs/src/pages/demos/lists/PinnedSubheaderList.js
@@ -8,13 +8,13 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
     position: 'relative',
     overflow: 'auto',
     maxHeight: 300,
   },
   listSection: {
-    background: 'inherit',
+    backgroundColor: 'inherit',
   },
 });
 

--- a/docs/src/pages/demos/lists/SimpleList.js
+++ b/docs/src/pages/demos/lists/SimpleList.js
@@ -10,7 +10,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/lists/SwitchListSecondary.js
+++ b/docs/src/pages/demos/lists/SwitchListSecondary.js
@@ -16,7 +16,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/menus/ListItemComposition.js
+++ b/docs/src/pages/demos/menus/ListItemComposition.js
@@ -11,7 +11,7 @@ import SendIcon from 'material-ui-icons/Send';
 const styles = theme => ({
   menuItem: {
     '&:focus': {
-      background: theme.palette.primary[500],
+      backgroundColor: theme.palette.primary[500],
       '& $text, & $icon': {
         color: theme.palette.common.white,
       },

--- a/docs/src/pages/demos/menus/SimpleListMenu.js
+++ b/docs/src/pages/demos/menus/SimpleListMenu.js
@@ -8,7 +8,7 @@ const styles = theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
-    background: theme.palette.background.paper,
+    backgroundColor: theme.palette.background.paper,
   },
 });
 

--- a/docs/src/pages/demos/selects/MultipleSelect.js
+++ b/docs/src/pages/demos/selects/MultipleSelect.js
@@ -44,7 +44,7 @@ class MultipleSelect extends React.Component {
   };
 
   render() {
-    const { classes } = this.props;
+    const { classes, theme } = this.props;
 
     return (
       <div className={classes.container}>
@@ -69,7 +69,10 @@ class MultipleSelect extends React.Component {
                 key={name}
                 value={name}
                 style={{
-                  fontWeight: this.state.name.indexOf(name) !== -1 ? '500' : '400',
+                  fontWeight:
+                    this.state.name.indexOf(name) === -1
+                      ? theme.typography.fontWeightRegular
+                      : theme.typography.fontWeightMedium,
                 }}
               >
                 {name}
@@ -84,6 +87,7 @@ class MultipleSelect extends React.Component {
 
 MultipleSelect.propTypes = {
   classes: PropTypes.object.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(MultipleSelect);
+export default withStyles(styles, { withTheme: true })(MultipleSelect);

--- a/docs/src/pages/demos/stepper/TextMobileStepper.js
+++ b/docs/src/pages/demos/stepper/TextMobileStepper.js
@@ -19,7 +19,7 @@ const styles = theme => ({
     height: 50,
     paddingLeft: theme.spacing.unit * 4,
     marginBottom: 20,
-    background: theme.palette.background.default,
+    backgroundColor: theme.palette.background.default,
   },
 });
 

--- a/docs/src/pages/demos/text-fields/CustomizedInputs.js
+++ b/docs/src/pages/demos/text-fields/CustomizedInputs.js
@@ -30,7 +30,7 @@ const styles = theme => ({
   },
   textFieldInput: {
     borderRadius: 4,
-    background: theme.palette.common.white,
+    backgroundColor: theme.palette.common.white,
     border: '1px solid #ced4da',
     fontSize: 16,
     padding: '10px 12px',

--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -11,7 +11,7 @@ The usage of `withStyles` in TypeScript can be a little tricky, so it's worth sh
 const decorate = withStyles(({ palette, spacing }) => ({
   root: {
     padding: spacing.unit,
-    background: palette.background,
+    backgroundColor: palette.background,
     color: palette.primary,
   },
 }));

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -169,8 +169,9 @@ class ButtonBase extends React.Component {
     }
 
     event.persist();
-    const keyboardFocusCallback = this.onKeyboardFocusHandler.bind(this, event);
-    detectKeyboardFocus(this, this.button, keyboardFocusCallback);
+    detectKeyboardFocus(this, this.button, () => {
+      this.onKeyboardFocusHandler(event);
+    });
 
     if (this.props.onFocus) {
       this.props.onFocus(event);

--- a/src/ExpansionPanel/ExpansionPanel.js
+++ b/src/ExpansionPanel/ExpansionPanel.js
@@ -72,7 +72,7 @@ class ExpansionPanel extends React.Component {
 
   componentWillMount() {
     const { expanded, defaultExpanded } = this.props;
-    this.isControlled = expanded !== undefined;
+    this.isControlled = expanded != null;
     this.setState({
       expanded: this.isControlled ? expanded : defaultExpanded,
     });

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -232,7 +232,7 @@ class Input extends React.Component {
   };
 
   componentWillMount() {
-    this.isControlled = hasValue(this.props.value);
+    this.isControlled = this.props.value != null;
 
     if (this.isControlled) {
       this.checkDirty(this.props);

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -136,6 +136,12 @@ describe('<Input />', () => {
   });
 
   describe('controlled', () => {
+    it('should considered [] as controlled', () => {
+      const wrapper = shallow(<Input value={[]} />);
+      const instance = wrapper.instance();
+      assert.strictEqual(instance.isControlled, true, 'isControlled should return true');
+    });
+
     ['', 0].forEach(value => {
       describe(`${typeof value} value`, () => {
         let wrapper;

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -33,12 +33,12 @@ class List extends React.Component {
 
   render() {
     const {
+      children,
       classes,
       className: classNameProp,
       component: ComponentProp,
-      disablePadding,
-      children,
       dense,
+      disablePadding,
       subheader,
       ...other
     } = this.props;

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -17,7 +17,7 @@ export const styles = theme => ({
     position: 'relative',
   },
   keyboardFocused: {
-    background: theme.palette.text.divider,
+    backgroundColor: theme.palette.text.divider,
   },
   default: {
     paddingTop: 12,

--- a/src/Menu/Menu.js
+++ b/src/Menu/Menu.js
@@ -60,7 +60,6 @@ class Menu extends React.Component {
 
   handleEnter = element => {
     const { theme } = this.props;
-
     const menuList = findDOMNode(this.menuList);
 
     // Focus so the scroll computation of the Popover works as expected.
@@ -68,12 +67,9 @@ class Menu extends React.Component {
 
     // Let's ignore that piece of logic if users are already overriding the width
     // of the menu.
-
     if (menuList && element.clientHeight < menuList.clientHeight && !menuList.style.width) {
       const size = `${getScrollbarSize()}px`;
-
       menuList.style[theme.direction === 'rtl' ? 'paddingLeft' : 'paddingRight'] = size;
-
       menuList.style.width = `calc(100% + ${size})`;
     }
 

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -9,22 +9,19 @@ import ListItem from '../List/ListItem';
 export const styles = theme => ({
   root: {
     ...theme.typography.subheading,
-    height: 24,
+    height: theme.spacing.unit * 3,
     boxSizing: 'content-box',
-    background: 'none',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    '&:focus': {
-      background: theme.palette.text.divider,
-    },
     '&:hover': {
+      backgroundColor: theme.palette.text.lightDivider,
+    },
+    '&$selected': {
       backgroundColor: theme.palette.text.divider,
     },
   },
-  selected: {
-    backgroundColor: theme.palette.text.divider,
-  },
+  selected: {},
 });
 
 function MenuItem(props) {

--- a/src/Menu/MenuList.js
+++ b/src/Menu/MenuList.js
@@ -22,7 +22,7 @@ class MenuList extends React.Component {
     clearTimeout(this.blurTimer);
   }
 
-  setTabIndex(index: number) {
+  setTabIndex(index) {
     this.setState({ currentTabIndex: index });
   }
 
@@ -30,7 +30,7 @@ class MenuList extends React.Component {
   selectedItem = undefined;
   blurTimer = undefined;
 
-  handleBlur = (event: SyntheticUIEvent<>) => {
+  handleBlur = event => {
     this.blurTimer = setTimeout(() => {
       if (this.list) {
         const list = findDOMNode(this.list);
@@ -46,7 +46,7 @@ class MenuList extends React.Component {
     }
   };
 
-  handleKeyDown = (event: SyntheticUIEvent<>) => {
+  handleKeyDown = event => {
     const list = findDOMNode(this.list);
     const key = keycode(event);
     const currentFocus = activeElement(ownerDocument(list));
@@ -77,7 +77,7 @@ class MenuList extends React.Component {
     }
   };
 
-  handleItemFocus = (event: SyntheticUIEvent<>) => {
+  handleItemFocus = event => {
     const list = findDOMNode(this.list);
     if (list) {
       for (let i = 0; i < list.children.length; i += 1) {

--- a/src/Reboot/Reboot.js
+++ b/src/Reboot/Reboot.js
@@ -17,9 +17,9 @@ const styles = theme => ({
     },
     body: {
       margin: 0, // Remove the margin in all browsers
-      background: theme.palette.background.default,
+      backgroundColor: theme.palette.background.default,
       '@media print': {
-        background: theme.palette.common.white,
+        backgroundColor: theme.palette.common.white,
       },
     },
   },

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -18,7 +18,7 @@ class SelectInput extends React.Component {
 
   ignoreNextBlur = false;
 
-  handleClick = (event: SyntheticMouseEvent<HTMLElement>) => {
+  handleClick = event => {
     // Opening the menu is going to blur the. It will be focused back when closed.
     this.ignoreNextBlur = true;
     this.setState({
@@ -33,7 +33,7 @@ class SelectInput extends React.Component {
     });
   };
 
-  handleItemClick = (child: Element<any>) => (event: SyntheticMouseEvent<> & { target?: any }) => {
+  handleItemClick = child => event => {
     if (!this.props.multiple) {
       this.setState({
         open: false,
@@ -68,7 +68,7 @@ class SelectInput extends React.Component {
     }
   };
 
-  handleBlur = (event: SyntheticFocusEvent<>) => {
+  handleBlur = event => {
     if (this.ignoreNextBlur === true) {
       // The parent components are relying on the bubbling of the event.
       event.stopPropagation();
@@ -81,7 +81,7 @@ class SelectInput extends React.Component {
     }
   };
 
-  handleKeyDown = (event: SyntheticKeyboardEvent<HTMLElement>) => {
+  handleKeyDown = event => {
     if (this.props.readOnly) {
       return;
     }
@@ -97,7 +97,7 @@ class SelectInput extends React.Component {
     }
   };
 
-  handleSelectRef = (node: ?HTMLElement) => {
+  handleSelectRef = node => {
     if (!this.props.selectRef) {
       return;
     }

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -21,11 +21,11 @@ export const styles = theme => ({
   },
   hover: {
     '&:hover': {
-      background: theme.palette.background.contentFrame,
+      backgroundColor: theme.palette.background.contentFrame,
     },
   },
   selected: {
-    background: theme.palette.background.appBar,
+    backgroundColor: theme.palette.background.appBar,
   },
 });
 

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -26,7 +26,7 @@ export const styles = theme => ({
     pointerEvents: 'none',
   },
   tooltip: {
-    background: grey[700],
+    backgroundColor: grey[700],
     borderRadius: 2,
     color: common.fullWhite,
     fontFamily: theme.typography.fontFamily,
@@ -101,7 +101,7 @@ class Tooltip extends React.Component {
   componentWillMount() {
     const { props } = this;
 
-    this.isControlled = props.open !== undefined;
+    this.isControlled = props.open != null;
 
     if (!this.isControlled) {
       // not controlled, use internal state

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -38,7 +38,7 @@ class SwitchBase extends React.Component {
   componentWillMount() {
     const { props } = this;
 
-    this.isControlled = props.checked !== undefined;
+    this.isControlled = props.checked != null;
 
     if (!this.isControlled) {
       // not controlled, use internal state

--- a/src/styles/getStylesCreator.spec.js
+++ b/src/styles/getStylesCreator.spec.js
@@ -41,7 +41,9 @@ describe('getStylesCreator', () => {
     it('should be able to overrides some rules, deep', () => {
       const theme = {
         overrides: {
-          [name]: { root: { color: 'white', '&:hover': { borderRadius: 2, background: 'black' } } },
+          [name]: {
+            root: { color: 'white', '&:hover': { borderRadius: 2, backgroundColor: 'black' } },
+          },
         },
       };
       const styles = stylesCreator.create(theme, name);
@@ -51,7 +53,7 @@ describe('getStylesCreator', () => {
           '&:hover': {
             color: 'red',
             borderRadius: 2,
-            background: 'black',
+            backgroundColor: 'black',
           },
         },
       });

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -22,7 +22,7 @@ const styles = theme => ({
     },
   },
   root: {
-    background: theme.palette.background.default,
+    backgroundColor: theme.palette.background.default,
     padding: theme.spacing.unit,
   },
 });

--- a/test/regressions/tests/List/AvatarListItem.js
+++ b/test/regressions/tests/List/AvatarListItem.js
@@ -7,7 +7,7 @@ import List, { ListItem, ListItemText } from 'material-ui/List';
 
 export default function AvatarListItem() {
   return (
-    <div style={{ background: '#fff', width: 300 }}>
+    <div style={{ backgroundColor: '#fff', width: 300 }}>
       <ListItem>
         <Avatar>
           <Icon>folder</Icon>

--- a/test/regressions/tests/List/IconListItem.js
+++ b/test/regressions/tests/List/IconListItem.js
@@ -6,7 +6,7 @@ import { ListItem, ListItemText, ListItemIcon } from 'material-ui/List';
 
 export default function IconListItem() {
   return (
-    <div style={{ background: '#fff', width: 300 }}>
+    <div style={{ backgroundColor: '#fff', width: 300 }}>
       <ListItem>
         <ListItemIcon>
           <Icon>phone</Icon>

--- a/test/regressions/tests/List/PrimaryActionCheckboxListItem.js
+++ b/test/regressions/tests/List/PrimaryActionCheckboxListItem.js
@@ -7,7 +7,7 @@ import IconButton from 'material-ui/IconButton';
 
 export default function PrimaryActionCheckboxListItem() {
   return (
-    <div style={{ background: '#fff', width: 300 }}>
+    <div style={{ backgroundColor: '#fff', width: 300 }}>
       <ListItem button>
         <Checkbox tabIndex={-1} disableRipple />
         <ListItemText primary="Primary" />

--- a/test/regressions/tests/List/SecondaryActionCheckboxListItem.js
+++ b/test/regressions/tests/List/SecondaryActionCheckboxListItem.js
@@ -6,7 +6,7 @@ import Checkbox from 'material-ui/Checkbox';
 
 export default function SecondaryActionCheckboxListItem() {
   return (
-    <div style={{ background: '#fff', width: 300 }}>
+    <div style={{ backgroundColor: '#fff', width: 300 }}>
       <ListItem button>
         <ListItemText primary="Primary" />
         <ListItemSecondaryAction>

--- a/test/regressions/tests/List/SimpleListItem.js
+++ b/test/regressions/tests/List/SimpleListItem.js
@@ -5,7 +5,7 @@ import { ListItem, ListItemText } from 'material-ui/List';
 
 export default function SimpleListItem() {
   return (
-    <div style={{ background: '#fff', width: 300 }}>
+    <div style={{ backgroundColor: '#fff', width: 300 }}>
       <ListItem>
         <ListItemText primary="Primary" />
       </ListItem>

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -23,7 +23,7 @@ interface ComponentProps {
 const styles: StyleRulesCallback<'root'> = ({ palette, spacing }) => ({
   root: {
     padding: spacing.unit,
-    background: palette.background,
+    backgroundColor: palette.background,
     color: palette.primary,
   },
 });
@@ -62,12 +62,12 @@ const StyledExampleThree = withStyles(styleRule)<{}>(ComponentWithChildren);
 // Also works with a plain object
 const stylesAsPojo = {
   root: {
-    background: 'hotpink',
+    backgroundColor: 'hotpink',
   },
 };
 
 const AnotherStyledSFC = withStyles({
-  root: { background: 'hotpink' },
+  root: { backgroundColor: 'hotpink' },
 })(({ classes }) => <div className={classes.root}>Stylish!</div>);
 
 // Overriding styles

--- a/test/typescript/styling-comparison.spec.tsx
+++ b/test/typescript/styling-comparison.spec.tsx
@@ -5,7 +5,7 @@ import { withStyles, WithStyles } from '../../src/styles';
 const decorate = withStyles(({ palette, spacing }) => ({
   root: {
     padding: spacing.unit,
-    background: palette.background,
+    backgroundColor: palette.background,
     color: palette.primary,
   },
 }));


### PR DESCRIPTION
- Use the same `isControlled` logic [that React is using internally](https://github.com/facebook/react/blob/4c3470eef832d64e03d18c19a70f2501f9becbfd/packages/react-dom/src/client/ReactDOMFiberInput.js#L37-L40). It's fixing a regression with the multi-select introduced in #9647.
- Use `backgroundColor` over `background` CSS. As it's making the override slightly simpler.
- Change the background color of the hover and focus state so we can see the difference with the selected state.
- Only apply the focus style to the first menu item if it was displayed after a keyboard interaction. So people don't confuse it with the selected state.

Closes #5186 