### PR TITLE
[Input] Reset the line-height

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -65,6 +65,7 @@ export const styles = theme => {
       fontFamily: theme.typography.fontFamily,
       color: light ? 'rgba(0, 0, 0, 0.87)' : theme.palette.common.white,
       fontSize: theme.typography.pxToRem(16),
+      lineHeight: '1.1875em', // Reset (19px), match the native input line-height
     },
     formControl: {
       'label + &': {


### PR DESCRIPTION
The `line-height` is inherited, it's easy to mess up the display of the input, e.g: https://codesandbox.io/s/2z5y03y81r.

![capture d ecran 2018-02-19 a 13 28 16](https://user-images.githubusercontent.com/3165635/36377824-c71f98f4-1578-11e8-815c-2ec3f80fcd59.png)

I believe it's safer to reset the property. It's also the approach used by Bootstrap.