### PR TITLE
[ClickAwayListener] Fix interaction with SVGElement

### DIFF
--- a/src/utils/ClickAwayListener.js
+++ b/src/utils/ClickAwayListener.js
@@ -35,7 +35,7 @@ class ClickAwayListener extends React.Component {
       const el = findDOMNode(this);
 
       if (
-        (event.target instanceof HTMLElement || event.target instanceof SVGSVGElement) &&
+        (event.target instanceof HTMLElement || event.target instanceof SVGElement) &&
         document.documentElement &&
         document.documentElement.contains(event.target) &&
         !isDescendant(el, event.target)

--- a/src/utils/ClickAwayListener.js
+++ b/src/utils/ClickAwayListener.js
@@ -35,7 +35,7 @@ class ClickAwayListener extends React.Component {
       const el = findDOMNode(this);
 
       if (
-        event.target instanceof HTMLElement &&
+        (event.target instanceof HTMLElement || event.target instanceof SVGSVGElement) &&
         document.documentElement &&
         document.documentElement.contains(event.target) &&
         !isDescendant(el, event.target)

--- a/src/utils/ClickAwayListener.js
+++ b/src/utils/ClickAwayListener.js
@@ -35,7 +35,6 @@ class ClickAwayListener extends React.Component {
       const el = findDOMNode(this);
 
       if (
-        (event.target instanceof HTMLElement || event.target instanceof SVGElement) &&
         document.documentElement &&
         document.documentElement.contains(event.target) &&
         !isDescendant(el, event.target)


### PR DESCRIPTION
in a situation when some <svg ... > element exists on page ClickAway() is not triggered because svg element is not an "instanceof HTMLElement"

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
