### PR TITLE
[ButtonBase] Use parent Window of ButtonBase when listening for keyboard events

### DIFF
--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { findDOMNode } from 'react-dom';
 import classNames from 'classnames';
 import keycode from 'keycode';
+import ownerWindow from 'dom-helpers/ownerWindow';
 import withStyles from '../styles/withStyles';
 import { listenForFocusKeys, detectKeyboardFocus, focusKeyPressed } from '../utils/keyboardFocus';
 import TouchRipple from './TouchRipple';
@@ -56,7 +57,7 @@ class ButtonBase extends React.Component {
 
   componentDidMount() {
     this.button = findDOMNode(this);
-    listenForFocusKeys();
+    listenForFocusKeys(ownerWindow(this.button));
   }
 
   componentWillReceiveProps(nextProps) {

--- a/src/utils/keyboardFocus.d.ts
+++ b/src/utils/keyboardFocus.d.ts
@@ -8,5 +8,5 @@ export function detectKeyboardFocus(
   element: Element,
   cb: () => void,
   attempt: number,
-): never;
-export function listenForFocusKeys(): never;
+): void;
+export function listenForFocusKeys(window: Window): void;

--- a/src/utils/keyboardFocus.js
+++ b/src/utils/keyboardFocus.js
@@ -3,10 +3,10 @@
 import keycode from 'keycode';
 import warning from 'warning';
 import contains from 'dom-helpers/query/contains';
+import ownerDocument from 'dom-helpers/ownerDocument';
 import addEventListener from '../utils/addEventListener';
 
 const internal = {
-  listening: false,
   focusKeyPressed: false,
 };
 
@@ -26,9 +26,11 @@ export function detectKeyboardFocus(instance, element, callback, attempt = 1) {
   );
 
   instance.keyboardFocusTimeout = setTimeout(() => {
+    const doc = ownerDocument(element);
+
     if (
       focusKeyPressed() &&
-      (document.activeElement === element || contains(element, document.activeElement))
+      (doc.activeElement === element || contains(element, doc.activeElement))
     ) {
       callback();
     } else if (attempt < instance.keyboardFocusMaxCheckTimes) {
@@ -43,15 +45,15 @@ function isFocusKey(event) {
   return FOCUS_KEYS.indexOf(keycode(event)) !== -1;
 }
 
-export function listenForFocusKeys() {
-  // It's a singleton, we only need to listen once.
-  // Also, this logic is client side only, we don't need a teardown.
-  if (!internal.listening) {
-    addEventListener(window, 'keyup', event => {
-      if (isFocusKey(event)) {
-        internal.focusKeyPressed = true;
-      }
-    });
-    internal.listening = true;
+const handleFocusEvent = event => {
+  if (isFocusKey(event)) {
+    internal.focusKeyPressed = true;
   }
+};
+
+export function listenForFocusKeys(win) {
+  // The event listener will only be added once per window.
+  // Duplicate event listeners will be ignored by addEventListener.
+  // Also, this logic is client side only, we don't need a teardown.
+  addEventListener(win, 'keyup', handleFocusEvent);
 }

--- a/src/utils/keyboardFocus.js
+++ b/src/utils/keyboardFocus.js
@@ -45,7 +45,7 @@ function isFocusKey(event) {
   return FOCUS_KEYS.indexOf(keycode(event)) !== -1;
 }
 
-const handleFocusEvent = event => {
+const handleKeyUpEvent = event => {
   if (isFocusKey(event)) {
     internal.focusKeyPressed = true;
   }
@@ -55,5 +55,5 @@ export function listenForFocusKeys(win) {
   // The event listener will only be added once per window.
   // Duplicate event listeners will be ignored by addEventListener.
   // Also, this logic is client side only, we don't need a teardown.
-  addEventListener(win, 'keyup', handleFocusEvent);
+  addEventListener(win, 'keyup', handleKeyUpEvent);
 }


### PR DESCRIPTION
Fixing some more issues when rendering MUI components in a separate window. This PR removes references to the global `window` and `document` objects, and instead respects the parent window/document of the ButtonBase when rendered.

Note that we don't keep track if the listener has already been added to the `window` or not. From the documentation at MDN https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener: 

> If multiple identical EventListeners are registered on the same EventTarget with the same parameters, the duplicate instances are discarded. They do not cause the EventListener to be called twice, and they do not need to be removed manually with the removeEventListener method.

The other option i considered was to store the `window` in a WeakMap to indicate that it already had a listener attached, but I figured this was simpler.