### PR TITLE
[docs] Fix next.js example to enable styled-jsx with material-ui

### DIFF
--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
 import JssProvider from 'react-jss/lib/JssProvider';
 import flush from 'styled-jsx/server';
@@ -70,14 +70,14 @@ MyDocument.getInitialProps = ctx => {
     ...page,
     pageContext,
     styles: (
-      <Fragment>
+      <React.Fragment>
         <style
           id="jss-server-side"
           // eslint-disable-next-line react/no-danger
           dangerouslySetInnerHTML={{ __html: pageContext.sheetsRegistry.toString() }}
         />
         {flush() || null}
-      </Fragment>
+      </React.Fragment>
     ),
   };
 };

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
 import JssProvider from 'react-jss/lib/JssProvider';
+import flush from 'styled-jsx/server';
 import getPageContext from '../src/getPageContext';
 
 class MyDocument extends Document {
@@ -69,11 +70,14 @@ MyDocument.getInitialProps = ctx => {
     ...page,
     pageContext,
     styles: (
-      <style
-        id="jss-server-side"
-        // eslint-disable-next-line react/no-danger
-        dangerouslySetInnerHTML={{ __html: pageContext.sheetsRegistry.toString() }}
-      />
+      <Fragment>
+        <style
+          id="jss-server-side"
+          // eslint-disable-next-line react/no-danger
+          dangerouslySetInnerHTML={{ __html: pageContext.sheetsRegistry.toString() }}
+        />
+        {flush() || null}
+      </Fragment>
     ),
   };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Next.js example injects Material UI specific CSS as a ``<style>`` tag during server side rendering. But this code overwrites original Next.js's ``_document.js`` behavior that injects styled-jsx's CSS.

My code enables both CSS.