### PR TITLE
[Checkbox, Radio, Switch] Fix id in internal input

### DIFF
--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -22,9 +22,9 @@ filename: /src/Checkbox/Checkbox.js
 | indeterminateIcon | node | &lt;IndeterminateCheckBoxIcon /> | The icon to display when the component is indeterminate. |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | func |  | Use that property to pass a ref callback to the native input component. |
-| inputType | string |  | The input component property `type`. |
 | name | string |  |  |
 | onChange | func |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback<br>*checked:* The `checked` value of the switch |
+| type | string |  | The input component property `type`. |
 | value | string |  | The value of the component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -18,6 +18,7 @@ filename: /src/Checkbox/Checkbox.js
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
 | icon | node |  | The icon to display when the component is unchecked. |
+| id | string |  | The id of the `input` element. |
 | indeterminate | bool | false | If `true`, the component appears indeterminate. |
 | indeterminateIcon | node | &lt;IndeterminateCheckBoxIcon /> | The icon to display when the component is indeterminate. |
 | inputProps | object |  | Properties applied to the `input` element. |

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -18,6 +18,7 @@ filename: /src/Radio/Radio.js
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
 | icon | node |  | The icon to display when the component is unchecked. |
+| id | string |  | The id of the `input` element. |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | func |  | Use that property to pass a ref callback to the native input component. |
 | name | string |  |  |

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -20,9 +20,9 @@ filename: /src/Radio/Radio.js
 | icon | node |  | The icon to display when the component is unchecked. |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | func |  | Use that property to pass a ref callback to the native input component. |
-| inputType | string |  | The input component property `type`. |
 | name | string |  |  |
 | onChange | func |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback<br>*checked:* The `checked` value of the switch |
+| type | string |  | The input component property `type`. |
 | value | string |  | The value of the component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -18,6 +18,7 @@ filename: /src/Switch/Switch.js
 | disabled | bool |  | If `true`, the switch will be disabled. |
 | disableRipple | bool |  | If `true`, the ripple effect will be disabled. |
 | icon | node |  | The icon to display when the component is unchecked. |
+| id | string |  | The id of the `input` element. |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | func |  | Use that property to pass a ref callback to the native input component. |
 | name | string |  |  |

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -20,9 +20,9 @@ filename: /src/Switch/Switch.js
 | icon | node |  | The icon to display when the component is unchecked. |
 | inputProps | object |  | Properties applied to the `input` element. |
 | inputRef | func |  | Use that property to pass a ref callback to the native input component. |
-| inputType | string |  | The input component property `type`. |
 | name | string |  |  |
 | onChange | func |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback<br>*checked:* The `checked` value of the switch |
