### PR TITLE
[StepLabel] Give more flexibility to the style of span surrounding label

### DIFF
--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -35,6 +35,7 @@ This property accepts the following keys:
 - `labelAlternativeLabel`
 - `iconContainer`
 - `iconContainerNoAlternative`
+- `labelContainer`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Stepper/StepLabel.js)

--- a/src/Stepper/Step.d.ts
+++ b/src/Stepper/Step.d.ts
@@ -15,7 +15,7 @@ export interface StepProps
   orientation?: Orientation;
 }
 
-export type StepClasskey = 'root' | 'horizontal' | 'alternativeLabel';
+export type StepClasskey = 'root' | 'horizontal' | 'vertical' | 'alternativeLabel';
 
 declare const Step: React.ComponentType<StepProps>;
 

--- a/src/Stepper/StepButton.d.ts
+++ b/src/Stepper/StepButton.d.ts
@@ -16,7 +16,7 @@ export interface StepButtonProps extends StandardProps<ButtonBaseProps, StepButt
   orientation?: Orientation;
 }
 
-export type StepButtonClasskey = ButtonBaseClassKey | 'root' | 'alternativeLabel';
+export type StepButtonClasskey = ButtonBaseClassKey | 'root';
 
 declare const StepButton: React.ComponentType<StepButtonProps>;
 

--- a/src/Stepper/StepConnector.d.ts
+++ b/src/Stepper/StepConnector.d.ts
@@ -10,7 +10,14 @@ export interface StepConnectorProps
   orientation?: Orientation;
 }
 
-export type StepConnectorClasskey = 'root' | 'alternativeLabel';
+export type StepConnectorClasskey =
+  | 'root'
+  | 'horizontal'
+  | 'vertical'
+  | 'alternativeLabel'
+  | 'line'
+  | 'lineHorizontal'
+  | 'lineVertical';
 
 declare const StepConnector: React.ComponentType<StepConnectorProps>;
 

--- a/src/Stepper/StepLabel.d.ts
+++ b/src/Stepper/StepLabel.d.ts
@@ -20,13 +20,14 @@ export type StepLabelClasskey =
   | 'root'
   | 'horizontal'
   | 'vertical'
-  | 'active'
-  | 'completed'
+  | 'alternativeLabel'
   | 'disabled'
+  | 'label'
+  | 'labelActive'
+  | 'labelCompleted'
+  | 'labelAlternativeLabel'
   | 'iconContainer'
   | 'iconContainerNoAlternative'
-  | 'alternativeLabelRoot'
-  | 'alternativeLabel'
   | 'labelContainer';
 
 declare const StepLabel: React.ComponentType<StepLabelProps>;

--- a/src/Stepper/StepLabel.d.ts
+++ b/src/Stepper/StepLabel.d.ts
@@ -26,7 +26,8 @@ export type StepLabelClasskey =
   | 'iconContainer'
   | 'iconContainerNoAlternative'
   | 'alternativeLabelRoot'
-  | 'alternativeLabel';
+  | 'alternativeLabel'
+  | 'labelContainer';
 
 declare const StepLabel: React.ComponentType<StepLabelProps>;
 

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -60,10 +60,15 @@ function StepLabel(props) {
 
   return (
     <span
-      className={classNames(classes.root, classes[orientation], classNameProp, {
-        [classes.disabled]: disabled,
-        [classes.alternativeLabel]: alternativeLabel,
-      })}
+      className={classNames(
+        classes.root,
+        classes[orientation],
+        {
+          [classes.disabled]: disabled,
+          [classes.alternativeLabel]: alternativeLabel,
+        },
+        classNameProp,
+      )}
       {...other}
     >
       {icon && (

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -37,6 +37,9 @@ export const styles = theme => ({
   iconContainerNoAlternative: {
     paddingRight: theme.spacing.unit,
   },
+  labelContainer: {
+    width: '100%',
+  },
 });
 
 function StepLabel(props) {
@@ -57,10 +60,9 @@ function StepLabel(props) {
 
   return (
     <span
-      className={classNames(classes.root, classes[orientation], {
+      className={classNames(classes.root, classes[orientation], classNameProp, {
         [classes.disabled]: disabled,
         [classes.alternativeLabel]: alternativeLabel,
-        classNameProp,
       })}
       {...other}
     >
@@ -78,7 +80,7 @@ function StepLabel(props) {
           />
         </span>
       )}
-      <span>
+      <span className={classes.labelContainer}>
         <Typography
           variant="body1"
           component="span"

--- a/src/Stepper/Stepper.d.ts
+++ b/src/Stepper/Stepper.d.ts
@@ -14,7 +14,7 @@ export interface StepperProps extends StandardProps<PaperProps, StepperClasskey>
   orientation?: Orientation;
 }
 
-export type StepperClasskey = PaperClassKey | 'root' | 'horizontal' | 'vertical';
+export type StepperClasskey = PaperClassKey | 'root' | 'horizontal' | 'vertical' | 'alternativeLabel';
 
 declare const Stepper: React.ComponentType<StepperProps>;
 


### PR DESCRIPTION
This PR allows you to configure style of the span that surrounds the label as this is not currently possible and is limiting.

This fix also correctly applies the className passed to the StepLabel component, as currently the text `classNameProp` gets applied no matter what.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
