### PR TITLE
[core] Two small fixes looking at #10005

### DIFF
--- a/docs/src/modules/components/Link.js
+++ b/docs/src/modules/components/Link.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import NextLink from 'next/link';
 import { withStyles } from 'material-ui/styles';
-import { capitalizeFirstLetter } from 'material-ui/utils/helpers';
+import { capitalize } from 'material-ui/utils/helpers';
 
 const styles = theme => ({
   root: {
@@ -68,7 +68,7 @@ function Link(props, context) {
   let ComponentRoot;
   const className = classNames(
     classes.root,
-    classes[`variant${capitalizeFirstLetter(variant)}`],
+    classes[`variant${capitalize(variant)}`],
     classNameProp,
   );
   let RootProps;

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 import Paper from '../Paper';
 
 export const styles = theme => ({
@@ -51,9 +51,9 @@ function AppBar(props) {
 
   const className = classNames(
     classes.root,
-    classes[`position${capitalizeFirstLetter(position)}`],
+    classes[`position${capitalize(position)}`],
     {
-      [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'inherit',
+      [classes[`color${capitalize(color)}`]]: color !== 'inherit',
       'mui-fixed': position === 'fixed', // Useful for the Dialog
     },
     classNameProp,

--- a/src/Badge/Badge.js
+++ b/src/Badge/Badge.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 
 const RADIUS = 12;
 
@@ -59,7 +59,7 @@ function Badge(props) {
   } = props;
 
   const badgeClassName = classNames(classes.badge, {
-    [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'default',
+    [classes[`color${capitalize(color)}`]]: color !== 'default',
   });
 
   return (

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 import Modal from '../Modal';
 import Fade from '../transitions/Fade';
 import { duration } from '../styles/transitions';
@@ -108,7 +108,7 @@ function Dialog(props) {
           data-mui-test="Dialog"
           elevation={24}
           className={classNames(classes.paper, {
-            [classes[`paperWidth${maxWidth ? capitalizeFirstLetter(maxWidth) : ''}`]]: maxWidth,
+            [classes[`paperWidth${maxWidth ? capitalize(maxWidth) : ''}`]]: maxWidth,
             [classes.fullScreen]: fullScreen,
             [classes.fullWidth]: fullWidth,
           })}

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -7,7 +7,7 @@ import Modal from '../Modal';
 import withStyles from '../styles/withStyles';
 import Slide from '../transitions/Slide';
 import Paper from '../Paper';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 import { duration } from '../styles/transitions';
 
 function getSlideDirection(anchor) {
@@ -124,13 +124,9 @@ class Drawer extends React.Component {
       <Paper
         elevation={type === 'temporary' ? elevation : 0}
         square
-        className={classNames(
-          classes.paper,
-          classes[`paperAnchor${capitalizeFirstLetter(anchor)}`],
-          {
-            [classes[`paperAnchorDocked${capitalizeFirstLetter(anchor)}`]]: type !== 'temporary',
-          },
-        )}
+        className={classNames(classes.paper, classes[`paperAnchor${capitalize(anchor)}`], {
+          [classes[`paperAnchorDocked${capitalize(anchor)}`]]: type !== 'temporary',
+        })}
       >
         {children}
       </Paper>

--- a/src/Hidden/HiddenCss.js
+++ b/src/Hidden/HiddenCss.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
 import { keys as breakpointKeys } from '../styles/createBreakpoints';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 import withStyles from '../styles/withStyles';
 
 const styles = theme => {
@@ -11,7 +11,7 @@ const styles = theme => {
   };
 
   return breakpointKeys.reduce((acc, key) => {
-    acc[`only${capitalizeFirstLetter(key)}`] = {
+    acc[`only${capitalize(key)}`] = {
       [theme.breakpoints.only(key)]: hidden,
     };
     acc[`${key}Up`] = {
@@ -72,7 +72,7 @@ function HiddenCss(props: Props) {
   if (only) {
     const onlyBreakpoints = Array.isArray(only) ? only : [only];
     onlyBreakpoints.forEach(breakpoint => {
-      className.push(classes[`only${capitalizeFirstLetter(breakpoint)}`]);
+      className.push(classes[`only${capitalize(breakpoint)}`]);
     });
   }
 

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -32,7 +32,7 @@ function Icon(props) {
     'material-icons',
     classes.root,
     {
-      [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'inherit',
+      [classes[`color${capitalize(color)}`]]: color !== 'inherit',
     },
     classNameProp,
   );

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 import { isMuiElement } from '../utils/reactHelpers';
 import '../SvgIcon'; // Ensure CSS specificity
 
@@ -59,7 +59,7 @@ function IconButton(props) {
       className={classNames(
         classes.root,
         {
-          [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'default',
+          [classes[`color${capitalize(color)}`]]: color !== 'default',
           [classes.disabled]: disabled,
         },
         className,

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -89,13 +89,13 @@ class ListItem extends React.Component {
 
     const className = classNames(
       classes.root,
+      isDense || hasAvatar ? classes.dense : classes.default,
       {
         [classes.gutters]: !disableGutters,
         [classes.divider]: divider,
         [classes.disabled]: disabled,
         [classes.button]: button,
         [classes.secondaryAction]: hasSecondaryAction,
-        [isDense || hasAvatar ? classes.dense : classes.default]: true,
       },
       classNameProp,
     );

--- a/src/List/ListSubheader.js
+++ b/src/List/ListSubheader.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -46,7 +46,7 @@ function ListSubheader(props) {
   const className = classNames(
     classes.root,
     {
-      [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'default',
+      [classes[`color${capitalize(color)}`]]: color !== 'default',
       [classes.inset]: inset,
       [classes.sticky]: !disableSticky,
     },

--- a/src/MobileStepper/MobileStepper.js
+++ b/src/MobileStepper/MobileStepper.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Paper from '../Paper';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 import { LinearProgress } from '../Progress';
 
 export const styles = theme => ({
@@ -66,7 +66,7 @@ function MobileStepper(props) {
 
   const className = classNames(
     classes.root,
-    classes[`position${capitalizeFirstLetter(position)}`],
+    classes[`position${capitalize(position)}`],
     classNameProp,
   );
 

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 
 const SIZE = 50;
 
@@ -94,7 +94,7 @@ function CircularProgress(props) {
       className={classNames(
         classes.root,
         {
-          [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'inherit',
+          [classes[`color${capitalize(color)}`]]: color !== 'inherit',
         },
         className,
       )}

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -5,7 +5,7 @@ import EventListener from 'react-event-listener';
 import withStyles from '../styles/withStyles';
 import { duration } from '../styles/transitions';
 import ClickAwayListener from '../utils/ClickAwayListener';
-import { capitalizeFirstLetter, createChainedFunction } from '../utils/helpers';
+import { capitalize, createChainedFunction } from '../utils/helpers';
 import Slide from '../transitions/Slide';
 import SnackbarContent from './SnackbarContent';
 
@@ -227,9 +227,7 @@ class Snackbar extends React.Component {
           <div
             className={classNames(
               classes.root,
-              classes[
-                `anchor${capitalizeFirstLetter(vertical)}${capitalizeFirstLetter(horizontal)}`
-              ],
+              classes[`anchor${capitalize(vertical)}${capitalize(horizontal)}`],
               className,
             )}
             onMouseEnter={this.handleMouseEnter}

--- a/src/SvgIcon/SvgIcon.js
+++ b/src/SvgIcon/SvgIcon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -48,7 +48,7 @@ function SvgIcon(props) {
   const className = classNames(
     classes.root,
     {
-      [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'inherit',
+      [classes[`color${capitalize(color)}`]]: color !== 'inherit',
     },
     classNameProp,
   );

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 import { darken, fade, lighten } from '../styles/colorManipulator';
 
 export const styles = theme => ({
@@ -75,8 +75,7 @@ function TableCell(props, context) {
     classes.root,
     {
       [classes.numeric]: numeric,
-      [classes[`padding${capitalizeFirstLetter(padding)}`]]:
-        padding !== 'none' && padding !== 'default',
+      [classes[`padding${capitalize(padding)}`]]: padding !== 'none' && padding !== 'default',
       [classes.paddingDefault]: padding !== 'none',
       [classes.typeHead]: type ? type === 'head' : table && table.head,
       [classes.typeBody]: type ? type === 'body' : table && table.body,

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -167,10 +167,10 @@ class Tab extends React.Component {
 
     const className = classNames(
       classes.root,
+      classes[`root${capitalize(textColor)}`],
       {
-        [classes[`root${capitalizeFirstLetter(textColor)}`]]: true,
-        [classes[`root${capitalizeFirstLetter(textColor)}Disabled`]]: disabled,
-        [classes[`root${capitalizeFirstLetter(textColor)}Selected`]]: selected,
+        [classes[`root${capitalize(textColor)}Disabled`]]: disabled,
+        [classes[`root${capitalize(textColor)}Selected`]]: selected,
         [classes.rootLabelIcon]: icon && label,
         [classes.fullWidth]: fullWidth,
       },

--- a/src/Tabs/TabIndicator.js
+++ b/src/Tabs/TabIndicator.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -30,7 +30,7 @@ function TabIndicator(props) {
   const className = classNames(
     classes.root,
     {
-      [classes[`color${capitalizeFirstLetter(color)}`]]: colorPredefined,
+      [classes[`color${capitalize(color)}`]]: colorPredefined,
     },
     classNameProp,
   );

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -8,7 +8,7 @@ import debounce from 'lodash/debounce';
 import warning from 'warning';
 import classNames from 'classnames';
 import { Manager, Target, Popper } from 'react-popper';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 import RefHolder from '../internal/RefHolder';
 import common from '../colors/common';
 import withStyles from '../styles/withStyles';
@@ -348,7 +348,7 @@ class Tooltip extends React.Component {
                     className={classNames(
                       classes.tooltip,
                       { [classes.tooltipOpen]: open },
-                      classes[`tooltip${capitalizeFirstLetter(actualPlacement.split('-')[0])}`],
+                      classes[`tooltip${capitalize(actualPlacement.split('-')[0])}`],
                     )}
                   >
                     {title}

--- a/src/Typography/Typography.js
+++ b/src/Typography/Typography.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalizeFirstLetter } from '../utils/helpers';
+import { capitalize } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -79,11 +79,11 @@ function Typography(props) {
     classes.root,
     classes[type],
     {
-      [classes[`color${capitalizeFirstLetter(color)}`]]: color !== 'default',
+      [classes[`color${capitalize(color)}`]]: color !== 'default',
       [classes.noWrap]: noWrap,
       [classes.gutterBottom]: gutterBottom,
       [classes.paragraph]: paragraph,
-      [classes[`align${capitalizeFirstLetter(align)}`]]: align !== 'inherit',
+      [classes[`align${capitalize(align)}`]]: align !== 'inherit',
     },
     classNameProp,
   );

--- a/src/utils/helpers.d.ts
+++ b/src/utils/helpers.d.ts
@@ -1,4 +1,4 @@
-export function capitalizeFirstLetter(str: string): string;
+export function capitalize(str: string): string;
 export function contains<O1 extends O2, O2>(obj: O1, pred: O2): boolean;
 export function findIndex(arr: any[], pred: any): number;
 export function find<T>(arr: T[], pred: any): T;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -2,11 +2,10 @@
 
 import warning from 'warning';
 
-export function capitalizeFirstLetter(string) {
-  warning(
-    typeof string === 'string',
-    'Material-UI: capitalizeFirstLetter(string) expects a string argument.',
-  );
+export function capitalize(string) {
+  if (process.env.NODE_ENV !== 'production' && typeof string !== 'string') {
+    throw new Error('Material-UI: capitalize(string) expects a string argument.');
+  }
 
   return string.charAt(0).toUpperCase() + string.slice(1);
 }

--- a/src/utils/helpers.spec.js
+++ b/src/utils/helpers.spec.js
@@ -1,12 +1,18 @@
 // @flow
 
 import { assert } from 'chai';
-import { capitalizeFirstLetter, contains, find } from './helpers';
+import { capitalize, contains, find } from './helpers';
 
 describe('utils/helpers.js', () => {
-  describe('capitalizeFirstLetter', () => {
+  describe('capitalize', () => {
     it('should work', () => {
-      assert.strictEqual(capitalizeFirstLetter('foo'), 'Foo');
+      assert.strictEqual(capitalize('foo'), 'Foo');
+    });
+
+    it('should throw when not used correctly', () => {
+      assert.throw(() => {
+        capitalize();
+      }, /expects a string argument/);
     });
   });
 


### PR DESCRIPTION
- It's clear now that people have been experiencing a `string.charAt(0)` error many times.
I have added an explicit throw to make it more obvious. DX
- `capitalizeFirstLetter()` method is frequently used. The name is longer than it needs to be. For instance, you will find the following CSS `text-transform: capitalize;`. DX
(the file isn't exported in the index.js, it's a private API, no breaking change)