### PR TITLE
[Tab] Add textColor inherit default props to Tab

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -274,6 +274,7 @@ Tab.propTypes = {
 
 Tab.defaultProps = {
   disabled: false,
+  textColor: 'inherit'
 };
 
 export default withStyles(styles, { name: 'MuiTab' })(Tab);

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -274,7 +274,7 @@ Tab.propTypes = {
 
 Tab.defaultProps = {
   disabled: false,
-  textColor: 'inherit'
+  textColor: 'inherit',
 };
 
 export default withStyles(styles, { name: 'MuiTab' })(Tab);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
When not using Tab component directly as a children of Tabs (for example when using react-router Link wrapper), textColor props is not set by default. 

This PR set textColor defaultProps to 'inherit'
