### PR TITLE
[ListItemText] Make the children an alias of the primary property

### DIFF
--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -12,10 +12,11 @@ filename: /src/List/ListItemText.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">children</span> | <span class="prop-type">element |  | Alias for `primary` property, |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">disableTypography</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the children won't be wrapped by a typography component. For instance, that can be useful to can render an h4 instead of a |
 | <span class="prop-name">inset</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the children will be indented. This should be used if there is no left avatar or left icon. |
-| <span class="prop-name">primary</span> | <span class="prop-type">node | <span class="prop-default">false</span> |  |
+| <span class="prop-name">primary</span> | <span class="prop-type">node | <span class="prop-default">undefined</span> |  |
 | <span class="prop-name">secondary</span> | <span class="prop-type">node | <span class="prop-default">false</span> |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -12,12 +12,12 @@ filename: /src/List/ListItemText.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">children</span> | <span class="prop-type">element |  | Alias for `primary` property, |
+| <span class="prop-name">children</span> | <span class="prop-type">element |  | Alias for the `primary` property. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">disableTypography</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the children won't be wrapped by a typography component. For instance, that can be useful to can render an h4 instead of a |
 | <span class="prop-name">inset</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the children will be indented. This should be used if there is no left avatar or left icon. |
-| <span class="prop-name">primary</span> | <span class="prop-type">node | <span class="prop-default">undefined</span> |  |
-| <span class="prop-name">secondary</span> | <span class="prop-type">node | <span class="prop-default">false</span> |  |
+| <span class="prop-name">primary</span> | <span class="prop-type">node |  |  |
+| <span class="prop-name">secondary</span> | <span class="prop-type">node |  |  |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -41,54 +41,60 @@ function ListItemText(props, context) {
     className: classNameProp,
     disableTypography,
     inset,
-    primary = children,
-    secondary,
+    primary: primaryProp,
+    secondary: secondaryProp,
     ...other
   } = props;
   const { dense } = context;
-  const className = classNames(
-    classes.root,
-    {
-      [classes.dense]: dense,
-      [classes.inset]: inset,
-    },
-    classNameProp,
-  );
+
+  let primary = primaryProp || children;
+  if (primary && !disableTypography) {
+    primary = (
+      <Typography
+        variant="subheading"
+        className={classNames(classes.primary, { [classes.textDense]: dense })}
+      >
+        {primary}
+      </Typography>
+    );
+  }
+
+  let secondary = secondaryProp;
+  if (secondary && !disableTypography) {
+    secondary = (
+      <Typography
+        variant="body1"
+        className={classNames(classes.secondary, {
+          [classes.textDense]: dense,
+        })}
+        color="textSecondary"
+      >
+        {secondary}
+      </Typography>
+    );
+  }
 
   return (
-    <div className={className} {...other}>
-      {primary &&
-        (disableTypography ? (
-          primary
-        ) : (
-          <Typography
-            variant="subheading"
-            className={classNames(classes.primary, { [classes.textDense]: dense })}
-          >
-            {primary}
-          </Typography>
-        ))}
-      {secondary &&
-        (disableTypography ? (
-          secondary
-        ) : (
-          <Typography
-            variant="body1"
-            className={classNames(classes.secondary, {
-              [classes.textDense]: dense,
-            })}
-            color="textSecondary"
-          >
-            {secondary}
-          </Typography>
-        ))}
+    <div
+      className={classNames(
+        classes.root,
+        {
+          [classes.dense]: dense,
+          [classes.inset]: inset,
+        },
+        classNameProp,
+      )}
+      {...other}
+    >
+      {primary}
+      {secondary}
     </div>
   );
 }
 
 ListItemText.propTypes = {
   /**
-   * Alias for `primary` property,
+   * Alias for the `primary` property.
    */
   children: PropTypes.element,
   /**
@@ -116,8 +122,6 @@ ListItemText.propTypes = {
 ListItemText.defaultProps = {
   disableTypography: false,
   inset: false,
-  primary: undefined,
-  secondary: false,
 };
 
 ListItemText.contextTypes = {

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -36,11 +36,12 @@ export const styles = theme => ({
 
 function ListItemText(props, context) {
   const {
+    children,
     classes,
     className: classNameProp,
     disableTypography,
     inset,
-    primary,
+    primary = children,
     secondary,
     ...other
   } = props;
@@ -87,6 +88,10 @@ function ListItemText(props, context) {
 
 ListItemText.propTypes = {
   /**
+   * Alias for `primary` property,
+   */
+  children: PropTypes.element,
+  /**
    * Useful to extend the style applied to components.
    */
   classes: PropTypes.object.isRequired,
@@ -111,7 +116,7 @@ ListItemText.propTypes = {
 ListItemText.defaultProps = {
   disableTypography: false,
   inset: false,
-  primary: false,
+  primary: undefined,
   secondary: false,
 };
 

--- a/src/List/ListItemText.spec.js
+++ b/src/List/ListItemText.spec.js
@@ -57,6 +57,12 @@ describe('<ListItemText />', () => {
       const wrapper = shallow(<ListItemText primary={primary} />);
       assert.strictEqual(wrapper.contains(primary), true, 'should find the node');
     });
+
+    it('should use the children prop as primary node', () => {
+      const primary = <span />;
+      const wrapper = shallow(<ListItemText>{primary}</ListItemText>);
+      assert.strictEqual(wrapper.contains(primary), true, 'should find the node');
+    });
   });
 
   describe('prop: secondary', () => {


### PR DESCRIPTION
I was confused today, as I wrote something like:

```js
<ListItemIcon>
	<Icon style={{ marginRight: 0 }}>{icon}</Icon>
</ListItemIcon>
<ListItemText>{label}</ListItemText>
```
took me some time to find out why the label wasn't rendered, after checking the docs

I'm not sure you'll like to have 2 possible ways to pass `primary`, but why not, just proposing it