### PR TITLE
[Icon] Remove icon ligature "magic" support

### DIFF
--- a/docs/src/pages/demos/bottom-navigation/LabelBottomNavigation.js
+++ b/docs/src/pages/demos/bottom-navigation/LabelBottomNavigation.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import BottomNavigation, { BottomNavigationAction } from 'material-ui/BottomNavigation';
+import Icon from 'material-ui/Icon';
 import RestoreIcon from 'material-ui-icons/Restore';
 import FavoriteIcon from 'material-ui-icons/Favorite';
 import LocationOnIcon from 'material-ui-icons/LocationOn';
-import FolderIcon from 'material-ui-icons/Folder';
 
 const styles = {
   root: {
@@ -31,7 +31,7 @@ class LabelBottomNavigation extends React.Component {
         <BottomNavigationAction label="Recents" value="recents" icon={<RestoreIcon />} />
         <BottomNavigationAction label="Favorites" value="favorites" icon={<FavoriteIcon />} />
         <BottomNavigationAction label="Nearby" value="nearby" icon={<LocationOnIcon />} />
-        <BottomNavigationAction label="Folder" value="folder" icon={<FolderIcon />} />
+        <BottomNavigationAction label="Folder" value="folder" icon={<Icon>folder</Icon>} />
       </BottomNavigation>
     );
   }

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -31,7 +31,6 @@ This property accepts the following keys:
 - `label`
 - `selectedLabel`
 - `hiddenLabel`
-- `icon`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/BottomNavigation/BottomNavigationAction.js)

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -13,7 +13,7 @@ filename: /src/BottomNavigation/BottomNavigationAction.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | classes | object |  | Useful to extend the style applied to components. |
-| icon | node |  | The icon element. If a string is provided, it will be used as a font ligature. |
+| icon | node |  | The icon element. |
 | label | node |  | The label element. |
 | showLabel | bool |  | If `true`, the BottomNavigationAction will show its label. |
 | value | any |  | You can provide your own value. Otherwise, we fallback to the child position index. |

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -13,13 +13,13 @@ filename: /src/Checkbox/Checkbox.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | checked | union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br> |  | If `true`, the component is checked. |
-| checkedIcon | node |  | The icon to display when the component is checked. If a string is provided, it will be used as a font ligature. |
+| checkedIcon | node |  | The icon to display when the component is checked. |
 | classes | object |  | Useful to extend the style applied to components. |
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
-| icon | node |  | The icon to display when the component is unchecked. If a string is provided, it will be used as a font ligature. |
+| icon | node |  | The icon to display when the component is unchecked. |
 | indeterminate | bool | false | If `true`, the component appears indeterminate. |
-| indeterminateIcon | node | &lt;IndeterminateCheckBoxIcon /> | The icon to display when the component is indeterminate. If a string is provided, it will be used as a font ligature. |
+| indeterminateIcon | node | &lt;IndeterminateCheckBoxIcon /> | The icon to display when the component is indeterminate. |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | func |  | Use that property to pass a ref callback to the native input component. |
 | inputType | string |  | The input component property `type`. |

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -15,7 +15,7 @@ Chips represent complex entities in small blocks, such as a contact.
 | avatar | element |  | Avatar element. |
 | classes | object |  | Useful to extend the style applied to components. |
 | component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
-| deleteIcon | node |  | Override the default delete icon element. Shown only if `onDelete` is set. |
+| deleteIcon | element |  | Override the default delete icon element. Shown only if `onDelete` is set. |
 | label | node |  | The content of the label. |
 | onDelete | func |  | Callback function fired when the delete icon is clicked. If set, the delete icon will be shown. |
 

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -15,7 +15,7 @@ Chips represent complex entities in small blocks, such as a contact.
 | avatar | element |  | Avatar element. |
 | classes | object |  | Useful to extend the style applied to components. |
 | component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
