### PR TITLE
[theme] Further simplification & standardization

### DIFF
--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -7,44 +7,49 @@ import withStyles from '../styles/withStyles';
 import { capitalizeFirstLetter } from '../utils/helpers';
 import Paper from '../Paper';
 
-export const styles = theme => ({
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    width: '100%',
-    boxSizing: 'border-box', // Prevent padding issue with the Modal and fixed positioned AppBar.
-    zIndex: theme.zIndex.appBar,
-    flexShrink: 0,
-  },
-  positionFixed: {
-    position: 'fixed',
-    top: 0,
-    left: 'auto',
-    right: 0,
-  },
-  positionAbsolute: {
-    position: 'absolute',
-    top: 0,
-    left: 'auto',
-    right: 0,
-  },
-  positionStatic: {
-    position: 'static',
-    flexShrink: 0,
-  },
-  colorDefault: {
-    backgroundColor: theme.palette.background.appBar,
-    color: theme.palette.getContrastText(theme.palette.background.appBar),
-  },
-  colorPrimary: {
-    backgroundColor: theme.palette.primary.main,
-    color: theme.palette.primary.contrastText,
-  },
-  colorSecondary: {
-    backgroundColor: theme.palette.secondary.main,
-    color: theme.palette.secondary.contrastText,
-  },
-});
+export const styles = theme => {
+  const backgroundColorDefault =
+    theme.palette.type === 'light' ? theme.palette.grey[100] : theme.palette.grey[900];
+
+  return {
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      width: '100%',
+      boxSizing: 'border-box', // Prevent padding issue with the Modal and fixed positioned AppBar.
+      zIndex: theme.zIndex.appBar,
+      flexShrink: 0,
+    },
+    positionFixed: {
+      position: 'fixed',
+      top: 0,
+      left: 'auto',
+      right: 0,
+    },
+    positionAbsolute: {
+      position: 'absolute',
+      top: 0,
+      left: 'auto',
+      right: 0,
+    },
+    positionStatic: {
+      position: 'static',
+      flexShrink: 0,
+    },
+    colorDefault: {
+      backgroundColor: backgroundColorDefault,
+      color: theme.palette.getContrastText(backgroundColorDefault),
+    },
+    colorPrimary: {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.primary.contrastText,
+    },
+    colorSecondary: {
+      backgroundColor: theme.palette.secondary.main,
+      color: theme.palette.secondary.contrastText,
+    },
+  };
+};
 
 function AppBar(props) {
   const { children, classes, className: classNameProp, color, position, ...other } = props;

--- a/src/Avatar/Avatar.js
+++ b/src/Avatar/Avatar.js
@@ -20,7 +20,8 @@ export const styles = theme => ({
   },
   colorDefault: {
     color: theme.palette.background.default,
-    backgroundColor: theme.palette.background.avatar,
+    backgroundColor:
+      theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
   },
   img: {
     width: '100%',

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -8,14 +8,14 @@ import { listenForFocusKeys, detectKeyboardFocus, focusKeyPressed } from '../uti
 import TouchRipple from './TouchRipple';
 import createRippleHandler from './createRippleHandler';
 
-export const styles = theme => ({
+export const styles = {
   root: {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
     position: 'relative',
     // Remove grey highlight
-    WebkitTapHighlightColor: theme.palette.common.transparent,
+    WebkitTapHighlightColor: 'transparent',
     backgroundColor: 'transparent', // Reset default value
     outline: 'none',
     border: 0,
@@ -37,7 +37,7 @@ export const styles = theme => ({
     pointerEvents: 'none', // Disable link interactions
     cursor: 'default',
   },
-});
+};
 
 /**
  * `ButtonBase` contains as few styles as possible.

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -11,7 +11,7 @@ import '../Avatar/Avatar'; // So we don't have any override priority issue.
 
 export const styles = theme => {
   const height = 32;
-  const backgroundColor = theme.palette.background.chip;
+  const backgroundColor = theme.palette.type === 'light' ? grey[300] : grey[700];
   const deleteIconColor = fade(theme.palette.text.primary, 0.26);
 
   return {

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -35,7 +35,7 @@ export const styles = theme => {
     },
     clickable: {
       // Remove grey highlight
-      WebkitTapHighlightColor: theme.palette.common.transparent,
+      WebkitTapHighlightColor: 'transparent',
       cursor: 'pointer',
       '&:hover, &:focus': {
         backgroundColor: emphasize(backgroundColor, 0.08),
@@ -72,7 +72,7 @@ export const styles = theme => {
     },
     deleteIcon: {
       // Remove grey highlight
-      WebkitTapHighlightColor: theme.palette.common.transparent,
+      WebkitTapHighlightColor: 'transparent',
       color: deleteIconColor,
       cursor: 'pointer',
       height: 'auto',

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -4,14 +4,14 @@ import classNames from 'classnames';
 import keycode from 'keycode';
 import CancelIcon from '../internal/svg-icons/Cancel';
 import withStyles from '../styles/withStyles';
-import grey from '../colors/grey';
 import { emphasize, fade } from '../styles/colorManipulator';
 import { cloneChildrenWithClassName } from '../utils/reactHelpers';
 import '../Avatar/Avatar'; // So we don't have any override priority issue.
 
 export const styles = theme => {
   const height = 32;
-  const backgroundColor = theme.palette.type === 'light' ? grey[300] : grey[700];
+  const backgroundColor =
+    theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[700];
   const deleteIconColor = fade(theme.palette.text.primary, 0.26);
 
   return {
@@ -54,7 +54,7 @@ export const styles = theme => {
       marginRight: -4,
       width: height,
       height,
-      color: theme.palette.type === 'light' ? grey[700] : grey[300],
+      color: theme.palette.type === 'light' ? theme.palette.grey[700] : theme.palette.grey[300],
       fontSize: theme.typography.pxToRem(16),
     },
     avatarChildren: {

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -14,7 +14,7 @@ export const styles = theme => ({
     // For correct alignment with the text.
     verticalAlign: 'middle',
     // Remove grey highlight
-    WebkitTapHighlightColor: theme.palette.common.transparent,
+    WebkitTapHighlightColor: 'transparent',
     marginLeft: -14,
     marginRight: theme.spacing.unit * 2, // used for row presentation of radio/checkbox
   },

--- a/src/GridList/GridListTileBar.js
+++ b/src/GridList/GridListTileBar.js
@@ -27,7 +27,7 @@ export const styles = theme => ({
     flexGrow: 1,
     marginLeft: theme.mixins.gutters({}).paddingLeft,
     marginRight: theme.mixins.gutters({}).paddingRight,
-    color: 'white',
+    color: theme.palette.common.white,
     overflow: 'hidden',
   },
   titleWrapActionLeft: {

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -66,7 +66,7 @@ export const styles = theme => {
       alignItems: 'baseline',
       position: 'relative',
       fontFamily: theme.typography.fontFamily,
-      color: light ? 'rgba(0, 0, 0, 0.87)' : theme.palette.common.fullWhite,
+      color: light ? 'rgba(0, 0, 0, 0.87)' : theme.palette.common.white,
       fontSize: theme.typography.pxToRem(16),
     },
     formControl: {
@@ -149,7 +149,7 @@ export const styles = theme => {
       background: 'none',
       margin: 0, // Reset for Safari
       // Remove grey highlight
-      WebkitTapHighlightColor: theme.palette.common.transparent,
+      WebkitTapHighlightColor: 'transparent',
       display: 'block',
       // Make the flex item shrink with Firefox
       minWidth: 0,

--- a/src/Modal/Backdrop.js
+++ b/src/Modal/Backdrop.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Fade from '../transitions/Fade';
 
-export const styles = theme => ({
+export const styles = {
   root: {
     zIndex: -1,
     width: '100%',
@@ -13,14 +13,14 @@ export const styles = theme => ({
     top: 0,
     left: 0,
     // Remove grey highlight
-    WebkitTapHighlightColor: theme.palette.common.transparent,
+    WebkitTapHighlightColor: 'transparent',
     willChange: 'opacity',
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   invisible: {
-    backgroundColor: theme.palette.common.transparent,
+    backgroundColor: 'transparent',
   },
-});
+};
 
 function Backdrop(props) {
   const { classes, invisible, open, transitionDuration, ...other } = props;

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -56,7 +56,8 @@ export const styles = theme => ({
   disabled: {
     color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
     '& + $bar': {
-      backgroundColor: theme.palette.type === 'light' ? '#000' : '#fff',
+      backgroundColor:
+        theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
       opacity: theme.palette.type === 'light' ? 0.12 : 0.1,
     },
   },

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -27,7 +27,7 @@ export const styles = theme => ({
   tooltip: {
     backgroundColor: theme.palette.grey[700],
     borderRadius: 2,
-    color: common.fullWhite,
+    color: common.white,
     fontFamily: theme.typography.fontFamily,
     opacity: 0,
     transform: 'scale(0)',

--- a/src/colors/common.d.ts
+++ b/src/colors/common.d.ts
@@ -1,9 +1,6 @@
 export interface CommonColors {
-  transparent: string;
   black: string;
-  fullBlack: string;
   white: string;
-  fullWhite: string;
 }
 
 declare const common: CommonColors;

--- a/src/colors/common.js
+++ b/src/colors/common.js
@@ -1,11 +1,8 @@
 // @flow
 
 const common = {
-  transparent: 'transparent',
   black: '#000',
-  fullBlack: 'rgba(0, 0, 0, 1)',
   white: '#fff',
-  fullWhite: 'rgba(255, 255, 255, 1)',
 };
 
 export default common;

--- a/src/styles/createPalette.d.ts
+++ b/src/styles/createPalette.d.ts
@@ -19,9 +19,6 @@ interface TypeAction {
 interface TypeBackground {
   default: string;
   paper: string;
-  appBar: string;
-  status: string;
-  avatar: string;
 }
 
 export type PaletteColorOptions = SimplePaletteColorOptions | Partial<Color>;

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -44,7 +44,7 @@ export const light = {
 
 export const dark = {
   text: {
-    primary: common.fullWhite,
+    primary: common.white,
     secondary: 'rgba(255, 255, 255, 0.7)',
     disabled: 'rgba(255, 255, 255, 0.5)',
     hint: 'rgba(255, 255, 255, 0.5)',
@@ -56,7 +56,7 @@ export const dark = {
     default: '#303030',
   },
   action: {
-    active: common.fullWhite,
+    active: common.white,
     hover: 'rgba(255, 255, 255, 0.14)',
     selected: 'rgba(255, 255, 255, 0.8)',
     disabled: 'rgba(255, 255, 255, 0.3)',

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -26,9 +26,6 @@ export const light = {
   background: {
     paper: common.white,
     default: grey[50],
-    appBar: grey[100],
-    chip: grey[300],
-    avatar: grey[400],
   },
   // The colors used to style the action elements.
   action: {
@@ -57,9 +54,6 @@ export const dark = {
   background: {
     paper: grey[800],
     default: '#303030',
-    appBar: grey[900],
-    chip: grey[700],
-    avatar: grey[600],
   },
   action: {
     active: common.fullWhite,

--- a/src/utils/withWidth.spec.tsx
+++ b/src/utils/withWidth.spec.tsx
@@ -6,7 +6,7 @@ import withWidth, { WithWidthProps } from '../utils/withWidth';
 
 const styles = (theme: Theme) => ({
   root: {
-    backgroundColor: theme.palette.common.fullBlack,
+    backgroundColor: theme.palette.common.black,
   },
 });
 

--- a/test/typescript/colors.spec.ts
+++ b/test/typescript/colors.spec.ts
@@ -36,11 +36,11 @@ import {
 });
 
 const {
-    black, white, transparent, fullBlack, fullWhite
+    black, white,
 } = common;
 
 [
-    black, white, transparent, fullBlack, fullWhite
+    black, white,
 ].forEach(color => {
     color as string;
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
**Breaking change**
- Most component specific `theme.palette.background` colors have been removed. The affected components use `theme.palette.grey` instead. Shift the values of `theme.palette.grey` if you wish to lighten or darken these as a whole; this will maintain the contrast relationship between them. (Paper remains in the theme, as it is used across multiple components.)

- `theme.palette.common.fullBlack` and `fullWhite` have been removed. Components that used these values now use `theme.palette.common.black` and `white` instead.

- `theme.palette.common.transparent`  has been removed. Components that used this value now use 'transparent' directly.

- Chip has been corrected to use `theme.palette.grey`. If you customize the values of `grey`, the appearance of Chip in your app may change.
