### PR TITLE
[examples] Update README for CRA with JSS

### DIFF
--- a/examples/create-react-app-with-jss/README.md
+++ b/examples/create-react-app-with-jss/README.md
@@ -5,8 +5,8 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```bash
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/v1-beta | tar -xz --strip=2 material-ui-1-beta/examples/create-react-app
-cd create-react-app
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/v1-beta | tar -xz --strip=2 material-ui-1-beta/examples/create-react-app-with-jss
+cd create-react-app-with-jss
 ```
 
 Install it and run:


### PR DESCRIPTION
README was referencing the wrong path: `create-react-app` instead of `create-react-app-with-jss`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
