### PR TITLE
[FormControlLabel] Allow highlighted options to be selectable

### DIFF
--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -20,9 +20,7 @@ export const styles = theme => ({
     color: theme.palette.text.disabled,
     cursor: 'default',
   },
-  label: {
-    userSelect: 'none',
-  },
+  label: {},
 });
 
 /**


### PR DESCRIPTION
Closes #9711, where the text of the highlighted [RadioButton] or [Checkbox] options can't currently be selected. This PR will make these text select-able.

  