### PR TITLE
[TextField] Small refinement

### DIFF
--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -24,7 +24,7 @@ This context is used by the following components:
 | component | union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | 'div' | The component used for the root node. Either a string to use a DOM element or a component. |
 | disabled | bool | false | If `true`, the label, input and helper text should be displayed in a disabled state. |
 | error | bool | false | If `true`, the label should be displayed in an error state. |
-| fullWidth | bool | false | If `true`, the component, as well as its children, will take up the full width of its container. |
+| fullWidth | bool | false | If `true`, the component will take up the full width of its container. |
 | margin | enum:&nbsp;'none'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'normal'<br> | 'none' | If `dense` or `normal`, will adjust vertical spacing of this and contained components. |
 | required | bool | false | If `true`, the label will indicate that the input is required. |
 

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import { isDirty, isAdornedStart } from '../Input/Input';
+import { capitalize } from '../utils/helpers';
 import { isMuiElement } from '../utils/reactHelpers';
 
 export const styles = theme => ({
@@ -132,8 +133,7 @@ class FormControl extends React.Component {
         className={classNames(
           classes.root,
           {
-            [classes.marginNormal]: margin === 'normal',
-            [classes.marginDense]: margin === 'dense',
+            [classes[`margin${capitalize(margin)}`]]: margin !== 'none',
             [classes.fullWidth]: fullWidth,
           },
           className,
@@ -173,8 +173,7 @@ FormControl.propTypes = {
    */
   error: PropTypes.bool,
   /**
-   * If `true`, the component, as well as its children,
-   * will take up the full width of its container.
+   * If `true`, the component will take up the full width of its container.
    */
   fullWidth: PropTypes.bool,
   /**


### PR DESCRIPTION
Related to #10018.
I wanted to add a `block` property to apply `display: block` but I wasn't sure it was a good addition. So I reverted.
I start to think that we would be better of with a systematic solution. I like how Bootstrap is handling it, maybe we can try to translate it to the React world (same concern with the color and the spacing)
https://getbootstrap.com/docs/4.0/utilities/display/