### PR TITLE
[Switch] Increase the box shadow when checked

### DIFF
--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -34,6 +34,7 @@ This property accepts the following keys:
 - `root`
 - `bar`
 - `icon`
+- `iconChecked`
 - `default`
 - `checked`
 - `disabled`

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -63,6 +63,9 @@ export const styles = theme => ({
         theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
       opacity: theme.palette.type === 'light' ? 0.12 : 0.1,
     },
+    '& $icon': {
+      boxShadow: theme.shadows[1],
+    },
   },
 });
 

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -37,6 +37,9 @@ export const styles = theme => ({
     height: 20,
     borderRadius: '50%',
   },
+  iconChecked: {
+    boxShadow: theme.shadows[2],
+  },
   // For SwitchBase
   default: {
     zIndex: 1,
@@ -66,6 +69,7 @@ export const styles = theme => ({
 function Switch(props) {
   const { classes, className, ...other } = props;
   const icon = <span className={classes.icon} />;
+  const checkedIcon = <span className={classNames(classes.icon, classes.iconChecked)} />;
 
   return (
     <span className={classNames(classes.root, className)}>
@@ -76,7 +80,7 @@ function Switch(props) {
           checked: classes.checked,
           disabled: classes.disabled,
         }}
-        checkedIcon={icon}
+        checkedIcon={checkedIcon}
         {...other}
       />
       <span className={classes.bar} />

--- a/src/Switch/Switch.spec.js
+++ b/src/Switch/Switch.spec.js
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { assert } from 'chai';
+import classNames from 'classnames';
 import { createShallow, getClasses } from '../test-utils';
 import SwitchBase from '../internal/SwitchBase';
 import Switch from './Switch';
@@ -41,6 +42,11 @@ describe('<Switch />', () => {
       assert.strictEqual(switchBase.type(), SwitchBase);
       assert.strictEqual(switchBase.props().icon.type, 'span');
       assert.strictEqual(switchBase.props().icon.props.className, classes.icon);
+      assert.strictEqual(switchBase.props().checkedIcon.type, 'span');
+      assert.strictEqual(
+        switchBase.props().checkedIcon.props.className,
+        classNames(classes.icon, classes.iconChecked),
+      );
     });
 
     it('should render the bar as the 2nd child', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This increases the box shadow of the "knob" if the switch is checked. The checked box shadow matches the [Material Web Components Switch](https://material-components-web.appspot.com/switch.html) and the Android implementation. When not checked, the box shadow is reduced (matching the Android implementation, but not the MWC implementation).

Closes #10168 (You can find more information on this change over there)