### PR TITLE
[Icon] Add fontSize to typings

### DIFF
--- a/src/Icon/Icon.d.ts
+++ b/src/Icon/Icon.d.ts
@@ -4,6 +4,7 @@ import { StandardProps, PropTypes } from '..';
 export interface IconProps
   extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, IconClassKey> {
   color?: PropTypes.Color | 'action' | 'disabled' | 'error';
+  fontSize?: boolean;
 }
 
 export type IconClassKey =

--- a/src/SvgIcon/SvgIcon.d.ts
+++ b/src/SvgIcon/SvgIcon.d.ts
@@ -1,12 +1,17 @@
 import * as React from 'react';
 import { StandardProps, PropTypes } from '..';
 
-export interface SvgIconProps
+interface SvgIconPropsInternal
   extends StandardProps<React.SVGProps<SVGSVGElement>, SvgIconClassKey> {
   color?: PropTypes.Color | 'action' | 'disabled' | 'error';
+  fontSize?: any;
   nativeColor?: string;
   titleAccess?: string;
   viewBox?: string;
+}
+
+export interface SvgIconProps extends SvgIconPropsInternal {
+  fontSize?: boolean;
 }
 
 export type SvgIconClassKey =

--- a/src/SvgIcon/SvgIcon.d.ts
+++ b/src/SvgIcon/SvgIcon.d.ts
@@ -1,17 +1,13 @@
 import * as React from 'react';
 import { StandardProps, PropTypes } from '..';
 
-interface SvgIconPropsInternal
-  extends StandardProps<React.SVGProps<SVGSVGElement>, SvgIconClassKey> {
+export interface SvgIconProps
+  extends StandardProps<React.SVGProps<SVGSVGElement>, SvgIconClassKey, 'fontSize'> {
   color?: PropTypes.Color | 'action' | 'disabled' | 'error';
-  fontSize?: any;
+  fontSize?: boolean;
   nativeColor?: string;
   titleAccess?: string;
   viewBox?: string;
-}
-
-export interface SvgIconProps extends SvgIconPropsInternal {
-  fontSize?: boolean;
 }
 
 export type SvgIconClassKey =


### PR DESCRIPTION
Add the missing  typing of `fontSize` to both `Icon` and `SvgIcon`.