### PR TITLE
[BottomNavigation] Rename BottomNavigationButton to BottomNavigationAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ None, merry christmas 🎄.
 - [Select] Typo fix (#9567) @bordagabor
 - [CardHeader] Add conditional rendering of the subheader (#9572) @jwwisgerhof
 - [Tooltip] children should be an element (#9568) @oliviertassinari
-- [BottomNavigationButton] onClick and onChange handler overwritten (#9564) @kgregory
+- [BottomNavigationAction] onClick and onChange handler overwritten (#9564) @kgregory
 - [typescript] Add typings to reactHelpers (#9565) @SSW-SCIENTIFIC
 - [TablePagination] Make onChangeRowsPerPage optional (#9563) @evantrimboli
 - [Toolbar] Make the children optional (#9581) @oliviertassinari
@@ -1292,7 +1292,7 @@ If you want to avoid the default browser required property handling, you can add
 - [FormControlLabel] Allow for node in the label prop (#7903) @Taldrain
 - [ListItemIcon] Icon should not shrink fixes (#7917) @gulderov
 - [withResponsiveFullScreen] missed type import (#7926) @rosskevin
-- [typescript] Fixes/improvements for withWith/withStyle/BottomNavigationButton (#7897) @sebald
+- [typescript] Fixes/improvements for withWith/withStyle/BottomNavigationAction (#7897) @sebald
 - [typescript] Update typings to popover changes (#7937) @sebald
 - [Popover] Expose the component (#7927) @oliviertassinari
 - [ButtonBase] Better warning message (#7904) @oliviertassinari

--- a/docs/src/pages/demos/bottom-navigation/LabelBottomNavigation.js
+++ b/docs/src/pages/demos/bottom-navigation/LabelBottomNavigation.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
-import BottomNavigation, { BottomNavigationButton } from 'material-ui/BottomNavigation';
+import BottomNavigation, { BottomNavigationAction } from 'material-ui/BottomNavigation';
 import RestoreIcon from 'material-ui-icons/Restore';
 import FavoriteIcon from 'material-ui-icons/Favorite';
 import LocationOnIcon from 'material-ui-icons/LocationOn';
@@ -28,10 +28,10 @@ class LabelBottomNavigation extends React.Component {
 
     return (
       <BottomNavigation value={value} onChange={this.handleChange} className={classes.root}>
-        <BottomNavigationButton label="Recents" value="recents" icon={<RestoreIcon />} />
-        <BottomNavigationButton label="Favorites" value="favorites" icon={<FavoriteIcon />} />
-        <BottomNavigationButton label="Nearby" value="nearby" icon={<LocationOnIcon />} />
-        <BottomNavigationButton label="Folder" value="folder" icon={<FolderIcon />} />
+        <BottomNavigationAction label="Recents" value="recents" icon={<RestoreIcon />} />
+        <BottomNavigationAction label="Favorites" value="favorites" icon={<FavoriteIcon />} />
+        <BottomNavigationAction label="Nearby" value="nearby" icon={<LocationOnIcon />} />
+        <BottomNavigationAction label="Folder" value="folder" icon={<FolderIcon />} />
       </BottomNavigation>
     );
   }

--- a/docs/src/pages/demos/bottom-navigation/SimpleBottomNavigation.js
+++ b/docs/src/pages/demos/bottom-navigation/SimpleBottomNavigation.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
-import BottomNavigation, { BottomNavigationButton } from 'material-ui/BottomNavigation';
+import BottomNavigation, { BottomNavigationAction } from 'material-ui/BottomNavigation';
 import RestoreIcon from 'material-ui-icons/Restore';
 import FavoriteIcon from 'material-ui-icons/Favorite';
 import LocationOnIcon from 'material-ui-icons/LocationOn';
@@ -32,9 +32,9 @@ class SimpleBottomNavigation extends React.Component {
         showLabels
         className={classes.root}
       >
-        <BottomNavigationButton label="Recents" icon={<RestoreIcon />} />
-        <BottomNavigationButton label="Favorites" icon={<FavoriteIcon />} />
-        <BottomNavigationButton label="Nearby" icon={<LocationOnIcon />} />
+        <BottomNavigationAction label="Recents" icon={<RestoreIcon />} />
+        <BottomNavigationAction label="Favorites" icon={<FavoriteIcon />} />
+        <BottomNavigationAction label="Nearby" icon={<LocationOnIcon />} />
       </BottomNavigation>
     );
   }

--- a/docs/src/pages/demos/bottom-navigation/bottom-navigation.md
+++ b/docs/src/pages/demos/bottom-navigation/bottom-navigation.md
@@ -1,5 +1,5 @@
 ---
-components: BottomNavigation, BottomNavigationButton
+components: BottomNavigation, BottomNavigationAction
 ---
 
 # Bottom Navigation

--- a/pages/api/bottom-navigation-action.js
+++ b/pages/api/bottom-navigation-action.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import withRoot from 'docs/src/modules/components/withRoot';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
-import markdown from './bottom-navigation-button.md';
+import markdown from './bottom-navigation-action.md';
 
 function Page() {
   return <MarkdownDocs markdown={markdown} />;

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -1,10 +1,10 @@
 ---
-filename: /src/BottomNavigation/BottomNavigationButton.js
+filename: /src/BottomNavigation/BottomNavigationAction.js
 ---
 
 <!--- This documentation is automatically generated, do not try to edit it. -->
 
-# BottomNavigationButton
+# BottomNavigationAction
 
 
 
@@ -15,7 +15,7 @@ filename: /src/BottomNavigation/BottomNavigationButton.js
 | classes | object |  | Useful to extend the style applied to components. |
 | icon | node |  | The icon element. If a string is provided, it will be used as a font ligature. |
 | label | node |  | The label element. |
-| showLabel | bool |  | If `true`, the BottomNavigationButton will show its label. |
+| showLabel | bool |  | If `true`, the BottomNavigationAction will show its label. |
 | value | any |  | You can provide your own value. Otherwise, we fallback to the child position index. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
@@ -34,12 +34,12 @@ This property accepts the following keys:
 - `icon`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/BottomNavigation/BottomNavigationButton.js)
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/BottomNavigation/BottomNavigationAction.js)
 for more detail.
 
 If using the `overrides` key of the theme as documented
 [here](/customization/themes#customizing-all-instances-of-a-component-type),
-you need to use the following style sheet name: `MuiBottomNavigationButton`.
+you need to use the following style sheet name: `MuiBottomNavigationAction`.
 
 ## Inheritance
 

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -15,8 +15,8 @@ filename: /src/BottomNavigation/BottomNavigation.js
 | <span style="color: #31a148">children *</span> | node |  | The content of the component. |
 | classes | object |  | Useful to extend the style applied to components. |
 | onChange | func |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: any) => void`<br>*event:* The event source of the callback<br>*value:* We default to the index of the child |
-| showLabels | bool | false | If `true`, all `BottomNavigationButton`s will show their labels. By default only the selected `BottomNavigationButton` will show its label. |
-| value | any |  | The value of the currently selected `BottomNavigationButton`. |
+| showLabels | bool | false | If `true`, all `BottomNavigationAction`s will show their labels. By default only the selected `BottomNavigationAction` will show its label. |
+| value | any |  | The value of the currently selected `BottomNavigationAction`. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -67,12 +67,12 @@ BottomNavigation.propTypes = {
    */
   onChange: PropTypes.func,
   /**
-   * If `true`, all `BottomNavigationButton`s will show their labels.
-   * By default only the selected `BottomNavigationButton` will show its label.
+   * If `true`, all `BottomNavigationAction`s will show their labels.
+   * By default only the selected `BottomNavigationAction` will show its label.
    */
   showLabels: PropTypes.bool,
   /**
-   * The value of the currently selected `BottomNavigationButton`.
+   * The value of the currently selected `BottomNavigationAction`.
    */
   value: PropTypes.any,
 };

--- a/src/BottomNavigation/BottomNavigation.spec.js
+++ b/src/BottomNavigation/BottomNavigation.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses } from '../test-utils';
-import BottomNavigationButton from './BottomNavigationButton';
+import BottomNavigationAction from './BottomNavigationAction';
 import Icon from '../Icon';
 import BottomNavigation from './BottomNavigation';
 
@@ -16,7 +16,7 @@ describe('<BottomNavigation />', () => {
     shallow = createShallow({ dive: true });
     classes = getClasses(
       <BottomNavigation showLabels value={0}>
-        <BottomNavigationButton icon={icon} />
+        <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
     mount = createMount();
@@ -29,18 +29,18 @@ describe('<BottomNavigation />', () => {
   it('renders with a null child', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={0}>
-        <BottomNavigationButton label="One" />
+        <BottomNavigationAction label="One" />
         {null}
-        <BottomNavigationButton label="Three" />
+        <BottomNavigationAction label="Three" />
       </BottomNavigation>,
     );
-    assert.strictEqual(wrapper.find(BottomNavigationButton).length, 2);
+    assert.strictEqual(wrapper.find(BottomNavigationAction).length, 2);
   });
 
   it('should render with the root class', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={0}>
-        <BottomNavigationButton icon={icon} />
+        <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
     assert.strictEqual(wrapper.name(), 'div');
@@ -50,7 +50,7 @@ describe('<BottomNavigation />', () => {
   it('should render with the user and root classes', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={0} className="woofBottomNavigation">
-        <BottomNavigationButton icon={icon} />
+        <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
     assert.strictEqual(wrapper.hasClass('woofBottomNavigation'), true);
@@ -60,8 +60,8 @@ describe('<BottomNavigation />', () => {
   it('should pass selected prop to children', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={1}>
-        <BottomNavigationButton icon={icon} />
-        <BottomNavigationButton icon={icon} />
+        <BottomNavigationAction icon={icon} />
+        <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
     assert.strictEqual(wrapper.childAt(0).props().selected, false, 'should have selected to false');
@@ -71,8 +71,8 @@ describe('<BottomNavigation />', () => {
   it('should overwrite parent showLabel prop', () => {
     const wrapper = shallow(
       <BottomNavigation showLabels value={1}>
-        <BottomNavigationButton icon={icon} />
-        <BottomNavigationButton icon={icon} showLabel={false} />
+        <BottomNavigationAction icon={icon} />
+        <BottomNavigationAction icon={icon} showLabel={false} />
       </BottomNavigation>,
     );
     assert.strictEqual(wrapper.childAt(0).props().showLabel, true, 'should have parent showLabel');
@@ -83,12 +83,12 @@ describe('<BottomNavigation />', () => {
     const handleChange = spy();
     const wrapper = mount(
       <BottomNavigation showLabels value={0} onChange={handleChange}>
-        <BottomNavigationButton icon={icon} />
-        <BottomNavigationButton icon={icon} />
+        <BottomNavigationAction icon={icon} />
+        <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
     wrapper
-      .find(BottomNavigationButton)
+      .find(BottomNavigationAction)
       .at(1)
       .simulate('click');
     assert.strictEqual(handleChange.callCount, 1, 'should have been called once');

--- a/src/BottomNavigation/BottomNavigationAction.d.ts
+++ b/src/BottomNavigation/BottomNavigationAction.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 
-export interface BottomNavigationButtonProps
-  extends StandardProps<ButtonBaseProps, BottomNavigationButtonClassKey, 'onChange'> {
+export interface BottomNavigationActionProps
+  extends StandardProps<ButtonBaseProps, BottomNavigationActionClassKey, 'onChange'> {
   icon?: string | React.ReactElement<any>;
   label?: React.ReactNode;
   onChange?: (event: React.ChangeEvent<{}>, value: any) => void;
@@ -13,7 +13,7 @@ export interface BottomNavigationButtonProps
   value?: any;
 }
 
-export type BottomNavigationButtonClassKey =
+export type BottomNavigationActionClassKey =
   | ButtonBaseClassKey
   | 'selected'
   | 'selectedIconOnly'
@@ -23,6 +23,6 @@ export type BottomNavigationButtonClassKey =
   | 'hiddenLabel'
   | 'icon';
 
-declare const BottomNavigationButton: React.ComponentType<BottomNavigationButtonProps>;
+declare const BottomNavigationAction: React.ComponentType<BottomNavigationActionProps>;
 
-export default BottomNavigationButton;
+export default BottomNavigationAction;

--- a/src/BottomNavigation/BottomNavigationAction.js
+++ b/src/BottomNavigation/BottomNavigationAction.js
@@ -55,7 +55,7 @@ export const styles = theme => ({
   },
 });
 
-class BottomNavigationButton extends React.Component {
+class BottomNavigationAction extends React.Component {
   handleChange = event => {
     const { onChange, value, onClick } = this.props;
 
@@ -119,7 +119,7 @@ class BottomNavigationButton extends React.Component {
   }
 }
 
-BottomNavigationButton.propTypes = {
+BottomNavigationAction.propTypes = {
   /**
    * Useful to extend the style applied to components.
    */
@@ -149,7 +149,7 @@ BottomNavigationButton.propTypes = {
    */
   selected: PropTypes.bool,
   /**
-   * If `true`, the BottomNavigationButton will show its label.
+   * If `true`, the BottomNavigationAction will show its label.
    */
   showLabel: PropTypes.bool,
   /**
@@ -158,4 +158,4 @@ BottomNavigationButton.propTypes = {
   value: PropTypes.any,
 };
 
-export default withStyles(styles, { name: 'MuiBottomNavigationButton' })(BottomNavigationButton);
+export default withStyles(styles, { name: 'MuiBottomNavigationAction' })(BottomNavigationAction);

--- a/src/BottomNavigation/BottomNavigationAction.spec.js
+++ b/src/BottomNavigation/BottomNavigationAction.spec.js
@@ -3,44 +3,44 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, getClasses } from '../test-utils';
 import Icon from '../Icon';
-import BottomNavigationButton from './BottomNavigationButton';
+import BottomNavigationAction from './BottomNavigationAction';
 
-describe('<BottomNavigationButton />', () => {
+describe('<BottomNavigationAction />', () => {
   let shallow;
   let classes;
   const icon = <Icon>restore</Icon>;
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(<BottomNavigationButton />);
+    classes = getClasses(<BottomNavigationAction />);
   });
 
   it('should render a ButtonBase', () => {
-    const wrapper = shallow(<BottomNavigationButton icon={icon} />);
+    const wrapper = shallow(<BottomNavigationAction icon={icon} />);
     assert.strictEqual(wrapper.name(), 'WithStyles');
   });
 
   it('should render with the root class', () => {
-    const wrapper = shallow(<BottomNavigationButton icon={icon} />);
+    const wrapper = shallow(<BottomNavigationAction icon={icon} />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render with the user and root classes', () => {
     const wrapper = shallow(
-      <BottomNavigationButton className="woofBottomNavigationButton" icon={icon} />,
+      <BottomNavigationAction className="woofBottomNavigationAction" icon={icon} />,
     );
-    assert.strictEqual(wrapper.hasClass('woofBottomNavigationButton'), true);
+    assert.strictEqual(wrapper.hasClass('woofBottomNavigationAction'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render with the selected and root classes', () => {
-    const wrapper = shallow(<BottomNavigationButton icon={icon} selected />);
+    const wrapper = shallow(<BottomNavigationAction icon={icon} selected />);
     assert.strictEqual(wrapper.hasClass(classes.selected), true, 'should have the selected class');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render with the selectedIconOnly and root classes', () => {
-    const wrapper = shallow(<BottomNavigationButton icon={icon} showLabel={false} />);
+    const wrapper = shallow(<BottomNavigationAction icon={icon} showLabel={false} />);
     assert.strictEqual(
       wrapper.hasClass(classes.selectedIconOnly),
       true,
@@ -50,13 +50,13 @@ describe('<BottomNavigationButton />', () => {
   });
 
   it('should render icon with the icon class', () => {
-    const wrapper = shallow(<BottomNavigationButton icon={icon} />);
+    const wrapper = shallow(<BottomNavigationAction icon={icon} />);
     const iconWrapper = wrapper.childAt(0).childAt(0);
     assert.strictEqual(iconWrapper.hasClass(classes.icon), true, 'should have the icon class');
   });
 
   it('should render icon with the user and icon classes', () => {
-    const wrapper = shallow(<BottomNavigationButton icon={icon} />);
+    const wrapper = shallow(<BottomNavigationAction icon={icon} />);
 
     const iconWrapper = wrapper.childAt(0).childAt(0);
     assert.strictEqual(iconWrapper.is(Icon), true, 'should be an Icon');
@@ -67,14 +67,14 @@ describe('<BottomNavigationButton />', () => {
   });
 
   it('should render label with the selectedLabel class', () => {
-    const wrapper = shallow(<BottomNavigationButton icon={icon} selected />);
+    const wrapper = shallow(<BottomNavigationAction icon={icon} selected />);
     const labelWrapper = wrapper.childAt(0).childAt(1);
     assert.strictEqual(labelWrapper.hasClass(classes.selectedLabel), true);
     assert.strictEqual(labelWrapper.hasClass(classes.label), true);
   });
 
   it('should render label with the hiddenLabel class', () => {
-    const wrapper = shallow(<BottomNavigationButton icon={icon} showLabel={false} />);
+    const wrapper = shallow(<BottomNavigationAction icon={icon} showLabel={false} />);
     const labelWrapper = wrapper.childAt(0).childAt(1);
     assert.strictEqual(
       labelWrapper.hasClass(classes.hiddenLabel),
@@ -85,13 +85,13 @@ describe('<BottomNavigationButton />', () => {
   });
 
   it('should render a font icon if a icon string is provided', () => {
-    const wrapper = shallow(<BottomNavigationButton icon="book" />);
+    const wrapper = shallow(<BottomNavigationAction icon="book" />);
     const iconWrapper = wrapper.childAt(0).childAt(0);
     assert.strictEqual(iconWrapper.is(Icon), true, 'should be an Icon');
   });
 
   it('should not render an Icon if icon is not provided', () => {
-    const wrapper = shallow(<BottomNavigationButton />);
+    const wrapper = shallow(<BottomNavigationAction />);
     assert.strictEqual(wrapper.find(Icon).exists(), false);
   });
 
@@ -99,7 +99,7 @@ describe('<BottomNavigationButton />', () => {
     it('should be called when a click is triggered', () => {
       const handleClick = spy();
       const wrapper = shallow(
-        <BottomNavigationButton icon="book" onClick={handleClick} value="foo" />,
+        <BottomNavigationAction icon="book" onClick={handleClick} value="foo" />,
       );
       wrapper.simulate('click', 'bar');
       assert.strictEqual(handleClick.callCount, 1, 'it should forward the onClick');
@@ -110,7 +110,7 @@ describe('<BottomNavigationButton />', () => {
     it('should be called when a click is triggered', () => {
       const handleChange = spy();
       const wrapper = shallow(
-        <BottomNavigationButton icon="book" onChange={handleChange} value="foo" />,
+        <BottomNavigationAction icon="book" onChange={handleChange} value="foo" />,
       );
       wrapper.simulate('click', 'bar');
       assert.strictEqual(handleChange.callCount, 1, 'it should forward the onChange');

--- a/src/BottomNavigation/index.d.ts
+++ b/src/BottomNavigation/index.d.ts
@@ -1,4 +1,4 @@
 export { default } from './BottomNavigation';
 export * from './BottomNavigation';
-export { default as BottomNavigationButton } from './BottomNavigationButton';
-export * from './BottomNavigationButton';
+export { default as BottomNavigationAction } from './BottomNavigationAction';
+export * from './BottomNavigationAction';

--- a/src/BottomNavigation/index.js
+++ b/src/BottomNavigation/index.js
@@ -1,2 +1,2 @@
 export { default } from './BottomNavigation';
-export { default as BottomNavigationButton } from './BottomNavigationButton';
+export { default as BottomNavigationAction } from './BottomNavigationAction';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -57,7 +57,7 @@ export namespace PropTypes {
 export { default as AppBar } from './AppBar';
 export { default as Avatar } from './Avatar';
 export { default as Badge } from './Badge';
-export { default as BottomNavigation, BottomNavigationButton } from './BottomNavigation';
+export { default as BottomNavigation, BottomNavigationAction } from './BottomNavigation';
 export { default as Button } from './Button';
 export { default as ButtonBase } from './ButtonBase';
 export { default as Card, CardActions, CardContent, CardHeader, CardMedia } from './Card';

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 export { default as AppBar } from './AppBar';
 export { default as Avatar } from './Avatar';
 export { default as Badge } from './Badge';
-export { default as BottomNavigation, BottomNavigationButton } from './BottomNavigation';
+export { default as BottomNavigation, BottomNavigationAction } from './BottomNavigation';
 export { default as Button } from './Button';
 export { default as ButtonBase } from './ButtonBase';
 export { default as Card, CardActions, CardContent, CardHeader, CardMedia } from './Card';

--- a/src/styles/overrides.d.ts
+++ b/src/styles/overrides.d.ts
@@ -3,7 +3,7 @@ import { AvatarClassKey } from '../Avatar/Avatar';
 import { BackdropClassKey } from '../Modal/Backdrop';
 import { BadgeClassKey } from '../Badge/Badge';
 import { BottomNavigationClassKey } from '../BottomNavigation/BottomNavigation';
-import { BottomNavigationButtonClassKey } from '../BottomNavigation/BottomNavigationButton';
+import { BottomNavigationActionClassKey } from '../BottomNavigation/BottomNavigationAction';
 import { ButtonClassKey } from '../Button/Button';
 import { ButtonBaseClassKey } from '../ButtonBase/ButtonBase';
 import { CardClassKey } from '../Card/Card';
@@ -88,7 +88,7 @@ type ComponentNameToClassKey = {
   MuiBackdrop: BackdropClassKey;
   MuiBadge: BadgeClassKey;
   MuiBottomNavigation: BottomNavigationClassKey;
-  MuiBottomNavigationButton: BottomNavigationButtonClassKey;
+  MuiBottomNavigationAction: BottomNavigationActionClassKey;
   MuiButton: ButtonClassKey;
   MuiButtonBase: ButtonBaseClassKey;
   // MuiCard: CardClassKey;

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -4,7 +4,7 @@ import {
   Avatar,
   Badge,
   BottomNavigation,
-  BottomNavigationButton,
+  BottomNavigationAction,
   Button,
   Card,
   CardActions,
@@ -92,9 +92,9 @@ const BottomNavigationTest = () => {
 
   return (
     <BottomNavigation value={value} onChange={event => log(event)} showLabels>
-      <BottomNavigationButton label="Recents" icon={<FakeIcon />} />
-      <BottomNavigationButton label="Favorites" />
-      <BottomNavigationButton label={<span>Nearby</span>} icon={<FakeIcon />} />
+      <BottomNavigationAction label="Recents" icon={<FakeIcon />} />
+      <BottomNavigationAction label="Favorites" />
+      <BottomNavigationAction label={<span>Nearby</span>} icon={<FakeIcon />} />
     </BottomNavigation>
   );
 };


### PR DESCRIPTION
This is for consistency with the spec, and with the upcoming SpeedDial component.
Motivated by: https://github.com/mui-org/material-ui/pull/9539#issuecomment-354648003

### Breaking change

-Rename the `BottomNavigationButton` component

```diff
-import BottomNavigation, { BottomNavigationButton } from 'material-ui/BottomNavigation';
+import BottomNavigation, { BottomNavigationAction } from 'material-ui/BottomNavigation';
```

