### PR TITLE
[docs] Improve the documentation on the breakpoints

### DIFF
--- a/docs/src/pages/customization/ThemeDefault.js
+++ b/docs/src/pages/customization/ThemeDefault.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import url from 'url';
 import PropTypes from 'prop-types';
 import Inspector from 'react-inspector';
 import { withStyles, withTheme, createMuiTheme } from 'material-ui/styles';
@@ -7,21 +8,44 @@ import Switch from 'material-ui/Switch';
 
 const styles = theme => ({
   root: {
-    padding: 8 * 2,
+    padding: theme.spacing.unit * 2,
+    paddingTop: 0,
     backgroundColor: theme.palette.type === 'light' ? '#fff' : 'rgb(36, 36, 36)',
-    minHeight: 8 * 40,
+    minHeight: theme.spacing.unit * 40,
     width: '100%',
+  },
+  switch: {
+    paddingBottom: theme.spacing.unit,
   },
 });
 
 class ThemeDefault extends React.Component {
   state = {
     checked: false,
+    expandPaths: null,
   };
+
+  componentDidMount() {
+    const URL = url.parse(document.location.href, true);
+    const expandPath = URL.query['expend-path'];
+
+    if (!expandPath) {
+      return;
+    }
+
+    // eslint-disable-next-line react/no-did-mount-set-state
+    this.setState({
+      expandPaths: expandPath.split('.').reduce((acc, path) => {
+        const last = acc.length > 0 ? `${acc[acc.length - 1]}.` : '';
+        acc.push(last + path);
+        return acc;
+      }, []),
+    });
+  }
 
   render() {
     const { classes, theme: docsTheme } = this.props;
-    const { checked } = this.state;
+    const { checked, expandPaths } = this.state;
 
     const theme = createMuiTheme({
       palette: {
@@ -30,14 +54,10 @@ class ThemeDefault extends React.Component {
       direction: docsTheme.direction,
     });
 
-    // Expose the theme as a global variable so people can play with it.
-    if (process.browser) {
-      window.theme = theme;
-    }
-
     return (
       <div className={classes.root}>
         <FormControlLabel
+          className={classes.switch}
           control={
             <Switch
               checked={checked}
@@ -49,6 +69,7 @@ class ThemeDefault extends React.Component {
         <Inspector
           theme={theme.palette.type === 'light' ? 'chromeLight' : 'chromeDark'}
           data={theme}
+          expandPaths={expandPaths}
           expandLevel={checked ? 100 : 1}
           key={`${checked}-${theme.palette.type}`} // Remount
         />

--- a/docs/src/pages/customization/theme-default.md
+++ b/docs/src/pages/customization/theme-default.md
@@ -1,10 +1,13 @@
 # Default Theme
 
-The theme normalizes implementation by providing default values for palette, dark and light types, typography, breakpoints, shadows, transitions, etc.
-
-If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/v1-beta/src/styles/createMuiTheme.js),
-and the related imports which `createMuiTheme` uses.
-
 Here's what the theme object looks like with the default values:
 
 {{"demo": "pages/customization/ThemeDefault.js", "hideEditButton": true}}
+
+The theme normalizes implementation by providing default values for palette, dark and light types, typography, breakpoints, shadows, transitions, etc.
+
+Tip: you can plan with the theme object in your console too.
+**We expose a global `theme` variable on all the pages**.
+
+If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/v1-beta/src/styles/createMuiTheme.js),
+and the related imports which `createMuiTheme` uses.

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -40,13 +40,18 @@ If you want to learn more about color, you can check out [the color section](/st
 
 You may override the default palette values by including a `palette` object as part of your theme.
 
-If any of the `palette.primary`, `palette.secondary` or `palette.error` 'intent' objects are provided,
+If any of the [`palette.primary`](/customization/theme-default?expend-path=$.palette.primary), [`palette.secondary`](/customization/theme-default?expend-path=$.palette.secondary) or [`palette.error`](/customization/theme-default?expend-path=$.palette.error) 'intent' objects are provided,
 they will replace the defaults.
 
 The intent objects accept either a color object, or an object with one or more of the following keys:
 
-```
-{ light: '', main: '', dark: '', contrastText: '' }
+```jsx
+interface PaletteColor {
+  light?: string;
+  main: string;
+  dark?: string;
+  contrastText?: string;
+};
 ```
 
 **Using a color object**
@@ -86,13 +91,18 @@ import red from 'material-ui/colors/red';
 // We try our best to provide a great default value.
 const theme = createMuiTheme({
   palette: {
-    contrastThreshold: 3,
-    tonalOffset: 0.2,
     primary: indigo,
     secondary: pink,
     error: {
       main: red[500],
     },
+    // Used by `getContrastText()` to maximize the contrast between the background and
+    // the text.
+    contrastThreshold: 3,
+    // Used by the functions below to shift a color's luminance by approximately
+    // two index within its tonal palette.
+    // E.g., shift from Red 500 to Red 300 or Red 700.
+    tonalOffset: 0.2,
   },
 });
 ```

--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -24,7 +24,7 @@ interface Props {
   text: string;
   type: TypographyProps['type'];
   color: TypographyProps['color'];
-}
+};
 ```
 
 Functional components are straightforward:

--- a/docs/src/pages/layout/basics.md
+++ b/docs/src/pages/layout/basics.md
@@ -10,14 +10,30 @@ For optimal user experience, material design interfaces need to be able to adapt
 Material-UI uses a **simplified** implementation of the original [specification](https://material.io/guidelines/layout/responsive-ui.html#responsive-ui-breakpoints).
 
 Each breakpoint matches with a *fixed* screen width:
-- **xs**, extra-small: 0dp or larger
-- **sm**, small: 600dp or larger
-- **md**, medium: 960dp or larger
-- **lg**, large: 1280dp or larger
-- **xl**, xlarge: 1920dp or larger
+- **xs**, extra-small: 0px or larger
+- **sm**, small: 600px or larger
+- **md**, medium: 960px or larger
+- **lg**, large: 1280px or larger
+- **xl**, xlarge: 1920px or larger
+
+Those values can always be customized.
+You will find them in the theme under the [`breakpoints.values`](/customization/theme-default?expend-path=$.breakpoints.values) path.
 
 ## z-index
 
 Several Material-UI components utilize `z-index`, the CSS property that helps control layout by providing a third axis to arrange content.
 We utilize a default z-index scale in Material-UI that's been designed to properly layer drawers,
 modals, snackbars, tooltips, and more.
+
+These values start at an arbitrary number, high and specific enough to ideally avoid conflicts.
+
+- mobile stepper: 1000
+- app bar: 1100
+- drawer: 1200
+- modal: 1300
+- snackbar: 1400
+- tooltip: 1500
+
+Those values can always be customized.
+You will find them in the theme under the [`zIndex`](/customization/theme-default?expend-path=$.zIndex) path.
+We don’t encourage customization of these individual values; should you change one, you likely need to change them all.

--- a/docs/src/pages/layout/css-in-js.md
+++ b/docs/src/pages/layout/css-in-js.md
@@ -1,10 +1,118 @@
 # CSS in JS
 
+## Responsive breakpoints
+
 Sometimes, wrapping things inside a layout component doesn't make much sense when
 everything you need can be handled by a small CSS change. By using the
-`breakpoints` attribute of the theme, you can utilise the same breakpoints used
+[`breakpoints`](/customization/theme-default?expend-path=$.breakpoints) attribute of the theme, you can utilise the same breakpoints used
 for the [Grid](/layout/grid) and [Hidden](/layout/hidden) components directly in your component.
 
 This can be accomplished using [CSS-in-JS](/customization/css-in-js).
 
 {{"demo": "pages/layout/MediaQuery.js"}}
+
+## API
+
+### `theme.breakpoings.up(key) => media query`
+
+#### Arguments
+
+1. `key` (*String* | *Number*): A breakpoint key (`xs`, `sm`, etc.) or a screen width number in pixel.
+
+#### Returns
+
+`media query`: A media query string ready to be used with JSS.
+
+#### Examples
+
+```js
+const styles = theme => ({
+  root: {
+    backgroundColor: 'blue',
+    // Match [md, ∞[
+    //       [960px, ∞[
+    [theme.breakpoints.up('md')]: {
+      backgroundColor: 'red',
+    },
+  },
+});
+```
+
+### `theme.breakpoings.down(key) => media query`
+
+#### Arguments
+
+1. `key` (*String* | *Number*): A breakpoint key (`xs`, `sm`, etc.) or a screen width number in pixel.
+
+#### Returns
+
+`media query`: A media query string ready to be used with JSS.
+
+#### Examples
+
+```js
+const styles = theme => ({
+  root: {
+    backgroundColor: 'blue',
+    // Match [0, md + 1[
+    //       [0, lg[
+    //       [0, 1280px[
+    [theme.breakpoints.down('md')]: {
+      backgroundColor: 'red',
+    },
+  },
+});
+```
+
+### `theme.breakpoings.only(key) => media query`
+
+#### Arguments
+
+1. `key` (*String*): A breakpoint key (`xs`, `sm`, etc.).
+
+#### Returns
+
+`media query`: A media query string ready to be used with JSS.
+
+#### Examples
+
+```js
+const styles = theme => ({
+  root: {
+    backgroundColor: 'blue',
+    // Match [md, md + 1[
+    //       [md, lg[
+    //       [960px, 1280px[
+    [theme.breakpoints.only('md')]: {
+      backgroundColor: 'red',
+    },
+  },
+});
+```
+
+### `theme.breakpoings.between(start, end) => media query`
+
+#### Arguments
+
+1. `start` (*String*): A breakpoint key (`xs`, `sm`, etc.).
+2. `end` (*String*): A breakpoint key (`xs`, `sm`, etc.).
+
+#### Returns
+
+`media query`: A media query string ready to be used with JSS.
+
+#### Examples
+
+```js
+const styles = theme => ({
+  root: {
+    backgroundColor: 'blue',
+    // Match [sm, md + 1[
+    //       [sm, lg[
+    //       [600px, 1280px[
+    [theme.breakpoints.between('sm', 'md')]: {
+      backgroundColor: 'red',
+    },
+  },
+});
+```

--- a/docs/src/pages/style/typography.md
+++ b/docs/src/pages/style/typography.md
@@ -39,6 +39,6 @@ For more info check out the [typeface](https://www.npmjs.com/package/typeface-ro
 ## CSS in JS
 
 In some situation you might not be able to use the `Typography` component.
-Hopefully, you might be able to take advantage of the `typography` keys of the theme.
+Hopefully, you might be able to take advantage of the [`typography`](/customization/theme-default?expend-path=$.typography) keys of the theme.
 
 {{"demo": "pages/style/TypographyTheme.js"}}

--- a/examples/create-react-app/src/withRoot.js
+++ b/examples/create-react-app/src/withRoot.js
@@ -21,6 +21,11 @@ const theme = createMuiTheme({
   },
 });
 
+// Expose the theme as a global variable so people can play with it.
+if (process.browser) {
+  window.theme = theme;
+}
+
 function withRoot(Component) {
   function WithRoot(props) {
     // MuiThemeProvider makes the theme available down the React tree

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -103,7 +103,12 @@ export default function createPalette(palette: Object) {
       main: red[500],
     },
     type = 'light',
+    // Used by `getContrastText()` to maximize the contrast between the background and
+    // the text.
     contrastThreshold = 3,
+    // Used by the functions below to shift a color's luminance by approximately
+    // two index within its tonal palette.
+    // E.g., shift from Red 500 to Red 300 or Red 700.
     tonalOffset = 0.2,
     ...other
   } = palette;


### PR DESCRIPTION
This should address @alexandru-paduraru's concerns around the breakpoint story of Material-UI.
Also:
- New `expand-path` query API for the documentation
- Expose `window.theme`on all the pages