### PR TITLE
[CircularProgress] Accept as string size property

### DIFF
--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -17,7 +17,7 @@ filename: /src/Progress/CircularProgress.js
 | max | number | 100 | The max value of progress in determinate mode. |
 | min | number | 0 | The min value of progress in determinate mode. |
 | mode | enum:&nbsp;'determinate'&nbsp;&#124;<br>&nbsp;'indeterminate'<br> | 'indeterminate' | The mode of show your progress. Indeterminate for when there is no value for progress. Determinate for controlled progress value. |
-| size | number | 40 | The size of the circle. |
+| size | union:&nbsp;number&nbsp;&#124;<br>&nbsp;string<br> | 40 | The size of the circle. |
 | thickness | number | 3.6 | The thickness of the circle. |
 | value | number | 0 | The value of progress in determinate mode. |
 

--- a/src/Progress/CircularProgress.d.ts
+++ b/src/Progress/CircularProgress.d.ts
@@ -7,7 +7,7 @@ export interface CircularProgressProps
   max?: number;
   min?: number;
   mode?: 'determinate' | 'indeterminate';
-  size?: number;
+  size?: number | string;
   thickness?: number;
   value?: number;
 }

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -153,7 +153,7 @@ CircularProgress.propTypes = {
   /**
    * The size of the circle.
    */
-  size: PropTypes.number,
+  size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * @ignore
    */


### PR DESCRIPTION
`<CircularProgress size="1.2em" />` already works because `"1.2em"` gets passed straight into the `style`, this just gets rid of the `PropTypes` warning that `size` has to be a `number`.

Closes #9699 