### PR TITLE
[TableCell] Fix TypeScript definition

### DIFF
--- a/src/Table/TableCell.d.ts
+++ b/src/Table/TableCell.d.ts
@@ -26,11 +26,12 @@ export type Type = 'head' | 'body' | 'footer';
 export type TableCellClassKey =
   | 'root'
   | 'numeric'
-  | 'head'
+  | 'typeHead'
+  | 'typeBody'
+  | 'typeFooter'
   | 'paddingDefault'
   | 'paddingDense'
-  | 'paddingCheckbox'
-  | 'footer';
+  | 'paddingCheckbox';
 
 declare const TableCell: React.ComponentType<TableCellProps>;
 


### PR DESCRIPTION
Another small update to the Typescript definition of `TableCellClassKey` to match the changes of PR #9852.