### PR TITLE
[typescript] Use React.ReactType instead of string | ComponentType

### DIFF
--- a/src/Avatar/Avatar.d.ts
+++ b/src/Avatar/Avatar.d.ts
@@ -5,7 +5,7 @@ export interface AvatarProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, AvatarClassKey> {
   alt?: string;
   childrenClassName?: string;
-  component?: string | React.ComponentType<AvatarProps>;
+  component?: React.ReactType<AvatarProps>;
   imgProps?: Object;
   sizes?: string;
   src?: string;

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -4,7 +4,7 @@ import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 
 export interface ButtonProps extends StandardProps<ButtonBaseProps, ButtonClassKey, 'component'> {
   color?: PropTypes.Color | 'contrast';
-  component?: string | React.ComponentType<ButtonProps>;
+  component?: React.ReactType<ButtonProps>;
   dense?: boolean;
   disabled?: boolean;
   disableFocusRipple?: boolean;

--- a/src/ButtonBase/ButtonBase.d.ts
+++ b/src/ButtonBase/ButtonBase.d.ts
@@ -7,7 +7,7 @@ export interface ButtonBaseProps
       ButtonBaseClassKey
     > {
   centerRipple?: boolean;
-  component?: string | React.ComponentType<ButtonBaseProps>;
+  component?: React.ReactType<ButtonBaseProps>;
   disableRipple?: boolean;
   focusRipple?: boolean;
   keyboardFocusedClassName?: string;

--- a/src/Card/CardHeader.d.ts
+++ b/src/Card/CardHeader.d.ts
@@ -6,7 +6,7 @@ export interface CardHeaderProps
   extends StandardProps<CardContentProps, CardHeaderClassKey, 'title'> {
   action?: React.ReactNode;
   avatar?: React.ReactNode;
-  component?: string | React.ComponentType<CardHeaderProps>;
+  component?: React.ReactType<CardHeaderProps>;
   subheader?: React.ReactNode;
   title?: React.ReactNode;
 }

--- a/src/Card/CardMedia.d.ts
+++ b/src/Card/CardMedia.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface CardMediaProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, CardMediaClassKey> {
-  component?: string | React.ComponentType<CardMediaProps>;
+  component?: React.ReactType<CardMediaProps>;
   image?: string;
   src?: string;
 }

--- a/src/Form/FormControl.d.ts
+++ b/src/Form/FormControl.d.ts
@@ -3,7 +3,7 @@ import { StandardProps, PropTypes } from '..';
 
 export interface FormControlProps
   extends StandardProps<React.HtmlHTMLAttributes<HTMLDivElement>, FormControlClassKey> {
-  component?: string | React.ComponentType<FormControlProps>;
+  component?: React.ReactType<FormControlProps>;
   disabled?: boolean;
   error?: boolean;
   fullWidth?: boolean;

--- a/src/Form/FormLabel.d.ts
+++ b/src/Form/FormLabel.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface FormLabelProps extends StandardProps<FormLabelBaseProps, FormLabelClassKey> {
-  component?: string | React.ComponentType<FormLabelBaseProps>;
+  component?: React.ReactType<FormLabelBaseProps>;
   disabled?: boolean;
   error?: boolean;
   focused?: boolean;

--- a/src/GridList/GridList.d.ts
+++ b/src/GridList/GridList.d.ts
@@ -5,7 +5,7 @@ export interface GridListProps
   extends StandardProps<React.HTMLAttributes<HTMLUListElement>, GridListClassKey> {
   cellHeight?: number | 'auto';
   cols?: number;
-  component?: string | React.ComponentType<GridListProps>;
+  component?: React.ReactType<GridListProps>;
   spacing?: number;
 }
 

--- a/src/GridList/GridListTile.d.ts
+++ b/src/GridList/GridListTile.d.ts
@@ -4,7 +4,7 @@ import { StandardProps } from '..';
 export interface GridListTileProps
   extends StandardProps<React.HTMLAttributes<HTMLLIElement>, GridListTileClassKey> {
   cols?: number;
-  component?: string | React.ComponentType<GridListTileProps>;
+  component?: React.ReactType<GridListTileProps>;
   rows?: number;
 }
 

--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -16,7 +16,7 @@ export interface InputProps
   error?: boolean;
   fullWidth?: boolean;
   id?: string;
-  inputComponent?: string | React.ComponentType<InputProps>;
+  inputComponent?: React.ReactType<InputProps>;
   inputProps?:
     | React.TextareaHTMLAttributes<HTMLTextAreaElement>
     | React.InputHTMLAttributes<HTMLInputElement>;

--- a/src/Input/InputAdornment.d.ts
+++ b/src/Input/InputAdornment.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface InputAdornmentProps extends StandardProps<{}, InputAdornmentClassKey> {
-  component?: string | React.ComponentType<InputAdornmentProps>;
+  component?: React.ReactType<InputAdornmentProps>;
   disableTypography?: boolean;
   position: 'start' | 'end';
 }

--- a/src/List/List.d.ts
+++ b/src/List/List.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface ListProps
   extends StandardProps<React.HTMLAttributes<HTMLUListElement>, ListClassKey> {
-  component?: string | React.ComponentType<ListProps>;
+  component?: React.ReactType<ListProps>;
   dense?: boolean;
   disablePadding?: boolean;
   rootRef?: React.Ref<any>;

--- a/src/List/ListItem.d.ts
+++ b/src/List/ListItem.d.ts
@@ -9,7 +9,7 @@ export interface ListItemProps
       'component'
     > {
   button?: boolean;
-  component?: string | React.ComponentType<ListItemProps>;
+  component?: React.ReactType<ListItemProps>;
   dense?: boolean;
   disabled?: boolean;
   disableGutters?: boolean;

--- a/src/List/ListSubheader.d.ts
+++ b/src/List/ListSubheader.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface ListSubheaderProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ListSubheaderClassKey> {
-  component?: string | React.ComponentType<ListSubheaderProps>;
+  component?: React.ReactType<ListSubheaderProps>;
   color?: 'default' | 'primary' | 'inherit';
   inset?: boolean;
   disableSticky?: boolean;

--- a/src/Menu/MenuItem.d.ts
+++ b/src/Menu/MenuItem.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { ListItemProps, ListItemClassKey } from '../List';
 
 export interface MenuItemProps extends StandardProps<ListItemProps, MenuItemClassKey> {
-  component?: string | React.ComponentType<MenuItemProps>;
+  component?: React.ReactType<MenuItemProps>;
   role?: string;
   selected?: boolean;
 }

--- a/src/Modal/Modal.d.ts
+++ b/src/Modal/Modal.d.ts
@@ -8,7 +8,7 @@ export interface ModalProps
       React.HtmlHTMLAttributes<HTMLDivElement> & Partial<PortalProps>,
       ModalClassKey
     > {
-  BackdropComponent?: string | React.ComponentType<BackdropProps>;
+  BackdropComponent?: React.ReactType<BackdropProps>;
   BackdropProps?: BackdropProps;
   disableAutoFocus?: boolean;
   disableBackdropClick?: boolean;

--- a/src/Paper/Paper.d.ts
+++ b/src/Paper/Paper.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface PaperProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, PaperClassKey> {
-  component?: string | React.ComponentType<PaperProps>;
+  component?: React.ReactType<PaperProps>;
   elevation?: number;
   square?: boolean;
 }

--- a/src/Table/Table.d.ts
+++ b/src/Table/Table.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface TableProps extends StandardProps<TableBaseProps, TableClassKey> {
-  component?: string | React.ComponentType<TableBaseProps>;
+  component?: React.ReactType<TableBaseProps>;
 }
 
 export type TableBaseProps = React.TableHTMLAttributes<HTMLTableElement>;

--- a/src/Table/TableBody.d.ts
+++ b/src/Table/TableBody.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface TableBodyProps extends StandardProps<TableBodyBaseProps, TableBodyClassKey> {
-  component?: string | React.ComponentType<TableBodyBaseProps>;
+  component?: React.ReactType<TableBodyBaseProps>;
 }
 
 export type TableBodyBaseProps = React.HTMLAttributes<HTMLTableSectionElement>;

--- a/src/Table/TableCell.d.ts
+++ b/src/Table/TableCell.d.ts
@@ -10,7 +10,7 @@ import { StandardProps } from '..';
  * here.
  */
 export interface TableCellProps extends StandardProps<TableCellBaseProps, TableCellClassKey> {
-  component?: string | React.ComponentType<TableCellBaseProps>;
+  component?: React.ReactType<TableCellBaseProps>;
   padding?: Padding;
   numeric?: boolean;
 }

--- a/src/Table/TableFooter.d.ts
+++ b/src/Table/TableFooter.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface TableFooterProps extends StandardProps<TableFooterBaseProps, TableFooterClassKey> {
-  component?: string | React.ComponentType<TableFooterBaseProps>;
+  component?: React.ReactType<TableFooterBaseProps>;
 }
 
 export type TableFooterBaseProps = React.HTMLAttributes<HTMLTableSectionElement>;

--- a/src/Table/TableHead.d.ts
+++ b/src/Table/TableHead.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface TableHeadProps extends StandardProps<TableHeadBaseProps, TableHeadClassKey> {
-  component?: string | React.ComponentType<TableHeadBaseProps>;
+  component?: React.ReactType<TableHeadBaseProps>;
 }
 
 export type TableHeadBaseProps = React.HTMLAttributes<HTMLTableSectionElement>;

--- a/src/Table/TablePagination.d.ts
+++ b/src/Table/TablePagination.d.ts
@@ -12,7 +12,7 @@ export interface LabelDisplayedRowsArgs {
 export interface TablePaginationProps
   extends StandardProps<TablePaginationBaseProps, TablePaginationClassKey> {
   backIconButtonProps?: Object;
-  component?: string | React.ComponentType<TablePaginationBaseProps>;
+  component?: React.ReactType<TablePaginationBaseProps>;
   count: number;
   labelDisplayedRows?: (paginationInfo: LabelDisplayedRowsArgs) => React.ReactNode;
   labelRowsPerPage?: React.ReactNode;

--- a/src/Table/TableRow.d.ts
+++ b/src/Table/TableRow.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface TableRowProps extends StandardProps<TableRowBaseProps, TableRowClassKey> {
-  component?: string | React.ComponentType<TableRowBaseProps>;
+  component?: React.ReactType<TableRowBaseProps>;
   hover?: boolean;
   selected?: boolean;
 }

--- a/src/Typography/Typography.d.ts
+++ b/src/Typography/Typography.d.ts
@@ -6,7 +6,7 @@ export interface TypographyProps
   extends StandardProps<React.HTMLAttributes<HTMLElement>, TypographyClassKey> {
   align?: PropTypes.Alignment;
   color?: PropTypes.Color | 'secondary' | 'error';
-  component?: string | React.ComponentType<TypographyProps>;
+  component?: React.ReactType<TypographyProps>;
   gutterBottom?: boolean;
   headlineMapping?: { [type in TextStyle]: string };
   noWrap?: boolean;

--- a/src/transitions/Collapse.d.ts
+++ b/src/transitions/Collapse.d.ts
@@ -7,7 +7,7 @@ export interface CollapseProps
   extends StandardProps<TransitionProps, CollapseClassKey, 'children'> {
   children?: React.ReactNode;
   collapsedHeight?: string;
-  component?: string | React.ComponentType<CollapseProps>;
+  component?: React.ReactType<CollapseProps>;
   containerProps?: Object;
   theme?: Theme;
   timeout?: TransitionDuration | 'auto';


### PR DESCRIPTION
Since `React.ReactType` can now be parameterized by prop types, we can use it to simplify the typings of all our `component` props.