### PR TITLE
[github] Add Support Requests bot config file

### DIFF
--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,0 +1,25 @@
+# Configuration for support-requests - https://github.com/dessant/support-requests
+
+# Label used to mark issues as support requests
+supportLabel: support
+
+# Comment to post on issues marked as support requests. Add a link
+# to a support page, or set to `false` to disable
+supportComment: >
+  👋 Thanks for using Material-UI!
+
+  We use the issue tracker exclusively for bug reports and feature requests, however,
+  this issue appears to be a support request or question.
+
+  Please ask on [StackOverflow](http://stackoverflow.com/questions/tagged/material-ui) where the
+  community will do their best to help. There is a "material-ui" tag that you can use to tag your
+  question.
+
+  If you would like to link from here to your question on SO, it will help others find it.
+  If your issues is confirmed as a bug, you are welcome to reopen the issue using the issue template.
+
+# Whether to close issues marked as support requests
+close: true
+
+# Whether to lock issues marked as support requests
+lock: false


### PR DESCRIPTION
This is a first pass at the wording for an automated response when an issue is tagged "support".

This feature will only be used for questions that are clearly how-to questions, or other non-issues. Other questions that a grey-are should be tagged "question" until they are confirmed as an issue or tagged "support". (Looking at you @mbrookes!)

https://probot.github.io/apps/support/

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
