### PR TITLE
[GridListTile] Fix error when overriding classes

### DIFF
--- a/src/GridList/GridListTile.js
+++ b/src/GridList/GridListTile.js
@@ -64,11 +64,11 @@ class GridListTile extends React.Component {
       imgElement.width / imgElement.height >
       imgElement.parentNode.offsetWidth / imgElement.parentNode.offsetHeight
     ) {
-      imgElement.classList.remove(this.props.classes.imgFullWidth);
-      imgElement.classList.add(this.props.classes.imgFullHeight);
+      imgElement.classList.remove(...this.props.classes.imgFullWidth.split(' '));
+      imgElement.classList.add(...this.props.classes.imgFullHeight.split(' '));
     } else {
-      imgElement.classList.remove(this.props.classes.imgFullHeight);
-      imgElement.classList.add(this.props.classes.imgFullWidth);
+      imgElement.classList.remove(...this.props.classes.imgFullHeight.split(' '));
+      imgElement.classList.add(...this.props.classes.imgFullWidth.split(' '));
     }
 
     imgElement.removeEventListener('load', this.fit);

--- a/src/GridList/GridListTile.spec.js
+++ b/src/GridList/GridListTile.spec.js
@@ -8,6 +8,7 @@ describe('<GridListTile />', () => {
   let shallow;
   let mount;
   let classes;
+  const GridListTileNaked = unwrap(GridListTile);
 
   before(() => {
     shallow = createShallow({ dive: true });
@@ -70,10 +71,9 @@ describe('<GridListTile />', () => {
     let wrapper;
 
     beforeEach(() => {
-      const GridListTileNaked = unwrap(GridListTile);
       wrapper = mount(
         <GridListTileNaked
-          classes={{ imgFullWidth: 'imgFullWidth', imgFullHeight: 'imgFullHeight' }}
+          classes={{ imgFullWidth: 'imgFullWidth foo', imgFullHeight: 'imgFullHeight' }}
         >
           <img alt="test" />
         </GridListTileNaked>,


### PR DESCRIPTION
Fixes the overriding of the classes `imgFullHeight` and `imgFullWidth`.

Closes #9856
