### PR TITLE
[API] Complete type to variant migration

### DIFF
--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -19,11 +19,9 @@ filename: /src/Button/Button.js
 | disabled | bool | false | If `true`, the button will be disabled. |
 | disableFocusRipple | bool | false | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
 | disableRipple | bool | false | If `true`, the ripple effect will be disabled. |
-| fab | bool |  | If `true`, will use floating action button styling. |
 | fullWidth | bool | false | If `true`, the button will take up the full width of its container. |
 | href | string |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | mini | bool | false | If `true`, and `fab` is `true`, will use mini floating action button styling. |
-| raised | bool |  | If `true`, the button will use raised styling. |
 | size | enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br> | 'medium' | The size of the button. `small` is equivalent to the dense button styling. |
 | variant | enum:&nbsp;'flat'&nbsp;&#124;<br>&nbsp;'raised'&nbsp;&#124;<br>&nbsp;'fab'<br> | 'flat' | The color of the component. It's using the theme palette when that makes sense. |
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -244,10 +244,6 @@ Button.propTypes = {
    */
   disableRipple: PropTypes.bool,
   /**
-   * If `true`, will use floating action button styling.
-   */
-  fab: PropTypes.bool,
-  /**
    * If `true`, the button will take up the full width of its container.
    */
   fullWidth: PropTypes.bool,
@@ -260,10 +256,6 @@ Button.propTypes = {
    * If `true`, and `fab` is `true`, will use mini floating action button styling.
    */
   mini: PropTypes.bool,
-  /**
-   * If `true`, the button will use raised styling.
-   */
-  raised: PropTypes.bool,
   /**
    * The size of the button.
    * `small` is equivalent to the dense button styling.

--- a/src/Drawer/Drawer.spec.js
+++ b/src/Drawer/Drawer.spec.js
@@ -20,7 +20,7 @@ describe('<Drawer />', () => {
     );
   });
 
-  describe('prop:  variant=temporary', () => {
+  describe('prop: variant=temporary', () => {
     it('should render a Modal', () => {
       const wrapper = shallow(
         <Drawer>
@@ -155,7 +155,7 @@ describe('<Drawer />', () => {
     });
   });
 
-  describe('prop:  variant=persistent', () => {
+  describe('prop: variant=persistent', () => {
     let wrapper;
 
     before(() => {
@@ -181,7 +181,7 @@ describe('<Drawer />', () => {
     });
   });
 
-  describe('prop:  variant=permanent', () => {
+  describe('prop: variant=permanent', () => {
     let wrapper;
 
     before(() => {

--- a/src/Progress/CircularProgress.d.ts
+++ b/src/Progress/CircularProgress.d.ts
@@ -6,10 +6,10 @@ export interface CircularProgressProps
   color?: 'primary' | 'secondary' | 'inherit';
   max?: number;
   min?: number;
-  variant?: 'determinate' | 'indeterminate';
   size?: number | string;
   thickness?: number;
   value?: number;
+  variant?: 'determinate' | 'indeterminate';
 }
 
 export type CircularProgressClassKey =

--- a/src/Progress/CircularProgress.js
+++ b/src/Progress/CircularProgress.js
@@ -80,11 +80,11 @@ function CircularProgress(props) {
     color,
     max,
     min,
-    variant,
     size,
     style,
     thickness,
     value,
+    variant,
     ...other
   } = props;
 
@@ -188,10 +188,10 @@ CircularProgress.defaultProps = {
   color: 'primary',
   max: 100,
   min: 0,
-  variant: 'indeterminate',
   size: 40,
   thickness: 3.6,
   value: 0,
+  variant: 'indeterminate',
 };
 
 export default withStyles(styles, { name: 'MuiCircularProgress', flip: false })(CircularProgress);

--- a/src/Progress/LinearProgress.d.ts
+++ b/src/Progress/LinearProgress.d.ts
@@ -4,9 +4,9 @@ import { StandardProps } from '..';
 export interface LinearProgressProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, LinearProgressClassKey> {
   color?: 'primary' | 'secondary';
-  variant?: 'determinate' | 'indeterminate' | 'buffer' | 'query';
   value?: number;
   valueBuffer?: number;
+  variant?: 'determinate' | 'indeterminate' | 'buffer' | 'query';
 }
 
 export type LinearProgressClassKey =

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -144,7 +144,7 @@ export const styles = theme => ({
  * attribute to `true` on that region until it has finished loading.
  */
 function LinearProgress(props) {
-  const { classes, className, color, variant, value, valueBuffer, ...other } = props;
+  const { classes, className, color, value, valueBuffer, variant, ...other } = props;
 
   const dashedClass = classNames(classes.dashed, {
     [classes.primaryDashed]: color === 'primary',

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -72,7 +72,7 @@ const AppBarTest = () => (
       <IconButton color="inherit" aria-label="Menu">
         <FakeIcon />
       </IconButton>
-      <Typography  variant="title" color="inherit">
+      <Typography variant="title" color="inherit">
         Title
       </Typography>
       <Button color="inherit">Login</Button>
@@ -144,11 +144,11 @@ const IconButtonTest = () => (
 const CardTest = () => (
   <Card>
     <CardContent>
-      <Typography  variant="body1">Word of the Day</Typography>
-      <Typography  variant="headline" component="h2">
+      <Typography variant="body1">Word of the Day</Typography>
+      <Typography variant="headline" component="h2">
         be-nev-o-lent
       </Typography>
-      <Typography  variant="body1">adjective</Typography>
+      <Typography variant="body1">adjective</Typography>
       <Typography component="p">
         well meaning and kindly.<br />
         {'"a benevolent smile"'}
@@ -189,7 +189,7 @@ const CardMediaTest = () => (
     </CardActions>
     <Collapse in={true} timeout="auto" unmountOnExit>
       <CardContent>
-        <Typography paragraph  variant="body2">
+        <Typography paragraph variant="body2">
           Method:
         </Typography>
         <Typography paragraph>
@@ -289,7 +289,7 @@ const DrawerTest = () => {
   return (
     <div>
       <Drawer
-         variant="persistent"
+        variant="persistent"
         open={open.left}
         onClose={event => log(event)}
         onClick={event => log(event)}
@@ -297,7 +297,7 @@ const DrawerTest = () => {
         List
       </Drawer>
       <Drawer
-         variant="temporary"
+        variant="temporary"
         anchor="top"
         open={open.top}
         onClose={event => log(event)}
@@ -310,7 +310,7 @@ const DrawerTest = () => {
       </Drawer>
       <Drawer
         anchor="bottom"
-         variant="temporary"
+        variant="temporary"
         open={open.bottom}
         onClose={event => log(event)}
         onClick={event => log(event)}
@@ -318,7 +318,7 @@ const DrawerTest = () => {
         List
       </Drawer>
       <Drawer
-         variant="persistent"
+        variant="persistent"
         anchor="right"
         open={open.right}
         onClose={event => log(event)}
@@ -412,10 +412,10 @@ const MenuTest = () => {
 
 const PaperTest = () => (
   <Paper elevation={4}>
-    <Typography  variant="headline" component="h3">
+    <Typography variant="headline" component="h3">
       This is a sheet of paper.
     </Typography>
-    <Typography  variant="body1" component="p">
+    <Typography variant="body1" component="p">
       Paper can be used to build surface or other elements for your application.
     </Typography>
   </Paper>
@@ -583,7 +583,7 @@ const StepperTest = () =>
       };
       return (
         <MobileStepper
-           variant="dots"
+          variant="dots"
           steps={6}
           position="static"
           activeStep={this.state.activeStep}

--- a/test/typescript/styling-comparison.spec.tsx
+++ b/test/typescript/styling-comparison.spec.tsx
@@ -11,13 +11,13 @@ const decorate = withStyles(({ palette, spacing }) => ({
 }));
 
 interface Props {
+  color: TypographyProps['color'];
   text: string;
   variant: TypographyProps['variant'];
-  color: TypographyProps['color'];
 }
 
 const DecoratedSFC = decorate<Props>(({ text, variant, color, classes }) => (
-  <Typography  variant={variant} color={color} classes={classes}>
+  <Typography variant={variant} color={color} classes={classes}>
     {text}
   </Typography>
 ));
@@ -27,7 +27,7 @@ const DecoratedClass = decorate(
     render() {
       const { text, variant, color, classes } = this.props;
       return (
-        <Typography  variant={variant} color={color} classes={classes}>
+        <Typography variant={variant} color={color} classes={classes}>
           {text}
         </Typography>
       );


### PR DESCRIPTION
These breaking changes aim at providing a systematic solution to the boolean vs enum naming problem.

We have documented our approach to solving the problem in #10023. Basically, we enforce the following rule:
- We use a *boolean* when the degrees of freedom required is **2**.
- We use an *enum* when the degrees of freedom required is **> 2**.

This is what motivated the button breaking change. Unfortunately `type` has its own meaning in the HTML specification. You can use it on the following elements: `<button>, <input>, <command>, <embed>, <object>, <script>, <source>, <style>, <menu>`.
We are using a more generic name to **avoid the confusion**: `variant`.

Umbrella pull-request for: #10084, #10086, #10088.

### Breaking change

```diff
<Button
- raised
+ variant="raised"

<Button
- fab
+ variant="fab"

<Typography
- type="title"
+ variant="title"

<MobileStepper
- type="dots"
+ variant="dots"

<Drawer
- type="persistent"
+ variant="persistent"

<LinearProgress
- mode="determinate"
+ variant="determinate"

<CircularProgress
- mode="determinate"
+ variant="determinate"
```