### PR TITLE
[Selection Controls] Change default color, add color prop

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -7,7 +7,7 @@
   {
     "name": "The size of the whole library.",
     "path": "build/index.js",
-    "limit": "96.7 KB"
+    "limit": "96.9 KB"
   },
   {
     "name": "The main bundle of the documentation",

--- a/docs/src/pages/demos/selection-controls/Checkboxes.js
+++ b/docs/src/pages/demos/selection-controls/Checkboxes.js
@@ -14,7 +14,7 @@ const styles = {
 class Checkboxes extends React.Component {
   state = {
     checkedA: true,
-    checkedB: false,
+    checkedB: true,
     checkedF: true,
     checkedG: true,
   };

--- a/docs/src/pages/demos/selection-controls/Checkboxes.js
+++ b/docs/src/pages/demos/selection-controls/Checkboxes.js
@@ -44,6 +44,7 @@ class Checkboxes extends React.Component {
               checked={this.state.checkedB}
               onChange={this.handleChange('checkedB')}
               value="checkedB"
+              color="primary"
             />
           }
           label="Option B"

--- a/docs/src/pages/demos/selection-controls/RadioButtons.js
+++ b/docs/src/pages/demos/selection-controls/RadioButtons.js
@@ -3,7 +3,7 @@ import Radio from 'material-ui/Radio';
 
 class RadioButtons extends React.Component {
   state = {
-    selectedValue: undefined,
+    selectedValue: 'a',
   };
 
   handleChange = event => {

--- a/docs/src/pages/demos/selection-controls/RadioButtonsGroup.js
+++ b/docs/src/pages/demos/selection-controls/RadioButtonsGroup.js
@@ -18,7 +18,7 @@ const styles = theme => ({
 
 class RadioButtonsGroup extends React.Component {
   state = {
-    value: '',
+    value: 'female',
   };
 
   handleChange = (event, value) => {
@@ -39,10 +39,15 @@ class RadioButtonsGroup extends React.Component {
             value={this.state.value}
             onChange={this.handleChange}
           >
-            <FormControlLabel value="male" control={<Radio />} label="Male" />
             <FormControlLabel value="female" control={<Radio />} label="Female" />
+            <FormControlLabel value="male" control={<Radio />} label="Male" />
             <FormControlLabel value="other" control={<Radio />} label="Other" />
-            <FormControlLabel value="disabled" disabled control={<Radio />} label="Disabled" />
+            <FormControlLabel
+              value="disabled"
+              disabled
+              control={<Radio />}
+              label="(Disabled option)"
+            />
           </RadioGroup>
         </FormControl>
         <FormControl component="fieldset" required error className={classes.formControl}>
@@ -54,10 +59,15 @@ class RadioButtonsGroup extends React.Component {
             value={this.state.value}
             onChange={this.handleChange}
           >
-            <FormControlLabel value="male" control={<Radio color="primary" />} label="Male" />
             <FormControlLabel value="female" control={<Radio color="primary" />} label="Female" />
+            <FormControlLabel value="male" control={<Radio color="primary" />} label="Male" />
             <FormControlLabel value="other" control={<Radio color="primary" />} label="Other" />
-            <FormControlLabel value="disabled" disabled control={<Radio />} label="Disabled" />
+            <FormControlLabel
+              value="disabled"
+              disabled
+              control={<Radio />}
+              label="(Disabled option)"
+            />
           </RadioGroup>
           <FormHelperText>You can display an error</FormHelperText>
         </FormControl>

--- a/docs/src/pages/demos/selection-controls/RadioButtonsGroup.js
+++ b/docs/src/pages/demos/selection-controls/RadioButtonsGroup.js
@@ -54,9 +54,9 @@ class RadioButtonsGroup extends React.Component {
             value={this.state.value}
             onChange={this.handleChange}
           >
-            <FormControlLabel value="male" control={<Radio />} label="Male" />
-            <FormControlLabel value="female" control={<Radio />} label="Female" />
-            <FormControlLabel value="other" control={<Radio />} label="Other" />
+            <FormControlLabel value="male" control={<Radio color="primary" />} label="Male" />
+            <FormControlLabel value="female" control={<Radio color="primary" />} label="Female" />
+            <FormControlLabel value="other" control={<Radio color="primary" />} label="Other" />
             <FormControlLabel value="disabled" disabled control={<Radio />} label="Disabled" />
           </RadioGroup>
           <FormHelperText>You can display an error</FormHelperText>

--- a/docs/src/pages/demos/selection-controls/Switches.js
+++ b/docs/src/pages/demos/selection-controls/Switches.js
@@ -39,6 +39,7 @@ class Switches extends React.Component {
           checked={this.state.checkedB}
           onChange={this.handleChange('checkedB')}
           aria-label="checkedB"
+          color="primary"
         />
         <Switch checked={false} aria-label="checkedC" disabled />
         <Switch checked aria-label="checkedD" disabled />

--- a/docs/src/pages/demos/selection-controls/Switches.js
+++ b/docs/src/pages/demos/selection-controls/Switches.js
@@ -17,7 +17,7 @@ const styles = {
 class Switches extends React.Component {
   state = {
     checkedA: true,
-    checkedB: false,
+    checkedB: true,
     checkedE: true,
   };
 
@@ -50,7 +50,7 @@ class Switches extends React.Component {
           }}
           checked={this.state.checkedE}
           onChange={this.handleChange('checkedE')}
-          aria-label="checkedD"
+          aria-label="checkedE"
         />
       </div>
     );

--- a/docs/src/pages/demos/selection-controls/selection-controls.md
+++ b/docs/src/pages/demos/selection-controls/selection-controls.md
@@ -28,9 +28,10 @@ If you have a single option, avoid using a checkbox and use an on/off switch ins
 
 ## Radio Buttons
 
-Radio buttons allow the user to select one option from a set. Use radio buttons for exclusive selection if you think that the user needs to see all available options side-by-side.
+Radio buttons allow the user to select one option from a set. Use radio buttons for exclusive selection if you think that the user needs to see all available options side-by-side;
+otherwise, consider a dropdown, which uses less space than displaying all options.
 
-Otherwise, consider a dropdown, which uses less space than displaying all options.
+Radio buttons should have the most commonly used option selected by default.
 
 `RadioGroup` is a helpful wrapper used to group `Radio` components that provides an easier API, and proper keyboard accessibility to the group.
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -15,6 +15,7 @@ filename: /src/Checkbox/Checkbox.js
 | checked | union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br> |  | If `true`, the component is checked. |
 | checkedIcon | node |  | The icon to display when the component is checked. |
 | classes | object |  | Useful to extend the style applied to components. |
+| color | enum:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br> | 'secondary' | The color of the component. It supports those theme colors that make sense for this component. |
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
 | icon | node |  | The icon to display when the component is unchecked. |
@@ -36,6 +37,8 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `default`
 - `checked`
+- `checkedPrimary`
+- `checkedSecondary`
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -15,6 +15,7 @@ filename: /src/Radio/Radio.js
 | checked | union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br> |  | If `true`, the component is checked. |
 | checkedIcon | node |  | The icon to display when the component is checked. |
 | classes | object |  | Useful to extend the style applied to components. |
+| color | enum:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br> | 'secondary' | The color of the component. It supports those theme colors that make sense for this component. |
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
 | icon | node |  | The icon to display when the component is unchecked. |
@@ -34,6 +35,8 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `default`
 - `checked`
+- `checkedPrimary`
+- `checkedSecondary`
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -15,6 +15,7 @@ filename: /src/Switch/Switch.js
 | checked | union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br> |  | If `true`, the component is checked. |
 | checkedIcon | node |  | The icon to display when the component is checked. |
 | classes | object |  | Useful to extend the style applied to components. |
+| color | enum:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br> | 'secondary' | The color of the component. It supports those theme colors that make sense for this component. |
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
 | icon | node |  | The icon to display when the component is unchecked. |
@@ -38,6 +39,8 @@ This property accepts the following keys:
 - `iconChecked`
 - `default`
 - `checked`
+- `checkedPrimary`
+- `checkedSecondary`
 - `disabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import SwitchBase from '../internal/SwitchBase';
 import IndeterminateCheckBoxIcon from '../internal/svg-icons/IndeterminateCheckBox';
 import withStyles from '../styles/withStyles';
@@ -8,8 +9,12 @@ export const styles = theme => ({
   default: {
     color: theme.palette.text.secondary,
   },
-  checked: {
+  checked: {},
+  checkedPrimary: {
     color: theme.palette.primary.main,
+  },
+  checkedSecondary: {
+    color: theme.palette.secondary.main,
   },
   disabled: {
     color: theme.palette.action.disabled,
@@ -17,11 +22,20 @@ export const styles = theme => ({
 });
 
 function Checkbox(props) {
-  const { checkedIcon, icon, indeterminate, indeterminateIcon, ...other } = props;
+  const { checkedIcon, classes, color, icon, indeterminate, indeterminateIcon, ...other } = props;
+  const checkedClass = classNames(classes.checked, {
+    [classes.checkedPrimary]: color === 'primary',
+    [classes.checkedSecondary]: color === 'secondary',
+  });
 
   return (
     <SwitchBase
       checkedIcon={indeterminate ? indeterminateIcon : checkedIcon}
+      classes={{
+        default: classes.default,
+        checked: checkedClass,
+        disabled: classes.disabled,
+      }}
       icon={indeterminate ? indeterminateIcon : icon}
       {...other}
     />
@@ -45,6 +59,10 @@ Checkbox.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   */
+  color: PropTypes.oneOf(['primary', 'secondary']),
   /**
    * @ignore
    */
@@ -107,6 +125,7 @@ Checkbox.propTypes = {
 };
 
 Checkbox.defaultProps = {
+  color: 'secondary',
   indeterminate: false,
   indeterminateIcon: <IndeterminateCheckBoxIcon />,
 };

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import SwitchBase from '../internal/SwitchBase';
 import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
 import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
@@ -9,8 +10,12 @@ export const styles = theme => ({
   default: {
     color: theme.palette.text.secondary,
   },
-  checked: {
+  checked: {},
+  checkedPrimary: {
     color: theme.palette.primary.main,
+  },
+  checkedSecondary: {
+    color: theme.palette.secondary.main,
   },
   disabled: {
     color: theme.palette.action.disabled,
@@ -18,12 +23,23 @@ export const styles = theme => ({
 });
 
 function Radio(props) {
+  const { classes, color, ...other } = props;
+  const checkedClass = classNames(classes.checked, {
+    [classes.checkedPrimary]: color === 'primary',
+    [classes.checkedSecondary]: color === 'secondary',
+  });
+
   return (
     <SwitchBase
       type="radio"
       icon={<RadioButtonUncheckedIcon />}
       checkedIcon={<RadioButtonCheckedIcon />}
-      {...props}
+      classes={{
+        default: classes.default,
+        checked: checkedClass,
+        disabled: classes.disabled,
+      }}
+      {...other}
     />
   );
 }
@@ -45,6 +61,10 @@ Radio.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   */
+  color: PropTypes.oneOf(['primary', 'secondary']),
   /**
    * @ignore
    */
@@ -96,6 +116,10 @@ Radio.propTypes = {
    * The value of the component.
    */
   value: PropTypes.string,
+};
+
+Radio.defaultProps = {
+  color: 'secondary',
 };
 
 export default withStyles(styles, { name: 'MuiRadio' })(Radio);

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -49,11 +49,21 @@ export const styles = theme => ({
     }),
   },
   checked: {
-    color: theme.palette.primary.main,
     transform: 'translateX(14px)',
     '& + $bar': {
-      backgroundColor: theme.palette.primary.main,
       opacity: 0.5,
+    },
+  },
+  checkedPrimary: {
+    color: theme.palette.primary.main,
+    '& + $bar': {
+      backgroundColor: theme.palette.primary.main,
+    },
+  },
+  checkedSecondary: {
+    color: theme.palette.secondary.main,
+    '& + $bar': {
+      backgroundColor: theme.palette.secondary.main,
     },
   },
   disabled: {
@@ -70,9 +80,13 @@ export const styles = theme => ({
 });
 
 function Switch(props) {
-  const { classes, className, ...other } = props;
+  const { classes, className, color, ...other } = props;
   const icon = <span className={classes.icon} />;
   const checkedIcon = <span className={classNames(classes.icon, classes.iconChecked)} />;
+  const checkedClass = classNames(classes.checked, {
+    [classes.checkedPrimary]: color === 'primary',
+    [classes.checkedSecondary]: color === 'secondary',
+  });
 
   return (
     <span className={classNames(classes.root, className)}>
@@ -80,7 +94,7 @@ function Switch(props) {
         icon={icon}
         classes={{
           default: classes.default,
-          checked: classes.checked,
+          checked: checkedClass,
           disabled: classes.disabled,
         }}
         checkedIcon={checkedIcon}
@@ -108,6 +122,10 @@ Switch.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   */
+  color: PropTypes.oneOf(['primary', 'secondary']),
   /**
    * @ignore
    */
@@ -159,6 +177,10 @@ Switch.propTypes = {
    * The value of the component.
    */
   value: PropTypes.string,
+};
+
+Switch.defaultProps = {
+  color: 'secondary',
 };
 
 export default withStyles(styles, { name: 'MuiSwitch' })(Switch);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes #4706

### Breaking change

The Material Design specification says that selection controls elements should [use the application's secondary color](https://material.io/guidelines/components/selection-controls.html).

<img width="289" alt="capture d ecran 2018-02-13 a 19 46 09" src="https://user-images.githubusercontent.com/3165635/36167538-91a2ac88-10f6-11e8-95be-263ad08e6319.png">


```diff
-<Checkbox />
-<Switch />
-<Radio />
+<Checkbox color="primary" />
+<Switch color="primary" />
+<Radio color="primary" />

```