### PR TITLE
Checkbox selection fixes for Table and TableRow components

### DIFF
--- a/src/Table/Table.js
+++ b/src/Table/Table.js
@@ -214,12 +214,14 @@ class Table extends Component {
     if (this.props.onRowHoverExit) this.props.onRowHoverExit(rowNumber);
   };
 
-  onRowSelection = (selectedRows) => {
+  onRowSelection = (selectedRows, allRowsSelected = false) => {
     if (this.state.allRowsSelected) {
       this.setState({allRowsSelected: false});
     }
 
-    if (this.props.onRowSelection) {
+    if (allRowsSelected) {
+      this.onSelectAll();
+    } else if (this.props.onRowSelection) {
       this.props.onRowSelection(selectedRows);
     }
   };

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -345,7 +345,10 @@ class TableBody extends Component {
     }
 
     if (this.props.onRowSelection) {
-      this.props.onRowSelection(this.flattenRanges(selectedRows));
+      this.props.onRowSelection(
+        this.flattenRanges(selectedRows),
+        this.flattenRanges(selectedRows).length === this.props.children.length
+      );
     }
   }
 

--- a/src/Table/TableBody.js
+++ b/src/Table/TableBody.js
@@ -143,7 +143,10 @@ class TableBody extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.allRowsSelected !== nextProps.allRowsSelected) {
-      if (!nextProps.allRowsSelected) {
+      const someRowsSelected = nextProps.children.some(
+        (child) => child.props.selected
+      );
+      if (!nextProps.allRowsSelected && !someRowsSelected) {
         this.setState({
           selectedRows: [],
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
As mentioned in #10045 this PR addresses two unexpected behaviours when selecting table rows.

- Selecting all rows, then unchecking any row, deselects all rows. Changed behaviour so remaining rows are checked.
- Selecting all rows via the body (not using select all checkbox in header), would not automatically check the 'select all' checkbox when all child rows were selected. Changed so 'select all' checkbox is now checked when all child rows are selected.

I'm not sure if my approach is _an optimal way_ to address auto checking the 'select all' checkbox. I've **added an optional parameter** to `onRowSelection()`, the parameters are not documented so hopefully this doesn't cause other consumers of mui `v0.x` any problems.