### PR TITLE
[Icon] add margin prop

### DIFF
--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -15,6 +15,7 @@ filename: /src/Icon/Icon.js
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The name of the icon font ligature. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'inherit', 'secondary', 'action', 'disabled', 'error', 'primary'<br> | <span class="prop-default">'inherit'</span> | The color of the component. It supports those theme colors that make sense for this component. |
+| <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'none'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'normal'<br> | <span class="prop-default">'none'</span> | If `dense` or `normal`, will adjust horizontal margin spacing with direct siblings. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 
@@ -28,6 +29,8 @@ This property accepts the following keys:
 - `colorAction`
 - `colorDisabled`
 - `colorError`
+- `marginNormal`
+- `marginDense`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Icon/Icon.js)

--- a/src/Icon/Icon.js
+++ b/src/Icon/Icon.js
@@ -26,10 +26,16 @@ export const styles = theme => ({
   colorError: {
     color: theme.palette.error.main,
   },
+  marginNormal: {
+    margin: `auto ${theme.spacing.unit}px}`,
+  },
+  marginDense: {
+    margin: `auto ${theme.spacing.unit / 2}px}`,
+  },
 });
 
 function Icon(props) {
-  const { children, classes, className, color, ...other } = props;
+  const { children, classes, className, color, margin, ...other } = props;
 
   return (
     <span
@@ -38,6 +44,7 @@ function Icon(props) {
         classes.root,
         {
           [classes[`color${capitalize(color)}`]]: color !== 'inherit',
+          [classes[`margin${capitalize(margin)}`]]: margin !== 'none',
         },
         className,
       )}
@@ -66,10 +73,15 @@ Icon.propTypes = {
    * The color of the component. It supports those theme colors that make sense for this component.
    */
   color: PropTypes.oneOf(['inherit', 'secondary', 'action', 'disabled', 'error', 'primary']),
+  /**
+   * If `dense` or `normal`, will adjust horizontal margin spacing with direct siblings.
+   */
+  margin: PropTypes.oneOf(['none', 'dense', 'normal']),
 };
 
 Icon.defaultProps = {
   color: 'inherit',
+  margin: 'none',
 };
 
 Icon.muiName = 'Icon';

--- a/src/Icon/Icon.spec.js
+++ b/src/Icon/Icon.spec.js
@@ -65,5 +65,14 @@ describe('<Icon />', () => {
         'should have the "primary" color',
       );
     });
+
+    it('should render with dense margin', () => {
+      const wrapper = shallow(<Icon margin="dense">account_circle</Icon>);
+      assert.strictEqual(
+        wrapper.hasClass(classes.marginDense),
+        true,
+        'should have the "dense" margin',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Proposal for `<Icon margin="normal">edit</Icon>`

I think it's quite frequent to need to detach the icon from some text on the left or right of it

I used the same margin props way than `FormControl` for example for `Icon`

It could be worth adding it to `Button` as well or even find a more generic way maybe
