### PR TITLE
[TableCell] Fix TypeScript definition

### DIFF
--- a/src/Table/TableCell.d.ts
+++ b/src/Table/TableCell.d.ts
@@ -28,7 +28,7 @@ export type TableCellClassKey =
   | 'numeric'
   | 'head'
   | 'paddingDefault'
-  | 'paddingCompact'
+  | 'paddingDense'
   | 'paddingCheckbox'
   | 'footer';
 


### PR DESCRIPTION
Closes #9907.

Small update to the typescript definitions for TableCellClassKey.