### PR TITLE
[Divider] Add component property

### DIFF
--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -14,6 +14,7 @@ filename: /src/Divider/Divider.js
 |:-----|:-----|:--------|:------------|
 | absolute | bool | false |  |
 | classes | object |  | Useful to extend the style applied to components. |
+| component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'hr' | The component used for the root node. Either a string to use a DOM element or a component. |
 | inset | bool | false | If `true`, the divider will be indented. |
 | light | bool | false | If `true`, the divider will have a lighter color. |
 
@@ -24,8 +25,8 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `default`
 - `inset`
+- `default`
 - `light`
 - `absolute`
 

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -12,6 +12,7 @@ filename: /src/Paper/Paper.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| children | node |  | The content of the component. |
 | classes | object |  | Useful to extend the style applied to components. |
 | component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | elevation | number | 2 | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -38,7 +38,7 @@ function Avatar(props) {
     childrenClassName: childrenClassNameProp,
     classes,
     className: classNameProp,
-    component: ComponentProp,
+    component: Component,
     imgProps,
     sizes,
     src,
@@ -80,9 +80,9 @@ function Avatar(props) {
   }
 
   return (
-    <ComponentProp className={className} {...other}>
+    <Component className={className} {...other}>
       {children}
-    </ComponentProp>
+    </Component>
   );
 }
 

