### PR TITLE
[transition] Standardize the components

### DIFF
--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -230,10 +230,6 @@ function generateInheritance(reactAPI) {
   let pathname;
 
   switch (component) {
-    case 'CSSTransition':
-      pathname = 'https://reactcommunity.org/react-transition-group/#CSSTransition';
-      break;
-
     case 'Transition':
       pathname = 'https://reactcommunity.org/react-transition-group/#Transition';
       break;

--- a/docs/src/pages/demos/buttons/FloatingActionButtonZoom.js
+++ b/docs/src/pages/demos/buttons/FloatingActionButtonZoom.js
@@ -110,12 +110,11 @@ class FloatingActionButtonZoom extends React.Component {
         </SwipeableViews>
         {fabs.map((fab, index) => (
           <Zoom
-            appear
             key={fab.color}
             in={this.state.value === index}
             timeout={transitionDuration}
             style={{
-              transitionDelay: transitionDuration.exit,
+              transitionDelay: this.state.value === index ? transitionDuration.exit : 0,
             }}
             unmountOnExit
           >

--- a/docs/src/pages/demos/buttons/FloatingActionButtonZoom.js
+++ b/docs/src/pages/demos/buttons/FloatingActionButtonZoom.js
@@ -110,11 +110,13 @@ class FloatingActionButtonZoom extends React.Component {
         </SwipeableViews>
         {fabs.map((fab, index) => (
           <Zoom
-            appear={false}
+            appear
             key={fab.color}
             in={this.state.value === index}
             timeout={transitionDuration}
-            enterDelay={transitionDuration.exit}
+            style={{
+              transitionDelay: transitionDuration.exit,
+            }}
             unmountOnExit
           >
             <Button variant="fab" className={fab.className} color={fab.color}>

--- a/docs/src/pages/demos/progress/DelayingAppearance.js
+++ b/docs/src/pages/demos/progress/DelayingAppearance.js
@@ -15,7 +15,7 @@ const styles = theme => ({
   button: {
     margin: theme.spacing.unit * 2,
   },
-  success: {
+  placeholder: {
     height: 40,
   },
 });
@@ -64,29 +64,35 @@ class DelayingAppearance extends React.Component {
 
     return (
       <div className={classes.root}>
-        <Fade
-          in={loading}
-          style={{
-            transitionDelay: loading ? '800ms' : '0ms',
-          }}
-        >
-          <CircularProgress />
-        </Fade>
-        <Button onClick={this.handleClickLoading} className={classes.button}>
-          {loading ? 'Stop loading' : 'Loading'}
-        </Button>
-        {query === 'success' ? (
-          <Typography className={classes.success}>Success!</Typography>
-        ) : (
+        <div className={classes.placeholder}>
           <Fade
-            in={query === 'progress'}
+            in={loading}
             style={{
-              transitionDelay: query === 'progress' ? '800ms' : '0ms',
+              transitionDelay: loading ? '800ms' : '0ms',
             }}
+            unmountOnExit
           >
             <CircularProgress />
           </Fade>
-        )}
+        </div>
+        <Button onClick={this.handleClickLoading} className={classes.button}>
+          {loading ? 'Stop loading' : 'Loading'}
+        </Button>
+        <div className={classes.placeholder}>
+          {query === 'success' ? (
+            <Typography>Success!</Typography>
+          ) : (
+            <Fade
+              in={query === 'progress'}
+              style={{
+                transitionDelay: query === 'progress' ? '800ms' : '0ms',
+              }}
+              unmountOnExit
+            >
+              <CircularProgress />
+            </Fade>
+          )}
+        </div>
         <Button onClick={this.handleClickQuery} className={classes.button}>
           {query !== 'idle' ? 'Reset' : 'Simulate a load'}
         </Button>

--- a/docs/src/pages/demos/progress/DelayingAppearance.js
+++ b/docs/src/pages/demos/progress/DelayingAppearance.js
@@ -64,7 +64,12 @@ class DelayingAppearance extends React.Component {
 
     return (
       <div className={classes.root}>
-        <Fade in={loading} enterDelay={800}>
+        <Fade
+          in={loading}
+          style={{
+            transitionDelay: loading ? '800ms' : '0ms',
+          }}
+        >
           <CircularProgress />
         </Fade>
         <Button onClick={this.handleClickLoading} className={classes.button}>
@@ -73,7 +78,12 @@ class DelayingAppearance extends React.Component {
         {query === 'success' ? (
           <Typography className={classes.success}>Success!</Typography>
         ) : (
-          <Fade in={query === 'progress'} enterDelay={800}>
+          <Fade
+            in={query === 'progress'}
+            style={{
+              transitionDelay: query === 'progress' ? '800ms' : '0ms',
+            }}
+          >
             <CircularProgress />
           </Fade>
         )}

--- a/docs/src/pages/demos/progress/progress.md
+++ b/docs/src/pages/demos/progress/progress.md
@@ -49,7 +49,7 @@ For example, a refresh operation should display either a refresh bar or an activ
 ## Delaying appearance
 
 There are [3 important limits](http://www.nngroup.com/articles/response-times-3-important-limits/) to know around reponse time.
-The ripple effect of the `ButtonBase` component will ensures that the user feels that the system is reacting instantaneously.
+The ripple effect of the `ButtonBase` component ensures that the user feels that the system is reacting instantaneously.
 Normally, no special feedback is necessary during delays of more than 0.1 but less than 1.0 second.
 After 1.0 second, you can display a loader to keep user's flow of thought uninterrupted.
 

--- a/docs/src/pages/demos/progress/progress.md
+++ b/docs/src/pages/demos/progress/progress.md
@@ -48,9 +48,9 @@ For example, a refresh operation should display either a refresh bar or an activ
 
 ## Delaying appearance
 
-There is a [school of thought](http://www.nngroup.com/articles/response-times-3-important-limits/)
-that feedback after user operations isn't necessary for about a second.
-To implement this, you can take advantage of the [Fade](/api/fade)
-transition `enterDelay` prop to delay the appearance of the progress indicators.
+There is [3 important limits](http://www.nngroup.com/articles/response-times-3-important-limits/) to know around reponse time.
+The ripple effect of the `ButtonBase` component will make sure the user feel that the system is reacting instantaneously.
+Normally, no special feedback is necessary during delays of more than 0.1 but less than 1.0 second.
+After 1.0 second, you can display a loader to keep user's flow of thought uninterrupted.
 
 {{"demo": "pages/demos/progress/DelayingAppearance.js"}}

--- a/docs/src/pages/demos/progress/progress.md
+++ b/docs/src/pages/demos/progress/progress.md
@@ -48,8 +48,8 @@ For example, a refresh operation should display either a refresh bar or an activ
 
 ## Delaying appearance
 
-There is [3 important limits](http://www.nngroup.com/articles/response-times-3-important-limits/) to know around reponse time.
-The ripple effect of the `ButtonBase` component will make sure the user feel that the system is reacting instantaneously.
+There are [3 important limits](http://www.nngroup.com/articles/response-times-3-important-limits/) to know around reponse time.
+The ripple effect of the `ButtonBase` component will ensures that the user feels that the system is reacting instantaneously.
 Normally, no special feedback is necessary during delays of more than 0.1 but less than 1.0 second.
 After 1.0 second, you can display a loader to keep user's flow of thought uninterrupted.
 

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -14,7 +14,6 @@ It's using [react-transition-group](https://github.com/reactjs/react-transition-
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | children | union:&nbsp;element&nbsp;&#124;<br>&nbsp;func<br> |  | A single child content element. |
-| enterDelay | number | 0 | The duration in milliseconds before the enter animation starts. |
 | in | bool |  | If `true`, the component will transition in. |
 | timeout | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -16,13 +16,12 @@ It's using [react-transition-group](https://github.com/reactjs/react-transition-
 | children | union:&nbsp;element&nbsp;&#124;<br>&nbsp;func<br> |  | A single child content element. |
 | in | bool |  | If `true`, show the component; triggers the enter or exit animation. |
 | timeout | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}&nbsp;&#124;<br>&nbsp;{0?: undefined}<br> | 'auto' | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
-| transitionClasses | shape |  | The animation classNames applied to the component as it enters or exits. This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames). |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 
 ## Inheritance
 
-The properties of the [&lt;CSSTransition /&gt;](https://reactcommunity.org/react-transition-group/#CSSTransition) component are also available.
+The properties of the [&lt;Transition /&gt;](https://reactcommunity.org/react-transition-group/#Transition) component are also available.
 
 ## Demos
 

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -14,7 +14,6 @@ It's using [react-transition-group](https://github.com/reactjs/react-transition-
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | children | union:&nbsp;element&nbsp;&#124;<br>&nbsp;func<br> |  | A single child content element. |
-| enterDelay | number | 0 | The duration in milliseconds before the enter animation starts. |
 | in | bool |  | If `true`, the component will transition in. |
 | timeout | union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | {  enter: duration.enteringScreen,  exit: duration.leavingScreen,} | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 

--- a/src/styles/transitions.d.ts
+++ b/src/styles/transitions.d.ts
@@ -24,7 +24,7 @@ export interface Transitions {
   duration: Duration;
   create(
     props: string | string[],
-    options?: Partial<{ duration: number; easing: string; delay: number }>,
+    options?: Partial<{ duration: number | string; easing: string; delay: number | string }>,
   ): string;
   getAutoHeightDuration(height: number): number;
 }
@@ -34,7 +34,7 @@ export interface TransitionsOptions {
   duration?: Partial<Duration>;
   create?: (
     props: string | string[],
-    options?: Partial<{ duration: number; easing: string; delay: number }>,
+    options?: Partial<{ duration: number | string; easing: string; delay: number | string }>,
   ) => string;
   getAutoHeightDuration?: (height: number) => number;
 }

--- a/src/styles/transitions.js
+++ b/src/styles/transitions.js
@@ -50,7 +50,12 @@ export default {
   duration,
   create(
     props: string | Array<string> = ['all'],
-    options: { prop?: string, duration?: number, easing?: string, delay?: number } = {},
+    options: {
+      prop?: string,
+      duration?: number | string,
+      easing?: string,
+      delay?: number | string,
+    } = {},
   ) {
     const {
       duration: durationOption = duration.standard,
@@ -61,14 +66,17 @@ export default {
 
     warning(
       isString(props) || Array.isArray(props),
-      'Material-UI: argument "props" must be a string or Array',
+      'Material-UI: argument "props" must be a string or Array.',
     );
     warning(
-      isNumber(durationOption),
-      `Material-UI: argument "duration" must be a number but found ${durationOption}`,
+      isNumber(durationOption) || isString(durationOption),
+      `Material-UI: argument "duration" must be a number or a string but found ${durationOption}.`,
     );
-    warning(isString(easingOption), 'Material-UI: argument "easing" must be a string');
-    warning(isNumber(delay), 'Material-UI: argument "delay" must be a string');
+    warning(isString(easingOption), 'Material-UI: argument "easing" must be a string.');
+    warning(
+      isNumber(delay) || isString(delay),
+      'Material-UI: argument "delay" must be a string or a string.',
+    );
     warning(
       Object.keys(other).length === 0,
       `Material-UI: unrecognized argument(s) [${Object.keys(other).join(',')}]`,
@@ -77,7 +85,9 @@ export default {
     return (Array.isArray(props) ? props : [props])
       .map(
         animatedProp =>
-          `${animatedProp} ${formatMs(durationOption)} ${easingOption} ${formatMs(delay)}`,
+          `${animatedProp} ${
+            typeof durationOption === 'string' ? durationOption : formatMs(durationOption)
+          } ${easingOption} ${typeof delay === 'string' ? delay : formatMs(delay)}`,
       )
       .join(',');
   },

--- a/src/styles/transitions.spec.js
+++ b/src/styles/transitions.spec.js
@@ -107,6 +107,12 @@ describe('transitions', () => {
       assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
     });
 
+    it('should optionally accept string "duration" option in second argument', () => {
+      const transition = transitions.create('font', { duration: '500ms' });
+      assert.strictEqual(transition, `font 500ms ${easing.easeInOut} 0ms`);
+      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+    });
+
     it('should round decimal digits of "duration" prop to whole numbers', () => {
       const transition = transitions.create('font', { duration: 12.125 });
       assert.strictEqual(transition, `font 12ms ${easing.easeInOut} 0ms`);
@@ -115,7 +121,7 @@ describe('transitions', () => {
 
     it('should warn when bad "duration" option type', () => {
       // $FlowIgnore
-      transitions.create('font', { duration: '' });
+      transitions.create('font', { duration: null });
       // $FlowIgnore
       transitions.create('font', { duration: {} });
       assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
@@ -141,6 +147,12 @@ describe('transitions', () => {
       assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
     });
 
+    it('should optionally accept string "delay" option in second argument', () => {
+      const transition = transitions.create('size', { delay: '150ms' });
+      assert.strictEqual(transition, `size ${duration.standard}ms ${easing.easeInOut} 150ms`);
+      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+    });
+
     it('should round decimal digits of "delay" prop to whole numbers', () => {
       const transition = transitions.create('size', { delay: 1.547 });
       assert.strictEqual(transition, `size ${duration.standard}ms ${easing.easeInOut} 2ms`);
@@ -149,7 +161,7 @@ describe('transitions', () => {
 
     it('should warn when bad "delay" option type', () => {
       // $FlowIgnore
-      transitions.create('size', { delay: '' });
+      transitions.create('size', { delay: null });
       // $FlowIgnore
       transitions.create('size', { delay: {} });
       assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -108,7 +108,6 @@ class Collapse extends React.Component {
 
   render() {
     const {
-      appear,
       children,
       classes,
       className,
@@ -127,7 +126,6 @@ class Collapse extends React.Component {
 
     return (
       <Transition
-        appear={appear}
         onEntering={this.handleEntering}
         onEnter={this.handleEnter}
         onEntered={this.handleEntered}
@@ -137,7 +135,7 @@ class Collapse extends React.Component {
         timeout={timeout === 'auto' ? null : timeout}
         {...other}
       >
-        {(state, otherInner) => {
+        {(state, childProps) => {
           return (
             <Component
               className={classNames(
@@ -151,7 +149,7 @@ class Collapse extends React.Component {
                 ...style,
                 minHeight: collapsedHeight,
               }}
-              {...otherInner}
+              {...childProps}
             >
               <div
                 className={classes.wrapper}
@@ -170,10 +168,6 @@ class Collapse extends React.Component {
 }
 
 Collapse.propTypes = {
-  /**
-   * @ignore
-   */
-  appear: PropTypes.bool,
   /**
    * The content node to be collapsed.
    */
@@ -241,7 +235,6 @@ Collapse.propTypes = {
 };
 
 Collapse.defaultProps = {
-  appear: false,
   collapsedHeight: '0px',
   component: 'div',
   timeout: duration.standard,

--- a/src/transitions/Collapse.js
+++ b/src/transitions/Collapse.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import Transition from 'react-transition-group/Transition';
 import withStyles from '../styles/withStyles';
 import { duration } from '../styles/transitions';
+import { getTransitionProps } from './utils';
 
 export const styles = theme => ({
   container: {
@@ -41,16 +42,17 @@ class Collapse extends React.Component {
     const { timeout, theme } = this.props;
     const wrapperHeight = this.wrapper ? this.wrapper.clientHeight : 0;
 
+    const { duration: transitionDuration } = getTransitionProps(this.props, {
+      mode: 'enter',
+    });
+
     if (timeout === 'auto') {
       const duration2 = theme.transitions.getAutoHeightDuration(wrapperHeight);
       node.style.transitionDuration = `${duration2}ms`;
       this.autoTransitionDuration = duration2;
-    } else if (typeof timeout === 'number') {
-      node.style.transitionDuration = `${timeout}ms`;
-    } else if (timeout && typeof timeout.enter === 'number') {
-      node.style.transitionDuration = `${timeout.enter}ms`;
     } else {
-      // The propType will warn in this case.
+      node.style.transitionDuration =
+        typeof transitionDuration === 'string' ? transitionDuration : `${transitionDuration}ms`;
     }
 
     node.style.height = `${wrapperHeight}px`;
@@ -81,16 +83,17 @@ class Collapse extends React.Component {
     const { timeout, theme } = this.props;
     const wrapperHeight = this.wrapper ? this.wrapper.clientHeight : 0;
 
+    const { duration: transitionDuration } = getTransitionProps(this.props, {
+      mode: 'exit',
+    });
+
     if (timeout === 'auto') {
       const duration2 = theme.transitions.getAutoHeightDuration(wrapperHeight);
       node.style.transitionDuration = `${duration2}ms`;
       this.autoTransitionDuration = duration2;
-    } else if (typeof timeout === 'number') {
-      node.style.transitionDuration = `${timeout}ms`;
-    } else if (timeout && typeof timeout.exit === 'number') {
-      node.style.transitionDuration = `${timeout.exit}ms`;
     } else {
-      // The propType will warn in this case.
+      node.style.transitionDuration =
+        typeof transitionDuration === 'string' ? transitionDuration : `${transitionDuration}ms`;
     }
 
     node.style.height = this.props.collapsedHeight;

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -5,8 +5,9 @@ import PropTypes from 'prop-types';
 import Transition from 'react-transition-group/Transition';
 import { duration } from '../styles/transitions';
 import withTheme from '../styles/withTheme';
+import { reflow, getTransitionProps } from './utils';
 
-const transitionStyles = {
+const styles = {
   entering: {
     opacity: 1,
   },
@@ -20,31 +21,39 @@ const transitionStyles = {
  * It's using [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 class Fade extends React.Component {
-  handleEntering = node => {
-    const { theme, timeout, style = {} } = this.props;
+  handleEnter = node => {
+    const { theme } = this.props;
+    reflow(node); // So the animation always start from the start.
+
+    const { duration: transitionDuration, delay } = getTransitionProps(this.props, {
+      mode: 'enter',
+    });
     node.style.transition = theme.transitions.create('opacity', {
-      duration: typeof timeout === 'number' ? timeout : timeout.enter,
-      delay: style.transitionDelay,
+      duration: transitionDuration,
+      delay,
     });
     node.style.webkitTransition = theme.transitions.create('opacity', {
-      duration: typeof timeout === 'number' ? timeout : timeout.enter,
-      delay: style.transitionDelay,
+      duration: transitionDuration,
+      delay,
     });
 
-    if (this.props.onEntering) {
-      this.props.onEntering(node);
+    if (this.props.onEnter) {
+      this.props.onEnter(node);
     }
   };
 
   handleExit = node => {
-    const { theme, timeout, style = {} } = this.props;
+    const { theme } = this.props;
+    const { duration: transitionDuration, delay } = getTransitionProps(this.props, {
+      mode: 'exit',
+    });
     node.style.transition = theme.transitions.create('opacity', {
-      duration: typeof timeout === 'number' ? timeout : timeout.exit,
-      delay: style.transitionDelay,
+      duration: transitionDuration,
+      delay,
     });
     node.style.webkitTransition = theme.transitions.create('opacity', {
-      duration: typeof timeout === 'number' ? timeout : timeout.exit,
-      delay: style.transitionDelay,
+      duration: transitionDuration,
+      delay,
     });
 
     if (this.props.onExit) {
@@ -53,7 +62,7 @@ class Fade extends React.Component {
   };
 
   render() {
-    const { children, onEntering, onExit, style: styleProp, theme, ...other } = this.props;
+    const { children, onEnter, onExit, style: styleProp, theme, ...other } = this.props;
 
     const style = {
       ...styleProp,
@@ -61,12 +70,12 @@ class Fade extends React.Component {
     };
 
     return (
-      <Transition appear onEntering={this.handleEntering} onExit={this.handleExit} {...other}>
+      <Transition appear onEnter={this.handleEnter} onExit={this.handleExit} {...other}>
         {(state, childProps) => {
           return React.cloneElement(children, {
             style: {
               opacity: 0,
-              ...transitionStyles[state],
+              ...styles[state],
               ...style,
             },
             ...childProps,

--- a/src/transitions/Fade.js
+++ b/src/transitions/Fade.js
@@ -21,14 +21,15 @@ const transitionStyles = {
  */
 class Fade extends React.Component {
   handleEntering = node => {
-    const { theme, timeout } = this.props;
+    const { theme, timeout, style = {} } = this.props;
     node.style.transition = theme.transitions.create('opacity', {
       duration: typeof timeout === 'number' ? timeout : timeout.enter,
+      delay: style.transitionDelay,
     });
     node.style.webkitTransition = theme.transitions.create('opacity', {
       duration: typeof timeout === 'number' ? timeout : timeout.enter,
+      delay: style.transitionDelay,
     });
-    node.style.transitionDelay = `${this.props.enterDelay}ms`;
 
     if (this.props.onEntering) {
       this.props.onEntering(node);
@@ -36,12 +37,14 @@ class Fade extends React.Component {
   };
 
   handleExit = node => {
-    const { theme, timeout } = this.props;
+    const { theme, timeout, style = {} } = this.props;
     node.style.transition = theme.transitions.create('opacity', {
       duration: typeof timeout === 'number' ? timeout : timeout.exit,
+      delay: style.transitionDelay,
     });
     node.style.webkitTransition = theme.transitions.create('opacity', {
       duration: typeof timeout === 'number' ? timeout : timeout.exit,
+      delay: style.transitionDelay,
     });
 
     if (this.props.onExit) {
@@ -50,16 +53,7 @@ class Fade extends React.Component {
   };
 
   render() {
-    const {
-      appear,
-      children,
-      enterDelay,
-      onEntering,
-      onExit,
-      style: styleProp,
-      theme,
-      ...other
-    } = this.props;
+    const { children, onEntering, onExit, style: styleProp, theme, ...other } = this.props;
 
     const style = {
       ...styleProp,
@@ -67,12 +61,7 @@ class Fade extends React.Component {
     };
 
     return (
-      <Transition
-        appear={appear}
-        onEntering={this.handleEntering}
-        onExit={this.handleExit}
-        {...other}
-      >
+      <Transition appear onEntering={this.handleEntering} onExit={this.handleExit} {...other}>
         {(state, childProps) => {
           return React.cloneElement(children, {
             style: {
@@ -90,17 +79,9 @@ class Fade extends React.Component {
 
 Fade.propTypes = {
   /**
-   * @ignore
-   */
-  appear: PropTypes.bool,
-  /**
    * A single child content element.
    */
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-  /**
-   * The duration in milliseconds before the enter animation starts.
-   */
-  enterDelay: PropTypes.number,
   /**
    * If `true`, the component will transition in.
    */
@@ -136,8 +117,6 @@ Fade.propTypes = {
 };
 
 Fade.defaultProps = {
-  appear: true,
-  enterDelay: 0,
   timeout: {
     enter: duration.enteringScreen,
     exit: duration.leavingScreen,

--- a/src/transitions/Fade.spec.js
+++ b/src/transitions/Fade.spec.js
@@ -55,10 +55,10 @@ describe('<Fade />', () => {
       instance = wrapper.instance();
     });
 
-    describe('handleEntering()', () => {
+    describe('handleEnter()', () => {
       it('should set style properties', () => {
         const element = { style: {} };
-        instance.handleEntering(element);
+        instance.handleEnter(element);
         assert.strictEqual(
           element.style.transition,
           'opacity 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',

--- a/src/transitions/Grow.js
+++ b/src/transitions/Grow.js
@@ -1,8 +1,8 @@
-// @inheritedComponent CSSTransition
+// @inheritedComponent Transition
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import CSSTransition from 'react-transition-group/CSSTransition';
+import Transition from 'react-transition-group/Transition';
 import withTheme from '../styles/withTheme';
 
 // Only exported for tests.
@@ -17,7 +17,7 @@ export function getScale(value: number) {
 class Grow extends React.Component {
   autoTimeout = undefined;
 
-  handleEnter = (node: HTMLElement) => {
+  handleEnter = node => {
     node.style.opacity = '0';
     node.style.transform = getScale(0.75);
 
@@ -26,7 +26,7 @@ class Grow extends React.Component {
     }
   };
 
-  handleEntering = (node: HTMLElement) => {
+  handleEntering = node => {
     const { theme, timeout } = this.props;
     let duration = 0;
 
@@ -58,7 +58,7 @@ class Grow extends React.Component {
     }
   };
 
-  handleExit = (node: HTMLElement) => {
+  handleExit = node => {
     const { theme, timeout } = this.props;
     let duration = 0;
 
@@ -107,7 +107,6 @@ class Grow extends React.Component {
       style: styleProp,
       theme,
       timeout,
-      transitionClasses = {},
       ...other
     } = this.props;
 
@@ -125,8 +124,7 @@ class Grow extends React.Component {
     };
 
     return (
-      <CSSTransition
-        classNames={transitionClasses}
+      <Transition
         onEnter={this.handleEnter}
         onEntering={this.handleEntering}
         onExit={this.handleExit}
@@ -137,7 +135,7 @@ class Grow extends React.Component {
         {...other}
       >
         {children}
-      </CSSTransition>
+      </Transition>
     );
   }
 }
@@ -198,18 +196,6 @@ Grow.propTypes = {
     PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
     PropTypes.oneOf(['auto']),
   ]),
-  /**
-   * The animation classNames applied to the component as it enters or exits.
-   * This property is a direct binding to [`CSSTransition.classNames`](https://reactcommunity.org/react-transition-group/#CSSTransition-prop-classNames).
-   */
-  transitionClasses: PropTypes.shape({
-    appear: PropTypes.string,
-    appearActive: PropTypes.string,
-    enter: PropTypes.string,
-    enterActive: PropTypes.string,
-    exit: PropTypes.string,
-    exitActive: PropTypes.string,
-  }),
 };
 
 Grow.defaultProps = {

--- a/src/transitions/Grow.spec.js
+++ b/src/transitions/Grow.spec.js
@@ -4,7 +4,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createShallow } from '../test-utils';
-import Grow, { getScale } from './Grow';
+import Grow from './Grow';
 
 describe('<Grow />', () => {
   let shallow;
@@ -64,7 +64,7 @@ describe('<Grow />', () => {
     });
 
     it('should create proper easeOut animation onEnter', () => {
-      instance.handleEntering(element);
+      instance.handleEnter(element);
       assert.match(element.style.transition, new RegExp(`${enterDuration}ms`));
     });
 
@@ -86,38 +86,12 @@ describe('<Grow />', () => {
       },
     };
 
-    describe('handleEnter(element)', () => {
+    describe('handleEnter()', () => {
       let wrapper;
-      let handleEnter;
 
       before(() => {
-        handleEnter = spy();
-        wrapper = shallow(<Grow {...props} onEnter={handleEnter} />);
+        wrapper = shallow(<Grow {...props} />);
         wrapper.instance().handleEnter(element);
-      });
-
-      it('should set the inline styles for the enter phase', () => {
-        assert.strictEqual(element.style.opacity, '0', 'should be transparent');
-        assert.strictEqual(
-          element.style.transform,
-          getScale(0.75),
-          'should have the starting scale',
-        );
-      });
-
-      it('should invoke the callback', () => {
-        assert.strictEqual(handleEnter.callCount, 1, 'should have been called once');
-      });
-    });
-
-    describe('handleEntering(element)', () => {
-      let wrapper;
-      let handleEntering;
-
-      before(() => {
-        handleEntering = spy();
-        wrapper = shallow(<Grow {...props} onEntering={handleEntering} />);
-        wrapper.instance().handleEntering(element);
       });
 
       it('should set the inline styles for the entering phase', () => {
@@ -125,34 +99,25 @@ describe('<Grow />', () => {
           element.style.transition,
           'opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,' +
             'transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',
-          'should apply a transition for transform and opacity',
         );
-        assert.strictEqual(element.style.opacity, '1', 'should be visible');
-        assert.strictEqual(element.style.transform, getScale(1), 'should have the full scale');
-      });
-
-      it('should invoke the callback', () => {
-        assert.strictEqual(handleEntering.callCount, 1, 'should have been called once');
       });
     });
 
-    describe('handleExit(element)', () => {
+    describe('handleExit()', () => {
       let wrapper;
-      let handleExit;
 
       before(() => {
-        handleExit = spy();
-        wrapper = shallow(<Grow {...props} onExit={handleExit} />);
+        wrapper = shallow(<Grow {...props} />);
         wrapper.instance().handleExit(element);
       });
 
       it('should set the inline styles for the exit phase', () => {
         assert.strictEqual(element.style.opacity, '0', 'should be transparent');
-        assert.strictEqual(element.style.transform, getScale(0.75), 'should have the exit scale');
-      });
-
-      it('should invoke the callback', () => {
-        assert.strictEqual(handleExit.callCount, 1, 'should have been called once');
+        assert.strictEqual(
+          element.style.transform,
+          'scale(0.75, 0.5625)',
+          'should have the exit scale',
+        );
       });
     });
   });

--- a/src/transitions/Grow.spec.js
+++ b/src/transitions/Grow.spec.js
@@ -17,9 +17,9 @@ describe('<Grow />', () => {
     shallow = createShallow({ dive: true });
   });
 
-  it('should render a CSSTransition', () => {
+  it('should render a Transition', () => {
     const wrapper = shallow(<Grow {...props} />);
-    assert.strictEqual(wrapper.name(), 'CSSTransition');
+    assert.strictEqual(wrapper.name(), 'Transition');
   });
 
   describe('event callbacks', () => {

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -129,14 +129,16 @@ class Slide extends React.Component {
   };
 
   handleEntering = node => {
-    const { theme, timeout } = this.props;
+    const { theme, timeout, style = {} } = this.props;
     node.style.transition = theme.transitions.create('transform', {
       duration: typeof timeout === 'number' ? timeout : timeout.enter,
       easing: theme.transitions.easing.easeOut,
+      delay: style.transitionDelay,
     });
     node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
       duration: typeof timeout === 'number' ? timeout : timeout.enter,
       easing: theme.transitions.easing.easeOut,
+      delay: style.transitionDelay,
     });
     node.style.transform = 'translate3d(0, 0, 0)';
     node.style.webkitTransform = 'translate3d(0, 0, 0)';
@@ -146,14 +148,16 @@ class Slide extends React.Component {
   };
 
   handleExit = node => {
-    const { theme, timeout } = this.props;
+    const { theme, timeout, style = {} } = this.props;
     node.style.transition = theme.transitions.create('transform', {
       duration: typeof timeout === 'number' ? timeout : timeout.exit,
       easing: theme.transitions.easing.sharp,
+      delay: style.transitionDelay,
     });
     node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
       duration: typeof timeout === 'number' ? timeout : timeout.exit,
       easing: theme.transitions.easing.sharp,
+      delay: style.transitionDelay,
     });
     setTranslateValue(this.props, node);
 

--- a/src/transitions/Slide.js
+++ b/src/transitions/Slide.js
@@ -8,6 +8,7 @@ import debounce from 'lodash/debounce';
 import Transition from 'react-transition-group/Transition';
 import withTheme from '../styles/withTheme';
 import { duration } from '../styles/transitions';
+import { reflow, getTransitionProps } from './utils';
 
 const GUTTER = 24;
 
@@ -61,8 +62,6 @@ export function setTranslateValue(props, node) {
     node.style.webkitTransform = transform;
   }
 }
-
-const reflow = node => node.scrollTop;
 
 class Slide extends React.Component {
   state = {
@@ -129,16 +128,20 @@ class Slide extends React.Component {
   };
 
   handleEntering = node => {
-    const { theme, timeout, style = {} } = this.props;
+    const { theme } = this.props;
+
+    const { duration: transitionDuration, delay } = getTransitionProps(this.props, {
+      mode: 'enter',
+    });
     node.style.transition = theme.transitions.create('transform', {
-      duration: typeof timeout === 'number' ? timeout : timeout.enter,
+      duration: transitionDuration,
       easing: theme.transitions.easing.easeOut,
-      delay: style.transitionDelay,
+      delay,
     });
     node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
-      duration: typeof timeout === 'number' ? timeout : timeout.enter,
+      duration: transitionDuration,
       easing: theme.transitions.easing.easeOut,
-      delay: style.transitionDelay,
+      delay,
     });
     node.style.transform = 'translate3d(0, 0, 0)';
     node.style.webkitTransform = 'translate3d(0, 0, 0)';
@@ -148,16 +151,20 @@ class Slide extends React.Component {
   };
 
   handleExit = node => {
-    const { theme, timeout, style = {} } = this.props;
+    const { theme } = this.props;
+
+    const { duration: transitionDuration, delay } = getTransitionProps(this.props, {
+      mode: 'exit',
+    });
     node.style.transition = theme.transitions.create('transform', {
-      duration: typeof timeout === 'number' ? timeout : timeout.exit,
+      duration: transitionDuration,
       easing: theme.transitions.easing.sharp,
-      delay: style.transitionDelay,
+      delay,
     });
     node.style.webkitTransition = theme.transitions.create('-webkit-transform', {
-      duration: typeof timeout === 'number' ? timeout : timeout.exit,
+      duration: transitionDuration,
       easing: theme.transitions.easing.sharp,
-      delay: style.transitionDelay,
+      delay,
     });
     setTranslateValue(this.props, node);
 

--- a/src/transitions/Zoom.js
+++ b/src/transitions/Zoom.js
@@ -5,8 +5,9 @@ import PropTypes from 'prop-types';
 import Transition from 'react-transition-group/Transition';
 import { duration } from '../styles/transitions';
 import withTheme from '../styles/withTheme';
+import { reflow, getTransitionProps } from './utils';
 
-const transitionStyles = {
+const styles = {
   entering: {
     transform: 'scale(1)',
   },
@@ -20,31 +21,39 @@ const transitionStyles = {
  * It's using [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
  */
 class Zoom extends React.Component {
-  handleEntering = node => {
-    const { theme, timeout, style = {} } = this.props;
+  handleEnter = node => {
+    const { theme } = this.props;
+    reflow(node); // So the animation always start from the start.
+
+    const { duration: transitionDuration, delay } = getTransitionProps(this.props, {
+      mode: 'enter',
+    });
     node.style.transition = theme.transitions.create('transform', {
-      duration: typeof timeout === 'number' ? timeout : timeout.enter,
-      delay: style.transitionDelay,
+      duration: transitionDuration,
+      delay,
     });
     node.style.webkitTransition = theme.transitions.create('transform', {
-      duration: typeof timeout === 'number' ? timeout : timeout.enter,
-      delay: style.transitionDelay,
+      duration: transitionDuration,
+      delay,
     });
 
-    if (this.props.onEntering) {
-      this.props.onEntering(node);
+    if (this.props.onEnter) {
+      this.props.onEnter(node);
     }
   };
 
   handleExit = node => {
-    const { theme, timeout, style = {} } = this.props;
+    const { theme } = this.props;
+    const { duration: transitionDuration, delay } = getTransitionProps(this.props, {
+      mode: 'exit',
+    });
     node.style.transition = theme.transitions.create('transform', {
-      duration: typeof timeout === 'number' ? timeout : timeout.exit,
-      delay: style.transitionDelay,
+      duration: transitionDuration,
+      delay,
     });
     node.style.webkitTransition = theme.transitions.create('transform', {
-      duration: typeof timeout === 'number' ? timeout : timeout.exit,
-      delay: style.transitionDelay,
+      duration: transitionDuration,
+      delay,
     });
 
     if (this.props.onExit) {
@@ -53,7 +62,7 @@ class Zoom extends React.Component {
   };
 
   render() {
-    const { children, onEntering, onExit, style: styleProp, theme, ...other } = this.props;
+    const { children, onEnter, onExit, style: styleProp, theme, ...other } = this.props;
 
     const style = {
       ...styleProp,
@@ -61,12 +70,12 @@ class Zoom extends React.Component {
     };
 
     return (
-      <Transition appear onEntering={this.handleEntering} onExit={this.handleExit} {...other}>
+      <Transition appear onEnter={this.handleEnter} onExit={this.handleExit} {...other}>
         {(state, childProps) => {
           return React.cloneElement(children, {
             style: {
               transform: 'scale(0)',
-              ...transitionStyles[state],
+              ...styles[state],
               ...style,
             },
             ...childProps,
@@ -90,10 +99,6 @@ Zoom.propTypes = {
    * @ignore
    */
   onEnter: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onEntering: PropTypes.func,
   /**
    * @ignore
    */

--- a/src/transitions/Zoom.js
+++ b/src/transitions/Zoom.js
@@ -21,14 +21,15 @@ const transitionStyles = {
  */
 class Zoom extends React.Component {
   handleEntering = node => {
-    const { theme, timeout } = this.props;
+    const { theme, timeout, style = {} } = this.props;
     node.style.transition = theme.transitions.create('transform', {
       duration: typeof timeout === 'number' ? timeout : timeout.enter,
+      delay: style.transitionDelay,
     });
     node.style.webkitTransition = theme.transitions.create('transform', {
       duration: typeof timeout === 'number' ? timeout : timeout.enter,
+      delay: style.transitionDelay,
     });
-    node.style.transitionDelay = `${this.props.enterDelay}ms`;
 
     if (this.props.onEntering) {
       this.props.onEntering(node);
@@ -36,12 +37,14 @@ class Zoom extends React.Component {
   };
 
   handleExit = node => {
-    const { theme, timeout } = this.props;
+    const { theme, timeout, style = {} } = this.props;
     node.style.transition = theme.transitions.create('transform', {
       duration: typeof timeout === 'number' ? timeout : timeout.exit,
+      delay: style.transitionDelay,
     });
     node.style.webkitTransition = theme.transitions.create('transform', {
       duration: typeof timeout === 'number' ? timeout : timeout.exit,
+      delay: style.transitionDelay,
     });
 
     if (this.props.onExit) {
@@ -50,16 +53,7 @@ class Zoom extends React.Component {
   };
 
   render() {
-    const {
-      appear,
-      children,
-      enterDelay,
-      onEntering,
-      onExit,
-      style: styleProp,
-      theme,
-      ...other
-    } = this.props;
+    const { children, onEntering, onExit, style: styleProp, theme, ...other } = this.props;
 
     const style = {
       ...styleProp,
@@ -67,12 +61,7 @@ class Zoom extends React.Component {
     };
 
     return (
-      <Transition
-        appear={appear}
-        onEntering={this.handleEntering}
-        onExit={this.handleExit}
-        {...other}
-      >
+      <Transition appear onEntering={this.handleEntering} onExit={this.handleExit} {...other}>
         {(state, childProps) => {
           return React.cloneElement(children, {
             style: {
@@ -90,17 +79,9 @@ class Zoom extends React.Component {
 
 Zoom.propTypes = {
   /**
-   * @ignore
-   */
-  appear: PropTypes.bool,
-  /**
    * A single child content element.
    */
   children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]),
-  /**
-   * The duration in milliseconds before the enter animation starts.
-   */
-  enterDelay: PropTypes.number,
   /**
    * If `true`, the component will transition in.
    */
@@ -136,8 +117,6 @@ Zoom.propTypes = {
 };
 
 Zoom.defaultProps = {
-  appear: true,
-  enterDelay: 0,
   timeout: {
     enter: duration.enteringScreen,
     exit: duration.leavingScreen,

--- a/src/transitions/Zoom.spec.js
+++ b/src/transitions/Zoom.spec.js
@@ -55,10 +55,10 @@ describe('<Zoom />', () => {
       instance = wrapper.instance();
     });
 
-    describe('handleEntering()', () => {
+    describe('handleEnter()', () => {
       it('should set the style properties', () => {
         const element = { style: {} };
-        instance.handleEntering(element);
+        instance.handleEnter(element);
         assert.strictEqual(
           element.style.transition,
           'transform 225ms cubic-bezier(0.4, 0, 0.2, 1) 0ms',

--- a/src/transitions/utils.js
+++ b/src/transitions/utils.js
@@ -1,0 +1,11 @@
+export const reflow = node => node.scrollTop;
+
+export function getTransitionProps(props, options) {
+  const { timeout, style = {} } = props;
+
+  return {
+    duration:
+      style.transitionDuration || typeof timeout === 'number' ? timeout : timeout[options.mode],
+    delay: style.transitionDelay,
+  };
+}


### PR DESCRIPTION
This pull request is making the implementation of the Fade, Zoom and Grow components much closer.

- Remove `CSSTransition` from Grow
- Remove `enterDelay` from Fade and Zoom
- Allow providing a string to the transition helper options
- Remove some dead code
- Fix `style.transitionDelay` override
- Fix `style.transitionDuration` override
- Fix reflow issue when first mounted

### Breaking change

```diff
           <Zoom
             in={in}
-            enterDelay={transitionDuration.exit}
+            style={{
+              transitionDelay: in ? transitionDuration.exit : 0,
+            }}
```