### PR TITLE
[core] Use tabIndex as number

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
@@ -101,7 +101,7 @@ function SelectWrapped(props) {
         if (onRemove) {
           return (
             <Chip
-              tabIndex="-1"
+              tabIndex={-1}
               label={children}
               className={classes.chip}
               deleteIcon={<CancelIcon onTouchEnd={onDelete} />}

--- a/docs/src/pages/demos/drawers/TemporaryDrawer.js
+++ b/docs/src/pages/demos/drawers/TemporaryDrawer.js
@@ -57,7 +57,7 @@ class TemporaryDrawer extends React.Component {
         <Button onClick={this.toggleDrawer('bottom', true)}>Open Bottom</Button>
         <Drawer open={this.state.left} onClose={this.toggleDrawer('left', false)}>
           <div
-            tabIndex="0"
+            tabIndex={0}
             role="button"
             onClick={this.toggleDrawer('left', false)}
             onKeyDown={this.toggleDrawer('left', false)}
@@ -67,7 +67,7 @@ class TemporaryDrawer extends React.Component {
         </Drawer>
         <Drawer anchor="top" open={this.state.top} onClose={this.toggleDrawer('top', false)}>
           <div
-            tabIndex="0"
+            tabIndex={0}
             role="button"
             onClick={this.toggleDrawer('top', false)}
             onKeyDown={this.toggleDrawer('top', false)}
@@ -81,7 +81,7 @@ class TemporaryDrawer extends React.Component {
           onClose={this.toggleDrawer('bottom', false)}
         >
           <div
-            tabIndex="0"
+            tabIndex={0}
             role="button"
             onClick={this.toggleDrawer('bottom', false)}
             onKeyDown={this.toggleDrawer('bottom', false)}
@@ -91,7 +91,7 @@ class TemporaryDrawer extends React.Component {
         </Drawer>
         <Drawer anchor="right" open={this.state.right} onClose={this.toggleDrawer('right', false)}>
           <div
-            tabIndex="0"
+            tabIndex={0}
             role="button"
             onClick={this.toggleDrawer('right', false)}
             onKeyDown={this.toggleDrawer('right', false)}

--- a/docs/src/pages/demos/lists/CheckboxList.js
+++ b/docs/src/pages/demos/lists/CheckboxList.js
@@ -51,7 +51,7 @@ class CheckboxList extends React.Component {
             >
               <Checkbox
                 checked={this.state.checked.indexOf(value) !== -1}
-                tabIndex="-1"
+                tabIndex={-1}
                 disableRipple
               />
               <ListItemText primary={`Line item ${value + 1}`} />

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -283,7 +283,7 @@ class EnhancedTable extends React.Component {
                     onClick={event => this.handleClick(event, n.id)}
                     role="checkbox"
                     aria-checked={isSelected}
-                    tabIndex="-1"
+                    tabIndex={-1}
                     key={n.id}
                     selected={isSelected}
                   >

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -67,7 +67,7 @@ class SpeedDialAction extends React.Component {
           className={classNames(classes.button, !open && classes.buttonClosed)}
           style={{ transitionDelay: `${delay}ms` }}
           onClick={onClick}
-          tabIndex="-1"
+          tabIndex={-1}
           role="menuitem"
           aria-labelledby={id}
           {...ButtonProps}

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -171,7 +171,7 @@ class Chip extends React.Component {
     let tabIndex = tabIndexProp;
 
     if (!tabIndex) {
-      tabIndex = onClick || onDelete ? '0' : '-1';
+      tabIndex = onClick || onDelete ? 0 : -1;
     }
 
     return (

--- a/src/Chip/Chip.spec.js
+++ b/src/Chip/Chip.spec.js
@@ -46,7 +46,7 @@ describe('<Chip />', () => {
     });
 
     it('should have a tabIndex prop with value -1', () => {
-      assert.strictEqual(wrapper.props().tabIndex, '-1');
+      assert.strictEqual(wrapper.props().tabIndex, -1);
     });
   });
 
@@ -76,17 +76,17 @@ describe('<Chip />', () => {
     });
 
     it('should have a tabIndex prop', () => {
-      assert.strictEqual(wrapper.props().tabIndex, '0');
+      assert.strictEqual(wrapper.props().tabIndex, 0);
     });
 
     it('should apply user value of tabIndex', () => {
       wrapper = shallow(
         // eslint-disable-next-line jsx-a11y/tabindex-no-positive
-        <Chip onClick={() => {}} tabIndex="5">
+        <Chip onClick={() => {}} tabIndex={5}>
           {'Text Chip'}
         </Chip>,
       );
-      assert.strictEqual(wrapper.props().tabIndex, '5');
+      assert.strictEqual(wrapper.props().tabIndex, 5);
     });
   });
 
@@ -129,7 +129,7 @@ describe('<Chip />', () => {
     });
 
     it('should have a tabIndex prop', () => {
-      assert.strictEqual(wrapper.props().tabIndex, '0');
+      assert.strictEqual(wrapper.props().tabIndex, 0);
     });
 
     it('should fire the function given in onDeleteRequest', () => {

--- a/src/ExpansionPanel/ExpansionPanelSummary.js
+++ b/src/ExpansionPanel/ExpansionPanelSummary.js
@@ -126,7 +126,7 @@ class ExpansionPanelSummary extends React.Component {
               [classes.expandIconExpanded]: expanded,
             })}
             component="div"
-            tabIndex="-1"
+            tabIndex={-1}
             aria-hidden="true"
           >
             {expandIcon}

--- a/src/Input/Textarea.js
+++ b/src/Input/Textarea.js
@@ -159,7 +159,7 @@ class Textarea extends React.Component {
         <textarea
           ref={this.handleRefSinglelineShadow}
           className={classnames(classes.shadow, classes.textarea)}
-          tabIndex="-1"
+          tabIndex={-1}
           rows="1"
           readOnly
           aria-hidden="true"
@@ -168,7 +168,7 @@ class Textarea extends React.Component {
         <textarea
           ref={this.handleRefShadow}
           className={classnames(classes.shadow, classes.textarea)}
-          tabIndex="-1"
+          tabIndex={-1}
           rows={rows}
           aria-hidden="true"
           readOnly

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -37,7 +37,7 @@ function MenuItem(props) {
     <ListItem
       button
       role={role}
-      tabIndex="-1"
+      tabIndex={-1}
       className={className}
       component={component}
       {...other}

--- a/src/Menu/MenuItem.spec.js
+++ b/src/Menu/MenuItem.spec.js
@@ -44,7 +44,7 @@ describe('<MenuItem />', () => {
 
   it('should have a tabIndex of -1 by default', () => {
     const wrapper = shallow(<MenuItem />);
-    assert.strictEqual(wrapper.props().tabIndex, '-1', 'should have a -1 tabIndex');
+    assert.strictEqual(wrapper.props().tabIndex, -1);
   });
 
   describe('event callbacks', () => {

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -267,7 +267,7 @@ class SelectInput extends React.Component {
     if (typeof tabIndexProp !== 'undefined') {
       tabIndex = tabIndexProp;
     } else {
-      tabIndex = disabled ? null : '0';
+      tabIndex = disabled ? null : 0;
     }
 
     return (

--- a/src/Select/SelectInput.spec.js
+++ b/src/Select/SelectInput.spec.js
@@ -287,8 +287,8 @@ describe('<SelectInput />', () => {
 
   describe('prop: multiple', () => {
     it('should take precedence', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} disabled tabIndex="0" />);
-      assert.strictEqual(wrapper.find('[data-mui-test="SelectDisplay"]').props().tabIndex, '0');
+      const wrapper = shallow(<SelectInput {...defaultProps} disabled tabIndex={0} />);
+      assert.strictEqual(wrapper.find('[data-mui-test="SelectDisplay"]').props().tabIndex, 0);
     });
   });
 

--- a/src/Tabs/TabScrollButton.js
+++ b/src/Tabs/TabScrollButton.js
@@ -26,7 +26,7 @@ function TabScrollButton(props) {
   }
 
   return (
-    <ButtonBase className={className} onClick={onClick} tabIndex="-1" {...other}>
+    <ButtonBase className={className} onClick={onClick} tabIndex={-1} {...other}>
       {direction === 'left' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
     </ButtonBase>
   );

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -109,9 +109,9 @@ describe('<SwitchBase />', () => {
   });
 
   it('should pass tabIndex to the input so it can be taken out of focus rotation', () => {
-    const wrapper = shallow(<SwitchBase tabIndex="-1" />);
+    const wrapper = shallow(<SwitchBase tabIndex={-1} />);
     const input = wrapper.find('input');
-    assert.strictEqual(input.props().tabIndex, '-1');
+    assert.strictEqual(input.props().tabIndex, -1);
   });
 
   it('should pass value, disabled, checked, and name to the input', () => {

--- a/test/regressions/tests/List/PrimaryActionCheckboxListItem.js
+++ b/test/regressions/tests/List/PrimaryActionCheckboxListItem.js
@@ -11,7 +11,7 @@ export default function PrimaryActionCheckboxListItem() {
     <div style={{ backgroundColor: '#fff', width: 300 }}>
       <List>
         <ListItem button>
-          <Checkbox tabIndex="-1" disableRipple />
+          <Checkbox tabIndex={-1} disableRipple />
           <ListItemText primary="Primary" />
           <ListItemSecondaryAction>
             <IconButton>
@@ -20,7 +20,7 @@ export default function PrimaryActionCheckboxListItem() {
           </ListItemSecondaryAction>
         </ListItem>
         <ListItem button dense>
-          <Checkbox tabIndex="-1" disableRipple />
+          <Checkbox tabIndex={-1} disableRipple />
           <ListItemText primary="Primary" />
           <ListItemSecondaryAction>
             <IconButton>


### PR DESCRIPTION
While React [is](https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html#why-are-we-changing-this) [promoting](https://github.com/facebook/react/blob/86914cb30a7654d13a17d34a3b3a5af97c2d2855/packages/react-dom/src/__tests__/ReactDOMServerIntegrationElements-test.js#L439) the string approach, the HTML specification refer to the tabIndex [as a number](https://www.w3.org/TR/html51/editing.html#the-tabindex-attribute).

> The tabindex attribute, if specified, must have a value that is a valid integer.
