### PR TITLE
[chip] Replace instrinic CSS 'fit-content' with 'inline-flex'

### DIFF
--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -16,7 +16,7 @@ export const styles = theme => {
     root: {
       fontFamily: theme.typography.fontFamily,
       fontSize: theme.typography.pxToRem(13),
-      display: 'flex',
+      display: 'inline-flex',
       alignItems: 'center',
       justifyContent: 'center',
       height,
@@ -24,7 +24,6 @@ export const styles = theme => {
       backgroundColor,
       borderRadius: height / 2,
       whiteSpace: 'nowrap',
-      width: 'fit-content',
       transition: theme.transitions.create(),
       // label will inherit this from root, then `clickable` class overrides this for both
       cursor: 'default',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This should resolve #9615. I've opened this up in Edge after and didn't see any issues after replacing width: 'fit-content' with display: 'inline-flex'

<img width="745" alt="screen shot 2018-01-06 at 1 41 33 pm" src="https://user-images.githubusercontent.com/19170080/34642814-ac707324-f2e7-11e7-864b-fd9fcc781c50.png">

