### PR TITLE
[Stepper] Increase StepButton space for click

### DIFF
--- a/docs/src/pages/demos/steppers/HorizontalLinearAlternativeLabelStepper.js
+++ b/docs/src/pages/demos/steppers/HorizontalLinearAlternativeLabelStepper.js
@@ -30,7 +30,6 @@ function getStepContent(stepIndex) {
       return 'What is an ad group anyways?';
     case 2:
       return 'This is the bit I really care about!';
-
     default:
       return 'Uknown stepIndex';
   }

--- a/docs/src/pages/demos/steppers/VerticalLinearStepper.js
+++ b/docs/src/pages/demos/steppers/VerticalLinearStepper.js
@@ -11,15 +11,14 @@ const styles = theme => ({
     width: '90%',
   },
   button: {
+    marginTop: theme.spacing.unit,
     marginRight: theme.spacing.unit,
   },
   actionsContainer: {
-    marginTop: theme.spacing.unit,
-    marginBottom: theme.spacing.unit,
+    marginBottom: theme.spacing.unit * 2,
   },
   resetContainer: {
-    marginTop: 0,
-    padding: theme.spacing.unit * 3, // TODO: See TODO note on Stepper
+    padding: theme.spacing.unit * 3,
   },
 });
 

--- a/packages/material-ui-icons/test/index.js
+++ b/packages/material-ui-icons/test/index.js
@@ -11,7 +11,6 @@ temp.track();
 const DISABLE_LOG = true;
 
 // To cut down on test time, use fixtures instead of node_modules
-// TODO: Make a flag to toggle this.
 const MUI_ICONS_ROOT = path.join(__dirname, './fixtures/material-design-icons/');
 // const MUI_ICONS_ROOT = path.join(__dirname, '../node_modules/material-design-icons/');
 const MUI_ICONS_SVG_DIR = path.join(MUI_ICONS_ROOT, 'svg');

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -23,7 +23,6 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `alternativeLabel`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/StepButton.js)

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -27,13 +27,14 @@ This property accepts the following keys:
 - `root`
 - `horizontal`
 - `vertical`
-- `active`
-- `completed`
+- `alternativeLabel`
 - `disabled`
+- `label`
+- `labelActive`
+- `labelCompleted`
+- `labelAlternativeLabel`
 - `iconContainer`
 - `iconContainerNoAlternative`
-- `alternativeLabelRoot`
-- `alternativeLabel`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/StepLabel.js)

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -25,6 +25,7 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `horizontal`
+- `vertical`
 - `alternativeLabel`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -29,6 +29,7 @@ This property accepts the following keys:
 - `root`
 - `horizontal`
 - `vertical`
+- `alternativeLabel`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/Stepper.js)

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -40,7 +40,7 @@ function Paper(props) {
 
   const className = classNames(
     classes.root,
-    classes[`shadow${elevation >= 0 ? elevation : 0}`],
+    classes[`shadow${elevation}`],
     {
       [classes.rounded]: !square,
     },

--- a/src/Stepper/Step.js
+++ b/src/Stepper/Step.js
@@ -15,10 +15,10 @@ export const styles = theme => ({
       paddingRight: 0,
     },
   },
+  vertical: {},
   alternativeLabel: {
     flex: 1,
     position: 'relative',
-    marginLeft: 0,
   },
 });
 

--- a/src/Stepper/StepButton.js
+++ b/src/Stepper/StepButton.js
@@ -10,16 +10,10 @@ import { isMuiElement } from '../utils/reactHelpers';
 
 export const styles = theme => ({
   root: {
-    display: 'flex',
-    alignItems: 'center',
-    padding: theme.spacing.unit * 3,
-    margin: -theme.spacing.unit * 3,
+    width: '100%',
+    padding: `${theme.spacing.unit * 3}px ${theme.spacing.unit * 2}px`,
+    margin: `${-theme.spacing.unit * 3}px ${-theme.spacing.unit * 2}px`,
     boxSizing: 'content-box',
-    background: 'none',
-  },
-  alternativeLabel: {
-    marginLeft: 'auto',
-    marginRight: 'auto',
   },
 });
 
@@ -39,13 +33,6 @@ function StepButton(props) {
     ...other
   } = props;
 
