### PR TITLE
[TextField] Fix caret position issue

### DIFF
--- a/src/TextField/EnhancedTextarea.js
+++ b/src/TextField/EnhancedTextarea.js
@@ -116,7 +116,7 @@ class EnhancedTextarea extends Component {
 
     if (this.state.height !== newHeight) {
       const input = this.refs.input;
-      const cursorPosition = input.selectionStart;
+      const cursorPosition = input.selectionEnd;
       this.setState({
         height: newHeight,
       }, () => {


### PR DESCRIPTION
Use selectionEnd instead of selectionStart to fix caret position issue.

Closes #10213
