### PR TITLE
[docs] Add How can I access the DOM element? in the FAQ

### DIFF
--- a/docs/src/pages/getting-started/frequently-asked-questions.md
+++ b/docs/src/pages/getting-started/frequently-asked-questions.md
@@ -53,6 +53,44 @@ export default compose(
 export default withTheme()(withStyles(styles)(Modal));
 ```
 
+## How can I access the DOM element?
+
+You can use the `ref` property in conjunction to the [`findDOMNode()`](https://reactjs.org/docs/react-dom.html#finddomnode) React API. Or you can [use an abstraction](https://github.com/facebook/react/issues/11401#issuecomment-340543801):
+
+```jsx
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
+
+class RootRef extends React.Component {
+  componentDidMount() {
+    this.props.rootRef(ReactDOM.findDOMNode(this))
+  }
+
+  componentWillUnmount() {
+    this.props.rootRef(null)
+  }
+
+  render() {
+    return this.props.children
+  }
+}
+
+RootRef.propTypes = {
+  children: PropTypes.element.isRequired,
+  rootRef: PropTypes.func.isRequired,
+};
+
+export default RootRef;
+```
+
+Usage:
+```jsx
+<RootRef rootRef={node => { console.log(node) }}>
+  <Paper />
+</RootRef>
+```
+
 ## Material-UI is awesome. How can I support the project?
 
 There are a lot of ways to support Material-UI:


### PR DESCRIPTION
> In **most cases**, you can attach a ref to the DOM node and avoid using findDOMNode at all.

The [React documentation](https://reactjs.org/docs/react-dom.html#finddomnode) is making `findDOMNode()` an escape hatch. But we don't fall under the **most cases** part. Maintaining a list of `rootRef` property would be an important pain in comparison to this alternative. We don't do it nor react-bootsrap, nor all the react libraries I'm aware of.
So we need an answer to this problem. It's the best one I can think for now. The React core team is looking into alternatives to the current ref implementation: https://github.com/facebook/react/issues/11401. The situation might change in the future.

cc @cherniavskii
  