### PR TITLE
fix lint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,10 @@ module.exports = {
     },
   },
   rules: {
+    quotes: ['error', 'single', {
+      avoidEscape: true,
+      allowTemplateLiterals: true
+    }],
     'linebreak-style': 'off', // Don't play nicely with Windows.
     'arrow-body-style': 'off', // Not our taste?
     'arrow-parens': 'off', // Incompatible with prettier
@@ -87,6 +91,7 @@ module.exports = {
     'react/sort-prop-types': 'error', // airbnb do nothing here.
     'react/default-props-match-prop-types': 'off', // Buggy
     'react/jsx-curly-brace-presence': 'off', // Buggy
+    'react/no-danger': 'warn',
 
     'material-ui/docgen-ignore-before-comment': 'error',
 


### PR DESCRIPTION
I had this locally

```
> eslint . --cache && echo "eslint: no lint errors"


/home/caub/dev/material-ui/packages/material-ui-icons/scripts/create-typings.js
  18:20  error  Strings must use singlequote  quotes

/home/caub/dev/material-ui/src/Select/SelectInput.js
  301:17  error  Dangerous property 'dangerouslySetInnerHTML' found  react/no-danger

✖ 2 problems (2 errors, 0 warnings)
  1 error, 0 warnings potentially fixable with the `--fix` option.
```