### PR TITLE
Use Partial props in TypeScript definitions

### DIFF
--- a/src/Menu/Menu.d.ts
+++ b/src/Menu/Menu.d.ts
@@ -7,7 +7,7 @@ import { StandardProps } from '..';
 export interface MenuProps
   extends StandardProps<PopoverProps & Partial<TransitionHandlers>, MenuClassKey> {
   anchorEl?: HTMLElement;
-  MenuListProps?: MenuListProps;
+  MenuListProps?: Partial<MenuListProps>;
   transitionDuration?: TransitionDuration;
 }
 

--- a/src/Modal/Modal.d.ts
+++ b/src/Modal/Modal.d.ts
@@ -9,7 +9,7 @@ export interface ModalProps
       ModalClassKey
     > {
   BackdropComponent?: React.ReactType<BackdropProps>;
-  BackdropProps?: BackdropProps;
+  BackdropProps?: Partial<BackdropProps>;
   disableAutoFocus?: boolean;
   disableBackdropClick?: boolean;
   disableEnforceFocus?: boolean;

--- a/src/Table/TablePagination.d.ts
+++ b/src/Table/TablePagination.d.ts
@@ -13,12 +13,12 @@ export interface LabelDisplayedRowsArgs {
 export interface TablePaginationProps
   extends StandardProps<TablePaginationBaseProps, TablePaginationClassKey> {
   Actions?: React.ReactType<TablePaginationBaseProps>;
-  backIconButtonProps?: IconButtonProps;
+  backIconButtonProps?: Partial<IconButtonProps>;
   component?: React.ReactType<TablePaginationBaseProps>;
   count: number;
   labelDisplayedRows?: (paginationInfo: LabelDisplayedRowsArgs) => React.ReactNode;
   labelRowsPerPage?: React.ReactNode;
-  nextIconButtonProps?: IconButtonProps;
+  nextIconButtonProps?: Partial<IconButtonProps>;
   onChangePage: (event: React.MouseEvent<HTMLButtonElement> | null, page: number) => void;
   onChangeRowsPerPage?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   page: number;

--- a/src/Table/TablePaginationActions.d.ts
+++ b/src/Table/TablePaginationActions.d.ts
@@ -5,9 +5,9 @@ import { IconButtonProps } from '../IconButton/IconButton';
 
 export interface TablePaginationActionsProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TablePaginationActionsClassKey> {
-  backIconButtonProps?: IconButtonProps;
+  backIconButtonProps?: Partial<IconButtonProps>;
   count: number;
-  nextIconButtonProps?: IconButtonProps;
+  nextIconButtonProps?: Partial<IconButtonProps>;
   onChangePage: (event: React.MouseEvent<HTMLButtonElement> | null, page: number) => void;
   page: number;
   rowsPerPage: number;

--- a/src/TextField/TextField.d.ts
+++ b/src/TextField/TextField.d.ts
@@ -13,13 +13,13 @@ export interface TextFieldProps
   defaultValue?: string | number;
   disabled?: boolean;
   error?: boolean;
-  FormHelperTextProps?: FormHelperTextProps;
+  FormHelperTextProps?: Partial<FormHelperTextProps>;
   fullWidth?: boolean;
   helperText?: React.ReactNode;
   helperTextClassName?: string;
   id?: string;
-  InputLabelProps?: InputLabelProps;
-  InputProps?: InputProps;
+  InputLabelProps?: Partial<InputLabelProps>;
+  InputProps?: Partial<InputProps>;
   inputProps?: InputProps['inputProps'];
   inputRef?: React.Ref<any>;
   label?: React.ReactNode;
@@ -33,7 +33,7 @@ export interface TextFieldProps
   rows?: string | number;
   rowsMax?: string | number;
   select?: boolean;
-  SelectProps?: SelectProps;
+  SelectProps?: Partial<SelectProps>;
   type?: string;
   value?: Array<string | number> | string | number;
 }


### PR DESCRIPTION
Closes #10146 .

Took a look through where we pass props through to child components and made them `Partial<>` where I thought was appropriate.

I wasn't sure about `hidden?: HiddenProps` in Grid.d.ts, so I left as is.