### PR TITLE
[ListItem] Avoid li > li issue

### DIFF
--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -110,7 +110,17 @@ class ListItem extends React.Component {
     }
 
     if (hasSecondaryAction) {
-      Component = Component !== ButtonBase && !componentProp ? 'div' : Component;
+      // Use div by default.
+      Component = !componentProps.component && !componentProp ? 'div' : Component;
+
+      // Avoid nesting of li > li.
+      if (ContainerComponent === 'li') {
+        if (Component === 'li') {
+          Component = 'div';
+        } else if (componentProps.component === 'li') {
+          componentProps.component = 'div';
+        }
+      }
 
       return (
         <ContainerComponent className={classes.container} {...ContainerProps}>

--- a/src/Menu/MenuItem.spec.js
+++ b/src/Menu/MenuItem.spec.js
@@ -1,17 +1,24 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, getClasses } from '../test-utils';
+import { createShallow, getClasses, createMount } from '../test-utils';
 import ListItem from '../List/ListItem';
+import ListItemSecondaryAction from '../List/ListItemSecondaryAction';
 import MenuItem from './MenuItem';
 
 describe('<MenuItem />', () => {
   let shallow;
   let classes;
+  let mount;
 
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<MenuItem />);
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
   });
 
   it('should render a button ListItem with with ripple', () => {
@@ -83,6 +90,27 @@ describe('<MenuItem />', () => {
 
       assert.strictEqual(wrapper.props().component, 'a');
       assert.strictEqual(wrapper.props().disableRipple, undefined);
+    });
+  });
+
+  describe('mount', () => {
+    it('should not fail with a li > li error message', () => {
+      const wrapper1 = mount(
+        <MenuItem>
+          <ListItemSecondaryAction>
+            <div />
+          </ListItemSecondaryAction>
+        </MenuItem>,
+      );
+      assert.strictEqual(wrapper1.find('li').length, 1);
+      const wrapper2 = mount(
+        <MenuItem button={false}>
+          <ListItemSecondaryAction>
+            <div />
+          </ListItemSecondaryAction>
+        </MenuItem>,
+      );
+      assert.strictEqual(wrapper2.find('li').length, 1);
     });
   });
 });


### PR DESCRIPTION
Closes #10452: we do our best to prevent li nesting. But people can always provide their own custom element and reach this issue. It's their responsibility to prevent it.

Closes #10463: there is nothing much to do here. The `MenuItem` ask for a `li` component while the `disabled` can't be applied on a `<li>` element. The `component property win over the `disabled` one.

