### PR TITLE
[docs] Interop guide: change Global CSS link from API to description

### DIFF
--- a/docs/src/pages/guides/interoperability.md
+++ b/docs/src/pages/guides/interoperability.md
@@ -58,7 +58,7 @@ export default RawCSSButton;
 
 Explicitly providing the class names to the component is too much effort?
 Rest assured, we provide an option to make the class names **deterministic** for quick
-prototyping: [`dangerouslyUseGlobalCSS`](/customization/css-in-js#creategenerateclassname-options-class-name-generator).
+prototyping: [`dangerouslyUseGlobalCSS`](/customization/css-in-js#global-css).
 
 **GlobalCSSButton.css**
 ```css


### PR DESCRIPTION
So that devs following that link see the warning.