### PR TITLE
[StepConnector][docs] Removing StepConnector from Steppers demo. Issue #10275.

### DIFF
--- a/docs/src/pages/demos/steppers/steppers.md
+++ b/docs/src/pages/demos/steppers/steppers.md
@@ -1,5 +1,5 @@
 ---
-components: MobileStepper, Step, StepButton, StepConnector, StepContent, StepIcon, StepLabel, Stepper
+components: MobileStepper, Step, StepButton, StepContent, StepIcon, StepLabel, Stepper
 ---
 
 # Steppers


### PR DESCRIPTION
Closes #10275 
StepConnector is a private API and shouldn't be referenced from the demo docs.