### PR TITLE
[List] Fix w3c issues

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -7,7 +7,7 @@
   {
     "name": "The size of the whole library.",
     "path": "build/index.js",
-    "limit": "96.5 KB"
+    "limit": "96.6 KB"
   },
   {
     "name": "The main bundle of the documentation",

--- a/docs/src/pages/demos/dividers/InsetDividers.js
+++ b/docs/src/pages/demos/dividers/InsetDividers.js
@@ -3,14 +3,15 @@ import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Avatar from 'material-ui/Avatar';
-import Divider from 'material-ui/Divider';
-import FolderIcon from 'material-ui-icons/Folder';
 import ImageIcon from 'material-ui-icons/Image';
+import WorkIcon from 'material-ui-icons/Work';
+import BeachAccessIcon from 'material-ui-icons/BeachAccess';
+import Divider from 'material-ui/Divider';
 
 const styles = theme => ({
   root: {
     width: '100%',
-    maxWidth: '360px',
+    maxWidth: 360,
     backgroundColor: theme.palette.background.paper,
   },
 });
@@ -18,21 +19,32 @@ const styles = theme => ({
 function InsetDividers(props) {
   const { classes } = props;
   return (
-    <List className={classes.root}>
-      <ListItem button>
-        <Avatar>
-          <FolderIcon />
-        </Avatar>
-        <ListItemText primary="Work" secondary="Jan 28, 2014" />
-      </ListItem>
-      <Divider inset />
-      <ListItem button>
-        <Avatar>
-          <ImageIcon />
-        </Avatar>
-        <ListItemText primary="Vacation" secondary="Jan 20, 2014" />
-      </ListItem>
-    </List>
+    <div className={classes.root}>
+      <List>
+        <ListItem>
+          <Avatar>
+            <ImageIcon />
+          </Avatar>
+          <ListItemText primary="Photos" secondary="Jan 9, 2014" />
+        </ListItem>
+        <li>
+          <Divider inset />
+        </li>
+        <ListItem>
+          <Avatar>
+            <WorkIcon />
+          </Avatar>
+          <ListItemText primary="Work" secondary="Jan 7, 2014" />
+        </ListItem>
+        <Divider inset component="li" />
+        <ListItem>
+          <Avatar>
+            <BeachAccessIcon />
+          </Avatar>
+          <ListItemText primary="Vacation" secondary="July 20, 2014" />
+        </ListItem>
+      </List>
+    </div>
   );
 }
 

--- a/docs/src/pages/demos/dividers/ListDividers.js
+++ b/docs/src/pages/demos/dividers/ListDividers.js
@@ -15,23 +15,24 @@ const styles = theme => ({
 function ListDividers(props) {
   const { classes } = props;
   return (
-    <List className={classes.root}>
-      <ListItem button>
-        <ListItemText primary="Inbox" />
-      </ListItem>
-      <Divider />
-      <ListItem button>
-        <ListItemText primary="Drafts" />
-      </ListItem>
-      <Divider />
-      <ListItem button>
-        <ListItemText primary="Trash" />
-      </ListItem>
-      <Divider light />
-      <ListItem button>
-        <ListItemText primary="Spam" />
-      </ListItem>
-    </List>
+    <div className={classes.root}>
+      <List component="nav">
+        <ListItem button>
+          <ListItemText primary="Inbox" />
+        </ListItem>
+        <Divider />
+        <ListItem button divider>
+          <ListItemText primary="Drafts" />
+        </ListItem>
+        <ListItem button>
+          <ListItemText primary="Trash" />
+        </ListItem>
+        <Divider light />
+        <ListItem button>
+          <ListItemText primary="Spam" />
+        </ListItem>
+      </List>
+    </div>
   );
 }
 

--- a/docs/src/pages/demos/dividers/dividers.md
+++ b/docs/src/pages/demos/dividers/dividers.md
@@ -8,8 +8,14 @@ components: Divider
 
 ## List Dividers
 
+The divider renders as a `<hr>` by default.
+You can save this DOM element by using the `divider` property on the `ListItem` component.
+
 {{"demo": "pages/demos/dividers/ListDividers.js"}}
 
 ## Inset Dividers
+
+The following example demonstrates the `inset` property.
+We need to make sure the `Divider` is rendered as a `li` to match the HTML5 specification.
 
 {{"demo": "pages/demos/dividers/InsetDividers.js"}}

--- a/docs/src/pages/demos/dividers/dividers.md
+++ b/docs/src/pages/demos/dividers/dividers.md
@@ -9,7 +9,7 @@ components: Divider
 ## List Dividers
 
 The divider renders as a `<hr>` by default.
-You can save this DOM element by using the `divider` property on the `ListItem` component.
+You can save rendering this DOM element by using the `divider` property on the `ListItem` component.
 
 {{"demo": "pages/demos/dividers/ListDividers.js"}}
 
@@ -17,5 +17,6 @@ You can save this DOM element by using the `divider` property on the `ListItem` 
 
 The following example demonstrates the `inset` property.
 We need to make sure the `Divider` is rendered as a `li` to match the HTML5 specification.
+The example shows two ways of achieving this.
 
 {{"demo": "pages/demos/dividers/InsetDividers.js"}}

--- a/docs/src/pages/demos/lists/FolderList.js
+++ b/docs/src/pages/demos/lists/FolderList.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import List, { ListItem, ListItemText } from 'material-ui/List';
 import Avatar from 'material-ui/Avatar';
-import FolderIcon from 'material-ui-icons/Folder';
+import ImageIcon from 'material-ui-icons/Image';
+import WorkIcon from 'material-ui-icons/Work';
+import BeachAccessIcon from 'material-ui-icons/BeachAccess';
 
 const styles = theme => ({
   root: {
@@ -18,17 +20,23 @@ function FolderList(props) {
   return (
     <div className={classes.root}>
       <List>
-        <ListItem button>
+        <ListItem>
           <Avatar>
-            <FolderIcon />
+            <ImageIcon />
           </Avatar>
-          <ListItemText primary="Photos" secondary="Jan 9, 2016" />
+          <ListItemText primary="Photos" secondary="Jan 9, 2014" />
         </ListItem>
-        <ListItem button>
+        <ListItem>
           <Avatar>
-            <FolderIcon />
+            <WorkIcon />
           </Avatar>
-          <ListItemText primary="Work" secondary="Jan 7, 2016" />
+          <ListItemText primary="Work" secondary="Jan 7, 2014" />
+        </ListItem>
+        <ListItem>
+          <Avatar>
+            <BeachAccessIcon />
+          </Avatar>
+          <ListItemText primary="Vacation" secondary="July 20, 2014" />
         </ListItem>
       </List>
     </div>

--- a/docs/src/pages/demos/lists/InsetList.js
+++ b/docs/src/pages/demos/lists/InsetList.js
@@ -15,17 +15,19 @@ const styles = theme => ({
 function InsetList(props) {
   const { classes } = props;
   return (
-    <List className={classes.root}>
-      <ListItem button>
-        <ListItemIcon>
-          <StarIcon />
-        </ListItemIcon>
-        <ListItemText inset primary="Chelsea Otakan" />
-      </ListItem>
-      <ListItem button>
-        <ListItemText inset primary="Eric Hoffman" />
-      </ListItem>
-    </List>
+    <div className={classes.root}>
+      <List component="nav">
+        <ListItem button>
+          <ListItemIcon>
+            <StarIcon />
+          </ListItemIcon>
+          <ListItemText inset primary="Chelsea Otakan" />
+        </ListItem>
+        <ListItem button>
+          <ListItemText inset primary="Eric Hoffman" />
+        </ListItem>
+      </List>
+    </div>
   );
 }
 

--- a/docs/src/pages/demos/lists/InteractiveList.js
+++ b/docs/src/pages/demos/lists/InteractiveList.js
@@ -80,7 +80,7 @@ class InteractiveList extends React.Component {
             <div className={classes.demo}>
               <List dense={dense}>
                 {generate(
-                  <ListItem button>
+                  <ListItem>
                     <ListItemText
                       primary="Single-line item"
                       secondary={secondary ? 'Secondary text' : null}
@@ -97,7 +97,7 @@ class InteractiveList extends React.Component {
             <div className={classes.demo}>
               <List dense={dense}>
                 {generate(
-                  <ListItem button>
+                  <ListItem>
                     <ListItemIcon>
                       <FolderIcon />
                     </ListItemIcon>
@@ -119,7 +119,7 @@ class InteractiveList extends React.Component {
             <div className={classes.demo}>
               <List dense={dense}>
                 {generate(
-                  <ListItem button>
+                  <ListItem>
                     <ListItemAvatar>
                       <Avatar>
                         <FolderIcon />
@@ -141,7 +141,7 @@ class InteractiveList extends React.Component {
             <div className={classes.demo}>
               <List dense={dense}>
                 {generate(
-                  <ListItem button>
+                  <ListItem>
                     <ListItemAvatar>
                       <Avatar>
                         <FolderIcon />

--- a/docs/src/pages/demos/lists/NestedList.js
+++ b/docs/src/pages/demos/lists/NestedList.js
@@ -33,37 +33,42 @@ class NestedList extends React.Component {
     const { classes } = this.props;
 
     return (
-      <List className={classes.root} subheader={<ListSubheader>Nested List Items</ListSubheader>}>
-        <ListItem button>
-          <ListItemIcon>
-            <SendIcon />
-          </ListItemIcon>
-          <ListItemText inset primary="Sent mail" />
-        </ListItem>
-        <ListItem button>
-          <ListItemIcon>
-            <DraftsIcon />
-          </ListItemIcon>
-          <ListItemText inset primary="Drafts" />
-        </ListItem>
-        <ListItem button onClick={this.handleClick}>
-          <ListItemIcon>
-            <InboxIcon />
-          </ListItemIcon>
-          <ListItemText inset primary="Inbox" />
-          {this.state.open ? <ExpandLess /> : <ExpandMore />}
-        </ListItem>
-        <Collapse component="li" in={this.state.open} timeout="auto" unmountOnExit>
-          <List disablePadding>
-            <ListItem button className={classes.nested}>
-              <ListItemIcon>
-                <StarBorder />
-              </ListItemIcon>
-              <ListItemText inset primary="Starred" />
-            </ListItem>
-          </List>
-        </Collapse>
-      </List>
+      <div className={classes.root}>
+        <List
+          component="nav"
+          subheader={<ListSubheader component="div">Nested List Items</ListSubheader>}
+        >
+          <ListItem button>
+            <ListItemIcon>
+              <SendIcon />
+            </ListItemIcon>
+            <ListItemText inset primary="Sent mail" />
+          </ListItem>
+          <ListItem button>
+            <ListItemIcon>
+              <DraftsIcon />
+            </ListItemIcon>
+            <ListItemText inset primary="Drafts" />
+          </ListItem>
+          <ListItem button onClick={this.handleClick}>
+            <ListItemIcon>
+              <InboxIcon />
+            </ListItemIcon>
+            <ListItemText inset primary="Inbox" />
+            {this.state.open ? <ExpandLess /> : <ExpandMore />}
+          </ListItem>
+          <Collapse in={this.state.open} timeout="auto" unmountOnExit>
+            <List component="div" disablePadding>
+              <ListItem button className={classes.nested}>
+                <ListItemIcon>
+                  <StarBorder />
+                </ListItemIcon>
+                <ListItemText inset primary="Starred" />
+              </ListItem>
+            </List>
+          </Collapse>
+        </List>
+      </div>
     );
   }
 }

--- a/docs/src/pages/demos/lists/PinnedSubheaderList.js
+++ b/docs/src/pages/demos/lists/PinnedSubheaderList.js
@@ -16,22 +16,28 @@ const styles = theme => ({
   listSection: {
     backgroundColor: 'inherit',
   },
+  ul: {
+    backgroundColor: 'inherit',
+    padding: 0,
+  },
 });
 
 function PinnedSubheaderList(props) {
   const { classes } = props;
 
   return (
-    <List className={classes.root} subheader={<div />}>
+    <List className={classes.root} subheader={<li />}>
       {[0, 1, 2, 3, 4].map(sectionId => (
-        <div key={`section-${sectionId}`} className={classes.listSection}>
-          <ListSubheader>{`I'm sticky ${sectionId}`}</ListSubheader>
-          {[0, 1, 2].map(item => (
-            <ListItem button key={`item-${sectionId}-${item}`}>
-              <ListItemText primary={`Item ${item}`} />
-            </ListItem>
-          ))}
-        </div>
+        <li key={`section-${sectionId}`} className={classes.listSection}>
+          <ul className={classes.ul}>
+            <ListSubheader>{`I'm sticky ${sectionId}`}</ListSubheader>
+            {[0, 1, 2].map(item => (
+              <ListItem key={`item-${sectionId}-${item}`}>
+                <ListItemText primary={`Item ${item}`} />
+              </ListItem>
+            ))}
+          </ul>
+        </li>
       ))}
     </List>
   );

--- a/docs/src/pages/demos/lists/SimpleList.js
+++ b/docs/src/pages/demos/lists/SimpleList.js
@@ -18,7 +18,7 @@ function SimpleList(props) {
   const { classes } = props;
   return (
     <div className={classes.root}>
-      <List>
+      <List component="nav">
         <ListItem button>
           <ListItemIcon>
             <InboxIcon />
@@ -33,7 +33,7 @@ function SimpleList(props) {
         </ListItem>
       </List>
       <Divider />
-      <List>
+      <List component="nav">
         <ListItem button>
           <ListItemText primary="Trash" />
         </ListItem>

--- a/docs/src/pages/demos/menus/SimpleListMenu.js
+++ b/docs/src/pages/demos/menus/SimpleListMenu.js
@@ -45,7 +45,7 @@ class SimpleListMenu extends React.Component {
 
     return (
       <div className={classes.root}>
-        <List>
+        <List component="nav">
           <ListItem
             button
             aria-haspopup="true"

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -7,7 +7,7 @@ filename: /src/ButtonBase/ButtonBase.js
 # ButtonBase
 
 `ButtonBase` contains as few styles as possible.
-It aims to be a building block for people who want to create a simple button.
+It aims to be a simple building block for creating a button.
 It contains a load of style reset and some focus/ripple logic.
 
 ## Props

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -12,10 +12,12 @@ filename: /src/List/ListItem.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| button | bool | false | If `true`, the ListItem will be a button. |
+| button | bool | false | If `true`, the list item will be a button (using `ButtonBase`). |
 | children | node |  | The content of the component. |
 | classes | object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'li' | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> |  | The component used for the root node. Either a string to use a DOM element or a component. By default, it's a `li` when `button` is `false` and a `div` when `button` is `true`. |
+| ContainerComponent | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'li' | The container component. Useful when a `ListItemSecondaryAction` is rendered. |
+| ContainerProps | object |  | Properties applied to the container element when the component is used to display a `ListItemSecondaryAction`. |
 | dense | bool | false | If `true`, compact vertical padding designed for keyboard and mouse input will be used. |
 | disableGutters | bool | false | If `true`, the left and right padding is removed. |
 | divider | bool | false | If `true`, a 1px light border is added to the bottom of the list item. |

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -14,7 +14,7 @@ filename: /src/Menu/MenuItem.js
 |:-----|:-----|:--------|:------------|
 | children | node |  | Menu item contents. |
 | classes | object |  | Useful to extend the style applied to components. |
-| component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> |  | The component used for the root node. Either a string to use a DOM element or a component. |
+| component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'li' | The component used for the root node. Either a string to use a DOM element or a component. |
 | selected | bool | false | Use to apply selected styling. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -13,7 +13,7 @@ export interface ButtonProps extends StandardProps<ButtonBaseProps, ButtonClassK
   href?: string;
   mini?: boolean;
   raised?: boolean;
-  size?: 'small' | 'medium' | 'large'
+  size?: 'small' | 'medium' | 'large';
   type?: string;
 }
 

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -39,6 +39,10 @@ export const styles = {
   },
 };
 
+// Don't automatically add the role="button" property on these components.
+// It's invalid HTML syntax.
+const INVALID_COMPONENT_ROLE = ['a'];
+
 /**
  * `ButtonBase` contains as few styles as possible.
  * It aims to be a building block for people who want to create a simple button.
@@ -241,9 +245,7 @@ class ButtonBase extends React.Component {
     if (ComponentProp === 'button') {
       buttonProps.type = type || 'button';
       buttonProps.disabled = disabled;
-    }
-
-    if (ComponentProp !== 'a' && buttonProps.type !== 'button') {
+    } else if (INVALID_COMPONENT_ROLE.indexOf(ComponentProp) === -1) {
       buttonProps.role = 'button';
     }
 

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -45,7 +45,7 @@ const INVALID_COMPONENT_ROLE = ['a'];
 
 /**
  * `ButtonBase` contains as few styles as possible.
- * It aims to be a building block for people who want to create a simple button.
+ * It aims to be a simple building block for creating a button.
  * It contains a load of style reset and some focus/ripple logic.
  */
 class ButtonBase extends React.Component {

--- a/src/ButtonBase/ButtonBase.spec.js
+++ b/src/ButtonBase/ButtonBase.spec.js
@@ -65,21 +65,28 @@ describe('<ButtonBase />', () => {
     it('should not apply role="button" if type="button"', () => {
       const wrapper = shallow(<ButtonBase>Hello</ButtonBase>);
       assert.strictEqual(wrapper.name(), 'button');
-      assert.strictEqual(wrapper.props().type, 'button', 'should not set a type');
-      assert.strictEqual(wrapper.props().role, undefined, 'should role to button');
+      assert.strictEqual(wrapper.props().type, 'button');
+      assert.strictEqual(wrapper.props().role, undefined);
     });
 
     it('should change the button type to span and set role="button"', () => {
       const wrapper = shallow(<ButtonBase component="span">Hello</ButtonBase>);
       assert.strictEqual(wrapper.name(), 'span');
-      assert.strictEqual(wrapper.props().type, undefined, 'should not set a type');
-      assert.strictEqual(wrapper.props().role, 'button', 'should role to button');
+      assert.strictEqual(wrapper.props().type, undefined);
+      assert.strictEqual(wrapper.props().role, 'button');
     });
 
     it('should automatically change the button to an a element when href is provided', () => {
       const wrapper = shallow(<ButtonBase href="http://google.com">Hello</ButtonBase>);
       assert.strictEqual(wrapper.name(), 'a');
       assert.strictEqual(wrapper.props().href, 'http://google.com');
+    });
+
+    it('should not set role="button" on an invalid component', () => {
+      const wrapper = shallow(<ButtonBase component="a">Hello</ButtonBase>);
+      assert.strictEqual(wrapper.name(), 'a');
+      assert.strictEqual(wrapper.props().type, undefined);
+      assert.strictEqual(wrapper.props().role, undefined);
     });
 
     it('should not change the button to an a element', () => {

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -12,6 +12,9 @@ export const styles = theme => ({
     alignItems: 'center',
     position: 'relative',
     textDecoration: 'none',
+    width: '100%',
+    boxSizing: 'border-box',
+    textAlign: 'left',
   },
   container: {
     position: 'relative',
@@ -32,6 +35,7 @@ export const styles = theme => ({
   },
   divider: {
     borderBottom: `1px solid ${theme.palette.divider}`,
+    backgroundClip: 'padding-box',
   },
   gutters: {
     paddingLeft: theme.spacing.unit * 2,
@@ -74,15 +78,17 @@ class ListItem extends React.Component {
       classes,
       className: classNameProp,
       component: componentProp,
+      ContainerComponent,
+      ContainerProps,
       dense,
       disabled,
       disableGutters,
       divider,
       ...other
     } = this.props;
+
     const isDense = dense || this.context.dense || false;
     const children = React.Children.toArray(childrenProp);
-
     const hasAvatar = children.some(value => isMuiElement(value, ['ListItemAvatar']));
     const hasSecondaryAction =
       children.length && isMuiElement(children[children.length - 1], ['ListItemSecondaryAction']);
@@ -100,31 +106,33 @@ class ListItem extends React.Component {
       classNameProp,
     );
 
-    const listItemProps = { className, disabled, ...other };
-    let ComponentMain = componentProp;
+    const componentProps = { className, disabled, ...other };
+    let Component = componentProp || 'li';
 
     if (button) {
-      ComponentMain = ButtonBase;
-      listItemProps.component = componentProp;
-      listItemProps.keyboardFocusedClassName = classes.keyboardFocused;
+      componentProps.component = componentProp || 'div';
+      componentProps.keyboardFocusedClassName = classes.keyboardFocused;
+      Component = ButtonBase;
     }
 
     if (hasSecondaryAction) {
+      Component = Component !== ButtonBase && !componentProp ? 'div' : Component;
+
       return (
-        <div className={classes.container}>
-          <ComponentMain {...listItemProps}>{children}</ComponentMain>
+        <ContainerComponent className={classes.container} {...ContainerProps}>
+          <Component {...componentProps}>{children}</Component>
           {children.pop()}
-        </div>
+        </ContainerComponent>
       );
     }
 
-    return <ComponentMain {...listItemProps}>{children}</ComponentMain>;
+    return <Component {...componentProps}>{children}</Component>;
   }
 }
 
 ListItem.propTypes = {
   /**
-   * If `true`, the ListItem will be a button.
+   * If `true`, the list item will be a button (using `ButtonBase`).
    */
   button: PropTypes.bool,
   /**
@@ -142,8 +150,18 @@ ListItem.propTypes = {
   /**
    * The component used for the root node.
    * Either a string to use a DOM element or a component.
+   * By default, it's a `li` when `button` is `false` and a `div` when `button` is `true`.
    */
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  /**
+   * The container component. Useful when a `ListItemSecondaryAction` is rendered.
+   */
+  ContainerComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  /**
+   * Properties applied to the container element when the component
+   * is used to display a `ListItemSecondaryAction`.
+   */
+  ContainerProps: PropTypes.object,
   /**
    * If `true`, compact vertical padding designed for keyboard and mouse input will be used.
    */
@@ -164,7 +182,7 @@ ListItem.propTypes = {
 
 ListItem.defaultProps = {
   button: false,
-  component: 'li',
+  ContainerComponent: 'li',
   dense: false,
   disabled: false,
   disableGutters: false,

--- a/src/List/ListItem.spec.js
+++ b/src/List/ListItem.spec.js
@@ -6,6 +6,7 @@ import ListItemSecondaryAction from './ListItemSecondaryAction';
 import ListItem from './ListItem';
 import ListItemAvatar from './ListItemAvatar';
 import Avatar from '../Avatar';
+import ButtonBase from '../ButtonBase';
 
 describe('<ListItem />', () => {
   let shallow;
@@ -61,9 +62,9 @@ describe('<ListItem />', () => {
   });
 
   describe('prop: button', () => {
-    it('should render a li', () => {
+    it('should render a div', () => {
       const wrapper = shallow(<ListItem button />);
-      assert.strictEqual(wrapper.props().component, 'li');
+      assert.strictEqual(wrapper.props().component, 'div');
     });
   });
 
@@ -71,6 +72,11 @@ describe('<ListItem />', () => {
     it('should change the component', () => {
       const wrapper = shallow(<ListItem button component="a" />);
       assert.strictEqual(wrapper.props().component, 'a');
+    });
+
+    it('should change the component', () => {
+      const wrapper = shallow(<ListItem button component="li" />);
+      assert.strictEqual(wrapper.props().component, 'li');
     });
   });
 
@@ -101,6 +107,44 @@ describe('<ListItem />', () => {
         </ListItem>,
       );
       assert.strictEqual(wrapper.hasClass(classes.container), true);
+      assert.strictEqual(wrapper.type(), 'li');
+      assert.strictEqual(wrapper.childAt(0).type(), 'div');
+    });
+
+    it('should accept a ContainerComponent property', () => {
+      const wrapper = shallow(
+        <ListItem ContainerComponent="div">
+          <ListItemText primary="primary" />
+          <ListItemSecondaryAction />
+        </ListItem>,
+      );
+      assert.strictEqual(wrapper.hasClass(classes.container), true);
+      assert.strictEqual(wrapper.type(), 'div');
+      assert.strictEqual(wrapper.childAt(0).type(), 'div');
+    });
+
+    it('should accept a component property', () => {
+      const wrapper = shallow(
+        <ListItem component="span">
+          <ListItemText primary="primary" />
+          <ListItemSecondaryAction />
+        </ListItem>,
+      );
+      assert.strictEqual(wrapper.hasClass(classes.container), true);
+      assert.strictEqual(wrapper.type(), 'li');
+      assert.strictEqual(wrapper.childAt(0).type(), 'span');
+    });
+
+    it('should accet a button property', () => {
+      const wrapper = shallow(
+        <ListItem button>
+          <ListItemText primary="primary" />
+          <ListItemSecondaryAction />
+        </ListItem>,
+      );
+      assert.strictEqual(wrapper.hasClass(classes.container), true);
+      assert.strictEqual(wrapper.type(), 'li');
+      assert.strictEqual(wrapper.childAt(0).type(), ButtonBase);
     });
   });
 });

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -11,6 +11,7 @@ export const styles = theme => ({
     ...theme.typography.subheading,
     height: theme.spacing.unit * 3,
     boxSizing: 'content-box',
+    width: 'auto',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -76,6 +77,7 @@ MenuItem.propTypes = {
 };
 
 MenuItem.defaultProps = {
+  component: 'li',
   role: 'menuitem',
   selected: false,
 };

--- a/test/regressions/tests/List/PrimaryActionCheckboxListItem.js
+++ b/test/regressions/tests/List/PrimaryActionCheckboxListItem.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import { ListItem, ListItemText, ListItemSecondaryAction } from 'material-ui/List';
+import List, { ListItem, ListItemText, ListItemSecondaryAction } from 'material-ui/List';
 import Checkbox from 'material-ui/Checkbox';
 import IconButton from 'material-ui/IconButton';
 import Icon from 'material-ui/Icon';
@@ -9,24 +9,26 @@ import Icon from 'material-ui/Icon';
 export default function PrimaryActionCheckboxListItem() {
   return (
     <div style={{ backgroundColor: '#fff', width: 300 }}>
-      <ListItem button>
-        <Checkbox tabIndex={-1} disableRipple />
-        <ListItemText primary="Primary" />
-        <ListItemSecondaryAction>
-          <IconButton>
-            <Icon>comment</Icon>
-          </IconButton>
-        </ListItemSecondaryAction>
-      </ListItem>
-      <ListItem button dense>
-        <Checkbox tabIndex={-1} disableRipple />
-        <ListItemText primary="Primary" />
-        <ListItemSecondaryAction>
-          <IconButton>
-            <Icon>comment</Icon>
-          </IconButton>
-        </ListItemSecondaryAction>
-      </ListItem>
+      <List>
+        <ListItem button>
+          <Checkbox tabIndex={-1} disableRipple />
+          <ListItemText primary="Primary" />
+          <ListItemSecondaryAction>
+            <IconButton>
+              <Icon>comment</Icon>
+            </IconButton>
+          </ListItemSecondaryAction>
+        </ListItem>
+        <ListItem button dense>
+          <Checkbox tabIndex={-1} disableRipple />
+          <ListItemText primary="Primary" />
+          <ListItemSecondaryAction>
+            <IconButton>
+              <Icon>comment</Icon>
+            </IconButton>
+          </ListItemSecondaryAction>
+        </ListItem>
+      </List>
     </div>
   );
 }

--- a/test/regressions/tests/List/SecondaryActionCheckboxListItem.js
+++ b/test/regressions/tests/List/SecondaryActionCheckboxListItem.js
@@ -1,24 +1,26 @@
 // @flow
 
 import React from 'react';
-import { ListItem, ListItemText, ListItemSecondaryAction } from 'material-ui/List';
+import List, { ListItem, ListItemText, ListItemSecondaryAction } from 'material-ui/List';
 import Checkbox from 'material-ui/Checkbox';
 
 export default function SecondaryActionCheckboxListItem() {
   return (
     <div style={{ backgroundColor: '#fff', width: 300 }}>
-      <ListItem button>
-        <ListItemText primary="Primary" />
-        <ListItemSecondaryAction>
-          <Checkbox />
-        </ListItemSecondaryAction>
-      </ListItem>
-      <ListItem button dense>
-        <ListItemText primary="Primary" />
-        <ListItemSecondaryAction>
-          <Checkbox />
-        </ListItemSecondaryAction>
-      </ListItem>
+      <List>
+        <ListItem button>
+          <ListItemText primary="Primary" />
+          <ListItemSecondaryAction>
+            <Checkbox />
+          </ListItemSecondaryAction>
+        </ListItem>
+        <ListItem button dense>
+          <ListItemText primary="Primary" />
+          <ListItemSecondaryAction>
+            <Checkbox />
+          </ListItemSecondaryAction>
+        </ListItem>
+      </List>
     </div>
   );
 }


### PR DESCRIPTION
I have fixed a lot of errors 🎉 :
-  [Dividers]:
Error: Element “hr” not allowed as child of element “ul” in this context.
Reason: hr is used as a direct chid of ul (I am not 100% sure if this is in component source or demo/docs only)
- [Lists]:
Error: Bad value “button” for attribute “role” on element “li”
Reason: May be demo error only.

It's tricky to get this right. it's related to #9867