### PR TITLE
[SpeedDial] Add a tooltip title to main button 

### DIFF
--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -139,7 +139,7 @@ class SpeedDial extends React.Component {
     return (
       <div className={classNames(classes.root, classNameProp)} {...other}>
         <Transition in={!hidden} timeout={transitionDuration} mountOnEnter unmountOnExit>
-          <Tooltip title={tooltipTitle}>
+          <Tooltip title={tooltipTitle} placement="left">
             <Button
               variant="fab"
               color="primary"

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -7,6 +7,7 @@ import { withStyles } from 'material-ui/styles';
 import Zoom from 'material-ui/transitions/Zoom';
 import { duration } from 'material-ui/styles/transitions';
 import Button from 'material-ui/Button';
+import Tooltip from 'material-ui/Tooltip';
 import { isMuiElement } from 'material-ui/utils/reactHelpers';
 
 const styles = theme => ({
@@ -98,6 +99,7 @@ class SpeedDial extends React.Component {
       onKeyDown,
       open,
       openIcon,
+      tooltipTitle,
       transition: Transition,
       transitionDuration,
       ...other
@@ -137,23 +139,25 @@ class SpeedDial extends React.Component {
     return (
       <div className={classNames(classes.root, classNameProp)} {...other}>
         <Transition in={!hidden} timeout={transitionDuration} mountOnEnter unmountOnExit>
-          <Button
-            variant="fab"
-            color="primary"
-            onClick={onClick}
-            onKeyDown={this.handleKeyDown}
-            aria-label={ariaLabel}
-            aria-haspopup="true"
-            aria-expanded={open ? 'true' : 'false'}
-            aria-controls={`${id}-actions`}
-            ref={fab => {
-              this.fab = fab;
-            }}
-            data-mui-test="SpeedDial"
-            {...ButtonProps}
-          >
-            {icon()}
-          </Button>
+          <Tooltip title={tooltipTitle}>
+            <Button
+              variant="fab"
+              color="primary"
+              onClick={onClick}
+              onKeyDown={this.handleKeyDown}
+              aria-label={ariaLabel}
+              aria-haspopup="true"
+              aria-expanded={open ? 'true' : 'false'}
+              aria-controls={`${id}-actions`}
+              ref={fab => {
+                this.fab = fab;
+              }}
+              data-mui-test="SpeedDial"
+              {...ButtonProps}
+            >
+              {icon()}
+            </Button>
+          </Tooltip>
         </Transition>
         <div
           id={`${id}-actions`}
@@ -224,6 +228,10 @@ SpeedDial.propTypes = {
    */
   openIcon: PropTypes.node,
   /**
+   * Label to display in the tooltip.
+   */
+  tooltipTitle: PropTypes.node,
+  /**
    * Transition component.
    */
   transition: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
@@ -244,6 +252,7 @@ SpeedDial.defaultProps = {
     enter: duration.enteringScreen,
     exit: duration.leavingScreen,
   },
+  tooltipTitle: '',
 };
 
 export default withStyles(styles)(SpeedDial);

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.spec.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.spec.js
@@ -5,6 +5,7 @@ import { spy } from 'sinon';
 import { createMount, createShallow, getClasses } from 'material-ui/test-utils';
 import Icon from 'material-ui/Icon';
 import Button from 'material-ui/Button';
+import Tooltip from 'material-ui/Tooltip';
 import SpeedDial from './SpeedDial';
 import SpeedDialAction from '../SpeedDialAction';
 
@@ -41,13 +42,26 @@ describe('<SpeedDial />', () => {
     assert.strictEqual(wrapper.type(), 'div');
   });
 
+  it('should render a tooltip', () => {
+    const wrapper = shallow(
+      <SpeedDial {...defaultProps} icon={icon}>
+        <div />
+      </SpeedDial>,
+    );
+    const toolTipWrapper = wrapper.childAt(0).childAt(0);
+    assert.strictEqual(toolTipWrapper.type(), Tooltip);
+  });
+
   it('should render a Button', () => {
     const wrapper = shallow(
       <SpeedDial {...defaultProps} icon={icon}>
         <div />
       </SpeedDial>,
     );
-    const buttonWrapper = wrapper.childAt(0).childAt(0);
+    const buttonWrapper = wrapper
+      .childAt(0)
+      .childAt(0)
+      .childAt(0);
     assert.strictEqual(buttonWrapper.type(), Button);
   });
 
@@ -133,7 +147,10 @@ describe('<SpeedDial />', () => {
           <div />
         </SpeedDial>,
       );
-      const buttonWrapper = wrapper.childAt(0).childAt(0);
+      const buttonWrapper = wrapper
+        .childAt(0)
+        .childAt(0)
+        .childAt(0);
       const event = {};
       buttonWrapper.simulate('keyDown', event);
       assert.strictEqual(handleKeyDown.callCount, 1);

--- a/pages/lab/api/speed-dial.md
+++ b/pages/lab/api/speed-dial.md
@@ -21,7 +21,7 @@ filename: /packages/material-ui-lab/src/SpeedDial/SpeedDial.js
 | <span class="prop-name">onClose</span> | <span class="prop-type">func |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object, key: string) => void`<br>*event:* The event source of the callback<br>*key:* The key pressed |
 | <span class="prop-name required">open *</span> | <span class="prop-type">bool |  | If `true`, the SpeedDial is open. |
 | <span class="prop-name">openIcon</span> | <span class="prop-type">node |  | The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open. |
-| <span class="prop-name">tooltipTitle</span> | <span class="prop-type">node |  | Label to display in the tooltip. |
+| <span class="prop-name">tooltipTitle</span> | <span class="prop-type">node | <span class="prop-default">''</span> | Label to display in the tooltip. |
 | <span class="prop-name">transition</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">Zoom</span> | Transition component. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 

--- a/pages/lab/api/speed-dial.md
+++ b/pages/lab/api/speed-dial.md
@@ -21,6 +21,7 @@ filename: /packages/material-ui-lab/src/SpeedDial/SpeedDial.js
 | <span class="prop-name">onClose</span> | <span class="prop-type">func |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object, key: string) => void`<br>*event:* The event source of the callback<br>*key:* The key pressed |
 | <span class="prop-name required">open *</span> | <span class="prop-type">bool |  | If `true`, the SpeedDial is open. |
 | <span class="prop-name">openIcon</span> | <span class="prop-type">node |  | The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open. |
+| <span class="prop-name">tooltipTitle</span> | <span class="prop-type">node |  | Label to display in the tooltip. |
 | <span class="prop-name">transition</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">Zoom</span> | Transition component. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 


### PR DESCRIPTION
Small pull request to give the ability to add a default tooltip to the main button.  We can see that this use case is often used :   

Google calendar (desktop) :   
<img width="1240" alt="screen shot 2018-03-04 at 3 58 29 pm" src="https://user-images.githubusercontent.com/6645382/36951177-8456e986-1fce-11e8-97a2-3d4306bd11db.png">

Google Inbox :   
<img width="1372" alt="screen shot 2018-03-04 at 3 57 15 pm" src="https://user-images.githubusercontent.com/6645382/36951178-897d7132-1fce-11e8-80c9-ee1ee6e24d5f.png">

Google calendar (mobile) :   
![28768364_10156113288494210_65731055_o](https://user-images.githubusercontent.com/6645382/36951179-8ff9747a-1fce-11e8-8c2a-bd35910257e0.jpg)


Let me know if this pull request needs anything else :) 