### PR TITLE
[ButtonBase] Avoid race condition with react-router

### DIFF
--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -89,6 +89,10 @@ class ButtonBase extends React.Component {
     }
   };
 
+  onRippleRef = node => {
+    this.ripple = node;
+  };
+
   ripple = null;
   keyDown = false; // Used to help track keyboard activation keyDown
   button = null;
@@ -262,12 +266,7 @@ class ButtonBase extends React.Component {
       >
         {children}
         {!disableRipple && !disabled ? (
-          <TouchRipple
-            innerRef={node => {
-              this.ripple = node;
-            }}
-            center={centerRipple}
-          />
+          <TouchRipple innerRef={this.onRippleRef} center={centerRipple} />
         ) : null}
       </ComponentProp>
     );


### PR DESCRIPTION
Closes #10047

It should help with performance too. This section of the React documentation is relevant to this change:
> If the ref callback is defined as an inline function, it will get called twice during updates, first with null and then again with the DOM element. This is because a new instance of the function is created with each render, so React needs to clear the old ref and set up the new one. You can avoid this by defining the ref callback as a bound method on the class, but note that it shouldn’t matter in most cases.

https://reactjs.org/docs/refs-and-the-dom.html#caveats