### PR TITLE
[palette] Standardize the secondary color

### DIFF
--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -28,9 +28,9 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `colorSecondary`
-- `colorPrimary`
 - `colorInherit`
+- `colorPrimary`
+- `colorSecondary`
 - `disabled`
 - `label`
 - `icon`

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -23,11 +23,11 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
+- `colorPrimary`
 - `colorSecondary`
 - `colorAction`
 - `colorDisabled`
 - `colorError`
-- `colorPrimary`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Icon/Icon.js)

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -26,11 +26,11 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
+- `colorPrimary`
 - `colorSecondary`
 - `colorAction`
 - `colorDisabled`
 - `colorError`
-- `colorPrimary`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/SvgIcon/SvgIcon.js)

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -26,13 +26,13 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `rootLabelIcon`
-- `rootSecondary`
-- `rootSecondarySelected`
-- `rootSecondaryDisabled`
+- `rootInherit`
 - `rootPrimary`
 - `rootPrimarySelected`
 - `rootPrimaryDisabled`
-- `rootInherit`
+- `rootSecondary`
+- `rootSecondarySelected`
+- `rootSecondaryDisabled`
 - `rootInheritSelected`
 - `rootInheritDisabled`
 - `fullWidth`

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -50,8 +50,8 @@ This property accepts the following keys:
 - `paragraph`
 - `colorInherit`
 - `colorPrimary`
-- `colorTextSecondary`
 - `colorSecondary`
