### PR TITLE
[StepIcon] enable CSS modifications of active step

### DIFF
--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -24,6 +24,7 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 - `root`
+- `active`
 - `completed`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section

--- a/src/Stepper/StepIcon.d.ts
+++ b/src/Stepper/StepIcon.d.ts
@@ -8,7 +8,7 @@ export interface StepIconProps
   icon: React.ReactNode;
 }
 
-export type StepIconClasskey = 'root' | 'completed';
+export type StepIconClasskey = 'root' | 'active' | 'completed';
 
 declare const StepIcon: React.ComponentType<StepIconProps>;
 

--- a/src/Stepper/StepIcon.js
+++ b/src/Stepper/StepIcon.js
@@ -9,6 +9,9 @@ export const styles = theme => ({
   root: {
     display: 'block',
   },
+  active: {
+    color: theme.palette.primary.main,
+  },
   completed: {
     color: theme.palette.primary.main,
   },
@@ -21,7 +24,14 @@ function StepIcon(props) {
     if (completed) {
       return <CheckCircle className={classNames(classes.root, classes.completed)} />;
     }
-    return <StepPositionIcon className={classes.root} position={icon} active={active} />;
+    return (
+      <StepPositionIcon
+        className={classNames(classes.root, {
+          [classes.active]: active,
+        })}
+        position={icon}
+      />
+    );
   }
 
   return icon;

--- a/src/Stepper/StepIcon.js
+++ b/src/Stepper/StepIcon.js
@@ -8,13 +8,15 @@ import StepPositionIcon from './StepPositionIcon';
 export const styles = theme => ({
   root: {
     display: 'block',
+    '&$active': {
+      color: theme.palette.primary.main,
+    },
+    '&$completed': {
+      color: theme.palette.primary.main,
+    },
   },
-  active: {
-    color: theme.palette.primary.main,
-  },
-  completed: {
-    color: theme.palette.primary.main,
-  },
+  active: {},
+  completed: {},
 });
 
 function StepIcon(props) {

--- a/src/Stepper/StepIcon.spec.js
+++ b/src/Stepper/StepIcon.spec.js
@@ -30,7 +30,7 @@ describe('<StepIcon />', () => {
     assert.strictEqual(checkCircle.length, 1, 'should have an <StepPositionIcon />');
     const props = checkCircle.props();
     assert.strictEqual(props.position, 1, 'should set position');
-    assert.strictEqual(props.active, true, 'should set active');
+    assert.include(props.className, 'active');
   });
 
   it('renders the custom icon', () => {

--- a/src/Stepper/StepPositionIcon.js
+++ b/src/Stepper/StepPositionIcon.js
@@ -8,9 +8,6 @@ export const styles = theme => ({
   root: {
     color: theme.palette.text.disabled,
   },
-  active: {
-    color: theme.palette.primary.main,
-  },
   text: {
     fill: theme.palette.primary.contrastText,
     fontSize: theme.typography.caption.fontSize,
@@ -22,14 +19,8 @@ export const styles = theme => ({
  * @ignore - internal component.
  */
 function StepPositionIcon(props) {
-  const { position, classes, className: classNameProp, active } = props;
-  const className = classNames(
-    classes.root,
-    {
-      [classes.active]: active,
-    },
-    classNameProp,
-  );
+  const { position, classes, className: classNameProp } = props;
+  const className = classNames(classes.root, classNameProp);
 
   return (
     <SvgIcon className={className}>
@@ -42,10 +33,6 @@ function StepPositionIcon(props) {
 }
 
 StepPositionIcon.propTypes = {
-  /**
-   * Whether this step is active.
-   */
-  active: PropTypes.bool,
   /**
    * Classses for component style customizations.
    */

--- a/src/Stepper/StepPositionIcon.js
+++ b/src/Stepper/StepPositionIcon.js
@@ -19,11 +19,10 @@ export const styles = theme => ({
  * @ignore - internal component.
  */
 function StepPositionIcon(props) {
-  const { position, classes, className: classNameProp } = props;
-  const className = classNames(classes.root, classNameProp);
+  const { position, classes, className } = props;
 
   return (
-    <SvgIcon className={className}>
+    <SvgIcon className={classNames(classes.root, className)}>
       <circle cx="12" cy="12" r="12" />
       <text className={classes.text} x="12" y="16" textAnchor="middle">
         {position}
@@ -47,4 +46,4 @@ StepPositionIcon.propTypes = {
   position: PropTypes.node,
 };
 
-export default withStyles(styles, { name: 'MuiStepPosition' })(StepPositionIcon);
+export default withStyles(styles, { name: 'MuiStepPositionIcon' })(StepPositionIcon);

--- a/src/Stepper/StepPositionIcon.spec.js
+++ b/src/Stepper/StepPositionIcon.spec.js
@@ -22,11 +22,6 @@ describe('<StepPositionIcon />', () => {
     assert.strictEqual(wrapper.find(SvgIcon).length, 1);
   });
 
-  it('sets active className when active = true', () => {
-    const wrapper = shallow(<StepPositionIcon position={1} active />);
-    assert.include(wrapper.find(SvgIcon).props().className, 'active');
-  });
-
   it('contains text "3" when position is "3"', () => {
     const wrapper = shallow(<StepPositionIcon position={3} />);
     assert.strictEqual(wrapper.find('text').text(), '3');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Move `active` class from internal `StepPositionIcon` to public `StepIcon`.
This enables modifications to `StepIcon` in active state via CSS API.

Use case: making the step icons have non default background color.