### PR TITLE
[Snackbar] Allow consecutive messages to display

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -110,7 +110,7 @@ class Snackbar extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (nextProps.open && this.state.exited) {
+    if (nextProps.open) {
       this.setState({ exited: false });
     }
   }

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -57,18 +57,19 @@ describe('<Snackbar />', () => {
     after(() => {
       clock.restore();
     });
-    it('should allow for consecutive messages', () => {
+
+    it('should support synchronous onExited callback', () => {
       const messageCount = 2;
       let wrapper;
       const handleCloseSpy = spy();
       const handleClose = () => {
-        wrapper.setProps({ open: false }); // Parent state updated
+        wrapper.setProps({ open: false });
         handleCloseSpy();
       };
       const handleExitedSpy = spy();
       const handleExited = () => {
         handleExitedSpy();
-        if (handleExitedSpy.callCount <= messageCount) {
+        if (handleExitedSpy.callCount < messageCount) {
           wrapper.setProps({ open: true });
         }
       };
@@ -80,11 +81,22 @@ describe('<Snackbar />', () => {
           onExited={handleExited}
           message="message"
           autoHideDuration={duration}
-          transitionDuration={duration}
+          transitionDuration={duration / 2}
         />,
       );
+      assert.strictEqual(handleCloseSpy.callCount, 0);
+      assert.strictEqual(handleExitedSpy.callCount, 0);
       wrapper.setProps({ open: true });
-      clock.tick(messageCount * (duration * 2));
+      clock.tick(duration);
+      assert.strictEqual(handleCloseSpy.callCount, 1);
+      assert.strictEqual(handleExitedSpy.callCount, 0);
+      clock.tick(duration / 2);
+      assert.strictEqual(handleCloseSpy.callCount, 1);
+      assert.strictEqual(handleExitedSpy.callCount, 1);
+      clock.tick(duration);
+      assert.strictEqual(handleCloseSpy.callCount, messageCount);
+      assert.strictEqual(handleExitedSpy.callCount, 1);
+      clock.tick(duration / 2);
       assert.strictEqual(handleCloseSpy.callCount, messageCount);
       assert.strictEqual(handleExitedSpy.callCount, messageCount);
     });

--- a/src/Snackbar/Snackbar.spec.js
+++ b/src/Snackbar/Snackbar.spec.js
@@ -47,6 +47,49 @@ describe('<Snackbar />', () => {
     });
   });
 
+  describe('Consecutive messages', () => {
+    let clock;
+
+    before(() => {
+      clock = useFakeTimers();
+    });
+
+    after(() => {
+      clock.restore();
+    });
+    it('should allow for consecutive messages', () => {
+      const messageCount = 2;
+      let wrapper;
+      const handleCloseSpy = spy();
+      const handleClose = () => {
+        wrapper.setProps({ open: false }); // Parent state updated
+        handleCloseSpy();
+      };
+      const handleExitedSpy = spy();
+      const handleExited = () => {
+        handleExitedSpy();
+        if (handleExitedSpy.callCount <= messageCount) {
+          wrapper.setProps({ open: true });
+        }
+      };
+      const duration = 250;
+      wrapper = mount(
+        <Snackbar
+          open={false}
+          onClose={handleClose}
+          onExited={handleExited}
+          message="message"
+          autoHideDuration={duration}
+          transitionDuration={duration}
+        />,
+      );
+      wrapper.setProps({ open: true });
+      clock.tick(messageCount * (duration * 2));
+      assert.strictEqual(handleCloseSpy.callCount, messageCount);
+      assert.strictEqual(handleExitedSpy.callCount, messageCount);
+    });
+  });
+
   describe('prop: autoHideDuration', () => {
     let clock;
 


### PR DESCRIPTION
Currently I can't get consecutive messages like this https://storage.googleapis.com/material-design/publish/material_v_12/assets/0B6Okdz75tqQsX3VhUHNoaWVEbDQ/components-snackbars-usage-consecutivesbdifferenttype-005.webm to render. I think this is because the state change that is called in `handleExited` is not effectuated until the next render, so the `componentWillReceiveProps` still sees the outdated state, so `exited` is not returned to `false`. I've added a test which shows how to use consecutive messages and this fails without the PR applied. 