### PR TITLE
[typescript] Fix Color typings to reflect new light/dark/main/contrastText implementation

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,20 +18,10 @@ export type StandardProps<C, ClassKey extends string, Removals extends keyof C =
 
 export type PaletteType = 'light' | 'dark';
 export interface Color {
-  50: string;
-  100: string;
-  200: string;
-  300: string;
-  400: string;
-  500: string;
-  600: string;
-  700: string;
-  800: string;
-  900: string;
-  A100: string;
-  A200: string;
-  A400: string;
-  A700: string;
+  light: string;
+  dark: string;
+  main: string;
+  contrastText: string;
 }
 
 /**


### PR DESCRIPTION
The newer Color typings were incorrect, still reflecting the old palette way. This fixes that.