-| deleteIcon | element |  | Custom delete icon element. Will be shown only if `onDelete` is set. |
+| deleteIcon | node |  | Override the default delete icon element. Shown only if `onDelete` is set. |
 | label | node |  | The content of the label. |
 | onDelete | func |  | Callback function fired when the delete icon is clicked. If set, the delete icon will be shown. |
 

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -14,7 +14,7 @@ regarding the available icon options.
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | buttonRef | func |  | Use that property to pass a ref callback to the native button component. |
-| children | node |  | The icon element. If a string is provided, it will be used as an icon font ligature. |
+| children | node |  | The icon element. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
 | disabled | bool | false | If `true`, the button will be disabled. |

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -13,11 +13,11 @@ filename: /src/Radio/Radio.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | checked | union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br> |  | If `true`, the component is checked. |
-| checkedIcon | node |  | The icon to display when the component is checked. If a string is provided, it will be used as a font ligature. |
+| checkedIcon | node |  | The icon to display when the component is checked. |
 | classes | object |  | Useful to extend the style applied to components. |
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
-| icon | node |  | The icon to display when the component is unchecked. If a string is provided, it will be used as a font ligature. |
+| icon | node |  | The icon to display when the component is unchecked. |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | func |  | Use that property to pass a ref callback to the native input component. |
 | inputType | string |  | The input component property `type`. |

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -15,7 +15,7 @@ filename: /src/Stepper/StepLabel.js
 | children | node |  | In most cases will simply be a string containing a title for the label. |
 | classes | object |  | Custom styles for component. |
 | disabled | bool | false | Mark the step as disabled, will also disable the button if `StepLabelButton` is a child of `StepLabel`. Is passed to child components. |
-| icon | node |  | The icon displayed by the step label - if not set will be set by Step component. |
+| icon | node |  | Override the default icon. |
 | optional | node |  | The optional node to display. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -13,11 +13,11 @@ filename: /src/Switch/Switch.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | checked | union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br> |  | If `true`, the component is checked. |
-| checkedIcon | node |  | The icon to display when the component is checked. If a string is provided, it will be used as a font ligature. |
+| checkedIcon | node |  | The icon to display when the component is checked. |
 | classes | object |  | Useful to extend the style applied to components. |
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
-| icon | node |  | The icon to display when the component is unchecked. If a string is provided, it will be used as a font ligature. |
+| icon | node |  | The icon to display when the component is unchecked. |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | func |  | Use that property to pass a ref callback to the native input component. |
 | inputType | string |  | The input component property `type`. |

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -14,7 +14,7 @@ filename: /src/Tabs/Tab.js
 |:-----|:-----|:--------|:------------|
 | classes | object |  | Useful to extend the style applied to components. |
 | disabled | bool | false | If `true`, the tab will be disabled. |
-| icon | node |  | The icon element. If a string is provided, it will be used as a font ligature. |
+| icon | node |  | The icon element. |
 | label | node |  | The label element. |
 | value | any |  | You can provide your own value. Otherwise, we fallback to the child position index. |
 

--- a/src/BottomNavigation/BottomNavigationAction.d.ts
+++ b/src/BottomNavigation/BottomNavigationAction.d.ts
@@ -20,8 +20,7 @@ export type BottomNavigationActionClassKey =
   | 'wrapper'
   | 'label'
   | 'selectedLabel'
-  | 'hiddenLabel'
-  | 'icon';
+  | 'hiddenLabel';
 
 declare const BottomNavigationAction: React.ComponentType<BottomNavigationActionProps>;
 

