### PR TITLE
[core] Upgrade jss to 9.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "deepmerge": "^2.0.1",
     "dom-helpers": "^3.2.1",
     "hoist-non-react-statics": "^2.3.1",
-    "jss": "^9.3.3",
+    "jss": "^9.5.0",
     "jss-camel-case": "^6.0.0",
     "jss-default-unit": "^8.0.2",
     "jss-global": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5517,7 +5517,7 @@ jss-vendor-prefixer@^8.0.0:
   dependencies:
     css-vendor "^1.0.0"
 
-jss@^9.3.2, jss@^9.3.3:
+jss@^9.3.2, jss@^9.5.0:
   version "9.5.1"
   resolved "https://registry.yarnpkg.com/jss/-/jss-9.5.1.tgz#c869f38cdc44a32f4425fe007ea46b8891536326"
   dependencies:


### PR DESCRIPTION
This fixes an issue of `jss.toCssValue is not a function` introduced by https://github.com/mui-org/material-ui/pull/9828

`jss-vendor-prefixer@8.0.0` requires `jss@9.5.0` to work since `toCssValue` function was only exposed on `jss@9.5.0`

Relevant the commits.
https://github.com/cssinjs/jss-vendor-prefixer/commit/a4619ccd7466f0006ddee59bd55c36e88929c531
https://github.com/cssinjs/jss/commit/2d642d9818b151c381fb368348c50ac9961a2960