### PR TITLE
[MenuItem] Better :hover and .selected logic

### DIFF
--- a/docs/src/pages/demos/selects/MultipleSelect.js
+++ b/docs/src/pages/demos/selects/MultipleSelect.js
@@ -103,7 +103,7 @@ class MultipleSelect extends React.Component {
           >
             {names.map(name => (
               <MenuItem key={name} value={name}>
-                <Checkbox checked={this.state.name === name} />
+                <Checkbox checked={this.state.name.indexOf(name) > -1} />
                 <ListItemText primary={name} />
               </MenuItem>
             ))}

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -52,9 +52,6 @@ export const styles = theme => ({
       '@media (hover: none)': {
         backgroundColor: 'transparent',
       },
-      '&$disabled': {
-        backgroundColor: 'transparent',
-      },
     },
   },
   secondaryAction: {

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -18,9 +18,6 @@ export const styles = theme => ({
     '&$selected': {
       backgroundColor: theme.palette.action.selected,
     },
-    '&:hover': {
-      backgroundColor: theme.palette.action.hover,
-    },
   },
   selected: {},
 });

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -32,9 +32,9 @@ export const light = {
     // The color of an active action like an icon button.
     active: 'rgba(0, 0, 0, 0.54)',
     // The color of an hovered action.
-    hover: 'rgba(0, 0, 0, 0.14)',
+    hover: 'rgba(0, 0, 0, 0.08)',
     // The color of a selected action.
-    selected: 'rgba(0, 0, 0, 0.08)',
+    selected: 'rgba(0, 0, 0, 0.14)',
     // The color of a disabled action.
     disabled: 'rgba(0, 0, 0, 0.26)',
     // The background color of a disabled action.
@@ -57,8 +57,8 @@ export const dark = {
   },
   action: {
     active: common.white,
-    hover: 'rgba(255, 255, 255, 0.2)',
-    selected: 'rgba(255, 255, 255, 0.1)',
+    hover: 'rgba(255, 255, 255, 0.1)',
+    selected: 'rgba(255, 255, 255, 0.2)',
     disabled: 'rgba(255, 255, 255, 0.3)',
     disabledBackground: 'rgba(255, 255, 255, 0.12)',
   },


### PR DESCRIPTION
- Inverse the hover and selected values:
  - [material-web-component](https://material-components-web.appspot.com/list.html) seems to use an even lighter background color for the focus state on the list.
  - The selected background color on [Bootstrap is way darker](https://getbootstrap.com/docs/4.0/components/dropdowns/#active-menu-items) than the focus background color.
- Make the selected state having a higher specificity than the hover state. It seems more intuitive and is allowing us to remove code.
- Fix a wrong logic with the Select demo

Closes #10193