### PR TITLE
[GridList] remove named export

### DIFF
--- a/docs/src/pages/demos/grid-list/AdvancedGridList.js
+++ b/docs/src/pages/demos/grid-list/AdvancedGridList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
-import { GridList, GridListTile, GridListTileBar } from 'material-ui/GridList';
+import GridList, { GridListTile, GridListTileBar } from 'material-ui/GridList';
 import IconButton from 'material-ui/IconButton';
 import StarBorderIcon from 'material-ui-icons/StarBorder';
 import tileData from './tileData';

--- a/docs/src/pages/demos/grid-list/ImageGridList.js
+++ b/docs/src/pages/demos/grid-list/ImageGridList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
-import { GridList, GridListTile } from 'material-ui/GridList';
+import GridList, { GridListTile } from 'material-ui/GridList';
 import tileData from './tileData';
 
 const styles = theme => ({

--- a/docs/src/pages/demos/grid-list/SingleLineGridList.js
+++ b/docs/src/pages/demos/grid-list/SingleLineGridList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
-import { GridList, GridListTile, GridListTileBar } from 'material-ui/GridList';
+import GridList, { GridListTile, GridListTileBar } from 'material-ui/GridList';
 import IconButton from 'material-ui/IconButton';
 import StarBorderIcon from 'material-ui-icons/StarBorder';
 import tileData from './tileData';

--- a/docs/src/pages/demos/grid-list/TitlebarGridList.js
+++ b/docs/src/pages/demos/grid-list/TitlebarGridList.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
-import { GridList, GridListTile, GridListTileBar } from 'material-ui/GridList';
+import GridList, { GridListTile, GridListTileBar } from 'material-ui/GridList';
 import Subheader from 'material-ui/List/ListSubheader';
 import IconButton from 'material-ui/IconButton';
 import InfoIcon from 'material-ui-icons/Info';

--- a/src/GridList/index.d.ts
+++ b/src/GridList/index.d.ts
@@ -1,7 +1,5 @@
 export { default } from './GridList';
 export * from './GridList';
-export { default as GridList } from './GridList';
-export * from './GridList';
 export { default as GridListTile } from './GridListTile';
 export * from './GridListTile';
 export { default as GridListTileBar } from './GridListTileBar';

--- a/src/GridList/index.js
+++ b/src/GridList/index.js
@@ -1,4 +1,3 @@
 export { default } from './GridList';
-export { default as GridList } from './GridList';
 export { default as GridListTile } from './GridListTile';
 export { default as GridListTileBar } from './GridListTileBar';

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -49,7 +49,7 @@ import {
   Input,
 } from '../../src';
 import Collapse from '../../src/transitions/Collapse';
-import { GridList } from '../../src/GridList';
+import GridList from '../../src/GridList';
 import MobileStepper from '../../src/MobileStepper/MobileStepper';
 import Table, {
   TableBody,
@@ -847,4 +847,3 @@ const ClickAwayListenerComponentTest = () =>
   <ClickAwayListener onClickAway={() => {}}>
     <div />
   </ClickAwayListener>
-


### PR DESCRIPTION
GridList is already exported as default. For consistency the named
export has been removed.

As requested in #9833

### Breaking change

```diff
-import { GridList, GridListTile, GridListTileBar } from 'material-ui/GridList';
+import GridList, { GridListTile, GridListTileBar } from 'material-ui/GridList';
```
