### PR TITLE
[palette] Remove grey

### DIFF
--- a/docs/src/modules/styles/getPageContext.js
+++ b/docs/src/modules/styles/getPageContext.js
@@ -4,6 +4,7 @@ import { create, SheetsRegistry } from 'jss';
 import rtl from 'jss-rtl';
 import { createMuiTheme, createGenerateClassName, jssPreset } from 'material-ui/styles';
 import blue from 'material-ui/colors/blue';
+import grey from 'material-ui/colors/grey';
 
 export function getTheme(theme) {
   return createMuiTheme({
@@ -11,6 +12,7 @@ export function getTheme(theme) {
     palette: {
       primary: blue,
       type: theme.paletteType,
+      grey,
     },
   });
 }

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import grey from '../colors/grey';
 import withStyles from '../styles/withStyles';
 import { fade } from '../styles/colorManipulator';
 import ButtonBase from '../ButtonBase';
@@ -68,8 +69,8 @@ export const styles = theme => ({
     color: 'inherit',
   },
   raised: {
-    color: theme.palette.getContrastText(theme.palette.grey[300]),
-    backgroundColor: theme.palette.grey[300],
+    color: theme.palette.getContrastText(grey[300]),
+    backgroundColor: grey[300],
     boxShadow: theme.shadows[2],
     '&$keyboardFocused': {
       boxShadow: theme.shadows[6],
@@ -82,10 +83,10 @@ export const styles = theme => ({
       backgroundColor: theme.palette.action.disabledBackground,
     },
     '&:hover': {
-      backgroundColor: theme.palette.grey.A100,
+      backgroundColor: grey.A100,
       // Reset on mouse devices
       '@media (hover: none)': {
-        backgroundColor: theme.palette.grey[300],
+        backgroundColor: grey[300],
       },
       '&$disabled': {
         backgroundColor: theme.palette.action.disabledBackground,

--- a/src/ExpansionPanel/ExpansionPanelSummary.js
+++ b/src/ExpansionPanel/ExpansionPanelSummary.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import grey from '../colors/grey';
 import ButtonBase from '../ButtonBase';
 import IconButton from '../IconButton';
 import withStyles from '../styles/withStyles';
@@ -29,7 +30,7 @@ export const styles = theme => {
       minHeight: 64,
     },
     focused: {
-      backgroundColor: theme.palette.grey[300],
+      backgroundColor: grey[300],
     },
     disabled: {
       opacity: 0.38,

--- a/src/Stepper/StepConnector.js
+++ b/src/Stepper/StepConnector.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import grey from '../colors/grey';
 import withStyles from '../styles/withStyles';
 
 export const styles = theme => ({
@@ -9,7 +10,7 @@ export const styles = theme => ({
   },
   line: {
     display: 'block',
-    borderColor: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
+    borderColor: theme.palette.type === 'light' ? grey[400] : grey[600],
   },
   rootVertical: {
     marginLeft: 12, // half icon

--- a/src/Stepper/StepContent.js
+++ b/src/Stepper/StepContent.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
 import classNames from 'classnames';
+import grey from '../colors/grey';
 import Collapse from '../transitions/Collapse';
 import withStyles from '../styles/withStyles';
 
@@ -11,9 +12,7 @@ export const styles = theme => ({
     marginLeft: 12, // half icon
     paddingLeft: theme.spacing.unit + 12, // margin + half icon
     paddingRight: theme.spacing.unit,
-    borderLeft: `1px solid ${
-      theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[600]
-    }`,
+    borderLeft: `1px solid ${theme.palette.type === 'light' ? grey[400] : grey[600]}`,
   },
   last: {
     borderLeft: 'none',

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import grey from '../colors/grey';
 import withStyles from '../styles/withStyles';
 import SwitchBase from '../internal/SwitchBase';
 
@@ -40,7 +41,7 @@ export const styles = theme => ({
   // For SwitchBase
   default: {
     zIndex: 1,
-    color: theme.palette.type === 'light' ? theme.palette.grey[50] : theme.palette.grey[400],
+    color: theme.palette.type === 'light' ? grey[50] : grey[400],
     transition: theme.transitions.create('transform', {
       duration: theme.transitions.duration.shortest,
     }),
@@ -54,7 +55,7 @@ export const styles = theme => ({
     },
   },
   disabled: {
-    color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
+    color: theme.palette.type === 'light' ? grey[400] : grey[800],
     '& + $bar': {
       backgroundColor: theme.palette.type === 'light' ? '#000' : '#fff',
       opacity: theme.palette.type === 'light' ? 0.12 : 0.1,

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -8,6 +8,7 @@ import debounce from 'lodash/debounce';
 import warning from 'warning';
 import classNames from 'classnames';
 import { Manager, Target, Popper } from 'react-popper';
+import grey from '../colors/grey';
 import { capitalizeFirstLetter } from '../utils/helpers';
 import RefHolder from '../internal/RefHolder';
 import common from '../colors/common';
@@ -25,7 +26,7 @@ export const styles = theme => ({
     pointerEvents: 'none',
   },
   tooltip: {
-    backgroundColor: theme.palette.grey[700],
+    backgroundColor: grey[700],
     borderRadius: 2,
     color: common.fullWhite,
     fontFamily: theme.typography.fontFamily,

--- a/src/styles/createPalette.d.ts
+++ b/src/styles/createPalette.d.ts
@@ -57,7 +57,6 @@ export interface Palette {
   primary: PaletteColor;
   secondary: PaletteColor;
   error: PaletteColor;
-  grey: Color;
   types: {
     dark: TypeObject;
     light: TypeObject;

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -56,7 +56,7 @@ export const dark = {
   divider: 'rgba(255, 255, 255, 0.12)',
   background: {
     paper: grey[800],
-    default: '#303030',
+    default: grey.A400,
     appBar: grey[900],
     chip: grey[700],
     avatar: grey[600],
@@ -158,8 +158,6 @@ export default function createPalette(palette: Object) {
       secondary,
       // The colors used to represent interface elements that the user should be made aware of.
       error,
-      // The grey color.
-      grey,
       // Used by `getContrastText()` to maximize the contrast between the background and
       // the text.
       contrastThreshold,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
**breaking change**

Palette no longer carries the grey color. It wasn't useful for theme customization, as it was used by random parts of random components. (Not to mention, setting `grey: pink` is just plain wrong! 💣 )

If you use it in you app, you can either import `grey` directly in the components where it is used, or add it to a [custom theme](https://material-ui-next.com/customization/themes/):

```js
import React from 'react';
import { render } from 'react-dom';
import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
import grey from 'material-ui/colors/grey';
import Root from './Root';

const theme = createMuiTheme({
  palette: { grey },
});

function App() {
  return (
    <MuiThemeProvider theme={theme}>
      <Root />
    </MuiThemeProvider>
  );
}
```


