### PR TITLE
[core] Remove the rootRef properties as unneeded

### DIFF
--- a/docs/src/pages/guides/api.md
+++ b/docs/src/pages/guides/api.md
@@ -48,12 +48,12 @@ All the components accept a [`classes`](/customization/overrides#overriding-with
 
 Internal components have:
 - their own flattened properties when these are key to the abstraction.
-- their own `xxxProps` property when users might need to tweak the internal render method's sub-components, 
+- their own `xxxProps` property when users might need to tweak the internal render method's sub-components,
 for instance, exposing the `inputProps` and `InputProps` properties on components that use `Input` internally.
   For instance, exposing a `value` property.
 - their own `xxxRef` property when user might need to perform imperative actions.
   For instance, exposing a `inputRef` property to access the native `input` on the `Input` component.
-  You fill often find a `rootRef` property, this property is applied as a `ref` to the root element of the component
+  It help answering the following question. [How can I access the DOM element?](/getting-started/frequently-asked-questions/#how-can-i-access-the-dom-element-)
 - their own `xxxClassName` property when `classes` isn't enough.
 
 ### Property naming

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -23,7 +23,6 @@ It contains a load of style reset and some focus/ripple logic.
 | focusRipple | bool | false | If `true`, the base button will have a keyboard focus ripple. `disableRipple` must also be `false`. |
 | keyboardFocusedClassName | string |  | The CSS class applied while the component is keyboard focused. |
 | onKeyboardFocus | func |  | Callback fired when the component is focused with a keyboard. We trigger a `onFocus` callback too. |
-| rootRef | func |  | Use that property to pass a ref callback to the root component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -13,13 +13,11 @@ regarding the available icon options.
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| buttonRef | func |  | Use that property to pass a ref callback to the native button component. |
 | children | node |  | The icon element. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br> | 'default' | The color of the component. It's using the theme palette when that makes sense. |
 | disabled | bool | false | If `true`, the button will be disabled. |
 | disableRipple | bool | false | If `true`, the ripple will be disabled. |
-| rootRef | func |  | Use that property to pass a ref callback to the root component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -59,7 +59,6 @@ For advanced cases, please look at the source of TextField by clicking on the
 | onChange | func |  | Callback fired when the value is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | placeholder | string |  | The short hint displayed in the input before the user enters a value. |
 | required | bool | false | If `true`, the label is displayed as required. |
-| rootRef | func |  | Use that property to pass a ref callback to the root component. |
 | rows | union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | Number of rows to display when multiline option is set to true. |
 | rowsMax | union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | Maximum number of rows to display when multiline option is set to true. |
 | select | bool | false | Render a `Select` element while passing the `Input` element to `Select` as `input` parameter. If this option is set you must pass the options of the select as children. |

--- a/src/ButtonBase/ButtonBase.d.ts
+++ b/src/ButtonBase/ButtonBase.d.ts
@@ -12,7 +12,6 @@ export interface ButtonBaseProps
   focusRipple?: boolean;
   keyboardFocusedClassName?: string;
   onKeyboardFocus?: React.FocusEventHandler<any>;
-  rootRef?: React.Ref<any>;
 }
 
 export type ButtonBaseClassKey = 'root' | 'disabled';

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -208,7 +208,6 @@ class ButtonBase extends React.Component {
       onTouchEnd,
       onTouchMove,
       onTouchStart,
-      rootRef,
       tabIndex,
       type,
       ...other
@@ -259,7 +258,6 @@ class ButtonBase extends React.Component {
         tabIndex={disabled ? -1 : tabIndex}
         className={className}
         {...buttonProps}
-        ref={rootRef}
         {...other}
       >
         {children}
@@ -370,10 +368,6 @@ ButtonBase.propTypes = {
    * @ignore
    */
   role: PropTypes.string,
-  /**
-   * Use that property to pass a ref callback to the root component.
-   */
-  rootRef: PropTypes.func,
   /**
    * @ignore
    */

--- a/src/ButtonBase/ButtonBase.spec.js
+++ b/src/ButtonBase/ButtonBase.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import keycode from 'keycode';
 import { assert } from 'chai';
+import PropTypes from 'prop-types';
 import { spy, useFakeTimers } from 'sinon';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
 import { focusKeyPressed } from '../utils/keyboardFocus';
@@ -533,17 +535,19 @@ describe('<ButtonBase />', () => {
     });
   });
 
-  describe('prop: rootRef', () => {
+  describe('prop: ref', () => {
     it('should be able to get a ref of the root element', () => {
-      const refCallback = spy();
-      const wrapper = mount(<ButtonBase rootRef={refCallback}>Hello</ButtonBase>);
-      assert.strictEqual(refCallback.callCount, 1, 'should call the ref function');
-      refCallback.args[0][0].focus();
-      assert.strictEqual(
-        document.activeElement,
-        wrapper.getDOMNode(),
-        'should be able to use the ref to focus the button',
-      );
+      function ButtonBaseRef(props) {
+        return <ButtonBase ref={props.rootRef} />;
+      }
+      ButtonBaseRef.propTypes = {
+        rootRef: PropTypes.func.isRequired,
+      };
+
+      const ref = spy();
+      mount(<ButtonBaseRef rootRef={ref}>Hello</ButtonBaseRef>);
+      assert.strictEqual(ref.callCount, 1, 'should call the ref function');
+      assert.strictEqual(ReactDOM.findDOMNode(ref.args[0][0]).type, 'button');
     });
   });
 });

--- a/src/IconButton/IconButton.d.ts
+++ b/src/IconButton/IconButton.d.ts
@@ -3,11 +3,9 @@ import { StandardProps, PropTypes } from '..';
 import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 
 export interface IconButtonProps extends StandardProps<ButtonBaseProps, IconButtonClassKey> {
-  buttonRef?: React.Ref<any>;
   color?: PropTypes.Color;
   disabled?: boolean;
   disableRipple?: boolean;
-  rootRef?: React.Ref<any>;
 }
 
 export type IconButtonClassKey =

--- a/src/IconButton/IconButton.js
+++ b/src/IconButton/IconButton.js
@@ -52,7 +52,7 @@ export const styles = theme => ({
  * regarding the available icon options.
  */
 function IconButton(props) {
-  const { buttonRef, children, classes, className, color, disabled, rootRef, ...other } = props;
+  const { children, classes, className, color, disabled, ...other } = props;
 
   return (
     <ButtonBase
@@ -67,8 +67,6 @@ function IconButton(props) {
       centerRipple
       focusRipple
       disabled={disabled}
-      rootRef={buttonRef}
-      ref={rootRef}
       {...other}
     >
       <span className={classes.label}>
@@ -86,10 +84,6 @@ function IconButton(props) {
 }
 
 IconButton.propTypes = {
-  /**
-   * Use that property to pass a ref callback to the native button component.
-   */
-  buttonRef: PropTypes.func,
   /**
    * The icon element.
    */
@@ -114,10 +108,6 @@ IconButton.propTypes = {
    * If `true`, the ripple will be disabled.
    */
   disableRipple: PropTypes.bool,
-  /**
-   * Use that property to pass a ref callback to the root component.
-   */
-  rootRef: PropTypes.func,
 };
 
 IconButton.defaultProps = {

--- a/src/IconButton/IconButton.spec.js
+++ b/src/IconButton/IconButton.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { spy } from 'sinon';
 import { assert } from 'chai';
+import PropTypes from 'prop-types';
 import { createShallow, createMount, getClasses } from '../test-utils';
 import Icon from '../Icon';
 import ButtonBase from '../ButtonBase';
@@ -95,12 +97,19 @@ describe('<IconButton />', () => {
     });
   });
 
-  describe('prop: buttonRef', () => {
+  describe('prop: ref', () => {
     it('should give a reference on the native button', () => {
+      function IconButtonRef(props) {
+        return <IconButton ref={props.rootRef} />;
+      }
+      IconButtonRef.propTypes = {
+        rootRef: PropTypes.func.isRequired,
+      };
+
       const ref = spy();
-      mount(<IconButton buttonRef={ref} />);
+      mount(<IconButtonRef rootRef={ref} />);
       assert.strictEqual(ref.callCount, 1);
-      assert.strictEqual(ref.args[0][0].type, 'button');
+      assert.strictEqual(ReactDOM.findDOMNode(ref.args[0][0]).type, 'button');
     });
   });
 });

--- a/src/List/List.d.ts
+++ b/src/List/List.d.ts
@@ -6,7 +6,6 @@ export interface ListProps
   component?: React.ReactType<ListProps>;
   dense?: boolean;
   disablePadding?: boolean;
-  rootRef?: React.Ref<any>;
   subheader?: React.ReactElement<any>;
 }
 

--- a/src/TextField/TextField.d.ts
+++ b/src/TextField/TextField.d.ts
@@ -30,7 +30,6 @@ export interface TextFieldProps
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   placeholder?: string;
   required?: boolean;
-  rootRef?: React.Ref<any>;
   rows?: string | number;
   rowsMax?: string | number;
   select?: boolean;

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -61,7 +61,6 @@ function TextField(props) {
     onChange,
     placeholder,
     required,
-    rootRef,
     rows,
     rowsMax,
     select,
@@ -105,7 +104,6 @@ function TextField(props) {
       className={className}
       error={error}
       fullWidth={fullWidth}
-      ref={rootRef}
       required={required}
       {...other}
     >
@@ -233,10 +231,6 @@ TextField.propTypes = {
    * If `true`, the label is displayed as required.
    */
   required: PropTypes.bool,
-  /**
-   * Use that property to pass a ref callback to the root component.
-   */
-  rootRef: PropTypes.func,
   /**
    * Number of rows to display when multiline option is set to true.
    */


### PR DESCRIPTION
I have been digging in the history of those properties. I believe we have been answering the problem with [How can I access the DOM element?](https://material-ui-next.com/getting-started/frequently-asked-questions/#how-can-i-access-the-dom-element-) FAQ question. We do no longer need them. Worse the property coverage of our component was weak. We need a systematic solution to the problem.

### Breaking change

```diff
+import ReactDOM from 'react-dom';

<IconButton
- buttonRef={node => {
-   this.button = node;
+ ref={node => {
+   this.button = ReactDOM.findDOMNode(node);
  }}
>
```