--- a/src/Card/CardContent.js
+++ b/src/Card/CardContent.js
@@ -13,9 +13,9 @@ export const styles = theme => ({
 });
 
 function CardContent(props) {
-  const { classes, className, component: ComponentProp, ...other } = props;
+  const { classes, className, component: Component, ...other } = props;
 
-  return <ComponentProp className={classNames(classes.root, className)} {...other} />;
+  return <Component className={classNames(classes.root, className)} {...other} />;
 }
 
 CardContent.propTypes = {

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -18,14 +18,14 @@ export const styles = {
 const MEDIA_COMPONENTS = ['video', 'audio', 'picture', 'iframe', 'img'];
 
 function CardMedia(props) {
-  const { classes, className, component: ComponentProp, image, src, style, ...other } = props;
+  const { classes, className, component: Component, image, src, style, ...other } = props;
 
   warning(
     Boolean(image || src),
     'Material-UI: either `image` or `src` property must be specified.',
   );
 
-  const isMediaComponent = MEDIA_COMPONENTS.indexOf(ComponentProp) !== -1;
+  const isMediaComponent = MEDIA_COMPONENTS.indexOf(Component) !== -1;
   const composedStyle =
     !isMediaComponent && image ? { backgroundImage: `url(${image})`, ...style } : style;
   const composedClassName = classNames(
@@ -37,7 +37,7 @@ function CardMedia(props) {
   );
 
   return (
-    <ComponentProp
+    <Component
       className={composedClassName}
       style={composedStyle}
       src={isMediaComponent ? image || src : undefined}

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -125,7 +125,7 @@ class Chip extends React.Component {
       avatar: avatarProp,
       classes,
       className: classNameProp,
-      component: ComponentProp,
+      component: Component,
       deleteIcon: deleteIconProp,
       label,
       onClick,
@@ -169,7 +169,7 @@ class Chip extends React.Component {
     }
 
     return (
-      <ComponentProp
+      <Component
         role="button"
         className={className}
         tabIndex={tabIndex}
@@ -183,7 +183,7 @@ class Chip extends React.Component {
         {avatar}
         <span className={classes.label}>{label}</span>
         {deleteIcon}
-      </ComponentProp>
+      </Component>
     );
   }
 }

--- a/src/Divider/Divider.d.ts
+++ b/src/Divider/Divider.d.ts
@@ -4,6 +4,7 @@ import { StandardProps } from '..';
 export interface DividerProps
   extends StandardProps<React.HTMLAttributes<HTMLHRElement>, DividerClassKey> {
   absolute?: boolean;
+  component?: React.ReactType<DividerProps>;
   inset?: boolean;
   light?: boolean;
 }

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -10,11 +10,11 @@ export const styles = theme => ({
     border: 'none',
     flexShrink: 0,
   },
-  default: {
-    backgroundColor: theme.palette.text.divider,
-  },
   inset: {
     marginLeft: 72,
+  },
+  default: {
+    backgroundColor: theme.palette.text.divider,
   },
   light: {
     backgroundColor: theme.palette.text.lightDivider,
@@ -28,19 +28,27 @@ export const styles = theme => ({
 });
 
 function Divider(props) {
-  const { absolute, classes, className: classNameProp, inset, light, ...other } = props;
+  const {
+    absolute,
+    classes,
+    className: classNameProp,
+    component: Component,
+    inset,
+    light,
+    ...other
+  } = props;
 
   const className = classNames(
     classes.root,
     {
       [classes.absolute]: absolute,
       [classes.inset]: inset,
-      [light ? classes.light : classes.default]: true,
     },
+    light ? classes.light : classes.default,
     classNameProp,
   );
 
-  return <hr className={className} {...other} />;
+  return <Component className={className} {...other} />;
 }
 
 Divider.propTypes = {
@@ -54,6 +62,11 @@ Divider.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  /**
    * If `true`, the divider will be indented.
    */
   inset: PropTypes.bool,
@@ -65,6 +78,7 @@ Divider.propTypes = {
 
 Divider.defaultProps = {
   absolute: false,
+  component: 'hr',
   inset: false,
   light: false,
 };

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -120,10 +120,9 @@ class FormControl extends React.Component {
 
   render() {
     const {
-      children,
       classes,
       className,
-      component: ComponentProp = 'div',
+      component: Component,
       disabled,
       error,
       fullWidth,
@@ -132,7 +131,7 @@ class FormControl extends React.Component {
     } = this.props;
 
     return (
-      <ComponentProp
+      <Component
         className={classNames(
           classes.root,
           {
@@ -145,9 +144,7 @@ class FormControl extends React.Component {
         {...other}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
-      >
-        {children}
-      </ComponentProp>
+      />
     );
   }
 }

--- a/src/Form/FormHelperText.js
+++ b/src/Form/FormHelperText.js
@@ -27,13 +27,12 @@ export const styles = theme => ({
 
 function FormHelperText(props, context) {
   const {
-    children,
     classes,
     className: classNameProp,
     disabled: disabledProp,
     error: errorProp,
     margin: marginProp,
-    component: ComponentProp,
+    component: Component,
     ...other
   } = props;
   const { muiFormControl } = context;
@@ -66,11 +65,7 @@ function FormHelperText(props, context) {
     classNameProp,
   );
 
-  return (
-    <ComponentProp className={className} {...other}>
-      {children}
-    </ComponentProp>
-  );
+  return <Component className={className} {...other} />;
 }
 
 FormHelperText.propTypes = {

--- a/src/Grid/Grid.js
+++ b/src/Grid/Grid.js
@@ -164,7 +164,7 @@ function Grid(props) {
     alignItems,
     classes,
     className: classNameProp,
-    component: ComponentProp,
+    component: Component,
     container,
     direction,
     hidden,
@@ -210,12 +210,12 @@ function Grid(props) {
   if (hidden) {
     return (
       <Hidden {...hidden}>
-        <ComponentProp {...gridProps} />
+        <Component {...gridProps} />
       </Hidden>
     );
   }
 
-  return <ComponentProp {...gridProps} />;
+  return <Component {...gridProps} />;
 }
 
 Grid.propTypes = {

--- a/src/GridList/GridList.js
+++ b/src/GridList/GridList.js
@@ -21,14 +21,14 @@ function GridList(props) {
     classes,
     className: classNameProp,
     cols,
-    component: ComponentProp,
+    component: Component,
     spacing,
     style,
     ...other
   } = props;
 
   return (
-    <ComponentProp
+    <Component
       className={classNames(classes.root, classNameProp)}
       style={{ margin: -spacing / 2, ...style }}
       {...other}
@@ -48,7 +48,7 @@ function GridList(props) {
           ),
         });
       })}
-    </ComponentProp>
+    </Component>
   );
 }
 

--- a/src/GridList/GridListTile.js
+++ b/src/GridList/GridListTile.js
@@ -87,18 +87,10 @@ class GridListTile extends React.Component {
   }
 
   render() {
-    const {
-      children,
-      classes,
-      className,
-      cols,
-      component: ComponentProp,
-      rows,
-      ...other
-    } = this.props;
+    const { children, classes, className, cols, component: Component, rows, ...other } = this.props;
 
     return (
-      <ComponentProp className={classNames(classes.root, className)} {...other}>
+      <Component className={classNames(classes.root, className)} {...other}>
         <EventListener target="window" onResize={this.handleResize} />
         <div className={classes.tile}>
           {React.Children.map(children, child => {
@@ -114,7 +106,7 @@ class GridListTile extends React.Component {
             return child;
           })}
         </div>
-      </ComponentProp>
+      </Component>
     );
   }
 }

--- a/src/List/List.js
+++ b/src/List/List.js
@@ -36,7 +36,7 @@ class List extends React.Component {
       children,
       classes,
       className: classNameProp,
-      component: ComponentProp,
+      component: Component,
       dense,
       disablePadding,
       subheader,
@@ -53,10 +53,10 @@ class List extends React.Component {
     );
 
     return (
-      <ComponentProp className={className} {...other}>
+      <Component className={className} {...other}>
         {subheader}
         {children}
-      </ComponentProp>
+      </Component>
     );
   }
 }

--- a/src/List/ListSubheader.js
+++ b/src/List/ListSubheader.js
@@ -35,11 +35,10 @@ export const styles = theme => ({
 
 function ListSubheader(props) {
   const {
-    children,
     classes,
     className: classNameProp,
     color,
-    component: ComponentProp,
+    component: Component,
     disableSticky,
     inset,
     ...other
@@ -54,11 +53,7 @@ function ListSubheader(props) {
     classNameProp,
   );
 
-  return (
-    <ComponentProp className={className} {...other}>
-      {children}
-    </ComponentProp>
-  );
+  return <Component className={className} {...other} />;
 }
 
 ListSubheader.propTypes = {

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -27,7 +27,7 @@ function Paper(props) {
   const {
     classes,
     className: classNameProp,
-    component: ComponentProp,
+    component: Component,
     square,
     elevation,
     ...other
@@ -47,12 +47,12 @@ function Paper(props) {
     classNameProp,
   );
 
-  return <ComponentProp className={className} {...other} />;
+  return <Component className={className} {...other} />;
 }
 
 Paper.propTypes = {
   /**
-   * @ignore
+   * The content of the component.
    */
   children: PropTypes.node,
   /**

--- a/src/Progress/LinearProgress.d.ts
+++ b/src/Progress/LinearProgress.d.ts
@@ -25,7 +25,7 @@ export type LinearProgressClassKey =
   | 'indeterminateBar1'
   | 'indeterminateBar2'
   | 'determinateBar1'
-  | 'bufferBar1'
+  | 'bufferBar1';
 
 declare const LinearProgress: React.ComponentType<LinearProgressProps>;
 

--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -22,19 +22,9 @@ class Table extends React.Component {
   }
 
   render() {
-    const {
-      classes,
-      className: classNameProp,
-      children,
-      component: ComponentProp,
-      ...other
-    } = this.props;
+    const { classes, className: classNameProp, component: Component, ...other } = this.props;
 
-    return (
-      <ComponentProp className={classNames(classes.root, classNameProp)} {...other}>
-        {children}
-      </ComponentProp>
-    );
+    return <Component className={classNames(classes.root, classNameProp)} {...other} />;
   }
 }
 

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -12,9 +12,9 @@ class TableBody extends React.Component {
   }
 
   render() {
-    const { children, component: ComponentProp, ...other } = this.props;
+    const { component: Component, ...other } = this.props;
 
-    return <ComponentProp {...other}>{children}</ComponentProp>;
+    return <Component {...other} />;
   }
 }
 

--- a/src/Table/TableFooter.js
+++ b/src/Table/TableFooter.js
@@ -12,9 +12,9 @@ class TableFooter extends React.Component {
   }
 
   render() {
-    const { children, component: ComponentProp, ...other } = this.props;
+    const { component: Component, ...other } = this.props;
 
-    return <ComponentProp {...other}>{children}</ComponentProp>;
+    return <Component {...other} />;
   }
 }
 

--- a/src/Table/TableHead.js
+++ b/src/Table/TableHead.js
@@ -12,9 +12,9 @@ class TableHead extends React.Component {
   }
 
   render() {
-    const { children, component: ComponentProp, ...other } = this.props;
+    const { component: Component, ...other } = this.props;
 
-    return <ComponentProp {...other}>{children}</ComponentProp>;
+    return <Component {...other} />;
   }
 }
 

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -35,7 +35,6 @@ export const styles = theme => ({
  */
 function TableRow(props, context) {
   const {
-    children,
     classes,
     className: classNameProp,
     component: Component,
@@ -56,11 +55,7 @@ function TableRow(props, context) {
     classNameProp,
   );
 
-  return (
-    <Component className={className} {...other}>
-      {children}
-    </Component>
-  );
+  return <Component className={className} {...other} />;
 }
 
 TableRow.propTypes = {

--- a/src/Tabs/Tabs.d.ts
+++ b/src/Tabs/Tabs.d.ts
@@ -25,8 +25,7 @@ export type TabsClassKey =
   | 'scrollingContainer'
   | 'fixed'
   | 'scrollable'
-  | 'centered'
-  ;
+  | 'centered';
 
 export interface TabsActions {
   updateIndicator(): void;

--- a/src/styles/createGenerateClassName.d.ts
+++ b/src/styles/createGenerateClassName.d.ts
@@ -6,5 +6,5 @@ interface GenerateClassNameOptions {
 }
 
 export default function createGenerateClassName(
-  options?: GenerateClassNameOptions
+  options?: GenerateClassNameOptions,
 ): GenerateClassName<any>;

--- a/src/styles/themeListener.d.ts
+++ b/src/styles/themeListener.d.ts
@@ -1,6 +1,6 @@
 // This is using the API from https://github.com/vesparny/brcast
 interface Broadcast<S> {
-  setState(state: S): void
+  setState(state: S): void;
   getState(): S;
   subscribe(callback: (state: S) => void): number;
   unsubscribe(subscriptionId: number): void;
@@ -16,6 +16,6 @@ export interface ThemeListener<S = {}> {
   unsubscribe(context: MuiContext<S>, subscriptionId: number): void;
 }
 
-declare const themeListener: ThemeListener
+declare const themeListener: ThemeListener;
 
 export default themeListener;

--- a/src/test-utils/createRender.d.ts
+++ b/src/test-utils/createRender.d.ts
@@ -4,6 +4,4 @@ export interface RenderOptions {
   render: typeof render;
 }
 
-export default function createRender(
-  options?: Partial<RenderOptions>,
-): typeof render;
+export default function createRender(options?: Partial<RenderOptions>): typeof render;

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -113,7 +113,7 @@ class Collapse extends React.Component {
       classes,
       className,
       collapsedHeight,
-      component: ComponentProp,
+      component: Component,
       onEnter,
       onEntered,
       onEntering,
@@ -139,7 +139,7 @@ class Collapse extends React.Component {
       >
         {(state, otherInner) => {
           return (
-            <ComponentProp
+            <Component
               className={classNames(
                 classes.container,
                 {
@@ -161,7 +161,7 @@ class Collapse extends React.Component {
               >
                 <div className={classes.wrapperInner}>{children}</div>
               </div>
-            </ComponentProp>
+            </Component>
           );
         }}
       </Transition>

--- a/src/utils/helpers.d.ts
+++ b/src/utils/helpers.d.ts
@@ -4,4 +4,4 @@ export function findIndex(arr: any[], pred: any): number;
 export function find<T>(arr: T[], pred: any): T;
 export function createChainedFunction(...funcs: ChainedFunction[]): (...args: any[]) => never;
 
-type ChainedFunction = ((...args: any[]) => void) | undefined | null
+type ChainedFunction = ((...args: any[]) => void) | undefined | null;

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -502,10 +502,12 @@ const SnackbarTest = () => (
       open={true}
       autoHideDuration={6e3}
       onClose={event => log(event)}
-      SnackbarContentProps={{
-        // 'aria-describedby': 'message-id',
-        // ^ will work once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22582 is merged.
-      }}
+      SnackbarContentProps={
+        {
+          // 'aria-describedby': 'message-id',
+          // ^ will work once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22582 is merged.
+        }
+      }
       message={<span id="message-id">Note archived</span>}
       action={[
         <Button key="undo" color="secondary" dense onClick={event => log(event)}>


### PR DESCRIPTION
It was also the occasion to normalize the piece of logic on the codebase.
We rename the property to `Component` instead of `ComponentProps`.

Also, we only explicit the `children` property when we need to. It's less code.