### PR TITLE
[ListItemText] Update Typings for primary and secondary text class keys

### DIFF
--- a/src/List/ListItemText.d.ts
+++ b/src/List/ListItemText.d.ts
@@ -13,8 +13,8 @@ export type ListItemTextClassKey =
   | 'root'
   | 'inset'
   | 'dense'
-  | 'textPrimary'
-  | 'textSecondary'
+  | 'primary'
+  | 'secondary'
   | 'textDense';
 
 declare const ListItemText: React.ComponentType<ListItemTextProps>;


### PR DESCRIPTION
Update Typings to reflect recent renaming of `textPrimary` to `primary` and `textSecondary` to `secondary` for `ListItemText` component.
