### PR TITLE
[ButtonBase] Add a TouchRippleProps property

### DIFF
--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -24,6 +24,7 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">focusRipple</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the base button will have a keyboard focus ripple. `disableRipple` must also be `false`. |
 | <span class="prop-name">keyboardFocusedClassName</span> | <span class="prop-type">string |  | The CSS class applied while the component is keyboard focused. |
 | <span class="prop-name">onKeyboardFocus</span> | <span class="prop-type">func |  | Callback fired when the component is focused with a keyboard. We trigger a `onFocus` callback too. |
+| <span class="prop-name">TouchRippleProps</span> | <span class="prop-type">object |  | Properties applied to the `TouchRipple` element. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/ButtonBase/ButtonBase.d.ts
+++ b/src/ButtonBase/ButtonBase.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StandardProps } from '..';
-import {TouchRippleProps} from './TouchRipple'
+import { TouchRippleProps } from './TouchRipple';
 
 export interface ButtonBaseProps
   extends StandardProps<

--- a/src/ButtonBase/ButtonBase.d.ts
+++ b/src/ButtonBase/ButtonBase.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { StandardProps } from '..';
+import {TouchRippleProps} from './TouchRipple'
 
 export interface ButtonBaseProps
   extends StandardProps<
@@ -13,6 +14,7 @@ export interface ButtonBaseProps
   focusRipple?: boolean;
   keyboardFocusedClassName?: string;
   onKeyboardFocus?: React.FocusEventHandler<any>;
+  TouchRippleProps?: Partial<TouchRippleProps>;
 }
 
 export type ButtonBaseClassKey = 'root' | 'disabled';

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -227,6 +227,7 @@ class ButtonBase extends React.Component {
       onTouchMove,
       onTouchStart,
       tabIndex,
+      TouchRippleProps,
       type,
       ...other
     } = this.props;
@@ -279,7 +280,7 @@ class ButtonBase extends React.Component {
       >
         {children}
         {!disableRipple && !disabled ? (
-          <TouchRipple innerRef={this.onRippleRef} center={centerRipple} />
+          <TouchRipple innerRef={this.onRippleRef} center={centerRipple} {...TouchRippleProps} />
         ) : null}
       </ComponentProp>
     );
@@ -389,6 +390,10 @@ ButtonBase.propTypes = {
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
+   * Properties applied to the `TouchRipple` element.
+   */
+  TouchRippleProps: PropTypes.object,
+  /**
    * @ignore
    */
   type: PropTypes.string,
@@ -399,6 +404,7 @@ ButtonBase.defaultProps = {
   disableRipple: false,
   focusRipple: false,
   tabIndex: '0',
+  TouchRippleProps: {},
   type: 'button',
 };
 

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -404,7 +404,6 @@ ButtonBase.defaultProps = {
   disableRipple: false,
   focusRipple: false,
   tabIndex: '0',
-  TouchRippleProps: {},
   type: 'button',
 };
 


### PR DESCRIPTION
I took the Popover component and its PaperProp property as a guideline.
Not sure how to update the specs of the ButtonBase component as I couldn't find an example in Popover specs.

Closes #10461 