### PR TITLE
[palette] Remove the palette.types from the theme

### DIFF
--- a/docs/src/pages/customization/WithTheme.js
+++ b/docs/src/pages/customization/WithTheme.js
@@ -22,7 +22,7 @@ function WithTheme(props) {
   };
 
   return (
-    <div>
+    <div style={{ width: 300 }}>
       <Typography style={styles.primaryColor}>{`Primary color ${primaryColor}`}</Typography>
       <Typography style={styles.primaryText}>{`Primary text ${primaryText}`}</Typography>
     </div>

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -136,6 +136,20 @@ Lacking imagination? The Material Design team has built an awesome [palette conf
 ### Dark/light theme
 
 You can make the theme dark by setting `type` to `dark`.
+It's a single property value change.
+Internally, it's modifying the value of the following keys:
+- `palette.text`
+- `palette.divider`
+- `palette.background`
+- `palette.action`
+
+```jsx
+const theme = createMuiTheme({
+  palette: {
+    type: 'dark',
+  },
+});
+```
 
 {{"demo": "pages/customization/DarkTheme.js", "hideEditButton": true}}
 

--- a/docs/src/pages/customization/themes.md
+++ b/docs/src/pages/customization/themes.md
@@ -136,8 +136,7 @@ Lacking imagination? The Material Design team has built an awesome [palette conf
 ### Dark/light theme
 
 You can make the theme dark by setting `type` to `dark`.
-It's a single property value change.
-Internally, it's modifying the value of the following keys:
+While it's only a single property value change, internally it modifies the value of the following keys:
 - `palette.text`
 - `palette.divider`
 - `palette.background`

--- a/src/styles/createPalette.d.ts
+++ b/src/styles/createPalette.d.ts
@@ -55,10 +55,6 @@ export interface Palette {
   secondary: PaletteColor;
   error: PaletteColor;
   grey: Color;
-  types: {
-    dark: TypeObject;
-    light: TypeObject;
-  };
   text: TypeText;
   divider: string;
   action: TypeAction;
@@ -76,10 +72,6 @@ export interface PaletteOptions {
   secondary?: PaletteColorOptions;
   error?: PaletteColorOptions;
   grey?: ColorPartial;
-  types?: {
-    dark?: PartialTypeObject;
-    light?: PartialTypeObject;
-  };
   text?: Partial<TypeText>;
   divider?: string;
   action?: Partial<TypeAction>;

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -164,7 +164,6 @@ export default function createPalette(palette: Object) {
       // E.g., shift from Red 500 to Red 300 or Red 700.
       tonalOffset,
       // The light and dark type object.
-      types,
       ...types[type],
     },
     other,


### PR DESCRIPTION
Closes #9891

In order to keep the palette simple to understand.
I have removed the `types` from the palette object.

The motivation is the following. The theme & palette should only store
the information needed to display one UI context.
Having the `types` object in the palette encourage people to rely on it.
No, we want people to do it the other way around.

For instance, instead of doing:
```jsx
const theme = createMuiTheme({
  palette: {
    type: 'dark',
    types: {
      dark: {
        background: {
          default: '#000',
        },
      },
      light: {
        background: {
          default: '#fff',
        },
      },
    },
  },
});
```

We would rather see people doing:
```jsx
const types = {
  dark: {
    background: {
      default: '#000',
    },
  },
  light: {
    background: {
      default: '#fff',
    },
  },
};

const theme = createMuiTheme({
  palette: {
    type: 'dark',
    ...types.dark,
  },
});
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
