### PR TITLE
[docs] Add missing code from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import Button from 'material-ui/Button';
 
 function App() {
   return (
-    <Button>
+    <Button raised color="primary">
       Hello World
     </Button>
   );


### PR DESCRIPTION
Very small.
Noticed that `raised color="primary"` was missing from the code example, but was present in the demo.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
