### PR TITLE
[docs] Avoid anchor id conflict in Progress

### DIFF
--- a/docs/src/modules/components/Carbon.js
+++ b/docs/src/modules/components/Carbon.js
@@ -120,7 +120,7 @@ class Carbon extends React.Component {
       return;
     }
 
-    if (attempt < 3) {
+    if (attempt < 4) {
       this.timerAdblock = setTimeout(() => {
         this.checkAdblock(attempt + 1);
       }, 500);

--- a/docs/src/pages/demos/progress/progress.md
+++ b/docs/src/pages/demos/progress/progress.md
@@ -16,7 +16,7 @@ For example, a refresh operation should display either a refresh bar or an activ
 
 ## Circular
 
-### Indeterminate
+### Circular Indeterminate
 
 {{"demo": "pages/demos/progress/CircularIndeterminate.js"}}
 
@@ -24,17 +24,17 @@ For example, a refresh operation should display either a refresh bar or an activ
 
 {{"demo": "pages/demos/progress/CircularIntegration.js"}}
 
-###  Determinate
+### Circular Determinate
 
 {{"demo": "pages/demos/progress/CircularDeterminate.js"}}
 
 ## Linear
 
-### Indeterminate
+### Linear Indeterminate
 
 {{"demo": "pages/demos/progress/LinearIndeterminate.js"}}
 
-### Determinate
+### Linear Determinate
 
 {{"demo": "pages/demos/progress/LinearDeterminate.js"}}
 


### PR DESCRIPTION
Two identical titles lead to a duplicated ids. This is bad for:
- Anchor links
- W3C compliance