### PR TITLE
[core] Follow the React HOC convention

### DIFF
--- a/src/AppBar/AppBar.spec.js
+++ b/src/AppBar/AppBar.spec.js
@@ -14,7 +14,6 @@ describe('<AppBar />', () => {
 
   it('should render a Paper component', () => {
     const wrapper = shallow(<AppBar>Hello World</AppBar>);
-    assert.strictEqual(wrapper.name(), 'WithStyles');
     assert.strictEqual(wrapper.props().elevation, 4, 'should render with a 4dp shadow');
   });
 

--- a/src/BottomNavigation/BottomNavigationAction.spec.js
+++ b/src/BottomNavigation/BottomNavigationAction.spec.js
@@ -16,8 +16,7 @@ describe('<BottomNavigationAction />', () => {
   });
 
   it('should render a ButtonBase', () => {
-    const wrapper = shallow(<BottomNavigationAction icon={icon} />);
-    assert.strictEqual(wrapper.name(), 'WithStyles');
+    shallow(<BottomNavigationAction icon={icon} />);
   });
 
   it('should render with the root class', () => {

--- a/src/Button/Button.spec.js
+++ b/src/Button/Button.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, createRender, getClasses } from '../test-utils';
 import Button from './Button';
+import ButtonBase from '../ButtonBase';
 
 describe('<Button />', () => {
   let shallow;
@@ -16,7 +17,7 @@ describe('<Button />', () => {
 
   it('should render a <ButtonBase> element', () => {
     const wrapper = shallow(<Button>Hello World</Button>);
-    assert.strictEqual(wrapper.name(), 'WithStyles');
+    assert.strictEqual(wrapper.type(), ButtonBase);
     assert.strictEqual(
       wrapper.props().type,
       'button',

--- a/src/Card/CardHeader.spec.js
+++ b/src/Card/CardHeader.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import CardHeader from './CardHeader';
+import Typography from '../Typography';
 
 describe('<CardHeader />', () => {
   let shallow;
@@ -57,20 +58,20 @@ describe('<CardHeader />', () => {
 
     it('should render the title as headline text', () => {
       const title = wrapper.childAt(0);
-      assert.strictEqual(title.name(), 'WithStyles');
+      assert.strictEqual(title.type(), Typography);
       assert.strictEqual(title.props().type, 'headline');
     });
 
     it('should render the subheader as body1 secondary text', () => {
       const subheader = wrapper.childAt(1);
-      assert.strictEqual(subheader.name(), 'WithStyles');
+      assert.strictEqual(subheader.type(), Typography);
       assert.strictEqual(subheader.props().type, 'body1');
       assert.strictEqual(subheader.props().color, 'secondary');
     });
 
     it('should not render the subheader if none is given', () => {
       const title = wrapper.childAt(0);
-      assert.strictEqual(title.name(), 'WithStyles');
+      assert.strictEqual(title.type(), Typography);
       assert.strictEqual(wrapper.length, 1);
     });
   });
@@ -100,7 +101,7 @@ describe('<CardHeader />', () => {
         'should have the content class',
       );
       const title = container.childAt(0);
-      assert.strictEqual(title.name(), 'WithStyles');
+      assert.strictEqual(title.type(), Typography);
       assert.strictEqual(title.props().type, 'body2');
     });
 
@@ -112,7 +113,7 @@ describe('<CardHeader />', () => {
         'should have the content class',
       );
       const subheader = container.childAt(1);
-      assert.strictEqual(subheader.name(), 'WithStyles');
+      assert.strictEqual(subheader.type(), Typography);
       assert.strictEqual(subheader.props().type, 'body2');
       assert.strictEqual(subheader.props().color, 'secondary');
     });

--- a/src/Checkbox/Checkbox.spec.js
+++ b/src/Checkbox/Checkbox.spec.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import IndeterminateCheckBoxIcon from '../internal/svg-icons/IndeterminateCheckBox';
 import { createShallow, getClasses, createMount } from '../test-utils';
+import SwitchBase from '../internal/SwitchBase';
 import Checkbox from './Checkbox';
 
 describe('<Checkbox />', () => {
@@ -29,7 +30,7 @@ describe('<Checkbox />', () => {
 
   it('should render a div with a SwitchBase', () => {
     const wrapper = shallow(<Checkbox />);
-    assert.strictEqual(wrapper.name(), 'WithStyles');
+    assert.strictEqual(wrapper.type(), SwitchBase);
   });
 
   describe('prop: indeterminate', () => {

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 import { createShallow, getClasses } from '../test-utils';
 import Paper from '../Paper';
 import Fade from '../transitions/Fade';
+import Modal from '../Modal';
 import Dialog from './Dialog';
 
 describe('<Dialog />', () => {
@@ -21,7 +22,7 @@ describe('<Dialog />', () => {
 
   it('should render a Modal', () => {
     const wrapper = shallow(<Dialog {...defaultProps}>foo</Dialog>);
-    assert.strictEqual(wrapper.name(), 'WithStyles');
+    assert.strictEqual(wrapper.type(), Modal);
   });
 
   it('should render a Modal with transition', () => {
@@ -94,7 +95,7 @@ describe('<Dialog />', () => {
     assert.strictEqual(fade.type(), Fade);
 
     const paper = fade.childAt(0);
-    assert.strictEqual(paper.length === 1 && paper.name(), 'WithStyles');
+    assert.strictEqual(paper.length === 1 && paper.type(), Paper);
 
     assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the dialog class');
   });

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -27,7 +27,7 @@ describe('<Drawer />', () => {
           <div />
         </Drawer>,
       );
-      assert.strictEqual(wrapper.name(), 'WithStyles');
+      assert.strictEqual(wrapper.type(), Modal);
     });
 
     it('should render Slide > Paper inside the Modal', () => {
@@ -45,7 +45,7 @@ describe('<Drawer />', () => {
       );
 
       const paper = slide.childAt(0);
-      assert.strictEqual(paper.length === 1 && paper.name(), 'WithStyles');
+      assert.strictEqual(paper.length === 1 && paper.type(), Paper);
 
       assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the paper class');
     });
@@ -177,7 +177,7 @@ describe('<Drawer />', () => {
       assert.strictEqual(slide.type(), Slide);
 
       const paper = slide.childAt(0);
-      assert.strictEqual(paper.length === 1 && paper.name(), 'WithStyles');
+      assert.strictEqual(paper.length === 1 && paper.type(), Paper);
     });
   });
 
@@ -203,7 +203,7 @@ describe('<Drawer />', () => {
       assert.strictEqual(slide.name(), 'div');
 
       const paper = slide.childAt(0);
-      assert.strictEqual(paper.length === 1 && paper.name(), 'WithStyles');
+      assert.strictEqual(paper.length === 1 && paper.type(), Paper);
     });
   });
 

--- a/src/Popover/Popover.spec.js
+++ b/src/Popover/Popover.spec.js
@@ -4,6 +4,7 @@ import { spy, stub, useFakeTimers } from 'sinon';
 import css from 'dom-helpers/style';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import Grow from '../transitions/Grow';
+import Paper from '../Paper';
 import mockPortal from '../../test/utils/mockPortal';
 import Popover from './Popover';
 
@@ -38,7 +39,6 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(wrapper.name(), 'WithStyles');
       assert.strictEqual(wrapper.props().BackdropProps.invisible, true);
     });
 
@@ -150,7 +150,7 @@ describe('<Popover />', () => {
         </Popover>,
       );
       assert.strictEqual(wrapper.children().length, 1, 'should have one child');
-      assert.strictEqual(wrapper.childAt(0).name(), 'WithTheme');
+      assert.strictEqual(wrapper.childAt(0).type(), Grow);
       assert.strictEqual(
         wrapper.childAt(0).props().appear,
         true,
@@ -209,8 +209,8 @@ describe('<Popover />', () => {
         wrapper
           .childAt(0)
           .childAt(0)
-          .name(),
-        'WithStyles',
+          .type(),
+        Paper,
       );
     });
 

--- a/src/Table/TablePagination.spec.js
+++ b/src/Table/TablePagination.spec.js
@@ -6,6 +6,7 @@ import { createShallow, createMount } from '../test-utils';
 import Select from '../Select';
 import IconButton from '../IconButton';
 import TableFooter from './TableFooter';
+import TableCell from './TableCell';
 import TablePagination from './TablePagination';
 import Typography from '../Typography';
 import TableRow from './TableRow';
@@ -34,7 +35,7 @@ describe('<TablePagination />', () => {
         rowsPerPage={5}
       />,
     );
-    assert.strictEqual(wrapper.name(), 'WithStyles');
+    assert.strictEqual(wrapper.type(), TableCell);
   });
 
   it('should spread custom props on the root node', () => {
@@ -66,7 +67,7 @@ describe('<TablePagination />', () => {
           rowsPerPage={5}
         />,
       );
-      assert.strictEqual(wrapper.name(), 'WithStyles');
+      assert.strictEqual(wrapper.type(), TableCell);
       assert.notStrictEqual(wrapper.props().colSpan, undefined);
     });
 

--- a/src/Tabs/Tab.spec.js
+++ b/src/Tabs/Tab.spec.js
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
 import Tab from './Tab';
+import ButtonBase from '../ButtonBase';
 import Icon from '../Icon';
 
 describe('<Tab />', () => {
@@ -23,7 +24,7 @@ describe('<Tab />', () => {
 
   it('should render with the root class', () => {
     const wrapper = shallow(<Tab textColor="inherit" />);
-    assert.strictEqual(wrapper.name(), 'WithStyles');
+    assert.strictEqual(wrapper.type(), ButtonBase);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { createShallow, createMount } from '../test-utils';
 import Input, { InputLabel } from '../Input';
 import FormHelperText from '../Form/FormHelperText';
+import FormControl from '../Form/FormControl';
 import TextField from './TextField';
 import Select from '../Select/Select';
 
@@ -28,8 +29,7 @@ describe('<TextField />', () => {
 
     describe('structure', () => {
       it('should be a FormControl', () => {
-        assert.strictEqual(wrapper.name(), 'WithStyles');
-        assert.strictEqual(wrapper.dive().name(), 'FormControl');
+        assert.strictEqual(wrapper.type(), FormControl);
       });
 
       it('should pass className to the FormControl', () => {

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -5,6 +5,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
 import SwitchBase from './SwitchBase';
+import IconButton from '../IconButton';
 import Icon from '../Icon';
 
 function assertIsChecked(wrapper) {
@@ -64,7 +65,7 @@ describe('<SwitchBase />', () => {
 
   it('should render an IconButton', () => {
     const wrapper = shallow(<SwitchBase />);
-    assert.strictEqual(wrapper.name(), 'WithStyles');
+    assert.strictEqual(wrapper.type(), IconButton);
   });
 
   it('should render an icon and input inside the button by default', () => {

--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import warning from 'warning';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import getDisplayName from 'recompose/getDisplayName';
+import wrapDisplayName from 'recompose/wrapDisplayName';
 import contextTypes from 'react-jss/lib/contextTypes';
 import { create } from 'jss';
 import jssGlobal from 'jss-global';
@@ -310,6 +311,10 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
     ...contextTypes,
     ...(listenToTheme ? themeListener.contextTypes : {}),
   };
+
+  if (process.env.NODE_ENV !== 'production') {
+    WithStyles.displayName = wrapDisplayName(Component, 'WithStyles');
+  }
 
   hoistNonReactStatics(WithStyles, Component);
 

--- a/src/styles/withTheme.js
+++ b/src/styles/withTheme.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
+import wrapDisplayName from 'recompose/wrapDisplayName';
 import createMuiTheme from './createMuiTheme';
 import themeListener from './themeListener';
 
@@ -47,6 +48,10 @@ const withTheme = () => Component => {
   }
 
   WithTheme.contextTypes = themeListener.contextTypes;
+
+  if (process.env.NODE_ENV !== 'production') {
+    WithTheme.displayName = wrapDisplayName(Component, 'WithTheme');
+  }
 
   hoistNonReactStatics(WithTheme, Component);
 

--- a/src/utils/withWidth.js
+++ b/src/utils/withWidth.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';
 import debounce from 'lodash/debounce';
+import wrapDisplayName from 'recompose/wrapDisplayName';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import withTheme from '../styles/withTheme';
 import { keys as breakpointKeys } from '../styles/createBreakpoints';
@@ -128,6 +129,10 @@ const withWidth = (options = {}) => Component => {
      */
     width: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
   };
+
+  if (process.env.NODE_ENV !== 'production') {
+    WithWidth.displayName = wrapDisplayName(Component, 'WithWidth');
+  }
 
   hoistNonReactStatics(WithWidth, Component);
 


### PR DESCRIPTION
This point was raised by @pandaiolo in https://github.com/mui-org/material-ui/pull/9613#issuecomment-354754714.

- [Convention: Wrap the Display Name for Easy Debugging](https://reactjs.org/docs/higher-order-components.html#convention-wrap-the-display-name-for-easy-debugging)
- Make our test suite less brittle by being *"displayName"* independent.