### PR TITLE
[LinearProgress] Property definition grammar fix

### DIFF
--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -18,7 +18,7 @@ attribute to `true` on that region until it has finished loading.
 | classes | object |  | Useful to extend the style applied to components. |
 | color | enum:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br> | 'primary' | The color of the component. It supports those theme colors that make sense for this component. |
 | value | number |  | The value of the progress indicator for the determinate and buffer variants. Value between 0 and 100. |
-| valueBuffer | number |  | The value for the buffer for the buffer variant. Value between 0 and 100. |
+| valueBuffer | number |  | The value for the buffer variant. Value between 0 and 100. |
 | variant | enum:&nbsp;'determinate'&nbsp;&#124;<br>&nbsp;'indeterminate'&nbsp;&#124;<br>&nbsp;'buffer'&nbsp;&#124;<br>&nbsp;'query'<br> | 'indeterminate' | The variant of progress indicator. Use indeterminate or query when there is no progress value. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -233,7 +233,7 @@ LinearProgress.propTypes = {
    */
   value: PropTypes.number,
   /**
-   * The value for the buffer for the buffer variant.
+   * The value for the buffer variant.
    * Value between 0 and 100.
    */
   valueBuffer: PropTypes.number,


### PR DESCRIPTION
I noticed duplicate text in one of the prop definitions. This PR is simply proposing a fix to correct that minor error.