### PR TITLE
[docs] Add react-select example

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
@@ -46,13 +46,11 @@ const suggestions = [
 ];
 
 function renderInput(inputProps) {
-  const { classes, autoFocus, value, ref, ...other } = inputProps;
+  const { classes, ref, ...other } = inputProps;
 
   return (
     <TextField
-      autoFocus={autoFocus}
-      className={classes.textField}
-      value={value}
+      fullWidth
       inputRef={ref}
       InputProps={{
         classes: {
@@ -125,6 +123,7 @@ const styles = theme => ({
     flexGrow: 1,
     position: 'relative',
     height: 200,
+    width: 200,
   },
   suggestionsContainerOpen: {
     position: 'absolute',
@@ -140,9 +139,6 @@ const styles = theme => ({
     margin: 0,
     padding: 0,
     listStyleType: 'none',
-  },
-  textField: {
-    width: '100%',
   },
 });
 
@@ -189,7 +185,6 @@ class IntegrationAutosuggest extends React.Component {
         getSuggestionValue={getSuggestionValue}
         renderSuggestion={renderSuggestion}
         inputProps={{
-          autoFocus: true,
           classes,
           placeholder: 'Search a country (start with a)',
           value: this.state.value,

--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Downshift from 'downshift';
+import { withStyles } from 'material-ui/styles';
 import TextField from 'material-ui/TextField';
 import Paper from 'material-ui/Paper';
 import { MenuItem } from 'material-ui/Menu';
-import { withStyles } from 'material-ui/styles';
+import Downshift from 'downshift';
 
 const suggestions = [
   { label: 'Afghanistan' },
@@ -44,26 +44,24 @@ const suggestions = [
 ];
 
 function renderInput(inputProps) {
-  const { classes, autoFocus, value, ref, ...other } = inputProps;
+  const { InputProps, classes, ref, ...other } = inputProps;
 
   return (
     <TextField
-      autoFocus={autoFocus}
-      className={classes.textField}
-      value={value}
+      {...other}
       inputRef={ref}
       InputProps={{
         classes: {
           input: classes.input,
         },
-        ...other,
+        ...InputProps,
       }}
     />
   );
 }
 
 function renderSuggestion(params) {
-  const { suggestion, index, itemProps, theme, highlightedIndex, selectedItem } = params;
+  const { suggestion, index, itemProps, highlightedIndex, selectedItem } = params;
   const isHighlighted = highlightedIndex === index;
   const isSelected = selectedItem === suggestion.label;
 
@@ -74,23 +72,11 @@ function renderSuggestion(params) {
       selected={isHighlighted}
       component="div"
       style={{
-        fontWeight: isSelected
-          ? theme.typography.fontWeightMedium
-          : theme.typography.fontWeightRegular,
+        fontWeight: isSelected ? 500 : 400,
       }}
     >
       {suggestion.label}
     </MenuItem>
-  );
-}
-
-function renderSuggestionsContainer(options) {
-  const { containerProps, children } = options;
-
-  return (
-    <Paper {...containerProps} square>
-      {children}
-    </Paper>
   );
 }
 
@@ -114,56 +100,46 @@ const styles = {
   container: {
     flexGrow: 1,
     height: 200,
-  },
-  textField: {
-    width: '100%',
+    width: 200,
   },
 };
 
 function IntegrationAutosuggest(props) {
-  const { classes, theme } = props;
+  const { classes } = props;
 
   return (
-    <Downshift
-      render={({
-        getInputProps,
-        getItemProps,
-        isOpen,
-        inputValue,
-        selectedItem,
-        highlightedIndex,
-      }) => (
+    <Downshift>
+      {({ getInputProps, getItemProps, isOpen, inputValue, selectedItem, highlightedIndex }) => (
         <div className={classes.container}>
-          {renderInput(
-            getInputProps({
-              classes,
+          {renderInput({
+            fullWidth: true,
+            classes,
+            InputProps: getInputProps({
               placeholder: 'Search a country (start with a)',
               id: 'integration-downshift',
             }),
-          )}
-          {isOpen
-            ? renderSuggestionsContainer({
-                children: getSuggestions(inputValue).map((suggestion, index) =>
-                  renderSuggestion({
-                    suggestion,
-                    index,
-                    theme,
-                    itemProps: getItemProps({ item: suggestion.label }),
-                    highlightedIndex,
-                    selectedItem,
-                  }),
-                ),
-              })
-            : null}
+          })}
+          {isOpen ? (
+            <Paper square>
+              {getSuggestions(inputValue).map((suggestion, index) =>
+                renderSuggestion({
+                  suggestion,
+                  index,
+                  itemProps: getItemProps({ item: suggestion.label }),
+                  highlightedIndex,
+                  selectedItem,
+                }),
+              )}
+            </Paper>
+          ) : null}
         </div>
       )}
-    />
+    </Downshift>
   );
 }
 
 IntegrationAutosuggest.propTypes = {
   classes: PropTypes.object.isRequired,
-  theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles, { withTheme: true })(IntegrationAutosuggest);
+export default withStyles(styles)(IntegrationAutosuggest);

--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
@@ -1,0 +1,291 @@
+/* eslint-disable react/prop-types */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import Typography from 'material-ui/Typography';
+import Input from 'material-ui/Input';
+import { MenuItem } from 'material-ui/Menu';
+import ArrowDropDownIcon from 'material-ui-icons/ArrowDropDown';
+import ArrowDropUpIcon from 'material-ui-icons/ArrowDropUp';
+import ClearIcon from 'material-ui-icons/Clear';
+import Chip from 'material-ui/Chip';
+import Select from 'react-select';
+import 'react-select/dist/react-select.css';
+
+const suggestions = [
+  { label: 'Afghanistan' },
+  { label: 'Aland Islands' },
+  { label: 'Albania' },
+  { label: 'Algeria' },
+  { label: 'American Samoa' },
+  { label: 'Andorra' },
+  { label: 'Angola' },
+  { label: 'Anguilla' },
+  { label: 'Antarctica' },
+  { label: 'Antigua and Barbuda' },
+  { label: 'Argentina' },
+  { label: 'Armenia' },
+  { label: 'Aruba' },
+  { label: 'Australia' },
+  { label: 'Austria' },
+  { label: 'Azerbaijan' },
+  { label: 'Bahamas' },
+  { label: 'Bahrain' },
+  { label: 'Bangladesh' },
+  { label: 'Barbados' },
+  { label: 'Belarus' },
+  { label: 'Belgium' },
+  { label: 'Belize' },
+  { label: 'Benin' },
+  { label: 'Bermuda' },
+  { label: 'Bhutan' },
+  { label: 'Bolivia, Plurinational State of' },
+  { label: 'Bonaire, Sint Eustatius and Saba' },
+  { label: 'Bosnia and Herzegovina' },
+  { label: 'Botswana' },
+  { label: 'Bouvet Island' },
+  { label: 'Brazil' },
+  { label: 'British Indian Ocean Territory' },
+  { label: 'Brunei Darussalam' },
+].map(suggestion => ({
+  value: suggestion.label,
+  label: suggestion.label,
+}));
+
+class Option extends React.Component {
+  handleClick = event => {
+    this.props.onSelect(this.props.option, event);
+  };
+
+  render() {
+    const { children, isFocused, isSelected, onFocus } = this.props;
+
+    return (
+      <MenuItem
+        onFocus={onFocus}
+        selected={isFocused}
+        onClick={this.handleClick}
+        component="div"
+        style={{
+          fontWeight: isSelected ? 500 : 400,
+        }}
+      >
+        {children}
+      </MenuItem>
+    );
+  }
+}
+
+function SelectWrapped(props) {
+  const { classes, ...other } = props;
+
+  return (
+    <Select
+      optionComponent={Option}
+      noResultsText={<Typography>{'No results found'}</Typography>}
+      arrowRenderer={arrowProps => {
+        return arrowProps.isOpen ? <ArrowDropUpIcon /> : <ArrowDropDownIcon />;
+      }}
+      clearRenderer={() => <ClearIcon />}
+      valueComponent={valueProps => {
+        const { value, children, onRemove } = valueProps;
+
+        if (onRemove) {
+          return (
+            <Chip
+              tabIndex={-1}
+              label={children}
+              className={classes.chip}
+              onDelete={event => {
+                event.preventDefault();
+                event.stopPropagation();
+                onRemove(value);
+              }}
+            />
+          );
+        }
+
+        return <div className="Select-value">{children}</div>;
+      }}
+      {...other}
+    />
+  );
+}
+
+const ITEM_HEIGHT = 48;
+
+const styles = theme => ({
+  root: {
+    flexGrow: 1,
+    height: 200,
+    width: 200,
+  },
+  chip: {
+    margin: theme.spacing.unit / 4,
+  },
+  // We had to use a lot of global selectors in order to style react-select.
+  // We are waiting on https://github.com/JedWatson/react-select/issues/1679
+  // to provide a better implementation.
+  // Also, we had to reset the default style injected by the library.
+  '@global': {
+    '.Select-control': {
+      display: 'flex',
+      alignItems: 'center',
+      border: 0,
+      height: 'auto',
+      background: 'transparent',
+      '&:hover': {
+        boxShadow: 'none',
+      },
+    },
+    '.Select-multi-value-wrapper': {
+      flexGrow: 1,
+      display: 'flex',
+      flexWrap: 'wrap',
+    },
+    '.Select--multi .Select-input': {
+      margin: 0,
+    },
+    '.Select.has-value.is-clearable.Select--single > .Select-control .Select-value': {
+      padding: 0,
+    },
+    '.Select-noresults': {
+      padding: theme.spacing.unit * 2,
+    },
+    '.Select-input': {
+      display: 'inline-flex !important',
+      padding: 0,
+      height: 'auto',
+    },
+    '.Select-input input': {
+      background: 'transparent',
+      border: 0,
+      padding: 0,
+      cursor: 'default',
+      display: 'inline-block',
+      fontFamily: 'inherit',
+      fontSize: 'inherit',
+      margin: 0,
+      outline: 0,
+    },
+    '.Select-placeholder, .Select--single .Select-value': {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      display: 'flex',
+      alignItems: 'center',
+      fontFamily: theme.typography.fontFamily,
+      fontSize: theme.typography.pxToRem(16),
+      padding: 0,
+    },
+    '.Select-placeholder': {
+      opacity: 0.42,
+      color: theme.palette.common.black,
+    },
+    '.Select-menu-outer': {
+      backgroundColor: theme.palette.background.paper,
+      boxShadow: theme.shadows[2],
+      position: 'absolute',
+      left: 0,
+      top: `calc(100% + ${theme.spacing.unit}px)`,
+      width: '100%',
+      zIndex: 2,
+      maxHeight: ITEM_HEIGHT * 4.5,
+    },
+    '.Select.is-focused:not(.is-open) > .Select-control': {
+      boxShadow: 'none',
+    },
+    '.Select-menu': {
+      maxHeight: ITEM_HEIGHT * 4.5,
+      overflowY: 'auto',
+    },
+    '.Select-menu div': {
+      boxSizing: 'content-box',
+    },
+    '.Select-arrow-zone, .Select-clear-zone': {
+      color: theme.palette.action.active,
+      cursor: 'pointer',
+      height: 21,
+      width: 21,
+      zIndex: 1,
+    },
+    // Only for screen readers. We can't use display none.
+    '.Select-aria-only': {
+      position: 'absolute',
+      overflow: 'hidden',
+      clip: 'rect(0 0 0 0)',
+      height: 1,
+      width: 1,
+      margin: -1,
+    },
+  },
+});
+
+class IntegrationReactSelect extends React.Component {
+  state = {
+    single: null,
+    multi: null,
+  };
+
+  handleChangeSingle = single => {
+    this.setState({
+      single,
+    });
+  };
+
+  handleChangeMulti = multi => {
+    this.setState({
+      multi,
+    });
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { single, multi } = this.state;
+
+    return (
+      <div className={classes.root}>
+        <Input
+          fullWidth
+          inputComponent={SelectWrapped}
+          inputProps={{
+            classes,
+            value: single,
+            onChange: this.handleChangeSingle,
+            placeholder: 'Select single-value…',
+            instanceId: 'react-select-single',
+            id: 'react-select-single',
+            name: 'react-select-single',
+            simpleValue: true,
+            options: suggestions,
+          }}
+        />
+        <Input
+          fullWidth
+          inputComponent={SelectWrapped}
+          inputProps={{
+            classes,
+            value: multi,
+            multi: true,
+            onChange: this.handleChangeMulti,
+            placeholder: 'Select multi-value…',
+            instanceId: 'react-select-chip',
+            id: 'react-select-chip',
+            name: 'react-select-chip',
+            simpleValue: true,
+            options: suggestions,
+          }}
+        />
+      </div>
+    );
+  }
+}
+
+IntegrationReactSelect.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(IntegrationReactSelect);

--- a/docs/src/pages/demos/autocomplete/autocomplete.md
+++ b/docs/src/pages/demos/autocomplete/autocomplete.md
@@ -5,16 +5,24 @@ components: TextField, Paper, MenuItem
 # Autocomplete
 
 The autocomplete is a normal text input enhanced by a panel of suggested options.
-
-## react-autosuggest
-
-In the following example, we demonstrate how to use [react-autosuggest](https://github.com/moroshko/react-autosuggest).
-You should also install [autosuggest-highlight](https://www.npmjs.com/package/autosuggest-highlight).
-
-{{"demo": "pages/demos/autocomplete/IntegrationAutosuggest.js"}}
+Material-UI doesn't provide any high-level API for solving this problem.
+We encourage people relying on the solutions the React community has built.
 
 ## downshift
 
 In the following example, we demonstrate how to use [downshift](https://github.com/paypal/downshift).
 
 {{"demo": "pages/demos/autocomplete/IntegrationDownshift.js"}}
+
+## react-autosuggest
+
+In the following example, we demonstrate how to use [react-autosuggest](https://github.com/moroshko/react-autosuggest).
+It's also using [autosuggest-highlight](https://www.npmjs.com/package/autosuggest-highlight) for the highlighting logic.
+
+{{"demo": "pages/demos/autocomplete/IntegrationAutosuggest.js"}}
+
+## react-select
+
+In the following example, we demonstrate how to use [react-select](https://github.com/JedWatson/react-select).
+
+{{"demo": "pages/demos/autocomplete/IntegrationReactSelect.js"}}

--- a/docs/src/pages/demos/selects/MultipleSelect.js
+++ b/docs/src/pages/demos/selects/MultipleSelect.js
@@ -7,6 +7,7 @@ import { FormControl } from 'material-ui/Form';
 import { ListItemText } from 'material-ui/List';
 import Select from 'material-ui/Select';
 import Checkbox from 'material-ui/Checkbox';
+import Chip from 'material-ui/Chip';
 
 const styles = theme => ({
   container: {
@@ -17,6 +18,13 @@ const styles = theme => ({
     margin: theme.spacing.unit,
     minWidth: 120,
     maxWidth: 300,
+  },
+  chips: {
+    display: 'flex',
+    flexWrap: 'wrap',
+  },
+  chip: {
+    margin: theme.spacing.unit / 4,
   },
 });
 
@@ -44,28 +52,13 @@ const names = [
   'Kelly Snyder',
 ];
 
-const tags = [
-  'material-ui',
-  'google-material',
-  'react-components',
-  'react',
-  'javascript',
-  'material-design',
-  'material',
-];
-
 class MultipleSelect extends React.Component {
   state = {
     name: [],
-    tag: new Set(), // immutableJS would be better in a real app
   };
 
-  handleNameChange = event => {
+  handleChange = event => {
     this.setState({ name: event.target.value });
-  };
-
-  handleTagChange = event => {
-    this.setState({ tag: new Set(event.target.value) });
   };
 
   render() {
@@ -74,12 +67,12 @@ class MultipleSelect extends React.Component {
     return (
       <div className={classes.container}>
         <FormControl className={classes.formControl}>
-          <InputLabel htmlFor="name-multiple">Name</InputLabel>
+          <InputLabel htmlFor="select-multiple">Name</InputLabel>
           <Select
             multiple
             value={this.state.name}
-            onChange={this.handleNameChange}
-            input={<Input id="name-multiple" />}
+            onChange={this.handleChange}
+            input={<Input id="select-multiple" />}
             MenuProps={MenuProps}
           >
             {names.map(name => (
@@ -99,19 +92,49 @@ class MultipleSelect extends React.Component {
           </Select>
         </FormControl>
         <FormControl className={classes.formControl}>
-          <InputLabel htmlFor="tag-multiple">Tag</InputLabel>
+          <InputLabel htmlFor="select-multiple-checkbox">Tag</InputLabel>
           <Select
             multiple
-            value={[...this.state.tag]}
-            onChange={this.handleTagChange}
-            input={<Input id="tag-multiple" />}
+            value={this.state.name}
+            onChange={this.handleChange}
+            input={<Input id="select-multiple-checkbox" />}
             renderValue={selected => selected.join(', ')}
             MenuProps={MenuProps}
           >
-            {tags.map(tag => (
-              <MenuItem key={tag} value={tag}>
-                <Checkbox checked={this.state.tag.has(tag)} />
-                <ListItemText primary={tag} />
+            {names.map(name => (
+              <MenuItem key={name} value={name}>
+                <Checkbox checked={this.state.name === name} />
+                <ListItemText primary={name} />
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl className={classes.formControl}>
+          <InputLabel htmlFor="select-multiple-chip">Chip</InputLabel>
+          <Select
+            multiple
+            value={this.state.name}
+            onChange={this.handleChange}
+            input={<Input id="select-multiple-chip" />}
+            renderValue={selected => (
+              <div className={classes.chips}>
+                {selected.map(value => <Chip key={value} label={value} className={classes.chip} />)}
+              </div>
+            )}
+            MenuProps={MenuProps}
+          >
+            {names.map(name => (
+              <MenuItem
+                key={name}
+                value={name}
+                style={{
+                  fontWeight:
+                    this.state.name.indexOf(name) === -1
+                      ? theme.typography.fontWeightRegular
+                      : theme.typography.fontWeightMedium,
+                }}
+              >
+                {name}
               </MenuItem>
             ))}
           </Select>

--- a/docs/src/pages/demos/text-fields/FormattedInputs.js
+++ b/docs/src/pages/demos/text-fields/FormattedInputs.js
@@ -17,39 +17,46 @@ const styles = theme => ({
   },
 });
 
-class TextMaskCustom extends React.Component {
-  render() {
-    return (
-      <MaskedInput
-        {...this.props}
-        mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
-        placeholderChar={'\u2000'}
-        showMask
-      />
-    );
-  }
+function TextMaskCustom(props) {
+  const { inputRef, ...other } = props;
+
+  return (
+    <MaskedInput
+      {...other}
+      ref={inputRef}
+      mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+      placeholderChar={'\u2000'}
+      showMask
+    />
+  );
 }
 
-class NumberFormatCustom extends React.Component {
-  render() {
-    return (
-      <NumberFormat
-        {...this.props}
-        onValueChange={values => {
-          this.props.onChange({
-            target: {
-              value: values.value,
-            },
-          });
-        }}
-        thousandSeparator
-        prefix="$"
-      />
-    );
-  }
+TextMaskCustom.propTypes = {
+  inputRef: PropTypes.func.isRequired,
+};
+
+function NumberFormatCustom(props) {
+  const { inputRef, onChange, ...other } = props;
+
+  return (
+    <NumberFormat
+      {...other}
+      ref={inputRef}
+      onValueChange={values => {
+        onChange({
+          target: {
+            value: values.value,
+          },
+        });
+      }}
+      thousandSeparator
+      prefix="$"
+    />
+  );
 }
 
 NumberFormatCustom.propTypes = {
+  inputRef: PropTypes.func.isRequired,
   onChange: PropTypes.func.isRequired,
 };
 

--- a/package.json
+++ b/package.json
@@ -174,6 +174,7 @@
     "react-inspector": "^2.2.2",
     "react-number-format": "^3.0.2",
     "react-redux": "^5.0.6",
+    "react-select": "^1.2.1",
     "react-swipeable-views": "^0.12.10",
     "react-test-renderer": "^16.1.1",
     "react-text-mask": "^5.0.2",

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -57,7 +57,7 @@ This property accepts the following keys:
 - `input`
 - `inputDense`
 - `inputDisabled`
-- `inputSingleline`
+- `inputType`
 - `inputMultiline`
 - `inputSearch`
 

--- a/pages/demos/autocomplete.js
+++ b/pages/demos/autocomplete.js
@@ -8,11 +8,11 @@ function Page() {
     <MarkdownDocs
       markdown={markdown}
       demos={{
-        'pages/demos/autocomplete/IntegrationAutosuggest.js': {
-          js: require('docs/src/pages/demos/autocomplete/IntegrationAutosuggest').default,
+        'pages/demos/autocomplete/IntegrationReactSelect.js': {
+          js: require('docs/src/pages/demos/autocomplete/IntegrationReactSelect').default,
           raw: preval`
 module.exports = require('fs')
-  .readFileSync(require.resolve('docs/src/pages/demos/autocomplete/IntegrationAutosuggest'), 'utf8')
+  .readFileSync(require.resolve('docs/src/pages/demos/autocomplete/IntegrationReactSelect'), 'utf8')
 `,
         },
         'pages/demos/autocomplete/IntegrationDownshift.js': {
@@ -20,6 +20,13 @@ module.exports = require('fs')
           raw: preval`
 module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/autocomplete/IntegrationDownshift'), 'utf8')
+`,
+        },
+        'pages/demos/autocomplete/IntegrationAutosuggest.js': {
+          js: require('docs/src/pages/demos/autocomplete/IntegrationAutosuggest').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/autocomplete/IntegrationAutosuggest'), 'utf8')
 `,
         },
       }}

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { isMuiComponent } from '../utils/reactHelpers';
 import Textarea from './Textarea';
 
 // Supports determination of isControlled().
@@ -187,8 +186,9 @@ export const styles = theme => {
     inputDisabled: {
       opacity: 1, // Reset iOS opacity
     },
-    inputSingleline: {
-      height: '1.1875em', // Reset (19px)
+    inputType: {
+      // type="date" or type="time", etc. have specific styles we need to reset.
+      height: '1.1875em', // Reset (19px), match the native input line-height
     },
     inputMultiline: {
       resize: 'none',
@@ -314,6 +314,7 @@ class Input extends React.Component {
 
   handleRefInput = node => {
     this.input = node;
+
     if (this.props.inputRef) {
       this.props.inputRef(node);
     } else if (this.props.inputProps && this.props.inputProps.ref) {
@@ -400,7 +401,7 @@ class Input extends React.Component {
       classes.input,
       {
         [classes.inputDisabled]: disabled,
-        [classes.inputSingleline]: !multiline,
+        [classes.inputType]: type !== 'text',
         [classes.inputMultiline]: multiline,
         [classes.inputSearch]: type === 'search',
         [classes.inputDense]: margin === 'dense',
@@ -418,14 +419,13 @@ class Input extends React.Component {
 
     if (inputComponent) {
       InputComponent = inputComponent;
-
-      if (isMuiComponent(InputComponent, ['SelectInput'])) {
-        inputProps = {
-          selectRef: this.handleRefInput,
-          ...inputProps,
-          ref: null,
-        };
-      }
+      inputProps = {
+        // Rename ref to inputRef as we don't know the
+        // provided `inputComponent` structure.
+        inputRef: this.handleRefInput,
+        ...inputProps,
+        ref: null,
+      };
     } else if (multiline) {
       if (rows && !rowsMax) {
         InputComponent = 'textarea';

--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -42,16 +42,19 @@ export const styles = theme => ({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
+    minHeight: '1.1875em', // Reset (19px), match the native input line-height
     lineHeight: '1.1875em', // Reset (19px), match the native input line-height
   },
   disabled: {
     cursor: 'default',
   },
   icon: {
+    // We use a position absolute over a flexbox in order to forward the pointer events
+    // to the input.
     position: 'absolute',
     right: 0,
-    top: 4,
-    color: theme.palette.text.secondary,
+    top: 'calc(50% - 12px)', // Center vertically
+    color: theme.palette.action.active,
     'pointer-events': 'none', // Don't block pointer events on the select under the icon.
   },
 });

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -5,6 +5,9 @@ import { MenuProps } from '../Menu';
 export interface SelectInputProps extends StandardProps<{}, SelectInputClassKey> {
   autoWidth: boolean;
   disabled?: boolean;
+  inputRef?: (
+    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps['value'] },
+  ) => void;
   MenuProps?: Partial<MenuProps>;
   multiple: boolean;
   name?: string;
@@ -17,9 +20,6 @@ export interface SelectInputProps extends StandardProps<{}, SelectInputClassKey>
   open?: boolean;
   readOnly?: boolean;
   renderValue?: (value: SelectInputProps['value']) => React.ReactNode;
-  selectRef?: (
-    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps['value'] },
-  ) => void;
   value?: string | number | Array<string | number>;
 }
 

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -115,11 +115,11 @@ class SelectInput extends React.Component {
   };
 
   handleSelectRef = node => {
-    if (!this.props.selectRef) {
+    if (!this.props.inputRef) {
       return;
     }
 
-    this.props.selectRef({
+    this.props.inputRef({
       node,
       // By pass the native input as we expose a rich object (array).
       value: this.props.value,
@@ -134,6 +134,7 @@ class SelectInput extends React.Component {
       className: classNameProp,
       disabled,
       displayEmpty,
+      inputRef,
       MenuProps = {},
       multiple,
       name,
@@ -146,7 +147,6 @@ class SelectInput extends React.Component {
       open,
       readOnly,
       renderValue,
-      selectRef,
       value,
       ...other
     } = this.props;
@@ -183,7 +183,7 @@ class SelectInput extends React.Component {
             onFocus={onFocus}
             value={value}
             readOnly={readOnly}
-            ref={selectRef}
+            ref={inputRef}
             {...other}
           >
             {children}
@@ -340,6 +340,10 @@ SelectInput.propTypes = {
    */
   displayEmpty: PropTypes.bool,
   /**
+   * Use that property to pass a ref callback to the native select element.
+   */
+  inputRef: PropTypes.func,
+  /**
    * Properties applied to the `Menu` element.
    */
   MenuProps: PropTypes.object,
@@ -400,10 +404,6 @@ SelectInput.propTypes = {
    */
   renderValue: PropTypes.func,
   /**
-   * Use that property to pass a ref callback to the native select element.
-   */
-  selectRef: PropTypes.func,
-  /**
    * The value of the component, required for a controlled component.
    */
   value: PropTypes.oneOfType([
@@ -412,7 +412,5 @@ SelectInput.propTypes = {
     PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
   ]),
 };
-
-SelectInput.muiName = 'SelectInput';
 
 export default SelectInput;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,15 +1991,9 @@ clap@^1.0.9:
   dependencies:
     chalk "^1.1.3"
 
-classnames@^2.2.5:
+classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-
-clean-css@^4.1.9:
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.1.9.tgz#35cee8ae7687a49b98034f70de00c4edd3826301"
-  dependencies:
-    source-map "0.5.x"
 
 cli-boxes@^1.0.0:
   version "1.0.0"
@@ -7804,6 +7798,12 @@ react-hot-loader@3.1.1:
     redbox-react "^1.3.6"
     source-map "^0.6.1"
 
+react-input-autosize@^2.1.2:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-inspector@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-2.2.2.tgz#c04f5248fa92ab6c23e37960e725fb7f48c34d05"
@@ -7867,6 +7867,14 @@ react-scrollbar-size@^2.0.2:
     babel-runtime "^6.23.0"
     prop-types "^15.5.10"
     react-event-listener "^0.5.0"
+
+react-select@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-1.2.1.tgz#a2fe58a569eb14dcaa6543816260b97e538120d1"
+  dependencies:
+    classnames "^2.2.4"
+    prop-types "^15.5.8"
+    react-input-autosize "^2.1.2"
 
 react-swipeable-views-core@^0.12.11:
   version "0.12.11"
@@ -8859,10 +8867,6 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
-  version "0.5.7"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
-
 source-map@0.6.1, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
@@ -8872,6 +8876,10 @@ source-map@^0.4.4:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   dependencies:
     amdefine ">=0.0.4"
+
+source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3, source-map@~0.5.6:
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
 sourcemapped-stacktrace@^1.1.6:
   version "1.1.8"


### PR DESCRIPTION
- Promote Downshift to the first position. As discussed with @rosskevin, we believe it's the simplest example and the more future proof.
- Add a react-select demo. This one was challenging to get right! I had to dig into react-select code base a lot. It's not pretty. I have put it at the last position. Closes #9546 
![giphy](https://user-images.githubusercontent.com/3165635/35486921-8e946dac-0475-11e8-8aab-3cba3e63e5c5.gif)
- Improve the select component to better support custom value renderer. For instance, you can easily render a Chip:
![capture d ecran 2018-01-28 a 21 55 12](https://user-images.githubusercontent.com/3165635/35486943-02213ba6-0476-11e8-88bd-8e8e69bafe87.png)
- Simplify downshift and react-autosuggest example.