### PR TITLE
[IconButton] Better follow the spec

### DIFF
--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -34,7 +34,6 @@ This property accepts the following keys:
 - `disabled`
 - `label`
 - `icon`
-- `keyboardFocused`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/IconButton/IconButton.js)

--- a/src/ButtonBase/TouchRipple.js
+++ b/src/ButtonBase/TouchRipple.js
@@ -36,7 +36,7 @@ export const styles = theme => ({
     display: 'block',
     width: '100%',
     height: '100%',
-    animation: `mui-ripple-pulsate 1500ms ${theme.transitions.easing.easeInOut} 200ms infinite`,
+    animation: `mui-ripple-pulsate 2500ms ${theme.transitions.easing.easeInOut} 200ms infinite`,
   },
   '@keyframes mui-ripple-enter': {
     '0%': {
@@ -59,7 +59,7 @@ export const styles = theme => ({
       transform: 'scale(1)',
     },
     '50%': {
-      transform: 'scale(0.9)',
+      transform: 'scale(0.92)',
     },
     '100%': {
       transform: 'scale(1)',

--- a/src/IconButton/IconButton.d.ts
+++ b/src/IconButton/IconButton.d.ts
@@ -16,8 +16,7 @@ export type IconButtonClassKey =
   | 'colorSecondary'
   | 'colorInherit'
   | 'label'
-  | 'icon'
-  | 'keyboardFocused';
+  | 'icon';
 
 declare const IconButton: React.ComponentType<IconButtonProps>;
 

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -46,9 +46,6 @@ export const styles = theme => ({
     width: '1em',
     height: '1em',
   },
-  keyboardFocused: {
-    backgroundColor: theme.palette.text.divider,
-  },
 });
 
 /**
@@ -69,7 +66,7 @@ function IconButton(props) {
         className,
       )}
       centerRipple
-      keyboardFocusedClassName={classes.keyboardFocused}
+      focusRipple
       disabled={disabled}
       rootRef={buttonRef}
       ref={rootRef}


### PR DESCRIPTION
**Before**
![capture d ecran 2018-01-20 a 12 23 36](https://user-images.githubusercontent.com/3165635/35182871-c6a2fe24-fddc-11e7-8155-0f38273332a5.png)

**After**
![capture d ecran 2018-01-20 a 12 22 48](https://user-images.githubusercontent.com/3165635/35182860-b0f84bce-fddc-11e7-9fe1-8577d04e12bb.png)

- Reduce the pulsating animation. It's the first step toward solving #9526.

> However, it seems that we don't follow the specification closely enough. The focus indicator ring should take the color of the icon into account. Right now, we don't.

- Closes https://github.com/mui-org/material-ui/issues/9941#issuecomment-358625818