### PR TITLE
[core] [experimental] Add nnnShade variable to the palette

### DIFF
--- a/docs/src/pages/customization/Palette.js
+++ b/docs/src/pages/customization/Palette.js
@@ -2,17 +2,13 @@ import React from 'react';
 import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
 import purple from 'material-ui/colors/purple';
 import green from 'material-ui/colors/green';
-import red from 'material-ui/colors/red';
 import Button from 'material-ui/Button';
 
 const theme = createMuiTheme({
   palette: {
     primary: purple, // Purple and green play nicely together.
-    secondary: {
-      ...green,
-      A400: '#00e677',
-    },
-    error: red,
+    secondary: green,
+    secondaryShade: 'A700',
   },
 });
 

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -37,12 +37,12 @@ export const styles = theme => ({
     color: theme.palette.getContrastText(theme.palette.background.appBar),
   },
   colorPrimary: {
-    backgroundColor: theme.palette.primary[500],
-    color: theme.palette.getContrastText(theme.palette.primary[500]),
+    backgroundColor: theme.palette.primary[theme.palette.primaryShade],
+    color: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
   },
   colorAccent: {
-    backgroundColor: theme.palette.secondary.A200,
-    color: theme.palette.getContrastText(theme.palette.secondary.A200),
+    backgroundColor: theme.palette.secondary[theme.palette.secondaryShade],
+    color: theme.palette.getContrastText(theme.palette.secondary[theme.palette.secondaryShade]),
   },
 });
 

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -34,12 +34,12 @@ export const styles = theme => ({
     zIndex: 1, // Render the badge on top of potential ripples.
   },
   colorPrimary: {
-    backgroundColor: theme.palette.primary[500],
-    color: theme.palette.getContrastText(theme.palette.primary[500]),
+    backgroundColor: theme.palette.primary[theme.palette.primaryShade],
+    color: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
   },
   colorAccent: {
-    backgroundColor: theme.palette.secondary.A200,
-    color: theme.palette.getContrastText(theme.palette.secondary.A200),
+    backgroundColor: theme.palette.secondary[theme.palette.secondaryShade],
+    color: theme.palette.getContrastText(theme.palette.secondary[theme.palette.secondaryShade]),
   },
 });
 

