### PR TITLE
Static properties for reason string constants

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -103,6 +103,11 @@ class Snackbar extends Component {
     muiTheme: PropTypes.object.isRequired,
   };
 
+  static reasons = {
+    CLICKAWAY: 'clickaway',
+    TIMEOUT: 'timeout'
+  }
+
   componentWillMount() {
     this.setState({
       open: this.props.open,
@@ -168,7 +173,7 @@ class Snackbar extends Component {
     }
 
     if (this.props.open !== null && this.props.onRequestClose) {
-      this.props.onRequestClose('clickaway');
+      this.props.onRequestClose(Snackbar.reasons.CLICKAWAY);
     } else {
       this.setState({open: false});
     }
@@ -182,7 +187,7 @@ class Snackbar extends Component {
       clearTimeout(this.timerAutoHideId);
       this.timerAutoHideId = setTimeout(() => {
         if (this.props.open !== null && this.props.onRequestClose) {
-          this.props.onRequestClose('timeout');
+          this.props.onRequestClose(Snackbar.reasons.TIMEOUT);
         } else {
           this.setState({open: false});
         }


### PR DESCRIPTION
Allows for users to utilize IDE autocompletion for these "reason" passed to `.onRequestClose()` limiting typos and simplifying refactors.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
