### PR TITLE
[typescript] Make Modal-/SlideProps on Drawer Partial

### DIFF
--- a/src/Drawer/Drawer.d.ts
+++ b/src/Drawer/Drawer.d.ts
@@ -14,9 +14,9 @@ export interface DrawerProps
   anchor?: 'left' | 'top' | 'right' | 'bottom';
   children?: React.ReactNode;
   elevation?: number;
-  ModalProps?: ModalProps;
+  ModalProps?: Partial<ModalProps>;
   open?: boolean;
-  SlideProps?: SlideProps;
+  SlideProps?: Partial<SlideProps>;
   theme?: Theme;
   transitionDuration?: TransitionDuration;
   type?: 'permanent' | 'persistent' | 'temporary';

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -309,6 +309,9 @@ const DrawerTest = () => {
         open={open.top}
         onClose={event => log(event)}
         onClick={event => log(event)}
+        ModalProps={{
+          hideBackdrop: true
+        }}
       >
         List
       </Drawer>


### PR DESCRIPTION
According to the source code of the Drawer the props for Modal and Slide
are partial; e.g. one can simply just pass in hideBackdrop as ModalProps

Compare: https://github.com/mui-org/material-ui/blob/v1-beta/src/Drawer/Drawer.js
