### PR TITLE
[TextField] Show length indicator

### DIFF
--- a/docs/src/pages/demos/text-fields/TextFields.js
+++ b/docs/src/pages/demos/text-fields/TextFields.js
@@ -42,6 +42,7 @@ class TextFields extends React.Component {
   state = {
     name: 'Cat in the Hat',
     age: '',
+    maxlength: '',
     multiline: 'Controlled',
     currency: 'EUR',
   };
@@ -200,6 +201,16 @@ class TextFields extends React.Component {
             </option>
           ))}
         </TextField>
+        <TextField
+          id="maxlength"
+          label="Maximum length"
+          value={this.state.maxlength}
+          className={classes.textField}
+          onChange={this.handleChange('maxlength')}
+          maxLength={10}
+          helperText="Don‘t exceed the limit"
+          margin="normal"
+        />
         <TextField
           id="full-width"
           label="Label"

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -357,6 +357,7 @@ class Input extends React.Component {
       inputProps: { className: inputPropsClassName, ...inputPropsProp } = {},
       inputRef,
       margin: marginProp,
+      maxLength,
       multiline,
       name,
       onBlur,
@@ -452,6 +453,7 @@ class Input extends React.Component {
           required={required ? true : undefined}
           value={value}
           id={id}
+          maxLength={maxLength}
           name={name}
           defaultValue={defaultValue}
           placeholder={placeholder}
@@ -535,6 +537,10 @@ Input.propTypes = {
    * FormControl.
    */
   margin: PropTypes.oneOf(['dense', 'none']),
+  /**
+   * The maxLength property of the `input` element.
+   */
+  maxLength: PropTypes.number,
   /**
    * If `true`, a textarea element will be rendered.
    */

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -56,6 +56,7 @@ function TextField(props) {
     inputRef,
     label,
     labelClassName,
+    maxLength,
     multiline,
     name,
     onChange,
@@ -85,6 +86,7 @@ function TextField(props) {
       disabled={disabled}
       fullWidth={fullWidth}
       multiline={multiline}
+      maxLength={maxLength}
       name={name}
       rows={rows}
       rowsMax={rowsMax}
@@ -121,9 +123,15 @@ function TextField(props) {
       ) : (
         InputComponent
       )}
-      {helperText && (
+      {(helperText || (maxLength != null && value != null)) && (
         <FormHelperText className={helperTextClassName} id={helperTextId} {...FormHelperTextProps}>
           {helperText}
+          {maxLength &&
+            value != null && (
+              <span style={{ float: 'right' }}>
+                {value.length} / {maxLength}
+              </span>
+            )}
         </FormHelperText>
       )}
     </FormControl>
@@ -211,6 +219,11 @@ TextField.propTypes = {
    * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
    */
   margin: PropTypes.oneOf(['none', 'dense', 'normal']),
+  /**
+   * If specified, this is passed, a length indicator is displayed on the bottom right of the
+   * element. It is also passed to the input element.
+   */
+  maxLength: PropTypes.number,
   /**
    * If `true`, a textarea element will be rendered instead of an input.
    */


### PR DESCRIPTION
This shows the character counter on text inputs.

It works, but I don‘t like the implementation. Should this feature get merged / Any ideas on how to improve this?