### PR TITLE
[AppBar] Add support for `position="sticky"`

### DIFF
--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -15,7 +15,7 @@ filename: /src/AppBar/AppBar.js
 | <span style="color: #31a148">children *</span> | node |  | The content of the component. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
-| position | enum:&nbsp;'static'&nbsp;&#124;<br>&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'<br> | 'fixed' | The positioning type. |
+| position | enum:&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'&nbsp;&#124;<br>&nbsp;'sticky'&#124;<br>&nbsp;'static'&nbsp; | 'fixed' | The positioning type. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 
@@ -26,6 +26,7 @@ This property accepts the following keys:
 - `root`
 - `positionFixed`
 - `positionAbsolute`
+- `positionSticky`
 - `positionStatic`
 - `colorDefault`
 - `colorPrimary`

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -15,7 +15,7 @@ filename: /src/AppBar/AppBar.js
 | <span style="color: #31a148">children *</span> | node |  | The content of the component. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
-| position | enum:&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'&nbsp;&#124;<br>&nbsp;'sticky'&nbsp;&#124;<br>&nbsp;'static'<br> | 'fixed' | The positioning type. |
+| position | enum:&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'&nbsp;&#124;<br>&nbsp;'sticky'&nbsp;&#124;<br>&nbsp;'static'<br> | 'fixed' | The positioning type. The behavior of the different options is described [here](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning). Note: `sticky` is not universally supported and will fall back to `static` when unavailable. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -15,7 +15,7 @@ filename: /src/AppBar/AppBar.js
 | <span style="color: #31a148">children *</span> | node |  | The content of the component. |
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br> | 'primary' | The color of the component. It's using the theme palette when that makes sense. |
-| position | enum:&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'&nbsp;&#124;<br>&nbsp;'sticky'&#124;<br>&nbsp;'static'&nbsp; | 'fixed' | The positioning type. |
+| position | enum:&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'&nbsp;&#124;<br>&nbsp;'sticky'&nbsp;&#124;<br>&nbsp;'static'<br> | 'fixed' | The positioning type. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/AppBar/AppBar.d.ts
+++ b/src/AppBar/AppBar.d.ts
@@ -3,13 +3,14 @@ import { PaperProps, PaperClassKey } from '../Paper/Paper';
 
 export interface AppBarProps extends StandardProps<PaperProps, AppBarClassKey> {
   color?: PropTypes.Color;
-  position?: 'static' | 'fixed' | 'absolute';
+  position?: 'fixed' | 'absolute' | 'sticky' | 'static';
 }
 
 export type AppBarClassKey =
   | PaperClassKey
   | 'positionFixed'
   | 'positionAbsolute'
+  | 'positionSticky'
   | 'positionStatic'
   | 'colorDefault'
   | 'colorPrimary'

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -96,7 +96,9 @@ AppBar.propTypes = {
    */
   color: PropTypes.oneOf(['inherit', 'primary', 'secondary', 'default']),
   /**
-   * The positioning type.
+   * The positioning type. The behavior of the different options is described
+   * [here](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning).
+   * Note: `sticky` is not universally supported and will fall back to `static` when unavailable.
    */
   position: PropTypes.oneOf(['fixed', 'absolute', 'sticky', 'static']),
 };

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -34,7 +34,6 @@ export const styles = theme => {
     },
     positionSticky: {
       position: 'sticky',
-      flexShrink: 0,
       top: 0,
       left: 'auto',
       right: 0,

--- a/src/AppBar/AppBar.js
+++ b/src/AppBar/AppBar.js
@@ -32,6 +32,13 @@ export const styles = theme => {
       left: 'auto',
       right: 0,
     },
+    positionSticky: {
+      position: 'sticky',
+      flexShrink: 0,
+      top: 0,
+      left: 'auto',
+      right: 0,
+    },
     positionStatic: {
       position: 'static',
       flexShrink: 0,
@@ -91,7 +98,7 @@ AppBar.propTypes = {
   /**
    * The positioning type.
    */
-  position: PropTypes.oneOf(['static', 'fixed', 'absolute']),
+  position: PropTypes.oneOf(['fixed', 'absolute', 'sticky', 'static']),
 };
 
 AppBar.defaultProps = {


### PR DESCRIPTION
Resolves #10085. I added sticky in all the places I could find that reference the `AppBar` positioning and reordered them consistently. Since sticky acts like a combination of static and fixed, I figured it should have the additional CSS rules for both, but not 100% sure on that point.