### PR TITLE
[FormControl] Fix alternating focus change bug

### DIFF
--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -89,9 +89,7 @@ class FormControl extends React.Component {
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }
-    if (!this.state.focused) {
-      this.setState({ focused: true });
-    }
+    this.setState(state => (!state.focused ? { focused: true } : null));
   };
 
   handleBlur = event => {
@@ -101,9 +99,7 @@ class FormControl extends React.Component {
     if (this.props.onBlur && event) {
       this.props.onBlur(event);
     }
-    if (this.state.focused) {
-      this.setState({ focused: false });
-    }
+    this.setState(state => (state.focused ? { focused: false } : null));
   };
 
   handleDirty = () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

In our project, the design strays from MUI spec a bit in the sense that menus appear below a `<Select>` input and not above it.

This revealed a weird bug: As I would cycle through the menu options with keyboard up/down, the Select's label would toggle focus on each key press.

I managed to fix this by noticing that `setState()` calls in `FormControl` depend on the old state. The recommended React way is to pass an updater function to `setState()` in these situations.

Also, returning `null` from an updater [cancels the update as of React 16](https://reactjs.org/blog/2017/09/26/react-v16.0.html#breaking-changes), so the effect should be the same.

This does trigger a re-render, though, on React 15. Is that acceptable?

![screen recording](https://user-images.githubusercontent.com/428060/34991419-303c4bd2-fad2-11e7-949a-29c50270ee36.gif)