### PR TITLE
[styles] Make sure to escape whitespace

### DIFF
--- a/src/styles/createGenerateClassName.js
+++ b/src/styles/createGenerateClassName.js
@@ -10,9 +10,13 @@ let generatorCounter = 0;
 // https://github.com/cssinjs/jss/blob/4e6a05dd3f7b6572fdd3ab216861d9e446c20331/src/utils/createGenerateClassName.js
 export default function createGenerateClassName(options = {}) {
   const { dangerouslyUseGlobalCSS = false } = options;
-  const escapeRegex = /([[\].#*$><+~=|^:(),"'`])/g;
+  const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;
   let ruleCounter = 0;
 
+  // HMR can lead us to instantiating many class name generator.
+  // The warning is only triggered in production.
+  // We expect people from instantiating a class name generator per new request on the server.
+  // The warning is only triggered client side.
   if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
     generatorCounter += 1;
 
@@ -40,17 +44,17 @@ export default function createGenerateClassName(options = {}) {
 
     // Code branch the whole block at the expense of more code.
     if (dangerouslyUseGlobalCSS) {
-      if (styleSheet && styleSheet.options.meta) {
-        let meta = styleSheet.options.meta;
+      if (styleSheet && styleSheet.options.classNamePrefix) {
+        let classNamePrefix = styleSheet.options.classNamePrefix;
         // Sanitize the string as will be used to prefix the generated class name.
-        meta = meta.replace(escapeRegex, '-');
+        classNamePrefix = classNamePrefix.replace(escapeRegex, '-');
 
-        if (meta.match(/^Mui/)) {
-          return `${meta}-${rule.key}`;
+        if (classNamePrefix.match(/^Mui/)) {
+          return `${classNamePrefix}-${rule.key}`;
         }
 
         if (process.env.NODE_ENV !== 'production') {
-          return `${meta}-${rule.key}-${ruleCounter}`;
+          return `${classNamePrefix}-${rule.key}-${ruleCounter}`;
         }
       }
 
@@ -65,12 +69,12 @@ export default function createGenerateClassName(options = {}) {
       return `c${ruleCounter}`;
     }
 
-    if (styleSheet && styleSheet.options.meta) {
-      let meta = styleSheet.options.meta;
+    if (styleSheet && styleSheet.options.classNamePrefix) {
+      let classNamePrefix = styleSheet.options.classNamePrefix;
       // Sanitize the string as will be used to prefix the generated class name.
-      meta = meta.replace(escapeRegex, '-');
+      classNamePrefix = classNamePrefix.replace(escapeRegex, '-');
 
-      return `${meta}-${rule.key}-${ruleCounter}`;
+      return `${classNamePrefix}-${rule.key}-${ruleCounter}`;
     }
 
     return `${rule.key}-${ruleCounter}`;

--- a/src/styles/createGenerateClassName.spec.js
+++ b/src/styles/createGenerateClassName.spec.js
@@ -14,18 +14,35 @@ describe('createGenerateClassName', () => {
     });
   });
 
-  it('should escape correctly', () => {
+  it('should escape parenthesis', () => {
     const generateClassName = createGenerateClassName();
     assert.strictEqual(
       generateClassName(
         { key: 'root' },
         {
           options: {
-            meta: 'pure(MuiButton)',
+            classNamePrefix: 'pure(MuiButton)',
+            jss: {},
           },
         },
       ),
       'pure-MuiButton--root-1',
+    );
+  });
+
+  it('should escape spaces', () => {
+    const generateClassName = createGenerateClassName();
+    assert.strictEqual(
+      generateClassName(
+        { key: 'root' },
+        {
+          options: {
+            classNamePrefix: 'foo bar',
+            jss: {},
+          },
+        },
+      ),
+      'foo-bar-root-1',
     );
   });
 
@@ -41,7 +58,8 @@ describe('createGenerateClassName', () => {
           },
           {
             options: {
-              meta: 'MuiButton',
+              classNamePrefix: 'MuiButton',
+              jss: {},
             },
           },
         ),
@@ -54,7 +72,8 @@ describe('createGenerateClassName', () => {
           },
           {
             options: {
-              meta: 'Button',
+              classNamePrefix: 'Button',
+              jss: {},
             },
           },
         ),
@@ -78,7 +97,7 @@ describe('createGenerateClassName', () => {
   describe('formatting', () => {
     it('should take the sheet meta in development if available', () => {
       const rule = { key: 'root' };
-      const styleSheet = { options: { meta: 'Button' } };
+      const styleSheet = { options: { classNamePrefix: 'Button' } };
       const generateClassName = createGenerateClassName();
       assert.strictEqual(generateClassName(rule, styleSheet), 'Button-root-1');
     });

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -186,6 +186,7 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
 
         const sheet = this.jss.createStyleSheet(styles, {
           meta,
+          classNamePrefix: meta,
           flip: typeof flip === 'boolean' ? flip : theme.direction === 'rtl',
           link: false,
           ...this.sheetOptions,


### PR DESCRIPTION
- Add a new `classNamePrefix` option, and use it over meta.
- Escape whitespace

Closes #9643 