### PR TITLE
[icon] Add "side-effects": false to material-ui-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "@types/react": "16.0.38"
   },
   "side-effects": false,
+  "sideEffects": false,
   "nyc": {
     "include": [
       "src/**/*.js"

--- a/package.json
+++ b/package.json
@@ -204,7 +204,6 @@
   "resolutions": {
     "@types/react": "16.0.38"
   },
-  "side-effects": false,
   "sideEffects": false,
   "nyc": {
     "include": [

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -51,6 +51,7 @@
     "yargs": "^11.0.0"
   },
   "side-effects": false,
+  "sideEffects": false,
   "engines": {
     "node": ">=6.11.0"
   }

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -50,6 +50,7 @@
     "temp": "^0.8.3",
     "yargs": "^11.0.0"
   },
+  "side-effects": false,
   "engines": {
     "node": ">=6.11.0"
   }

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -50,7 +50,6 @@
     "temp": "^0.8.3",
     "yargs": "^11.0.0"
   },
-  "side-effects": false,
   "sideEffects": false,
   "engines": {
     "node": ">=6.11.0"


### PR DESCRIPTION
Extends #8340 to material-ui-icons.
Also add "sideEffects" because webpack4 use the new name.
See [here](https://github.com/webpack/webpack/commit/1bc572a38516bb1b54938e8d2d04b0d25bc74f16).