### PR TITLE
[Avatar] Handle non-square images

### DIFF
--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -24,10 +24,11 @@ export const styles = theme => ({
     backgroundColor: emphasize(theme.palette.background.default, 0.26),
   },
   img: {
-    maxWidth: '100%',
     width: '100%',
-    height: 'auto',
+    height: '100%',
     textAlign: 'center',
+    // Handle non-square image. The property isn't supported by IE11.
+    objectFit: 'cover',
   },
 });
 


### PR DESCRIPTION
Apply https://github.com/mui-org/material-ui/issues/6142#issuecomment-351603662 of @igorbt. We sacrifice 3.32% of the market share (IE11) for the good of 96.68%.