--- a/src/BottomNavigation/BottomNavigationAction.js
+++ b/src/BottomNavigation/BottomNavigationAction.js
@@ -23,7 +23,7 @@ export const styles = theme => ({
   },
   selected: {
     paddingTop: 6,
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
   selectedIconOnly: {
     paddingTop: theme.spacing.unit * 2,

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -45,9 +45,9 @@ export const styles = theme => ({
     justifyContent: 'inherit',
   },
   flatPrimary: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
     '&:hover': {
-      backgroundColor: fade(theme.palette.primary[500], 0.12),
+      backgroundColor: fade(theme.palette.primary[theme.palette.primaryShade], 0.12),
       // Reset on mouse devices
       '@media (hover: none)': {
         backgroundColor: 'transparent',
@@ -55,9 +55,9 @@ export const styles = theme => ({
     },
   },
   flatAccent: {
-    color: theme.palette.secondary.A200,
+    color: theme.palette.secondary[theme.palette.secondaryShade],
     '&:hover': {
-      backgroundColor: fade(theme.palette.secondary.A200, 0.12),
+      backgroundColor: fade(theme.palette.secondary[theme.palette.secondaryShade], 0.12),
       // Reset on mouse devices
       '@media (hover: none)': {
         backgroundColor: 'transparent',
@@ -65,9 +65,12 @@ export const styles = theme => ({
     },
   },
   flatContrast: {
-    color: theme.palette.getContrastText(theme.palette.primary[500]),
+    color: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
     '&:hover': {
-      backgroundColor: fade(theme.palette.getContrastText(theme.palette.primary[500]), 0.12),
+      backgroundColor: fade(
+        theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
+        0.12,
+      ),
       // Reset on mouse devices
       '@media (hover: none)': {
         backgroundColor: 'transparent',
@@ -108,29 +111,29 @@ export const styles = theme => ({
   },
   keyboardFocused: {},
   raisedPrimary: {
-    color: theme.palette.getContrastText(theme.palette.primary[500]),
-    backgroundColor: theme.palette.primary[500],
+    color: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
+    backgroundColor: theme.palette.primary[theme.palette.primaryShade],
     '&:hover': {
       backgroundColor: theme.palette.primary[700],
       // Reset on mouse devices
       '@media (hover: none)': {
-        backgroundColor: theme.palette.primary[500],
+        backgroundColor: theme.palette.primary[theme.palette.primaryShade],
       },
     },
   },
   raisedAccent: {
-    color: theme.palette.getContrastText(theme.palette.secondary.A200),
-    backgroundColor: theme.palette.secondary.A200,
+    color: theme.palette.getContrastText(theme.palette.secondary[theme.palette.secondaryShade]),
+    backgroundColor: theme.palette.secondary[theme.palette.secondaryShade],
     '&:hover': {
       backgroundColor: theme.palette.secondary.A400,
       // Reset on mouse devices
       '@media (hover: none)': {
-        backgroundColor: theme.palette.secondary.A200,
+        backgroundColor: theme.palette.secondary[theme.palette.secondaryShade],
       },
     },
   },
   raisedContrast: {
-    color: theme.palette.getContrastText(theme.palette.primary[500]),
+    color: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
   },
   disabled: {
     color: theme.palette.action.disabled,

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -9,7 +9,7 @@ export const styles = theme => ({
     color: theme.palette.text.secondary,
   },
   checked: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
   disabled: {
     color: theme.palette.action.disabled,

--- a/src/Form/FormHelperText.js
+++ b/src/Form/FormHelperText.js
@@ -18,7 +18,7 @@ export const styles = theme => ({
     marginTop: theme.spacing.unit / 2,
   },
   error: {
-    color: theme.palette.error.A400,
+    color: theme.palette.error[theme.palette.errorShade],
   },
   disabled: {
     color: theme.palette.input.disabled,

--- a/src/Form/FormLabel.js
+++ b/src/Form/FormLabel.js
@@ -17,7 +17,7 @@ export const styles = theme => {
       color: focusColor,
     },
     error: {
-      color: theme.palette.error.A400,
+      color: theme.palette.error[theme.palette.errorShade],
     },
     disabled: {
       color: theme.palette.input.disabled,

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -9,13 +9,13 @@ export const styles = theme => ({
     userSelect: 'none',
   },
   colorAccent: {
-    color: theme.palette.secondary.A200,
+    color: theme.palette.secondary[theme.palette.secondaryShade],
   },
   colorAction: {
     color: theme.palette.action.active,
   },
   colorContrast: {
-    color: theme.palette.getContrastText(theme.palette.primary[500]),
+    color: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
   },
   colorDisabled: {
     color: theme.palette.action.disabled,
@@ -24,7 +24,7 @@ export const styles = theme => ({
     color: theme.palette.error[500],
   },
   colorPrimary: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
 });
 

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -25,13 +25,13 @@ export const styles = theme => ({
     }),
   },
   colorAccent: {
-    color: theme.palette.secondary.A200,
+    color: theme.palette.secondary[theme.palette.secondaryShade],
   },
   colorContrast: {
-    color: theme.palette.getContrastText(theme.palette.primary[500]),
+    color: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
   },
   colorPrimary: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
   colorInherit: {
     color: 'inherit',

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -95,7 +95,7 @@ export const styles = theme => {
     },
     error: {
       '&:after': {
-        backgroundColor: theme.palette.error.A400,
+        backgroundColor: theme.palette.error[theme.palette.errorShade],
         transform: 'scaleX(1)', // error is always underlined in red
       },
     },

--- a/src/List/ListSubheader.js
+++ b/src/List/ListSubheader.js
@@ -17,7 +17,7 @@ export const styles = theme => ({
     fontSize: theme.typography.pxToRem(theme.typography.fontSize),
   },
   colorPrimary: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
   colorInherit: {
     color: 'inherit',

--- a/src/MobileStepper/MobileStepper.js
+++ b/src/MobileStepper/MobileStepper.js
@@ -44,7 +44,7 @@ export const styles = theme => ({
     margin: '0 2px',
   },
   dotActive: {
-    backgroundColor: theme.palette.primary[500],
+    backgroundColor: theme.palette.primary[theme.palette.primaryShade],
   },
   progress: {
     width: '50%',

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -15,10 +15,10 @@ export const styles = theme => ({
     display: 'inline-block',
   },
   primaryColor: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
   accentColor: {
-    color: theme.palette.secondary.A200,
+    color: theme.palette.secondary[theme.palette.secondaryShade],
   },
   svgIndeterminate: {
     animation: 'mui-progress-circular-rotate 1.4s linear infinite',

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -16,7 +16,7 @@ export const styles = theme => ({
     backgroundColor: theme.palette.primary[100],
   },
   primaryColorBar: {
-    backgroundColor: theme.palette.primary[500],
+    backgroundColor: theme.palette.primary[theme.palette.primaryShade],
   },
   primaryDashed: {
     background: `radial-gradient(${theme.palette.primary[100]} 0%, ${

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -10,7 +10,7 @@ export const styles = theme => ({
     color: theme.palette.text.secondary,
   },
   checked: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
   disabled: {
     color: theme.palette.action.disabled,

--- a/src/Stepper/StepIcon.js
+++ b/src/Stepper/StepIcon.js
@@ -10,7 +10,7 @@ export const styles = theme => ({
     display: 'block',
   },
   completed: {
-    fill: theme.palette.primary[500],
+    fill: theme.palette.primary[theme.palette.primaryShade],
   },
 });
 

--- a/src/Stepper/StepPositionIcon.js
+++ b/src/Stepper/StepPositionIcon.js
@@ -9,10 +9,10 @@ export const styles = theme => ({
     fill: theme.palette.action.disabled,
   },
   active: {
-    fill: theme.palette.primary[500],
+    fill: theme.palette.primary[theme.palette.primaryShade],
   },
   text: {
-    fill: theme.palette.getContrastText(theme.palette.primary[500]),
+    fill: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
     fontSize: theme.typography.caption.fontSize,
     fontFamily: theme.typography.fontFamily,
   },

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -17,13 +17,13 @@ export const styles = theme => ({
     }),
   },
   colorAccent: {
-    color: theme.palette.secondary.A200,
+    color: theme.palette.secondary[theme.palette.secondaryShade],
   },
   colorAction: {
     color: theme.palette.action.active,
   },
   colorContrast: {
-    color: theme.palette.getContrastText(theme.palette.primary[500]),
+    color: theme.palette.getContrastText(theme.palette.primary[theme.palette.primaryShade]),
   },
   colorDisabled: {
     color: theme.palette.action.disabled,
@@ -32,7 +32,7 @@ export const styles = theme => ({
     color: theme.palette.error[500],
   },
   colorPrimary: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
 });
 

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -45,10 +45,10 @@ export const styles = theme => ({
     }),
   },
   checked: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
     transform: 'translateX(14px)',
     '& + $bar': {
-      backgroundColor: theme.palette.primary[500],
+      backgroundColor: theme.palette.primary[theme.palette.primaryShade],
       opacity: 0.5,
     },
   },

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -29,7 +29,7 @@ export const styles = theme => ({
     color: theme.palette.text.secondary,
   },
   rootAccentSelected: {
-    color: theme.palette.secondary.A200,
+    color: theme.palette.secondary[theme.palette.secondaryShade],
   },
   rootAccentDisabled: {
     color: theme.palette.text.disabled,
@@ -38,7 +38,7 @@ export const styles = theme => ({
     color: theme.palette.text.secondary,
   },
   rootPrimarySelected: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
   rootPrimaryDisabled: {
     color: theme.palette.text.disabled,

--- a/src/Tabs/TabIndicator.js
+++ b/src/Tabs/TabIndicator.js
@@ -14,10 +14,10 @@ export const styles = theme => ({
     willChange: 'left, width',
   },
   colorAccent: {
-    backgroundColor: theme.palette.secondary.A200,
+    backgroundColor: theme.palette.secondary[theme.palette.secondaryShade],
   },
   colorPrimary: {
-    backgroundColor: theme.palette.primary[500],
+    backgroundColor: theme.palette.primary[theme.palette.primaryShade],
   },
 });
 

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -47,7 +47,7 @@ export const styles = theme => ({
     color: 'inherit',
   },
   colorPrimary: {
-    color: theme.palette.primary[500],
+    color: theme.palette.primary[theme.palette.primaryShade],
   },
   colorSecondary: {
     color: theme.palette.text.secondary,
@@ -56,7 +56,7 @@ export const styles = theme => ({
     color: theme.palette.secondary.A400,
   },
   colorError: {
-    color: theme.palette.error.A400,
+    color: theme.palette.error[theme.palette.errorShade],
   },
 });
 

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -76,33 +76,45 @@ export const dark = {
   },
 };
 
-function getContrastText(hue) {
-  if (getContrastRatio(hue, common.black) < 7) {
+function getContrastText(color) {
+  if (getContrastRatio(color, common.black) < 7) {
     return dark.text.primary;
   }
   return light.text.primary;
 }
 
 export default function createPalette(palette: Object) {
-  const { primary = indigo, secondary = pink, error = red, type = 'light', ...other } = palette;
-  const shades = { dark, light };
+  const {
+    primary = indigo,
+    primaryShade = 500,
+    secondary = pink,
+    secondaryShade = 'A200',
+    error = red,
+    errorShade = 'A400',
+    type = 'light',
+    ...other
+  } = palette;
+  const types = { dark, light };
 
-  warning(Boolean(shades[type]), `Material-UI: the palette type \`${type}\` is not supported.`);
+  warning(Boolean(types[type]), `Material-UI: the palette type \`${type}\` is not supported.`);
 
   const paletteOutput = deepmerge(
     {
       common,
       type,
       primary,
+      primaryShade,
       secondary,
+      secondaryShade,
       error,
+      errorShade,
       grey,
-      shades,
-      text: shades[type].text,
-      input: shades[type].input,
-      action: shades[type].action,
-      background: shades[type].background,
-      line: shades[type].line,
+      types,
+      text: types[type].text,
+      input: types[type].input,
+      action: types[type].action,
+      background: types[type].background,
+      line: types[type].line,
       getContrastText,
     },
     other,
@@ -118,24 +130,24 @@ export default function createPalette(palette: Object) {
         compare = {};
       }
 
-      return Object.keys(base).filter(hue => !compare[hue]);
+      return Object.keys(base).filter(shade => !compare[shade]);
     };
 
-    const paletteColorError = (name, base, compare) => {
+    const paletteHueError = (name, base, compare) => {
       const missing = difference(base, compare);
       warning(
         missing.length === 0,
         [
-          `Material-UI: ${name} color is missing the following hues: ${missing.join(',')}`,
+          `Material-UI: theme.${name} does not have the following shades: 
+          ${missing.join(',')}`,
           'See the default colors, indigo, or pink, as exported from material-ui/colors.',
         ].join('\n'),
       );
     };
 
-    paletteColorError('primary', indigo, paletteOutput.primary);
-    paletteColorError('secondary', pink, paletteOutput.secondary);
-    paletteColorError('error', red, paletteOutput.error);
-    paletteColorError('grey', red, paletteOutput.grey);
+    paletteHueError('primary', indigo, paletteOutput.primary);
+    paletteHueError('secondary', pink, paletteOutput.secondary);
+    paletteHueError('error', red, paletteOutput.error);
   }
 
   return paletteOutput;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This allows users to specify the specific base shade to use for their primary, secondary and error hues.

Also clarifies the wording on the color and theme docs pages.

Updates the `/customization/themes#theme-configuration-variables` example to demonstrate the usage (note the better match of colors).