--- a/src/BottomNavigation/BottomNavigationAction.js
+++ b/src/BottomNavigation/BottomNavigationAction.js
@@ -5,14 +5,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
-import { cloneChildrenWithClassName } from '../utils/reactHelpers';
 
 export const styles = theme => ({
   root: {
     transition: theme.transitions.create(['color', 'padding-top'], {
       duration: theme.transitions.duration.short,
     }),
-    paddingTop: 8,
+    paddingTop: theme.spacing.unit,
     paddingBottom: 10,
     paddingLeft: 12,
     paddingRight: 12,
@@ -49,10 +48,6 @@ export const styles = theme => ({
     opacity: 0,
     transitionDelay: '0s',
   },
-  icon: {
-    display: 'block',
-    margin: 'auto',
-  },
 });
 
 class BottomNavigationAction extends React.Component {
@@ -72,7 +67,7 @@ class BottomNavigationAction extends React.Component {
     const {
       classes,
       className: classNameProp,
-      icon: iconProp,
+      icon,
       label,
       onChange,
       onClick,
@@ -90,8 +85,6 @@ class BottomNavigationAction extends React.Component {
       },
       classNameProp,
     );
-
-    const icon = iconProp ? cloneChildrenWithClassName(iconProp, classes.icon) : null;
 
     const labelClassName = classNames(classes.label, {
       [classes.selectedLabel]: selected,

--- a/src/BottomNavigation/BottomNavigationAction.js
+++ b/src/BottomNavigation/BottomNavigationAction.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
-import Icon from '../Icon';
+import { cloneChildrenWithClassName } from '../utils/reactHelpers';
 
 export const styles = theme => ({
   root: {
@@ -91,17 +91,7 @@ class BottomNavigationAction extends React.Component {
       classNameProp,
     );
 
-    let icon = null;
-
-    if (iconProp) {
-      if (React.isValidElement(iconProp) && typeof iconProp !== 'string') {
-        icon = React.cloneElement(iconProp, {
-          className: classNames(classes.icon, iconProp.props.className),
-        });
-      } else {
-        icon = <Icon>{iconProp}</Icon>;
-      }
-    }
+    const icon = iconProp ? cloneChildrenWithClassName(iconProp, classes.icon) : null;
 
     const labelClassName = classNames(classes.label, {
       [classes.selectedLabel]: selected,
@@ -129,7 +119,7 @@ BottomNavigationAction.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * The icon element. If a string is provided, it will be used as a font ligature.
+   * The icon element.
    */
   icon: PropTypes.node,
   /**

--- a/src/BottomNavigation/BottomNavigationAction.spec.js
+++ b/src/BottomNavigation/BottomNavigationAction.spec.js
@@ -48,21 +48,9 @@ describe('<BottomNavigationAction />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
-  it('should render icon with the icon class', () => {
+  it('should render icon', () => {
     const wrapper = shallow(<BottomNavigationAction icon={icon} />);
-    const iconWrapper = wrapper.childAt(0).childAt(0);
-    assert.strictEqual(iconWrapper.hasClass(classes.icon), true, 'should have the icon class');
-  });
-
-  it('should render icon with the user and icon classes', () => {
-    const wrapper = shallow(<BottomNavigationAction icon={icon} />);
-
-    const iconWrapper = wrapper.childAt(0).childAt(0);
-    assert.strictEqual(iconWrapper.is(Icon), true, 'should be an Icon');
-    assert.strictEqual(iconWrapper.hasClass(classes.icon), true, 'should have the icon class');
-
-    const labelWrapper = wrapper.childAt(0).childAt(1);
-    assert.strictEqual(labelWrapper.hasClass(classes.label), true, 'should have the label class');
+    assert.strictEqual(wrapper.contains(icon), true, 'should have the icon');
   });
 
   it('should render label with the selectedLabel class', () => {

--- a/src/BottomNavigation/BottomNavigationAction.spec.js
+++ b/src/BottomNavigation/BottomNavigationAction.spec.js
@@ -83,12 +83,6 @@ describe('<BottomNavigationAction />', () => {
     assert.strictEqual(labelWrapper.hasClass(classes.label), true, 'should have the label class');
   });
 
-  it('should render a font icon if a icon string is provided', () => {
-    const wrapper = shallow(<BottomNavigationAction icon="book" />);
-    const iconWrapper = wrapper.childAt(0).childAt(0);
-    assert.strictEqual(iconWrapper.is(Icon), true, 'should be an Icon');
-  });
-
   it('should not render an Icon if icon is not provided', () => {
     const wrapper = shallow(<BottomNavigationAction />);
     assert.strictEqual(wrapper.find(Icon).exists(), false);

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -19,8 +19,9 @@ export const styles = theme => ({
     backgroundColor: 'transparent', // Reset default value
     outline: 'none',
     border: 0,
+    margin: 0, // Remove the margin in Safari
     borderRadius: 0,
-    padding: 0, // Reset default style
+    padding: 0, // Remove the padding in Firefox
     cursor: 'pointer',
     userSelect: 'none',
     verticalAlign: 'middle',

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -35,7 +35,6 @@ Checkbox.propTypes = {
   checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /**
    * The icon to display when the component is checked.
-   * If a string is provided, it will be used as a font ligature.
    */
   checkedIcon: PropTypes.node,
   /**
@@ -60,7 +59,6 @@ Checkbox.propTypes = {
   disableRipple: PropTypes.bool,
   /**
    * The icon to display when the component is unchecked.
-   * If a string is provided, it will be used as a font ligature.
    */
   icon: PropTypes.node,
   /**
@@ -69,7 +67,6 @@ Checkbox.propTypes = {
   indeterminate: PropTypes.bool,
   /**
    * The icon to display when the component is indeterminate.
-   * If a string is provided, it will be used as a font ligature.
    */
   indeterminateIcon: PropTypes.node,
   /**

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -209,7 +209,7 @@ Chip.propTypes = {
   /**
    * Override the default delete icon element. Shown only if `onDelete` is set.
    */
-  deleteIcon: PropTypes.node,
+  deleteIcon: PropTypes.element,
   /**
    * The content of the label.
    */

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -6,6 +6,7 @@ import CancelIcon from '../internal/svg-icons/Cancel';
 import withStyles from '../styles/withStyles';
 import grey from '../colors/grey';
 import { emphasize, fade } from '../styles/colorManipulator';
+import { cloneChildrenWithClassName } from '../utils/reactHelpers';
 import '../Avatar/Avatar'; // So we don't have any override priority issue.
 
 export const styles = theme => {
@@ -143,13 +144,12 @@ class Chip extends React.Component {
     );
 
     let deleteIcon = null;
-    if (onDelete && deleteIconProp && React.isValidElement(deleteIconProp)) {
-      deleteIcon = React.cloneElement(deleteIconProp, {
-        onClick: this.handleDeleteIconClick,
-        className: classNames(classes.deleteIcon, deleteIconProp.props.className),
-      });
-    } else if (onDelete) {
-      deleteIcon = (
+    if (onDelete) {
+      deleteIcon = deleteIconProp ? (
+        cloneChildrenWithClassName(deleteIconProp, classes.deleteIcon, {
+          onClick: this.handleDeleteIconClick,
+        })
+      ) : (
         <CancelIcon className={classes.deleteIcon} onClick={this.handleDeleteIconClick} />
       );
     }
@@ -207,9 +207,9 @@ Chip.propTypes = {
    */
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   /**
-   * Custom delete icon element. Will be shown only if `onDelete` is set.
+   * Override the default delete icon element. Shown only if `onDelete` is set.
    */
-  deleteIcon: PropTypes.element,
+  deleteIcon: PropTypes.node,
   /**
    * The content of the label.
    */

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -6,8 +6,7 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import { capitalizeFirstLetter } from '../utils/helpers';
-import Icon from '../Icon';
-import { isMuiElement } from '../utils/reactHelpers';
+import { cloneChildrenWithClassName } from '../utils/reactHelpers';
 import '../SvgIcon'; // Ensure CSS specificity
 
 export const styles = theme => ({
@@ -72,21 +71,7 @@ function IconButton(props) {
       ref={rootRef}
       {...other}
     >
-      <span className={classes.label}>
-        {typeof children === 'string' ? (
-          <Icon className={classes.icon}>{children}</Icon>
-        ) : (
-          React.Children.map(children, child => {
-            if (isMuiElement(child, ['Icon', 'SvgIcon'])) {
-              return React.cloneElement(child, {
-                className: classNames(classes.icon, child.props.className),
-              });
-            }
-
-            return child;
-          })
-        )}
-      </span>
+      <span className={classes.label}>{cloneChildrenWithClassName(children, classes.icon)}</span>
     </ButtonBase>
   );
 }
@@ -98,7 +83,6 @@ IconButton.propTypes = {
   buttonRef: PropTypes.func,
   /**
    * The icon element.
-   * If a string is provided, it will be used as an icon font ligature.
    */
   children: PropTypes.node,
   /**

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import { capitalizeFirstLetter } from '../utils/helpers';
-import { cloneChildrenWithClassName } from '../utils/reactHelpers';
+import { isMuiElement } from '../utils/reactHelpers';
 import '../SvgIcon'; // Ensure CSS specificity
 
 export const styles = theme => ({
@@ -71,7 +71,16 @@ function IconButton(props) {
       ref={rootRef}
       {...other}
     >
-      <span className={classes.label}>{cloneChildrenWithClassName(children, classes.icon)}</span>
+      <span className={classes.label}>
+        {React.Children.map(children, child => {
+          if (isMuiElement(child, ['Icon', 'SvgIcon'])) {
+            return React.cloneElement(child, {
+              className: classNames(classes.icon, child.props.className),
+            });
+          }
+          return child;
+        })}
+      </span>
     </ButtonBase>
   );
 }

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -33,21 +33,6 @@ describe('<IconButton />', () => {
     assert.strictEqual(label.is('span'), true, 'should be a span');
   });
 
-  it('should render a font icon if a string is provided', () => {
-    const wrapper = shallow(<IconButton>book</IconButton>);
-    const label = wrapper.childAt(0);
-    const icon = label.childAt(0);
-    assert.strictEqual(icon.is(Icon), true, 'should be an Icon');
-  });
-
-  it('should render the child normally inside the label span', () => {
-    const child = <p>H</p>;
-    const wrapper = shallow(<IconButton>{child}</IconButton>);
-    const label = wrapper.childAt(0);
-    const icon = label.childAt(0);
-    assert.strictEqual(icon.equals(child), true, 'should be the child');
-  });
-
   it('should render Icon children with right classes', () => {
     const childClassName = 'child-woof';
     const iconChild = <Icon className={childClassName} />;

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -33,6 +33,14 @@ describe('<IconButton />', () => {
     assert.strictEqual(label.is('span'), true, 'should be a span');
   });
 
+  it('should render the child normally inside the label span', () => {
+    const child = <p>H</p>;
+    const wrapper = shallow(<IconButton>{child}</IconButton>);
+    const label = wrapper.childAt(0);
+    const icon = label.childAt(0);
+    assert.strictEqual(icon.equals(child), true, 'should be the child');
+  });
+
   it('should render Icon children with right classes', () => {
     const childClassName = 'child-woof';
     const iconChild = <Icon className={childClassName} />;

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -35,7 +35,6 @@ Radio.propTypes = {
   checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /**
    * The icon to display when the component is checked.
-   * If a string is provided, it will be used as a font ligature.
    */
   checkedIcon: PropTypes.node,
   /**
@@ -60,7 +59,6 @@ Radio.propTypes = {
   disableRipple: PropTypes.bool,
   /**
    * The icon to display when the component is unchecked.
-   * If a string is provided, it will be used as a font ligature.
    */
   icon: PropTypes.node,
   /**

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -122,7 +122,7 @@ StepLabel.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
-   * The icon displayed by the step label - if not set will be set by Step component.
+   * Override the default icon.
    */
   icon: PropTypes.node,
   /**

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -90,7 +90,6 @@ Switch.propTypes = {
   checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /**
    * The icon to display when the component is checked.
-   * If a string is provided, it will be used as a font ligature.
    */
   checkedIcon: PropTypes.node,
   /**
@@ -115,7 +114,6 @@ Switch.propTypes = {
   disableRipple: PropTypes.bool,
   /**
    * The icon to display when the component is unchecked.
-   * If a string is provided, it will be used as a font ligature.
    */
   icon: PropTypes.node,
   /**

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -6,7 +6,6 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import { capitalizeFirstLetter } from '../utils/helpers';
-import Icon from '../Icon';
 
 export const styles = theme => ({
   root: {
@@ -136,7 +135,7 @@ class Tab extends React.Component {
       className: classNameProp,
       disabled,
       fullWidth,
-      icon: iconProp,
+      icon,
       indicator,
       label: labelProp,
       onChange,
@@ -146,12 +145,6 @@ class Tab extends React.Component {
       value,
       ...other
     } = this.props;
-
-    let icon;
-
-    if (iconProp !== undefined) {
-      icon = React.isValidElement(iconProp) ? iconProp : <Icon>{iconProp}</Icon>;
-    }
 
     let label;
 
@@ -237,7 +230,7 @@ Tab.propTypes = {
    */
   fullWidth: PropTypes.bool,
   /**
-   * The icon element. If a string is provided, it will be used as a font ligature.
+   * The icon element.
    */
   icon: PropTypes.node,
   /**

--- a/src/Tabs/Tab.spec.js
+++ b/src/Tabs/Tab.spec.js
@@ -115,11 +115,6 @@ describe('<Tab />', () => {
       const iconWrapper = wrapper.childAt(0).childAt(0);
       assert.strictEqual(iconWrapper.is(Icon), true);
     });
-
-    it('should render a font icon if a icon string is provided', () => {
-      const wrapper = shallow(<Tab textColor="inherit" icon="book" />);
-      assert.strictEqual(wrapper.find(Icon).length, 1, 'should have an Icon');
-    });
   });
 
   describe('prop: textColor', () => {

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -5,7 +5,6 @@ import CheckBoxOutlineBlankIcon from '../internal/svg-icons/CheckBoxOutlineBlank
 import CheckBoxIcon from '../internal/svg-icons/CheckBox';
 import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';
-import Icon from '../Icon';
 
 export const styles = {
   root: {
@@ -96,11 +95,7 @@ class SwitchBase extends React.Component {
       [classes.disabled]: disabled,
     });
 
-    let icon = checked ? checkedIcon : iconProp;
-
-    if (typeof icon === 'string') {
-      icon = <Icon>{icon}</Icon>;
-    }
+    const icon = checked ? checkedIcon : iconProp;
 
     return (
       <IconButton
@@ -139,7 +134,6 @@ SwitchBase.propTypes = {
   checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /**
    * The icon to display when the component is checked.
-   * If a string is provided, it will be used as a font ligature.
    */
   checkedIcon: PropTypes.node,
   /**
@@ -164,7 +158,6 @@ SwitchBase.propTypes = {
   disableRipple: PropTypes.bool,
   /**
    * The icon to display when the component is unchecked.
-   * If a string is provided, it will be used as a font ligature.
    */
   icon: PropTypes.node,
   /**
@@ -173,7 +166,6 @@ SwitchBase.propTypes = {
   indeterminate: PropTypes.bool,
   /**
    * The icon to display when the component is indeterminate.
-   * If a string is provided, it will be used as a font ligature.
    */
   indeterminateIcon: PropTypes.node,
   /**

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -230,8 +230,8 @@ describe('<SwitchBase />', () => {
   });
 
   describe('prop: icon', () => {
-    it('should accept a string and use Icon', () => {
-      const wrapper = shallow(<SwitchBase icon="heart" />);
+    it('should render an Icon', () => {
+      const wrapper = shallow(<SwitchBase icon={<Icon>heart</Icon>} />);
       assert.strictEqual(wrapper.childAt(0).is(Icon), true);
     });
   });

--- a/src/utils/reactHelpers.js
+++ b/src/utils/reactHelpers.js
@@ -4,7 +4,7 @@
 import { cloneElement, Children, isValidElement } from 'react';
 import type { Node } from 'react';
 
-export function cloneChildrenWithClassName(children: Node, className: string) {
+export function cloneChildrenWithClassName(children: Node, className: string, props: Object) {
   return Children.map(children, child => {
     return (
       isValidElement(child) &&
@@ -12,6 +12,7 @@ export function cloneChildrenWithClassName(children: Node, className: string) {
         className: child.props.hasOwnProperty('className')
           ? `${child.props.className} ${className}`
           : className,
+        ...props,
       })
     );
   });

--- a/test/regressions/tests/List/PrimaryActionCheckboxListItem.js
+++ b/test/regressions/tests/List/PrimaryActionCheckboxListItem.js
@@ -4,6 +4,7 @@ import React from 'react';
 import { ListItem, ListItemText, ListItemSecondaryAction } from 'material-ui/List';
 import Checkbox from 'material-ui/Checkbox';
 import IconButton from 'material-ui/IconButton';
+import Icon from 'material-ui/Icon';
 
 export default function PrimaryActionCheckboxListItem() {
   return (
@@ -12,14 +13,18 @@ export default function PrimaryActionCheckboxListItem() {
         <Checkbox tabIndex={-1} disableRipple />
         <ListItemText primary="Primary" />
         <ListItemSecondaryAction>
-          <IconButton>comment</IconButton>
+          <IconButton>
+            <Icon>comment</Icon>
+          </IconButton>
         </ListItemSecondaryAction>
       </ListItem>
       <ListItem button dense>
         <Checkbox tabIndex={-1} disableRipple />
         <ListItemText primary="Primary" />
         <ListItemSecondaryAction>
-          <IconButton>comment</IconButton>
+          <IconButton>
+            <Icon>comment</Icon>
+          </IconButton>
         </ListItemSecondaryAction>
       </ListItem>
     </div>


### PR DESCRIPTION
Also:
Expand use of cloneChildrenWithClassName helper
Standardise some icon prop descriptions

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #9968

### Breaking change

We have removed the "magic" `<Icon>` wrapping logic. It should be done explicitly now.
It's making our components less biased around the svg icon vs font icon choice.

```diff
+import Icon from 'material-ui/Icon';

-      <IconButton>comment</IconButton>
+      <IconButton>
+        <Icon>comment</Icon>
+      </IconButton>
```