### PR TITLE
[Select] Add inputProps property

### DIFF
--- a/docs/src/pages/demos/selects/NativeSelect.js
+++ b/docs/src/pages/demos/selects/NativeSelect.js
@@ -40,7 +40,9 @@ class NativeSelect extends React.Component {
             native
             value={this.state.age}
             onChange={this.handleChange('age')}
-            input={<Input id="age-native-simple" />}
+            inputProps={{
+              id: 'age-native-simple',
+            }}
           >
             <option value="" />
             <option value={10}>Ten</option>

--- a/docs/src/pages/demos/selects/SimpleSelect.js
+++ b/docs/src/pages/demos/selects/SimpleSelect.js
@@ -40,7 +40,10 @@ class SimpleSelect extends React.Component {
           <Select
             value={this.state.age}
             onChange={this.handleChange}
-            input={<Input name="age" id="age-simple" />}
+            inputProps={{
+              name: 'age',
+              id: 'age-simple',
+            }}
           >
             <MenuItem value="">
               <em>None</em>

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -17,6 +17,7 @@ filename: /src/Select/Select.js
 | classes | object |  | Useful to extend the style applied to components. |
 | displayEmpty | bool | false | If `true`, the selected item is displayed even if its value is empty. You can only use it when the `native` property is `false` (default). |
 | input | element | &lt;Input /> | An `Input` element; does not have to be a material-ui specific `Input`. |
+| inputProps | object |  | Properties applied to the `input` element. When `native` is `true`, the properties are applied on the `select` element. |
 | MenuProps | object |  | Properties applied to the `Menu` element. |
 | multiple | bool | false | If true, `value` must be an array and the menu will support multiple selections. You can only use it when the `native` property is `false` (default). |
 | native | bool | false | If `true`, the component will be using a native `select` element. |

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -64,6 +64,7 @@ function Select(props) {
     classes,
     displayEmpty,
     input,
+    inputProps,
     MenuProps,
     multiple,
     native,
@@ -80,6 +81,7 @@ function Select(props) {
     inputComponent: SelectInput,
     ...other,
     inputProps: {
+      ...inputProps,
       ...(input ? input.props.inputProps : {}),
       autoWidth,
       children,
@@ -120,6 +122,11 @@ Select.propTypes = {
    * An `Input` element; does not have to be a material-ui specific `Input`.
    */
   input: PropTypes.element,
+  /**
+   * Properties applied to the `input` element.
+   * When `native` is `true`, the properties are applied on the `select` element.
+   */
+  inputProps: PropTypes.object,
   /**
    * Properties applied to the `Menu` element.
    */

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -598,7 +598,7 @@ const TableTest = () => {
         backgroundColor,
         overflowX: 'auto',
       },
-    }
+    };
   };
 
   let id = 0;


### PR DESCRIPTION
Apply the same specificity rule as everywhere else. The closer the properties are applied from the consummation, the more priority overrides they have: `inputProps={x}` < `<Input inputProps={x} />`.

Closes #9977 
