### PR TITLE
[Drawer] Add Swipeable feature

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -7,7 +7,7 @@
   {
     "name": "The size of the whole library.",
     "path": "build/index.js",
-    "limit": "96.7 KB"
+    "limit": "96.8 KB"
   },
   {
     "name": "The main bundle of the documentation",

--- a/.size-limit
+++ b/.size-limit
@@ -13,7 +13,7 @@
     "name": "The main bundle of the documentation",
     "webpack": false,
     "path": ".next/main.js",
-    "limit": "179 KB"
+    "limit": "180 KB"
   },
   {
     "name": "The home page of the documentation",

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -152,6 +152,7 @@ AppDrawer.propTypes = {
   disablePermanent: PropTypes.bool.isRequired,
   mobileOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
+  onOpen: PropTypes.func.isRequired,
 };
 
 AppDrawer.contextTypes = {

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -85,7 +85,7 @@ function reduceChildRoutes({ props, activePage, items, page, depth }) {
 const GITHUB_RELEASE_BASE_URL = 'https://github.com/mui-org/material-ui/releases/tag/';
 
 function AppDrawer(props, context) {
-  const { classes, className, disablePermanent, mobileOpen, onClose } = props;
+  const { classes, className, disablePermanent, mobileOpen, onClose, onOpen } = props;
 
   const drawer = (
     <div className={classes.nav}>
@@ -120,6 +120,7 @@ function AppDrawer(props, context) {
           }}
           variant="temporary"
           open={mobileOpen}
+          onOpen={onOpen}
           onClose={onClose}
           ModalProps={{
             keepMounted: true,

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import List from 'material-ui/List';
 import Drawer from 'material-ui/Drawer';
+import SwipeableDrawer from 'material-ui/SwipeableDrawer';
 import Typography from 'material-ui/Typography';
 import Divider from 'material-ui/Divider';
 import Hidden from 'material-ui/Hidden';
@@ -114,7 +115,7 @@ function AppDrawer(props, context) {
   return (
     <div className={className}>
       <Hidden lgUp={!disablePermanent}>
-        <Drawer
+        <SwipeableDrawer
           classes={{
             paper: classNames(classes.paper, 'algolia-drawer'),
           }}
@@ -127,7 +128,7 @@ function AppDrawer(props, context) {
           }}
         >
           {drawer}
-        </Drawer>
+        </SwipeableDrawer>
       </Hidden>
       {disablePermanent ? null : (
         <Hidden mdDown implementation="css">

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -188,6 +188,7 @@ class AppFrame extends React.Component {
           className={classes.drawer}
           disablePermanent={disablePermanent}
           onClose={this.handleDrawerToggle}
+          onOpen={this.handleDrawerToggle}
           mobileOpen={this.state.mobileOpen}
         />
         {children}

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -175,6 +175,9 @@ function generateProps(reactAPI) {
 
   text = Object.keys(reactAPI.props).reduce((textProps, propRaw) => {
     const prop = getProp(reactAPI.props, propRaw);
+    if (prop.flowType == null && prop.type == null) {
+      return textProps;
+    }
     const description = generatePropDescription(prop.description, prop.flowType || prop.type);
 
     if (description === null) {

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -15,12 +15,15 @@ filename: /src/Drawer/Drawer.js
 | <span class="prop-name">anchor</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'top'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'bottom'<br> | <span class="prop-default">'left'</span> | Side from which the drawer will appear. |
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The contents of the drawer. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">disableSwipeToOpen</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the drawer cannot be opened by swiping from the edge of the screen. |
 | <span class="prop-name">elevation</span> | <span class="prop-type">number | <span class="prop-default">16</span> | The elevation of the drawer. |
 | <span class="prop-name">ModalProps</span> | <span class="prop-type">object |  | Properties applied to the `Modal` element. |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
+| <span class="prop-name">onOpen</span> | <span class="prop-type">func |  | Callback fired when the component requests to be opened.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span class="prop-name">open</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the drawer is open. |
 | <span class="prop-name">PaperProps</span> | <span class="prop-type">object |  | Properties applied to the `Paper` element. |
 | <span class="prop-name">SlideProps</span> | <span class="prop-type">object |  | Properties applied to the `Slide` element. |
+| <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | <span class="prop-default">'temporary'</span> | The type of drawer. |
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -15,6 +15,7 @@ filename: /src/Drawer/Drawer.js
 | <span class="prop-name">anchor</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'top'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'bottom'<br> | <span class="prop-default">'left'</span> | Side from which the drawer will appear. |
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The contents of the drawer. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">disableAccidentalDiscovery</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit to promote accidental discovery of the swipe gesture. |
 | <span class="prop-name">disableSwipeToOpen</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the drawer cannot be opened by swiping from the edge of the screen. |
 | <span class="prop-name">elevation</span> | <span class="prop-type">number | <span class="prop-default">16</span> | The elevation of the drawer. |
 | <span class="prop-name">ModalProps</span> | <span class="prop-type">object |  | Properties applied to the `Modal` element. |
@@ -25,7 +26,7 @@ filename: /src/Drawer/Drawer.js
 | <span class="prop-name">SlideProps</span> | <span class="prop-type">object |  | Properties applied to the `Slide` element. |
 | <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | <span class="prop-default">'temporary'</span> | The type of drawer. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | <span class="prop-default">'temporary'</span> | The variant of drawer. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -15,16 +15,12 @@ filename: /src/Drawer/Drawer.js
 | <span class="prop-name">anchor</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'top'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'bottom'<br> | <span class="prop-default">'left'</span> | Side from which the drawer will appear. |
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The contents of the drawer. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
-| <span class="prop-name">disableDiscovery</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit to promote accidental discovery of the swipe gesture. |
-| <span class="prop-name">disableSwipeToOpen</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the drawer cannot be opened by swiping from the edge of the screen. |
 | <span class="prop-name">elevation</span> | <span class="prop-type">number | <span class="prop-default">16</span> | The elevation of the drawer. |
 | <span class="prop-name">ModalProps</span> | <span class="prop-type">object |  | Properties applied to the `Modal` element. |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
-| <span class="prop-name">onOpen</span> | <span class="prop-type">func |  | Callback fired when the component requests to be opened.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span class="prop-name">open</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the drawer is open. |
 | <span class="prop-name">PaperProps</span> | <span class="prop-type">object |  | Properties applied to the `Paper` element. |
 | <span class="prop-name">SlideProps</span> | <span class="prop-type">object |  | Properties applied to the `Slide` element. |
-| <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | <span class="prop-default">'temporary'</span> | The variant of drawer. |
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -15,7 +15,7 @@ filename: /src/Drawer/Drawer.js
 | <span class="prop-name">anchor</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'top'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'bottom'<br> | <span class="prop-default">'left'</span> | Side from which the drawer will appear. |
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The contents of the drawer. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
-| <span class="prop-name">disableAccidentalDiscovery</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit to promote accidental discovery of the swipe gesture. |
+| <span class="prop-name">disableDiscovery</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit to promote accidental discovery of the swipe gesture. |
 | <span class="prop-name">disableSwipeToOpen</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the drawer cannot be opened by swiping from the edge of the screen. |
 | <span class="prop-name">elevation</span> | <span class="prop-type">number | <span class="prop-default">16</span> | The elevation of the drawer. |
 | <span class="prop-name">ModalProps</span> | <span class="prop-type">object |  | Properties applied to the `Modal` element. |

--- a/pages/api/swipeable-drawer.js
+++ b/pages/api/swipeable-drawer.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './swipeable-drawer.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default withRoot(Page);

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -1,0 +1,26 @@
+---
+filename: /src/SwipeableDrawer/SwipeableDrawer.js
+---
+
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# SwipeableDrawer
+
+
+
+## Props
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">disableDiscovery</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit to promote accidental discovery of the swipe gesture. |
+| <span class="prop-name required">onClose *</span> | <span class="prop-type">func |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
+| <span class="prop-name required">onOpen *</span> | <span class="prop-type">func |  | Callback fired when the component requests to be opened.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
+| <span class="prop-name required">open *</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the drawer is open. |
+| <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
+
+Any other properties supplied will be [spread to the root element](/guides/api#spread).
+
+## Inheritance
+
+The properties of the [Drawer](/api/drawer) component are also available.
+

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -13,10 +13,13 @@ filename: /src/SwipeableDrawer/SwipeableDrawer.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">disableDiscovery</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit to promote accidental discovery of the swipe gesture. |
+| <span class="prop-name">ModalProps</span> | <span class="prop-type">object |  | Properties applied to the `Modal` element. |
 | <span class="prop-name required">onClose *</span> | <span class="prop-type">func |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span class="prop-name required">onOpen *</span> | <span class="prop-type">func |  | Callback fired when the component requests to be opened.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
-| <span class="prop-name required">open *</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the drawer is open. |
+| <span class="prop-name required">open *</span> | <span class="prop-type">bool |  | If `true`, the drawer is open. |
 | <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
+| <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | <span class="prop-default">'temporary'</span> | The variant of drawer. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/Drawer/Drawer.d.ts
+++ b/src/Drawer/Drawer.d.ts
@@ -14,8 +14,11 @@ export interface DrawerProps
     > {
   anchor?: 'left' | 'top' | 'right' | 'bottom';
   children?: React.ReactNode;
+  disableAccidentalDiscovery?: boolean;
+  disableSwipeToOpen?: boolean;
   elevation?: number;
   ModalProps?: Partial<ModalProps>;
+  onOpen?: React.ReactEventHandler<{}>;
   open?: boolean;
   PaperProps?: Partial<PaperProps>;
   SlideProps?: Partial<SlideProps>;

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -301,6 +301,7 @@ class Drawer extends React.Component {
     } = this.props;
 
     const anchor = this.getAnchor();
+    const transitionDuration = this.maybeSwiping ? 0 : transitionDurationProp; // prevent flickering when swiping fast
 
     const drawer = (
       <Paper
@@ -349,7 +350,7 @@ class Drawer extends React.Component {
       <Modal
         BackdropProps={{
           ref: (ref) => { this.backdrop = ref },
-          transitionDuration
+          transitionDuration,
         }}
         className={classNames(classes.modal, className)}
         open={open || (type === 'temporary' && this.maybeSwiping)}

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -306,7 +306,7 @@ class Drawer extends React.Component {
 
   render() {
     const {
-      anchor, // eslint-disable-line
+      anchor: anchorProp, // eslint-disable-line
       children,
       classes,
       className,

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -242,7 +242,7 @@ class Drawer extends React.Component {
     this.removeBodyTouchListeners();
   };
 
-  getAnchor () {
+  getAnchor() {
     let anchor = this.props.anchor;
     if (this.props.theme.direction === 'rtl' && ['left', 'right'].indexOf(anchor) !== -1) {
       anchor = anchor === 'left' ? 'right' : 'left';

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -119,25 +119,12 @@ class Drawer extends React.Component {
   }
 
   getTranslatedWidth() {
-    // if (typeof this.props.width === 'string') {
-    //   if (!/^\d+(\.\d+)?%$/.test(this.props.width)) {
-    //     throw new Error('Not a valid percentage format.');
-    //   }
-    //   const width = parseFloat(this.props.width) / 100.0;
-    //   // We are doing our best on the Server to render a consistent UI, hence the
-    //   // default value of 10000
-    //   return typeof window !== 'undefined' ? width * window.innerWidth : 10000;
-    // } else {
-    //   return this.props.width;
-    // }
-
     const drawer = ReactDOM.findDOMNode(this.drawer);
-    return drawer.clientWidth // TODO
+    return drawer.clientWidth // TODO server-side rendering?
   }
 
   getMaxTranslateX() {
-    const width = this.getTranslatedWidth() || this.context.muiTheme.drawer.width;
-    return width + 10;
+    return this.getTranslatedWidth() || this.context.muiTheme.drawer.width;
   }
 
   enableSwipeHandling () {
@@ -149,7 +136,7 @@ class Drawer extends React.Component {
   }
 
   onBodyTouchStart = (event) => {
-    const swipeAreaWidth = 30 // this.props.swipeAreaWidth;
+    const swipeAreaWidth = this.props.swipeAreaWidth;
 
     const touchStartX = this.getAnchor() === 'right' ?
       (document.body.offsetWidth - event.touches[0].pageX) :
@@ -193,14 +180,15 @@ class Drawer extends React.Component {
     const rtlTranslateMultiplier = this.getAnchor() === 'right' ? 1 : -1; // TODO up/down
     const drawer = ReactDOM.findDOMNode(this.drawer);
     const transformCSS = `translate(${(rtlTranslateMultiplier * translateX)}px, 0)`;
-    drawer.style.transform = transformCSS // TODO prefixing
+    drawer.style.transform = transformCSS
+    drawer.style.webkitTransform = transformCSS
 
     const backdrop = ReactDOM.findDOMNode(this.backdrop)
     backdrop.style.opacity = 1 - translateX / this.getMaxTranslateX();
   }
 
   getTranslateX(currentX) {
-    const swipeAreaWidth = 30 // this.props.swipeAreaWidth;
+    const swipeAreaWidth = this.props.swipeAreaWidth;
     return Math.min(
              Math.max(
                this.state.swiping === 'closing' ?
@@ -304,8 +292,9 @@ class Drawer extends React.Component {
       open,
       PaperProps,
       SlideProps,
+      swipeAreaWidth, // eslint-disable-line
       theme, // eslint-disable-line
-      transitionDuration,
+      transitionDuration: transitionDurationProp,
       variant,
       ...other
     } = this.props;
@@ -424,6 +413,10 @@ Drawer.propTypes = {
    */
   SlideProps: PropTypes.object,
   /**
+   * The width of the left most (or right most) area in pixels where the drawer can be swiped open from.
+   */
+  swipeAreaWidth: PropTypes.number,
+  /**
    * @ignore
    */
   theme: PropTypes.object.isRequired,
@@ -445,6 +438,7 @@ Drawer.defaultProps = {
   anchor: 'left',
   elevation: 16,
   open: false,
+  swipeAreaWidth: 20,
   transitionDuration: { enter: duration.enteringScreen, exit: duration.leavingScreen },
   variant: 'temporary', // Mobile first.
 };

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -91,31 +91,28 @@ class Drawer extends React.Component {
     if (this.props.variant === 'temporary') {
       this.enableSwipeHandling();
     }
-    this.mounted = true;
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      firstMount: false,
-    });
-
-    if (this.props.variant !== 'temporary' && nextProps.variant === 'temporary') {
+  componentDidUpdate(prevProps, prevState) {
+    if (this.props.variant === 'temporary' && prevProps.variant !== 'temporary') {
       this.enableSwipeHandling();
-    } else if (this.props.variant === 'temporary' && nextProps.variant !== 'temporary') {
+    } else if (this.props.variant !== 'temporary' && prevProps.variant === 'temporary') {
       this.disableSwipeHandling();
+    }
+
+    if (this.state.firstMount) {
+      this.setState({
+        firstMount: false,
+      });
     }
   }
 
   componentWillUnmount() {
     this.disableSwipeHandling();
     this.removeBodyTouchListeners();
-    this.mounted = false;
   }
 
   onBodyTouchStart = event => {
-    // sometimes the event handler is called after unbinding it
-    if (!this.mounted) return;
-
     const anchor = this.getAnchor();
     const swipeAreaWidth = this.props.swipeAreaWidth;
 
@@ -141,7 +138,7 @@ class Drawer extends React.Component {
     this.touchStartX = touchStartX;
     this.touchStartY = touchStartY;
 
-    if (!this.props.open && !this.props.disableAccidentalDiscovery) {
+    if (!this.props.open && !this.props.disableDiscovery) {
       this.setPosition(this.getMaxTranslate() - swipeAreaWidth);
     }
 
@@ -151,9 +148,6 @@ class Drawer extends React.Component {
   };
 
   onBodyTouchMove = event => {
-    // sometimes the event handler is called after unbinding it
-    if (!this.mounted) return;
-
     const anchor = this.getAnchor();
     const horizontalSwipe = this.isHorizontalSwiping();
 
@@ -199,9 +193,6 @@ class Drawer extends React.Component {
   };
 
   onBodyTouchEnd = event => {
-    // sometimes the event handler is called after unbinding it
-    if (!this.mounted) return;
-
     if (this.state.swiping) {
       const anchor = this.getAnchor();
       const currentX =
@@ -302,21 +293,21 @@ class Drawer extends React.Component {
 
   render() {
     const {
-      anchor: anchorProp, // eslint-disable-line
+      anchor: anchorProp,
       children,
       classes,
       className,
-      disableAccidentalDiscovery, // eslint-disable-line
-      disableSwipeToOpen, // eslint-disable-line
+      disableDiscovery,
+      disableSwipeToOpen,
       elevation,
       ModalProps,
       onClose,
-      onOpen, // eslint-disable-line
+      onOpen,
       open,
       PaperProps,
       SlideProps,
-      swipeAreaWidth, // eslint-disable-line
-      theme, // eslint-disable-line
+      swipeAreaWidth,
+      theme,
       transitionDuration: transitionDurationProp,
       variant,
       ...other
@@ -352,7 +343,7 @@ class Drawer extends React.Component {
 
     const slidingDrawer = (
       <Slide
-        in={open || (variant === 'temporary' && !!this.maybeSwiping)}
+        in={open || (variant === 'temporary' && this.maybeSwiping)}
         direction={oppositeDirection[anchor]}
         timeout={transitionDuration}
         appear={!this.state.firstMount}
@@ -412,7 +403,7 @@ Drawer.propTypes = {
    * If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit
    * to promote accidental discovery of the swipe gesture.
    */
-  disableAccidentalDiscovery: PropTypes.bool,
+  disableDiscovery: PropTypes.bool,
   /**
    * If `true`, the drawer cannot be opened by swiping from the edge of the screen.
    */
@@ -474,7 +465,7 @@ Drawer.propTypes = {
 
 Drawer.defaultProps = {
   anchor: 'left',
-  disableAccidentalDiscovery: false,
+  disableDiscovery: false,
   disableSwipeToOpen: false,
   elevation: 16,
   open: false,

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -314,6 +314,7 @@ class Drawer extends React.Component {
       elevation,
       ModalProps,
       onClose,
+      onOpen, // eslint-disable-line
       open,
       PaperProps,
       SlideProps,

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -97,6 +97,7 @@ class Drawer extends React.Component {
     if (this.props.type === 'temporary') {
       this.enableSwipeHandling();
     }
+    this.mounted = true;
   }
 
   componentWillReceiveProps(nextProps) {
@@ -114,9 +115,13 @@ class Drawer extends React.Component {
   componentWillUnmount() {
     this.disableSwipeHandling();
     this.removeBodyTouchListeners();
+    this.mounted = false;
   }
 
   onBodyTouchStart = event => {
+    // sometimes the event handler is called after unbinding it
+    if (!this.mounted) return;
+
     const swipeAreaWidth = this.props.swipeAreaWidth;
 
     const touchStartX =
@@ -151,6 +156,9 @@ class Drawer extends React.Component {
   };
 
   onBodyTouchMove = event => {
+    // sometimes the event handler is called after unbinding it
+    if (!this.mounted) return;
+
     const anchor = this.getAnchor();
     const horizontalSwipe = this.isHorizontalSwiping();
 
@@ -196,6 +204,9 @@ class Drawer extends React.Component {
   };
 
   onBodyTouchEnd = event => {
+    // sometimes the event handler is called after unbinding it
+    if (!this.mounted) return;
+
     if (this.state.swiping) {
       const anchor = this.getAnchor();
       const currentX =

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -170,8 +170,13 @@ class Drawer extends React.Component {
     }
 
     this.maybeSwiping = true;
+    this.forceUpdate();
     this.touchStartX = touchStartX;
     this.touchStartY = touchStartY;
+
+    if (!this.props.open) {
+      this.setPosition(this.getMaxTranslateX() - swipeAreaWidth)
+    }
 
     document.body.addEventListener('touchmove', this.onBodyTouchMove);
     document.body.addEventListener('touchend', this.onBodyTouchEnd);
@@ -195,11 +200,12 @@ class Drawer extends React.Component {
   }
 
   getTranslateX(currentX) {
+    const swipeAreaWidth = 30 // this.props.swipeAreaWidth;
     return Math.min(
              Math.max(
                this.state.swiping === 'closing' ?
                  -(currentX - this.swipeStartX) :
-                 this.getMaxTranslateX() + (this.swipeStartX - currentX),
+                 this.getMaxTranslateX() + (this.swipeStartX - currentX) - swipeAreaWidth,
                0
              ),
              this.getMaxTranslateX()
@@ -267,8 +273,12 @@ class Drawer extends React.Component {
           this.setPosition(0);
         }
       }
-    } else {
+    } else if (this.maybeSwiping) {
+      if (!this.props.open) {
+        event.preventDefault(); // prevent ghost clicks in the menu
+      }
       this.maybeSwiping = false;
+      this.forceUpdate();
     }
 
     this.removeBodyTouchListeners();
@@ -353,7 +363,7 @@ class Drawer extends React.Component {
           transitionDuration,
         }}
         className={classNames(classes.modal, className)}
-        open={open || (type === 'temporary' && this.maybeSwiping)}
+        open={open || (type === 'temporary' && !!this.maybeSwiping)}
         onClose={onClose}
         {...other}
         {...ModalProps}

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -93,19 +93,18 @@ class Drawer extends React.Component {
     if (this.props.variant === 'temporary') {
       this.enableSwipeHandling();
     }
+
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({
+      firstMount: false,
+    });
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if (this.props.variant === 'temporary' && prevProps.variant !== 'temporary') {
       this.enableSwipeHandling();
     } else if (this.props.variant !== 'temporary' && prevProps.variant === 'temporary') {
       this.disableSwipeHandling();
-    }
-
-    if (this.state.firstMount) {
-      this.setState({
-        firstMount: false,
-      });
     }
   }
 
@@ -313,9 +312,7 @@ class Drawer extends React.Component {
       ...other
     } = this.props;
 
-    const {
-      maybeSwiping
-    } = this.state;
+    const { maybeSwiping } = this.state;
 
     const anchor = this.getAnchor();
     // prevent flickering when swiping fast

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -119,8 +119,7 @@ class Drawer extends React.Component {
   }
 
   getMaxTranslate() {
-    const drawer = ReactDOM.findDOMNode(this.drawer); // TODO what about server-side rendering?
-    return this.isHorizontalSwiping() ? drawer.clientWidth : drawer.clientHeight;
+    return this.isHorizontalSwiping() ? this.drawer.clientWidth : this.drawer.clientHeight;
   }
 
   enableSwipeHandling() {
@@ -175,15 +174,13 @@ class Drawer extends React.Component {
 
   setPosition(translate) {
     const rtlTranslateMultiplier = ['right', 'bottom'].includes(this.getAnchor()) ? 1 : -1;
-    const drawer = ReactDOM.findDOMNode(this.drawer);
     const transformCSS = this.isHorizontalSwiping()
       ? `translate(${rtlTranslateMultiplier * translate}px, 0)`
       : `translate(0, ${rtlTranslateMultiplier * translate}px)`;
-    drawer.style.transform = transformCSS;
-    drawer.style.webkitTransform = transformCSS;
+    this.drawer.style.transform = transformCSS;
+    this.drawer.style.webkitTransform = transformCSS;
 
-    const backdrop = ReactDOM.findDOMNode(this.backdrop);
-    backdrop.style.opacity = 1 - translate / this.getMaxTranslate();
+    this.backdrop.style.opacity = 1 - translate / this.getMaxTranslate();
   }
 
   getTranslate(current) {
@@ -235,7 +232,9 @@ class Drawer extends React.Component {
           swiping: this.props.open ? 'closing' : 'opening',
         });
         this.setPosition(this.getTranslate(horizontalSwipe ? currentX : currentY));
-      } else if (dXAbs <= threshold && dYAbs > threshold) {
+      } else if (horizontalSwipe
+        ? (dXAbs <= threshold && dYAbs > threshold)
+        : (dYAbs <= threshold && dXAbs > threshold)) {
         this.onBodyTouchEnd();
       }
     }
@@ -335,7 +334,9 @@ class Drawer extends React.Component {
         className={classNames(classes.paper, classes[`paperAnchor${capitalize(anchor)}`], {
           [classes[`paperAnchorDocked${capitalize(anchor)}`]]: variant !== 'temporary',
         })}
-        ref={(ref) => { this.drawer = ref }}
+        ref={ref => {
+          this.drawer = ref != null ? ReactDOM.findDOMNode(ref) : null;
+        }}
         {...PaperProps}
       >
         {children}
@@ -352,7 +353,7 @@ class Drawer extends React.Component {
 
     const slidingDrawer = (
       <Slide
-        in={open || (type === 'temporary' && this.maybeSwiping)}
+        in={open || (type === 'temporary' && !!this.maybeSwiping)}
         direction={getSlideDirection(anchor)}
         timeout={transitionDuration}
         appear={!this.state.firstMount}
@@ -375,7 +376,7 @@ class Drawer extends React.Component {
       <Modal
         BackdropProps={{
           ref: ref => {
-            this.backdrop = ref;
+            this.backdrop = ref != null ? ReactDOM.findDOMNode(ref) : null;
           },
           transitionDuration,
         }}

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -264,7 +264,7 @@ class Drawer extends React.Component {
       Math.max(
         this.state.swiping === 'closing'
           ? -(current - swipeStart)
-          : this.getMaxTranslate() + (swipeStart - current) - this.props.swipeAreaWidth
+          : this.getMaxTranslate() + (swipeStart - current) - this.props.swipeAreaWidth,
         0,
       ),
       this.getMaxTranslate(),

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -17,14 +17,14 @@ const oppositeDirection = {
   bottom: 'up',
 };
 
+export function isHorizontal(props) {
+  return ['left', 'right'].indexOf(props.anchor) !== -1;
+}
+
 export function getAnchor(props) {
   return props.theme.direction === 'rtl' && isHorizontal(props)
     ? oppositeDirection[props.anchor]
     : props.anchor;
-}
-
-export function isHorizontal(props) {
-  return ['left', 'right'].indexOf(props.anchor) !== -1;
 }
 
 export const styles = theme => ({

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -85,6 +85,8 @@ class Drawer extends React.Component {
     // We use that state is order to skip the appear transition during the
     // initial mount of the component.
     firstMount: true,
+    maybeSwiping: false,
+    swiping: false,
   };
 
   componentDidMount() {
@@ -133,8 +135,7 @@ class Drawer extends React.Component {
       if (this.props.disableSwipeToOpen) return;
     }
 
-    this.maybeSwiping = true;
-    this.forceUpdate();
+    this.setState({ maybeSwiping: true });
     this.touchStartX = touchStartX;
     this.touchStartY = touchStartY;
 
@@ -163,7 +164,7 @@ class Drawer extends React.Component {
     if (this.state.swiping) {
       event.preventDefault();
       this.setPosition(this.getTranslate(horizontalSwipe ? currentX : currentY));
-    } else if (this.maybeSwiping) {
+    } else if (this.state.maybeSwiping) {
       const dXAbs = Math.abs(currentX - this.touchStartX);
       const dYAbs = Math.abs(currentY - this.touchStartY);
       // If the user has moved his thumb ten pixels in either direction,
@@ -207,10 +208,10 @@ class Drawer extends React.Component {
         ? this.getTranslate(currentX) / this.getMaxTranslate()
         : this.getTranslate(currentY) / this.getMaxTranslate();
 
-      this.maybeSwiping = false;
       const swiping = this.state.swiping;
       this.setState({
         swiping: null,
+        maybeSwiping: false,
       });
 
       // We have to open or close after setting swiping to null,
@@ -228,12 +229,11 @@ class Drawer extends React.Component {
       } else {
         this.setPosition(0);
       }
-    } else if (this.maybeSwiping) {
+    } else if (this.state.maybeSwiping) {
       if (!this.props.open && event != null) {
         event.preventDefault(); // prevent ghost clicks
       }
-      this.maybeSwiping = false;
-      this.forceUpdate();
+      this.setState({ maybeSwiping: false });
     }
 
     this.removeBodyTouchListeners();
@@ -313,9 +313,13 @@ class Drawer extends React.Component {
       ...other
     } = this.props;
 
+    const {
+      maybeSwiping
+    } = this.state;
+
     const anchor = this.getAnchor();
     // prevent flickering when swiping fast
-    const transitionDuration = this.maybeSwiping ? 0 : transitionDurationProp;
+    const transitionDuration = maybeSwiping ? 0 : transitionDurationProp;
 
     const drawer = (
       <Paper
@@ -343,7 +347,7 @@ class Drawer extends React.Component {
 
     const slidingDrawer = (
       <Slide
-        in={open || (variant === 'temporary' && this.maybeSwiping)}
+        in={open || (variant === 'temporary' && maybeSwiping)}
         direction={oppositeDirection[anchor]}
         timeout={transitionDuration}
         appear={!this.state.firstMount}
@@ -371,7 +375,7 @@ class Drawer extends React.Component {
           transitionDuration,
         }}
         className={classNames(classes.modal, className)}
-        open={open || (variant === 'temporary' && !!this.maybeSwiping)}
+        open={open || (variant === 'temporary' && maybeSwiping)}
         onClose={onClose}
         {...other}
         {...ModalProps}

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -106,7 +106,6 @@ class Drawer extends React.Component {
   render() {
     const {
       anchor: anchorProp,
-      backdropRef,
       children,
       classes,
       className,
@@ -115,7 +114,6 @@ class Drawer extends React.Component {
       onClose,
       open,
       PaperProps,
-      paperRef,
       SlideProps,
       theme,
       transitionDuration,
@@ -132,7 +130,6 @@ class Drawer extends React.Component {
         className={classNames(classes.paper, classes[`paperAnchor${capitalize(anchor)}`], {
           [classes[`paperAnchorDocked${capitalize(anchor)}`]]: variant !== 'temporary',
         })}
-        ref={paperRef}
         {...PaperProps}
       >
         {children}
@@ -171,7 +168,6 @@ class Drawer extends React.Component {
     return (
       <Modal
         BackdropProps={{
-          ref: backdropRef,
           transitionDuration,
         }}
         className={classNames(classes.modal, className)}

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -1,7 +1,6 @@
 // @inheritedComponent Modal
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Modal from '../Modal';
@@ -17,6 +16,16 @@ const oppositeDirection = {
   top: 'down',
   bottom: 'up',
 };
+
+export function getAnchor(props) {
+  return props.theme.direction === 'rtl' && isHorizontal(props)
+    ? oppositeDirection[props.anchor]
+    : props.anchor;
+}
+
+export function isHorizontal(props) {
+  return ['left', 'right'].indexOf(props.anchor) !== -1;
+}
 
 export const styles = theme => ({
   docked: {
@@ -85,238 +94,36 @@ class Drawer extends React.Component {
     // We use that state is order to skip the appear transition during the
     // initial mount of the component.
     firstMount: true,
-    maybeSwiping: false,
-    swiping: false,
   };
 
   componentDidMount() {
-    if (this.props.variant === 'temporary') {
-      this.enableSwipeHandling();
-    }
-
     // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({
       firstMount: false,
     });
   }
 
-  componentDidUpdate(prevProps) {
-    if (this.props.variant === 'temporary' && prevProps.variant !== 'temporary') {
-      this.enableSwipeHandling();
-    } else if (this.props.variant !== 'temporary' && prevProps.variant === 'temporary') {
-      this.disableSwipeHandling();
-    }
-  }
-
-  componentWillUnmount() {
-    this.disableSwipeHandling();
-    this.removeBodyTouchListeners();
-  }
-
-  onBodyTouchStart = event => {
-    const anchor = this.getAnchor();
-    const swipeAreaWidth = this.props.swipeAreaWidth;
-
-    const touchStartX =
-      anchor === 'right'
-        ? document.body.offsetWidth - event.touches[0].pageX
-        : event.touches[0].pageX;
-    const touchStartY =
-      anchor === 'bottom'
-        ? window.innerHeight - event.touches[0].clientY
-        : event.touches[0].clientY;
-
-    if (!this.props.open) {
-      if (this.isHorizontalSwiping()) {
-        if (touchStartX > swipeAreaWidth) return;
-      } else if (touchStartY > swipeAreaWidth) return;
-
-      if (this.props.disableSwipeToOpen) return;
-    }
-
-    this.setState({ maybeSwiping: true });
-    this.touchStartX = touchStartX;
-    this.touchStartY = touchStartY;
-
-    if (!this.props.open && !this.props.disableDiscovery) {
-      this.setPosition(this.getMaxTranslate() - swipeAreaWidth);
-    }
-
-    document.body.addEventListener('touchmove', this.onBodyTouchMove, { passive: false });
-    document.body.addEventListener('touchend', this.onBodyTouchEnd);
-    document.body.addEventListener('touchcancel', this.onBodyTouchEnd);
-  };
-
-  onBodyTouchMove = event => {
-    const anchor = this.getAnchor();
-    const horizontalSwipe = this.isHorizontalSwiping();
-
-    const currentX =
-      anchor === 'right'
-        ? document.body.offsetWidth - event.touches[0].pageX
-        : event.touches[0].pageX;
-    const currentY =
-      anchor === 'bottom'
-        ? window.innerHeight - event.touches[0].clientY
-        : event.touches[0].clientY;
-
-    if (this.state.swiping) {
-      event.preventDefault();
-      this.setPosition(this.getTranslate(horizontalSwipe ? currentX : currentY));
-    } else if (this.state.maybeSwiping) {
-      const dXAbs = Math.abs(currentX - this.touchStartX);
-      const dYAbs = Math.abs(currentY - this.touchStartY);
-      // If the user has moved his thumb ten pixels in either direction,
-      // we can safely make an assumption about whether he was intending
-      // to swipe or scroll.
-      const threshold = 10;
-
-      const isSwiping = horizontalSwipe
-        ? dXAbs > threshold && dYAbs <= threshold
-        : dYAbs > threshold && dXAbs <= threshold;
-
-      if (isSwiping) {
-        this.swipeStartX = currentX;
-        this.swipeStartY = currentY;
-        this.setState({
-          swiping: this.props.open ? 'closing' : 'opening',
-        });
-        this.setPosition(this.getTranslate(horizontalSwipe ? currentX : currentY));
-      } else if (
-        horizontalSwipe
-          ? dXAbs <= threshold && dYAbs > threshold
-          : dYAbs <= threshold && dXAbs > threshold
-      ) {
-        this.onBodyTouchEnd();
-      }
-    }
-  };
-
-  onBodyTouchEnd = event => {
-    if (this.state.swiping) {
-      const anchor = this.getAnchor();
-      const currentX =
-        anchor === 'right'
-          ? document.body.offsetWidth - event.changedTouches[0].pageX
-          : event.changedTouches[0].pageX;
-      const currentY =
-        anchor === 'bottom'
-          ? window.innerHeight - event.changedTouches[0].clientY
-          : event.changedTouches[0].clientY;
-      const translateRatio = this.isHorizontalSwiping()
-        ? this.getTranslate(currentX) / this.getMaxTranslate()
-        : this.getTranslate(currentY) / this.getMaxTranslate();
-
-      const swiping = this.state.swiping;
-      this.setState({
-        swiping: null,
-        maybeSwiping: false,
-      });
-
-      // We have to open or close after setting swiping to null,
-      // because only then CSS transition is enabled.
-      if (translateRatio > 0.5) {
-        if (swiping === 'opening') {
-          this.setPosition(this.getMaxTranslate());
-        } else if (this.props.onClose != null) {
-          this.props.onClose();
-        }
-      } else if (swiping === 'opening') {
-        if (this.props.onOpen != null) {
-          this.props.onOpen();
-        }
-      } else {
-        this.setPosition(0);
-      }
-    } else if (this.state.maybeSwiping) {
-      if (!this.props.open && event != null) {
-        event.preventDefault(); // prevent ghost clicks
-      }
-      this.setState({ maybeSwiping: false });
-    }
-
-    this.removeBodyTouchListeners();
-  };
-
-  getAnchor() {
-    return this.props.theme.direction === 'rtl' && this.isHorizontalSwiping()
-      ? oppositeDirection[this.props.anchor]
-      : this.props.anchor;
-  }
-
-  getMaxTranslate() {
-    return this.isHorizontalSwiping() ? this.drawer.clientWidth : this.drawer.clientHeight;
-  }
-
-  getTranslate(current) {
-    const swipeStart = this.isHorizontalSwiping() ? this.swipeStartX : this.swipeStartY;
-    return Math.min(
-      Math.max(
-        this.state.swiping === 'closing'
-          ? -(current - swipeStart)
-          : this.getMaxTranslate() + (swipeStart - current) - this.props.swipeAreaWidth,
-        0,
-      ),
-      this.getMaxTranslate(),
-    );
-  }
-
-  setPosition(translate) {
-    const rtlTranslateMultiplier = ['right', 'bottom'].indexOf(this.getAnchor()) !== -1 ? 1 : -1;
-    const transformCSS = this.isHorizontalSwiping()
-      ? `translate(${rtlTranslateMultiplier * translate}px, 0)`
-      : `translate(0, ${rtlTranslateMultiplier * translate}px)`;
-    this.drawer.style.transform = transformCSS;
-    this.drawer.style.webkitTransform = transformCSS;
-
-    this.backdrop.style.opacity = 1 - translate / this.getMaxTranslate();
-  }
-
-  isHorizontalSwiping() {
-    return ['left', 'right'].indexOf(this.props.anchor) !== -1;
-  }
-
-  enableSwipeHandling() {
-    document.body.addEventListener('touchstart', this.onBodyTouchStart);
-  }
-
-  disableSwipeHandling() {
-    document.body.removeEventListener('touchstart', this.onBodyTouchStart);
-  }
-
-  removeBodyTouchListeners() {
-    document.body.removeEventListener('touchmove', this.onBodyTouchMove);
-    document.body.removeEventListener('touchend', this.onBodyTouchEnd);
-    document.body.removeEventListener('touchcancel', this.onBodyTouchEnd);
-  }
-
   render() {
     const {
       anchor: anchorProp,
+      backdropRef,
       children,
       classes,
       className,
-      disableDiscovery,
-      disableSwipeToOpen,
       elevation,
       ModalProps,
       onClose,
-      onOpen,
       open,
       PaperProps,
+      paperRef,
       SlideProps,
-      swipeAreaWidth,
       theme,
-      transitionDuration: transitionDurationProp,
+      transitionDuration,
       variant,
       ...other
     } = this.props;
 
-    const { maybeSwiping } = this.state;
-
-    const anchor = this.getAnchor();
-    // prevent flickering when swiping fast
-    const transitionDuration = maybeSwiping ? 0 : transitionDurationProp;
+    const anchor = getAnchor(this.props);
 
     const drawer = (
       <Paper
@@ -325,9 +132,7 @@ class Drawer extends React.Component {
         className={classNames(classes.paper, classes[`paperAnchor${capitalize(anchor)}`], {
           [classes[`paperAnchorDocked${capitalize(anchor)}`]]: variant !== 'temporary',
         })}
-        ref={ref => {
-          this.drawer = ref != null ? ReactDOM.findDOMNode(ref) : null;
-        }}
+        ref={paperRef}
         {...PaperProps}
       >
         {children}
@@ -344,7 +149,7 @@ class Drawer extends React.Component {
 
     const slidingDrawer = (
       <Slide
-        in={open || (variant === 'temporary' && maybeSwiping)}
+        in={open}
         direction={oppositeDirection[anchor]}
         timeout={transitionDuration}
         appear={!this.state.firstMount}
@@ -366,13 +171,11 @@ class Drawer extends React.Component {
     return (
       <Modal
         BackdropProps={{
-          ref: ref => {
-            this.backdrop = ref != null ? ReactDOM.findDOMNode(ref) : null;
-          },
+          ref: backdropRef,
           transitionDuration,
         }}
         className={classNames(classes.modal, className)}
-        open={open || (variant === 'temporary' && maybeSwiping)}
+        open={open}
         onClose={onClose}
         {...other}
         {...ModalProps}
@@ -401,15 +204,6 @@ Drawer.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit
-   * to promote accidental discovery of the swipe gesture.
-   */
-  disableDiscovery: PropTypes.bool,
-  /**
-   * If `true`, the drawer cannot be opened by swiping from the edge of the screen.
-   */
-  disableSwipeToOpen: PropTypes.bool,
-  /**
    * The elevation of the drawer.
    */
   elevation: PropTypes.number,
@@ -424,12 +218,6 @@ Drawer.propTypes = {
    */
   onClose: PropTypes.func,
   /**
-   * Callback fired when the component requests to be opened.
-   *
-   * @param {object} event The event source of the callback
-   */
-  onOpen: PropTypes.func,
-  /**
    * If `true`, the drawer is open.
    */
   open: PropTypes.bool,
@@ -441,11 +229,6 @@ Drawer.propTypes = {
    * Properties applied to the `Slide` element.
    */
   SlideProps: PropTypes.object,
-  /**
-   * The width of the left most (or right most) area in pixels where the
-   * drawer can be swiped open from.
-   */
-  swipeAreaWidth: PropTypes.number,
   /**
    * @ignore
    */
@@ -466,11 +249,8 @@ Drawer.propTypes = {
 
 Drawer.defaultProps = {
   anchor: 'left',
-  disableDiscovery: false,
-  disableSwipeToOpen: false,
   elevation: 16,
   open: false,
-  swipeAreaWidth: 20,
   transitionDuration: { enter: duration.enteringScreen, exit: duration.leavingScreen },
   variant: 'temporary', // Mobile first.
 };

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -263,7 +263,7 @@ class Drawer extends React.Component {
   }
 
   setPosition(translate) {
-    const rtlTranslateMultiplier = ['right', 'bottom'].indexOf(this.props.anchor) !== -1 ? 1 : -1;
+    const rtlTranslateMultiplier = ['right', 'bottom'].indexOf(this.getAnchor()) !== -1 ? 1 : -1;
     const transformCSS = this.isHorizontalSwiping()
       ? `translate(${rtlTranslateMultiplier * translate}px, 0)`
       : `translate(0, ${rtlTranslateMultiplier * translate}px)`;

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -146,7 +146,7 @@ class Drawer extends React.Component {
     this.touchStartX = touchStartX;
     this.touchStartY = touchStartY;
 
-    if (!this.props.open) {
+    if (!this.props.open && !this.props.disableAccidentalDiscovery) {
       this.setPosition(this.getMaxTranslate() - swipeAreaWidth);
     }
 
@@ -314,6 +314,7 @@ class Drawer extends React.Component {
       children,
       classes,
       className,
+      disableAccidentalDiscovery, // eslint-disable-line
       disableSwipeToOpen, // eslint-disable-line
       elevation,
       ModalProps,
@@ -416,6 +417,11 @@ Drawer.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit
+   * to promote accidental discovery of the swipe gesture.
+   */
+  disableAccidentalDiscovery: PropTypes.bool,
+  /**
    * If `true`, the drawer cannot be opened by swiping from the edge of the screen.
    */
   disableSwipeToOpen: PropTypes.bool,
@@ -476,6 +482,7 @@ Drawer.propTypes = {
 
 Drawer.defaultProps = {
   anchor: 'left',
+  disableAccidentalDiscovery: false,
   disableSwipeToOpen: false,
   elevation: 16,
   open: false,

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -94,7 +94,7 @@ class Drawer extends React.Component {
   };
 
   componentDidMount() {
-    if (this.props.type === 'temporary') {
+    if (this.props.variant === 'temporary') {
       this.enableSwipeHandling();
     }
     this.mounted = true;
@@ -105,9 +105,9 @@ class Drawer extends React.Component {
       firstMount: false,
     });
 
-    if (this.props.type !== 'temporary' && nextProps.type === 'temporary') {
+    if (this.props.variant !== 'temporary' && nextProps.variant === 'temporary') {
       this.enableSwipeHandling();
-    } else if (this.props.type === 'temporary' && nextProps.type !== 'temporary') {
+    } else if (this.props.variant === 'temporary' && nextProps.variant !== 'temporary') {
       this.disableSwipeHandling();
     }
   }
@@ -359,7 +359,7 @@ class Drawer extends React.Component {
 
     const slidingDrawer = (
       <Slide
-        in={open || (type === 'temporary' && !!this.maybeSwiping)}
+        in={open || (variant === 'temporary' && !!this.maybeSwiping)}
         direction={getSlideDirection(anchor)}
         timeout={transitionDuration}
         appear={!this.state.firstMount}
@@ -387,7 +387,7 @@ class Drawer extends React.Component {
           transitionDuration,
         }}
         className={classNames(classes.modal, className)}
-        open={open || (type === 'temporary' && !!this.maybeSwiping)}
+        open={open || (variant === 'temporary' && !!this.maybeSwiping)}
         onClose={onClose}
         {...other}
         {...ModalProps}
@@ -469,7 +469,7 @@ Drawer.propTypes = {
     PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
   ]),
   /**
-   * The type of drawer.
+   * The variant of drawer.
    */
   variant: PropTypes.oneOf(['permanent', 'persistent', 'temporary']),
 };

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -3,7 +3,6 @@ import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import ReactDOM from 'react-dom';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
-import mockPortal from '../../test/utils/mockPortal';
 import Slide from '../transitions/Slide';
 import createMuiTheme from '../styles/createMuiTheme';
 import Paper from '../Paper';
@@ -23,12 +22,10 @@ describe('<Drawer />', () => {
         <div />
       </Drawer>,
     );
-    mockPortal.init();
   });
 
   after(() => {
     mount.cleanUp();
-    mockPortal.reset();
   });
 
   describe('prop: variant=temporary', () => {
@@ -395,6 +392,29 @@ describe('<Drawer />', () => {
             'should be listening for swipe',
           );
           assert.strictEqual(setPosition.callCount, 1, 'should slide in a bit');
+          fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
+          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
+          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+        });
+
+        it(`should stay hidden if disableAccidentalDiscovery is true ` +
+          `when touching near the ${params.anchor} edge`, () => {
+          wrapper.setProps({ anchor: params.anchor, disableAccidentalDiscovery: true });
+
+          // mock the internal setPosition function that moves the drawer while swiping
+          const setPosition = spy();
+          wrapper.instance().setPosition = setPosition;
+
+          const handleOpen = spy();
+          const handleClose = spy();
+          wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
+          fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
+          assert.strictEqual(
+            wrapper.instance().maybeSwiping,
+            true,
+            'should be listening for swipe',
+          );
+          assert.strictEqual(setPosition.callCount, 0, 'should not slide in');
           fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
           assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
           assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -39,7 +39,7 @@ describe('<Drawer />', () => {
         </Drawer>,
       );
       assert.strictEqual(wrapper.type(), Modal);
-      
+
       // temporary drawers need to be unmounted in the tests to remove the touchstart event handler
       wrapper.unmount();
     });
@@ -200,7 +200,8 @@ describe('<Drawer />', () => {
         // mock the drawer DOM node, since jsdom doesn't do layouting but its size is required
         const findDOMNode = ReactDOM.findDOMNode;
         findDOMNodeStub = stub(ReactDOM, 'findDOMNode').callsFake(arg => {
-          if (arg instanceof Paper) { // mock the drawer's DOM node
+          if (arg instanceof Paper) {
+            // mock the drawer's DOM node
             return { clientWidth: 250, clientHeight: 250, style: {} };
           }
           return findDOMNode(arg);
@@ -221,7 +222,7 @@ describe('<Drawer />', () => {
 
       afterEach(() => {
         wrapper.unmount();
-      })
+      });
 
       const bodyWidth = document.body.offsetWidth; // jsdom emulates these
       const windowHeight = window.innerHeight;
@@ -401,7 +402,7 @@ describe('<Drawer />', () => {
 
     after(() => {
       wrapper.unmount();
-    })
+    });
 
     it('should return the opposing slide direction', () => {
       wrapper.setProps({ anchor: 'left' });

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -7,7 +7,7 @@ import Slide from '../transitions/Slide';
 import createMuiTheme from '../styles/createMuiTheme';
 import Paper from '../Paper';
 import Modal from '../Modal';
-import Drawer from './Drawer';
+import Drawer, { isHorizontal, getAnchor } from './Drawer';
 
 describe('<Drawer />', () => {
   let shallow;
@@ -176,248 +176,6 @@ describe('<Drawer />', () => {
         assert.strictEqual(wrapper.find(Slide).props().in, false, 'should not transition in');
       });
     });
-
-    describe('swipe to open', () => {
-      let wrapper;
-      let DrawerNaked;
-      let findDOMNodeStub;
-
-      function fireBodyMouseEvent(name, properties) {
-        const event = document.createEvent('MouseEvents');
-        event.initEvent(name, true, true);
-        Object.keys(properties).forEach(key => {
-          event[key] = properties[key];
-        });
-        document.body.dispatchEvent(event);
-      }
-
-      before(() => {
-        DrawerNaked = unwrap(Drawer);
-
-        // mock the drawer DOM node, since jsdom doesn't do layouting but its size is required
-        const findDOMNode = ReactDOM.findDOMNode;
-        findDOMNodeStub = stub(ReactDOM, 'findDOMNode').callsFake(arg => {
-          if (arg instanceof Paper) {
-            // mock the drawer's DOM node
-            return { clientWidth: 250, clientHeight: 250, style: {} };
-          }
-          return findDOMNode(arg);
-        });
-      });
-
-      after(() => {
-        findDOMNodeStub.restore();
-      });
-
-      beforeEach(() => {
-        wrapper = mount(
-          <DrawerNaked classes={{}} theme={{ direction: 'ltr' }}>
-            <h1>Hello</h1>
-          </DrawerNaked>,
-        );
-      });
-
-      afterEach(() => {
-        wrapper.unmount();
-      });
-
-      const bodyWidth = document.body.offsetWidth; // jsdom emulates these
-      const windowHeight = window.innerHeight;
-      const toTouchPoint = ({ x, y }) => ({ pageX: x, clientY: y });
-      const tests = [
-        {
-          anchor: 'left',
-          openTouches: [{ x: 0, y: 0 }, { x: 20, y: 0 }, { x: 180, y: 0 }].map(toTouchPoint),
-          closeTouches: [{ x: 200, y: 0 }, { x: 180, y: 0 }, { x: 10, y: 0 }].map(toTouchPoint),
-          edgeTouch: { x: 10, y: 50 },
-        },
-        {
-          anchor: 'right',
-          openTouches: [
-            { x: bodyWidth, y: 0 },
-            { x: bodyWidth - 20, y: 0 },
-            { x: bodyWidth - 180, y: 0 },
-          ].map(toTouchPoint),
-          closeTouches: [
-            { x: bodyWidth - 200, y: 0 },
-            { x: bodyWidth - 180, y: 0 },
-            { x: bodyWidth - 10, y: 0 },
-          ].map(toTouchPoint),
-          edgeTouch: { x: bodyWidth - 10, y: 50 },
-        },
-        {
-          anchor: 'top',
-          openTouches: [{ x: 0, y: 0 }, { x: 0, y: 20 }, { x: 0, y: 180 }].map(toTouchPoint),
-          closeTouches: [{ x: 0, y: 200 }, { x: 0, y: 180 }, { x: 0, y: 10 }].map(toTouchPoint),
-          edgeTouch: { x: 50, y: 10 },
-        },
-        {
-          anchor: 'bottom',
-          openTouches: [
-            { x: 0, y: windowHeight },
-            { x: 0, y: windowHeight - 20 },
-            { x: 0, y: windowHeight - 180 },
-          ].map(toTouchPoint),
-          closeTouches: [
-            { x: 0, y: windowHeight - 200 },
-            { x: 0, y: windowHeight - 180 },
-            { x: 0, y: windowHeight - 10 },
-          ].map(toTouchPoint),
-          edgeTouch: { x: 50, y: windowHeight - 10 },
-        },
-      ];
-
-      tests.forEach(params => {
-        it(`should open and close when swiping from ${params.anchor}`, () => {
-          wrapper.setProps({ anchor: params.anchor });
-
-          // mock the internal setPosition function that moves the drawer while swiping
-          const setPosition = spy();
-          wrapper.instance().setPosition = setPosition;
-
-          // simulate open swipe
-          const handleOpen = spy();
-          wrapper.setProps({ onOpen: handleOpen });
-          fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
-          fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
-          assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening');
-          fireBodyMouseEvent('touchmove', { touches: [params.openTouches[2]] });
-          fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[2]] });
-          assert.strictEqual(handleOpen.callCount, 1, 'should call onOpen');
-          assert.strictEqual(
-            setPosition.callCount,
-            3,
-            'should move the drawer on touchstart and touchmove',
-          );
-
-          // simulate close swipe
-          setPosition.resetHistory();
-          const handleClose = spy();
-          wrapper.setProps({ open: true, onClose: handleClose });
-          fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
-          fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
-          assert.strictEqual(wrapper.state().swiping, 'closing', 'should be closing');
-          fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[2]] });
-          fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[2]] });
-          assert.strictEqual(handleClose.callCount, 1, 'should call onClose');
-          assert.strictEqual(setPosition.callCount, 2, 'should move the drawer on touchmove');
-        });
-
-        it(`should stay closed when not swiping far enough from ${params.anchor}`, () => {
-          wrapper.setProps({ anchor: params.anchor });
-
-          // simulate open swipe that doesn't swipe far enough
-          const handleOpen = spy();
-          wrapper.setProps({ onOpen: handleOpen });
-          fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
-          fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
-          assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening');
-          fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[1]] });
-          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
-        });
-
-        it(`should stay opened when not swiping ${params.anchor} far enough`, () => {
-          wrapper.setProps({ anchor: params.anchor, open: true });
-
-          // simulate close swipe that doesn't swipe far enough
-          const handleClose = spy();
-          wrapper.setProps({ open: true, onClose: handleClose });
-          fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
-          fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
-          assert.strictEqual(wrapper.state().swiping, 'closing', 'should be closing');
-          fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[1]] });
-          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
-        });
-
-        it('should not start swiping when swiping in the wrong direction', () => {
-          wrapper.setProps({ anchor: params.anchor });
-
-          fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
-          if (['left', 'right'].includes(params.anchor)) {
-            fireBodyMouseEvent('touchmove', {
-              touches: [
-                {
-                  pageX: params.openTouches[0].pageX,
-                  clientY: params.openTouches[0].clientY + 50,
-                },
-              ],
-            });
-          } else {
-            fireBodyMouseEvent('touchmove', {
-              touches: [
-                {
-                  pageX: params.openTouches[0].pageX + 50,
-                  clientY: params.openTouches[0].clientY,
-                },
-              ],
-            });
-          }
-          assert.equal(wrapper.state().swiping, false, 'should not be swiping');
-        });
-
-        it(`should slide in a bit when touching near the ${params.anchor} edge`, () => {
-          wrapper.setProps({ anchor: params.anchor });
-
-          // mock the internal setPosition function that moves the drawer while swiping
-          const setPosition = spy();
-          wrapper.instance().setPosition = setPosition;
-
-          const handleOpen = spy();
-          const handleClose = spy();
-          wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
-          fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
-          assert.strictEqual(setPosition.callCount, 1, 'should slide in a bit');
-          fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
-          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
-          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
-        });
-
-        describe('disableDiscovery', () => {
-          it(`makes the drawer stay hidden when touching near the ${params.anchor} edge `, () => {
-            wrapper.setProps({ anchor: params.anchor, disableDiscovery: true });
-
-            // mock the internal setPosition function that moves the drawer while swiping
-            const setPosition = spy();
-            wrapper.instance().setPosition = setPosition;
-
-            const handleOpen = spy();
-            const handleClose = spy();
-            wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
-            fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
-            assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
-            assert.strictEqual(setPosition.callCount, 0, 'should not slide in');
-            fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
-            assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
-            assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
-          });
-        });
-      });
-
-      it('removes event listeners on unmount', () => {
-        fireBodyMouseEvent('touchstart', { touches: [{ pageX: 0, clientY: 0 }] });
-        wrapper.unmount();
-        // should trigger setState warning if listeners aren't cleaned.
-        fireBodyMouseEvent('touchmove', { touches: [{ pageX: 180, clientY: 0 }] });
-        // should trigger setState warning if swipe handling is not cleaned, too
-        fireBodyMouseEvent('touchstart', { touches: [{ pageX: 0, clientY: 0 }] });
-      });
-
-      it('toggles swipe handling when the variant is changed', () => {
-        // variant is 'temporary' by default
-        spy(wrapper.instance(), 'disableSwipeHandling');
-        wrapper.setProps({ variant: 'persistent' });
-        assert.strictEqual(wrapper.instance().disableSwipeHandling.callCount, 1);
-
-        spy(wrapper.instance(), 'enableSwipeHandling');
-        wrapper.setProps({ variant: 'temporary' });
-        assert.strictEqual(wrapper.instance().enableSwipeHandling.callCount, 1);
-      });
-    });
   });
 
   describe('prop: variant=persistent', () => {
@@ -500,20 +258,6 @@ describe('<Drawer />', () => {
       wrapper.setProps({ anchor: 'bottom' });
       assert.strictEqual(wrapper.find(Slide).props().direction, 'up');
     });
-
-    it('should recognize left and right as horizontal swiping directions', () => {
-      wrapper.setProps({ anchor: 'left' });
-      assert.strictEqual(wrapper.instance().isHorizontalSwiping(), true);
-
-      wrapper.setProps({ anchor: 'right' });
-      assert.strictEqual(wrapper.instance().isHorizontalSwiping(), true);
-
-      wrapper.setProps({ anchor: 'top' });
-      assert.strictEqual(wrapper.instance().isHorizontalSwiping(), false);
-
-      wrapper.setProps({ anchor: 'bottom' });
-      assert.strictEqual(wrapper.instance().isHorizontalSwiping(), false);
-    });
   });
 
   describe('Right To Left', () => {
@@ -543,5 +287,14 @@ describe('<Drawer />', () => {
       // slide direction for right is left, if right is switched to left, we should get right
       assert.strictEqual(wrapper.find(Slide).props().direction, 'right');
     });
+  });
+});
+
+describe('isHorizontal', () => {
+  it('should recognize left and right as horizontal swiping directions', () => {
+    assert.strictEqual(isHorizontal({ anchor: 'left' }), true);
+    assert.strictEqual(isHorizontal({ anchor: 'right' }), true);
+    assert.strictEqual(isHorizontal({ anchor: 'top' }), false);
+    assert.strictEqual(isHorizontal({ anchor: 'bottom' }), false);
   });
 });

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -39,6 +39,9 @@ describe('<Drawer />', () => {
         </Drawer>,
       );
       assert.strictEqual(wrapper.type(), Modal);
+      
+      // temporary drawers need to be unmounted in the tests to remove the touchstart event handler
+      wrapper.unmount();
     });
 
     it('should render Slide > Paper inside the Modal', () => {
@@ -57,8 +60,9 @@ describe('<Drawer />', () => {
 
       const paper = slide.childAt(0);
       assert.strictEqual(paper.length === 1 && paper.type(), Paper);
-
       assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the paper class');
+
+      wrapper.unmount();
     });
 
     describe('transitionDuration property', () => {
@@ -74,6 +78,7 @@ describe('<Drawer />', () => {
           </Drawer>,
         );
         assert.strictEqual(wrapper.find(Slide).props().timeout, transitionDuration);
+        wrapper.unmount();
       });
 
       it("should be passed to to Modal's BackdropTransitionDuration when open=true", () => {
@@ -86,6 +91,7 @@ describe('<Drawer />', () => {
           wrapper.find(Modal).props().BackdropProps.transitionDuration,
           transitionDuration,
         );
+        wrapper.unmount();
       });
     });
 
@@ -97,6 +103,7 @@ describe('<Drawer />', () => {
         </Drawer>,
       );
       assert.strictEqual(wrapper.find(Modal).props().BackdropTransitionDuration, testDuration);
+      wrapper.unmount();
     });
 
     it('should set the custom className for Modal when variant is temporary', () => {
@@ -109,6 +116,7 @@ describe('<Drawer />', () => {
       const modal = wrapper.find(Modal);
 
       assert.strictEqual(modal.hasClass('woofDrawer'), true, 'should have the woofDrawer class');
+      wrapper.unmount();
     });
 
     it('should set the Paper className', () => {
@@ -120,6 +128,7 @@ describe('<Drawer />', () => {
       const paper = wrapper.find(Paper);
       assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the paper class');
       assert.strictEqual(paper.hasClass('woofDrawer'), true, 'should have the woofDrawer class');
+      wrapper.unmount();
     });
 
     it('should be closed by default', () => {
@@ -134,6 +143,7 @@ describe('<Drawer />', () => {
 
       assert.strictEqual(modal.props().open, false, 'should not show the modal');
       assert.strictEqual(slide.props().in, false, 'should not transition in');
+      wrapper.unmount();
     });
 
     describe('opening and closing', () => {
@@ -146,6 +156,10 @@ describe('<Drawer />', () => {
           </Drawer>,
         );
         wrapper.update();
+      });
+
+      after(() => {
+        wrapper.unmount();
       });
 
       it('should start closed', () => {
@@ -186,7 +200,7 @@ describe('<Drawer />', () => {
         // mock the drawer DOM node, since jsdom doesn't do layouting but its size is required
         const findDOMNode = ReactDOM.findDOMNode;
         findDOMNodeStub = stub(ReactDOM, 'findDOMNode').callsFake(arg => {
-          if (arg instanceof Paper) {
+          if (arg instanceof Paper) { // mock the drawer's DOM node
             return { clientWidth: 250, clientHeight: 250, style: {} };
           }
           return findDOMNode(arg);
@@ -204,6 +218,10 @@ describe('<Drawer />', () => {
           </DrawerNaked>,
         );
       });
+
+      afterEach(() => {
+        wrapper.unmount();
+      })
 
       const bodyWidth = document.body.offsetWidth; // jsdom emulates these
       const windowHeight = window.innerHeight;
@@ -381,6 +399,10 @@ describe('<Drawer />', () => {
       );
     });
 
+    after(() => {
+      wrapper.unmount();
+    })
+
     it('should return the opposing slide direction', () => {
       wrapper.setProps({ anchor: 'left' });
       assert.strictEqual(wrapper.find(Slide).props().direction, 'right');
@@ -422,6 +444,10 @@ describe('<Drawer />', () => {
           <div />
         </Drawer>,
       );
+    });
+
+    after(() => {
+      wrapper.unmount();
     });
 
     it('should switch left and right anchor when theme is right-to-left', () => {

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -397,27 +397,28 @@ describe('<Drawer />', () => {
           assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
         });
 
-        it(`should stay hidden if disableAccidentalDiscovery is true ` +
-          `when touching near the ${params.anchor} edge`, () => {
-          wrapper.setProps({ anchor: params.anchor, disableAccidentalDiscovery: true });
+        describe('disableAccidentalDiscovery', () => {
+          it(`makes the drawer stay hidden when touching near the ${params.anchor} edge `, () => {
+            wrapper.setProps({ anchor: params.anchor, disableAccidentalDiscovery: true });
 
-          // mock the internal setPosition function that moves the drawer while swiping
-          const setPosition = spy();
-          wrapper.instance().setPosition = setPosition;
+            // mock the internal setPosition function that moves the drawer while swiping
+            const setPosition = spy();
+            wrapper.instance().setPosition = setPosition;
 
-          const handleOpen = spy();
-          const handleClose = spy();
-          wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
-          fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
-          assert.strictEqual(
-            wrapper.instance().maybeSwiping,
-            true,
-            'should be listening for swipe',
-          );
-          assert.strictEqual(setPosition.callCount, 0, 'should not slide in');
-          fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
-          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
-          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+            const handleOpen = spy();
+            const handleClose = spy();
+            wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
+            fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
+            assert.strictEqual(
+              wrapper.instance().maybeSwiping,
+              true,
+              'should be listening for swipe',
+            );
+            assert.strictEqual(setPosition.callCount, 0, 'should not slide in');
+            fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
+            assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
+            assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+          });
         });
       });
 

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import { assert } from 'chai';
-import { spy, stub } from 'sinon';
-import ReactDOM from 'react-dom';
-import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
+import { createShallow, createMount, getClasses } from '../test-utils';
 import Slide from '../transitions/Slide';
 import createMuiTheme from '../styles/createMuiTheme';
 import Paper from '../Paper';
 import Modal from '../Modal';
-import Drawer, { isHorizontal, getAnchor } from './Drawer';
+import Drawer, { getAnchor, isHorizontal } from './Drawer';
 
 describe('<Drawer />', () => {
   let shallow;
@@ -296,5 +294,27 @@ describe('isHorizontal', () => {
     assert.strictEqual(isHorizontal({ anchor: 'right' }), true);
     assert.strictEqual(isHorizontal({ anchor: 'top' }), false);
     assert.strictEqual(isHorizontal({ anchor: 'bottom' }), false);
+  });
+});
+
+describe('getAnchor', () => {
+  it('should return the anchor', () => {
+    const theme = createMuiTheme({
+      direction: 'ltr',
+    });
+
+    assert.strictEqual(getAnchor({ anchor: 'left', theme }), 'left');
+    assert.strictEqual(getAnchor({ anchor: 'right', theme }), 'right');
+    assert.strictEqual(getAnchor({ anchor: 'top', theme }), 'top');
+    assert.strictEqual(getAnchor({ anchor: 'bottom', theme }), 'bottom');
+  });
+
+  it('should switch left/right if RTL is enabled', () => {
+    const theme = createMuiTheme({
+      direction: 'rtl',
+    });
+
+    assert.strictEqual(getAnchor({ anchor: 'left', theme }), 'right');
+    assert.strictEqual(getAnchor({ anchor: 'right', theme }), 'left');
   });
 });

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -397,9 +397,9 @@ describe('<Drawer />', () => {
           assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
         });
 
-        describe('disableAccidentalDiscovery', () => {
+        describe('disableDiscovery', () => {
           it(`makes the drawer stay hidden when touching near the ${params.anchor} edge `, () => {
-            wrapper.setProps({ anchor: params.anchor, disableAccidentalDiscovery: true });
+            wrapper.setProps({ anchor: params.anchor, disableDiscovery: true });
 
             // mock the internal setPosition function that moves the drawer while swiping
             const setPosition = spy();

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -279,11 +279,7 @@ describe('<Drawer />', () => {
           const handleOpen = spy();
           wrapper.setProps({ onOpen: handleOpen });
           fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
-          assert.strictEqual(
-            wrapper.instance().maybeSwiping,
-            true,
-            'should be listening for swipe',
-          );
+          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
           assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening');
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[2]] });
@@ -300,11 +296,7 @@ describe('<Drawer />', () => {
           const handleClose = spy();
           wrapper.setProps({ open: true, onClose: handleClose });
           fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
-          assert.strictEqual(
-            wrapper.instance().maybeSwiping,
-            true,
-            'should be listening for swipe',
-          );
+          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
           assert.strictEqual(wrapper.state().swiping, 'closing', 'should be closing');
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[2]] });
@@ -320,11 +312,7 @@ describe('<Drawer />', () => {
           const handleOpen = spy();
           wrapper.setProps({ onOpen: handleOpen });
           fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
-          assert.strictEqual(
-            wrapper.instance().maybeSwiping,
-            true,
-            'should be listening for swipe',
-          );
+          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
           assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening');
           fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[1]] });
@@ -338,11 +326,7 @@ describe('<Drawer />', () => {
           const handleClose = spy();
           wrapper.setProps({ open: true, onClose: handleClose });
           fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
-          assert.strictEqual(
-            wrapper.instance().maybeSwiping,
-            true,
-            'should be listening for swipe',
-          );
+          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
           assert.strictEqual(wrapper.state().swiping, 'closing', 'should be closing');
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[1]] });
@@ -372,7 +356,7 @@ describe('<Drawer />', () => {
               ],
             });
           }
-          assert.equal(wrapper.state().swiping, null, 'should not be swiping');
+          assert.equal(wrapper.state().swiping, false, 'should not be swiping');
         });
 
         it(`should slide in a bit when touching near the ${params.anchor} edge`, () => {
@@ -386,11 +370,7 @@ describe('<Drawer />', () => {
           const handleClose = spy();
           wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
           fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
-          assert.strictEqual(
-            wrapper.instance().maybeSwiping,
-            true,
-            'should be listening for swipe',
-          );
+          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           assert.strictEqual(setPosition.callCount, 1, 'should slide in a bit');
           fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
           assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
@@ -409,11 +389,7 @@ describe('<Drawer />', () => {
             const handleClose = spy();
             wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
             fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
-            assert.strictEqual(
-              wrapper.instance().maybeSwiping,
-              true,
-              'should be listening for swipe',
-            );
+            assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
             assert.strictEqual(setPosition.callCount, 0, 'should not slide in');
             fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
             assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -410,14 +410,14 @@ describe('<Drawer />', () => {
         fireBodyMouseEvent('touchstart', { touches: [{ pageX: 0, clientY: 0 }] });
       });
 
-      it('toggles swipe handling when the type is changed', () => {
-        // type is 'temporary' by default
+      it('toggles swipe handling when the variant is changed', () => {
+        // variant is 'temporary' by default
         spy(wrapper.instance(), 'disableSwipeHandling');
-        wrapper.setProps({ type: 'persistent' });
+        wrapper.setProps({ variant: 'persistent' });
         assert.strictEqual(wrapper.instance().disableSwipeHandling.callCount, 1);
 
         spy(wrapper.instance(), 'enableSwipeHandling');
-        wrapper.setProps({ type: 'temporary' });
+        wrapper.setProps({ variant: 'temporary' });
         assert.strictEqual(wrapper.instance().enableSwipeHandling.callCount, 1);
       });
     });

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
-import ReactDOM, { findDOMNode } from 'react-dom';
+import ReactDOM from 'react-dom';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
 import mockPortal from '../../test/utils/mockPortal';
 import Slide from '../transitions/Slide';
@@ -10,7 +10,7 @@ import Paper from '../Paper';
 import Modal from '../Modal';
 import Drawer from './Drawer';
 
-describe.only('<Drawer />', () => {
+describe('<Drawer />', () => {
   let shallow;
   let mount;
   let classes;
@@ -29,7 +29,7 @@ describe.only('<Drawer />', () => {
   after(() => {
     mount.cleanUp();
     mockPortal.reset();
-  })
+  });
 
   describe('prop: variant=temporary', () => {
     it('should render a Modal', () => {
@@ -145,7 +145,7 @@ describe.only('<Drawer />', () => {
             <h1>Hello</h1>
           </Drawer>,
         );
-        wrapper.update()
+        wrapper.update();
       });
 
       it('should start closed', () => {
@@ -168,14 +168,15 @@ describe.only('<Drawer />', () => {
 
     describe('swipe to open', () => {
       let wrapper;
-      let instance;
       let DrawerNaked;
       let findDOMNodeStub;
 
-      function fireBodyMouseEvent (name, properties) {
+      function fireBodyMouseEvent(name, properties) {
         const event = document.createEvent('MouseEvents');
         event.initEvent(name, true, true);
-        Object.keys(properties).forEach((key) => { event[key] = properties[key] });
+        Object.keys(properties).forEach(key => {
+          event[key] = properties[key];
+        });
         document.body.dispatchEvent(event);
       }
 
@@ -183,17 +184,16 @@ describe.only('<Drawer />', () => {
         DrawerNaked = unwrap(Drawer);
 
         // mock the drawer DOM node, since jsdom doesn't do layouting but its size is required
-        const findDOMNode = ReactDOM.findDOMNode
+        const findDOMNode = ReactDOM.findDOMNode;
         findDOMNodeStub = stub(ReactDOM, 'findDOMNode').callsFake(arg => {
           if (arg instanceof Paper) {
             return { clientWidth: 250, clientHeight: 250, style: {} };
-          } else {
-            return findDOMNode(arg)
           }
+          return findDOMNode(arg);
         });
       });
 
-      after(() =>  {
+      after(() => {
         findDOMNodeStub.restore();
       });
 
@@ -201,60 +201,89 @@ describe.only('<Drawer />', () => {
         wrapper = mount(
           <DrawerNaked classes={{}} theme={{ direction: 'ltr' }}>
             <h1>Hello</h1>
-          </DrawerNaked>
+          </DrawerNaked>,
         );
       });
 
-      const bodyWidth = document.body.offsetWidth // jsdom emulates these
-      const windowHeight = window.innerHeight
-      const toTouchPoint = ({x, y}) => ({pageX: x, clientY: y})
-      const tests = [{
-        anchor: 'left',
-        openTouches: [{x: 0, y: 0}, {x: 20, y: 0}, {x: 180, y: 0}].map(toTouchPoint),
-        closeTouches: [{x: 200, y: 0}, {x: 180, y: 0}, {x: 10, y: 0}].map(toTouchPoint),
-        edgeTouch: {x: 10, y: 50}
-      }, {
-        anchor: 'right',
-        openTouches: [{x: bodyWidth, y: 0}, {x: bodyWidth - 20, y: 0}, {x: bodyWidth - 180, y: 0}].map(toTouchPoint),
-        closeTouches: [{x: bodyWidth - 200, y: 0}, {x: bodyWidth - 180, y: 0}, {x: bodyWidth - 10, y: 0}].map(toTouchPoint),
-        edgeTouch: {x: bodyWidth - 10, y: 50}
-      }, {
-        anchor: 'top',
-        openTouches: [{x: 0, y: 0}, {x: 0, y: 20}, {x: 0, y: 180}].map(toTouchPoint),
-        closeTouches: [{x: 0, y: 200}, {x: 0, y: 180}, {x: 0, y: 10}].map(toTouchPoint),
-        edgeTouch: {x: 50, y: 10}
-      }, {
-        anchor: 'bottom',
-        openTouches: [{x: 0, y: windowHeight}, {x: 0, y: windowHeight - 20}, {x: 0, y: windowHeight - 180}].map(toTouchPoint),
-        closeTouches: [{x: 0, y: windowHeight - 200}, {x: 0, y: windowHeight - 180}, {x: 0, y: windowHeight - 10}].map(toTouchPoint),
-        edgeTouch: {x: 50, y: windowHeight - 10}
-      }]
+      const bodyWidth = document.body.offsetWidth; // jsdom emulates these
+      const windowHeight = window.innerHeight;
+      const toTouchPoint = ({ x, y }) => ({ pageX: x, clientY: y });
+      const tests = [
+        {
+          anchor: 'left',
+          openTouches: [{ x: 0, y: 0 }, { x: 20, y: 0 }, { x: 180, y: 0 }].map(toTouchPoint),
+          closeTouches: [{ x: 200, y: 0 }, { x: 180, y: 0 }, { x: 10, y: 0 }].map(toTouchPoint),
+          edgeTouch: { x: 10, y: 50 },
+        },
+        {
+          anchor: 'right',
+          openTouches: [
+            { x: bodyWidth, y: 0 },
+            { x: bodyWidth - 20, y: 0 },
+            { x: bodyWidth - 180, y: 0 },
+          ].map(toTouchPoint),
+          closeTouches: [
+            { x: bodyWidth - 200, y: 0 },
+            { x: bodyWidth - 180, y: 0 },
+            { x: bodyWidth - 10, y: 0 },
+          ].map(toTouchPoint),
+          edgeTouch: { x: bodyWidth - 10, y: 50 },
+        },
+        {
+          anchor: 'top',
+          openTouches: [{ x: 0, y: 0 }, { x: 0, y: 20 }, { x: 0, y: 180 }].map(toTouchPoint),
+          closeTouches: [{ x: 0, y: 200 }, { x: 0, y: 180 }, { x: 0, y: 10 }].map(toTouchPoint),
+          edgeTouch: { x: 50, y: 10 },
+        },
+        {
+          anchor: 'bottom',
+          openTouches: [
+            { x: 0, y: windowHeight },
+            { x: 0, y: windowHeight - 20 },
+            { x: 0, y: windowHeight - 180 },
+          ].map(toTouchPoint),
+          closeTouches: [
+            { x: 0, y: windowHeight - 200 },
+            { x: 0, y: windowHeight - 180 },
+            { x: 0, y: windowHeight - 10 },
+          ].map(toTouchPoint),
+          edgeTouch: { x: 50, y: windowHeight - 10 },
+        },
+      ];
 
-      tests.forEach((params) => {
+      tests.forEach(params => {
         it(`should open and close when swiping from ${params.anchor}`, () => {
           wrapper.setProps({ anchor: params.anchor });
 
           // simulate open swipe
           const handleOpen = spy();
-          wrapper.setProps({ onOpen: handleOpen })
-          fireBodyMouseEvent('touchstart', {touches: [params.openTouches[0]]})
-          assert.strictEqual(wrapper.instance().maybeSwiping, true, 'should be listening for swipe')
-          fireBodyMouseEvent('touchmove', {touches: [params.openTouches[1]]})
-          assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening')
-          fireBodyMouseEvent('touchend', {changedTouches: [params.openTouches[2]]})
-          assert.strictEqual(handleOpen.callCount, 1, 'should call onOpen')
+          wrapper.setProps({ onOpen: handleOpen });
+          fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
+          assert.strictEqual(
+            wrapper.instance().maybeSwiping,
+            true,
+            'should be listening for swipe',
+          );
+          fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
+          assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening');
+          fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[2]] });
+          assert.strictEqual(handleOpen.callCount, 1, 'should call onOpen');
 
           // simulate close swipe
           const handleClose = spy();
-          wrapper.setProps({ open: true, onClose: handleClose })
-          fireBodyMouseEvent('touchstart', {touches: [params.closeTouches[0]]});
-          assert.strictEqual(wrapper.instance().maybeSwiping, true, 'should be listening for swipe');
-          fireBodyMouseEvent('touchmove', {touches: [params.closeTouches[1]]});
+          wrapper.setProps({ open: true, onClose: handleClose });
+          fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
+          assert.strictEqual(
+            wrapper.instance().maybeSwiping,
+            true,
+            'should be listening for swipe',
+          );
+          fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
           assert.strictEqual(wrapper.state().swiping, 'closing', 'should be closing');
-          fireBodyMouseEvent('touchend', {changedTouches: [params.closeTouches[2]]});
+          fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[2]] });
           assert.strictEqual(handleClose.callCount, 1, 'should call onClose');
         });
-        
+
         it(`should slide in a bit when touching near the ${params.anchor} edge`, () => {
           wrapper.setProps({ anchor: params.anchor });
 
@@ -265,24 +294,28 @@ describe.only('<Drawer />', () => {
           const handleOpen = spy();
           const handleClose = spy();
           wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
-          fireBodyMouseEvent('touchstart', {touches: [params.edgeTouch]})
-          assert.strictEqual(wrapper.instance().maybeSwiping, true, 'should be listening for swipe')
-          assert.strictEqual(setPosition.callCount, 1, 'should slide in a bit')
-          fireBodyMouseEvent('touchend', {changedTouches: [params.edgeTouch]})
-          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen')
-          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose')
+          fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
+          assert.strictEqual(
+            wrapper.instance().maybeSwiping,
+            true,
+            'should be listening for swipe',
+          );
+          assert.strictEqual(setPosition.callCount, 1, 'should slide in a bit');
+          fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
+          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
+          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
         });
       });
 
       it('removes event listeners on unmount', () => {
-        fireBodyMouseEvent('touchstart', {touches: [{pageX: 0, clientY: 0}]})
+        fireBodyMouseEvent('touchstart', { touches: [{ pageX: 0, clientY: 0 }] });
         wrapper.unmount();
         // should trigger setState warning if listeners aren't cleaned.
-        fireBodyMouseEvent('touchmove', {touches: [{pageX: 180, clientY: 0}]});
+        fireBodyMouseEvent('touchmove', { touches: [{ pageX: 180, clientY: 0 }] });
         // should trigger setState warning if swipe handling is not cleaned, too
-        fireBodyMouseEvent('touchstart', {touches: [{pageX: 0, clientY: 0}]});
-      })
-    })
+        fireBodyMouseEvent('touchstart', { touches: [{ pageX: 0, clientY: 0 }] });
+      });
+    });
   });
 
   describe('prop: variant=persistent', () => {
@@ -374,7 +407,7 @@ describe.only('<Drawer />', () => {
 
       wrapper.setProps({ anchor: 'bottom' });
       assert.strictEqual(wrapper.instance().isHorizontalSwiping(), false);
-    })
+    });
   });
 
   describe('Right To Left', () => {

--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -1,0 +1,278 @@
+// @inheritedComponent Drawer
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
+import Drawer, { getAnchor, isHorizontal } from '../Drawer/Drawer';
+import withTheme from '../styles/withTheme';
+import { duration } from '../styles/transitions';
+
+const oppositeDirection = {
+  left: 'right',
+  right: 'left',
+  top: 'down',
+  bottom: 'up',
+};
+
+class SwipeableDrawer extends React.Component {
+  state = {
+    maybeSwiping: false,
+    swiping: false,
+  };
+
+  componentDidMount() {
+    if (this.props.variant === 'temporary') {
+      this.enableSwipeHandling();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.variant === 'temporary' && prevProps.variant !== 'temporary') {
+      this.enableSwipeHandling();
+    } else if (this.props.variant !== 'temporary' && prevProps.variant === 'temporary') {
+      this.disableSwipeHandling();
+    }
+  }
+
+  componentWillUnmount() {
+    this.disableSwipeHandling();
+    this.removeBodyTouchListeners();
+  }
+
+  onBodyTouchStart = event => {
+    const anchor = getAnchor(this.props);
+    const swipeAreaWidth = this.props.swipeAreaWidth;
+
+    const touchStartX =
+      anchor === 'right'
+        ? document.body.offsetWidth - event.touches[0].pageX
+        : event.touches[0].pageX;
+    const touchStartY =
+      anchor === 'bottom'
+        ? window.innerHeight - event.touches[0].clientY
+        : event.touches[0].clientY;
+
+    if (!this.props.open) {
+      if (isHorizontal(this.props)) {
+        if (touchStartX > swipeAreaWidth) return;
+      } else if (touchStartY > swipeAreaWidth) return;
+    }
+
+    this.setState({ maybeSwiping: true });
+    this.touchStartX = touchStartX;
+    this.touchStartY = touchStartY;
+
+    if (!this.props.open && !this.props.disableDiscovery) {
+      this.setPosition(this.getMaxTranslate() - swipeAreaWidth);
+    }
+
+    document.body.addEventListener('touchmove', this.onBodyTouchMove, { passive: false });
+    document.body.addEventListener('touchend', this.onBodyTouchEnd);
+    document.body.addEventListener('touchcancel', this.onBodyTouchEnd);
+  };
+
+  onBodyTouchMove = event => {
+    const anchor = getAnchor(this.props);
+    const horizontalSwipe = isHorizontal(this.props);
+
+    const currentX =
+      anchor === 'right'
+        ? document.body.offsetWidth - event.touches[0].pageX
+        : event.touches[0].pageX;
+    const currentY =
+      anchor === 'bottom'
+        ? window.innerHeight - event.touches[0].clientY
+        : event.touches[0].clientY;
+
+    if (this.state.swiping) {
+      event.preventDefault();
+      this.setPosition(this.getTranslate(horizontalSwipe ? currentX : currentY));
+    } else if (this.state.maybeSwiping) {
+      const dXAbs = Math.abs(currentX - this.touchStartX);
+      const dYAbs = Math.abs(currentY - this.touchStartY);
+      // If the user has moved his thumb ten pixels in either direction,
+      // we can safely make an assumption about whether he was intending
+      // to swipe or scroll.
+      const threshold = 10;
+
+      const isSwiping = horizontalSwipe
+        ? dXAbs > threshold && dYAbs <= threshold
+        : dYAbs > threshold && dXAbs <= threshold;
+
+      if (isSwiping) {
+        this.swipeStartX = currentX;
+        this.swipeStartY = currentY;
+        this.setState({
+          swiping: this.props.open ? 'closing' : 'opening',
+        });
+        this.setPosition(this.getTranslate(horizontalSwipe ? currentX : currentY));
+      } else if (
+        horizontalSwipe
+          ? dXAbs <= threshold && dYAbs > threshold
+          : dYAbs <= threshold && dXAbs > threshold
+      ) {
+        this.onBodyTouchEnd();
+      }
+    }
+  };
+
+  onBodyTouchEnd = event => {
+    if (this.state.swiping) {
+      const anchor = getAnchor(this.props);
+      const currentX =
+        anchor === 'right'
+          ? document.body.offsetWidth - event.changedTouches[0].pageX
+          : event.changedTouches[0].pageX;
+      const currentY =
+        anchor === 'bottom'
+          ? window.innerHeight - event.changedTouches[0].clientY
+          : event.changedTouches[0].clientY;
+      const translateRatio = isHorizontal(this.props)
+        ? this.getTranslate(currentX) / this.getMaxTranslate()
+        : this.getTranslate(currentY) / this.getMaxTranslate();
+
+      const swiping = this.state.swiping;
+      this.setState({
+        swiping: null,
+        maybeSwiping: false,
+      });
+
+      // We have to open or close after setting swiping to null,
+      // because only then CSS transition is enabled.
+      if (translateRatio > 0.5) {
+        if (swiping === 'opening') {
+          this.setPosition(this.getMaxTranslate());
+        } else {
+          this.props.onClose();
+        }
+      } else if (swiping === 'opening') {
+        this.props.onOpen();
+      } else {
+        this.setPosition(0);
+      }
+    } else if (this.state.maybeSwiping) {
+      if (!this.props.open && event != null) {
+        event.preventDefault(); // prevent ghost clicks
+      }
+      this.setState({ maybeSwiping: false });
+    }
+
+    this.removeBodyTouchListeners();
+  };
+
+  getMaxTranslate() {
+    return isHorizontal(this.props) ? this.drawer.clientWidth : this.drawer.clientHeight;
+  }
+
+  getTranslate(current) {
+    const swipeStart = isHorizontal(this.props) ? this.swipeStartX : this.swipeStartY;
+    return Math.min(
+      Math.max(
+        this.state.swiping === 'closing'
+          ? -(current - swipeStart)
+          : this.getMaxTranslate() + (swipeStart - current) - this.props.swipeAreaWidth,
+        0,
+      ),
+      this.getMaxTranslate(),
+    );
+  }
+
+  setPosition(translate) {
+    const anchor = getAnchor(this.props);
+    const rtlTranslateMultiplier = ['right', 'bottom'].indexOf(anchor) !== -1 ? 1 : -1;
+    const transformCSS = isHorizontal(this.props)
+      ? `translate(${rtlTranslateMultiplier * translate}px, 0)`
+      : `translate(0, ${rtlTranslateMultiplier * translate}px)`;
+    this.drawer.style.transform = transformCSS;
+    this.drawer.style.webkitTransform = transformCSS;
+
+    this.backdrop.style.opacity = 1 - translate / this.getMaxTranslate();
+  }
+
+  enableSwipeHandling() {
+    document.body.addEventListener('touchstart', this.onBodyTouchStart);
+  }
+
+  disableSwipeHandling() {
+    document.body.removeEventListener('touchstart', this.onBodyTouchStart);
+  }
+
+  removeBodyTouchListeners() {
+    document.body.removeEventListener('touchmove', this.onBodyTouchMove);
+    document.body.removeEventListener('touchend', this.onBodyTouchEnd);
+    document.body.removeEventListener('touchcancel', this.onBodyTouchEnd);
+  }
+
+  render() {
+    const {
+      disableDiscovery,
+      onOpen,
+      open,
+      swipeAreaWidth,
+      transitionDuration: transitionDurationProp,
+      ...other
+    } = this.props;
+
+    const { maybeSwiping } = this.state;
+
+    // prevent flickering when swiping fast
+    const transitionDuration = maybeSwiping ? 0 : transitionDurationProp;
+
+    return (
+      <Drawer
+        backdropRef={ref => {
+          this.backdrop = ref != null ? ReactDOM.findDOMNode(ref) : null;
+        }}
+        paperRef={ref => {
+          this.drawer = ref != null ? ReactDOM.findDOMNode(ref) : null;
+        }}
+        open={open || (this.props.variant === 'temporary' && maybeSwiping)}
+        transitionDuration={transitionDuration}
+        {...other}
+      />
+    );
+  }
+}
+
+SwipeableDrawer.defaultProps = {
+  anchor: 'left',
+  disableDiscovery: false,
+  swipeAreaWidth: 20,
+  transitionDuration: { enter: duration.enteringScreen, exit: duration.leavingScreen },
+  variant: 'temporary', // Mobile first.
+};
+
+SwipeableDrawer.propTypes = {
+  /**
+   * If `true`, touching the screen near the edge of the drawer will not slide in the drawer a bit
+   * to promote accidental discovery of the swipe gesture.
+   */
+  disableDiscovery: PropTypes.bool,
+  /**
+   * Callback fired when the component requests to be closed.
+   *
+   * @param {object} event The event source of the callback
+   */
+  onClose: PropTypes.func.isRequired,
+  /**
+   * Callback fired when the component requests to be opened.
+   *
+   * @param {object} event The event source of the callback
+   */
+  onOpen: PropTypes.func.isRequired,
+  /**
+   * If `true`, the drawer is open.
+   */
+  open: PropTypes.bool.isRequired,
+  /**
+   * The width of the left most (or right most) area in pixels where the
+   * drawer can be swiped open from.
+   */
+  swipeAreaWidth: PropTypes.number,
+  /**
+   * @ignore
+   */
+  theme: PropTypes.object.isRequired,
+};
+
+export default withTheme()(SwipeableDrawer);

--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -206,6 +206,7 @@ class SwipeableDrawer extends React.Component {
   render() {
     const {
       disableDiscovery,
+      ModalProps,
       onOpen,
       open,
       swipeAreaWidth,
@@ -220,11 +221,19 @@ class SwipeableDrawer extends React.Component {
 
     return (
       <Drawer
-        backdropRef={ref => {
-          this.backdrop = ref != null ? ReactDOM.findDOMNode(ref) : null;
+        ModalProps={{
+          BackdropProps: {
+            transitionDuration,
+            ref: ref => {
+              this.backdrop = ref != null ? ReactDOM.findDOMNode(ref) : null;
+            },
+          },
+          ...ModalProps
         }}
-        paperRef={ref => {
-          this.drawer = ref != null ? ReactDOM.findDOMNode(ref) : null;
+        PaperProps={{
+          ref: ref => {
+            this.drawer = ref != null ? ReactDOM.findDOMNode(ref) : null;
+          }
         }}
         open={open || (this.props.variant === 'temporary' && maybeSwiping)}
         transitionDuration={transitionDuration}

--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -191,7 +191,7 @@ class SwipeableDrawer extends React.Component {
   }
 
   removeBodyTouchListeners() {
-    document.body.removeEventListener('touchmove', this.onBodyTouchMove);
+    document.body.removeEventListener('touchmove', this.onBodyTouchMove, { passive: false });
     document.body.removeEventListener('touchend', this.onBodyTouchEnd);
     document.body.removeEventListener('touchcancel', this.onBodyTouchEnd);
   }

--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -7,13 +7,6 @@ import Drawer, { getAnchor, isHorizontal } from '../Drawer/Drawer';
 import withTheme from '../styles/withTheme';
 import { duration } from '../styles/transitions';
 
-const oppositeDirection = {
-  left: 'right',
-  right: 'left',
-  top: 'down',
-  bottom: 'up',
-};
-
 class SwipeableDrawer extends React.Component {
   state = {
     maybeSwiping: false,
@@ -228,12 +221,12 @@ class SwipeableDrawer extends React.Component {
               this.backdrop = ref != null ? ReactDOM.findDOMNode(ref) : null;
             },
           },
-          ...ModalProps
+          ...ModalProps,
         }}
         PaperProps={{
           ref: ref => {
             this.drawer = ref != null ? ReactDOM.findDOMNode(ref) : null;
-          }
+          },
         }}
         open={open || (this.props.variant === 'temporary' && maybeSwiping)}
         transitionDuration={transitionDuration}
@@ -257,6 +250,10 @@ SwipeableDrawer.propTypes = {
    * to promote accidental discovery of the swipe gesture.
    */
   disableDiscovery: PropTypes.bool,
+  /**
+   * Properties applied to the `Modal` element.
+   */
+  ModalProps: PropTypes.object,
   /**
    * Callback fired when the component requests to be closed.
    *
@@ -282,6 +279,18 @@ SwipeableDrawer.propTypes = {
    * @ignore
    */
   theme: PropTypes.object.isRequired,
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
+  transitionDuration: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
+  ]),
+  /**
+   * The variant of drawer.
+   */
+  variant: PropTypes.oneOf(['permanent', 'persistent', 'temporary']),
 };
 
 export default withTheme()(SwipeableDrawer);

--- a/src/SwipeableDrawer/SwipeableDrawer.spec.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.spec.js
@@ -1,0 +1,279 @@
+import React from 'react';
+import { assert } from 'chai';
+import { spy, stub } from 'sinon';
+import ReactDOM from 'react-dom';
+import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
+import Slide from '../transitions/Slide';
+import createMuiTheme from '../styles/createMuiTheme';
+import Paper from '../Paper';
+import Drawer from '../Drawer';
+import SwipeableDrawer from './SwipeableDrawer';
+
+describe('<SwipeableDrawer />', () => {
+  let shallow;
+  let mount;
+  let classes;
+
+  before(() => {
+    shallow = createShallow({ dive: true });
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  it('should render a Drawer', () => {
+    const wrapper = shallow(
+      <SwipeableDrawer>
+        <div />
+      </SwipeableDrawer>,
+    );
+    assert.strictEqual(wrapper.type(), Drawer);
+
+    // temporary drawers need to be unmounted in the tests to remove the touchstart event handler
+    wrapper.unmount();
+  });
+
+  describe('swipe to open', () => {
+    let wrapper;
+    let DrawerNaked;
+    let findDOMNodeStub;
+
+    function fireBodyMouseEvent(name, properties) {
+      const event = document.createEvent('MouseEvents');
+      event.initEvent(name, true, true);
+      Object.keys(properties).forEach(key => {
+        event[key] = properties[key];
+      });
+      document.body.dispatchEvent(event);
+    }
+
+    before(() => {
+      DrawerNaked = unwrap(SwipeableDrawer);
+
+      // mock the drawer DOM node, since jsdom doesn't do layouting but its size is required
+      const findDOMNode = ReactDOM.findDOMNode;
+      findDOMNodeStub = stub(ReactDOM, 'findDOMNode').callsFake(arg => {
+        if (arg instanceof Paper) {
+          // mock the drawer's DOM node
+          return { clientWidth: 250, clientHeight: 250, style: {} };
+        }
+        return findDOMNode(arg);
+      });
+    });
+
+    after(() => {
+      findDOMNodeStub.restore();
+    });
+
+    beforeEach(() => {
+      wrapper = mount(
+        <DrawerNaked theme={{ direction: 'ltr' }}>
+          <h1>Hello</h1>
+        </DrawerNaked>,
+      );
+    });
+
+    afterEach(() => {
+      wrapper.unmount();
+    });
+
+    const bodyWidth = document.body.offsetWidth; // jsdom emulates these
+    const windowHeight = window.innerHeight;
+    const toTouchPoint = ({ x, y }) => ({ pageX: x, clientY: y });
+    const tests = [
+      {
+        anchor: 'left',
+        openTouches: [{ x: 0, y: 0 }, { x: 20, y: 0 }, { x: 180, y: 0 }].map(toTouchPoint),
+        closeTouches: [{ x: 200, y: 0 }, { x: 180, y: 0 }, { x: 10, y: 0 }].map(toTouchPoint),
+        edgeTouch: { x: 10, y: 50 },
+      },
+      {
+        anchor: 'right',
+        openTouches: [
+          { x: bodyWidth, y: 0 },
+          { x: bodyWidth - 20, y: 0 },
+          { x: bodyWidth - 180, y: 0 },
+        ].map(toTouchPoint),
+        closeTouches: [
+          { x: bodyWidth - 200, y: 0 },
+          { x: bodyWidth - 180, y: 0 },
+          { x: bodyWidth - 10, y: 0 },
+        ].map(toTouchPoint),
+        edgeTouch: { x: bodyWidth - 10, y: 50 },
+      },
+      {
+        anchor: 'top',
+        openTouches: [{ x: 0, y: 0 }, { x: 0, y: 20 }, { x: 0, y: 180 }].map(toTouchPoint),
+        closeTouches: [{ x: 0, y: 200 }, { x: 0, y: 180 }, { x: 0, y: 10 }].map(toTouchPoint),
+        edgeTouch: { x: 50, y: 10 },
+      },
+      {
+        anchor: 'bottom',
+        openTouches: [
+          { x: 0, y: windowHeight },
+          { x: 0, y: windowHeight - 20 },
+          { x: 0, y: windowHeight - 180 },
+        ].map(toTouchPoint),
+        closeTouches: [
+          { x: 0, y: windowHeight - 200 },
+          { x: 0, y: windowHeight - 180 },
+          { x: 0, y: windowHeight - 10 },
+        ].map(toTouchPoint),
+        edgeTouch: { x: 50, y: windowHeight - 10 },
+      },
+    ];
+
+    tests.forEach(params => {
+      it(`should open and close when swiping from ${params.anchor}`, () => {
+        wrapper.setProps({ anchor: params.anchor });
+
+        // mock the internal setPosition function that moves the drawer while swiping
+        const setPosition = spy();
+        wrapper.instance().setPosition = setPosition;
+
+        // simulate open swipe
+        const handleOpen = spy();
+        wrapper.setProps({ onOpen: handleOpen });
+        fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
+        assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+        fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
+        assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening');
+        fireBodyMouseEvent('touchmove', { touches: [params.openTouches[2]] });
+        fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[2]] });
+        assert.strictEqual(handleOpen.callCount, 1, 'should call onOpen');
+        assert.strictEqual(
+          setPosition.callCount,
+          3,
+          'should move the drawer on touchstart and touchmove',
+        );
+
+        // simulate close swipe
+        setPosition.resetHistory();
+        const handleClose = spy();
+        wrapper.setProps({ open: true, onClose: handleClose });
+        fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
+        assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+        fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
+        assert.strictEqual(wrapper.state().swiping, 'closing', 'should be closing');
+        fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[2]] });
+        fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[2]] });
+        assert.strictEqual(handleClose.callCount, 1, 'should call onClose');
+        assert.strictEqual(setPosition.callCount, 2, 'should move the drawer on touchmove');
+      });
+
+      it(`should stay closed when not swiping far enough from ${params.anchor}`, () => {
+        wrapper.setProps({ anchor: params.anchor });
+
+        // simulate open swipe that doesn't swipe far enough
+        const handleOpen = spy();
+        wrapper.setProps({ onOpen: handleOpen });
+        fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
+        assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+        fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
+        assert.strictEqual(wrapper.state().swiping, 'opening', 'should be opening');
+        fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[1]] });
+        assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
+      });
+
+      it(`should stay opened when not swiping ${params.anchor} far enough`, () => {
+        wrapper.setProps({ anchor: params.anchor, open: true });
+
+        // simulate close swipe that doesn't swipe far enough
+        const handleClose = spy();
+        wrapper.setProps({ open: true, onClose: handleClose });
+        fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
+        assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+        fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
+        assert.strictEqual(wrapper.state().swiping, 'closing', 'should be closing');
+        fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[1]] });
+        assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+      });
+
+      it('should not start swiping when swiping in the wrong direction', () => {
+        wrapper.setProps({ anchor: params.anchor });
+
+        fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
+        if (['left', 'right'].includes(params.anchor)) {
+          fireBodyMouseEvent('touchmove', {
+            touches: [
+              {
+                pageX: params.openTouches[0].pageX,
+                clientY: params.openTouches[0].clientY + 50,
+              },
+            ],
+          });
+        } else {
+          fireBodyMouseEvent('touchmove', {
+            touches: [
+              {
+                pageX: params.openTouches[0].pageX + 50,
+                clientY: params.openTouches[0].clientY,
+              },
+            ],
+          });
+        }
+        assert.equal(wrapper.state().swiping, false, 'should not be swiping');
+      });
+
+      it(`should slide in a bit when touching near the ${params.anchor} edge`, () => {
+        wrapper.setProps({ anchor: params.anchor });
+
+        // mock the internal setPosition function that moves the drawer while swiping
+        const setPosition = spy();
+        wrapper.instance().setPosition = setPosition;
+
+        const handleOpen = spy();
+        const handleClose = spy();
+        wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
+        fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
+        assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+        assert.strictEqual(setPosition.callCount, 1, 'should slide in a bit');
+        fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
+        assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
+        assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+      });
+
+      describe('disableDiscovery', () => {
+        it(`makes the drawer stay hidden when touching near the ${params.anchor} edge `, () => {
+          wrapper.setProps({ anchor: params.anchor, disableDiscovery: true });
+
+          // mock the internal setPosition function that moves the drawer while swiping
+          const setPosition = spy();
+          wrapper.instance().setPosition = setPosition;
+
+          const handleOpen = spy();
+          const handleClose = spy();
+          wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
+          fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
+          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+          assert.strictEqual(setPosition.callCount, 0, 'should not slide in');
+          fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
+          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
+          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+        });
+      });
+    });
+
+    it('removes event listeners on unmount', () => {
+      fireBodyMouseEvent('touchstart', { touches: [{ pageX: 0, clientY: 0 }] });
+      wrapper.unmount();
+      // should trigger setState warning if listeners aren't cleaned.
+      fireBodyMouseEvent('touchmove', { touches: [{ pageX: 180, clientY: 0 }] });
+      // should trigger setState warning if swipe handling is not cleaned, too
+      fireBodyMouseEvent('touchstart', { touches: [{ pageX: 0, clientY: 0 }] });
+    });
+
+    it('toggles swipe handling when the variant is changed', () => {
+      // variant is 'temporary' by default
+      spy(wrapper.instance(), 'disableSwipeHandling');
+      wrapper.setProps({ variant: 'persistent' });
+      assert.strictEqual(wrapper.instance().disableSwipeHandling.callCount, 1);
+
+      spy(wrapper.instance(), 'enableSwipeHandling');
+      wrapper.setProps({ variant: 'temporary' });
+      assert.strictEqual(wrapper.instance().enableSwipeHandling.callCount, 1);
+    });
+  });
+});

--- a/src/SwipeableDrawer/SwipeableDrawer.spec.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.spec.js
@@ -2,9 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import ReactDOM from 'react-dom';
-import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
-import Slide from '../transitions/Slide';
-import createMuiTheme from '../styles/createMuiTheme';
+import { createShallow, createMount, unwrap } from '../test-utils';
 import Paper from '../Paper';
 import Drawer from '../Drawer';
 import SwipeableDrawer from './SwipeableDrawer';
@@ -12,7 +10,6 @@ import SwipeableDrawer from './SwipeableDrawer';
 describe('<SwipeableDrawer />', () => {
   let shallow;
   let mount;
-  let classes;
 
   before(() => {
     shallow = createShallow({ dive: true });
@@ -25,7 +22,7 @@ describe('<SwipeableDrawer />', () => {
 
   it('should render a Drawer', () => {
     const wrapper = shallow(
-      <SwipeableDrawer>
+      <SwipeableDrawer onOpen={() => {}} onClose={() => {}} open={false}>
         <div />
       </SwipeableDrawer>,
     );
@@ -69,7 +66,7 @@ describe('<SwipeableDrawer />', () => {
 
     beforeEach(() => {
       wrapper = mount(
-        <DrawerNaked theme={{ direction: 'ltr' }}>
+        <DrawerNaked theme={{ direction: 'ltr' }} onOpen={() => {}} onClose={() => {}} open={false}>
           <h1>Hello</h1>
         </DrawerNaked>,
       );

--- a/src/SwipeableDrawer/index.js
+++ b/src/SwipeableDrawer/index.js
@@ -1,0 +1,1 @@
+export { default } from './SwipeableDrawer';

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -53,7 +53,7 @@ function getTranslateValue(props, node) {
   }
 
   // direction === 'down'
-  return `translate3d(0, ${0 - (rect.top + rect.height)}px, 0)`;
+  return `translateY(-${rect.top + rect.height + GUTTER - offsetY}px)`;
 }
 
 export function setTranslateValue(props, node) {

--- a/src/transitions/Slide.spec.js
+++ b/src/transitions/Slide.spec.js
@@ -175,7 +175,7 @@ describe('<Slide />', () => {
         assert.strictEqual(element.style.transform, 'translateY(100vh) translateY(-200px)');
         wrapper.setProps({ direction: 'down' });
         instance.handleEnter(element);
-        assert.strictEqual(element.style.transform, 'translate3d(0, -500px, 0)');
+        assert.strictEqual(element.style.transform, 'translateY(-524px)');
       });
 
       it('should reset the previous transition if needed', () => {
@@ -229,7 +229,7 @@ describe('<Slide />', () => {
         assert.strictEqual(element.style.transform, 'translateY(100vh) translateY(-200px)');
         wrapper.setProps({ direction: 'down' });
         instance.handleEnter(element);
-        assert.strictEqual(element.style.transform, 'translate3d(0, -500px, 0)');
+        assert.strictEqual(element.style.transform, 'translateY(-524px)');
       });
     });
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
[![Bountysource](https://api.bountysource.com/badge/issue?issue_id=49178088)](https://www.bountysource.com/issues/49178088-drawer-support-gestures?utm_source=49178088&utm_medium=shield&utm_campaign=ISSUE_BADGE)

This PR adds swiping support for the drawer, for all four supported anchors.
Closes #8127 and #2126

Swiping only works with `variant='temporary'`.

New props:
* `disableSwipeToOpen` disables the swiping feature
* `disableDiscovery` disables opening the drawer a bit when touching the edge of the screen (default behavior on Android)
* `onOpen` invoked when the drawer is swiped open
* `swipeAreaWidth` configures the width of the area where you can swipe the menu when it is hidden

---
Current progress:

- [x] Swiping (from left)
- [x] RTL support (i.e. swiping from right)
- [x] Discoverability (i.e. showing a bit of the drawer when touching near the edge of the screen, similar to how Android does it)
- [x] `anchor='top'` and `anchor='bottom'` support for swiping ~(not sure if this is even a use case)~
  Still amazed by the fact that we get bottom sheets for free :open_mouth: 
- [x] :100: percent test coverage
- [x] Code cleanup
- [x] Update typings
- [x] A `disableAccidentalDiscovery` prop to disable showing the drawer when touching near the edge of the screen
- [x] Try to minimize the package footprint of the swiping feature
- [x] Implement `SwipeableDrawer` as a new component to make this feature easier to maintain and to allow using the drawer without swiping without increasing the bundle size