### PR TITLE
[docs] Move 'Default Theme' to it's own section

### DIFF
--- a/docs/src/modules/components/withRoot.js
+++ b/docs/src/modules/components/withRoot.js
@@ -52,6 +52,10 @@ const pages = [
         pathname: '/customization/themes',
       },
       {
+        pathname: '/customization/theme-default',
+        title: 'Default Theme',
+      },
+      {
         pathname: '/customization/css-in-js',
         title: 'CSS in JS',
       },

--- a/docs/src/pages/customization/ThemeDefault.js
+++ b/docs/src/pages/customization/ThemeDefault.js
@@ -1,28 +1,39 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
-import { withTheme } from 'material-ui/styles';
+import { withStyles, withTheme } from 'material-ui/styles';
+import Inspector from 'react-inspector';
 
-const style = {
-  maxWidth: '100%',
-  maxHeight: '100%',
-  overflow: 'auto',
-};
+const styles = theme => ({
+  root: {
+    padding: 8 * 2,
+    backgroundColor: theme.palette.type === 'light' ? '#fff' : 'rgb(36, 36, 36)',
+    minHeight: 8 * 40,
+    width: '100%',
+  },
+});
 
 function ThemeDefault(props) {
-  const { theme: { id, ...theme } } = props;
+  const { classes, theme } = props;
 
-  const text = `
-\`\`\`js
-${JSON.stringify(theme, null, 2)}
-\`\`\`
-  `;
+  // Expose the theme as a global variable so people can play with it.
+  if (process.browser) {
+    window.theme = theme;
+  }
 
-  return <MarkdownElement style={style} text={text} />;
+  return (
+    <div className={classes.root}>
+      <Inspector
+        theme={theme.palette.type === 'light' ? 'chromeLight' : 'chromeDark'}
+        data={theme}
+        expandLevel={1}
+      />
+    </div>
+  );
 }
 
 ThemeDefault.propTypes = {
+  classes: PropTypes.object.isRequired,
   theme: PropTypes.object.isRequired,
 };
 
-export default withTheme()(ThemeDefault);
+export default withStyles(styles)(withTheme()(ThemeDefault));

--- a/docs/src/pages/customization/ThemeDefault.js
+++ b/docs/src/pages/customization/ThemeDefault.js
@@ -5,7 +5,7 @@ import { withTheme } from 'material-ui/styles';
 
 const style = {
   maxWidth: '100%',
-  maxHeight: 400,
+  maxHeight: '100%',
   overflow: 'auto',
 };
 

