### PR TITLE
[Table] Fix table pagination example empty row height

### DIFF
--- a/docs/src/pages/demos/tables/CustomPaginationActionsTable.js
+++ b/docs/src/pages/demos/tables/CustomPaginationActionsTable.js
@@ -166,7 +166,7 @@ class CustomPaginationActionsTable extends React.Component {
                 );
               })}
               {emptyRows > 0 && (
-                <TableRow style={{ height: 49 * emptyRows }}>
+                <TableRow style={{ height: 48 * emptyRows }}>
                   <TableCell colSpan={6} />
                 </TableRow>
               )}


### PR DESCRIPTION
Simple aesthetic example code fix.  Tested in Chrome, Firefox, Safari.

Fix height of empty rows in the Tables custom pagination example - the rows are of height 48 but the empty rows were calculated with a height of 49, causing a jitter in the overall table height when paging to the final set of rows.  Most noticeable with 10 rows per page.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
