### PR TITLE
[TextField] Accessibility improvements

### DIFF
--- a/docs/src/pages/demos/text-fields/ComposedTextField.js
+++ b/docs/src/pages/demos/text-fields/ComposedTextField.js
@@ -32,20 +32,20 @@ class ComposedTextField extends React.Component {
           <InputLabel htmlFor="name-simple">Name</InputLabel>
           <Input id="name-simple" value={this.state.name} onChange={this.handleChange} />
         </FormControl>
-        <FormControl className={classes.formControl}>
+        <FormControl className={classes.formControl} aria-describedby="name-helper-text">
           <InputLabel htmlFor="name-helper">Name</InputLabel>
           <Input id="name-helper" value={this.state.name} onChange={this.handleChange} />
-          <FormHelperText>Some important helper text</FormHelperText>
+          <FormHelperText id="name-helper-text">Some important helper text</FormHelperText>
         </FormControl>
         <FormControl className={classes.formControl} disabled>
           <InputLabel htmlFor="name-disabled">Name</InputLabel>
           <Input id="name-disabled" value={this.state.name} onChange={this.handleChange} />
           <FormHelperText>Disabled</FormHelperText>
         </FormControl>
-        <FormControl className={classes.formControl} error>
+        <FormControl className={classes.formControl} error aria-describedby="name-error-text">
           <InputLabel htmlFor="name-error">Name</InputLabel>
           <Input id="name-error" value={this.state.name} onChange={this.handleChange} />
-          <FormHelperText>Error</FormHelperText>
+          <FormHelperText id="name-error-text">Error</FormHelperText>
         </FormControl>
       </div>
     );

