### PR TITLE
[docs] Hide sandbox button on more demos

### DIFF
--- a/docs/src/pages/guides/interoperability.md
+++ b/docs/src/pages/guides/interoperability.md
@@ -1,7 +1,7 @@
 # Interoperability with Style Libraries
 
-While it is simple to use the JSS based styling solution provided by Material-UI to style your application, 
-it is possible to use any styling solution you prefer, from plain CSS to any number of CSS-in-JS libraries. 
+While it is simple to use the JSS based styling solution provided by Material-UI to style your application,
+it is possible to use any styling solution you prefer, from plain CSS to any number of CSS-in-JS libraries.
 
 This guide aims to document the most popular alternatives, but you should find that the principals
 applied here can be adapted to other libraries.
@@ -112,7 +112,7 @@ const styles = theme => ({
 });
 ```
 
-{{"demo": "pages/guides/ReactJss.js"}}
+{{"demo": "pages/guides/ReactJss.js", "hideEditButton": true}}
 
 ## CSS Modules
 

--- a/docs/src/pages/guides/right-to-left.md
+++ b/docs/src/pages/guides/right-to-left.md
@@ -60,4 +60,4 @@ If you want to prevent a specific rule-set from being affected by the `rtl` tran
 
 *Use the direction toggle button on the top left corner to see the effect*
 
-{{"demo": "pages/guides/RtlOptOut.js"}}
+{{"demo": "pages/guides/RtlOptOut.js", "hideEditButton": true}}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
this is follow up to #9685. (for issue #9683)


hides sandbox button on these demos
- https://material-ui-next.com/guides/right-to-left/#opting-out-of-rtl-transformation
- https://material-ui-next.com/guides/interoperability/#react-jss

