### PR TITLE
[Toolbar] Make the children optional

### DIFF
--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -12,7 +12,7 @@ filename: /src/Toolbar/Toolbar.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span style="color: #31a148">children *</span> | node |  | Toolbar children, usually a mixture of `IconButton`, `Button` and `Typography`. |
+| children | node |  | Toolbar children, usually a mixture of `IconButton`, `Button` and `Typography`. |
 | classes | object |  | Useful to extend the style applied to components. |
 | disableGutters | bool | false | If `true`, disables gutter padding. |
 

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -35,7 +35,7 @@ Toolbar.propTypes = {
   /**
    * Toolbar children, usually a mixture of `IconButton`, `Button` and `Typography`.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * Useful to extend the style applied to components.
    */


### PR DESCRIPTION
Given the Toolbar has a height, it makes sense to render it without any children.