### PR TITLE
[docs] Fix SSR rendering in Gatsby example

### DIFF
--- a/examples/gatsby/src/withRoot.js
+++ b/examples/gatsby/src/withRoot.js
@@ -14,7 +14,7 @@ function withRoot(Component) {
 
     componentDidMount() {
       // Remove the server-side injected CSS.
-      const jssStyles = document.querySelector('#jss-server-side');
+      const jssStyles = document.querySelector('#server-side-jss');
       if (jssStyles && jssStyles.parentNode) {
         jssStyles.parentNode.removeChild(jssStyles);
       }


### PR DESCRIPTION
The wrong id was being used here, which makes the SSR css never removed as it isn't the id used in `gatsby-ssr.js`. This appears to work fine using `gatsby develop` but breaks when building for production (`gatsby build`).