### PR TITLE
[ListItemText] Fix noWrap primary text ellipsis

### DIFF
--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -7,6 +7,7 @@ import Typography from '../Typography';
 export const styles = theme => ({
   root: {
     flex: '1 1 auto',
+    minWidth: 0,
     padding: '0 16px',
     '&:first-child': {
       paddingLeft: 0,


### PR DESCRIPTION
Fix long noWrap `<Typography>`  text as `<ListItemText>` primary not show ellipsis correctly.
Currently the text will render out of `<ListItemText>`.

[codesandbox DEMO](https://codesandbox.io/s/4qz4440m60)

Minimal Test code:
```js
<List>
  <ListItem>
    <ListItemText primary={<Typography noWrap>LONG TEXT HERE</Typography>} />
  </ListItem>
</List>
```

For the source of the fix, check: https://stackoverflow.com/questions/39838908/text-overflow-ellipsis-not-working-in-nested-flexbox