### PR TITLE
[GridList] Allow null children in GridListTile

### DIFF
--- a/src/GridList/GridListTile.js
+++ b/src/GridList/GridListTile.js
@@ -94,7 +94,7 @@ class GridListTile extends React.Component {
         <EventListener target="window" onResize={this.handleResize} />
         <div className={classes.tile}>
           {React.Children.map(children, child => {
-            if (child.type === 'img') {
+            if (child && child.type === 'img') {
               return React.cloneElement(child, {
                 key: 'img',
                 ref: node => {


### PR DESCRIPTION
```jsx
<GridListTile>
        <span>goo</span>
        {false && <i>bar</i>}
      </GridListTile>  
```

will throw `Cannot read property 'type' of null` (surprising, I though false would be unboxed to Boolean, but anyway it should allow null/undefined)

demo: https://codesandbox.io/s/vqn8mrolz0