### PR TITLE
[docs] Expose the theme as a global object

### DIFF
--- a/docs/src/modules/styles/getPageContext.js
+++ b/docs/src/modules/styles/getPageContext.js
@@ -7,18 +7,25 @@ import blue from 'material-ui/colors/blue';
 import pink from 'material-ui/colors/pink';
 import { darken } from 'material-ui/styles/colorManipulator';
 
-export function getTheme(theme) {
-  return createMuiTheme({
-    direction: theme.direction,
+export function getTheme(uiTheme) {
+  const theme = createMuiTheme({
+    direction: uiTheme.direction,
     palette: {
       primary: blue,
       secondary: {
         // Darken so we reach the AA contrast ratio level.
         main: darken(pink.A400, 0.08),
       },
-      type: theme.paletteType,
+      type: uiTheme.paletteType,
     },
   });
+
+  // Expose the theme as a global variable so people can play with it.
+  if (process.browser) {
+    window.theme = theme;
+  }
+
+  return theme;
 }
 
 const theme = getTheme({

--- a/examples/create-react-app/src/withRoot.js
+++ b/examples/create-react-app/src/withRoot.js
@@ -21,11 +21,6 @@ const theme = createMuiTheme({
   },
 });
 
-// Expose the theme as a global variable so people can play with it.
-if (process.browser) {
-  window.theme = theme;
-}
-
 function withRoot(Component) {
   function WithRoot(props) {
     // MuiThemeProvider makes the theme available down the React tree


### PR DESCRIPTION
It was supposed to work. Now, it does.

<img width="724" alt="capture d ecran 2018-02-17 a 00 18 27" src="https://user-images.githubusercontent.com/3165635/36333616-1e8c3906-1378-11e8-957d-ef501b547668.png">
