### PR TITLE
[docs] Add zero click example of Wrapping components

### DIFF
--- a/docs/src/pages/guides/composition.md
+++ b/docs/src/pages/guides/composition.md
@@ -17,4 +17,9 @@ If you encounter this issue, you need to:
 
 Let's see an example:
 
+```jsx
+const WrappedIcon = props => <Icon {...props} />;
+WrappedIcon.muiName = 'Icon';
+```
+
 {{"demo": "pages/guides/Composition.js"}}


### PR DESCRIPTION
People don't always realize they can use the "<>" source code button. Also, people tend to scan the docs. Providing a "zero click" example should help. 

*By people, I'm referring to myself*

Closes #10036