### PR TITLE
[styles] Reduce the likeliness of conflict

### DIFF
--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -62,7 +62,7 @@ can implement optimizations for development and production.
 They are easy to debug in development and as short as possible in production:
 
 - development: `.MuiAppBar-root-12`
-- production: `.c12`
+- production: `.jss12`
 
 If you don't like this default behavior, you can change it.
 JSS relies on the concept of [class name generator](http://cssinjs.org/js-api/#generate-your-own-class-names).
@@ -184,11 +184,11 @@ For instance, it can be used to defined a `getInitialProps()` static method (nex
 It will be linked to the component.
 Use the function signature if you need to have access to the theme. It's provided as the first argument.
 2. `options` (*Object* [optional]):
-  - `options.withTheme` (Boolean [optional]): Provide the `theme` object to the component as a property. It's `false` by default.
-  - `options.name` (*String* [optional]): The name of the style sheet. Useful for debugging.
+  - `options.withTheme` (Boolean [optional]): Default to `false`. Provide the `theme` object to the component as a property.
+  - `options.name` (*String* [optional]): Default to `null`. The name of the style sheet. Useful for debugging.
     If the value isn't provided, we will try to fallback to the name of the component.
-  - `options.flip` (*Boolean* [optional]): When set to false, this sheet will opt-out of `rtl` transformation.
-  - The other keys are forwarded to the options argument of [jss.createStyleSheet()](http://cssinjs.org/js-api/#create-style-sheet).
+  - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, we follow `theme.direction`.
+  - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](http://cssinjs.org/js-api/#create-style-sheet).
 
 #### Returns
 
@@ -242,7 +242,8 @@ A function which returns a class name generator function.
 #### Arguments
 
 1. `options` (*Object* [optional]):
-  - `options.dangerouslyUseGlobalCSS` (Boolean [optional]): Makes the Material-UI class names deterministic. It's `false` by default.
+  - `options.dangerouslyUseGlobalCSS` (*Boolean* [optional]): Default to `false`. Makes the Material-UI class names deterministic.
+  - `options.productionPrefix` (*String* [optional]): Default to `'jss'`. The string used to prefix the class names in production.
 
 #### Returns
 
@@ -258,6 +259,7 @@ import { createGenerateClassName } from 'material-ui/styles';
 
 const generateClassName = createGenerateClassName({
   dangerouslyUseGlobalCSS: true,
+  productionPrefix: 'c',
 });
 const jss = create(preset());
 

--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -184,10 +184,10 @@ For instance, it can be used to defined a `getInitialProps()` static method (nex
 It will be linked to the component.
 Use the function signature if you need to have access to the theme. It's provided as the first argument.
 2. `options` (*Object* [optional]):
-  - `options.withTheme` (Boolean [optional]): Default to `false`. Provide the `theme` object to the component as a property.
-  - `options.name` (*String* [optional]): Default to `null`. The name of the style sheet. Useful for debugging.
-    If the value isn't provided, we will try to fallback to the name of the component.
-  - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, we follow `theme.direction`.
+  - `options.withTheme` (Boolean [optional]): Defaults to `false`. Provide the `theme` object to the component as a property.
+  - `options.name` (*String* [optional]): The name of the style sheet. Useful for debugging.
+    If the value isn't provided, it will try to fallback to the name of the component.
+  - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, it follows `theme.direction`.
   - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](http://cssinjs.org/js-api/#create-style-sheet).
 
 #### Returns
@@ -242,8 +242,8 @@ A function which returns a class name generator function.
 #### Arguments
 
 1. `options` (*Object* [optional]):
-  - `options.dangerouslyUseGlobalCSS` (*Boolean* [optional]): Default to `false`. Makes the Material-UI class names deterministic.
-  - `options.productionPrefix` (*String* [optional]): Default to `'jss'`. The string used to prefix the class names in production.
+  - `options.dangerouslyUseGlobalCSS` (*Boolean* [optional]): Defaults to `false`. Makes the Material-UI class names deterministic.
+  - `options.productionPrefix` (*String* [optional]): Defaults to `'jss'`. The string used to prefix the class names in production.
 
 #### Returns
 

--- a/src/styles/createGenerateClassName.js
+++ b/src/styles/createGenerateClassName.js
@@ -13,11 +13,12 @@ export default function createGenerateClassName(options = {}) {
   const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;
   let ruleCounter = 0;
 
-  // - HMR can lead us to instantiating many class name generator.
-  // The warning is only triggered in production.
-  // - We expect people from instantiating a class name generator per new request on the server.
-  // The warning is only triggered client side.
-  // - People can get away by modifying the productionPrefix.
+  // - HMR can lead to many class name generators being instantiated,
+  // so the warning is only triggered in production.
+  // - We expect a class name generator to be instantiated per new request on the server,
+  // so the warning is only triggered client side.
+  // - People can get away with multiple class name generator
+  // by modifying the `productionPrefix`.
   if (
     process.env.NODE_ENV === 'production' &&
     typeof window !== 'undefined' &&

--- a/src/styles/createGenerateClassName.js
+++ b/src/styles/createGenerateClassName.js
@@ -9,15 +9,20 @@ let generatorCounter = 0;
 // It's inspired by
 // https://github.com/cssinjs/jss/blob/4e6a05dd3f7b6572fdd3ab216861d9e446c20331/src/utils/createGenerateClassName.js
 export default function createGenerateClassName(options = {}) {
-  const { dangerouslyUseGlobalCSS = false } = options;
+  const { dangerouslyUseGlobalCSS = false, productionPrefix = 'jss' } = options;
   const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;
   let ruleCounter = 0;
 
-  // HMR can lead us to instantiating many class name generator.
+  // - HMR can lead us to instantiating many class name generator.
   // The warning is only triggered in production.
-  // We expect people from instantiating a class name generator per new request on the server.
+  // - We expect people from instantiating a class name generator per new request on the server.
   // The warning is only triggered client side.
-  if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
+  // - People can get away by modifying the productionPrefix.
+  if (
+    process.env.NODE_ENV === 'production' &&
+    typeof window !== 'undefined' &&
+    productionPrefix === 'jss'
+  ) {
     generatorCounter += 1;
 
     if (generatorCounter > 2) {
@@ -45,36 +50,36 @@ export default function createGenerateClassName(options = {}) {
     // Code branch the whole block at the expense of more code.
     if (dangerouslyUseGlobalCSS) {
       if (styleSheet && styleSheet.options.classNamePrefix) {
-        let classNamePrefix = styleSheet.options.classNamePrefix;
+        let prefix = styleSheet.options.classNamePrefix;
         // Sanitize the string as will be used to prefix the generated class name.
-        classNamePrefix = classNamePrefix.replace(escapeRegex, '-');
+        prefix = prefix.replace(escapeRegex, '-');
 
-        if (classNamePrefix.match(/^Mui/)) {
-          return `${classNamePrefix}-${rule.key}`;
+        if (prefix.match(/^Mui/)) {
+          return `${prefix}-${rule.key}`;
         }
 
         if (process.env.NODE_ENV !== 'production') {
-          return `${classNamePrefix}-${rule.key}-${ruleCounter}`;
+          return `${prefix}-${rule.key}-${ruleCounter}`;
         }
       }
 
       if (process.env.NODE_ENV === 'production') {
-        return `c${ruleCounter}`;
+        return `${productionPrefix}${ruleCounter}`;
       }
 
       return `${rule.key}-${ruleCounter}`;
     }
 
     if (process.env.NODE_ENV === 'production') {
-      return `c${ruleCounter}`;
+      return `${productionPrefix}${ruleCounter}`;
     }
 
     if (styleSheet && styleSheet.options.classNamePrefix) {
-      let classNamePrefix = styleSheet.options.classNamePrefix;
+      let prefix = styleSheet.options.classNamePrefix;
       // Sanitize the string as will be used to prefix the generated class name.
-      classNamePrefix = classNamePrefix.replace(escapeRegex, '-');
+      prefix = prefix.replace(escapeRegex, '-');
 
-      return `${classNamePrefix}-${rule.key}-${ruleCounter}`;
+      return `${prefix}-${rule.key}-${ruleCounter}`;
     }
 
     return `${rule.key}-${ruleCounter}`;

--- a/src/styles/createGenerateClassName.spec.js
+++ b/src/styles/createGenerateClassName.spec.js
@@ -140,7 +140,7 @@ describe('createGenerateClassName', () => {
       it('should output a short representation', () => {
         const rule = { key: 'root' };
         const generateClassName = createGenerateClassName();
-        assert.strictEqual(generateClassName(rule), 'c1');
+        assert.strictEqual(generateClassName(rule), 'jss1');
       });
 
       it('should work with global CSS', () => {
@@ -148,7 +148,7 @@ describe('createGenerateClassName', () => {
         const generateClassName = createGenerateClassName({
           dangerouslyUseGlobalCSS: true,
         });
-        assert.strictEqual(generateClassName(rule), 'c1');
+        assert.strictEqual(generateClassName(rule), 'jss1');
       });
 
       it('should warn', () => {

--- a/src/styles/getStylesCreator.js
+++ b/src/styles/getStylesCreator.js
@@ -2,8 +2,10 @@ import warning from 'warning';
 import deepmerge from 'deepmerge'; // < 1kb payload overhead when lodash/merge is > 3kb.
 
 function getStylesCreator(stylesOrCreator) {
+  const themingEnabled = typeof stylesOrCreator === 'function';
+
   function create(theme, name) {
-    const styles = typeof stylesOrCreator === 'function' ? stylesOrCreator(theme) : stylesOrCreator;
+    const styles = themingEnabled ? stylesOrCreator(theme) : stylesOrCreator;
 
     if (!theme.overrides || !name || !theme.overrides[name]) {
       return styles;
@@ -28,10 +30,8 @@ function getStylesCreator(stylesOrCreator) {
 
   return {
     create,
-    options: {
-      index: undefined,
-    },
-    themingEnabled: typeof stylesOrCreator === 'function',
+    options: {},
+    themingEnabled,
   };
 }
 

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -69,10 +69,8 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
   const stylesCreator = getStylesCreator(stylesOrCreator);
   const listenToTheme = stylesCreator.themingEnabled || withTheme || typeof name === 'string';
 
-  if (stylesCreator.options.index === undefined) {
-    indexCounter += 1;
-    stylesCreator.options.index = indexCounter;
-  }
+  indexCounter += 1;
+  stylesCreator.options.index = indexCounter;
 
   warning(
     indexCounter < 0,
@@ -86,10 +84,9 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
     constructor(props, context) {
       super(props, context);
 
-      const { muiThemeProviderOptions } = this.context;
-
       this.jss = this.context[ns.jss] || jss;
 
+      const { muiThemeProviderOptions } = this.context;
       if (muiThemeProviderOptions) {
         if (muiThemeProviderOptions.sheetsManager) {
           this.sheetsManager = muiThemeProviderOptions.sheetsManager;


### PR DESCRIPTION
This is at the expense of longer class names in production. People can tweak it as they see fit with `productionPrefix`.
