### PR TITLE
[Button] Add size property

### DIFF
--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -80,7 +80,7 @@ class Notifications extends React.Component {
           <span id="notification-message" dangerouslySetInnerHTML={{ __html: message.text }} />
         }
         action={
-          <Button dense color="secondary" onClick={this.handleClose}>
+          <Button size="small" color="secondary" onClick={this.handleClose}>
             Close
           </Button>
         }

--- a/docs/src/pages/demos/buttons/ButtonSizes.js
+++ b/docs/src/pages/demos/buttons/ButtonSizes.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import Button from 'material-ui/Button';
+import AddIcon from 'material-ui-icons/Add';
+
+const styles = theme => ({
+  button: {
+    margin: theme.spacing.unit,
+  },
+});
+
+function ButtonSizes(props) {
+  const { classes } = props;
+  return (
+    <div>
+      <div>
+        <Button size="small" className={classes.button}>
+          Small
+        </Button>
+        <Button size="medium" className={classes.button}>
+          Medium
+        </Button>
+        <Button size="large" className={classes.button}>
+          Large
+        </Button>
+      </div>
+      <div>
+        <Button raised size="small" color="primary" className={classes.button}>
+          Small
+        </Button>
+        <Button raised size="medium" color="primary" className={classes.button}>
+          Medium
+        </Button>
+        <Button raised size="large" color="primary" className={classes.button}>
+          Large
+        </Button>
+      </div>
+      <div>
+        <Button fab mini color="secondary" aria-label="add" className={classes.button}>
+          <AddIcon />
+        </Button>
+        <Button fab color="secondary" aria-label="add" className={classes.button}>
+          <AddIcon />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+ButtonSizes.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(ButtonSizes);

--- a/docs/src/pages/demos/buttons/FlatButtons.js
+++ b/docs/src/pages/demos/buttons/FlatButtons.js
@@ -34,9 +34,6 @@ function FlatButtons(props) {
       <Button disabled href="/" className={classes.button}>
         Link disabled
       </Button>
-      <Button dense className={classes.button}>
-        Dense
-      </Button>
       <Button className={classes.button} onClick={doSomething} data-something="here I am">
         Does something
       </Button>

--- a/docs/src/pages/demos/buttons/FloatingActionButtons.js
+++ b/docs/src/pages/demos/buttons/FloatingActionButtons.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 import AddIcon from 'material-ui-icons/Add';
-import ModeEditIcon from 'material-ui-icons/ModeEdit';
+import Icon from 'material-ui/Icon';
 import DeleteIcon from 'material-ui-icons/Delete';
 
 const styles = theme => ({
@@ -19,19 +19,10 @@ function FloatingActionButtons(props) {
       <Button fab color="primary" aria-label="add" className={classes.button}>
         <AddIcon />
       </Button>
-      <Button fab mini color="primary" aria-label="add" className={classes.button}>
-        <AddIcon />
-      </Button>
       <Button fab color="secondary" aria-label="edit" className={classes.button}>
-        <ModeEditIcon />
-      </Button>
-      <Button fab mini color="secondary" aria-label="edit" className={classes.button}>
-        <ModeEditIcon />
+        <Icon>edit_icon</Icon>
       </Button>
       <Button fab disabled aria-label="delete" className={classes.button}>
-        <DeleteIcon />
-      </Button>
-      <Button fab mini disabled aria-label="delete" className={classes.button}>
         <DeleteIcon />
       </Button>
     </div>

--- a/docs/src/pages/demos/buttons/IconLabelButtons.js
+++ b/docs/src/pages/demos/buttons/IconLabelButtons.js
@@ -40,7 +40,7 @@ function IconLabelButtons(props) {
         <KeyboardVoice className={classes.leftIcon} />
         Talk
       </Button>
-      <Button className={classes.button} raised dense>
+      <Button className={classes.button} raised size="small">
         <Save className={classes.leftIcon} />
         Save
       </Button>

--- a/docs/src/pages/demos/buttons/RaisedButtons.js
+++ b/docs/src/pages/demos/buttons/RaisedButtons.js
@@ -40,9 +40,6 @@ function RaisedButtons(props) {
           Upload
         </Button>
       </label>
-      <Button raised dense className={classes.button}>
-        Dense
-      </Button>
     </div>
   );
 }

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -46,6 +46,12 @@ animation to finish before the new one enters.
 
 {{"demo": "pages/demos/buttons/FloatingActionButtonZoom.js"}}
 
+## Sizes
+
+Fancy larger or smaller buttons? Use the `size` or the `mini` property.
+
+{{"demo": "pages/demos/buttons/ButtonSizes.js"}}
+
 ## Icon Buttons
 
 Icon buttons are commonly found in app bars and toolbars.

--- a/docs/src/pages/demos/cards/SimpleCard.js
+++ b/docs/src/pages/demos/cards/SimpleCard.js
@@ -44,7 +44,7 @@ function SimpleCard(props) {
           </Typography>
         </CardContent>
         <CardActions>
-          <Button dense>Learn More</Button>
+          <Button size="small">Learn More</Button>
         </CardActions>
       </Card>
     </div>

--- a/docs/src/pages/demos/cards/SimpleMediaCard.js
+++ b/docs/src/pages/demos/cards/SimpleMediaCard.js
@@ -34,10 +34,10 @@ function SimpleMediaCard(props) {
           </Typography>
         </CardContent>
         <CardActions>
-          <Button dense color="primary">
+          <Button size="small" color="primary">
             Share
           </Button>
-          <Button dense color="primary">
+          <Button size="small" color="primary">
             Learn More
           </Button>
         </CardActions>

--- a/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
@@ -77,8 +77,8 @@ function DetailedExpansionPanel(props) {
         </ExpansionPanelDetails>
         <Divider />
         <ExpansionPanelActions>
-          <Button dense>Cancel</Button>
-          <Button dense color="primary">
+          <Button size="small">Cancel</Button>
+          <Button size="small" color="primary">
             Save
           </Button>
         </ExpansionPanelActions>

--- a/docs/src/pages/demos/snackbars/LongTextSnackbar.js
+++ b/docs/src/pages/demos/snackbars/LongTextSnackbar.js
@@ -5,7 +5,7 @@ import { withStyles } from 'material-ui/styles';
 import { SnackbarContent } from 'material-ui/Snackbar';
 
 const action = (
-  <Button color="secondary" dense>
+  <Button color="secondary" size="small">
     lorem ipsum dolorem
   </Button>
 );

--- a/docs/src/pages/demos/snackbars/SimpleSnackbar.js
+++ b/docs/src/pages/demos/snackbars/SimpleSnackbar.js
@@ -48,7 +48,7 @@ class SimpleSnackbar extends React.Component {
           }}
           message={<span id="message-id">Note archived</span>}
           action={[
-            <Button key="undo" color="secondary" dense onClick={this.handleClose}>
+            <Button key="undo" color="secondary" size="small" onClick={this.handleClose}>
               UNDO
             </Button>,
             <IconButton

--- a/docs/src/pages/demos/stepper/DotsMobileStepper.js
+++ b/docs/src/pages/demos/stepper/DotsMobileStepper.js
@@ -41,13 +41,13 @@ class DotsMobileStepper extends React.Component {
         activeStep={this.state.activeStep}
         className={classes.root}
         nextButton={
-          <Button dense onClick={this.handleNext} disabled={this.state.activeStep === 5}>
+          <Button size="small" onClick={this.handleNext} disabled={this.state.activeStep === 5}>
             Next
             {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
           </Button>
         }
         backButton={
-          <Button dense onClick={this.handleBack} disabled={this.state.activeStep === 0}>
+          <Button size="small" onClick={this.handleBack} disabled={this.state.activeStep === 0}>
             {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
             Back
           </Button>

--- a/docs/src/pages/demos/stepper/ProgressMobileStepper.js
+++ b/docs/src/pages/demos/stepper/ProgressMobileStepper.js
@@ -41,13 +41,13 @@ class ProgressMobileStepper extends React.Component {
         activeStep={this.state.activeStep}
         className={classes.root}
         nextButton={
-          <Button dense onClick={this.handleNext} disabled={this.state.activeStep === 5}>
+          <Button size="small" onClick={this.handleNext} disabled={this.state.activeStep === 5}>
             Next
             {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
           </Button>
         }
         backButton={
-          <Button dense onClick={this.handleBack} disabled={this.state.activeStep === 0}>
+          <Button size="small" onClick={this.handleBack} disabled={this.state.activeStep === 0}>
             {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
             Back
           </Button>

--- a/docs/src/pages/demos/stepper/TextMobileStepper.js
+++ b/docs/src/pages/demos/stepper/TextMobileStepper.js
@@ -55,13 +55,13 @@ class TextMobileStepper extends React.Component {
           activeStep={this.state.activeStep}
           className={classes.mobileStepper}
           nextButton={
-            <Button dense onClick={this.handleNext} disabled={this.state.activeStep === 5}>
+            <Button size="small" onClick={this.handleNext} disabled={this.state.activeStep === 5}>
               Next
               {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
             </Button>
           }
           backButton={
-            <Button dense onClick={this.handleBack} disabled={this.state.activeStep === 0}>
+            <Button size="small" onClick={this.handleBack} disabled={this.state.activeStep === 0}>
               {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
               Back
             </Button>

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -16,7 +16,6 @@ filename: /src/Button/Button.js
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
 | component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> |  | The component used for the root node. Either a string to use a DOM element or a component. The default value is a `button`. |
-| dense | bool | false | Uses a smaller minWidth, ideal for things like card actions. |
 | disabled | bool | false | If `true`, the button will be disabled. |
 | disableFocusRipple | bool | false | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
 | disableRipple | bool | false | If `true`, the ripple effect will be disabled. |
@@ -25,6 +24,7 @@ filename: /src/Button/Button.js
 | href | string |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | mini | bool | false | If `true`, and `fab` is `true`, will use mini floating action button styling. |
 | raised | bool | false | If `true`, the button will use raised styling. |
+| size | enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br> | 'medium' | The size of the button. `small` is equivalent to the dense button styling. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 
@@ -33,7 +33,6 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `dense`
 - `label`
 - `flatPrimary`
 - `flatSecondary`
@@ -45,6 +44,8 @@ This property accepts the following keys:
 - `disabled`
 - `fab`
 - `mini`
+- `sizeSmall`
+- `sizeLarge`
 - `fullWidth`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -33,7 +33,6 @@ This property accepts the following keys:
 - `colorSecondary`
 - `disabled`
 - `label`
-- `icon`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/IconButton/IconButton.js)

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -15,6 +15,7 @@ filename: /src/Icon/Icon.js
 | children | node |  | The name of the icon font ligature. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'inherit', 'secondary', 'action', 'disabled', 'error', 'primary'<br> | 'inherit' | The color of the component. It's using the theme palette when that makes sense. |
+| fontSize | bool | false | If `true`, the icon size will be determined by the font-size. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 
@@ -28,6 +29,7 @@ This property accepts the following keys:
 - `colorAction`
 - `colorDisabled`
 - `colorError`
+- `fontSize`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Icon/Icon.js)

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -15,6 +15,7 @@ filename: /src/SvgIcon/SvgIcon.js
 | <span style="color: #31a148">children *</span> | node |  | Node passed into the SVG element. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'action', 'disabled', 'error', 'inherit', 'primary', 'secondary'<br> | 'inherit' | The color of the component. It's using the theme palette when that makes sense. You can use the `nativeColor` property to apply a color attribute to the SVG element. |
+| fontSize | bool | false | If `true`, the icon size will be determined by the font-size. |
 | nativeColor | string |  | Applies a color attribute to the SVG element. |
 | titleAccess | string |  | Provides a human-readable title for the element that contains it. https://www.w3.org/TR/SVG-access/#Equivalent |
 | viewBox | string | '0 0 24 24' | Allows you to redefine what the coordinates without units mean inside an SVG element. For example, if the SVG element is 500 (width) by 200 (height), and you pass viewBox="0 0 50 20", this means that the coordinates inside the SVG will go from the top left corner (0,0) to bottom right (50,20) and each unit will be worth 10px. |
@@ -31,6 +32,7 @@ This property accepts the following keys:
 - `colorAction`
 - `colorDisabled`
 - `colorError`
+- `fontSize`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/SvgIcon/SvgIcon.js)

--- a/pages/demos/buttons.js
+++ b/pages/demos/buttons.js
@@ -36,6 +36,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/buttons/FloatingActionButtonZoom'), 'utf8')
 `,
         },
+        'pages/demos/buttons/ButtonSizes.js': {
+          js: require('docs/src/pages/demos/buttons/ButtonSizes').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/buttons/ButtonSizes'), 'utf8')
+`,
+        },
         'pages/demos/buttons/IconButtons.js': {
           js: require('docs/src/pages/demos/buttons/IconButtons').default,
           raw: preval`

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -5,7 +5,6 @@ import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 export interface ButtonProps extends StandardProps<ButtonBaseProps, ButtonClassKey, 'component'> {
   color?: PropTypes.Color;
   component?: React.ReactType<ButtonProps>;
-  dense?: boolean;
   disabled?: boolean;
   disableFocusRipple?: boolean;
   disableRipple?: boolean;
@@ -14,6 +13,7 @@ export interface ButtonProps extends StandardProps<ButtonBaseProps, ButtonClassK
   href?: string;
   mini?: boolean;
   raised?: boolean;
+  size?: 'small' | 'medium' | 'large'
   type?: string;
 }
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -6,13 +6,15 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import { fade } from '../styles/colorManipulator';
 import ButtonBase from '../ButtonBase';
+import { capitalize } from '../utils/helpers';
+import { isMuiElement } from '../utils/reactHelpers';
 
 export const styles = theme => ({
   root: {
     ...theme.typography.button,
     lineHeight: '1.4em', // Improve readability for multiline button.
     boxSizing: 'border-box',
-    minWidth: 88,
+    minWidth: theme.spacing.unit * 11,
     minHeight: 36,
     padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`,
     borderRadius: 2,
@@ -31,12 +33,6 @@ export const styles = theme => ({
         backgroundColor: 'transparent',
       },
     },
-  },
-  dense: {
-    padding: `${theme.spacing.unit - 1}px ${theme.spacing.unit}px`,
-    minWidth: 64,
-    minHeight: 32,
-    fontSize: theme.typography.pxToRem(theme.typography.fontSize - 1),
   },
   label: {
     width: '100%',
@@ -123,6 +119,7 @@ export const styles = theme => ({
     padding: 0,
     minWidth: 0,
     width: 56,
+    fontSize: 24,
     height: 56,
     boxShadow: theme.shadows[6],
     '&:active': {
@@ -133,6 +130,18 @@ export const styles = theme => ({
     width: 40,
     height: 40,
   },
+  sizeSmall: {
+    padding: `${theme.spacing.unit - 1}px ${theme.spacing.unit}px`,
+    minWidth: theme.spacing.unit * 8,
+    minHeight: 32,
+    fontSize: theme.typography.pxToRem(theme.typography.fontSize - 1),
+  },
+  sizeLarge: {
+    padding: `${theme.spacing.unit}px ${theme.spacing.unit * 3}px`,
+    minWidth: theme.spacing.unit * 14,
+    minHeight: 40,
+    fontSize: theme.typography.pxToRem(theme.typography.fontSize + 1),
+  },
   fullWidth: {
     width: '100%',
   },
@@ -140,17 +149,17 @@ export const styles = theme => ({
 
 function Button(props) {
   const {
-    children,
+    children: childrenProp,
     classes,
     className: classNameProp,
     color,
-    dense,
     disabled,
     disableFocusRipple,
     fab,
     fullWidth,
     mini,
     raised,
+    size,
     ...other
   } = props;
 
@@ -166,12 +175,23 @@ function Button(props) {
       [classes.flatSecondary]: flat && color === 'secondary',
       [classes.raisedPrimary]: !flat && color === 'primary',
       [classes.raisedSecondary]: !flat && color === 'secondary',
-      [classes.dense]: dense,
+      [classes[`size${capitalize(size)}`]]: size !== 'medium',
       [classes.disabled]: disabled,
       [classes.fullWidth]: fullWidth,
     },
     classNameProp,
   );
+
+  let children = childrenProp;
+
+  if (fab) {
+    children = React.Children.map(children, child => {
+      if (isMuiElement(child, ['Icon', 'SvgIcon'])) {
+        return React.cloneElement(child, { fontSize: true });
+      }
+      return child;
+    });
+  }
 
   return (
     <ButtonBase
@@ -210,10 +230,6 @@ Button.propTypes = {
    */
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   /**
-   * Uses a smaller minWidth, ideal for things like card actions.
-   */
-  dense: PropTypes.bool,
-  /**
    * If `true`, the button will be disabled.
    */
   disabled: PropTypes.bool,
@@ -248,6 +264,11 @@ Button.propTypes = {
    */
   raised: PropTypes.bool,
   /**
+   * The size of the button.
+   * `small` is equivalent to the dense button styling.
+   */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /**
    * @ignore
    */
   type: PropTypes.string,
@@ -255,7 +276,6 @@ Button.propTypes = {
 
 Button.defaultProps = {
   color: 'default',
-  dense: false,
   disabled: false,
   disableFocusRipple: false,
   disableRipple: false,
@@ -263,6 +283,7 @@ Button.defaultProps = {
   fullWidth: false,
   mini: false,
   raised: false,
+  size: 'medium',
   type: 'button',
 };
 

--- a/src/Button/Button.spec.js
+++ b/src/Button/Button.spec.js
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { createShallow, createRender, getClasses } from '../test-utils';
 import Button from './Button';
 import ButtonBase from '../ButtonBase';
+import Icon from '../Icon';
 
 describe('<Button />', () => {
   let shallow;
@@ -208,6 +209,17 @@ describe('<Button />', () => {
   it('should pass disableFocusRipple to ButtonBase', () => {
     const wrapper = shallow(<Button disableFocusRipple>Hello World</Button>);
     assert.strictEqual(wrapper.props().focusRipple, false, 'should set focusRipple to false');
+  });
+
+  it('should render Icon children with right classes', () => {
+    const childClassName = 'child-woof';
+    const iconChild = <Icon className={childClassName} />;
+    const wrapper = shallow(<Button fab>{iconChild}</Button>);
+    const label = wrapper.childAt(0);
+    const renderedIconChild = label.childAt(0);
+    assert.strictEqual(renderedIconChild.type(), Icon);
+    assert.strictEqual(renderedIconChild.hasClass(childClassName), true, 'child should be icon');
+    assert.strictEqual(renderedIconChild.props().fontSize, true);
   });
 
   describe('server side', () => {

--- a/src/Icon/Icon.d.ts
+++ b/src/Icon/Icon.d.ts
@@ -12,7 +12,8 @@ export type IconClassKey =
   | 'colorAction'
   | 'colorDisabled'
   | 'colorError'
-  | 'colorPrimary';
+  | 'colorPrimary'
+  | 'fontSize';
 
 declare const Icon: React.ComponentType<IconProps>;
 

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -23,16 +23,21 @@ export const styles = theme => ({
   colorError: {
     color: theme.palette.error.main,
   },
+  fontSize: {
+    width: '1em',
+    height: '1em',
+  },
 });
 
 function Icon(props) {
-  const { children, classes, className: classNameProp, color, ...other } = props;
+  const { children, classes, className: classNameProp, color, fontSize, ...other } = props;
 
   const className = classNames(
     'material-icons',
     classes.root,
     {
       [classes[`color${capitalize(color)}`]]: color !== 'inherit',
+      [classes.fontSize]: fontSize,
     },
     classNameProp,
   );
@@ -61,10 +66,15 @@ Icon.propTypes = {
    * The color of the component. It's using the theme palette when that makes sense.
    */
   color: PropTypes.oneOf(['inherit', 'secondary', 'action', 'disabled', 'error', 'primary']),
+  /**
+   * If `true`, the icon size will be determined by the font-size.
+   */
+  fontSize: PropTypes.bool,
 };
 
 Icon.defaultProps = {
   color: 'inherit',
+  fontSize: false,
 };
 
 Icon.muiName = 'Icon';

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -41,10 +41,6 @@ export const styles = theme => ({
     alignItems: 'inherit',
     justifyContent: 'inherit',
   },
-  icon: {
-    width: '1em',
-    height: '1em',
-  },
 });
 
 /**
@@ -74,9 +70,7 @@ function IconButton(props) {
       <span className={classes.label}>
         {React.Children.map(children, child => {
           if (isMuiElement(child, ['Icon', 'SvgIcon'])) {
-            return React.cloneElement(child, {
-              className: classNames(classes.icon, child.props.className),
-            });
+            return React.cloneElement(child, { fontSize: true });
           }
           return child;
         })}

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -44,16 +44,12 @@ describe('<IconButton />', () => {
   it('should render Icon children with right classes', () => {
     const childClassName = 'child-woof';
     const iconChild = <Icon className={childClassName} />;
-    const buttonClassName = 'button-woof';
-    const wrapper = shallow(
-      <IconButton classes={{ icon: buttonClassName }}>{iconChild}</IconButton>,
-    );
+    const wrapper = shallow(<IconButton>{iconChild}</IconButton>);
     const label = wrapper.childAt(0);
     const renderedIconChild = label.childAt(0);
-    assert.strictEqual(renderedIconChild.is(Icon), true, 'child should be icon');
+    assert.strictEqual(renderedIconChild.type(), Icon);
     assert.strictEqual(renderedIconChild.hasClass(childClassName), true, 'child should be icon');
-    assert.strictEqual(renderedIconChild.hasClass(buttonClassName), true, 'child should be icon');
-    assert.strictEqual(renderedIconChild.hasClass(classes.icon), true, 'child should be icon');
+    assert.strictEqual(renderedIconChild.props().fontSize, true);
   });
 
   it('should have a ripple by default', () => {

--- a/src/SvgIcon/SvgIcon.d.ts
+++ b/src/SvgIcon/SvgIcon.d.ts
@@ -15,7 +15,8 @@ export type SvgIconClassKey =
   | 'colorAction'
   | 'colorDisabled'
   | 'colorError'
-  | 'colorPrimary';
+  | 'colorPrimary'
+  | 'fontSize';
 
 declare const SvgIcon: React.ComponentType<SvgIconProps>;
 

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -31,6 +31,10 @@ export const styles = theme => ({
   colorError: {
     color: theme.palette.error.main,
   },
+  fontSize: {
+    width: '1em',
+    height: '1em',
+  },
 });
 
 function SvgIcon(props) {
@@ -39,6 +43,7 @@ function SvgIcon(props) {
     classes,
     className: classNameProp,
     color,
+    fontSize,
     nativeColor,
     titleAccess,
     viewBox,
@@ -49,6 +54,7 @@ function SvgIcon(props) {
     classes.root,
     {
       [classes[`color${capitalize(color)}`]]: color !== 'inherit',
+      [classes.fontSize]: fontSize,
     },
     classNameProp,
   );
@@ -87,6 +93,10 @@ SvgIcon.propTypes = {
    */
   color: PropTypes.oneOf(['action', 'disabled', 'error', 'inherit', 'primary', 'secondary']),
   /**
+   * If `true`, the icon size will be determined by the font-size.
+   */
+  fontSize: PropTypes.bool,
+  /**
    * Applies a color attribute to the SVG element.
    */
   nativeColor: PropTypes.string,
@@ -107,6 +117,7 @@ SvgIcon.propTypes = {
 
 SvgIcon.defaultProps = {
   color: 'inherit',
+  fontSize: false,
   viewBox: '0 0 24 24',
 };
 

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -86,12 +86,12 @@ describe('<MuiThemeProvider />', () => {
       assert.notStrictEqual(markup.match('Hello World'), null);
       assert.strictEqual(sheetsRegistry.registry.length, 3);
       assert.strictEqual(sheetsRegistry.toString().length > 4000, true);
-      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-17');
+      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-18');
       assert.deepEqual(
         sheetsRegistry.registry[1].classes,
         {
-          disabled: 'MuiButtonBase-disabled-16',
-          root: 'MuiButtonBase-root-15',
+          disabled: 'MuiButtonBase-disabled-17',
+          root: 'MuiButtonBase-root-16',
         },
         'the class names should be deterministic',
       );

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -102,7 +102,7 @@ const ButtonTest = () => (
     <Button color="inherit">Contrast</Button>
     <Button disabled>Disabled</Button>
     <Button href="#flat-buttons">Link</Button>
-    <Button dense>Dense</Button>
+    <Button size="small">Small</Button>
     <Button raised>Raised</Button>
     <Button fab color="primary" aria-label="add">
       <FakeIcon />
@@ -149,7 +149,7 @@ const CardTest = () => (
       </Typography>
     </CardContent>
     <CardActions>
-      <Button dense>Learn More</Button>
+      <Button size="small">Learn More</Button>
     </CardActions>
   </Card>
 );
@@ -338,7 +338,7 @@ const ExpansionPanelTest = () => (
         <Typography>...</Typography>
       </ExpansionPanelDetails>
       <ExpansionPanelActions>
-        <Button dense>Save</Button>
+        <Button size="small">Save</Button>
       </ExpansionPanelActions>
     </ExpansionPanel>
   </div>
@@ -510,7 +510,7 @@ const SnackbarTest = () => (
       }
       message={<span id="message-id">Note archived</span>}
       action={[
-        <Button key="undo" color="secondary" dense onClick={event => log(event)}>
+        <Button key="undo" color="secondary" size="small" onClick={event => log(event)}>
           UNDO
         </Button>,
         <IconButton key="close" aria-label="Close" color="inherit" onClick={event => log(event)}>
@@ -523,7 +523,7 @@ const SnackbarTest = () => (
 
 const SnackbarContentTest = () => {
   const action = (
-    <Button color="secondary" dense>
+    <Button color="secondary" size="small">
       lorem ipsum dolorem
     </Button>
   );


### PR DESCRIPTION
Something I wanted to add a long time ago. You won't find the large size in the Material specification. However, it's a common pattern you will find in most of the UI.

![capture d ecran 2018-01-24 a 20 47 48](https://user-images.githubusercontent.com/3165635/35353594-ebf627f0-0147-11e8-8e4a-441a404ae6ea.png)

## Breaking change

```diff
-<Button dense>
+<Button size="small">
```