### PR TITLE
[Select] Remove the input warning

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -2,11 +2,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import warning from 'warning';
 import SelectInput from './SelectInput';
 import withStyles from '../styles/withStyles';
 import Input from '../Input'; // Import to enforce the CSS injection order
-import { isMuiElement } from '../utils/reactHelpers';
 
 export const styles = theme => ({
   root: {
@@ -73,15 +71,6 @@ function Select(props) {
     renderValue,
     ...other
   } = props;
-
-  // Instead of `Element<typeof Input>` to have more flexibility.
-  warning(
-    isMuiElement(input, ['Input']),
-    [
-      'Material-UI: you have provided an invalid value to the `input` property.',
-      'We expect an element instance of the `Input` component.',
-    ].join('\n'),
-  );
 
   return React.cloneElement(input, {
     // Most of the logic is implemented in `SelectInput`.

--- a/src/Select/Select.spec.js
+++ b/src/Select/Select.spec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses, createMount } from '../test-utils';
-import consoleErrorMock from '../../test/utils/consoleErrorMock';
 import { MenuItem } from '../Menu';
 import Input from '../Input';
 import Select from './Select';
@@ -33,26 +32,6 @@ describe('<Select />', () => {
   it('should provide the classes to the input component', () => {
     const wrapper = shallow(<Select {...props} />);
     assert.deepEqual(wrapper.props().inputProps.classes, classes);
-  });
-
-  describe('warning', () => {
-    before(() => {
-      consoleErrorMock.spy();
-    });
-
-    after(() => {
-      consoleErrorMock.reset();
-    });
-
-    it('should warn if the input is invalid', () => {
-      const FakeInput = () => <div />;
-      props.input = <FakeInput />;
-      shallow(<Select {...props} />);
-      assert.match(
-        consoleErrorMock.args()[0][0],
-        /Material-UI: you have provided an invalid value to the `input` property/,
-      );
-    });
   });
 
   it('should be able to mount the component', () => {


### PR DESCRIPTION
I have initially added this warning to help user finding wrong usages of our API.
It was an innovation. Before, we were using the `muiName` to only code branch our rendering tree.
I have been giving more thought about it. It doesn't solve much of the root cause as #9737 has shown. I'm removing the warning here. 

> Perfection is achieved, not when there is nothing more to add, but when there is nothing left to take away. Antoine de Saint-Exupery 

Closes #9736
  
  