### PR TITLE
[MuiThemeProvider] Forward the options when nested

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -29,7 +29,7 @@
             "alias": {
               "pages": "./pages",
               "material-ui": "./src",
-              "material-ui-icons": "./packages/material-ui-icons/src",
+              "material-ui-icons": './packages/material-ui-icons/src',
               "docs": "./docs"
             }
           }
@@ -49,7 +49,7 @@
             "alias": {
               "pages": "./pages",
               "material-ui": "./src",
-              "material-ui-icons": "./packages/material-ui-icons/src",
+              "material-ui-icons": './packages/material-ui-icons/src',
               "docs": "./docs"
             }
           }

--- a/.babelrc
+++ b/.babelrc
@@ -29,7 +29,7 @@
             "alias": {
               "pages": "./pages",
               "material-ui": "./src",
-              "material-ui-icons": './packages/material-ui-icons/src',
+              "material-ui-icons": "./packages/material-ui-icons/src",
               "docs": "./docs"
             }
           }
@@ -49,7 +49,7 @@
             "alias": {
               "pages": "./pages",
               "material-ui": "./src",
-              "material-ui-icons": './packages/material-ui-icons/src',
+              "material-ui-icons": "./packages/material-ui-icons/src",
               "docs": "./docs"
             }
           }

--- a/docs/src/modules/components/Carbon.js
+++ b/docs/src/modules/components/Carbon.js
@@ -123,7 +123,7 @@ class Carbon extends React.Component {
     if (attempt < 6) {
       this.timerAdblock = setTimeout(() => {
         this.checkAdblock(attempt + 1);
-      }, 500);
+      }, 600);
     } else {
       this.setState({
         adblock: true,

--- a/pages/api/mui-theme-provider.md
+++ b/pages/api/mui-theme-provider.md
@@ -15,8 +15,8 @@ This component should preferably be used at **the root of your component tree**.
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span style="color: #31a148">children *</span> | node |  | You can only provide a single element with react@15, a node with react@16. |
-| disableStylesGeneration | bool | false | You can disable the generation of the styles with this option. It can be useful when traversing the React tree outside of the HTML rendering step on the server. Let's say you are using react-apollo to extract all the queries made by the interface server side. You can significantly speed up the traversal with this property. |
-| sheetsManager | object | null | The sheetsManager is used to deduplicate style sheet injection in the page. It's deduplicating using the (theme, styles) couple. On the server, you should provide a new instance for each request. |
+| disableStylesGeneration | bool |  | You can disable the generation of the styles with this option. It can be useful when traversing the React tree outside of the HTML rendering step on the server. Let's say you are using react-apollo to extract all the queries made by the interface server side. You can significantly speed up the traversal with this property. |
+| sheetsManager | object |  | The sheetsManager is used to deduplicate style sheet injection in the page. It's deduplicating using the (theme, styles) couple. On the server, you should provide a new instance for each request. |
 | <span style="color: #31a148">theme *</span> | union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br> |  | A theme object. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -21,17 +21,20 @@ class MuiThemeProvider extends React.Component {
   }
 
   getChildContext() {
-    const contextDisableStylesGeneration =
-      (this.context.muiThemeProviderOptions &&
-        this.context.muiThemeProviderOptions.disableStylesGeneration) ||
-      false;
+    const { sheetsManager, disableStylesGeneration } = this.props;
+    const muiThemeProviderOptions = this.context.muiThemeProviderOptions || {};
+
+    if (sheetsManager !== undefined) {
+      muiThemeProviderOptions.sheetsManager = sheetsManager;
+    }
+
+    if (disableStylesGeneration !== undefined) {
+      muiThemeProviderOptions.disableStylesGeneration = disableStylesGeneration;
+    }
+
     return {
       [CHANNEL]: this.broadcast,
-      muiThemeProviderOptions: {
-        sheetsManager: this.props.sheetsManager,
-        disableStylesGeneration:
-          this.props.disableStylesGeneration || contextDisableStylesGeneration,
-      },
+      muiThemeProviderOptions,
     };
   }
 
@@ -120,11 +123,6 @@ MuiThemeProvider.propTypes = {
 };
 
 MuiThemeProvider.propTypes = exactProp(MuiThemeProvider.propTypes, 'MuiThemeProvider');
-
-MuiThemeProvider.defaultProps = {
-  disableStylesGeneration: false,
-  sheetsManager: null,
-};
 
 MuiThemeProvider.childContextTypes = {
   ...themeListener.contextTypes,

--- a/src/styles/MuiThemeProvider.js
+++ b/src/styles/MuiThemeProvider.js
@@ -21,11 +21,16 @@ class MuiThemeProvider extends React.Component {
   }
 
   getChildContext() {
+    const contextDisableStylesGeneration =
+      (this.context.muiThemeProviderOptions &&
+        this.context.muiThemeProviderOptions.disableStylesGeneration) ||
+      false;
     return {
       [CHANNEL]: this.broadcast,
       muiThemeProviderOptions: {
         sheetsManager: this.props.sheetsManager,
-        disableStylesGeneration: this.props.disableStylesGeneration,
+        disableStylesGeneration:
+          this.props.disableStylesGeneration || contextDisableStylesGeneration,
       },
     };
   }
@@ -126,6 +131,9 @@ MuiThemeProvider.childContextTypes = {
   muiThemeProviderOptions: PropTypes.object,
 };
 
-MuiThemeProvider.contextTypes = themeListener.contextTypes;
+MuiThemeProvider.contextTypes = {
+  ...themeListener.contextTypes,
+  muiThemeProviderOptions: PropTypes.object,
+};
 
 export default MuiThemeProvider;

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -22,7 +22,7 @@ function getThemeSpy() {
   };
 
   ThemeSpy.propTypes = {
-    children: PropTypes.element.isRequired,
+    children: PropTypes.node.isRequired,
     theme: PropTypes.object,
   };
 
@@ -112,18 +112,16 @@ describe('<MuiThemeProvider />', () => {
       const wrapper = mount(
         <MuiThemeProvider theme={theme1}>
           <ThemeSpy1>
-            <div>
-              <MuiThemeProvider theme={theme2}>
-                <ThemeSpy2>
-                  <span>Foo</span>
-                </ThemeSpy2>
-              </MuiThemeProvider>
-              <MuiThemeProvider theme={theme3}>
-                <ThemeSpy3>
-                  <span>Bar</span>
-                </ThemeSpy3>
-              </MuiThemeProvider>
-            </div>
+            <MuiThemeProvider theme={theme2}>
+              <ThemeSpy2>
+                <span>Foo</span>
+              </ThemeSpy2>
+            </MuiThemeProvider>
+            <MuiThemeProvider theme={theme3}>
+              <ThemeSpy3>
+                <span>Bar</span>
+              </ThemeSpy3>
+            </MuiThemeProvider>
           </ThemeSpy1>
         </MuiThemeProvider>,
       );
@@ -143,6 +141,33 @@ describe('<MuiThemeProvider />', () => {
       assert.strictEqual(themeSpy2.args[1][0].status.color, 'green');
       assert.strictEqual(themeSpy3.callCount, 2);
       assert.strictEqual(themeSpy3.args[1][0].status.color, 'yellow');
+    });
+
+    it('should forward the parent options', () => {
+      const theme = createMuiTheme({ status: { color: 'orange' } });
+
+      const optionsSpy = spy();
+
+      function OptionsSpy(props, context) {
+        optionsSpy(context.muiThemeProviderOptions);
+        return <div />;
+      }
+
+      OptionsSpy.contextTypes = {
+        muiThemeProviderOptions: PropTypes.object.isRequired,
+      };
+
+      mount(
+        <MuiThemeProvider theme={theme} disableStylesGeneration>
+          <MuiThemeProvider theme={theme}>
+            <OptionsSpy />
+          </MuiThemeProvider>
+        </MuiThemeProvider>,
+      );
+      assert.strictEqual(optionsSpy.callCount, 1);
+      assert.deepEqual(optionsSpy.args[0][0], {
+        disableStylesGeneration: true,
+      });
     });
   });
 


### PR DESCRIPTION
Actually the MuiThemeProvider don't use the context to determine whether or not disableStylesGeneration

Closes #10175 

The problem is that in the apollo case, the JSS is rendered twice on the server
The way to avoid this is to pass the `disableStylesGeneration` props to MuiThemeProvider

But, in some cases, the MuiThemeProvider can be rendered down in the app, so It require some additionnal logic from the user to make it render JSS once


This PR add a way to simply disable JSS rendering by setting the context to :
````js
{
  muiThemeProviderOptions: {
    disableStylesGeneration: true
  }
}
````

The MuiThemeProvider then grab the value from the context if no disableStylesGeneration prop is passed

If this is a correct way of handle the case, I will commit on the PR a new Component
 `<DisableStyle disable:bool />`

which toggle the `context.muiThemeProviderOptions.disableStylesGeneration` property according to the disable prop