+| type | string |  | The input component property `type`. |
 | value | string |  | The value of the component. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -77,10 +77,6 @@ Checkbox.propTypes = {
    * Use that property to pass a ref callback to the native input component.
    */
   inputRef: PropTypes.func,
-  /**
-   * The input component property `type`.
-   */
-  inputType: PropTypes.string,
   /*
    * @ignore
    */
@@ -96,6 +92,10 @@ Checkbox.propTypes = {
    * @ignore
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * The input component property `type`.
+   */
+  type: PropTypes.string,
   /**
    * The value of the component.
    */

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -62,6 +62,10 @@ Checkbox.propTypes = {
    */
   icon: PropTypes.node,
   /**
+   * The id of the `input` element.
+   */
+  id: PropTypes.string,
+  /**
    * If `true`, the component appears indeterminate.
    */
   indeterminate: PropTypes.bool,

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -62,6 +62,10 @@ Radio.propTypes = {
    */
   icon: PropTypes.node,
   /**
+   * The id of the `input` element.
+   */
+  id: PropTypes.string,
+  /**
    * Properties applied to the `input` element.
    */
   inputProps: PropTypes.object,

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -20,7 +20,7 @@ export const styles = theme => ({
 function Radio(props) {
   return (
     <SwitchBase
-      inputType="radio"
+      type="radio"
       icon={<RadioButtonUncheckedIcon />}
       checkedIcon={<RadioButtonCheckedIcon />}
       {...props}
@@ -69,10 +69,6 @@ Radio.propTypes = {
    * Use that property to pass a ref callback to the native input component.
    */
   inputRef: PropTypes.func,
-  /**
-   * The input component property `type`.
-   */
-  inputType: PropTypes.string,
   /*
    * @ignore
    */
@@ -88,6 +84,10 @@ Radio.propTypes = {
    * @ignore
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * The input component property `type`.
+   */
+  type: PropTypes.string,
   /**
    * The value of the component.
    */

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -125,6 +125,10 @@ Switch.propTypes = {
    */
   icon: PropTypes.node,
   /**
+   * The id of the `input` element.
+   */
+  id: PropTypes.string,
+  /**
    * Properties applied to the `input` element.
    */
   inputProps: PropTypes.object,

--- a/src/Switch/Switch.js
+++ b/src/Switch/Switch.js
@@ -132,10 +132,6 @@ Switch.propTypes = {
    * Use that property to pass a ref callback to the native input component.
    */
   inputRef: PropTypes.func,
-  /**
-   * The input component property `type`.
-   */
-  inputType: PropTypes.string,
   /*
    * @ignore
    */
@@ -151,6 +147,10 @@ Switch.propTypes = {
    * @ignore
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * The input component property `type`.
+   */
+  type: PropTypes.string,
   /**
    * The value of the component.
    */

--- a/src/internal/SwitchBase.d.ts
+++ b/src/internal/SwitchBase.d.ts
@@ -29,7 +29,7 @@ export type SwitchBase = React.Component<SwitchBaseProps>;
 export interface CreateSwitchBaseOptions {
   defaultIcon?: React.ReactNode;
   defaultCheckedIcon?: React.ReactNode;
-  inputType?: string;
+  type?: string;
 }
 
 export default function createSwitch(options: CreateSwitchBaseOptions): SwitchBase;

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -165,7 +165,7 @@ SwitchBase.propTypes = {
    */
   icon: PropTypes.node,
   /**
-   * @ignore
+   * The id of the `input` element.
    */
   id: PropTypes.string,
   /**

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -73,10 +73,10 @@ class SwitchBase extends React.Component {
       id,
       inputProps,
       inputRef,
-      inputType,
       name,
       onChange,
       tabIndex,
+      type,
       value,
       ...other
     } = this.props;
@@ -98,11 +98,10 @@ class SwitchBase extends React.Component {
 
     const icon = checked ? checkedIcon : iconProp;
 
-    const hasLabelFor = inputType === 'checkbox' || inputType === 'radio';
+    const hasLabelFor = type === 'checkbox' || type === 'radio';
 
     return (
       <IconButton
-        id={hasLabelFor ? '' : id}
         data-mui-test="SwitchBase"
         component="span"
         className={className}
@@ -114,7 +113,7 @@ class SwitchBase extends React.Component {
         {icon}
         <input
           id={hasLabelFor && id}
-          type={inputType}
+          type={type}
           name={name}
           checked={checkedProp}
           onChange={this.handleInputChange}
@@ -185,10 +184,6 @@ SwitchBase.propTypes = {
    * Use that property to pass a ref callback to the native input component.
    */
   inputRef: PropTypes.func,
-  /**
-   * The input component property `type`.
-   */
-  inputType: PropTypes.string,
   /*
    * @ignore
    */
@@ -205,6 +200,10 @@ SwitchBase.propTypes = {
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
+   * The input component property `type`.
+   */
+  type: PropTypes.string,
+  /**
    * The value of the component.
    */
   value: PropTypes.string,
@@ -214,7 +213,7 @@ SwitchBase.defaultProps = {
   checkedIcon: <CheckBoxIcon />,
   disableRipple: false,
   icon: <CheckBoxOutlineBlankIcon />,
-  inputType: 'checkbox',
+  type: 'checkbox',
 };
 
 SwitchBase.contextTypes = {

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -102,6 +102,7 @@ class SwitchBase extends React.Component {
 
     return (
       <IconButton
+        id={hasLabelFor ? '' : id}
         data-mui-test="SwitchBase"
         component="span"
         className={className}

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -70,6 +70,7 @@ class SwitchBase extends React.Component {
       className: classNameProp,
       disabled: disabledProp,
       icon: iconProp,
+      id,
       inputProps,
       inputRef,
       inputType,
@@ -97,6 +98,8 @@ class SwitchBase extends React.Component {
 
     const icon = checked ? checkedIcon : iconProp;
 
+    const hasLabelFor = inputType === 'checkbox' || inputType === 'radio';
+
     return (
       <IconButton
         data-mui-test="SwitchBase"
@@ -109,6 +112,7 @@ class SwitchBase extends React.Component {
       >
         {icon}
         <input
+          id={hasLabelFor && id}
           type={inputType}
           name={name}
           checked={checkedProp}
@@ -160,6 +164,10 @@ SwitchBase.propTypes = {
    * The icon to display when the component is unchecked.
    */
   icon: PropTypes.node,
+  /**
+   * @ignore
+   */
+  id: PropTypes.string,
   /**
    * If `true`, the component appears indeterminate.
    */

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -307,6 +307,18 @@ describe('<SwitchBase />', () => {
         assert.strictEqual(wrapper2.find('input').props()['aria-label'], 'foo');
       });
     });
+
+    describe('prop: id', () => {
+      it('should be able to add id to a checkbox input', () => {
+        const wrapper2 = shallow(<SwitchBase inputType="checkbox" id="foo" />);
+        assert.strictEqual(wrapper2.find('input').props().id, 'foo');
+      });
+
+      it('should be able to add id to a radio input', () => {
+        const wrapper2 = shallow(<SwitchBase inputType="radio" id="foo" />);
+        assert.strictEqual(wrapper2.find('input').props().id, 'foo');
+      });
+    });
   });
 
   describe('with muiFormControl context', () => {

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -310,12 +310,12 @@ describe('<SwitchBase />', () => {
 
     describe('prop: id', () => {
       it('should be able to add id to a checkbox input', () => {
-        const wrapper2 = shallow(<SwitchBase inputType="checkbox" id="foo" />);
+        const wrapper2 = shallow(<SwitchBase type="checkbox" id="foo" />);
         assert.strictEqual(wrapper2.find('input').props().id, 'foo');
       });
 
       it('should be able to add id to a radio input', () => {
-        const wrapper2 = shallow(<SwitchBase inputType="radio" id="foo" />);
+        const wrapper2 = shallow(<SwitchBase type="radio" id="foo" />);
         assert.strictEqual(wrapper2.find('input').props().id, 'foo');
       });
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This make the id of input wrapper goes down to input when it's a checkbox/radio/switch.

Closes #10113 

### Breaking change

For consistency between the `Input` and the `Checkbox`, `Switch`, `Radio` the following small breaking changes have been done:
- The usage of the `inputProps` property is no longer needed to apply an id to the input. The `id` is applied to the input instead of the root.
- The `inputType` property was renamed `type`.