### PR TITLE
[Select] Set type undefined rather than null

### DIFF
--- a/src/Select/Select.js
+++ b/src/Select/Select.js
@@ -94,7 +94,7 @@ function Select(props) {
       open,
       renderValue,
       SelectDisplayProps,
-      type: null, // We render a select. We can ignore the type provided by the `Input`.
+      type: undefined, // We render a select. We can ignore the type provided by the `Input`.
       ...inputProps,
       ...(input ? input.props.inputProps : {}),
     },

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -156,7 +156,7 @@ class SelectInput extends React.Component {
       renderValue,
       SelectDisplayProps,
       tabIndex: tabIndexProp,
-      type,
+      type = 'hidden',
       value,
       ...other
     } = this.props;
@@ -306,7 +306,7 @@ class SelectInput extends React.Component {
           name={name}
           readOnly={readOnly}
           ref={this.handleSelectRef}
-          type={type || 'hidden'}
+          type={type}
           {...other}
         />
         <ArrowDropDownIcon className={classes.icon} />


### PR DESCRIPTION
*continuation of https://github.com/mui-org/material-ui/pull/10361#discussion_r170417306*


I couldn't use defaultProps for type,
If I put a 
```js
SelectInput.defaultProps = {
  type: undefined,
};
```
and remove `= 'hidden'` in render

test:unit fails with:
```
1) <Select> integration
       with Dialog
         should focus the selected item:
     Error: Uncaught [Error: Warning: Failed prop type: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`
```
______
note: would you like to refactor all components, and define `propTypes` and `defaultProps` as static properties at the start of component class?
If you want them at the end, still possible too:

```js
class SelectInput extends React.Component {
  static propTypes = propTypes;
  state = {
    open: false,
  };
  // ...

} 

const propTypes = {
  //..
};
```