### PR TITLE
[docs] Using TypeScript & withStyles for class component w/union props

### DIFF
--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -94,7 +94,7 @@ const DecoratedNoProps = decorate<{}>( // <-- note the type argument!
 );
 ```
 
-Scenario 2: `Props` is a union type. To avoid getting a compiler error, you'll need to provide an explict type argument: 
+Scenario 2: `Props` is a union type. Again, to avoid getting a compiler error, you'll need to provide an explict type argument: 
 
 ```jsx
 import { WithStyles } from 'material-ui/styles';

--- a/docs/src/pages/guides/typescript.md
+++ b/docs/src/pages/guides/typescript.md
@@ -56,7 +56,9 @@ const DecoratedClass = decorate(
 );
 ```
 
-Note that in the class example you didn't need to annotate `<Props>` in the call to `decorate`; type inference took care of everything. One caveat is that if your styled component takes _no_ additional props in addition to `classes`. The natural thing would be to write:
+Note that in the class example you didn't need to annotate `<Props>` in the call to `decorate`; type inference took care of everything. However, there are 2 scenarios where you _do_ need to provide an explicit type argument to `decorate`. 
+
+Scenario 1: your styled component takes _no_ additional props in addition to `classes`. The natural thing would be to write:
 
 ```jsx
 import { WithStyles } from 'material-ui/styles';
@@ -92,7 +94,38 @@ const DecoratedNoProps = decorate<{}>( // <-- note the type argument!
 );
 ```
 
-To avoid worrying about this edge case it may be a good habit to always provide an explicit type argument to `decorate`.
+Scenario 2: `Props` is a union type. To avoid getting a compiler error, you'll need to provide an explict type argument: 
+
+```jsx
+import { WithStyles } from 'material-ui/styles';
+
+interface Book {
+  category: "book";
+  author: string;
+}
+
+interface Painting {
+  category: "painting";
+  artist: string;
+}
+
+type Props = Book | Painting;
+
+const DecoratedUnionProps = decorate<Props>( // <-- without the type argument, we'd get a compiler error!
+  class extends React.Component<Props & WithStyles<'root'>> {
+    render() {
+      const props = this.props;
+      return (
+        <Typography classes={props.classes}>
+          {props.category === "book" ? props.author : props.artist}
+        </Typography>
+      );
+    }
+  }
+);
+```
+
+To avoid worrying about these 2 edge cases, it may be a good habit to always provide an explicit type argument to `decorate`.
 
 ### Injecting Multiple Classes
 


### PR DESCRIPTION
This PR adds a section to the TypeScript + withStyles docs about the need to pass an explicit type argument to `decorate` when using a class component whose props are a union type. If you don't pass the explicit type, the TypeScript compiler will throw an error. Here's a repro:

```tsx
import * as React from "react";
import { withStyles, WithStyles } from "material-ui/styles";
import { Typography } from "material-ui";

const decorate = withStyles<"root">({
  root: {
    color: "green"
  }
});

interface Book {
  category: "book";
  author: string;
}

interface Painting {
  category: "painting";
  artist: string;
}

type Props = Book | Painting;

export const DecoratedUnionProps = decorate( // <-- notice there's no type param here
  class extends React.Component<Props & WithStyles<"root">> {
    render() {
      const props = this.props;
      return (
        <Typography classes={props.classes}>
          {props.category === "book" ? props.author : props.artist}
        </Typography>
      );
    }
  }
);

```

This will cause the following error:

![screen shot 2018-01-20 at 2 26 34 pm](https://user-images.githubusercontent.com/17934735/35188625-fd4335c8-fded-11e7-90d5-8f1e07f37e3e.png)

You can resolve the issue by simply passing `Props` to `decorate`:
```tsx
export const DecoratedUnionProps = decorate<Props>(
  class extends React.Component<Props & WithStyles<"root">> {
    ...
  }
);
```
