### PR TITLE
[docs] Add paragraph on withStyles with multiple classes

### DIFF
--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -94,6 +94,44 @@ const DecoratedNoProps = decorate<{}>( // <-- note the type argument!
 
 To avoid worrying about this edge case it may be a good habit to always provide an explicit type argument to `decorate`.
 
+### Injecting Multiple Classes
+
+TypeScript does not support variadic types, therefore there is no clean way to type usage of `withStyles` that injects multiple classes into a component. There is a hacky workaround that allows you to get support for classes inside your component while only exposing the props you define.
+
+Take the following code as an example: We define our own props in the `Prop`-type, while the props the component actually receives is a union of our `Prop`-type and a `WithStyles`-type for each respective style we defined (`one` and `two`). To prevent TypeScript from exposing the props set through `withStyles` to the consumers of our component, we cast it to a `React.ComponentType<Props>` before exporting it. 
+
+```tsx
+import { Theme, withStyles, WithStyles } from "material-ui/styles";
+import * as React from "react";
+
+const style = (theme: Theme) => ({
+  one: {
+    backgroundColor: "red",
+  },
+  two: {
+    backgroundColor: "pink",
+  },
+});
+
+type Props = {
+   someProp: string;
+};
+
+type PropsWithStyles = Props & WithStyles<"one"> & WithStyles<"two">;
+
+const MyComponent: React.SFC<PropsWithStyles> = ({
+  classes,
+  ...props
+}: PropsWithStyles) => (
+  <div>
+    <div className={classes.one}>One</div>
+    <div className={classes.two}>Two</div>
+  </div>
+);
+
+export default withStyles(style)(MyComponent) as React.ComponentType<Props>;
+```
+
 ## Customization of `Theme`
 
 When adding custom properties to the `Theme`, you may continue to use it in a strongly typed way by exploiting

--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -127,7 +127,7 @@ const Component: React.SFC<PropsWithStyles> = ({
   </div>
 );
 
-export default withStyles(style)(Component);
+export default withStyles(style)<Props>(Component);
 ```
 
 ## Customization of `Theme`

--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -96,9 +96,7 @@ To avoid worrying about this edge case it may be a good habit to always provide 
 
 ### Injecting Multiple Classes
 
-TypeScript does not support variadic types, therefore there is no clean way to type usage of `withStyles` that injects multiple classes into a component. However, there is a hacky workaround that allows you to get support for classes inside your component while only exposing the props you define.
-
-Take the following code for example: The actual props of the component are defined in the `Prop`-type, while the props the component actually receives is a union of the `Prop`-type and a `WithStyles`-type for each respective style defined (`one` and `two`). To prevent TypeScript from exposing the props set through `withStyles` to the consumers of the component, the component is cast to a `React.ComponentType<Props>` before being exported. 
+Injecting multiple classes into a component is straightforward possible. Take the following code for example: The classes `one` and `two` are both available with type information on the `classes`-prop passed in by `withStyles`.
 
 ```tsx
 import { Theme, withStyles, WithStyles } from "material-ui/styles";
@@ -117,9 +115,9 @@ type Props = {
    someProp: string;
 };
 
-type PropsWithStyles = Props & WithStyles<"one"> & WithStyles<"two">;
+type PropsWithStyles = Props & WithStyles<"one" | "two">;
 
-const MyComponent: React.SFC<PropsWithStyles> = ({
+const Component: React.SFC<PropsWithStyles> = ({
   classes,
   ...props
 }: PropsWithStyles) => (
@@ -129,7 +127,7 @@ const MyComponent: React.SFC<PropsWithStyles> = ({
   </div>
 );
 
-export default withStyles(style)(MyComponent) as React.ComponentType<Props>;
+export default withStyles(style)(Component);
 ```
 
 ## Customization of `Theme`

--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -96,7 +96,7 @@ To avoid worrying about this edge case it may be a good habit to always provide 
 
 ### Injecting Multiple Classes
 
-Injecting multiple classes into a component is straightforward possible. Take the following code for example: The classes `one` and `two` are both available with type information on the `classes`-prop passed in by `withStyles`.
+Injecting multiple classes into a component is as straightforward as possible. Take the following code for example. The classes `one` and `two` are both available with type information on the `classes`-prop passed in by `withStyles`.
 
 ```tsx
 import { Theme, withStyles, WithStyles } from "material-ui/styles";

--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -96,9 +96,9 @@ To avoid worrying about this edge case it may be a good habit to always provide 
 
 ### Injecting Multiple Classes
 
-TypeScript does not support variadic types, therefore there is no clean way to type usage of `withStyles` that injects multiple classes into a component. There is a hacky workaround that allows you to get support for classes inside your component while only exposing the props you define.
+TypeScript does not support variadic types, therefore there is no clean way to type usage of `withStyles` that injects multiple classes into a component. However, there is a hacky workaround that allows you to get support for classes inside your component while only exposing the props you define.
 
-Take the following code as an example: We define our own props in the `Prop`-type, while the props the component actually receives is a union of our `Prop`-type and a `WithStyles`-type for each respective style we defined (`one` and `two`). To prevent TypeScript from exposing the props set through `withStyles` to the consumers of our component, we cast it to a `React.ComponentType<Props>` before exporting it. 
+Take the following code for example: The actual props of the component are defined in the `Prop`-type, while the props the component actually receives is a union of the `Prop`-type and a `WithStyles`-type for each respective style defined (`one` and `two`). To prevent TypeScript from exposing the props set through `withStyles` to the consumers of the component, the component is cast to a `React.ComponentType<Props>` before being exported. 
 
 ```tsx
 import { Theme, withStyles, WithStyles } from "material-ui/styles";


### PR DESCRIPTION
**Summary**:

Add a paragraph to the TypeScript specific documenation of `withStyles` that explains how to type components receiving multiple classes from `withStyles`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