--- a/docs/src/pages/customization/theme-default.md
+++ b/docs/src/pages/customization/theme-default.md
@@ -1,0 +1,10 @@
+# Default Theme
+
+The theme normalizes implementation by providing default values for palette, dark and light types, typography, breakpoints, shadows, transitions, etc.
+
+If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/v1-beta/src/styles/createMuiTheme.js),
+and the related imports which `createMuiTheme` uses.
+
+Here's what the theme object looks like with the default values:
+
+{{"demo": "pages/customization/ThemeDefault.js", "hideEditButton": true}}

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -9,11 +9,12 @@ We use [jss](https://github.com/cssinjs/jss) under the hood.
 
 ## Theme provider
 
-You need to use the `MuiThemeProvider` component in order to inject a theme into your application. However, this is optional, Material-UI components come with a default theme.
-We rely on the context feature of React.
+If you wish to customise the theme, you need to use the `MuiThemeProvider` component in order to inject a theme into your application. 
+However, this is optional; Material-UI components come with a default theme.
 
-Make sure that `MuiThemeProvider` is a parent of the components you are trying to customize.
-You can learn more about it [reading the API section](#muithemeprovider).
+`MuiThemeProvider` relies on the context feature of React to pass the theme down,
+so you need to make sure that `MuiThemeProvider` is a parent of the components you are trying to customize.
+You can learn more about this in [the API section](#muithemeprovider).
 
 ## Configuration variables
 
@@ -25,7 +26,7 @@ Changing the configurations variables is the most effective way to match Materia
 
 A color intention is a mapping of a palette to a given intention within your application.
 
-We expose the following color intentions:
+The theme expose the following color intentions:
 
 - primary - used to represent primary interface elements for a user.
 - secondary - used to represent secondary interface elements for a user.
@@ -38,14 +39,21 @@ If you want to learn more about color, you can check out [the color section](/st
 
 {{"demo": "pages/customization/Palette.js"}}
 
+### Dark/light theme
+
+You can make a theme dark by setting `type` to `dark`.
+
+{{"demo": "pages/customization/DarkTheme.js", "hideEditButton": true}}
+
+
 ### Typography
 
-Too many type sizes and styles at once can wreck any layout.
-We use a **limited set of type sizes** that work well together along with the layout grid.
-Those sizes are used across our components.
+Too many type sizes and styles at once can spoil any layout.
+The theme provides a **limited set of type sizes** that work well together along with the layout grid.
+These sizes are used across the components.
 
-Have a look at the following example regarding changing the default values, like the font family.
-If you want to learn more about color, you can check out [the typography section](/style/typography).
+Have a look at the following example regarding changing the default values, such as the font family.
+If you want to learn more about typograpy, you can check out [the typography section](/style/typography).
 
 {{"demo": "pages/customization/TypographyTheme.js"}}
 
@@ -69,22 +77,14 @@ html {
 
 {{"demo": "pages/customization/FontSizeTheme.js"}}
 
-### Dark/light theme
+### Other variables
 
-You can make a theme dark by setting `type` to `dark`.
+In addition to the palette, dark and light types, and typography, the theme normalizes implementation by providing many more default values, such as breakpoints, shadows, transitions, etc.
+You can check out the [default theme section](/customization/theme-default) to view the default theme in full.
 
-{{"demo": "pages/customization/DarkTheme.js", "hideEditButton": true}}
+### Adding custom style
 
-### The other variables
-
-We have tried to normalize the implementation by adding many more variables: typography, breakpoints, transitions, etc. You can see below what the theme object looks like with the default values.
-If you want to learn more, we suggesting having a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/v1-beta/src/styles/createMuiTheme.js).
-
-{{"demo": "pages/customization/ThemeDefault.js", "hideEditButton": true}}
-
-### Adding custom styles
-
-When using our [styling solution](/customization/css-in-js) with your own components,
+When using Material-UI's [styling solution](/customization/css-in-js) with your own components,
 you can also take advantage of the theme.
 It can be convenient to add additional variables to the theme so you can use them everywhere.
 For instance:
@@ -112,18 +112,17 @@ Let's say you want to display the value of the primary color, you can use the `w
 
 ## Nesting the theme
 
-Our theming solution is very flexible, you can nest multiple theme providers.
-That can be really useful when dealing with different area of your application.
+The theming solution is very flexible, as you can nest multiple theme providers.
+This can be really useful when dealing with different area of your application that have distinct appearance from each other.
 
 {{"demo": "pages/customization/Nested.js"}}
 
 ## API
 
-### `<MuiThemeProvider />`
+### `MuiThemeProvider`
 
-This component takes a `theme` property.
-It makes the `theme` available down the React tree thanks to React context.
-This component should preferably be used at **the root of your component tree**.
+This component takes a `theme` property, and makes the `theme` available down the React tree thanks to React context.
+It should preferably be used at **the root of your component tree**.
 
 You can see the full properties API in [this dedicated page](/api/mui-theme-provider).
 

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "react": "^16.1.1",
     "react-autosuggest": "^9.3.2",
     "react-dom": "^16.1.1",
+    "react-inspector": "^2.2.2",
     "react-number-format": "^3.0.2",
     "react-redux": "^5.0.6",
     "react-swipeable-views": "^0.12.10",

--- a/pages/customization/theme-default.js
+++ b/pages/customization/theme-default.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from 'docs/src/pages/customization/theme-default.md';
+
+function Page() {
+  return (
+    <MarkdownDocs
+      markdown={markdown}
+      demos={{
+        'pages/customization/ThemeDefault.js': {
+          js: require('docs/src/pages/customization/ThemeDefault').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/customization/ThemeDefault'), 'utf8')
+`,
+        },
+      }}
+    />
+  );
+}
+
+export default withRoot(Page);

--- a/pages/customization/themes.js
+++ b/pages/customization/themes.js
@@ -36,13 +36,6 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/customization/DarkTheme'), 'utf8')
 `,
         },
-        'pages/customization/ThemeDefault.js': {
-          js: require('docs/src/pages/customization/ThemeDefault').default,
-          raw: preval`
-module.exports = require('fs')
-  .readFileSync(require.resolve('docs/src/pages/customization/ThemeDefault'), 'utf8')
-`,
-        },
         'pages/customization/CustomStyles.js': {
           js: require('docs/src/pages/customization/CustomStyles').default,
           raw: preval`

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,6 +4931,10 @@ is-directory@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
 
+is-dom@^1.0.9:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.0.9.tgz#483832d52972073de12b9fe3f60320870da8370d"
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -7849,6 +7853,13 @@ react-hot-loader@3.1.1:
     react-proxy "^3.0.0-alpha.0"
     redbox-react "^1.3.6"
     source-map "^0.6.1"
+
+react-inspector@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.2.tgz#c04f5248fa92ab6c23e37960e725fb7f48c34d05"
+  dependencies:
+    babel-runtime "^6.26.0"
+    is-dom "^1.0.9"
 
 react-jss@^8.1.0:
   version "8.2.0"


### PR DESCRIPTION
- This allows the full theme to be viewed more easily
- Use [react-json-tree](https://github.com/alexkuz/react-json-tree)
- Expose theme as a global variable
