### PR TITLE
[TypeScript] re-declare `isMuiElement` and `isMuiComponent` as typeguard

### DIFF
--- a/src/utils/reactHelpers.d.ts
+++ b/src/utils/reactHelpers.d.ts
@@ -1,6 +1,15 @@
 import * as React from 'react';
+import { StandardProps } from '../';
 
 export function cloneChildrenWithClassName<T>(children: React.ReactNode, className: string): T[];
 
-export function isMuiElement(element: any, muiNames: Array<string>): boolean;
-export function isMuiComponent(element: any, muiNames: Array<string>): boolean;
+type NamedMuiComponent = React.ComponentType<{}> & { muiName: string };
+
+interface NamedMuiElement {
+  type: NamedMuiComponent;
+  props: StandardProps<{}, never>;
+  key: string | number | null;
+}
+
+export function isMuiElement(element: any, muiNames: string[]): element is NamedMuiElement;
+export function isMuiComponent(element: any, muiNames: string[]): element is NamedMuiComponent;


### PR DESCRIPTION
Previous PR(#9565), reactHelpers functions simply return boolean value, now re-declared as typeguard  refs #9583

thanks @pelotom!

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
