### PR TITLE
[Table] Allow null in direction prop

### DIFF
--- a/src/Table/TableSortLabel.js
+++ b/src/Table/TableSortLabel.js
@@ -62,7 +62,7 @@ function TableSortLabel(props) {
     >
       {children}
       <ArrowDownwardIcon
-        className={classNames(classes.icon, classes[`iconDirection${capitalize(direction)}`])}
+        className={classNames(classes.icon, classes[`iconDirection${capitalize(direction || '')}`])}
       />
     </ButtonBase>
   );


### PR DESCRIPTION
For some reason in my set up, this was throwing an error when using SSR in Nextjs.