### PR TITLE
[autocomplete] selectedItem can be null

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
@@ -62,11 +62,9 @@ function renderInput(inputProps) {
   );
 }
 
-function renderSuggestion(params) {
-  const { suggestion, index, itemProps, highlightedIndex, selectedItem } = params;
+function renderSuggestion({ suggestion, index, itemProps, highlightedIndex, selectedItem }) {
   const isHighlighted = highlightedIndex === index;
-  const isSelected =
-    selectedItem === suggestion.label || (selectedItem || '').indexOf(suggestion.label) > -1;
+  const isSelected = (selectedItem || '').indexOf(suggestion.label) > -1;
 
   return (
     <MenuItem
@@ -82,6 +80,13 @@ function renderSuggestion(params) {
     </MenuItem>
   );
 }
+renderSuggestion.propTypes = {
+  highlightedIndex: PropTypes.number,
+  index: PropTypes.number,
+  itemProps: PropTypes.object,
+  selectedItem: PropTypes.string,
+  suggestion: PropTypes.shape({ label: PropTypes.string }).isRequired,
+};
 
 function getSuggestions(inputValue) {
   let count = 0;

--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
@@ -66,7 +66,7 @@ function renderSuggestion(params) {
   const { suggestion, index, itemProps, highlightedIndex, selectedItem } = params;
   const isHighlighted = highlightedIndex === index;
   const isSelected =
-    selectedItem === suggestion.label || selectedItem.indexOf(suggestion.label) > -1;
+    selectedItem === suggestion.label || (selectedItem || '').indexOf(suggestion.label) > -1;
 
   return (
     <MenuItem


### PR DESCRIPTION
```
Cannot read property 'indexOf' of null
TypeError: Cannot read property 'indexOf' of null
    at renderSuggestion (http://localhost:3000/_next/-/page/demos/autocomplete.js:5079:70)
    at http://localhost:3000/_next/-/page/demos/autocomplete.js:5326:22
```

note `.includes` is used several times, I think at some point we should use it everywhere, and warn users to polyfill it (instead of doing it here, because I think it's the responsibility of library users to do this, only once, to avoid duplications) it reduces code size slightly also!

I added those propTypes because eslint complained