### PR TITLE
[Button] Add fullWidth to ButtonClassKey

### DIFF
--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -27,7 +27,8 @@ export type ButtonClassKey =
   | 'keyboardFocused'
   | 'raisedPrimary'
   | 'raisedSecondary'
-  | 'fab';
+  | 'fab'
+  | 'fullWidth';
 
 declare const Button: React.ComponentType<ButtonProps>;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes #10305.

Adds the 'fullWidth' key to `ButtonClassKey`.