--- a/docs/src/pages/demos/text-fields/InputAdornments.js
+++ b/docs/src/pages/demos/text-fields/InputAdornments.js
@@ -55,14 +55,17 @@ class InputAdornments extends React.Component {
             startAdornment={<InputAdornment position="start">$</InputAdornment>}
           />
         </FormControl>
-        <FormControl className={classNames(classes.formControl, classes.withoutLabel)}>
+        <FormControl
+          className={classNames(classes.formControl, classes.withoutLabel)}
+          aria-describedby="weight-helper-text"
+        >
           <Input
             id="weight"
             value={this.state.weight}
             onChange={this.handleChange('weight')}
             endAdornment={<InputAdornment position="end">Kg</InputAdornment>}
           />
-          <FormHelperText>Weight</FormHelperText>
+          <FormHelperText id="weight-helper-text">Weight</FormHelperText>
         </FormControl>
         <FormControl className={classes.formControl}>
           <InputLabel htmlFor="password">Password</InputLabel>

--- a/docs/src/pages/demos/text-fields/TextFields.js
+++ b/docs/src/pages/demos/text-fields/TextFields.js
@@ -124,12 +124,14 @@ class TextFields extends React.Component {
           margin="normal"
         />
         <TextField
+          id="with-placeholder"
           label="With placeholder"
           placeholder="Placeholder"
           className={classes.textField}
           margin="normal"
         />
         <TextField
+          id="textarea"
           label="With placeholder multiline"
           placeholder="Placeholder"
           multiline

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -46,7 +46,7 @@ For advanced cases, please look at the source of TextField by clicking on the
 | fullWidth | bool |  | If `true`, the input will take up the full width of its container. |
 | helperText | node |  | The helper text content. |
 | helperTextClassName | string |  | The CSS class name of the helper text element. |
-| id | string |  | The id of the `input` element. |
+| id | string |  | The id of the `input` element. Use that property to make `label` and `helperText` accessible for screen readers. |
 | InputLabelProps | object |  | Properties applied to the `InputLabel` element. |
 | InputProps | object |  | Properties applied to the `Input` element. |
 | inputProps | object |  | Properties applied to the native `input` element. |

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -464,6 +464,8 @@ class Input extends React.Component {
           type={type}
           readOnly={readOnly}
           rows={rows}
+          aria-required={required}
+          aria-invalid={error}
           {...inputProps}
         />
         {endAdornment}

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -188,6 +188,7 @@ TextField.propTypes = {
   helperTextClassName: PropTypes.string,
   /**
    * The id of the `input` element.
+   * Use that property to make `label` and `helperText` accessible for screen readers.
    */
   id: PropTypes.string,
   /**

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -94,11 +94,7 @@ function TextField(props) {
       inputRef={inputRef}
       onChange={onChange}
       placeholder={placeholder}
-      inputProps={{
-        'aria-required': required,
-        'aria-invalid': error,
-        ...inputProps,
-      }}
+      inputProps={inputProps}
       {...InputProps}
     />
   );

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -92,7 +92,10 @@ function TextField(props) {
       inputRef={inputRef}
       onChange={onChange}
       placeholder={placeholder}
-      inputProps={inputProps}
+      inputProps={{
+        'aria-required': required,
+        ...inputProps,
+      }}
       {...InputProps}
     />
   );

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -122,11 +122,7 @@ function TextField(props) {
         InputComponent
       )}
       {helperText && (
-        <FormHelperText
-          className={helperTextClassName}
-          id={helperTextId}
-          {...FormHelperTextProps}
-        >
+        <FormHelperText className={helperTextClassName} id={helperTextId} {...FormHelperTextProps}>
           {helperText}
         </FormHelperText>
       )}

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -76,7 +76,7 @@ function TextField(props) {
     'Material-UI: `children` must be passed when using the `TextField` component with `select`.',
   );
 
-  const helperTextId = helperText && id ? `${id}-$mui_helper_text$` : undefined;
+  const helperTextId = helperText && id ? `${id}-mui-helper-text` : undefined;
 
   const InputComponent = (
     <Input

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -76,6 +76,8 @@ function TextField(props) {
     'Material-UI: `children` must be passed when using the `TextField` component with `select`.',
   );
 
+  const helperTextId = helperText && id ? `${id}-mui_helper_text` : undefined;
+
   const InputComponent = (
     <Input
       autoComplete={autoComplete}
@@ -107,6 +109,7 @@ function TextField(props) {
       className={className}
       error={error}
       required={required}
+      aria-describedby={helperTextId}
       {...other}
       ref={rootRef}
     >
@@ -123,7 +126,11 @@ function TextField(props) {
         InputComponent
       )}
       {helperText && (
-        <FormHelperText className={helperTextClassName} {...FormHelperTextProps}>
+        <FormHelperText
+          className={helperTextClassName}
+          id={helperTextId}
+          {...FormHelperTextProps}
+        >
           {helperText}
         </FormHelperText>
       )}

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -76,7 +76,7 @@ function TextField(props) {
     'Material-UI: `children` must be passed when using the `TextField` component with `select`.',
   );
 
-  const helperTextId = helperText && id ? `${id}-mui_helper_text` : undefined;
+  const helperTextId = helperText && id ? `${id}-$mui_helper_text$` : undefined;
 
   const InputComponent = (
     <Input

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -94,6 +94,7 @@ function TextField(props) {
       placeholder={placeholder}
       inputProps={{
         'aria-required': required,
+        'aria-invalid': error,
         ...inputProps,
       }}
       {...InputProps}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Currently there is no way for screen reader to know if field has error or not, if it's required or not.
Also, `helperText` is not accessible for screen reader at all, which is a huge problem, cause `helperText` is used for validation or field description.
This PR:
- adds `aria-required` attribute to `Input` - so screen reader knows if fild is required or not
- adds `aria-invalid` attribute to `Input` - so screen reader knows if fild has error
- creates `id` attribute for `FormHelperText` inside `TextField` and adds `aria-describedby` to field container - so screen reader reads `helperText` as field description after reading `label`, `value`, `required` and `error`.
Creating `id` for `FormHelperText`: concatenates `TextField`s `id` with `-$mui_helper_text$` suffix. Since `id` is unique, `FormHelperText`s `id` will be also unique. And of course it will work properly in case of SSR. Let me know if you want suffix to be changed :) 
- adds missing `id`s for `TextField` examples
- adds `id`s to `FormHelperText`s and `aria-describedby` attributes to `FormControl`s to make it work as `TextField` (since code is often copied from those examples, I think it's a good practice to add aria attributes to make those copied parts of code accessible out of the box)

Also, this PR automatically makes `Select`s `helperText` accessible for screen readers.