### PR TITLE
[docs] Reorder Drawer items

### DIFF
--- a/docs/src/modules/components/withRoot.js
+++ b/docs/src/modules/components/withRoot.js
@@ -29,78 +29,20 @@ const pages = [
         pathname: '/getting-started/usage',
       },
       {
-        pathname: '/getting-started/example-projects',
-      },
-      {
         pathname: '/getting-started/supported-components',
       },
       {
         pathname: '/getting-started/supported-platforms',
       },
       {
+        pathname: '/getting-started/example-projects',
+      },
+      {
         pathname: '/getting-started/frequently-asked-questions',
       },
-    ],
-  },
-  {
-    pathname: '/customization',
-    children: [
       {
-        pathname: '/customization/overrides',
-      },
-      {
-        pathname: '/customization/themes',
-      },
-      {
-        pathname: '/customization/theme-default',
-        title: 'Default Theme',
-      },
-      {
-        pathname: '/customization/css-in-js',
-        title: 'CSS in JS',
-      },
-    ],
-  },
-  {
-    pathname: '/guides',
-    children: [
-      {
-        pathname: '/guides/api',
-        title: 'API',
-      },
-      {
-        pathname: '/guides/minimizing-bundle-size',
-      },
-      {
-        pathname: '/guides/interoperability',
-        title: 'Style Library Interoperability',
-      },
-      {
-        pathname: '/guides/migration-v0.x',
-        title: 'Migration from v0.x',
-      },
-      {
-        pathname: '/guides/server-rendering',
-      },
-      {
-        pathname: '/guides/composition',
-      },
-      {
-        pathname: '/guides/comparison',
-      },
-      {
-        pathname: '/guides/testing',
-      },
-      {
-        pathname: '/guides/typescript',
-        title: 'TypeScript',
-      },
-      {
-        pathname: '/guides/flow',
-      },
-      {
-        pathname: '/guides/right-to-left',
-        title: 'Right-to-left',
+        pathname: '/getting-started/comparison',
+        title: 'Comparison With Other Libraries',
       },
     ],
   },
@@ -151,10 +93,78 @@ const pages = [
     title: 'Component API',
   },
   {
+    pathname: '/customization',
+    children: [
+      {
+        pathname: '/customization/overrides',
+      },
+      {
+        pathname: '/customization/themes',
+      },
+      {
+        pathname: '/customization/theme-default',
+        title: 'Default Theme',
+      },
+      {
+        pathname: '/customization/css-in-js',
+        title: 'CSS in JS',
+      },
+    ],
+  },
+  {
+    pathname: '/guides',
+    children: [
+      {
+        pathname: '/guides/api',
+        title: 'API',
+      },
+      {
+        pathname: '/guides/minimizing-bundle-size',
+      },
+      {
+        pathname: '/guides/interoperability',
+        title: 'Style Library Interoperability',
+      },
+      {
+        pathname: '/guides/migration-v0.x',
+        title: 'Migration From v0.x',
+      },
+      {
+        pathname: '/guides/server-rendering',
+      },
+      {
+        pathname: '/guides/composition',
+      },
+      {
+        pathname: '/guides/testing',
+      },
+      {
+        pathname: '/guides/typescript',
+        title: 'TypeScript',
+      },
+      {
+        pathname: '/guides/flow',
+      },
+      {
+        pathname: '/guides/right-to-left',
+        title: 'Right-to-left',
+      },
+    ],
+  },
+  {
     pathname: '/discover-more',
     children: [
       {
         pathname: '/discover-more/vision',
+      },
+      {
+        pathname: '/discover-more/roadmap',
+      },
+      {
+        pathname: '/discover-more/governance',
+      },
+      {
+        pathname: '/discover-more/team',
       },
       {
         pathname: '/discover-more/backers',
@@ -168,15 +178,6 @@ const pages = [
       },
       {
         pathname: '/discover-more/related-projects',
-      },
-      {
-        pathname: '/discover-more/roadmap',
-      },
-      {
-        pathname: '/discover-more/team',
-      },
-      {
-        pathname: '/discover-more/governance',
       },
     ],
   },

--- a/docs/src/pages/getting-started/comparison.md
+++ b/docs/src/pages/getting-started/comparison.md
@@ -7,7 +7,15 @@ That’s what we hope to answer for you here.
 
 We’d like your help keeping this document up-to-date because the JavaScript world moves fast!
 If you notice an inaccuracy or something that doesn’t seem quite right, please let us know by
-[opening an issue](https://github.com/mui-org/material-ui/issues/new?title=[Docs]+Inaccuracy+in+comparison+guide).
+[opening an issue](https://github.com/mui-org/material-ui/issues/new?title=[docs]+Inaccuracy+in+comparison+guide).
+
+We cover the following libraries:
+
+- [Material-UI](#material-ui)
+- [Material Design Lite (MDL)](#material-design-lite-mdl-)
+- [Material Components Web (MDC-web)](#material-components-web-mdc-web-)
+- [Materialize](#materialize)
+- [React Toolbox](#react-toolbox)
 
 ## Material-UI
 

--- a/docs/src/pages/guides/interoperability.md
+++ b/docs/src/pages/guides/interoperability.md
@@ -1,4 +1,4 @@
-# Interoperability with Style Libraries
+# Style Library Interoperability
 
 While it is simple to use the JSS based styling solution provided by Material-UI to style your application,
 it is possible to use any styling solution you prefer, from plain CSS to any number of CSS-in-JS libraries.

--- a/docs/src/pages/guides/migration-v0.x.md
+++ b/docs/src/pages/guides/migration-v0.x.md
@@ -1,4 +1,4 @@
-# Migration from v0.x
+# Migration From v0.x
 
 ## FAQ
 

--- a/pages/getting-started/comparison.js
+++ b/pages/getting-started/comparison.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import withRoot from 'docs/src/modules/components/withRoot';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
-import markdown from 'docs/src/pages/guides/comparison.md';
+import markdown from 'docs/src/pages/getting-started/comparison.md';
 
 function Page() {
   return <MarkdownDocs markdown={markdown} />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR rearranges the content of the Drawer into what (to me) feels like a more natural order.

The only slightly contraversial change is moving the "Comparison With Other Libraries" from "Guides" to "Getting Started" - it feels like it's information you should know when getting started, and deciding whether to use MUI.

<img width="170" alt="screen shot 2018-01-02 at 11 19 04" src="https://user-images.githubusercontent.com/357702/34482270-cdac7574-efae-11e7-8da7-03510c471efc.png">
