### PR TITLE
[Select] allow to pass a function as children

### DIFF
--- a/docs/src/pages/demos/selects/MultipleSelect.js
+++ b/docs/src/pages/demos/selects/MultipleSelect.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import Input, { InputLabel } from 'material-ui/Input';
 import { MenuItem } from 'material-ui/Menu';
+import Button from 'material-ui/Button';
 import { FormControl } from 'material-ui/Form';
 import Select from 'material-ui/Select';
 
@@ -37,6 +38,7 @@ const names = [
 class MultipleSelect extends React.Component {
   state = {
     name: [],
+    nameWithClose: [],
   };
 
   handleChange = event => {
@@ -78,6 +80,48 @@ class MultipleSelect extends React.Component {
                 {name}
               </MenuItem>
             ))}
+          </Select>
+        </FormControl>
+
+        <FormControl className={classes.formControl}>
+          <InputLabel htmlFor="name-multiple">Name</InputLabel>
+          <Select
+            multiple
+            value={this.state.nameWithClose}
+            onChange={e => this.setState({ nameWithClose: e.target.value })}
+            input={<Input id="name-multiple" />}
+            renderValue={selected => selected.filter(x => x).join(', ')}
+            MenuProps={{
+              PaperProps: {
+                style: {
+                  maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+                  width: 200,
+                },
+              },
+            }}
+          >
+            {({ close }) =>
+              names
+                .map(name => (
+                  <MenuItem
+                    key={name}
+                    value={name}
+                    style={{
+                      fontWeight:
+                        this.state.name.indexOf(name) === -1
+                          ? theme.typography.fontWeightRegular
+                          : theme.typography.fontWeightMedium,
+                    }}
+                  >
+                    {name}
+                  </MenuItem>
+                ))
+                .concat(
+                  <MenuItem>
+                    <Button onClick={close}>close</Button>
+                  </MenuItem>,
+                )
+            }
           </Select>
         </FormControl>
       </div>

--- a/src/ExpansionPanel/ExpansionPanel.d.ts
+++ b/src/ExpansionPanel/ExpansionPanel.d.ts
@@ -3,7 +3,8 @@ import { StandardProps } from '..';
 import { CollapseProps } from '../transitions/Collapse';
 import { PaperProps, PaperClassKey } from '../Paper';
 
-export interface ExpansionPanelProps extends StandardProps<PaperProps, ExpansionPanelClassKey, 'onChange'> {
+export interface ExpansionPanelProps
+  extends StandardProps<PaperProps, ExpansionPanelClassKey, 'onChange'> {
   CollapseProps?: React.ComponentType<CollapseProps>;
   defaultExpanded?: boolean;
   disabled?: boolean;

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -18,6 +18,7 @@ export interface SelectInputProps extends StandardProps<{}, SelectInputClassKey>
     ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps['value'] },
   ) => void;
   value?: string | number | Array<string | number>;
+  children: React.ReactNode | ((o: Object) => React.ReactNode);
 }
 
 export type SelectInputClassKey = 'root' | 'select' | 'selectMenu' | 'disabled' | 'icon';

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -131,6 +131,14 @@ class SelectInput extends React.Component {
       ...other
     } = this.props;
 
+    const childrenNodes =
+      typeof children === 'function'
+        ? children({
+            close: this.handleClose,
+            open: this.state.open,
+          })
+        : children;
+
     if (native) {
       warning(
         multiple === false,
@@ -166,7 +174,7 @@ class SelectInput extends React.Component {
             ref={selectRef}
             {...other}
           >
-            {children}
+            {childrenNodes}
           </select>
           <ArrowDropDownIcon className={classes.icon} />
         </div>
@@ -194,7 +202,7 @@ class SelectInput extends React.Component {
       }
     }
 
-    const items = React.Children.map(children, child => {
+    const items = React.Children.map(childrenNodes, child => {
       if (!React.isValidElement(child)) {
         return null;
       }
@@ -301,7 +309,7 @@ SelectInput.propTypes = {
    * The option elements to populate the select with.
    * Can be some `MenuItem` when `native` is false and `option` when `native` is true.
    */
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   /**
    * Useful to extend the style applied to components.
    */

--- a/src/Select/SelectInput.spec.js
+++ b/src/Select/SelectInput.spec.js
@@ -58,6 +58,14 @@ describe('<SelectInput />', () => {
     );
   });
 
+  it('should accept a function as children', () => {
+    shallow(
+      <SelectInput {...props}>
+        {({ open }) => <MenuItem>{`this menu item is ${open}`}</MenuItem>}
+      </SelectInput>,
+    );
+  });
+
   describe('prop: readOnly', () => {
     it('should not trigger any event with readOnly', () => {
       const wrapper = shallow(<SelectInput {...props} readOnly />);
@@ -168,6 +176,32 @@ describe('<SelectInput />', () => {
         backdrop.click();
         assert.strictEqual(wrapper.state().open, false);
       });
+
+      it('should call handleClose', () => {
+        wrapper.find(`.${props.classes.select}`).simulate('click');
+        assert.strictEqual(wrapper.state().open, true);
+
+        const portalLayer = wrapper
+          .find('Portal')
+          .instance()
+          .getMountNode();
+        const backdrop = portalLayer.querySelector('[data-mui-test="Backdrop"]');
+        backdrop.click();
+        assert.strictEqual(wrapper.state().open, false);
+      });
+    });
+
+    it('prop: onChange using children function close argument', () => {
+      const wrapper = mount(
+        <SelectInput {...props}>
+          {({ close, open }) => <MenuItem onClick={close}>{`this menu item is ${open}`}</MenuItem>}
+        </SelectInput>,
+      );
+
+      wrapper.find(`.${props.classes.select}`).simulate('click');
+      assert.strictEqual(wrapper.state().open, true);
+      wrapper.find('MenuItem').simulate('click');
+      assert.strictEqual(wrapper.state().open, false);
     });
   });
 


### PR DESCRIPTION
usecase: see demos/select/MultiSelect, it allows to close a Select from a parent scope/component, and helps to avoid the burden of maintaining a state for `open`

it could be generalized in other components, like Dialogs


