### PR TITLE
[docs] Rename IntegrationAutosuggest to IntegrationDownshift

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
@@ -104,7 +104,7 @@ const styles = {
   },
 };
 
-function IntegrationAutosuggest(props) {
+function IntegrationDownshift(props) {
   const { classes } = props;
 
   return (
@@ -138,8 +138,8 @@ function IntegrationAutosuggest(props) {
   );
 }
 
-IntegrationAutosuggest.propTypes = {
+IntegrationDownshift.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(IntegrationAutosuggest);
+export default withStyles(styles)(IntegrationDownshift);


### PR DESCRIPTION
I imagine this was the result of a simple copy/paste error

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
