### PR TITLE
[typescript] Move @types/react-transition-group from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@types/jss": "^9.3.0",
+    "@types/react-transition-group": "^2.0.6",
     "babel-runtime": "^6.26.0",
     "brcast": "^3.0.1",
     "classnames": "^2.2.5",
@@ -94,7 +95,6 @@
     "@rosskevin/react-docgen": "^3.0.0-beta9",
     "@types/enzyme": "^3.1.4",
     "@types/react": "16.0.34",
-    "@types/react-transition-group": "^2.0.6",
     "app-module-path": "^2.2.0",
     "argos-cli": "^0.0.9",
     "autosuggest-highlight": "^3.1.1",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Resolves #9873.