### PR TITLE
[Popover] Add action property

### DIFF
--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -12,6 +12,7 @@ filename: /src/Popover/Popover.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| action | func |  | This is callback property. It's called by the component on mount. This is useful when you want to trigger an action programmatically. It currently only supports updatePosition() action.<br><br>**Signature:**<br>`function(actions: object) => void`<br>*actions:* This object contains all posible actions that can be triggered programmatically. |
 | anchorEl | object |  | This is the DOM element that may be used to set the position of the popover. |
 | anchorOrigin | shape | {  vertical: 'top',  horizontal: 'left',} | This is the point on the anchor where the popover's `anchorEl` will attach to. This is not used when the anchorReference is 'anchorPosition'.<br>Options: vertical: [top, center, bottom]; horizontal: [left, center, right]. |
 | anchorPosition | shape |  | This is the position that may be used to set the position of the popover. The coordinates are relative to the application's client area. |

--- a/src/Popover/Popover.js
+++ b/src/Popover/Popover.js
@@ -78,6 +78,14 @@ export const styles = {
 };
 
 class Popover extends React.Component {
+  componentDidMount() {
+    if (this.props.action) {
+      this.props.action({
+        updatePosition: this.handleResize,
+      });
+    }
+  }
+
   componentWillUnmount = () => {
     this.handleResize.cancel();
   };
@@ -85,7 +93,6 @@ class Popover extends React.Component {
   setPositioningStyles = element => {
     if (element && element.style) {
       const positioning = this.getPositioningStyle(element);
-
       element.style.top = positioning.top;
       element.style.left = positioning.left;
       element.style.transformOrigin = positioning.transformOrigin;
@@ -255,6 +262,7 @@ class Popover extends React.Component {
       transformOrigin,
       transitionClasses,
       transitionDuration,
+      action,
       ...other
     } = this.props;
 
@@ -292,6 +300,15 @@ class Popover extends React.Component {
 }
 
 Popover.propTypes = {
+  /**
+   * This is callback property. It's called by the component on mount.
+   * This is useful when you want to trigger an action programmatically.
+   * It currently only supports updatePosition() action.
+   *
+   * @param {object} actions This object contains all posible actions
+   * that can be triggered programmatically.
+   */
+  action: PropTypes.func,
   /**
    * This is the DOM element that may be used
    * to set the position of the popover.

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -692,4 +692,28 @@ describe('<Popover />', () => {
       assert.strictEqual(wrapper.instance().getContentAnchorOffset(element), 45);
     });
   });
+
+  describe('prop: action', () => {
+    it('should be able to access updatePosition function', () => {
+      let popoverActions = {};
+      mount(
+        <Popover
+          action={actions => {
+            popoverActions = actions;
+          }}
+        >
+          <div>content #1</div>
+          <div>content #2</div>
+          <div>content #3</div>
+        </Popover>,
+      );
+
+      assert.strictEqual(
+        typeof popoverActions.updatePosition === 'function',
+        true,
+        'Should be a function.',
+      );
+      popoverActions.updatePosition();
+    });
+  });
 });


### PR DESCRIPTION
Here's an implementation of how I could see access to the getPositioningStyle method. It's simply a reference callback which will allow access to outside components to trigger updates.  It is useful for content that could come in delayed and you need to reposition the Popover manually

Closes #9584 