### PR TITLE
[docs] EnhancedTable Demo

### DIFF
--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -99,8 +99,8 @@ const toolbarStyles = theme => ({
   highlight:
     theme.palette.type === 'light'
       ? {
-          color: theme.palette.secondary.dark,
-          backgroundColor: lighten(theme.palette.secondary.light, 0.4),
+          color: theme.palette.secondary.main,
+          backgroundColor: lighten(theme.palette.secondary.light, 0.85),
         }
       : {
           color: lighten(theme.palette.secondary.light, 0.4),
@@ -114,6 +114,7 @@ const toolbarStyles = theme => ({
   },
   title: {
     flex: '0 0 auto',
+    color: 'inherit',
   },
 });
 
@@ -128,7 +129,9 @@ let EnhancedTableToolbar = props => {
     >
       <div className={classes.title}>
         {numSelected > 0 ? (
-          <Typography variant="subheading">{numSelected} selected</Typography>
+          <Typography color="inherit" variant="subheading">
+            {numSelected} selected
+          </Typography>
         ) : (
           <Typography variant="title">Nutrition</Typography>
         )}

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -103,7 +103,7 @@ const toolbarStyles = theme => ({
           backgroundColor: lighten(theme.palette.secondary.light, 0.85),
         }
       : {
-          color: lighten(theme.palette.secondary.light, 0.4),
+          color: theme.palette.text.primary,
           backgroundColor: theme.palette.secondary.dark,
         },
   spacer: {
@@ -114,7 +114,6 @@ const toolbarStyles = theme => ({
   },
   title: {
     flex: '0 0 auto',
-    color: 'inherit',
   },
 });
 


### PR DESCRIPTION
The Table Header presented in the [Sorting and Selecting Table demo](https://material-ui-next.com/demos/tables/#sorting-amp-selecting) has a few inconsistencies when compared to the example in the [Material Design standard](https://material.io/guidelines/components/data-tables.html#data-tables-tables-within-cards):

- Selection header `color` should match the checkbox color, and should be inherited by the presented `Typography`
- Selection header `background-color` should be the 50 value of the secondary color.  I used [mcg](http://mcg.mbitson.com) to get as close to an A50 value for the current default theme.  Passing a coefficient of 0.85 to the `lighten` function got us very close.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
