### PR TITLE
[ListItemText] Add extra class to style secondary text

### DIFF
--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -27,7 +27,8 @@ This property accepts the following keys:
 - `root`
 - `inset`
 - `dense`
-- `text`
+- `textPrimary`
+- `textSecondary`
 - `textDense`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/src/List/ListItemText.d.ts
+++ b/src/List/ListItemText.d.ts
@@ -9,7 +9,7 @@ export interface ListItemTextProps
   secondary?: React.ReactNode;
 }
 
-export type ListItemTextClassKey = 'root' | 'inset' | 'dense' | 'text' | 'textDense';
+export type ListItemTextClassKey = 'root' | 'inset' | 'dense' | 'text' | 'textDense' | 'textSecondary';
 
 declare const ListItemText: React.ComponentType<ListItemTextProps>;
 

--- a/src/List/ListItemText.d.ts
+++ b/src/List/ListItemText.d.ts
@@ -9,7 +9,13 @@ export interface ListItemTextProps
   secondary?: React.ReactNode;
 }
 
-export type ListItemTextClassKey = 'root' | 'inset' | 'dense' | 'text' | 'textDense' | 'textSecondary';
+export type ListItemTextClassKey =
+  | 'root'
+  | 'inset'
+  | 'dense'
+  | 'textPrimary'
+  | 'textSecondary'
+  | 'textDense';
 
 declare const ListItemText: React.ComponentType<ListItemTextProps>;
 

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -21,7 +21,8 @@ export const styles = theme => ({
   dense: {
     fontSize: theme.typography.pxToRem(13),
   },
-  text: {}, // Present to allow external customization
+  text: {}, // Present to allow external customization,
+  textSecondary: {}, // Present to allow external customization on secondary text
   textDense: {
     fontSize: 'inherit',
   },
@@ -67,7 +68,9 @@ function ListItemText(props, context) {
           <Typography
             color="secondary"
             type="body1"
-            className={classNames(classes.text, { [classes.textDense]: dense })}
+            className={classNames(classes.text, classes.textSecondary, {
+              [classes.textDense]: dense,
+            })}
           >
             {secondary}
           </Typography>

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -21,11 +21,17 @@ export const styles = theme => ({
   dense: {
     fontSize: theme.typography.pxToRem(13),
   },
-  text: {}, // Present to allow external customization,
-  textSecondary: {}, // Present to allow external customization on secondary text
-  textDense: {
-    fontSize: 'inherit',
+  textPrimary: {
+    '&$textDense': {
+      fontSize: 'inherit',
+    },
   },
+  textSecondary: {
+    '&$textDense': {
+      fontSize: 'inherit',
+    },
+  },
+  textDense: {},
 });
 
 function ListItemText(props, context) {
@@ -56,7 +62,7 @@ function ListItemText(props, context) {
         ) : (
           <Typography
             type="subheading"
-            className={classNames(classes.text, { [classes.textDense]: dense })}
+            className={classNames(classes.textPrimary, { [classes.textDense]: dense })}
           >
             {primary}
           </Typography>
@@ -66,11 +72,11 @@ function ListItemText(props, context) {
           secondary
         ) : (
           <Typography
-            color="secondary"
             type="body1"
-            className={classNames(classes.text, classes.textSecondary, {
+            className={classNames(classes.textSecondary, {
               [classes.textDense]: dense,
             })}
+            color="secondary"
           >
             {secondary}
           </Typography>

--- a/src/List/ListItemText.spec.js
+++ b/src/List/ListItemText.spec.js
@@ -161,7 +161,7 @@ describe('<ListItemText />', () => {
 
   it('should render primary and secondary text with customisable classes', () => {
     const textClasses = {
-      text: 'GeneralText',
+      textPrimary: 'GeneralText',
       textSecondary: 'SecondaryText',
     };
     const wrapper = shallow(

--- a/src/List/ListItemText.spec.js
+++ b/src/List/ListItemText.spec.js
@@ -158,4 +158,35 @@ describe('<ListItemText />', () => {
       'should have the secondary text',
     );
   });
+
+  it('should render primary and secondary text with customisable classes', () => {
+    const textClasses = {
+      text: 'GeneralText',
+      textSecondary: 'SecondaryText',
+    };
+    const wrapper = shallow(
+      <ListItemText
+        primary="This is the primary text"
+        secondary="This is the secondary text"
+        classes={textClasses}
+      />,
+    );
+
+    assert.strictEqual(
+      wrapper
+        .childAt(0)
+        .props()
+        .className.includes('GeneralText'),
+      true,
+      'should have the primary text class',
+    );
+    assert.strictEqual(
+      wrapper
+        .childAt(1)
+        .props()
+        .className.includes('SecondaryText'),
+      true,
+      'should have the secondary text class',
+    );
+  });
 });


### PR DESCRIPTION
Add a new attribute `textSecondary` to ListItemText component `classes` property.
It allows customising secondary text styles separately from the primary text.

### Breaking change

```diff
<ListItem
  classes={{
-   text: 'my-class',
+   textPrimary: 'my-class',
  }}
/>
```

Closes #9223