-  const className = classNames(
-    classes.root,
-    {
-      [classes.alternativeLabel]: alternativeLabel,
-    },
-    classNameProp,
-  );
   const childProps = {
     active,
     alternativeLabel,
@@ -62,7 +49,7 @@ function StepButton(props) {
   );
 
   return (
-    <ButtonBase disabled={disabled} className={className} {...other}>
+    <ButtonBase disabled={disabled} className={classNames(classes.root, classNameProp)} {...other}>
       {child}
     </ButtonBase>
   );

--- a/src/Stepper/StepButton.js
+++ b/src/Stepper/StepButton.js
@@ -8,18 +8,20 @@ import ButtonBase from '../ButtonBase';
 import StepLabel from './StepLabel';
 import { isMuiElement } from '../utils/reactHelpers';
 
-export const styles = {
+export const styles = theme => ({
   root: {
     display: 'flex',
     alignItems: 'center',
-    paddingLeft: 0,
-    paddingRight: 0,
+    padding: theme.spacing.unit * 3,
+    margin: -theme.spacing.unit * 3,
+    boxSizing: 'content-box',
     background: 'none',
   },
   alternativeLabel: {
-    margin: '0 auto',
+    marginLeft: 'auto',
+    marginRight: 'auto',
   },
-};
+});
 
 function StepButton(props) {
   const {

--- a/src/Stepper/StepConnector.js
+++ b/src/Stepper/StepConnector.js
@@ -7,13 +7,20 @@ export const styles = theme => ({
   root: {
     flex: '1 1 auto',
   },
+  horizontal: {},
+  vertical: {
+    marginLeft: 12, // half icon
+    padding: `0 0 ${theme.spacing.unit}px`,
+  },
+  alternativeLabel: {
+    position: 'absolute',
+    top: theme.spacing.unit + 4,
+    left: 'calc(50% + 20px)',
+    right: 'calc(-50% + 20px)',
+  },
   line: {
     display: 'block',
     borderColor: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[600],
-  },
-  rootVertical: {
-    marginLeft: 12, // half icon
-    padding: `0 0 ${theme.spacing.unit}px`,
   },
   lineHorizontal: {
     borderTopStyle: 'solid',
@@ -22,16 +29,7 @@ export const styles = theme => ({
   lineVertical: {
     borderLeftStyle: 'solid',
     borderLeftWidth: 1,
-    minHeight: 24,
-  },
-  alternativeLabelRoot: {
-    position: 'absolute',
-    top: theme.spacing.unit + 4,
-    left: 'calc(50% + 20px)',
-    right: 'calc(-50% + 20px)',
-  },
-  alternativeLabelLine: {
-    marginLeft: 0,
+    minHeight: theme.spacing.unit * 3,
   },
 });
 
@@ -42,17 +40,16 @@ function StepConnector(props) {
   const { alternativeLabel, className: classNameProp, classes, orientation, ...other } = props;
 
   const className = classNames(
+    classes.root,
+    classes[orientation],
     {
-      [classes.root]: !alternativeLabel,
-      [classes.rootVertical]: orientation === 'vertical',
-      [classes.alternativeLabelRoot]: alternativeLabel,
+      [classes.alternativeLabel]: alternativeLabel,
     },
     classNameProp,
   );
   const lineClassName = classNames(classes.line, {
     [classes.lineHorizontal]: orientation === 'horizontal',
     [classes.lineVertical]: orientation === 'vertical',
-    [classes.alternativeLabelLine]: alternativeLabel,
   });
 
   return (

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -12,25 +12,30 @@ export const styles = theme => ({
   },
   horizontal: {},
   vertical: {},
-  active: {
-    fontWeight: 500,
-  },
-  completed: {
-    fontWeight: 500,
+  alternativeLabel: {
+    flexDirection: 'column',
   },
   disabled: {
     cursor: 'default',
   },
+  label: {
+    color: theme.palette.text.secondary,
+  },
+  labelActive: {
+    color: theme.palette.text.primary,
+    fontWeight: 500,
+  },
+  labelCompleted: {
+    color: theme.palette.text.primary,
+    fontWeight: 500,
+  },
+  labelAlternativeLabel: {
+    textAlign: 'center',
+    marginTop: theme.spacing.unit * 2,
+  },
   iconContainer: {},
   iconContainerNoAlternative: {
     paddingRight: theme.spacing.unit,
-  },
-  alternativeLabelRoot: {
-    flexDirection: 'column',
-  },
-  alternativeLabel: {
-    textAlign: 'center',
-    marginTop: theme.spacing.unit * 2,
   },
 });
 
@@ -50,20 +55,15 @@ function StepLabel(props) {
     ...other
   } = props;
 
-  const className = classNames(classes.root, classes[orientation], {
-    [classes.disabled]: disabled,
-    [classes.completed]: completed,
-    [classes.alternativeLabelRoot]: alternativeLabel,
-    classNameProp,
-  });
-  const labelClassName = classNames({
-    [classes.alternativeLabel]: alternativeLabel,
-    [classes.completed]: completed,
-    [classes.active]: active,
-  });
-
   return (
-    <span className={className} {...other}>
+    <span
+      className={classNames(classes.root, classes[orientation], {
+        [classes.disabled]: disabled,
+        [classes.alternativeLabel]: alternativeLabel,
+        classNameProp,
+      })}
+      {...other}
+    >
       {icon && (
         <span
           className={classNames(classes.iconContainer, {
@@ -79,7 +79,15 @@ function StepLabel(props) {
         </span>
       )}
       <span>
-        <Typography variant="body1" component="span" className={labelClassName}>
+        <Typography
+          variant="body1"
+          component="span"
+          className={classNames(classes.label, {
+            [classes.labelAlternativeLabel]: alternativeLabel,
+            [classes.labelCompleted]: completed,
+            [classes.labelActive]: active,
+          })}
+        >
           {children}
         </Typography>
         {optional}

--- a/src/Stepper/StepLabel.spec.js
+++ b/src/Stepper/StepLabel.spec.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, createMount } from '../test-utils';
+import { createShallow, createMount, getClasses } from '../test-utils';
 import Typography from '../Typography';
 import StepLabel from './StepLabel';
 import StepIcon from './StepIcon';
 
 describe('<StepLabel />', () => {
   let shallow;
+  let classes;
   let mount;
 
   before(() => {
     shallow = createShallow({ dive: true });
+    classes = getClasses(<StepLabel />);
     mount = createMount();
   });
 
@@ -58,7 +60,7 @@ describe('<StepLabel />', () => {
     it('renders <Typography> without the className active', () => {
       const wrapper = shallow(<StepLabel active={false}>Step One</StepLabel>);
       const text = wrapper.find(Typography);
-      assert.notInclude(text.props().className, 'active');
+      assert.strictEqual(text.hasClass(classes.labelActive), false);
     });
   });
 
@@ -66,7 +68,7 @@ describe('<StepLabel />', () => {
     it('renders <Typography> with the className active', () => {
       const wrapper = shallow(<StepLabel active>Step One</StepLabel>);
       const text = wrapper.find(Typography);
-      assert.include(text.props().className, 'active');
+      assert.strictEqual(text.hasClass(classes.labelActive), true);
     });
 
     it('renders <StepIcon> with the prop active set to true', () => {
@@ -84,7 +86,7 @@ describe('<StepLabel />', () => {
     it('renders <Typography> with the className completed', () => {
       const wrapper = shallow(<StepLabel completed>Step One</StepLabel>);
       const text = wrapper.find(Typography);
-      assert.include(text.props().className, 'completed');
+      assert.strictEqual(text.hasClass(classes.labelCompleted), true);
     });
 
     it('renders <StepIcon> with the prop completed set to true', () => {
@@ -105,7 +107,7 @@ describe('<StepLabel />', () => {
           Step One
         </StepLabel>,
       );
-      assert.include(wrapper.props().className, 'disabled');
+      assert.strictEqual(wrapper.hasClass(classes.disabled), true);
     });
   });
 

--- a/src/Stepper/StepPositionIcon.js
+++ b/src/Stepper/StepPositionIcon.js
@@ -6,7 +6,7 @@ import SvgIcon from '../SvgIcon';
 
 export const styles = theme => ({
   root: {
-    color: theme.palette.action.disabled,
+    color: theme.palette.text.disabled,
   },
   active: {
     color: theme.palette.primary.main,
@@ -33,7 +33,7 @@ function StepPositionIcon(props) {
 
   return (
     <SvgIcon className={className}>
-      <circle cx="12" cy="12" r="10" />
+      <circle cx="12" cy="12" r="12" />
       <text className={classes.text} x="12" y="16" textAnchor="middle">
         {position}
       </text>

--- a/src/Stepper/Stepper.js
+++ b/src/Stepper/Stepper.js
@@ -19,15 +19,18 @@ export const styles = theme => ({
   vertical: {
     flexDirection: 'column',
   },
+  alternativeLabel: {
+    alignItems: 'flex-start',
+  },
 });
 
 function Stepper(props) {
   const {
     activeStep,
     alternativeLabel,
+    children,
     classes,
     className: classNameProp,
-    children,
     connector: connectorProp,
     nonLinear,
     orientation,
@@ -36,11 +39,16 @@ function Stepper(props) {
 
   const className = classNames(
     classes.root,
+    classes[orientation],
+    {
+      [classes.alternativeLabel]: alternativeLabel,
+    },
     classNameProp,
-    alternativeLabel ? null : classes[orientation],
   );
 
-  const connector = connectorProp ? React.cloneElement(connectorProp, { orientation }) : null;
+  const connector = React.isValidElement(connectorProp)
+    ? React.cloneElement(connectorProp, { orientation })
+    : null;
   const childrenArray = React.Children.toArray(children);
   const steps = childrenArray.map((step, index) => {
     const controlProps = {
@@ -67,7 +75,7 @@ function Stepper(props) {
         connector &&
         index > 0 &&
         React.cloneElement(connector, {
-          key: `connect-${index - 1}-to-${index}`, // eslint-disable-line react/no-array-index-key
+          key: index, // eslint-disable-line react/no-array-index-key
         }),
       React.cloneElement(step, { ...controlProps, ...step.props }),
     ];

--- a/src/internal/svg-icons/CheckCircle.js
+++ b/src/internal/svg-icons/CheckCircle.js
@@ -7,7 +7,7 @@ import SvgIcon from '../../SvgIcon';
  */
 let CheckCircle = props => (
   <SvgIcon {...props}>
-    <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+    <path d="M12 0a12 12 0 1 0 0 24 12 12 0 0 0 0-24zm-2 17l-5-5 1.4-1.4 3.6 3.6 7.6-7.6L19 8l-9 9z" />
   </SvgIcon>
 );
 CheckCircle = pure(CheckCircle);


### PR DESCRIPTION
Closes #10035.

## Basic Idea
Currently, component **`Stepper`** has a `padding` size based on theme, which is `theme.spacing.unit * 3`. This `padding` causes components inside it, including **`StepButton`** which `width` and `height` are both `100%`, to squeeze.

One possible solution is to add `padding` for component **`StepButton`** with the size of **`Stepper`** padding. Ensuring the `width` and `height` do not include the `padding`, it should change its style's `box-sizing` property to `content-box`. This way increases the spacing of the **`StepperButton`**.

This comes to a problem that `StepperButton` is jerked because of this new `padding`. It can be solved by adding negative `margin` the size of that `padding`.

## Screenshots
### 1. Horizontal Non-linear
![screen shot 2018-02-08 at 12 04 45 am 2](https://user-images.githubusercontent.com/23165866/35928109-4ecd7fde-0c67-11e8-98e7-fdb8f1091c26.png)

### 2. Horizontal Non Linear - Alternative Label

The `StepButton` with the biggest height will span the container height.

![screen shot 2018-02-08 at 12 06 33 am 2](https://user-images.githubusercontent.com/23165866/35928200-8916efd6-0c67-11e8-9f93-a1bdea6ca00d.png)

However, the other `StepButton` still does not fully span the container height. Is this tolerable, or is there any suggestion for this?

![screen shot 2018-02-08 at 12 07 09 am 2](https://user-images.githubusercontent.com/23165866/35928205-8b818a9c-0c67-11e8-8ade-ae599d0f7d8b.png)

-----------
It seems there's no breaking changes nor test updates required in this PR.

### Really appreciate for a review!
