### PR TITLE
[classes] Normalize the classes names

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -103,7 +103,7 @@ that **are needed for the stable version**:
    +<CssBaseline />
    ```
 
-- [ ] Remove the `fontSize` property from the `Icon` and `SvgIcon` components in order to make it the default behavior.
+- [x] Remove the `fontSize` property from the `Icon` and `SvgIcon` components in order to make it the default behavior.
 It's already the default behavior of the `Icon` component. You will still be able to change the size of the icons with the `width` and `height` CSS properties. The difference is that they can use the `font-size` as a shorthand.
 
   ```diff
@@ -111,7 +111,7 @@ It's already the default behavior of the `Icon` component. You will still be abl
   +<SvgIcon style={{ fontSize: 20 }} />
   ```
 
-- [ ] Do not prefix the classes keys when used for a variation. >80% of the components enforce this rule, let's make this figure 100%.
+- [x] Do not prefix the classes keys when used for a variation. >80% of the components enforce this rule, let's make this figure 100%.
 
   ```diff
   -<TableCell variant="head" classes={{ typeHead: 'typeHead' }} />

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -168,12 +168,12 @@ const styles = theme => ({
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
       },
       '& .required': {
-        color: theme.palette.type === 'light' ? '#008900' : '#65a665',
+        color: theme.palette.type === 'light' ? '#006500' : '#9bc89b',
       },
       '& .prop-type': {
         fontSize: 13,
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
-        color: theme.palette.type === 'light' ? '#a65e97' : '#bd86b0',
+        color: theme.palette.type === 'light' ? '#932981' : '#dbb0d0',
       },
       '& .prop-default': {
         fontSize: 13,

--- a/docs/src/pages/guides/api/api.md
+++ b/docs/src/pages/guides/api/api.md
@@ -40,9 +40,32 @@ The `disableRipple` property will flow this way: [`MenuItem`](/api/menu-item) > 
 
 We avoid documenting native properties supported by the DOM like [`className`](/customization/overrides#overriding-with-class-names).
 
-### Classes
+### CSS Classes
 
 All the components accept a [`classes`](/customization/overrides#overriding-with-classes) property to customize the styles.
+The classes design answers two constraints.
+We try to make the classes structure as simple as possible while keeping it complex enough for implementing the Material specification.
+- The class applied on the root element is always called `root`.
+- The classes applied on non-root element are prefixed with the name of the element, e.g. `dashedXX`.
+- All the default styles are grouped in a single class.
+- The boolean variants applied **aren't** prefixed e.g. `rounded`.
+- The enum variants applied **are** prefixed e.g. `colorXX`.
+- A variant has **one level of specificity**.
+For instance, the `color` and `variant` properties are considered a variant.
+The lower the style specificity is, the simpler you can override it.
+- We increase the specificity for a variant modifier. We already **have to do** it for the pseudo-classes (`:hover`, `:focus`, etc.). It allows much more control at the cost of extra complexity. Hopefully, it's more intuitive.
+
+```js
+const styles = {
+  root: {
+    color: green[600],
+    '&$checked': {
+      color: green[500],
+    },
+  },
+  checked: {},
+};
+```
 
 ### Internal components
 

--- a/docs/src/pages/guides/migration-v0.x/migration-v0.x.md
+++ b/docs/src/pages/guides/migration-v0.x/migration-v0.x.md
@@ -42,7 +42,7 @@ Curious to learn more about it? You can checkout our [Q&A on the v1 version](/di
 
   If you can't use Yarn, we also provide a separate package for **NPM**.
   However, the package might not be always up to date.
-  **It's why we encourage people to use a Yarn alias**.
+  **It's why we encourage you to use a Yarn alias**.
 
   ```sh
   npm install material-ui@latest
@@ -90,7 +90,7 @@ Curious to learn more about it? You can checkout our [Q&A on the v1 version](/di
 ### Autocomplete
 
 Material-UI doesn't provide any high-level API for solving this problem.
-We encourage people relying on [the solutions the React community has built](https://material-ui-next.com/demos/autocomplete/).
+You're encouraged you to explore [the solutions the React community has built](https://material-ui-next.com/demos/autocomplete/).
 
 In the future, we will look into providing a simple component to solve the simple use cases: [#9997](https://github.com/mui-org/material-ui/issues/9997).
 

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -29,8 +29,8 @@ This property accepts the following keys:
 - `selectedIconOnly`
 - `wrapper`
 - `label`
-- `selectedLabel`
-- `hiddenLabel`
+- `labelSelected`
+- `labelHidden`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/BottomNavigation/BottomNavigationAction.js)

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -24,7 +24,7 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `rootMedia`
+- `media`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Card/CardMedia.js)

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -14,6 +14,7 @@ filename: /src/Dialog/DialogActions.js
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">disableActionSpacing</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the dialog actions do not have additional margin. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 
@@ -23,7 +24,6 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `action`
-- `button`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Dialog/DialogActions.js)

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -44,8 +44,8 @@ This property accepts the following keys:
 - `paperWidthXs`
 - `paperWidthSm`
 - `paperWidthMd`
-- `fullWidth`
-- `fullScreen`
+- `paperFullWidth`
+- `paperFullScreen`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Dialog/Dialog.js)

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -25,10 +25,9 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `inset`
-- `default`
-- `light`
 - `absolute`
+- `inset`
+- `light`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Divider/Divider.js)

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -26,9 +26,9 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `dense`
 - `error`
 - `disabled`
+- `marginDense`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Form/FormHelperText.js)

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -28,8 +28,10 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `focused`
-- `error`
 - `disabled`
+- `error`
+- `asterisk`
+- `asteriskError`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Form/FormLabel.js)

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -26,16 +26,16 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `rootBottom`
-- `rootTop`
-- `rootWithSubtitle`
+- `titlePositionBottom`
+- `titlePositionTop`
+- `rootSubtitle`
 - `titleWrap`
-- `titleWrapActionLeft`
-- `titleWrapActionRight`
+- `titleWrapActionPosLeft`
+- `titleWrapActionPosRight`
 - `title`
 - `subtitle`
-- `actionIconPositionLeft`
-- `childImg`
+- `actionIcon`
+- `actionIconActionPosLeft`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/GridList/GridListTileBar.js)

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -31,7 +31,7 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `formControl`
-- `labelDense`
+- `marginDense`
 - `shrink`
 - `animated`
 - `disabled`

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -47,19 +47,18 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `formControl`
-- `inkbar`
-- `error`
 - `focused`
 - `disabled`
 - `underline`
+- `error`
 - `multiline`
 - `fullWidth`
 - `input`
-- `inputDense`
+- `inputMarginDense`
 - `inputDisabled`
-- `inputType`
 - `inputMultiline`
-- `inputSearch`
+- `inputType`
+- `inputTypeSearch`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Input/Input.js)

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -29,21 +29,21 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `primaryColor`
-- `primaryColorBar`
-- `primaryDashed`
-- `secondaryColor`
-- `secondaryColorBar`
-- `secondaryDashed`
-- `bar`
+- `colorPrimary`
+- `colorSecondary`
+- `buffer`
+- `query`
 - `dashed`
-- `bufferBar2`
-- `rootBuffer`
-- `rootQuery`
-- `indeterminateBar1`
-- `indeterminateBar2`
-- `determinateBar1`
-- `bufferBar1`
+- `dashedColorPrimary`
+- `dashedColorSecondary`
+- `bar`
+- `barColorPrimary`
+- `barColorSecondary`
+- `bar1Indeterminate`
+- `bar2Indeterminate`
+- `bar1Determinate`
+- `bar1Buffer`
+- `bar2Buffer`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Progress/LinearProgress.js)

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -26,31 +26,31 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `rounded`
-- `shadow0`
-- `shadow1`
-- `shadow2`
-- `shadow3`
-- `shadow4`
-- `shadow5`
-- `shadow6`
-- `shadow7`
-- `shadow8`
-- `shadow9`
-- `shadow10`
-- `shadow11`
-- `shadow12`
-- `shadow13`
-- `shadow14`
-- `shadow15`
-- `shadow16`
-- `shadow17`
-- `shadow18`
-- `shadow19`
-- `shadow20`
-- `shadow21`
-- `shadow22`
-- `shadow23`
-- `shadow24`
+- `elevation0`
+- `elevation1`
+- `elevation2`
+- `elevation3`
+- `elevation4`
+- `elevation5`
+- `elevation6`
+- `elevation7`
+- `elevation8`
+- `elevation9`
+- `elevation10`
+- `elevation11`
+- `elevation12`
+- `elevation13`
+- `elevation14`
+- `elevation15`
+- `elevation16`
+- `elevation17`
+- `elevation18`
+- `elevation19`
+- `elevation20`
+- `elevation21`
+- `elevation22`
+- `elevation23`
+- `elevation24`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Paper/Paper.js)

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -40,12 +40,12 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `anchorTopCenter`
-- `anchorBottomCenter`
-- `anchorTopRight`
-- `anchorBottomRight`
-- `anchorTopLeft`
-- `anchorBottomLeft`
+- `anchorOriginTopCenter`
+- `anchorOriginBottomCenter`
+- `anchorOriginTopRight`
+- `anchorOriginBottomRight`
+- `anchorOriginTopLeft`
+- `anchorOriginBottomLeft`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Snackbar/Snackbar.js)

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -34,7 +34,7 @@ This property accepts the following keys:
 - `labelCompleted`
 - `labelAlternativeLabel`
 - `iconContainer`
-- `iconContainerNoAlternative`
+- `iconContainerAlternativeLabel`
 - `labelContainer`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -25,16 +25,16 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `rootLabelIcon`
-- `rootInherit`
-- `rootPrimary`
-- `rootPrimarySelected`
-- `rootPrimaryDisabled`
-- `rootSecondary`
-- `rootSecondarySelected`
-- `rootSecondaryDisabled`
-- `rootInheritSelected`
-- `rootInheritDisabled`
+- `labelIcon`
+- `textColorInherit`
+- `textColorPrimary`
+- `textColorPrimarySelected`
+- `textColorPrimaryDisabled`
+- `textColorSecondary`
+- `textColorSecondarySelected`
+- `textColorSecondaryDisabled`
+- `textColorInheritSelected`
+- `textColorInheritDisabled`
 - `fullWidth`
 - `wrapper`
 - `labelContainer`

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -28,13 +28,13 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
+- `head`
+- `body`
+- `footer`
 - `numeric`
-- `typeHead`
-- `typeBody`
-- `typeFooter`
-- `paddingDefault`
 - `paddingDense`
 - `paddingCheckbox`
+- `paddingNone`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TableCell.js)

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -26,8 +26,8 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
-- `typeHead`
-- `typeFooter`
+- `head`
+- `footer`
 - `selected`
 - `hover`
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -26,8 +26,8 @@ This property accepts the following keys:
 - `root`
 - `active`
 - `icon`
-- `desc`
-- `asc`
+- `iconDirectionDesc`
+- `iconDirectionAsc`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Table/TableSortLabel.js)

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -35,11 +35,11 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `flexContainer`
-- `scrollingContainer`
+- `scroller`
 - `fixed`
 - `scrollable`
 - `centered`
-- `buttonAuto`
+- `scrollButtonsAuto`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Tabs/Tabs.js)

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -37,10 +37,10 @@ This property accepts the following keys:
 - `popper`
 - `popperClose`
 - `tooltip`
-- `tooltipLeft`
-- `tooltipRight`
-- `tooltipTop`
-- `tooltipBottom`
+- `tooltipPlacementLeft`
+- `tooltipPlacementRight`
+- `tooltipPlacementTop`
+- `tooltipPlacementBottom`
 - `tooltipOpen`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/src/BottomNavigation/BottomNavigationAction.js
+++ b/src/BottomNavigation/BottomNavigationAction.js
@@ -41,10 +41,10 @@ export const styles = theme => ({
     transition: 'font-size 0.2s, opacity 0.2s',
     transitionDelay: '0.1s',
   },
-  selectedLabel: {
+  labelSelected: {
     fontSize: theme.typography.pxToRem(theme.typography.fontSize),
   },
-  hiddenLabel: {
+  labelHidden: {
     opacity: 0,
     transitionDelay: '0s',
   },
@@ -87,8 +87,8 @@ class BottomNavigationAction extends React.Component {
     );
 
     const labelClassName = classNames(classes.label, {
-      [classes.selectedLabel]: selected,
-      [classes.hiddenLabel]: !showLabelProp && !selected,
+      [classes.labelSelected]: selected,
+      [classes.labelHidden]: !showLabelProp && !selected,
     });
 
     return (

--- a/src/BottomNavigation/BottomNavigationAction.spec.js
+++ b/src/BottomNavigation/BottomNavigationAction.spec.js
@@ -53,20 +53,20 @@ describe('<BottomNavigationAction />', () => {
     assert.strictEqual(wrapper.contains(icon), true, 'should have the icon');
   });
 
-  it('should render label with the selectedLabel class', () => {
+  it('should render label with the labelSelected class', () => {
     const wrapper = shallow(<BottomNavigationAction icon={icon} selected />);
     const labelWrapper = wrapper.childAt(0).childAt(1);
-    assert.strictEqual(labelWrapper.hasClass(classes.selectedLabel), true);
+    assert.strictEqual(labelWrapper.hasClass(classes.labelSelected), true);
     assert.strictEqual(labelWrapper.hasClass(classes.label), true);
   });
 
-  it('should render label with the hiddenLabel class', () => {
+  it('should render label with the labelHidden class', () => {
     const wrapper = shallow(<BottomNavigationAction icon={icon} showLabel={false} />);
     const labelWrapper = wrapper.childAt(0).childAt(1);
     assert.strictEqual(
-      labelWrapper.hasClass(classes.hiddenLabel),
+      labelWrapper.hasClass(classes.labelHidden),
       true,
-      'should have the hiddenLabel class',
+      'should have the labelHidden class',
     );
     assert.strictEqual(labelWrapper.hasClass(classes.label), true, 'should have the label class');
   });

--- a/src/ButtonBase/Ripple.js
+++ b/src/ButtonBase/Ripple.js
@@ -8,19 +8,19 @@ import Transition from 'react-transition-group/Transition';
  */
 class Ripple extends React.Component {
   state = {
-    rippleVisible: false,
-    rippleLeaving: false,
+    visible: false,
+    leaving: false,
   };
 
   handleEnter = () => {
     this.setState({
-      rippleVisible: true,
+      visible: true,
     });
   };
 
   handleExit = () => {
     this.setState({
-      rippleLeaving: true,
+      leaving: true,
     });
   };
 
@@ -34,20 +34,20 @@ class Ripple extends React.Component {
       rippleSize,
       ...other
     } = this.props;
-    const { rippleVisible, rippleLeaving } = this.state;
+    const { visible, leaving } = this.state;
 
     const className = classNames(
       classes.wrapper,
       {
-        [classes.wrapperLeaving]: rippleLeaving,
-        [classes.wrapperPulsating]: pulsate,
+        [classes.wrapperLeaving]: leaving,
+        [classes.wrapperPulsate]: pulsate,
       },
       classNameProp,
     );
 
     const rippleClassName = classNames(classes.ripple, {
-      [classes.rippleVisible]: rippleVisible,
-      [classes.rippleFast]: pulsate,
+      [classes.rippleVisible]: visible,
+      [classes.ripplePulsate]: pulsate,
     });
 
     const rippleStyles = {

--- a/src/ButtonBase/Ripple.spec.js
+++ b/src/ButtonBase/Ripple.spec.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createShallow, createMount } from '../test-utils';
+import { createShallow, getClasses, createMount } from '../test-utils';
+import TouchRipple from './TouchRipple';
 import Ripple from './Ripple';
 
 describe('<Ripple />', () => {
@@ -11,14 +12,7 @@ describe('<Ripple />', () => {
 
   before(() => {
     shallow = createShallow();
-    classes = {
-      wrapperLeaving: 'wrapperLeaving',
-      wrapperPulsating: 'wrapperPulsating',
-      fast: 'fast',
-      ripple: 'ripple',
-      rippleVisible: 'rippleVisible',
-      rippleFast: 'rippleFast',
-    };
+    classes = getClasses(<TouchRipple />);
     mount = createMount();
   });
 
@@ -69,10 +63,10 @@ describe('<Ripple />', () => {
     });
 
     it('should start the ripple', () => {
-      assert.strictEqual(wrapper.state().rippleVisible, false, 'should not be visible');
+      assert.strictEqual(wrapper.state().visible, false, 'should not be visible');
       wrapper.setProps({ in: true });
       wrapper.update();
-      assert.strictEqual(wrapper.state().rippleVisible, true, 'should be visible');
+      assert.strictEqual(wrapper.state().visible, true, 'should be visible');
       const spanWrapper = wrapper.find('span').first();
       assert.strictEqual(
         spanWrapper.childAt(0).hasClass(classes.rippleVisible),
@@ -85,7 +79,7 @@ describe('<Ripple />', () => {
       wrapper.setProps({ in: true });
       wrapper.setProps({ in: false });
       wrapper.update();
-      assert.strictEqual(wrapper.state().rippleLeaving, true, 'should be leaving');
+      assert.strictEqual(wrapper.state().leaving, true, 'should be leaving');
       const spanWrapper = wrapper.find('span').first();
       assert.strictEqual(
         spanWrapper.hasClass(classes.wrapperLeaving),
@@ -116,23 +110,27 @@ describe('<Ripple />', () => {
       assert.strictEqual(wrapper.name(), 'Ripple');
       const spanWrapper = wrapper.find('span').first();
       assert.strictEqual(
-        spanWrapper.hasClass(classes.wrapperPulsating),
+        spanWrapper.hasClass(classes.wrapperPulsate),
         true,
         'should have the pulsating class',
       );
       const ripple = spanWrapper.childAt(0);
       assert.strictEqual(ripple.hasClass(classes.ripple), true, 'should have the ripple class');
-      assert.strictEqual(ripple.hasClass(classes.rippleFast), true, 'should have the fast class');
+      assert.strictEqual(
+        ripple.hasClass(classes.ripplePulsate),
+        true,
+        'should have the fast class',
+      );
     });
 
     it('should start the ripple', () => {
-      assert.strictEqual(wrapper.state().rippleVisible, false, 'should not be visible');
+      assert.strictEqual(wrapper.state().visible, false, 'should not be visible');
       wrapper.setProps({ in: true });
       wrapper.update();
-      assert.strictEqual(wrapper.state().rippleVisible, true, 'should be visible');
+      assert.strictEqual(wrapper.state().visible, true, 'should be visible');
       const spanWrapper = wrapper.find('span').first();
       assert.strictEqual(
-        spanWrapper.hasClass(classes.wrapperPulsating),
+        spanWrapper.hasClass(classes.wrapperPulsate),
         true,
         'should have the pulsating class',
       );
@@ -146,7 +144,7 @@ describe('<Ripple />', () => {
     it('should stop the ripple', () => {
       wrapper.setProps({ in: false });
       wrapper.update();
-      assert.strictEqual(wrapper.state().rippleLeaving, true, 'should be leaving');
+      assert.strictEqual(wrapper.state().leaving, true, 'should be leaving');
       const spanWrapper = wrapper.find('span').first();
       assert.strictEqual(
         spanWrapper.hasClass(classes.wrapperLeaving),

--- a/src/ButtonBase/TouchRipple.js
+++ b/src/ButtonBase/TouchRipple.js
@@ -29,7 +29,7 @@ export const styles = theme => ({
     opacity: 0,
     animation: `mui-ripple-exit ${DURATION}ms ${theme.transitions.easing.easeInOut}`,
   },
-  wrapperPulsating: {
+  wrapperPulsate: {
     position: 'absolute',
     left: 0,
     top: 0,
@@ -80,7 +80,7 @@ export const styles = theme => ({
     transform: 'scale(1)',
     animation: `mui-ripple-enter ${DURATION}ms ${theme.transitions.easing.easeInOut}`,
   },
-  rippleFast: {
+  ripplePulsate: {
     animationDuration: '200ms',
   },
 });

--- a/src/Card/Card.js
+++ b/src/Card/Card.js
@@ -12,10 +12,6 @@ function Card(props) {
 
 Card.propTypes = {
   /**
-   * @ignore
-   */
-  className: PropTypes.string,
-  /**
    * If `true`, the card will use raised styling.
    */
   raised: PropTypes.bool,

--- a/src/Card/CardActions.js
+++ b/src/Card/CardActions.js
@@ -15,7 +15,7 @@ export const styles = theme => ({
     },
   },
   action: {
-    margin: '0 4px',
+    margin: `0 ${theme.spacing.unit / 2}px`,
   },
 });
 

--- a/src/Card/CardMedia.js
+++ b/src/Card/CardMedia.js
@@ -10,7 +10,7 @@ export const styles = {
     backgroundRepeat: 'no-repeat',
     backgroundPosition: 'center',
   },
-  rootMedia: {
+  media: {
     width: '100%',
   },
 };
@@ -28,17 +28,16 @@ function CardMedia(props) {
   const isMediaComponent = MEDIA_COMPONENTS.indexOf(Component) !== -1;
   const composedStyle =
     !isMediaComponent && image ? { backgroundImage: `url(${image})`, ...style } : style;
-  const composedClassName = classNames(
-    {
-      [classes.root]: !isMediaComponent,
-      [classes.rootMedia]: isMediaComponent,
-    },
-    className,
-  );
 
   return (
     <Component
-      className={composedClassName}
+      className={classNames(
+        classes.root,
+        {
+          [classes.media]: isMediaComponent,
+        },
+        className,
+      )}
       style={composedStyle}
       src={isMediaComponent ? image || src : undefined}
       {...other}

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -36,10 +36,10 @@ export const styles = theme => ({
   paperWidthMd: {
     maxWidth: theme.breakpoints.values.md,
   },
-  fullWidth: {
+  paperFullWidth: {
     width: '100%',
   },
-  fullScreen: {
+  paperFullScreen: {
     margin: 0,
     width: '100%',
     maxWidth: '100%',
@@ -109,8 +109,8 @@ function Dialog(props) {
           elevation={24}
           className={classNames(classes.paper, {
             [classes[`paperWidth${maxWidth ? capitalize(maxWidth) : ''}`]]: maxWidth,
-            [classes.fullScreen]: fullScreen,
-            [classes.fullWidth]: fullWidth,
+            [classes.paperFullScreen]: fullScreen,
+            [classes.paperFullWidth]: fullWidth,
           })}
           {...PaperProps}
         >

--- a/src/Dialog/Dialog.spec.js
+++ b/src/Dialog/Dialog.spec.js
@@ -151,12 +151,12 @@ describe('<Dialog />', () => {
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.fullWidth), true);
+      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullWidth), true);
     });
 
     it('should not set `fullWidth` class if not specified', () => {
       const wrapper = shallow(<Dialog {...defaultProps}>foo</Dialog>);
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.fullWidth), false);
+      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullWidth), false);
     });
   });
 
@@ -167,7 +167,7 @@ describe('<Dialog />', () => {
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.fullScreen), true);
+      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullScreen), true);
     });
 
     it('false should not render fullScreen', () => {
@@ -176,7 +176,7 @@ describe('<Dialog />', () => {
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.fullScreen), false);
+      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullScreen), false);
     });
   });
 });

--- a/src/Dialog/DialogActions.js
+++ b/src/Dialog/DialogActions.js
@@ -2,42 +2,29 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
+import { cloneChildrenWithClassName } from '../utils/reactHelpers';
 import '../Button'; // So we don't have any override priority issue.
 
 export const styles = theme => ({
   root: {
+    flex: '0 0 auto',
+    margin: `${theme.spacing.unit}px ${theme.spacing.unit / 2}px`,
     display: 'flex',
     justifyContent: 'flex-end',
     alignItems: 'center',
-    margin: `${theme.spacing.unit}px ${theme.spacing.unit / 2}px`,
-    flex: '0 0 auto',
   },
   action: {
     margin: `0 ${theme.spacing.unit / 2}px`,
-  },
-  button: {
     minWidth: 64,
   },
 });
 
 function DialogActions(props) {
-  const { children, classes, className, ...other } = props;
+  const { disableActionSpacing, children, classes, className, ...other } = props;
 
   return (
     <div className={classNames(classes.root, className)} {...other}>
-      {React.Children.map(children, child => {
-        if (!React.isValidElement(child)) {
-          return null;
-        }
-
-        return (
-          <div className={classes.action}>
-            {React.cloneElement(child, {
-              className: classNames(classes.button, child.props.className),
-            })}
-          </div>
-        );
-      })}
+      {disableActionSpacing ? children : cloneChildrenWithClassName(children, classes.action)}
     </div>
   );
 }
@@ -55,6 +42,14 @@ DialogActions.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * If `true`, the dialog actions do not have additional margin.
+   */
+  disableActionSpacing: PropTypes.bool,
+};
+
+DialogActions.defaultProps = {
+  disableActionSpacing: false,
 };
 
 export default withStyles(styles, { name: 'MuiDialogActions' })(DialogActions);

--- a/src/Dialog/DialogActions.spec.js
+++ b/src/Dialog/DialogActions.spec.js
@@ -40,13 +40,10 @@ describe('<DialogActions />', () => {
         <button className="woofDialogActions">Hello</button>
       </DialogActions>,
     );
-    const container = wrapper.childAt(0);
-    assert.strictEqual(container.hasClass(classes.action), true, 'should have the action wrapper');
-    assert.strictEqual(container.is('div'), true, 'should be a div');
-    const button = container.childAt(0);
+    const button = wrapper.childAt(0);
     assert.strictEqual(button.is('button'), true, 'should be a button');
     assert.strictEqual(button.hasClass('woofDialogActions'), true, 'should have the user class');
-    assert.strictEqual(button.hasClass(classes.button), true, 'should have the button class');
+    assert.strictEqual(button.hasClass(classes.action), true, 'should have the action wrapper');
   });
 
   it('should render children with the conditional buttons', () => {
@@ -58,12 +55,9 @@ describe('<DialogActions />', () => {
       </DialogActions>,
     );
 
-    const container = wrapper.childAt(0);
-    assert.strictEqual(container.hasClass(classes.action), true, 'should have the action wrapper');
-    assert.strictEqual(container.is('div'), true, 'should be a div');
-    const button = container.childAt(0);
-    assert.strictEqual(button.is('button'), true, 'should be a button');
+    const button = wrapper.childAt(0);
     assert.strictEqual(button.hasClass('woofDialogActions'), true, 'should have the user class');
-    assert.strictEqual(button.hasClass(classes.button), true, 'should have the button class');
+    assert.strictEqual(button.hasClass(classes.action), true, 'should have the action wrapper');
+    assert.strictEqual(button.is('button'), true, 'should be a button');
   });
 });

--- a/src/Dialog/withMobileDialog.spec.js
+++ b/src/Dialog/withMobileDialog.spec.js
@@ -29,7 +29,7 @@ describe('withMobileDialog', () => {
             foo
           </ResponsiveDialog>,
         );
-        assert.strictEqual(wrapper.find(Paper).hasClass(classes.fullScreen), true);
+        assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullScreen), true);
       });
     });
   }
@@ -43,7 +43,7 @@ describe('withMobileDialog', () => {
             foo
           </ResponsiveDialog>,
         );
-        assert.strictEqual(wrapper.find(Paper).hasClass(classes.fullScreen), false);
+        assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullScreen), false);
       });
     });
   }

--- a/src/Divider/Divider.js
+++ b/src/Divider/Divider.js
@@ -10,21 +10,19 @@ export const styles = theme => ({
     margin: 0, // Reset browser default style.
     border: 'none',
     flexShrink: 0,
-  },
-  inset: {
-    marginLeft: 72,
-  },
-  default: {
     backgroundColor: theme.palette.divider,
-  },
-  light: {
-    backgroundColor: fade(theme.palette.divider, 0.08),
   },
   absolute: {
     position: 'absolute',
     bottom: 0,
     left: 0,
     width: '100%',
+  },
+  inset: {
+    marginLeft: theme.spacing.unit * 9,
+  },
+  light: {
+    backgroundColor: fade(theme.palette.divider, 0.08),
   },
 });
 
@@ -44,8 +42,8 @@ function Divider(props) {
     {
       [classes.absolute]: absolute,
       [classes.inset]: inset,
+      [classes.light]: light,
     },
-    light ? classes.light : classes.default,
     classNameProp,
   );
 

--- a/src/Divider/Divider.spec.js
+++ b/src/Divider/Divider.spec.js
@@ -22,7 +22,6 @@ describe('<Divider />', () => {
   it('should render with the root and default class', () => {
     const wrapper = shallow(<Divider />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.default), true, 'should have the default class');
   });
 
   it('should set the absolute class', () => {

--- a/src/Form/FormGroup.js
+++ b/src/Form/FormGroup.js
@@ -21,16 +21,18 @@ export const styles = {
  */
 function FormGroup(props) {
   const { classes, className, children, row, ...other } = props;
-  const rootClassName = classNames(
-    classes.root,
-    {
-      [classes.row]: row,
-    },
-    className,
-  );
 
   return (
-    <div className={rootClassName} {...other}>
+    <div
+      className={classNames(
+        classes.root,
+        {
+          [classes.row]: row,
+        },
+        className,
+      )}
+      {...other}
+    >
       {children}
     </div>
   );

--- a/src/Form/FormHelperText.js
+++ b/src/Form/FormHelperText.js
@@ -14,14 +14,14 @@ export const styles = theme => ({
     minHeight: '1em',
     margin: 0,
   },
-  dense: {
-    marginTop: theme.spacing.unit / 2,
-  },
   error: {
     color: theme.palette.error.main,
   },
   disabled: {
     color: theme.palette.text.disabled,
+  },
+  marginDense: {
+    marginTop: theme.spacing.unit / 2,
   },
 });
 
@@ -60,7 +60,7 @@ function FormHelperText(props, context) {
     {
       [classes.disabled]: disabled,
       [classes.error]: error,
-      [classes.dense]: margin === 'dense',
+      [classes.marginDense]: margin === 'dense',
     },
     classNameProp,
   );

--- a/src/Form/FormHelperText.spec.js
+++ b/src/Form/FormHelperText.spec.js
@@ -72,14 +72,14 @@ describe('<FormHelperText />', () => {
         });
 
         it('should have the dense class', () => {
-          assert.strictEqual(wrapper.hasClass(classes.dense), true);
+          assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
         });
       });
 
       it('should be overridden by props', () => {
-        assert.strictEqual(wrapper.hasClass(classes.dense), false);
+        assert.strictEqual(wrapper.hasClass(classes.marginDense), false);
         wrapper.setProps({ margin: 'dense' });
-        assert.strictEqual(wrapper.hasClass(classes.dense), true);
+        assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
       });
     });
   });

--- a/src/Form/FormLabel.js
+++ b/src/Form/FormLabel.js
@@ -14,11 +14,15 @@ export const styles = theme => ({
   focused: {
     color: theme.palette.primary[theme.palette.type === 'light' ? 'dark' : 'light'],
   },
+  disabled: {
+    color: theme.palette.text.disabled,
+  },
   error: {
     color: theme.palette.error.main,
   },
-  disabled: {
-    color: theme.palette.text.disabled,
+  asterisk: {},
+  asteriskError: {
+    color: theme.palette.error.main,
   },
 });
 
@@ -67,15 +71,16 @@ function FormLabel(props, context) {
     classNameProp,
   );
 
-  const asteriskClassName = classNames({
-    [classes.error]: error,
-  });
-
   return (
     <Component className={className} {...other}>
       {children}
       {required && (
-        <span className={asteriskClassName} data-mui-test="FormLabelAsterisk">
+        <span
+          className={classNames(classes.asterisk, {
+            [classes.asteriskError]: error,
+          })}
+          data-mui-test="FormLabelAsterisk"
+        >
           {'\u2009*'}
         </span>
       )}

--- a/src/Form/FormLabel.spec.js
+++ b/src/Form/FormLabel.spec.js
@@ -39,11 +39,7 @@ describe('<FormLabel />', () => {
       const wrapper = shallow(<FormLabel required error />);
       const asteriskWrapper = wrapper.find('[data-mui-test="FormLabelAsterisk"]');
       assert.strictEqual(asteriskWrapper.length, 1);
-      assert.strictEqual(
-        asteriskWrapper.hasClass(classes.error),
-        true,
-        'asterisk should have the error class',
-      );
+      assert.strictEqual(asteriskWrapper.hasClass(classes.asteriskError), true);
       assert.strictEqual(wrapper.hasClass(classes.error), true, 'should have the error class');
     });
   });

--- a/src/GridList/GridListTileBar.js
+++ b/src/GridList/GridListTileBar.js
@@ -14,13 +14,13 @@ export const styles = theme => ({
     alignItems: 'center',
     fontFamily: theme.typography.fontFamily,
   },
-  rootBottom: {
+  titlePositionBottom: {
     bottom: 0,
   },
-  rootTop: {
+  titlePositionTop: {
     top: 0,
   },
-  rootWithSubtitle: {
+  rootSubtitle: {
     height: 68,
   },
   titleWrap: {
@@ -30,10 +30,10 @@ export const styles = theme => ({
     color: theme.palette.common.white,
     overflow: 'hidden',
   },
-  titleWrapActionLeft: {
+  titleWrapActionPosLeft: {
     marginLeft: 0,
   },
-  titleWrapActionRight: {
+  titleWrapActionPosRight: {
     marginRight: 0,
   },
   title: {
@@ -50,14 +50,9 @@ export const styles = theme => ({
     overflow: 'hidden',
     whiteSpace: 'nowrap',
   },
-  actionIconPositionLeft: {
+  actionIcon: {},
+  actionIconActionPosLeft: {
     order: -1,
-  },
-  childImg: {
-    height: '100%',
-    transform: 'translateX(-50%)',
-    position: 'relative',
-    left: '50%',
   },
 });
 
@@ -77,17 +72,17 @@ function GridListTileBar(props) {
   const className = classNames(
     classes.root,
     {
-      [classes.rootBottom]: titlePosition === 'bottom',
-      [classes.rootTop]: titlePosition === 'top',
-      [classes.rootWithSubtitle]: subtitle,
+      [classes.titlePositionBottom]: titlePosition === 'bottom',
+      [classes.titlePositionTop]: titlePosition === 'top',
+      [classes.rootSubtitle]: subtitle,
     },
     classNameProp,
   );
 
   // Remove the margin between the title / subtitle wrapper, and the Action Icon
   const titleWrapClassName = classNames(classes.titleWrap, {
-    [classes.titleWrapActionLeft]: actionPos === 'left',
-    [classes.titleWrapActionRight]: actionPos === 'right',
+    [classes.titleWrapActionPosLeft]: actionPos === 'left',
+    [classes.titleWrapActionPosRight]: actionPos === 'right',
   });
 
   return (
@@ -97,7 +92,11 @@ function GridListTileBar(props) {
         {subtitle ? <div className={classes.subtitle}>{subtitle}</div> : null}
       </div>
       {actionIcon ? (
-        <div className={classNames({ [classes.actionIconPositionLeft]: actionPos === 'left' })}>
+        <div
+          className={classNames(classes.actionIcon, {
+            [classes.actionIconActionPosLeft]: actionPos === 'left',
+          })}
+        >
           {actionIcon}
         </div>
       ) : null}

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -29,19 +29,21 @@ export const styles = theme => ({
 });
 
 function Icon(props) {
-  const { children, classes, className: classNameProp, color, ...other } = props;
-
-  const className = classNames(
-    'material-icons',
-    classes.root,
-    {
-      [classes[`color${capitalize(color)}`]]: color !== 'inherit',
-    },
-    classNameProp,
-  );
+  const { children, classes, className, color, ...other } = props;
 
   return (
-    <span className={className} aria-hidden="true" {...other}>
+    <span
+      className={classNames(
+        'material-icons',
+        classes.root,
+        {
+          [classes[`color${capitalize(color)}`]]: color !== 'inherit',
+        },
+        className,
+      )}
+      aria-hidden="true"
+      {...other}
+    >
       {children}
     </span>
   );

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -72,7 +72,11 @@ export const styles = theme => {
         marginTop: theme.spacing.unit * 2,
       },
     },
-    inkbar: {
+    focused: {},
+    disabled: {
+      color: theme.palette.text.disabled,
+    },
+    underline: {
       '&:after': {
         backgroundColor: theme.palette.primary[light ? 'dark' : 'light'],
         left: 0,
@@ -92,18 +96,6 @@ export const styles = theme => {
       '&$focused:after': {
         transform: 'scaleX(1)',
       },
-    },
-    error: {
-      '&:after': {
-        backgroundColor: theme.palette.error.main,
-        transform: 'scaleX(1)', // error is always underlined in red
-      },
-    },
-    focused: {},
-    disabled: {
-      color: theme.palette.text.disabled,
-    },
-    underline: {
       '&:before': {
         backgroundColor: bottomLineColor,
         left: 0,
@@ -128,6 +120,12 @@ export const styles = theme => {
         backgroundPosition: 'left top',
         backgroundRepeat: 'repeat-x',
         backgroundSize: '5px 1px',
+      },
+    },
+    error: {
+      '&:after': {
+        backgroundColor: theme.palette.error.main,
+        transform: 'scaleX(1)', // error is always underlined in red
       },
     },
     multiline: {
@@ -178,21 +176,21 @@ export const styles = theme => {
         '&:focus::-ms-input-placeholder': placeholderVisible, // Edge
       },
     },
-    inputDense: {
+    inputMarginDense: {
       paddingTop: theme.spacing.unit / 2 - 1,
     },
     inputDisabled: {
       opacity: 1, // Reset iOS opacity
     },
-    inputType: {
-      // type="date" or type="time", etc. have specific styles we need to reset.
-      height: '1.1875em', // Reset (19px), match the native input line-height
-    },
     inputMultiline: {
       resize: 'none',
       padding: 0,
     },
-    inputSearch: {
+    inputType: {
+      // type="date" or type="time", etc. have specific styles we need to reset.
+      height: '1.1875em', // Reset (19px), match the native input line-height
+    },
+    inputTypeSearch: {
       // Improve type search style.
       '-moz-appearance': 'textfield',
       '-webkit-appearance': 'textfield',
@@ -396,7 +394,6 @@ class Input extends React.Component {
         [classes.fullWidth]: fullWidth,
         [classes.focused]: this.state.focused,
         [classes.formControl]: muiFormControl,
-        [classes.inkbar]: !disableUnderline,
         [classes.multiline]: multiline,
         [classes.underline]: !disableUnderline,
       },
@@ -408,9 +405,9 @@ class Input extends React.Component {
       {
         [classes.inputDisabled]: disabled,
         [classes.inputType]: type !== 'text',
+        [classes.inputTypeSearch]: type === 'search',
         [classes.inputMultiline]: multiline,
-        [classes.inputSearch]: type === 'search',
-        [classes.inputDense]: margin === 'dense',
+        [classes.inputMarginDense]: margin === 'dense',
       },
       inputPropsClassName,
     );

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -27,7 +27,6 @@ describe('<Input />', () => {
     const wrapper = shallow(<Input />);
     assert.strictEqual(wrapper.name(), 'div');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.inkbar), true, 'should have the inkbar class');
     assert.strictEqual(
       wrapper.hasClass(classes.underline),
       true,
@@ -306,15 +305,15 @@ describe('<Input />', () => {
           setFormControlContext({ margin: 'dense' });
         });
 
-        it('should have the inputDense class', () => {
-          assert.strictEqual(wrapper.find('input').hasClass(classes.inputDense), true);
+        it('should have the inputMarginDense class', () => {
+          assert.strictEqual(wrapper.find('input').hasClass(classes.inputMarginDense), true);
         });
       });
 
       it('should be overridden by props', () => {
-        assert.strictEqual(wrapper.find('input').hasClass(classes.inputDense), false);
+        assert.strictEqual(wrapper.find('input').hasClass(classes.inputMarginDense), false);
         wrapper.setProps({ margin: 'dense' });
-        assert.strictEqual(wrapper.find('input').hasClass(classes.inputDense), true);
+        assert.strictEqual(wrapper.find('input').hasClass(classes.inputMarginDense), true);
       });
     });
 

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -17,7 +17,7 @@ export const styles = theme => ({
     // slight alteration to spec spacing to match visual spec result
     transform: `translate(0, ${theme.spacing.unit * 3}px) scale(1)`,
   },
-  labelDense: {
+  marginDense: {
     // Compensation for the `Input.inputDense` style.
     transform: `translate(0, ${theme.spacing.unit * 2.5 + 1}px) scale(1)`,
   },
@@ -68,7 +68,7 @@ function InputLabel(props, context) {
       [classes.animated]: !disableAnimation,
       [classes.shrink]: shrink,
       [classes.disabled]: disabled,
-      [classes.labelDense]: margin === 'dense',
+      [classes.marginDense]: margin === 'dense',
     },
     classNameProp,
   );

--- a/src/Input/InputLabel.spec.js
+++ b/src/Input/InputLabel.spec.js
@@ -62,7 +62,7 @@ describe('<InputLabel />', () => {
 
     it('should have the labelDense class when margin is dense', () => {
       setFormControlContext({ margin: 'dense' });
-      assert.strictEqual(wrapper.hasClass(classes.labelDense), true);
+      assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
     });
 
     ['dirty', 'focused'].forEach(state => {

--- a/src/List/ListSubheader.js
+++ b/src/List/ListSubheader.js
@@ -32,26 +32,22 @@ export const styles = theme => ({
 });
 
 function ListSubheader(props) {
-  const {
-    classes,
-    className: classNameProp,
-    color,
-    component: Component,
-    disableSticky,
-    inset,
-    ...other
-  } = props;
-  const className = classNames(
-    classes.root,
-    {
-      [classes[`color${capitalize(color)}`]]: color !== 'default',
-      [classes.inset]: inset,
-      [classes.sticky]: !disableSticky,
-    },
-    classNameProp,
-  );
+  const { classes, className, color, component: Component, disableSticky, inset, ...other } = props;
 
-  return <Component className={className} {...other} />;
+  return (
+    <Component
+      className={classNames(
+        classes.root,
+        {
+          [classes[`color${capitalize(color)}`]]: color !== 'default',
+          [classes.inset]: inset,
+          [classes.sticky]: !disableSticky,
+        },
+        className,
+      )}
+      {...other}
+    />
+  );
 }
 
 ListSubheader.propTypes = {

--- a/src/Menu/MenuItem.js
+++ b/src/Menu/MenuItem.js
@@ -25,22 +25,14 @@ export const styles = theme => ({
 });
 
 function MenuItem(props) {
-  const { classes, className: classNameProp, component, selected, role, ...other } = props;
-
-  const className = classNames(
-    classes.root,
-    {
-      [classes.selected]: selected,
-    },
-    classNameProp,
-  );
+  const { classes, className, component, selected, role, ...other } = props;
 
   return (
     <ListItem
       button
       role={role}
       tabIndex={-1}
-      className={className}
+      className={classNames(classes.root, { [classes.selected]: selected }, className)}
       component={component}
       {...other}
     />

--- a/src/MobileStepper/MobileStepper.js
+++ b/src/MobileStepper/MobileStepper.js
@@ -76,21 +76,20 @@ function MobileStepper(props) {
       {variant === 'dots' && (
         <div className={classes.dots}>
           {[...new Array(steps)].map((_, step) => {
-            const dotClassName = classNames(
-              {
-                [classes.dotActive]: step === activeStep,
-              },
-              classes.dot,
-            );
+            const dotClassName = classNames(classes.dot, {
+              [classes.dotActive]: step === activeStep,
+            });
             // eslint-disable-next-line react/no-array-index-key
             return <div key={step} className={dotClassName} />;
           })}
         </div>
       )}
       {variant === 'progress' && (
-        <div className={classes.progress}>
-          <LinearProgress variant="determinate" value={Math.ceil(activeStep / (steps - 1) * 100)} />
-        </div>
+        <LinearProgress
+          className={classes.progress}
+          variant="determinate"
+          value={Math.ceil(activeStep / (steps - 1) * 100)}
+        />
       )}
       {nextButton}
     </Paper>

--- a/src/Paper/Paper.js
+++ b/src/Paper/Paper.js
@@ -5,9 +5,9 @@ import warning from 'warning';
 import withStyles from '../styles/withStyles';
 
 export const styles = theme => {
-  const shadows = {};
+  const elevations = {};
   theme.shadows.forEach((shadow, index) => {
-    shadows[`shadow${index}`] = {
+    elevations[`elevation${index}`] = {
       boxShadow: shadow,
     };
   });
@@ -19,7 +19,7 @@ export const styles = theme => {
     rounded: {
       borderRadius: 2,
     },
-    ...shadows,
+    ...elevations,
   };
 };
 
@@ -40,7 +40,7 @@ function Paper(props) {
 
   const className = classNames(
     classes.root,
-    classes[`shadow${elevation}`],
+    classes[`elevation${elevation}`],
     {
       [classes.rounded]: !square,
     },

--- a/src/Paper/Paper.spec.js
+++ b/src/Paper/Paper.spec.js
@@ -17,24 +17,36 @@ describe('<Paper />', () => {
     assert.strictEqual(wrapper.name(), 'div');
   });
 
-  it('should render with the root class, default depth class, and rounded', () => {
+  it('should render with the root class, default depth class', () => {
     const wrapper = shallow(<Paper>Hello World</Paper>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.rounded), true, 'should be rounded by default');
+    assert.strictEqual(wrapper.hasClass(classes.rounded), true);
   });
 
   it('should disable the rounded class', () => {
     const wrapper = shallow(<Paper square>Hello World</Paper>);
-    assert.strictEqual(wrapper.hasClass(classes.rounded), false, 'should not be rounded');
+    assert.strictEqual(wrapper.hasClass(classes.rounded), false);
   });
 
-  it('should set the elevation shadow class', () => {
+  it('should set the elevation elevation class', () => {
     const wrapper = shallow(<Paper elevation={16}>Hello World</Paper>);
-    assert.strictEqual(wrapper.hasClass(classes.shadow16), true, 'should have the 16 shadow class');
+    assert.strictEqual(
+      wrapper.hasClass(classes.elevation16),
+      true,
+      'should have the 16 elevation class',
+    );
     wrapper.setProps({ elevation: 24 });
-    assert.strictEqual(wrapper.hasClass(classes.shadow24), true, 'should have the 24 shadow class');
+    assert.strictEqual(
+      wrapper.hasClass(classes.elevation24),
+      true,
+      'should have the 24 elevation class',
+    );
     wrapper.setProps({ elevation: 2 });
-    assert.strictEqual(wrapper.hasClass(classes.shadow2), true, 'should have the 2 shadow class');
+    assert.strictEqual(
+      wrapper.hasClass(classes.elevation2),
+      true,
+      'should have the 2 elevation class',
+    );
   });
 
   describe('prop: component', () => {

--- a/src/Progress/LinearProgress.js
+++ b/src/Progress/LinearProgress.js
@@ -13,28 +13,35 @@ export const styles = theme => ({
     overflow: 'hidden',
     height: 5,
   },
-  primaryColor: {
+  colorPrimary: {
     backgroundColor: lighten(theme.palette.primary.light, 0.6),
   },
-  primaryColorBar: {
-    backgroundColor: theme.palette.primary.main,
+  colorSecondary: {
+    backgroundColor: lighten(theme.palette.secondary.light, 0.4),
   },
-  primaryDashed: {
-    background: `radial-gradient(${lighten(theme.palette.primary.light, 0.6)} 0%, ${lighten(
+  buffer: {
+    backgroundColor: 'transparent',
+  },
+  query: {
+    transform: 'rotate(180deg)',
+  },
+  dashed: {
+    position: 'absolute',
+    marginTop: 0,
+    height: '100%',
+    width: '100%',
+    animation: 'buffer 3s infinite linear',
+  },
+  dashedColorPrimary: {
+    backgroundImage: `radial-gradient(${lighten(theme.palette.primary.light, 0.6)} 0%, ${lighten(
       theme.palette.primary.light,
       0.6,
     )} 16%, transparent 42%)`,
     backgroundSize: '10px 10px',
     backgroundPosition: '0px -23px',
   },
-  secondaryColor: {
-    backgroundColor: lighten(theme.palette.secondary.light, 0.4),
-  },
-  secondaryColorBar: {
-    backgroundColor: theme.palette.secondary.main,
-  },
-  secondaryDashed: {
-    background: `radial-gradient(${lighten(theme.palette.secondary.light, 0.4)} 0%, ${lighten(
+  dashedColorSecondary: {
+    backgroundImage: `radial-gradient(${lighten(theme.palette.secondary.light, 0.4)} 0%, ${lighten(
       theme.palette.secondary.light,
       0.6,
     )} 16%, transparent 42%)`,
@@ -50,39 +57,32 @@ export const styles = theme => ({
     transition: 'transform 0.2s linear',
     transformOrigin: 'left',
   },
-  dashed: {
-    position: 'absolute',
-    marginTop: 0,
-    height: '100%',
-    width: '100%',
-    animation: 'buffer 3s infinite linear',
+  barColorPrimary: {
+    backgroundColor: theme.palette.primary.main,
   },
-  bufferBar2: {
-    transition: `transform .${TRANSITION_DURATION}s linear`,
+  barColorSecondary: {
+    backgroundColor: theme.palette.secondary.main,
   },
-  rootBuffer: {
-    backgroundColor: 'transparent',
-  },
-  rootQuery: {
-    transform: 'rotate(180deg)',
-  },
-  indeterminateBar1: {
+  bar1Indeterminate: {
     width: 'auto',
     willChange: 'left, right',
     animation: 'mui-indeterminate1 2.1s cubic-bezier(0.65, 0.815, 0.735, 0.395) infinite',
   },
-  indeterminateBar2: {
+  bar2Indeterminate: {
     width: 'auto',
     willChange: 'left, right',
     animation: 'mui-indeterminate2 2.1s cubic-bezier(0.165, 0.84, 0.44, 1) infinite',
     animationDelay: '1.15s',
   },
-  determinateBar1: {
+  bar1Determinate: {
     willChange: 'transform',
     transition: `transform .${TRANSITION_DURATION}s linear`,
   },
-  bufferBar1: {
+  bar1Buffer: {
     zIndex: 1,
+    transition: `transform .${TRANSITION_DURATION}s linear`,
+  },
+  bar2Buffer: {
     transition: `transform .${TRANSITION_DURATION}s linear`,
   },
   // Legends:
@@ -145,45 +145,44 @@ export const styles = theme => ({
  * attribute to `true` on that region until it has finished loading.
  */
 function LinearProgress(props) {
-  const { classes, className, color, value, valueBuffer, variant, ...other } = props;
+  const { classes, className: classNameProp, color, value, valueBuffer, variant, ...other } = props;
 
-  const dashedClass = classNames(classes.dashed, {
-    [classes.primaryDashed]: color === 'primary',
-    [classes.secondaryDashed]: color === 'secondary',
-  });
-
-  const rootClassName = classNames(
+  const className = classNames(
     classes.root,
     {
-      [classes.primaryColor]: color === 'primary',
-      [classes.secondaryColor]: color === 'secondary',
-      [classes.rootBuffer]: variant === 'buffer',
-      [classes.rootQuery]: variant === 'query',
+      [classes.colorPrimary]: color === 'primary',
+      [classes.colorSecondary]: color === 'secondary',
+      [classes.buffer]: variant === 'buffer',
+      [classes.query]: variant === 'query',
     },
-    className,
+    classNameProp,
   );
-  const primaryClassName = classNames(classes.bar, {
-    [classes.primaryColorBar]: color === 'primary',
-    [classes.secondaryColorBar]: color === 'secondary',
-    [classes.indeterminateBar1]: variant === 'indeterminate' || variant === 'query',
-    [classes.determinateBar1]: variant === 'determinate',
-    [classes.bufferBar1]: variant === 'buffer',
+  const dashedClass = classNames(classes.dashed, {
+    [classes.dashedColorPrimary]: color === 'primary',
+    [classes.dashedColorSecondary]: color === 'secondary',
   });
-  const secondaryClassName = classNames(classes.bar, {
-    [classes.bufferBar2]: variant === 'buffer',
-    [classes.primaryColorBar]: color === 'primary' && variant !== 'buffer',
-    [classes.primaryColor]: color === 'primary' && variant === 'buffer',
-    [classes.secondaryColorBar]: color === 'secondary' && variant !== 'buffer',
-    [classes.secondaryColor]: color === 'secondary' && variant === 'buffer',
-    [classes.indeterminateBar2]: variant === 'indeterminate' || variant === 'query',
+  const bar1ClassName = classNames(classes.bar, {
+    [classes.barColorPrimary]: color === 'primary',
+    [classes.barColorSecondary]: color === 'secondary',
+    [classes.bar1Indeterminate]: variant === 'indeterminate' || variant === 'query',
+    [classes.bar1Determinate]: variant === 'determinate',
+    [classes.bar1Buffer]: variant === 'buffer',
   });
-  const inlineStyles = { primary: {}, secondary: {} };
+  const bar2ClassName = classNames(classes.bar, {
+    [classes.barColorPrimary]: color === 'primary' && variant !== 'buffer',
+    [classes.colorPrimary]: color === 'primary' && variant === 'buffer',
+    [classes.barColorSecondary]: color === 'secondary' && variant !== 'buffer',
+    [classes.colorSecondary]: color === 'secondary' && variant === 'buffer',
+    [classes.bar2Indeterminate]: variant === 'indeterminate' || variant === 'query',
+    [classes.bar2Buffer]: variant === 'buffer',
+  });
   const rootProps = {};
+  const inlineStyles = { bar1: {}, bar2: {} };
 
   if (variant === 'determinate' || variant === 'buffer') {
     if (value !== undefined) {
-      inlineStyles.primary.transform = `scaleX(${value / 100})`;
       rootProps['aria-valuenow'] = Math.round(value);
+      inlineStyles.bar1.transform = `scaleX(${value / 100})`;
     } else {
       warning(
         false,
@@ -194,7 +193,7 @@ function LinearProgress(props) {
   }
   if (variant === 'buffer') {
     if (valueBuffer !== undefined) {
-      inlineStyles.secondary.transform = `scaleX(${(valueBuffer || 0) / 100})`;
+      inlineStyles.bar2.transform = `scaleX(${(valueBuffer || 0) / 100})`;
     } else {
       warning(
         false,
@@ -205,11 +204,11 @@ function LinearProgress(props) {
   }
 
   return (
-    <div className={rootClassName} role="progressbar" {...rootProps} {...other}>
+    <div className={className} role="progressbar" {...rootProps} {...other}>
       {variant === 'buffer' ? <div className={dashedClass} /> : null}
-      <div className={primaryClassName} style={inlineStyles.primary} />
+      <div className={bar1ClassName} style={inlineStyles.bar1} />
       {variant === 'determinate' ? null : (
-        <div className={secondaryClassName} style={inlineStyles.secondary} />
+        <div className={bar2ClassName} style={inlineStyles.bar2} />
       )}
     </div>
   );

--- a/src/Progress/LinearProgress.spec.js
+++ b/src/Progress/LinearProgress.spec.js
@@ -31,24 +31,24 @@ describe('<LinearProgress />', () => {
     const wrapper = shallow(<LinearProgress />);
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.primaryColorBar),
+      wrapper.childAt(0).hasClass(classes.barColorPrimary),
       true,
-      'should have the primaryColorBar class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.indeterminateBar1),
+      wrapper.childAt(0).hasClass(classes.bar1Indeterminate),
       true,
-      'should have the indeterminateBar1 class',
+      'should have the bar1Indeterminate class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.primaryColorBar),
+      wrapper.childAt(1).hasClass(classes.barColorPrimary),
       true,
-      'should have the primaryColorBar class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.indeterminateBar2),
+      wrapper.childAt(1).hasClass(classes.bar2Indeterminate),
       true,
-      'should have the indeterminateBar2 class',
+      'should have the bar2Indeterminate class',
     );
   });
 
@@ -56,14 +56,14 @@ describe('<LinearProgress />', () => {
     const wrapper = shallow(<LinearProgress color="primary" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.primaryColorBar),
+      wrapper.childAt(0).hasClass(classes.barColorPrimary),
       true,
-      'should have the primaryColorBar class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.primaryColorBar),
+      wrapper.childAt(1).hasClass(classes.barColorPrimary),
       true,
-      'should have the primaryColorBar class',
+      'should have the barColorPrimary class',
     );
   });
 
@@ -71,14 +71,14 @@ describe('<LinearProgress />', () => {
     const wrapper = shallow(<LinearProgress color="secondary" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.secondaryColorBar),
+      wrapper.childAt(0).hasClass(classes.barColorSecondary),
       true,
-      'should have the secondaryColorBar class',
+      'should have the barColorSecondary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.secondaryColorBar),
+      wrapper.childAt(1).hasClass(classes.barColorSecondary),
       true,
-      'should have the secondaryColorBar class',
+      'should have the barColorSecondary class',
     );
   });
 
@@ -86,14 +86,14 @@ describe('<LinearProgress />', () => {
     const wrapper = shallow(<LinearProgress value={1} variant="determinate" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.primaryColorBar),
+      wrapper.childAt(0).hasClass(classes.barColorPrimary),
       true,
-      'should have the primaryColorBar class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.determinateBar1),
+      wrapper.childAt(0).hasClass(classes.bar1Determinate),
       true,
-      'should have the determinateBar1 class',
+      'should have the bar1Determinate class',
     );
   });
 
@@ -101,14 +101,14 @@ describe('<LinearProgress />', () => {
     const wrapper = shallow(<LinearProgress color="primary" value={1} variant="determinate" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.primaryColorBar),
+      wrapper.childAt(0).hasClass(classes.barColorPrimary),
       true,
-      'should have the primaryColorBar class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.determinateBar1),
+      wrapper.childAt(0).hasClass(classes.bar1Determinate),
       true,
-      'should have the determinateBar1 class',
+      'should have the bar1Determinate class',
     );
   });
 
@@ -116,14 +116,14 @@ describe('<LinearProgress />', () => {
     const wrapper = shallow(<LinearProgress color="secondary" value={1} variant="determinate" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.secondaryColorBar),
+      wrapper.childAt(0).hasClass(classes.barColorSecondary),
       true,
-      'should have the secondaryColorBar class',
+      'should have the barColorSecondary class',
     );
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.determinateBar1),
+      wrapper.childAt(0).hasClass(classes.bar1Determinate),
       true,
-      'should have the determinateBar1 class',
+      'should have the bar1Determinate class',
     );
   });
 
@@ -142,29 +142,29 @@ describe('<LinearProgress />', () => {
     const wrapper = shallow(<LinearProgress value={1} valueBuffer={1} variant="buffer" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.primaryDashed),
+      wrapper.childAt(0).hasClass(classes.dashedColorPrimary),
       true,
-      'should have the primaryDashed class',
+      'should have the dashedColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.primaryColorBar),
+      wrapper.childAt(1).hasClass(classes.barColorPrimary),
       true,
-      'should have the primaryColorBar class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.bufferBar1),
+      wrapper.childAt(1).hasClass(classes.bar1Buffer),
       true,
-      'should have the bufferBar1 class',
+      'should have the bar1Buffer class',
     );
     assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.primaryColor),
+      wrapper.childAt(2).hasClass(classes.colorPrimary),
       true,
-      'should have the primaryColor class',
+      'should have the colorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.bufferBar2),
+      wrapper.childAt(2).hasClass(classes.bar2Buffer),
       true,
-      'should have the bufferBar2 class',
+      'should have the bar2Buffer class',
     );
   });
 
@@ -174,29 +174,29 @@ describe('<LinearProgress />', () => {
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.primaryDashed),
+      wrapper.childAt(0).hasClass(classes.dashedColorPrimary),
       true,
-      'should have the primaryDashed class',
+      'should have the dashedColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.primaryColorBar),
+      wrapper.childAt(1).hasClass(classes.barColorPrimary),
       true,
-      'should have the primaryColorBar class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.bufferBar1),
+      wrapper.childAt(1).hasClass(classes.bar1Buffer),
       true,
-      'should have the bufferBar1 class',
+      'should have the bar1Buffer class',
     );
     assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.primaryColor),
+      wrapper.childAt(2).hasClass(classes.colorPrimary),
       true,
-      'should have the primaryColor class',
+      'should have the colorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.bufferBar2),
+      wrapper.childAt(2).hasClass(classes.bar2Buffer),
       true,
-      'should have the bufferBar2 class',
+      'should have the bar2Buffer class',
     );
   });
 
@@ -206,29 +206,29 @@ describe('<LinearProgress />', () => {
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.secondaryDashed),
+      wrapper.childAt(0).hasClass(classes.dashedColorSecondary),
       true,
-      'should have the secondaryDashed class',
+      'should have the dashedColorSecondary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.secondaryColorBar),
+      wrapper.childAt(1).hasClass(classes.barColorSecondary),
       true,
-      'should have the secondaryColorBar class',
+      'should have the barColorSecondary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.bufferBar1),
+      wrapper.childAt(1).hasClass(classes.bar1Buffer),
       true,
-      'should have the bufferBar1 class',
+      'should have the bar1Buffer class',
     );
     assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.secondaryColor),
+      wrapper.childAt(2).hasClass(classes.colorSecondary),
       true,
-      'should have the secondaryColor class',
+      'should have the colorSecondary class',
     );
     assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.bufferBar2),
+      wrapper.childAt(2).hasClass(classes.bar2Buffer),
       true,
-      'should have the bufferBar2 class',
+      'should have the bar2Buffer class',
     );
   });
 
@@ -250,30 +250,26 @@ describe('<LinearProgress />', () => {
   it('should render with query classes', () => {
     const wrapper = shallow(<LinearProgress variant="query" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass(classes.query), true, 'should have the query class');
     assert.strictEqual(
-      wrapper.hasClass(classes.rootQuery),
+      wrapper.childAt(0).hasClass(classes.barColorPrimary),
       true,
-      'should have the rootQuery class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.primaryColorBar),
+      wrapper.childAt(0).hasClass(classes.bar1Indeterminate),
       true,
-      'should have the primaryColorBar class',
+      'should have the bar1Indeterminate class',
     );
     assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.indeterminateBar1),
+      wrapper.childAt(1).hasClass(classes.barColorPrimary),
       true,
-      'should have the indeterminateBar1 class',
+      'should have the barColorPrimary class',
     );
     assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.primaryColorBar),
+      wrapper.childAt(1).hasClass(classes.bar2Indeterminate),
       true,
-      'should have the primaryColorBar class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.indeterminateBar2),
-      true,
-      'should have the indeterminateBar2 class',
+      'should have the bar2Indeterminate class',
     );
   });
 

--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -35,19 +35,19 @@ export const styles = theme => {
       justifyContent: 'center',
       alignItems: 'center',
     },
-    anchorTopCenter: {
+    anchorOriginTopCenter: {
       ...top,
       [theme.breakpoints.up('md')]: {
         ...center,
       },
     },
-    anchorBottomCenter: {
+    anchorOriginBottomCenter: {
       ...bottom,
       [theme.breakpoints.up('md')]: {
         ...center,
       },
     },
-    anchorTopRight: {
+    anchorOriginTopRight: {
       ...top,
       ...right,
       [theme.breakpoints.up('md')]: {
@@ -56,7 +56,7 @@ export const styles = theme => {
         ...rightSpace,
       },
     },
-    anchorBottomRight: {
+    anchorOriginBottomRight: {
       ...bottom,
       ...right,
       [theme.breakpoints.up('md')]: {
@@ -65,7 +65,7 @@ export const styles = theme => {
         ...rightSpace,
       },
     },
-    anchorTopLeft: {
+    anchorOriginTopLeft: {
       ...top,
       ...left,
       [theme.breakpoints.up('md')]: {
@@ -74,7 +74,7 @@ export const styles = theme => {
         ...leftSpace,
       },
     },
-    anchorBottomLeft: {
+    anchorOriginBottomLeft: {
       ...bottom,
       ...left,
       [theme.breakpoints.up('md')]: {
@@ -232,7 +232,7 @@ class Snackbar extends React.Component {
           <div
             className={classNames(
               classes.root,
-              classes[`anchor${capitalize(vertical)}${capitalize(horizontal)}`],
+              classes[`anchorOrigin${capitalize(vertical)}${capitalize(horizontal)}`],
               className,
             )}
             onMouseEnter={this.handleMouseEnter}

--- a/src/Stepper/StepContent.js
+++ b/src/Stepper/StepContent.js
@@ -27,7 +27,7 @@ function StepContent(props) {
     alternativeLabel,
     children,
     classes,
-    className: classNameProp,
+    className,
     completed,
     last,
     optional,
@@ -42,16 +42,8 @@ function StepContent(props) {
     'Material-UI: <StepContent /> is only designed for use with the vertical stepper.',
   );
 
-  const className = classNames(
-    classes.root,
-    {
-      [classes.last]: last,
-    },
-    classNameProp,
-  );
-
   return (
-    <div className={className} {...other}>
+    <div className={classNames(classes.root, { [classes.last]: last }, className)} {...other}>
       <Transition
         in={active}
         className={classes.transition}

--- a/src/Stepper/StepLabel.js
+++ b/src/Stepper/StepLabel.js
@@ -33,9 +33,11 @@ export const styles = theme => ({
     textAlign: 'center',
     marginTop: theme.spacing.unit * 2,
   },
-  iconContainer: {},
-  iconContainerNoAlternative: {
+  iconContainer: {
     paddingRight: theme.spacing.unit,
+  },
+  iconContainerAlternativeLabel: {
+    paddingRight: 0,
   },
   labelContainer: {
     width: '100%',
@@ -74,7 +76,7 @@ function StepLabel(props) {
       {icon && (
         <span
           className={classNames(classes.iconContainer, {
-            [classes.iconContainerNoAlternative]: !alternativeLabel,
+            [classes.iconContainerAlternativeLabel]: alternativeLabel,
           })}
         >
           <StepIcon

--- a/src/Table/TableCell.js
+++ b/src/Table/TableCell.js
@@ -18,38 +18,42 @@ export const styles = theme => ({
         : darken(fade(theme.palette.divider, 1), 0.8)
     }`,
     textAlign: 'left',
-  },
-  numeric: {
-    textAlign: 'right',
-    flexDirection: 'row-reverse', // can be dynamically inherited at runtime by contents
-  },
-  typeHead: {
-    color: theme.palette.text.secondary,
-    fontSize: theme.typography.pxToRem(12),
-    fontWeight: theme.typography.fontWeightMedium,
-    position: 'relative', // Workaround for Tooltip positioning issue.
-  },
-  typeBody: {
-    fontSize: theme.typography.pxToRem(13),
-    color: theme.palette.text.primary,
-  },
-  typeFooter: {
-    borderBottom: 0,
-    color: theme.palette.text.secondary,
-    fontSize: theme.typography.pxToRem(12),
-  },
-  paddingDefault: {
     padding: `${theme.spacing.unit / 2}px ${theme.spacing.unit * 7}px ${theme.spacing.unit /
       2}px ${theme.spacing.unit * 3}px`,
     '&:last-child': {
       paddingRight: theme.spacing.unit * 3,
     },
   },
+  head: {
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.pxToRem(12),
+    fontWeight: theme.typography.fontWeightMedium,
+    position: 'relative', // Workaround for Tooltip positioning issue.
+  },
+  body: {
+    fontSize: theme.typography.pxToRem(13),
+    color: theme.palette.text.primary,
+  },
+  footer: {
+    borderBottom: 0,
+    color: theme.palette.text.secondary,
+    fontSize: theme.typography.pxToRem(12),
+  },
+  numeric: {
+    textAlign: 'right',
+    flexDirection: 'row-reverse', // can be dynamically inherited at runtime by contents
+  },
   paddingDense: {
     paddingRight: theme.spacing.unit * 3,
   },
   paddingCheckbox: {
     padding: '0 12px',
+  },
+  paddingNone: {
+    padding: 0,
+    '&:last-child': {
+      padding: 0,
+    },
   },
 });
 
@@ -82,12 +86,11 @@ function TableCell(props, context) {
   const className = classNames(
     classes.root,
     {
+      [classes.head]: variant ? variant === 'head' : table && table.head,
+      [classes.body]: variant ? variant === 'body' : table && table.body,
+      [classes.footer]: variant ? variant === 'footer' : table && table.footer,
       [classes.numeric]: numeric,
-      [classes[`padding${capitalize(padding)}`]]: padding !== 'none' && padding !== 'default',
-      [classes.paddingDefault]: padding !== 'none',
-      [classes.typeHead]: variant ? variant === 'head' : table && table.head,
-      [classes.typeBody]: variant ? variant === 'body' : table && table.body,
-      [classes.typeFooter]: variant ? variant === 'footer' : table && table.footer,
+      [classes[`padding${capitalize(padding)}`]]: padding !== 'default',
     },
     classNameProp,
   );

--- a/src/Table/TableCell.spec.js
+++ b/src/Table/TableCell.spec.js
@@ -30,11 +30,7 @@ describe('<TableCell />', () => {
     const wrapper = shallow(<TableCell className="woofTableCell" />);
     assert.strictEqual(wrapper.hasClass('woofTableCell'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.paddingDefault),
-      true,
-      'should have the padding class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.paddingDefault), false);
   });
 
   it('should render with the user, root and without the padding classes', () => {
@@ -52,7 +48,6 @@ describe('<TableCell />', () => {
     const wrapper = shallow(<TableCell className="woofTableCell" padding="checkbox" />);
     assert.strictEqual(wrapper.hasClass('woofTableCell'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.paddingDefault), true);
     assert.strictEqual(wrapper.hasClass(classes.paddingCheckbox), true);
   });
 
@@ -60,7 +55,6 @@ describe('<TableCell />', () => {
     const wrapper = shallow(<TableCell className="woofTableCell" padding="dense" />);
     assert.strictEqual(wrapper.hasClass('woofTableCell'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.paddingDefault), true);
     assert.strictEqual(wrapper.hasClass(classes.paddingDense), true);
   });
 
@@ -75,7 +69,7 @@ describe('<TableCell />', () => {
     wrapper.setContext({ table: { head: true } });
     assert.strictEqual(wrapper.name(), 'th');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.typeHead), true, 'should have the head class');
+    assert.strictEqual(wrapper.hasClass(classes.head), true, 'should have the head class');
     assert.strictEqual(wrapper.props().scope, 'col', 'should have the correct scope attribute');
   });
 
@@ -90,7 +84,7 @@ describe('<TableCell />', () => {
     wrapper.setContext({ table: { footer: true } });
     assert.strictEqual(wrapper.name(), 'td');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.typeFooter), true, 'should have the footer class');
+    assert.strictEqual(wrapper.hasClass(classes.footer), true, 'should have the footer class');
   });
 
   it('should render a div when custom component prop is used', () => {
@@ -103,32 +97,32 @@ describe('<TableCell />', () => {
     const wrapper = shallow(<TableCell />);
     wrapper.setContext({ table: { footer: true } });
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.typeFooter), true, 'should have the footer class');
+    assert.strictEqual(wrapper.hasClass(classes.footer), true, 'should have the footer class');
   });
 
   it('should render with the head class when variant is head, overriding context', () => {
     const wrapper = shallow(<TableCell variant="head" />);
     wrapper.setContext({ table: { footer: true } });
-    assert.strictEqual(wrapper.hasClass(classes.typeHead), true);
+    assert.strictEqual(wrapper.hasClass(classes.head), true);
     assert.strictEqual(wrapper.props().scope, undefined, 'should have the correct scope attribute');
   });
 
   it('should render without head class when variant is body, overriding context', () => {
     const wrapper = shallow(<TableCell variant="body" />);
     wrapper.setContext({ table: { head: true } });
-    assert.strictEqual(wrapper.hasClass(classes.typeHead), false);
+    assert.strictEqual(wrapper.hasClass(classes.head), false);
   });
 
   it('should render without footer class when variant is body, overriding context', () => {
     const wrapper = shallow(<TableCell variant="body" />);
     wrapper.setContext({ table: { footer: true } });
-    assert.strictEqual(wrapper.hasClass(classes.typeFooter), false);
+    assert.strictEqual(wrapper.hasClass(classes.footer), false);
   });
 
   it('should render with the footer class when variant is footer, overriding context', () => {
     const wrapper = shallow(<TableCell variant="footer" />);
     wrapper.setContext({ table: { head: true } });
-    assert.strictEqual(wrapper.hasClass(classes.typeFooter), true);
+    assert.strictEqual(wrapper.hasClass(classes.footer), true);
   });
 
   it('should render with the numeric class', () => {

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -105,14 +105,7 @@ class TablePagination extends React.Component {
                 select: classes.select,
                 icon: classes.selectIcon,
               }}
-              input={
-                <Input
-                  classes={{
-                    root: classes.input,
-                  }}
-                  disableUnderline
-                />
-              }
+              input={<Input className={classes.input} disableUnderline />}
               value={rowsPerPage}
               onChange={onChangeRowsPerPage}
             >

--- a/src/Table/TableRow.js
+++ b/src/Table/TableRow.js
@@ -8,15 +8,15 @@ export const styles = theme => ({
     color: 'inherit',
     display: 'table-row',
     height: 48,
+    verticalAlign: 'middle',
     '&:focus': {
       outline: 'none',
     },
-    verticalAlign: 'middle',
   },
-  typeHead: {
+  head: {
     height: 56,
   },
-  typeFooter: {
+  footer: {
     height: 56,
   },
   selected: {
@@ -53,8 +53,8 @@ function TableRow(props, context) {
   const className = classNames(
     classes.root,
     {
-      [classes.typeHead]: table && table.head,
-      [classes.typeFooter]: table && table.footer,
+      [classes.head]: table && table.head,
+      [classes.footer]: table && table.footer,
       [classes.hover]: table && hover,
       [classes.selected]: table && selected,
     },

--- a/src/Table/TableRow.spec.js
+++ b/src/Table/TableRow.spec.js
@@ -49,13 +49,13 @@ describe('<TableRow />', () => {
     const wrapper = shallow(<TableRow />);
     wrapper.setContext({ table: { head: true } });
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.typeHead), true, 'should have the head class');
+    assert.strictEqual(wrapper.hasClass(classes.head), true, 'should have the head class');
   });
 
   it('should render with the footer class when in the context of a table footer', () => {
     const wrapper = shallow(<TableRow />);
     wrapper.setContext({ table: { footer: true } });
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.typeFooter), true, 'should have the footer class');
+    assert.strictEqual(wrapper.hasClass(classes.footer), true, 'should have the footer class');
   });
 });

--- a/src/Table/TableSortLabel.js
+++ b/src/Table/TableSortLabel.js
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import ArrowDownwardIcon from '../internal/svg-icons/ArrowDownward';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
+import { capitalize } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -38,10 +39,10 @@ export const styles = theme => ({
     userSelect: 'none',
     width: 16,
   },
-  desc: {
+  iconDirectionDesc: {
     transform: 'rotate(0deg)',
   },
-  asc: {
+  iconDirectionAsc: {
     transform: 'rotate(180deg)',
   },
 });
@@ -50,23 +51,19 @@ export const styles = theme => ({
  * A button based label for placing inside `TableCell` for column sorting.
  */
 function TableSortLabel(props) {
-  const { active, classes, className: classNameProp, children, direction, ...other } = props;
-  const className = classNames(
-    classes.root,
-    {
-      [classes.active]: active,
-    },
-    classNameProp,
-  );
-
-  const iconClassName = classNames(classes.icon, {
-    [classes[direction]]: !!direction,
-  });
+  const { active, classes, className, children, direction, ...other } = props;
 
   return (
-    <ButtonBase className={className} component="span" disableRipple {...other}>
+    <ButtonBase
+      className={classNames(classes.root, { [classes.active]: active }, className)}
+      component="span"
+      disableRipple
+      {...other}
+    >
       {children}
-      <ArrowDownwardIcon className={iconClassName} />
+      <ArrowDownwardIcon
+        className={classNames(classes.icon, classes[`iconDirection${capitalize(direction)}`])}
+      />
     </ButtonBase>
   );
 }

--- a/src/Table/TableSortLabel.spec.js
+++ b/src/Table/TableSortLabel.spec.js
@@ -45,22 +45,22 @@ describe('<TableSortLabel />', () => {
     it('by default should have desc direction class', () => {
       const wrapper = shallow(<TableSortLabel />);
       const icon = wrapper.find(`.${classes.icon}`).first();
-      assert.strictEqual(icon.hasClass(classes.asc), false);
-      assert.strictEqual(icon.hasClass(classes.desc), true);
+      assert.strictEqual(icon.hasClass(classes.iconDirectionAsc), false);
+      assert.strictEqual(icon.hasClass(classes.iconDirectionDesc), true);
     });
 
     it('when given direction desc should have desc direction class', () => {
       const wrapper = shallow(<TableSortLabel direction="desc" />);
       const icon = wrapper.find(`.${classes.icon}`).first();
-      assert.strictEqual(icon.hasClass(classes.asc), false);
-      assert.strictEqual(icon.hasClass(classes.desc), true);
+      assert.strictEqual(icon.hasClass(classes.iconDirectionAsc), false);
+      assert.strictEqual(icon.hasClass(classes.iconDirectionDesc), true);
     });
 
     it('when given direction asc should have asc direction class', () => {
       const wrapper = shallow(<TableSortLabel direction="asc" />);
       const icon = wrapper.find(`.${classes.icon}`).first();
-      assert.strictEqual(icon.hasClass(classes.asc), true);
-      assert.strictEqual(icon.hasClass(classes.desc), false);
+      assert.strictEqual(icon.hasClass(classes.iconDirectionAsc), true);
+      assert.strictEqual(icon.hasClass(classes.iconDirectionDesc), false);
     });
   });
 

--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -21,35 +21,35 @@ export const styles = theme => ({
       minWidth: 160,
     },
   },
-  rootLabelIcon: {
+  labelIcon: {
     height: 72,
   },
-  rootInherit: {
+  textColorInherit: {
     color: 'inherit',
     opacity: 0.7,
   },
-  rootPrimary: {
+  textColorPrimary: {
     color: theme.palette.text.secondary,
   },
-  rootPrimarySelected: {
+  textColorPrimarySelected: {
     color: theme.palette.primary.main,
   },
-  rootPrimaryDisabled: {
+  textColorPrimaryDisabled: {
     color: theme.palette.text.disabled,
   },
-  rootSecondary: {
+  textColorSecondary: {
     color: theme.palette.text.secondary,
   },
-  rootSecondarySelected: {
+  textColorSecondarySelected: {
     color: theme.palette.secondary.main,
   },
-  rootSecondaryDisabled: {
+  textColorSecondaryDisabled: {
     color: theme.palette.text.disabled,
   },
-  rootInheritSelected: {
+  textColorInheritSelected: {
     opacity: 1,
   },
-  rootInheritDisabled: {
+  textColorInheritDisabled: {
     opacity: 0.4,
   },
   fullWidth: {
@@ -167,11 +167,11 @@ class Tab extends React.Component {
 
     const className = classNames(
       classes.root,
-      classes[`root${capitalize(textColor)}`],
+      classes[`textColor${capitalize(textColor)}`],
       {
-        [classes[`root${capitalize(textColor)}Disabled`]]: disabled,
-        [classes[`root${capitalize(textColor)}Selected`]]: selected,
-        [classes.rootLabelIcon]: icon && label,
+        [classes[`textColor${capitalize(textColor)}Disabled`]]: disabled,
+        [classes[`textColor${capitalize(textColor)}Selected`]]: selected,
+        [classes.labelIcon]: icon && label,
         [classes.fullWidth]: fullWidth,
       },
       classNameProp,

--- a/src/Tabs/Tab.spec.js
+++ b/src/Tabs/Tab.spec.js
@@ -39,8 +39,8 @@ describe('<Tab />', () => {
   describe('prop: selected', () => {
     it('should render with the selected and root classes', () => {
       const wrapper = shallow(<Tab selected textColor="secondary" />);
-      assert.strictEqual(wrapper.hasClass(classes.rootSecondarySelected), true);
-      assert.strictEqual(wrapper.hasClass(classes.rootSecondary), true);
+      assert.strictEqual(wrapper.hasClass(classes.textColorSecondarySelected), true);
+      assert.strictEqual(wrapper.hasClass(classes.textColorSecondary), true);
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.props()['aria-selected'], true);
     });
@@ -49,8 +49,8 @@ describe('<Tab />', () => {
   describe('prop: disabled', () => {
     it('should render with the disabled and root classes', () => {
       const wrapper = shallow(<Tab disabled textColor="secondary" />);
-      assert.strictEqual(wrapper.hasClass(classes.rootSecondaryDisabled), true);
-      assert.strictEqual(wrapper.hasClass(classes.rootSecondary), true);
+      assert.strictEqual(wrapper.hasClass(classes.textColorSecondaryDisabled), true);
+      assert.strictEqual(wrapper.hasClass(classes.textColorSecondary), true);
       assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
   });
@@ -120,8 +120,8 @@ describe('<Tab />', () => {
   describe('prop: textColor', () => {
     it('should support the inherit value', () => {
       const wrapper = shallow(<Tab selected textColor="inherit" />);
-      assert.strictEqual(wrapper.hasClass(classes.rootInheritSelected), true);
-      assert.strictEqual(wrapper.hasClass(classes.rootInherit), true);
+      assert.strictEqual(wrapper.hasClass(classes.textColorInheritSelected), true);
+      assert.strictEqual(wrapper.hasClass(classes.textColorInherit), true);
       assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
 

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -20,7 +20,7 @@ export const styles = theme => ({
   flexContainer: {
     display: 'flex',
   },
-  scrollingContainer: {
+  scroller: {
     position: 'relative',
     display: 'inline-block',
     flex: '1 1 auto',
@@ -36,7 +36,7 @@ export const styles = theme => ({
   centered: {
     justifyContent: 'center',
   },
-  buttonAuto: {
+  scrollButtonsAuto: {
     [theme.breakpoints.down('xs')]: {
       display: 'none',
     },
@@ -110,7 +110,7 @@ class Tabs extends React.Component {
         visible={this.state.showLeftScroll}
         className={classNames(
           {
-            [classes.buttonAuto]: scrollButtons === 'auto',
+            [classes.scrollButtonsAuto]: scrollButtons === 'auto',
           },
           buttonClassName,
         )}
@@ -124,7 +124,7 @@ class Tabs extends React.Component {
         visible={this.state.showRightScroll}
         className={classNames(
           {
-            [classes.buttonAuto]: scrollButtons === 'auto',
+            [classes.scrollButtonsAuto]: scrollButtons === 'auto',
           },
           buttonClassName,
         )}
@@ -299,11 +299,11 @@ class Tabs extends React.Component {
     } = this.props;
 
     const className = classNames(classes.root, classNameProp);
-    const scrollerClassName = classNames(classes.scrollingContainer, {
+    const scrollerClassName = classNames(classes.scroller, {
       [classes.fixed]: !scrollable,
       [classes.scrollable]: scrollable,
     });
-    const tabItemContainerClassName = classNames(classes.flexContainer, {
+    const flexContainerClassName = classNames(classes.flexContainer, {
       [classes.centered]: centered && !scrollable,
     });
 
@@ -354,7 +354,7 @@ class Tabs extends React.Component {
             role="tablist"
             onScroll={this.handleTabsScroll}
           >
-            <div className={tabItemContainerClassName}>{children}</div>
+            <div className={flexContainerClassName}>{children}</div>
             {this.state.mounted && indicator}
           </div>
           {conditionalElements.scrollButtonRight}

--- a/src/Tabs/Tabs.spec.js
+++ b/src/Tabs/Tabs.spec.js
@@ -338,7 +338,7 @@ describe('<Tabs />', () => {
     });
 
     it('should render with the scrollable class', () => {
-      const selector = `.${classes.scrollingContainer}.${classes.scrollable}`;
+      const selector = `.${classes.scroller}.${classes.scrollable}`;
       assert.strictEqual(wrapper.find(selector).is('div'), true, 'should be a div');
       assert.strictEqual(wrapper.find(selector).length, 1, 'should only be one');
     });
@@ -347,7 +347,7 @@ describe('<Tabs />', () => {
       const instance = wrapper.instance();
       instance.tabs = { scrollLeft: 100, ...fakeTabs };
       spy(instance, 'updateScrollButtonState');
-      const selector = `.${classes.scrollingContainer}.${classes.scrollable}`;
+      const selector = `.${classes.scroller}.${classes.scrollable}`;
       wrapper.find(selector).simulate('scroll');
       clock.tick(166);
       assert.strictEqual(
@@ -378,8 +378,8 @@ describe('<Tabs />', () => {
           <Tab />
         </Tabs>,
       );
-      const baseSelector = `.${classes.scrollingContainer}`;
-      const selector = `.${classes.scrollingContainer}.${classes.scrollable}`;
+      const baseSelector = `.${classes.scroller}`;
+      const selector = `.${classes.scroller}.${classes.scrollable}`;
       assert.strictEqual(wrapper.find(baseSelector).length, 1, 'base selector should exist');
       assert.strictEqual(wrapper.find(selector).length, 0, 'scrolling selector should not exist');
     });
@@ -425,7 +425,7 @@ describe('<Tabs />', () => {
       );
       assert.strictEqual(wrapper.find(TabScrollButton).length, 2, 'should be zero');
       assert.strictEqual(
-        wrapper.find(TabScrollButton).everyWhere(node => node.hasClass(classes.buttonAuto)),
+        wrapper.find(TabScrollButton).everyWhere(node => node.hasClass(classes.scrollButtonsAuto)),
         true,
       );
     });

--- a/src/Toolbar/Toolbar.js
+++ b/src/Toolbar/Toolbar.js
@@ -5,10 +5,10 @@ import withStyles from '../styles/withStyles';
 
 export const styles = theme => ({
   root: {
+    ...theme.mixins.toolbar,
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
-    ...theme.mixins.toolbar,
   },
   gutters: theme.mixins.gutters(),
 });

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -44,28 +44,28 @@ export const styles = theme => ({
       lineHeight: `${theme.typography.round(14 / 10)}em`,
     },
   },
-  tooltipLeft: {
+  tooltipPlacementLeft: {
     transformOrigin: 'right center',
     margin: `0 ${theme.spacing.unit * 3}px`,
     [theme.breakpoints.up('sm')]: {
       margin: '0 14px',
     },
   },
-  tooltipRight: {
+  tooltipPlacementRight: {
     transformOrigin: 'left center',
     margin: `0 ${theme.spacing.unit * 3}px`,
     [theme.breakpoints.up('sm')]: {
       margin: '0 14px',
     },
   },
-  tooltipTop: {
+  tooltipPlacementTop: {
     transformOrigin: 'center bottom',
     margin: `${theme.spacing.unit * 3}px 0`,
     [theme.breakpoints.up('sm')]: {
       margin: '14px 0',
     },
   },
-  tooltipBottom: {
+  tooltipPlacementBottom: {
     transformOrigin: 'center top',
     margin: `${theme.spacing.unit * 3}px 0`,
     [theme.breakpoints.up('sm')]: {
@@ -348,7 +348,7 @@ class Tooltip extends React.Component {
                     className={classNames(
                       classes.tooltip,
                       { [classes.tooltipOpen]: open },
-                      classes[`tooltip${capitalize(actualPlacement.split('-')[0])}`],
+                      classes[`tooltipPlacement${capitalize(actualPlacement.split('-')[0])}`],
                     )}
                   >
                     {title}

--- a/src/Tooltip/Tooltip.spec.js
+++ b/src/Tooltip/Tooltip.spec.js
@@ -100,7 +100,7 @@ describe('<Tooltip />', () => {
       const popperChildren = getPopperChildren(wrapper);
       assert.strictEqual(popperChildren.childAt(0).hasClass(classes.tooltip), true);
       wrapper.childAt(0).simulate('click');
-      assert.strictEqual(popperChildren.childAt(0).hasClass(classes.tooltipTop), true);
+      assert.strictEqual(popperChildren.childAt(0).hasClass(classes.tooltipPlacementTop), true);
     });
 
     const theme = createMuiTheme({

--- a/src/utils/reactHelpers.js
+++ b/src/utils/reactHelpers.js
@@ -1,18 +1,18 @@
-// @flow
 /* eslint-disable import/prefer-default-export */
 
 import React from 'react';
 import type { Node } from 'react';
 import classNames from 'classnames';
 
+export function cloneElementWithClassName(child, className) {
+  return React.cloneElement(child, {
+    className: classNames(child.props.className, className),
+  });
+}
+
 export function cloneChildrenWithClassName(children: Node, className: string) {
   return React.Children.map(children, child => {
-    return (
-      React.isValidElement(child) &&
-      React.cloneElement(child, {
-        className: classNames(child.props.className, className),
-      })
-    );
+    return React.isValidElement(child) && cloneElementWithClassName(child, className);
   });
 }
 


### PR DESCRIPTION
### Breaking change

This is an effort in order to harmonize the classes API. The best way to recover from this breaking change is to check the warnings in the console and to check the added documentation around the design rules around this API.

I'm quite happy with the current "classes" state, the main thing missing is documented in the roadmap:
> Change the CSS specificity rule to solve #10010 and #9742 at scale. It's inspired by the Bootstrap approach to writing CSS.

----

### CSS Classes

All the components accept a [`classes`](/customization/overrides#overriding-with-classes) property to customize the styles.
The classes design answers two constraints.
We try to make the classes structure as simple as possible while keeping it complex enough for implementing the Material specification.
- The class applied on the root element is always called `root`.
- The classes applied on non-root element are prefixed with the name of the element, e.g. `dashedXX`.
- All the default styles are grouped in a single class.
- The boolean variants applied **aren't** prefixed e.g. `rounded`.
- The enum variants applied **are** prefixed e.g. `colorXX`.
- A variant has **one level of specificity**.
For instance, the `color` and `variant` properties are considered a variant.
The lower the style specificity is, the simpler you can override it.
- We increase the specificity for a variant modifier. We already **have to do** it for the pseudo-classes (`:hover`, `:focus`, etc.). It allows much more control at the cost of extra complexity. Hopefully, it's more intuitive.

```js
const styles = {
  root: {
    color: green[600],
    '&$checked': {
      color: green[500],
    },
  },
  checked: {},
};
```
