### PR TITLE
[Button] Add fullWidth boolean property

### DIFF
--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -21,6 +21,7 @@ filename: /src/Button/Button.js
 | disableFocusRipple | bool | false | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
 | disableRipple | bool | false | If `true`, the ripple effect will be disabled. |
 | fab | bool | false | If `true`, will use floating action button styling. |
+| fullWidth | bool | false | If `true`, the button will take up the full width of its container. |
 | href | string |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | mini | bool | false | If `true`, and `fab` is `true`, will use mini floating action button styling. |
 | raised | bool | false | If `true`, the button will use raised styling. |
@@ -46,6 +47,7 @@ This property accepts the following keys:
 - `disabled`
 - `fab`
 - `mini`
+- `fullWidth`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Button/Button.js)

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -10,6 +10,7 @@ export interface ButtonProps extends StandardProps<ButtonBaseProps, ButtonClassK
   disableFocusRipple?: boolean;
   disableRipple?: boolean;
   fab?: boolean;
+  fullWidth?: boolean;
   href?: string;
   mini?: boolean;
   raised?: boolean;

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -150,6 +150,9 @@ export const styles = theme => ({
     width: 40,
     height: 40,
   },
+  fullWidth: {
+    width: '100%',
+  },
 });
 
 function Button(props) {
@@ -162,6 +165,7 @@ function Button(props) {
     disabled,
     disableFocusRipple,
     fab,
+    fullWidth,
     mini,
     raised,
     ...other
@@ -183,6 +187,7 @@ function Button(props) {
       [classes.raisedContrast]: !flat && color === 'contrast',
       [classes.dense]: dense,
       [classes.disabled]: disabled,
+      [classes.fullWidth]: fullWidth,
     },
     classNameProp,
   );
@@ -245,6 +250,10 @@ Button.propTypes = {
    */
   fab: PropTypes.bool,
   /**
+   * If `true`, the button will take up the full width of its container.
+   */
+  fullWidth: PropTypes.bool,
+  /**
    * The URL to link to when the button is clicked.
    * If defined, an `a` element will be used as the root node.
    */
@@ -270,6 +279,7 @@ Button.defaultProps = {
   disableFocusRipple: false,
   disableRipple: false,
   fab: false,
+  fullWidth: false,
   mini: false,
   raised: false,
   type: 'button',

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -86,12 +86,12 @@ describe('<MuiThemeProvider />', () => {
       assert.notStrictEqual(markup.match('Hello World'), null);
       assert.strictEqual(sheetsRegistry.registry.length, 3);
       assert.strictEqual(sheetsRegistry.toString().length > 4000, true);
-      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-18');
+      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-19');
       assert.deepEqual(
         sheetsRegistry.registry[1].classes,
         {
-          disabled: 'MuiButtonBase-disabled-17',
-          root: 'MuiButtonBase-root-16',
+          disabled: 'MuiButtonBase-disabled-18',
+          root: 'MuiButtonBase-root-17',
         },
         'the class names should be deterministic',
       );


### PR DESCRIPTION
While I don't find this use case in the Material Design specification,
we used to have the feature on Material-UI v0.x.
So far, I have been writing a lot of custom width: '100%' style for the buttons.

The equivalent feature on Bootstrap side is `.btn-block`.

Closes #9510

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