+- `colorTextSecondary`
 - `colorError`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -41,8 +41,8 @@ export const styles = theme => ({
     color: theme.palette.primary.contrastText,
   },
   colorSecondary: {
-    backgroundColor: theme.palette.secondary.light,
-    color: theme.palette.getContrastText(theme.palette.secondary.light),
+    backgroundColor: theme.palette.secondary.main,
+    color: theme.palette.secondary.contrastText,
   },
 });
 

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -38,8 +38,8 @@ export const styles = theme => ({
     color: theme.palette.primary.contrastText,
   },
   colorSecondary: {
-    backgroundColor: theme.palette.secondary.light,
-    color: theme.palette.getContrastText(theme.palette.secondary.light),
+    backgroundColor: theme.palette.secondary.main,
+    color: theme.palette.secondary.contrastText,
   },
 });
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -55,9 +55,9 @@ export const styles = theme => ({
     },
   },
   flatSecondary: {
-    color: theme.palette.secondary.light,
+    color: theme.palette.secondary.main,
     '&:hover': {
-      backgroundColor: fade(theme.palette.secondary.light, 0.12),
+      backgroundColor: fade(theme.palette.secondary.main, 0.12),
       // Reset on mouse devices
       '@media (hover: none)': {
         backgroundColor: 'transparent',
@@ -110,12 +110,12 @@ export const styles = theme => ({
   },
   raisedSecondary: {
     color: theme.palette.secondary.contrastText,
-    backgroundColor: theme.palette.secondary.light,
+    backgroundColor: theme.palette.secondary.main,
     '&:hover': {
-      backgroundColor: theme.palette.secondary.main,
+      backgroundColor: theme.palette.secondary.dark,
       // Reset on mouse devices
       '@media (hover: none)': {
-        backgroundColor: theme.palette.secondary.light,
+        backgroundColor: theme.palette.secondary.main,
       },
     },
   },

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -8,8 +8,11 @@ export const styles = theme => ({
   root: {
     userSelect: 'none',
   },
+  colorPrimary: {
+    color: theme.palette.primary.main,
+  },
   colorSecondary: {
-    color: theme.palette.secondary.light,
+    color: theme.palette.secondary.main,
   },
   colorAction: {
     color: theme.palette.action.active,
@@ -19,9 +22,6 @@ export const styles = theme => ({
   },
   colorError: {
     color: theme.palette.error.main,
-  },
-  colorPrimary: {
-    color: theme.palette.primary.main,
   },
 });
 

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -24,14 +24,14 @@ export const styles = theme => ({
       duration: theme.transitions.duration.shortest,
     }),
   },
-  colorSecondary: {
-    color: theme.palette.secondary.light,
+  colorInherit: {
+    color: 'inherit',
   },
   colorPrimary: {
     color: theme.palette.primary.main,
   },
-  colorInherit: {
-    color: 'inherit',
+  colorSecondary: {
+    color: theme.palette.secondary.main,
   },
   disabled: {
     color: theme.palette.action.disabled,

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -19,7 +19,7 @@ export const styles = theme => ({
     color: theme.palette.primary.main,
   },
   colorSecondary: {
-    color: theme.palette.secondary.light,
+    color: theme.palette.secondary.main,
   },
   svgIndeterminate: {
     animation: 'mui-progress-circular-rotate 1.4s linear infinite',

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -16,8 +16,11 @@ export const styles = theme => ({
       duration: theme.transitions.duration.shorter,
     }),
   },
+  colorPrimary: {
+    color: theme.palette.primary.main,
+  },
   colorSecondary: {
-    color: theme.palette.secondary.light,
+    color: theme.palette.secondary.main,
   },
   colorAction: {
     color: theme.palette.action.active,
@@ -27,9 +30,6 @@ export const styles = theme => ({
   },
   colorError: {
     color: theme.palette.error.main,
-  },
-  colorPrimary: {
-    color: theme.palette.primary.main,
   },
 });
 

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -25,14 +25,9 @@ export const styles = theme => ({
   rootLabelIcon: {
     height: 72,
   },
-  rootSecondary: {
-    color: theme.palette.text.secondary,
-  },
-  rootSecondarySelected: {
-    color: theme.palette.secondary.light,
-  },
-  rootSecondaryDisabled: {
-    color: theme.palette.text.disabled,
+  rootInherit: {
+    color: 'inherit',
+    opacity: 0.7,
   },
   rootPrimary: {
     color: theme.palette.text.secondary,
@@ -43,9 +38,14 @@ export const styles = theme => ({
   rootPrimaryDisabled: {
     color: theme.palette.text.disabled,
   },
-  rootInherit: {
-    color: 'inherit',
-    opacity: 0.7,
+  rootSecondary: {
+    color: theme.palette.text.secondary,
+  },
+  rootSecondarySelected: {
+    color: theme.palette.secondary.main,
+  },
+  rootSecondaryDisabled: {
+    color: theme.palette.text.disabled,
   },
   rootInheritSelected: {
     opacity: 1,

--- a/src/Tabs/TabIndicator.js
+++ b/src/Tabs/TabIndicator.js
@@ -17,7 +17,7 @@ export const styles = theme => ({
     backgroundColor: theme.palette.primary.main,
   },
   colorSecondary: {
-    backgroundColor: theme.palette.secondary.light,
+    backgroundColor: theme.palette.secondary.main,
   },
 });
 

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -49,11 +49,11 @@ export const styles = theme => ({
   colorPrimary: {
     color: theme.palette.primary.main,
   },
-  colorTextSecondary: {
-    color: theme.palette.text.secondary,
-  },
   colorSecondary: {
     color: theme.palette.secondary.main,
+  },
+  colorTextSecondary: {
+    color: theme.palette.text.secondary,
   },
   colorError: {
     color: theme.palette.error.main,


### PR DESCRIPTION
Looking at the different resources I can gather:
- https://material-components-web.appspot.com/button.html
- https://material.io/color/#!/?view.left=0&view.right=0
- https://material.io/guidelines/components/buttons.html#buttons-raised-buttons

There is no reason for the secondary color to use different color hues than the primary color.
Fix @mbrookes's concern in https://github.com/mui-org/material-ui/pull/9913#discussion_r161888416

### Breaking change

The secondary color now behaves the same way than the other colors (primary, error). We always use the `main` tone by default instead of the `light` tone.
It's unclear if this change is making the implementation follow the specification more closely. The direct win is **simplicity and predictability**. 