### PR TITLE
[Drawer] Add PaperProps property

### DIFF
--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -19,6 +19,7 @@ filename: /src/Drawer/Drawer.js
 | ModalProps | object |  | Properties applied to the `Modal` element. |
 | onClose | func |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | open | bool | false | If `true`, the drawer is open. |
+| PaperProps | object |  | Properties applied to the `Paper` element. |
 | SlideProps | object |  | Properties applied to the `Slide` element. |
 | transitionDuration | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | { enter: duration.enteringScreen, exit: duration.leavingScreen } | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | variant | enum:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | 'temporary' | The type of drawer. |

--- a/src/Drawer/Drawer.d.ts
+++ b/src/Drawer/Drawer.d.ts
@@ -3,6 +3,7 @@ import { StandardProps } from '..';
 import { ModalProps, ModalClassKey } from '../Modal';
 import { TransitionDuration, TransitionHandlers } from '../internal/transition';
 import { SlideProps } from '../transitions/Slide';
+import { PaperProps } from '../Paper';
 import { Theme } from '../styles/createMuiTheme';
 
 export interface DrawerProps
@@ -16,6 +17,7 @@ export interface DrawerProps
   elevation?: number;
   ModalProps?: Partial<ModalProps>;
   open?: boolean;
+  PaperProps?: Partial<PaperProps>;
   SlideProps?: Partial<SlideProps>;
   theme?: Theme;
   transitionDuration?: TransitionDuration;

--- a/src/Drawer/Drawer.js
+++ b/src/Drawer/Drawer.js
@@ -108,6 +108,7 @@ class Drawer extends React.Component {
       ModalProps,
       onClose,
       open,
+      PaperProps,
       SlideProps,
       theme,
       transitionDuration,
@@ -127,6 +128,7 @@ class Drawer extends React.Component {
         className={classNames(classes.paper, classes[`paperAnchor${capitalize(anchor)}`], {
           [classes[`paperAnchorDocked${capitalize(anchor)}`]]: variant !== 'temporary',
         })}
+        {...PaperProps}
       >
         {children}
       </Paper>
@@ -213,6 +215,10 @@ Drawer.propTypes = {
    * If `true`, the drawer is open.
    */
   open: PropTypes.bool,
+  /**
+   * Properties applied to the `Paper` element.
+   */
+  PaperProps: PropTypes.object,
   /**
    * Properties applied to the `Slide` element.
    */


### PR DESCRIPTION
The issue was raised in #10092 by @kirill-konshin. The property is available on the Dialog but not on the Drawer. It's fixing the inconsistency.
https://github.com/mui-org/material-ui/blob/16975283332c02fcfb09c22bbb3cbd1903b429e4/src/Dialog/Dialog.js#L203-L206
