### PR TITLE
[Backdrop] Allow setting of onTouchMove

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -7,7 +7,7 @@
   {
     "name": "The size of the whole library.",
     "path": "build/index.js",
-    "limit": "96.2 KB"
+    "limit": "96.3 KB"
   },
   {
     "name": "The main bundle of the documentation",

--- a/src/Modal/Backdrop.d.ts
+++ b/src/Modal/Backdrop.d.ts
@@ -5,6 +5,7 @@ import { TransitionDuration } from '../internal/transition';
 export interface BackdropProps extends StandardProps<{}, BackdropClassKey> {
   invisible?: boolean;
   onClick?: React.ReactEventHandler<{}>;
+  onTouchMove?: React.ReactEventHandler<{}>;
   open: boolean;
   transitionDuration?: TransitionDuration;
 }

--- a/src/Modal/Backdrop.d.ts
+++ b/src/Modal/Backdrop.d.ts
@@ -1,11 +1,15 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { TransitionDuration } from '../internal/transition';
+import { FadeProps } from '../transitions/Fade';
 
-export interface BackdropProps extends StandardProps<{}, BackdropClassKey> {
+export interface BackdropProps
+  extends StandardProps<
+      React.HTMLAttributes<HTMLDivElement> & Partial<FadeProps>,
+      BackdropClassKey
+    > {
   invisible?: boolean;
   onClick?: React.ReactEventHandler<{}>;
-  onTouchMove?: React.ReactEventHandler<{}>;
   open: boolean;
   transitionDuration?: TransitionDuration;
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -95,6 +95,7 @@ export {
   ListSubheader,
 } from './List';
 export { default as Menu, MenuItem, MenuList } from './Menu';
+export { default as MobileStepper } from './MobileStepper';
 export { default as Modal, Backdrop, ModalManager } from './Modal';
 export { default as Paper } from './Paper';
 export { default as Popover } from './Popover';

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ export {
   ListSubheader,
 } from './List';
 export { default as Menu, MenuItem, MenuList } from './Menu';
+export { default as MobileStepper } from './MobileStepper';
 export { default as Modal, Backdrop, ModalManager } from './Modal';
 export { default as Paper } from './Paper';
 export { default as Popover } from './Popover';

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   AppBar,
   Avatar,
+  Backdrop,
   Badge,
   BottomNavigation,
   BottomNavigationAction,
@@ -15,17 +16,23 @@ import {
   Chip,
   CircularProgress,
   ClickAwayListener,
+  Collapse,
   Dialog,
   DialogTitle,
   Divider,
   Drawer,
   ExpansionPanel,
-  ExpansionPanelSummary,
-  ExpansionPanelDetails,
   ExpansionPanelActions,
+  ExpansionPanelDetails,
+  ExpansionPanelSummary,
+  Fade,
   FormControlLabel,
   FormGroup,
+  Grid,
+  GridList,
+  GridListTile,
   IconButton,
+  Input,
   LinearProgress,
   List,
   ListItem,
@@ -34,28 +41,27 @@ import {
   ListItemText,
   Menu,
   MenuItem,
+  MobileStepper,
   Paper,
+  Select,
   Snackbar,
   SnackbarContent,
   Switch,
   Tab,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
   Tabs,
   TextField,
   Toolbar,
   Tooltip,
   Typography,
-  Grid,
-  Select,
-  Input,
 } from '../../src';
-import Collapse from '../../src/transitions/Collapse';
-import GridList from '../../src/GridList';
-import MobileStepper from '../../src/MobileStepper/MobileStepper';
-import Table, { TableBody, TableCell, TableHead, TableRow } from '../../src/Table';
 import { withStyles, StyleRulesCallback } from '../../src/styles';
 import { withMobileDialog, DialogProps } from '../../src/Dialog';
 import { WithStyles } from '../../src/styles/withStyles';
-import GridListTile from '../../src/GridList/GridListTile';
 
 const log = console.log;
 const FakeIcon = () => <div>ICON</div>;
@@ -752,3 +758,11 @@ const ClickAwayListenerComponentTest = () => (
     <div />
   </ClickAwayListener>
 );
+
+const FadeTest = () => (
+  <Fade in={false}>
+    <div />
+  </Fade>
+);
+
+const BackdropTest = () => <Backdrop open onTouchMove={() => {}} />;


### PR DESCRIPTION
If we can set onTouchMove with something like (event) => { event.preventDefault(); } we can disable scrolling of content behind the backdrop on IOS.