### PR TITLE
[TextField] Make TextField's "value" prop type match Input

### DIFF
--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -65,7 +65,7 @@ For advanced cases, please look at the source of TextField and consider either:
 | select | bool | false | Render a `Select` element while passing the `Input` element to `Select` as `input` parameter. If this option is set you must pass the options of the select as children. |
 | SelectProps | object |  | Properties applied to the `Select` element. |
 | type | string |  | Type attribute of the `Input` element. It should be a valid HTML5 input type. |
-| value | union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | The value of the `Input` element, required for a controlled component. |
+| value | union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;{name?: undefined, value?: undefined}<br> |  | The value of the `Input` element, required for a controlled component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -28,7 +28,7 @@ export interface InputProps extends StandardProps<
   rowsMax?: string | number;
   startAdornment?: React.ReactNode;
   type?: string;
-  value?: string | number;
+  value?: Array<string | number> | string | number;
   onClean?: () => void;
   onDirty?: () => void;
   /**

--- a/src/TextField/TextField.d.ts
+++ b/src/TextField/TextField.d.ts
@@ -38,7 +38,7 @@ export interface TextFieldProps extends StandardProps<
   select?: boolean;
   SelectProps?: SelectProps;
   type?: string;
-  value?: string | number;
+  value?: Array<string | number> | string | number;
 }
 
 export type TextFieldClassKey =

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -252,7 +252,11 @@ TextField.propTypes = {
   /**
    * The value of the `Input` element, required for a controlled component.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
+  ]),
 };
 
 TextField.defaultProps = {


### PR DESCRIPTION
Given that `TextField` passes its `value` prop to either `Input` or `Select` (when `select={true}`) its prop type and TS definition should be a superset of those from `Input` and `Select`. I've encountered prop type warnings from rendering something like the following, even though it functions perfectly well for multi-select:

```jsx
<TextField
  select
  SelectProps={{ multiple: true }}
  value={['a', 'b', 'c']}
  ...
/>
```

I also noticed that the TS definition for `Input`'s `value` was mismatched with its prop type, so I updated the TS definition to match the prop type. If it was actually the prop type that was erroneous, instead of the TS definition, please let me know and I'll switch it around.