### PR TITLE
fix: handle case where ref is null

### DIFF
--- a/src/Slider/Slider.js
+++ b/src/Slider/Slider.js
@@ -671,7 +671,8 @@ class Slider extends Component {
     const {isRtl} = this.context.muiTheme;
 
     const calculatedAxis = calculateAxis(axis, isRtl);
-
+    
+    if (!this.track) return 0;
     return this.track.getBoundingClientRect()[mainAxisOffsetProperty[calculatedAxis]];
   }
 


### PR DESCRIPTION
while unmounting `this.track` is null and exception is raised. 
returning 0 offset when no ref.

fixes #8969 
