### PR TITLE
[Button] Update Button mini description

### DIFF
--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -21,7 +21,7 @@ filename: /src/Button/Button.js
 | disableRipple | bool | false | If `true`, the ripple effect will be disabled. |
 | fullWidth | bool | false | If `true`, the button will take up the full width of its container. |
 | href | string |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
-| mini | bool | false | If `true`, and `fab` is `true`, will use mini floating action button styling. |
+| mini | bool | false | If `true`, and `variant` is `'fab'`, will use mini floating action button styling. |
 | size | enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br> | 'medium' | The size of the button. `small` is equivalent to the dense button styling. |
 | variant | enum:&nbsp;'flat'&nbsp;&#124;<br>&nbsp;'raised'&nbsp;&#124;<br>&nbsp;'fab'<br> | 'flat' | The color of the component. It supports those theme colors that make sense for this component. |
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -253,7 +253,7 @@ Button.propTypes = {
    */
   href: PropTypes.string,
   /**
-   * If `true`, and `fab` is `true`, will use mini floating action button styling.
+   * If `true`, and `variant` is `'fab'`, will use mini floating action button styling.
    */
   mini: PropTypes.bool,
   /**


### PR DESCRIPTION
Looks like the API changed from `<Button fab />` to `<Button variant="fab" />`