### PR TITLE
[typescript] Move @types/jss from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-dom": "^15.3.0 || ^16.0.0"
   },
   "dependencies": {
+    "@types/jss": "^9.3.0",
     "babel-runtime": "^6.26.0",
     "brcast": "^3.0.1",
     "classnames": "^2.2.5",
@@ -91,7 +92,6 @@
   "devDependencies": {
     "@rosskevin/react-docgen": "^3.0.0-beta9",
     "@types/enzyme": "^3.1.4",
-    "@types/jss": "^9.3.0",
     "@types/react": "16.0.31",
     "@types/react-transition-group": "^2.0.6",
     "app-module-path": "^2.2.0",


### PR DESCRIPTION
#9678 added a `devDependency` on `@types/jss`, however it exposes types obtained from JSS to consumers of Material UI, so it should really be a `dependency`. Currently one has to add a dependency on `@types/jss` to one's own project or the Material UI dependency doesn't type check.