### PR TITLE
Add override support for sizeLarge and sizeSmall

### DIFF
--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -28,6 +28,8 @@ export type ButtonClassKey =
   | 'raisedPrimary'
   | 'raisedSecondary'
   | 'fab'
+  | 'sizeSmall'
+  | 'sizeLarge'
   | 'fullWidth';
 
 declare const Button: React.ComponentType<ButtonProps>;


### PR DESCRIPTION
sizeLarge and sizeSmall are missing from ButtonClassKey, can't override them without getting ts error. this will fix it.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
