### PR TITLE
[examples] Update gatsby example to work with v1.0.0-beta.28

### DIFF
--- a/examples/gatsby/src/getPageContext.js
+++ b/examples/gatsby/src/getPageContext.js
@@ -18,7 +18,7 @@ const theme = createMuiTheme({
       light: green[300],
       main: green[500],
       dark: green[700],
-    }
+    },
   },
 });
 

--- a/examples/gatsby/src/getPageContext.js
+++ b/examples/gatsby/src/getPageContext.js
@@ -9,8 +9,16 @@ import green from 'material-ui/colors/green';
 // It's optional.
 const theme = createMuiTheme({
   palette: {
-    primary: purple,
-    secondary: green,
+    primary: {
+      light: purple[300],
+      main: purple[500],
+      dark: purple[700],
+    },
+    secondary: {
+      light: green[300],
+      main: green[500],
+      dark: green[700],
+    }
   },
 });
 


### PR DESCRIPTION
@oliviertassinari 

The current gatsby example fails to build (https://github.com/mui-org/material-ui/pull/9779#issuecomment-357541519)

This PR fixes the example according to the release notes here https://github.com/mui-org/material-ui/releases/tag/v1.0.0-beta.28

Thanks!