### PR TITLE
[docs] Fix missing sandbox files

### DIFF
--- a/docs/src/pages/customization/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js.md
@@ -37,7 +37,7 @@ When rendering on the server, you will need to get all rendered styles as a CSS 
 The `SheetsRegistry` class allows you to manually aggregate and stringify them.
 Read more about [Server Rendering](/guides/server-rendering).
 
-{{"demo": "pages/customization/JssRegistry.js"}}
+{{"demo": "pages/customization/JssRegistry.js", "hideEditButton": true}}
 
 ## Sheets manager
 

--- a/docs/src/pages/customization/overrides.md
+++ b/docs/src/pages/customization/overrides.md
@@ -58,7 +58,7 @@ You might need to create a variation of a component and use it in different cont
 
 The best approach is to follow option 1 and then take advantage of the composition power of React by exporting your customized component to use wherever you need it.
 
-{{"demo": "pages/customization/OverridesComponent.js"}}
+{{"demo": "pages/customization/OverridesComponent.js", "hideEditButton": true}}
 
 ## 3. Material Design variations
 

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -73,7 +73,7 @@ html {
 
 You can make a theme dark by setting `type` to `dark`.
 
-{{"demo": "pages/customization/DarkTheme.js"}}
+{{"demo": "pages/customization/DarkTheme.js", "hideEditButton": true}}
 
 ### The other variables
 

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -80,7 +80,7 @@ You can make a theme dark by setting `type` to `dark`.
 We have tried to normalize the implementation by adding many more variables: typography, breakpoints, transitions, etc. You can see below what the theme object looks like with the default values.
 If you want to learn more, we suggesting having a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/v1-beta/src/styles/createMuiTheme.js).
 
-{{"demo": "pages/customization/ThemeDefault.js"}}
+{{"demo": "pages/customization/ThemeDefault.js", "hideEditButton": true}}
 
 ### Adding custom styles
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Resolves #9683.  

I disabled the two demos mentioned by @oliviertassinari 
- https://github.com/mui-org/material-ui/blob/ee199f60e30513ed26054a6fdebfe9048eaa4a19/docs/src/pages/customization/themes.md#darklight-theme
- https://github.com/mui-org/material-ui/blob/ee199f60e30513ed26054a6fdebfe9048eaa4a19/docs/src/pages/customization/css-in-js.md#sheets-registry

I also found two others that do no work in sandbox. If these should be removed as well i can update the PR. 

- https://github.com/mui-org/material-ui/blob/v1-beta/docs/src/pages/customization/themes.md#the-other-variables
- https://github.com/mui-org/material-ui/blob/v1-beta/docs/src/pages/customization/overrides.md#2-specific-variation-of-a-component

cc @mbrookes 

