### PR TITLE
[StepButton] Fix TypeScript definition

### DIFF
--- a/src/Stepper/StepButton.d.ts
+++ b/src/Stepper/StepButton.d.ts
@@ -8,13 +8,12 @@ export type StepButtonIcon = React.ReactElement<any> | string | number;
 export interface StepButtonProps extends StandardProps<ButtonBaseProps, StepButtonClasskey> {
   active?: boolean;
   alternativeLabel?: boolean;
-  children: React.ReactElement<any>;
   completed?: boolean;
   disabled?: boolean;
   icon?: StepButtonIcon;
   last?: boolean;
   optional?: React.ReactNode;
-  orientation: Orientation;
+  orientation?: Orientation;
 }
 
 export type StepButtonClasskey = ButtonBaseClassKey | 'root' | 'alternativeLabel';


### PR DESCRIPTION
Orientation should not be a required prop, now it became optional.

And children be React.ReactElement<any> will cause string not assignable to children, refer to ButtonProps remove children in props.

Closes #9782 