### PR TITLE
[ButtonBase] Fix accessibility

### DIFF
--- a/docs/src/pages/demos/lists/CheckboxList.js
+++ b/docs/src/pages/demos/lists/CheckboxList.js
@@ -44,6 +44,7 @@ class CheckboxList extends React.Component {
           {[0, 1, 2, 3].map(value => (
             <ListItem
               key={value}
+              role={undefined}
               dense
               button
               onClick={this.handleToggle(value)}

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -41,10 +41,6 @@ export const styles = {
   },
 };
 
-// Don't automatically add the role="button" property on these components.
-// It's invalid HTML syntax.
-const INVALID_COMPONENT_ROLE = ['a'];
-
 /**
  * `ButtonBase` contains as few styles as possible.
  * It aims to be a simple building block for creating a button.
@@ -131,15 +127,15 @@ class ButtonBase extends React.Component {
 
     // Keyboard accessibility for non interactive elements
     if (
-      event.target === this.button &&
-      onClick &&
+      event.target === event.currentTarget &&
       component &&
-      component !== 'a' &&
       component !== 'button' &&
       (key === 'space' || key === 'enter')
     ) {
       event.preventDefault();
-      onClick(event);
+      if (onClick) {
+        onClick(event);
+      }
     }
   };
 
@@ -259,7 +255,7 @@ class ButtonBase extends React.Component {
     if (ComponentProp === 'button') {
       buttonProps.type = type || 'button';
       buttonProps.disabled = disabled;
-    } else if (INVALID_COMPONENT_ROLE.indexOf(ComponentProp) === -1) {
+    } else {
       buttonProps.role = 'button';
     }
 

--- a/src/ButtonBase/ButtonBase.spec.js
+++ b/src/ButtonBase/ButtonBase.spec.js
@@ -82,11 +82,11 @@ describe('<ButtonBase />', () => {
       assert.strictEqual(wrapper.props().href, 'http://google.com');
     });
 
-    it('should not set role="button" on an invalid component', () => {
+    it('should change the button type to a and set role="button"', () => {
       const wrapper = shallow(<ButtonBase component="a">Hello</ButtonBase>);
       assert.strictEqual(wrapper.name(), 'a');
       assert.strictEqual(wrapper.props().type, undefined);
-      assert.strictEqual(wrapper.props().role, undefined);
+      assert.strictEqual(wrapper.props().role, 'button');
     });
 
     it('should not change the button to an a element', () => {
@@ -526,11 +526,11 @@ describe('<ButtonBase />', () => {
           preventDefault: spy(),
           keyCode: keycode('space'),
           target: eventTargetMock,
+          currentTarget: eventTargetMock,
         };
 
         instance = wrapper.instance();
         instance.keyDown = false;
-        instance.button = eventTargetMock;
         instance.handleKeyDown(event);
 
         assert.strictEqual(instance.keyDown, false, 'should not change keydown');


### PR DESCRIPTION
- Fix a W3C issue on the list demo page.
- Set `role="button"` on non `<button>` elements.
- Handle the `space` key event.

Closes #10339