### PR TITLE
[core] allow theme palette primary, secondary, error as colors string

### DIFF
--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -75,7 +75,7 @@ const theme = createMuiTheme({
 });
 ```
 
-If `palette.primary` or `palette.secondary` objects are provided, 
+If `palette.primary` or `palette.secondary` objects or color strings are provided, 
 they will replace the defaults.
 
 If the `dark` and / or `light` keys are omitted, their value(s) will be calculated from `main`, 

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -79,19 +79,19 @@ export const dark = {
 
 export default function createPalette(palette: Object) {
   const {
-    primary = {
+    primary: primaryValue = {
       light: indigo[300],
       main: indigo[500],
       dark: indigo[700],
       contrastText: '',
     },
-    secondary = {
+    secondary: secondaryValue = {
       light: pink.A200,
       main: pink.A400,
       dark: pink.A700,
       contrastText: '',
     },
-    error = {
+    error: errorValue = {
       main: red[500],
     },
     type = 'light',
@@ -101,6 +101,10 @@ export default function createPalette(palette: Object) {
     tonalOffset = 0.2,
     ...other
   } = palette;
+
+  const primary = typeof primaryValue === 'string' ? { main: primaryValue } : primaryValue;
+  const secondary = typeof secondaryValue === 'string' ? { main: secondaryValue } : secondaryValue;
+  const error = typeof errorValue === 'string' ? { main: errorValue } : primaryValue;
 
   if (!primary.light) {
     primary.light = lighten(primary.main, tonalOffset);

--- a/src/styles/createPalette.spec.js
+++ b/src/styles/createPalette.spec.js
@@ -197,6 +197,17 @@ describe('createPalette()', () => {
     );
   });
 
+  it('should allow to initialize palette {primary, secondary, error} as primitive', () => {
+    const palette = createPalette({
+      primary: deepOrange[500],
+      secondary: green.A400,
+      error: pink[200],
+    });
+    assert.strictEqual(palette.primary.main, deepOrange[500]);
+    assert.strictEqual(palette.secondary.main, green.A400);
+    assert.strictEqual(palette.error.main, pink[200]);
+  });
+
   it('should calculate contrastText using the provided contrastThreshold', () => {
     const palette = createPalette({ contrastThreshold: 7 });
     assert.strictEqual(


### PR DESCRIPTION
maybe useful / less surprising for users  (https://github.com/mui-org/material-ui/issues/9093#issuecomment-357553666)

@mbrookes 