### PR TITLE
[SvgIcon] Add a nativeColor property

### DIFF
--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -12,11 +12,12 @@ filename: /src/SvgIcon/SvgIcon.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span style="color: #31a148">children *</span> | node |  | Node passed into the SVG Icon. |
+| <span style="color: #31a148">children *</span> | node |  | Node passed into the SVG element. |
 | classes | object |  | Useful to extend the style applied to components. |
-| color | enum:&nbsp;'inherit', 'accent', 'action', 'contrast', 'disabled', 'error', 'primary'<br> | 'inherit' | The color of the component. It's using the theme palette when that makes sense. |
+| color | enum:&nbsp;'inherit', 'accent', 'action', 'contrast', 'disabled', 'error', 'primary'<br> | 'inherit' | The color of the component. It's using the theme palette when that makes sense. You can use the `nativeColor` property to apply a color attribute to the SVG element. |
+| nativeColor | string |  | Applies a color attribute to the SVG element. |
 | titleAccess | string |  | Provides a human-readable title for the element that contains it. https://www.w3.org/TR/SVG-access/#Equivalent |
-| viewBox | string | '0 0 24 24' | Allows you to redefine what the coordinates without units mean inside an svg element. For example, if the SVG element is 500 (width) by 200 (height), and you pass viewBox="0 0 50 20", this means that the coordinates inside the svg will go from the top left corner (0,0) to bottom right (50,20) and each unit will be worth 10px. |
+| viewBox | string | '0 0 24 24' | Allows you to redefine what the coordinates without units mean inside an SVG element. For example, if the SVG element is 500 (width) by 200 (height), and you pass viewBox="0 0 50 20", this means that the coordinates inside the SVG will go from the top left corner (0,0) to bottom right (50,20) and each unit will be worth 10px. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/SvgIcon/SvgIcon.d.ts
+++ b/src/SvgIcon/SvgIcon.d.ts
@@ -4,6 +4,7 @@ import { StandardProps, PropTypes } from '..';
 export interface SvgIconProps
   extends StandardProps<React.SVGProps<SVGSVGElement>, SvgIconClassKey> {
   color?: PropTypes.Color | 'action' | 'contrast' | 'disabled' | 'error';
+  nativeColor?: string;
   titleAccess?: string;
   viewBox?: string;
 }

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -42,6 +42,7 @@ function SvgIcon(props) {
     classes,
     className: classNameProp,
     color,
+    nativeColor,
     titleAccess,
     viewBox,
     ...other
@@ -60,6 +61,7 @@ function SvgIcon(props) {
       className={className}
       focusable="false"
       viewBox={viewBox}
+      color={nativeColor}
       aria-hidden={titleAccess ? 'false' : 'true'}
       {...other}
     >
@@ -71,7 +73,7 @@ function SvgIcon(props) {
 
 SvgIcon.propTypes = {
   /**
-   * Node passed into the SVG Icon.
+   * Node passed into the SVG element.
    */
   children: PropTypes.node.isRequired,
   /**
@@ -84,6 +86,7 @@ SvgIcon.propTypes = {
   className: PropTypes.string,
   /**
    * The color of the component. It's using the theme palette when that makes sense.
+   * You can use the `nativeColor` property to apply a color attribute to the SVG element.
    */
   color: PropTypes.oneOf([
     'inherit',
@@ -95,15 +98,19 @@ SvgIcon.propTypes = {
     'primary',
   ]),
   /**
+   * Applies a color attribute to the SVG element.
+   */
+  nativeColor: PropTypes.string,
+  /**
    * Provides a human-readable title for the element that contains it.
    * https://www.w3.org/TR/SVG-access/#Equivalent
    */
   titleAccess: PropTypes.string,
   /**
-   * Allows you to redefine what the coordinates without units mean inside an svg element.
+   * Allows you to redefine what the coordinates without units mean inside an SVG element.
    * For example, if the SVG element is 500 (width) by 200 (height),
    * and you pass viewBox="0 0 50 20",
-   * this means that the coordinates inside the svg will go from the top left corner (0,0)
+   * this means that the coordinates inside the SVG will go from the top left corner (0,0)
    * to bottom right (50,20) and each unit will be worth 10px.
    */
   viewBox: PropTypes.string,


### PR DESCRIPTION
A breaking change was introduced in #9367 with no workaround.
You can no longer apply a color property to the native SVG element.
This pull request objective is to provide a simple upgrade path.

cc @lucasterra
