### PR TITLE
[docs] Remove unneeded dependencies from examples

### DIFF
--- a/examples/create-react-app-with-flow/package.json
+++ b/examples/create-react-app-with-flow/package.json
@@ -3,13 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "jss": "^9.0.0",
-    "jss-preset-default": "^4.0.0",
     "material-ui": "^1.0.0-beta.26",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
-    "react-jss": "^8.2.0",
     "react-scripts": "^1.0.16"
   },
   "devDependencies": {

--- a/examples/create-react-app-with-jss/package.json
+++ b/examples/create-react-app-with-jss/package.json
@@ -3,13 +3,10 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "jss": "latest",
-    "jss-preset-default": "latest",
     "material-ui": "next",
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-jss": "latest",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/examples/create-react-app-with-jss/package.json
+++ b/examples/create-react-app-with-jss/package.json
@@ -3,10 +3,12 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "jss": "latest",
     "material-ui": "next",
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
+    "react-jss": "latest",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/examples/create-react-app-with-jss/src/withRoot.js
+++ b/examples/create-react-app-with-jss/src/withRoot.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import { create } from 'jss';
-import preset from 'jss-preset-default';
 import JssProvider from 'react-jss/lib/JssProvider';
-import { MuiThemeProvider, createMuiTheme, createGenerateClassName } from 'material-ui/styles';
+import {
+  MuiThemeProvider,
+  createMuiTheme,
+  createGenerateClassName,
+  jssPreset,
+} from 'material-ui/styles';
 import purple from 'material-ui/colors/purple';
 import green from 'material-ui/colors/green';
 import Reboot from 'material-ui/Reboot';
@@ -18,7 +22,7 @@ const theme = createMuiTheme({
 
 // Create a JSS instance with the default preset of plugins.
 // It's optional.
-const jss = create(preset());
+const jss = create(jssPreset());
 
 // The standard class name generator.
 // It's optional.

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -3,13 +3,11 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "jss": "latest",
     "material-ui": "next",
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-jss": "latest"
   },
   "scripts": {
     "dev": "next",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -3,11 +3,13 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
+    "jss": "latest",
     "material-ui": "next",
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "react-jss": "latest"
   },
   "scripts": {
     "dev": "next",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -7,7 +7,7 @@
     "next": "latest",
     "prop-types": "latest",
     "react": "latest",
-    "react-dom": "latest",
+    "react-dom": "latest"
   },
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR is continuation of #9735 and is raised by #9732.

Note, that `examples/create-react-app-with-jss` example will not work until beta.27 is released, since `jssPreset` is not exposed in earlier versions.
So it's better to not merge it until beta.27 is released.