### PR TITLE
[ButtonBase] Add buttonRef property

### DIFF
--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -14,6 +14,7 @@ It contains a load of style reset and some focus/ripple logic.
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| buttonRef | func |  | Use that property to pass a ref callback to the native button component. |
 | centerRipple | bool | false | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | children | node |  | The content of the component. |
 | classes | object |  | Useful to extend the style applied to components. |

--- a/src/ButtonBase/ButtonBase.d.ts
+++ b/src/ButtonBase/ButtonBase.d.ts
@@ -6,6 +6,7 @@ export interface ButtonBaseProps
       React.AnchorHTMLAttributes<HTMLElement> & React.ButtonHTMLAttributes<HTMLElement>,
       ButtonBaseClassKey
     > {
+  buttonRef?: React.Ref<any>;
   centerRipple?: boolean;
   component?: React.ReactType<ButtonBaseProps>;
   disableRipple?: boolean;

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -197,6 +197,7 @@ class ButtonBase extends React.Component {
 
   render() {
     const {
+      buttonRef,
       centerRipple,
       children,
       classes,
@@ -264,6 +265,7 @@ class ButtonBase extends React.Component {
         onTouchStart={this.handleTouchStart}
         tabIndex={disabled ? -1 : tabIndex}
         className={className}
+        ref={buttonRef}
         {...buttonProps}
         {...other}
       >
@@ -277,6 +279,10 @@ class ButtonBase extends React.Component {
 }
 
 ButtonBase.propTypes = {
+  /**
+   * Use that property to pass a ref callback to the native button component.
+   */
+  buttonRef: PropTypes.func,
   /**
    * If `true`, the ripples will be centered.
    * They won't start at the cursor interaction position.


### PR DESCRIPTION
This pull-request follows #10025. We use the same solution for the button that we use for the input component:
https://github.com/mui-org/material-ui/blob/b706b42b70c606ef1ac3170198e7038c6ce67416/src/Input/Input.js#L531-L534

Closes #10081

