### PR TITLE
[Modal] Add TransitionHandlers to Modal props TypeScript definitions

### DIFF
--- a/src/Dialog/Dialog.d.ts
+++ b/src/Dialog/Dialog.d.ts
@@ -1,9 +1,14 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { ModalProps, ModalClassKey } from '../Modal';
-import { TransitionDuration } from '../internal/transition';
+import { TransitionDuration, TransitionHandlers } from '../internal/transition';
 
-export interface DialogProps extends StandardProps<ModalProps, DialogClassKey, 'children'> {
+export interface DialogProps
+  extends StandardProps<
+      ModalProps & Partial<TransitionHandlers>,
+      DialogClassKey,
+      'children'
+    > {
   children?: React.ReactNode;
   fullScreen?: boolean;
   fullWidth?: boolean;

--- a/src/Drawer/Drawer.d.ts
+++ b/src/Drawer/Drawer.d.ts
@@ -1,12 +1,16 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { ModalProps, ModalClassKey } from '../Modal';
-import { TransitionDuration } from '../internal/transition';
+import { TransitionDuration, TransitionHandlers } from '../internal/transition';
 import { SlideProps } from '../transitions/Slide';
 import { Theme } from '../styles/createMuiTheme';
 
 export interface DrawerProps
-  extends StandardProps<ModalProps, DrawerClassKey, 'open' | 'children'> {
+  extends StandardProps<
+      ModalProps & Partial<TransitionHandlers>,
+      DrawerClassKey,
+      'open' | 'children'
+    > {
   anchor?: 'left' | 'top' | 'right' | 'bottom';
   children?: React.ReactNode;
   elevation?: number;

--- a/src/Modal/Modal.d.ts
+++ b/src/Modal/Modal.d.ts
@@ -2,10 +2,11 @@ import * as React from 'react';
 import { StandardProps, ModalManager } from '..';
 import { BackdropProps } from './Backdrop';
 import { PortalProps } from '../Portal';
+import { TransitionHandlers } from '../internal/transition';
 
 export interface ModalProps
   extends StandardProps<
-      React.HtmlHTMLAttributes<HTMLDivElement> & Partial<PortalProps>,
+      React.HtmlHTMLAttributes<HTMLDivElement> & Partial<PortalProps> & Partial<TransitionHandlers>,
       ModalClassKey
     > {
   BackdropComponent?: React.ReactType<BackdropProps>;

--- a/src/Modal/Modal.d.ts
+++ b/src/Modal/Modal.d.ts
@@ -2,11 +2,10 @@ import * as React from 'react';
 import { StandardProps, ModalManager } from '..';
 import { BackdropProps } from './Backdrop';
 import { PortalProps } from '../Portal';
-import { TransitionHandlers } from '../internal/transition';
 
 export interface ModalProps
   extends StandardProps<
-      React.HtmlHTMLAttributes<HTMLDivElement> & Partial<PortalProps> & Partial<TransitionHandlers>,
+      React.HtmlHTMLAttributes<HTMLDivElement> & Partial<PortalProps>,
       ModalClassKey
     > {
   BackdropComponent?: React.ReactType<BackdropProps>;


### PR DESCRIPTION
Resolves #9689.

As of beta 26, it is no longer possible to use transition event handlers (`onEnter`, `onExit`, and their variations) in several components using the Modal base component. The implementation has not been removed however, only the TypeScript definitions have been modified to no longer expose these APIs.

As discussed in the issue mentioned above (specifically [this comment](https://github.com/mui-org/material-ui/issues/9689#issuecomment-354758499)), this change should be reverted. Thus, the TransitionHandler props have been added to ModalProps, and transitively the components extending ModalProps.