### PR TITLE
[core] Fix some w3c validation errors

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -129,7 +129,7 @@ if (rootElement) {
   };
 
   render() {
-    const { classes, demoOptions, githubLocation, js: DemoComponent, raw } = this.props;
+    const { classes, demoOptions, githubLocation, index, js: DemoComponent, raw } = this.props;
     const { codeOpen } = this.state;
 
     return (
@@ -145,29 +145,31 @@ if (rootElement) {
           >
             <input type="hidden" name="parameters" value="" />
           </form>
-          <Tooltip
-            id="demo-github"
-            title="See the source on GitHub"
-            target="_blank"
-            placement="top"
-          >
-            <IconButton href={githubLocation} aria-labelledby="demo-github">
+          <Tooltip id={`demo-github-${index}`} title="See the source on GitHub" placement="top">
+            <IconButton
+              href={githubLocation}
+              target="_blank"
+              aria-labelledby={`demo-github-${index}`}
+            >
               <Github />
             </IconButton>
           </Tooltip>
           {demoOptions.hideEditButton ? null : (
-            <Tooltip id="demo-codesandbox" title="Edit in codesandbox" placement="top">
-              <IconButton onClick={this.handleClickCodesandbox} aria-labelledby="demo-codesandbox">
+            <Tooltip id={`demo-codesandbox-${index}`} title="Edit in codesandbox" placement="top">
+              <IconButton
+                onClick={this.handleClickCodesandbox}
+                aria-labelledby={`demo-codesandbox-${index}`}
+              >
                 <ModeEditIcon />
               </IconButton>
             </Tooltip>
           )}
           <Tooltip
-            id="demo-source"
+            id={`demo-source-${index}`}
             title={codeOpen ? 'Hide the source' : 'Show the source'}
             placement="top"
           >
-            <IconButton onClick={this.handleClickCodeOpen} aria-labelledby="demo-source">
+            <IconButton onClick={this.handleClickCodeOpen} aria-labelledby={`demo-source-${index}`}>
               <CodeIcon />
             </IconButton>
           </Tooltip>
@@ -187,6 +189,7 @@ Demo.propTypes = {
   classes: PropTypes.object.isRequired,
   demoOptions: PropTypes.object.isRequired,
   githubLocation: PropTypes.string.isRequired,
+  index: PropTypes.number.isRequired,
   js: PropTypes.func.isRequired,
   raw: PropTypes.string.isRequired,
 };

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -58,7 +58,7 @@ function MarkdownDocs(props, context) {
         </Button>
       </div>
       <Carbon key={markdownLocation} />
-      {contents.map(content => {
+      {contents.map((content, index) => {
         const match = content.match(demoRegexp);
 
         if (match && demos) {
@@ -71,6 +71,7 @@ function MarkdownDocs(props, context) {
               key={content}
               js={demos[name].js}
               raw={demos[name].raw}
+              index={index}
               demoOptions={demoOptions}
               githubLocation={`${SOURCE_CODE_ROOT_URL}/docs/src/${name}`}
             />

--- a/docs/src/pages/demos/drawers/PersistentDrawer.js
+++ b/docs/src/pages/demos/drawers/PersistentDrawer.js
@@ -83,10 +83,8 @@ const styles = theme => ({
     height: 'calc(100% - 56px)',
     marginTop: 56,
     [theme.breakpoints.up('sm')]: {
-      content: {
-        height: 'calc(100% - 64px)',
-        marginTop: 64,
-      },
+      height: 'calc(100% - 64px)',
+      marginTop: 64,
     },
   },
   'content-left': {

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -16,6 +16,7 @@ filename: /src/Badge/Badge.js
 | <span style="color: #31a148">children *</span> | node |  | The badge will be added relative to this node. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
+| component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'span' | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/Badge/Badge.d.ts
+++ b/src/Badge/Badge.d.ts
@@ -6,6 +6,7 @@ export interface BadgeProps
   badgeContent: React.ReactNode;
   children: React.ReactNode;
   color?: PropTypes.Color;
+  component?: React.ReactType<BadgeProps>;
 }
 
 export type BadgeClassKey = 'root' | 'badge' | 'colorPrimary' | 'colorSecondary';

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -44,17 +44,25 @@ export const styles = theme => ({
 });
 
 function Badge(props) {
-  const { badgeContent, classes, className: classNameProp, color, children, ...other } = props;
+  const {
+    badgeContent,
+    children,
+    classes,
+    className: classNameProp,
+    color,
+    component: ComponentProp,
+    ...other
+  } = props;
 
   const badgeClassName = classNames(classes.badge, {
     [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'default',
   });
 
   return (
-    <span className={classNames(classes.root, classNameProp)} {...other}>
+    <ComponentProp className={classNames(classes.root, classNameProp)} {...other}>
       {children}
       <span className={badgeClassName}>{badgeContent}</span>
-    </span>
+    </ComponentProp>
   );
 }
 
@@ -79,10 +87,16 @@ Badge.propTypes = {
    * The color of the component. It's using the theme palette when that makes sense.
    */
   color: PropTypes.oneOf(['default', 'primary', 'secondary']),
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 };
 
 Badge.defaultProps = {
   color: 'default',
+  component: 'span',
 };
 
 export default withStyles(styles, { name: 'MuiBadge' })(Badge);


### PR DESCRIPTION
Look into #9867

- [x] Add component property to Badge like https://github.com/mui-org/material-ui/pull/9890/files
- [x] And following are docs/demo specific on every page:
Error: Attribute “target” not allowed on element “div” at this point
Reason: target used on div for icon buttons of github, codesandbox and link to file
- [x] Error: Duplicate ID {`demo-github|demo-codesandbox|demo-source`}
Reason: the ids when there are more than one demos on a page.
