### PR TITLE
[docs] Fix the migration guide doc page

### DIFF
--- a/docs/src/pages/guides/migration-v0.x.md
+++ b/docs/src/pages/guides/migration-v0.x.md
@@ -14,63 +14,76 @@ Material-UI was started [3 years ago](https://github.com/mui-org/material-ui/com
 The ecosystem has evolved a lot since then, we have also learned a lot.
 [@nathanmarks](https://github.com/nathanmarks/) started an ambitious task, rebuilding Material-UI from the **ground-up**
 taking advantage of this knowledge to address long-standing issues. To name some of the major changes:
-- New styling solution using CSS-in-JS (better [customization](/customization/overrides) power, better performance)
-- New [theme handling](/customization/themes) (nesting, self-supporting, etc.)
-- Blazing fast documentation thanks to [Next.js](https://github.com/zeit/next.js)
-- Way better [test coverage](/guides/testing) (99%+, run on all the major browsers, [visual regression tests](https://www.argos-ci.com/mui-org/material-ui))
-- Full [server-side rendering](/guides/server-rendering) support
-- Wide range of [supported browsers](/getting-started/supported-platforms)
+
+* New styling solution using CSS-in-JS (better [customization](/customization/overrides) power, better performance)
+* New [theme handling](/customization/themes) (nesting, self-supporting, etc.)
+* Blazing fast documentation thanks to [Next.js](https://github.com/zeit/next.js)
+* Way better [test coverage](/guides/testing) (99%+, run on all the major browsers, [visual regression tests](https://www.argos-ci.com/mui-org/material-ui))
+* Full [server-side rendering](/guides/server-rendering) support
+* Wide range of [supported browsers](/getting-started/supported-platforms)
 
 Curious to learn more about it? You can checkout our [Q&A on the v1 version](/discover-more/roadmap#q-amp-a-with-the-v1-version).
 
 ### Where should I start in a migration?
 
 1. Start by installing the v1.x version of Material-UI along side the v0.x version.
-[**Yarn**](https://github.com/yarnpkg/yarn) provides an alias feature to do so:
-```sh
-yarn add material-ui@latest
-yarn add material-ui-next@npm:material-ui@next
-```
-then
-```js
-import FlatButton from 'material-ui/FlatButton'; // v0.x
-import Button from 'material-ui-next/Button'; // v1.x
-```
-If you can't use Yarn, we also provide a separate package for **NPM**.
-However, the package might not be always up to date.
-**It's why we encourage people to use a Yarn alias**.
-```sh
-npm install material-ui@latest
-npm install material-ui-next@latest
-```
-then
-```js
-import FlatButton from 'material-ui/FlatButton'; // v0.x
-import Button from 'material-ui-next/Button'; // v1.x
-```
+   [**Yarn**](https://github.com/yarnpkg/yarn) provides an alias feature to do so:
+
+  ```sh
+  yarn add material-ui@latest
+  yarn add material-ui-next@npm:material-ui@next
+  ```
+
+  then
+
+  ```js
+  import FlatButton from 'material-ui/FlatButton'; // v0.x
+  import Button from 'material-ui-next/Button'; // v1.x
+  ```
+
+  If you can't use Yarn, we also provide a separate package for **NPM**.
+  However, the package might not be always up to date.
+  **It's why we encourage people to use a Yarn alias**.
+
+  ```sh
+  npm install material-ui@latest
+  npm install material-ui-next@latest
+  ```
+
+  then
+
+  ```js
+  import FlatButton from 'material-ui/FlatButton'; // v0.x
+  import Button from 'material-ui-next/Button'; // v1.x
+  ```
+
 2. Run [the migration helper](https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui-codemod) on your project.
 3. `MuiThemeProvider` is optional for v1.x. Still, you are free to use v0.x and v1.x versions of the component at the same time like so:
-```jsx
-import React from 'react';
-import { MuiThemeProvider as NewMuiThemeProvider, createMuiTheme } from 'material-ui-next/styles';
-import { MuiThemeProvider } from 'material-ui';
-import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
-const themeV1 = createMuiTheme({/* theme for v1 */});
-const themeV0 = getMuiTheme({/* theme v0.x */});
+  ```jsx
+  import React from 'react';
+  import { MuiThemeProvider as NewMuiThemeProvider, createMuiTheme } from 'material-ui-next/styles';
+  import { MuiThemeProvider } from 'material-ui';
+  import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
-function App() {
-  return (
-    <NewMuiThemeProvider theme={themeV1}>
-       <MuiThemeProvider muiTheme={themeV0}>
-          {/*Components*/}
-       </MuiThemeProvider>
-    </NewMuiThemeProvider>
-  );
-}
+  const themeV1 = createMuiTheme({
+    /* theme for v1 */
+  });
+  const themeV0 = getMuiTheme({
+    /* theme v0.x */
+  });
 
-export default App;
-```
+  function App() {
+    return (
+      <NewMuiThemeProvider theme={themeV1}>
+        <MuiThemeProvider muiTheme={themeV0}>{/*Components*/}</MuiThemeProvider>
+      </NewMuiThemeProvider>
+    );
+  }
+
+  export default App;
+  ```
+
 4. After that, you are free to migrate one component instance at the time.
 
 ## Components
@@ -86,6 +99,7 @@ You might see some missing context errors and wrong colors.
 
 You can fix those issues with the following code.
 Apply it before all the other imports:
+
 ```js
 import SvgIcon from 'material-ui-next/SvgIcon';
 

--- a/docs/src/pages/guides/migration-v0.x.md
+++ b/docs/src/pages/guides/migration-v0.x.md
@@ -14,13 +14,12 @@ Material-UI was started [3 years ago](https://github.com/mui-org/material-ui/com
 The ecosystem has evolved a lot since then, we have also learned a lot.
 [@nathanmarks](https://github.com/nathanmarks/) started an ambitious task, rebuilding Material-UI from the **ground-up**
 taking advantage of this knowledge to address long-standing issues. To name some of the major changes:
-
-* New styling solution using CSS-in-JS (better [customization](/customization/overrides) power, better performance)
-* New [theme handling](/customization/themes) (nesting, self-supporting, etc.)
-* Blazing fast documentation thanks to [Next.js](https://github.com/zeit/next.js)
-* Way better [test coverage](/guides/testing) (99%+, run on all the major browsers, [visual regression tests](https://www.argos-ci.com/mui-org/material-ui))
-* Full [server-side rendering](/guides/server-rendering) support
-* Wide range of [supported browsers](/getting-started/supported-platforms)
+- New styling solution using CSS-in-JS (better [customization](/customization/overrides) power, better performance)
+- New [theme handling](/customization/themes) (nesting, self-supporting, etc.)
+- Blazing fast documentation thanks to [Next.js](https://github.com/zeit/next.js)
+- Way better [test coverage](/guides/testing) (99%+, run on all the major browsers, [visual regression tests](https://www.argos-ci.com/mui-org/material-ui))
+- Full [server-side rendering](/guides/server-rendering) support
+- Wide range of [supported browsers](/getting-started/supported-platforms)
 
 Curious to learn more about it? You can checkout our [Q&A on the v1 version](/discover-more/roadmap#q-amp-a-with-the-v1-version).
 


### PR DESCRIPTION
In this pull request, we are applying some markdown fixes to the migration guide page in the docs folder.

There is no change in the content of the page, only markdown fixes, as you can see in the screenshots below:

## Migration guide before:
![before](https://user-images.githubusercontent.com/208312/36089001-f8776368-0fd9-11e8-997c-16a59ecc4a7f.png)

## Migration guide after:
![after](https://user-images.githubusercontent.com/208312/36088978-e4d0676a-0fd9-11e8-80af-e92653199905.png)
