### PR TITLE
[docs] Sort the pages by path and ignore dashes

### DIFF
--- a/docs/src/modules/utils/find.js
+++ b/docs/src/modules/utils/find.js
@@ -118,6 +118,15 @@ function findPages(
     });
   });
 
+  // sort by pathnames without '-' so that e.g. card comes before card-action
+  pages.sort((a, b) => {
+    const pathnameA = a.pathname.replace(/-/g, '');
+    const pathnameB = b.pathname.replace(/-/g, '');
+    if (pathnameA < pathnameB) return -1;
+    if (pathnameA > pathnameB) return 1;
+    return 0;
+  });
+
   return pages;
 }
 


### PR DESCRIPTION
This PR changes the page list generation code to explicitly sort the pages by pathname, ignoring dashes.

Fixes #10388

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
