### PR TITLE
[CardHeader] Add conditional rendering of the subheader

### DIFF
--- a/src/Card/CardHeader.js
+++ b/src/Card/CardHeader.js
@@ -39,14 +39,16 @@ function CardHeader(props) {
         <Typography type={avatar ? 'body2' : 'headline'} component="span" className={classes.title}>
           {title}
         </Typography>
-        <Typography
-          type={avatar ? 'body2' : 'body1'}
-          component="span"
-          color="secondary"
-          className={classes.subheader}
-        >
-          {subheader}
-        </Typography>
+        {subheader && (
+          <Typography
+            type={avatar ? 'body2' : 'body1'}
+            component="span"
+            color="secondary"
+            className={classes.subheader}
+          >
+            {subheader}
+          </Typography>
+        )}
       </div>
       {action && <div className={classes.action}>{action}</div>}
     </CardContent>

--- a/src/Card/CardHeader.spec.js
+++ b/src/Card/CardHeader.spec.js
@@ -61,11 +61,17 @@ describe('<CardHeader />', () => {
       assert.strictEqual(title.props().type, 'headline');
     });
 
-    it('should render the subeader as body1 secondary text', () => {
+    it('should render the subheader as body1 secondary text', () => {
       const subheader = wrapper.childAt(1);
       assert.strictEqual(subheader.name(), 'withStyles(Typography)');
       assert.strictEqual(subheader.props().type, 'body1');
       assert.strictEqual(subheader.props().color, 'secondary');
+    });
+
+    it('should not render the subheader if none is given', () => {
+      const title = wrapper.childAt(0);
+      assert.strictEqual(title.name(), 'withStyles(Typography)');
+      assert.strictEqual(wrapper.length, 1);
     });
   });
 


### PR DESCRIPTION
This PR adds conditional rendering to the "subheader" part of the CardHeader as raised in issue #9552. This is causing warning messages in the console and stops builds if the build is set to fail on warnings.

Closes #9552. 