### PR TITLE
[Input] More predictible value behavior

### DIFF
--- a/docs/src/pages/demos/text-fields/InputAdornments.js
+++ b/docs/src/pages/demos/text-fields/InputAdornments.js
@@ -49,7 +49,7 @@ class InputAdornments extends React.Component {
         <FormControl fullWidth className={classes.formControl}>
           <InputLabel htmlFor="amount">Amount</InputLabel>
           <Input
-            id="amount"
+            id="adornment-amount"
             value={this.state.amount}
             onChange={this.handleChange('amount')}
             startAdornment={<InputAdornment position="start">$</InputAdornment>}
@@ -60,7 +60,7 @@ class InputAdornments extends React.Component {
           aria-describedby="weight-helper-text"
         >
           <Input
-            id="weight"
+            id="adornment-weight"
             value={this.state.weight}
             onChange={this.handleChange('weight')}
             endAdornment={<InputAdornment position="end">Kg</InputAdornment>}
@@ -70,7 +70,7 @@ class InputAdornments extends React.Component {
         <FormControl className={classes.formControl}>
           <InputLabel htmlFor="password">Password</InputLabel>
           <Input
-            id="password"
+            id="adornment-password"
             type={this.state.showPassword ? 'text' : 'password'}
             value={this.state.password}
             onChange={this.handleChange('password')}

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -12,7 +12,7 @@ import Textarea from './Textarea';
 // @param value
 // @returns {boolean} true if string (including '') or number (including zero)
 export function hasValue(value) {
-  return value !== undefined && value !== null && !(Array.isArray(value) && value.length === 0);
+  return value != null && !(Array.isArray(value) && value.length === 0);
 }
 
 // Determine if field is dirty (a.k.a. filled).
@@ -232,13 +232,15 @@ class Input extends React.Component {
   };
 
   componentWillMount() {
-    if (this.isControlled()) {
+    this.isControlled = hasValue(this.props.value);
+
+    if (this.isControlled) {
       this.checkDirty(this.props);
     }
   }
 
   componentDidMount() {
-    if (!this.isControlled()) {
+    if (!this.isControlled) {
       this.checkDirty(this.input);
     }
   }
@@ -257,7 +259,7 @@ class Input extends React.Component {
   }
 
   componentWillUpdate(nextProps, nextState, nextContext) {
-    if (this.isControlled(nextProps)) {
+    if (this.isControlled) {
       this.checkDirty(nextProps);
     } // else performed in the onChange
 
@@ -298,7 +300,7 @@ class Input extends React.Component {
   };
 
   handleChange = (event: SyntheticInputEvent<HTMLElement>) => {
-    if (!this.isControlled()) {
+    if (!this.isControlled) {
       this.checkDirty(this.input);
     }
 
@@ -316,14 +318,6 @@ class Input extends React.Component {
       this.props.inputProps.ref(node);
     }
   };
-
-  // A controlled input accepts its current value as a prop.
-  //
-  // @see https://facebook.github.io/react/docs/forms.html#controlled-components
-  // @returns {boolean} true if string (including '') or number (including zero)
-  isControlled(props = this.props) {
-    return hasValue(props.value);
-  }
 
   checkDirty(obj) {
     const { muiFormControl } = this.context;

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -136,14 +136,6 @@ describe('<Input />', () => {
   });
 
   describe('controlled', () => {
-    it('should fire the onDirty callback when moving from uncontrolled to controlled', () => {
-      const handleDirty = spy();
-      const wrapper = shallow(<Input value={undefined} onDirty={handleDirty} />);
-      assert.strictEqual(handleDirty.callCount, 0);
-      wrapper.setProps({ value: 'foo' });
-      assert.strictEqual(handleDirty.callCount, 1);
-    });
-
     ['', 0].forEach(value => {
       describe(`${typeof value} value`, () => {
         let wrapper;
@@ -158,7 +150,7 @@ describe('<Input />', () => {
 
         it('should check that the component is controlled', () => {
           const instance = wrapper.instance();
-          assert.strictEqual(instance.isControlled(), true, 'isControlled() should return true');
+          assert.strictEqual(instance.isControlled, true, 'isControlled should return true');
         });
 
         // don't test number because zero is a dirty state, whereas '' is not
@@ -211,7 +203,7 @@ describe('<Input />', () => {
 
     it('should check that the component is uncontrolled', () => {
       const instance = wrapper.instance();
-      assert.strictEqual(instance.isControlled(), false, 'isControlled() should return false');
+      assert.strictEqual(instance.isControlled, false, 'isControlled should return false');
     });
 
     it('should fire the onDirty callback when dirtied', () => {
@@ -343,32 +335,32 @@ describe('<Input />', () => {
     });
 
     it('should not call checkDirty if controlled', () => {
-      instance.isControlled = () => true;
+      instance.isControlled = true;
       instance.componentDidMount();
       assert.strictEqual(instance.checkDirty.callCount, 0);
     });
 
     it('should call checkDirty if controlled', () => {
-      instance.isControlled = () => false;
+      instance.isControlled = false;
       instance.componentDidMount();
       assert.strictEqual(instance.checkDirty.callCount, 1);
     });
 
     it('should call checkDirty with input value', () => {
-      instance.isControlled = () => false;
+      instance.isControlled = false;
       instance.input = 'woofinput';
       instance.componentDidMount();
       assert.strictEqual(instance.checkDirty.calledWith(instance.input), true);
     });
 
     it('should call or not call checkDirty consistently', () => {
-      instance.isControlled = () => true;
+      instance.isControlled = true;
       instance.componentDidMount();
       assert.strictEqual(instance.checkDirty.callCount, 0);
-      instance.isControlled = () => false;
+      instance.isControlled = false;
       instance.componentDidMount();
       assert.strictEqual(instance.checkDirty.callCount, 1);
-      instance.isControlled = () => true;
+      instance.isControlled = true;
       instance.componentDidMount();
       assert.strictEqual(instance.checkDirty.callCount, 1);
     });


### PR DESCRIPTION
At first, I thought that this change was a breaking one. But it turns out, the logic is only useful for a specific condition.
```jsx
import React from 'react';
import Input from 'material-ui/Input';

class Inputs extends React.Component {
  state = {
    defaultValue: 'hihi',
  };

  handleChange = event => {
    if (event.target.value === 'test') {
      this.setState({
        value: 'test completed',
      });
    }
  };

  render() {
    const { value, defaultValue } = this.state;
    return <Input value={value} defaultValue={defaultValue} onChange={this.handleChange} />;
  }
}

export default Inputs;
```

A condition where React is already raising a warning:
> main.js:1057 Warning: A component is changing an uncontrolled input of type text to be controlled. Input elements should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://fb.me/react-controlled-components

Closes #9525 
