### PR TITLE
[classes] Move the XXXClassName to the classes property

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -110,6 +110,15 @@ It's already the default behavior of the `Icon` component. You will still be abl
   +<TableCell variant="head" classes={{ head: 'head' }} />
   ```
 
+- [x] Remove the `xxxClassName` properties when already covered the `classes` property.
+  These properties were introduced before`classes`.
+  Using a single pattern makes things more predictable and easier to work with.
+
+  ```diff
+  -<Tabs buttonClassName="buttonClassName" indicatorClassName="indicatorClassName" />
+  +<Tabs classes={{ scrollButtons: 'buttonClassName', indicator: 'indicatorClassName' }} />
+  ```
+
 - [ ] Rename `Reboot` to `CssBaseline` [#10233](https://github.com/mui-org/material-ui/issues/10233).
   The new wording should clarify the purpose of the component. For instance, it's not about adding JavaScript polyfills.
 
@@ -117,15 +126,6 @@ It's already the default behavior of the `Icon` component. You will still be abl
    -<Reboot />
    +<CssBaseline />
    ```
-
-- [ ] Remove the `xxxClassName` properties when already covered the `classes` property.
-  These properties were introduced before`classes`.
-  Using a single pattern makes things more predictable and easier to work with.
-
-  ```diff
-  -<Tabs buttonClassName="buttonClassName" indicatorClassName="indicatorClassName" />
-  +<Tabs classes={{ buttonClassName: 'buttonClassName', indicatorClassName: 'indicatorClassName' }} />
-  ```
 
 - [ ] Grid with no spacing by default [#10223](https://github.com/mui-org/material-ui/issues/10223).
   The negative margin implementation solution currently used comes with [serious limitations](https://material-ui-next.com/layout/grid/#negative-margin).

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -22,7 +22,6 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool |  | If `true`, the base button will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">focusRipple</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the base button will have a keyboard focus ripple. `disableRipple` must also be `false`. |
-| <span class="prop-name">keyboardFocusedClassName</span> | <span class="prop-type">string |  | The CSS class applied while the component is keyboard focused. |
 | <span class="prop-name">onKeyboardFocus</span> | <span class="prop-type">func |  | Callback fired when the component is focused with a keyboard. We trigger a `onFocus` callback too. |
 | <span class="prop-name">TouchRippleProps</span> | <span class="prop-type">object |  | Properties applied to the `TouchRipple` element. |
 
@@ -34,6 +33,7 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `disabled`
+- `keyboardFocused`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/ButtonBase/ButtonBase.js)

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -13,12 +13,10 @@ filename: /src/Tabs/Tabs.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">action</span> | <span class="prop-type">func |  | Callback fired when the component mounts. This is useful when you want to trigger an action programmatically. It currently only supports `updateIndicator()` action.<br><br>**Signature:**<br>`function(actions: object) => void`<br>*actions:* This object contains all possible actions that can be triggered programmatically. |
-| <span class="prop-name">buttonClassName</span> | <span class="prop-type">string |  | The CSS class name of the scroll button elements. |
 | <span class="prop-name">centered</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the tabs will be centered. This property is intended for large views. |
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the tabs will grow to use all the available space. This property is intended for small views, like on mobile. |
-| <span class="prop-name">indicatorClassName</span> | <span class="prop-type">string |  | The CSS class name of the indicator element. |
 | <span class="prop-name">indicatorColor</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;enum:&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'primary'<br><br> | <span class="prop-default">'secondary'</span> | Determines the color of the indicator. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: number) => void`<br>*event:* The event source of the callback<br>*value:* We default to the index of the child |
 | <span class="prop-name">scrollable</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | True invokes scrolling properties and allow for horizontally scrolling (or swiping) the tab bar. |
@@ -39,7 +37,9 @@ This property accepts the following keys:
 - `fixed`
 - `scrollable`
 - `centered`
+- `scrollButtons`
 - `scrollButtonsAuto`
+- `indicator`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Tabs/Tabs.js)

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -45,14 +45,12 @@ For advanced cases, please look at the source of TextField by clicking on the
 | <span class="prop-name">FormHelperTextProps</span> | <span class="prop-type">object |  | Properties applied to the `FormHelperText` element. |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool |  | If `true`, the input will take up the full width of its container. |
 | <span class="prop-name">helperText</span> | <span class="prop-type">node |  | The helper text content. |
-| <span class="prop-name">helperTextClassName</span> | <span class="prop-type">string |  | The CSS class name of the helper text element. |
 | <span class="prop-name">id</span> | <span class="prop-type">string |  | The id of the `input` element. Use that property to make `label` and `helperText` accessible for screen readers. |
 | <span class="prop-name">InputLabelProps</span> | <span class="prop-type">object |  | Properties applied to the `InputLabel` element. |
 | <span class="prop-name">InputProps</span> | <span class="prop-type">object |  | Properties applied to the `Input` element. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |  | Properties applied to the native `input` element. |
 | <span class="prop-name">inputRef</span> | <span class="prop-type">func |  | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">label</span> | <span class="prop-type">node |  | The label content. |
-| <span class="prop-name">labelClassName</span> | <span class="prop-type">string |  | The CSS class name of the label element. |
 | <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'none'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'normal'<br> |  | If `dense` or `normal`, will adjust vertical spacing of this and contained components. |
 | <span class="prop-name">multiline</span> | <span class="prop-type">bool |  | If `true`, a textarea element will be rendered instead of an input. |
 | <span class="prop-name">name</span> | <span class="prop-type">string |  | Name attribute of the `input` element. |

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -187,7 +187,9 @@ function Button(props) {
       className={className}
       disabled={disabled}
       focusRipple={!disableFocusRipple}
-      keyboardFocusedClassName={classes.keyboardFocused}
+      classes={{
+        keyboardFocused: classes.keyboardFocused,
+      }}
       {...other}
     >
       <span className={classes.label}>{children}</span>

--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -39,6 +39,7 @@ export const styles = {
     pointerEvents: 'none', // Disable link interactions
     cursor: 'default',
   },
+  keyboardFocused: {},
 };
 
 /**
@@ -214,7 +215,6 @@ class ButtonBase extends React.Component {
       disabled,
       disableRipple,
       focusRipple,
-      keyboardFocusedClassName,
       onBlur,
       onFocus,
       onKeyboardFocus,
@@ -236,7 +236,7 @@ class ButtonBase extends React.Component {
       classes.root,
       {
         [classes.disabled]: disabled,
-        [keyboardFocusedClassName || '']: this.state.keyboardFocused,
+        [classes.keyboardFocused]: this.state.keyboardFocused,
       },
       classNameProp,
     );
@@ -328,10 +328,6 @@ ButtonBase.propTypes = {
    * `disableRipple` must also be `false`.
    */
   focusRipple: PropTypes.bool,
-  /**
-   * The CSS class applied while the component is keyboard focused.
-   */
-  keyboardFocusedClassName: PropTypes.string,
   /**
    * @ignore
    */

--- a/src/List/ListItem.js
+++ b/src/List/ListItem.js
@@ -105,7 +105,9 @@ class ListItem extends React.Component {
 
     if (button) {
       componentProps.component = componentProp || 'div';
-      componentProps.keyboardFocusedClassName = classes.keyboardFocused;
+      componentProps.classes = {
+        keyboardFocused: classes.keyboardFocused,
+      };
       Component = ButtonBase;
     }
 

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -36,11 +36,13 @@ export const styles = theme => ({
   centered: {
     justifyContent: 'center',
   },
+  scrollButtons: {},
   scrollButtonsAuto: {
     [theme.breakpoints.down('xs')]: {
       display: 'none',
     },
   },
+  indicator: {},
 });
 
 class Tabs extends React.Component {
@@ -87,7 +89,6 @@ class Tabs extends React.Component {
   getConditionalElements = () => {
     const {
       classes,
-      buttonClassName,
       scrollable,
       scrollButtons,
       TabScrollButton: TabScrollButtonProp,
@@ -108,12 +109,9 @@ class Tabs extends React.Component {
         direction={theme && theme.direction === 'rtl' ? 'right' : 'left'}
         onClick={this.handleLeftScrollClick}
         visible={this.state.showLeftScroll}
-        className={classNames(
-          {
-            [classes.scrollButtonsAuto]: scrollButtons === 'auto',
-          },
-          buttonClassName,
-        )}
+        className={classNames(classes.scrollButtons, {
+          [classes.scrollButtonsAuto]: scrollButtons === 'auto',
+        })}
       />
     ) : null;
 
@@ -122,12 +120,9 @@ class Tabs extends React.Component {
         direction={theme && theme.direction === 'rtl' ? 'left' : 'right'}
         onClick={this.handleRightScrollClick}
         visible={this.state.showRightScroll}
-        className={classNames(
-          {
-            [classes.scrollButtonsAuto]: scrollButtons === 'auto',
-          },
-          buttonClassName,
-        )}
+        className={classNames(classes.scrollButtons, {
+          [classes.scrollButtonsAuto]: scrollButtons === 'auto',
+        })}
       />
     ) : null;
 
@@ -280,13 +275,11 @@ class Tabs extends React.Component {
   render() {
     const {
       action,
-      buttonClassName,
       centered,
       children: childrenProp,
       classes,
       className: classNameProp,
       fullWidth,
-      indicatorClassName,
       indicatorColor,
       onChange,
       scrollable,
@@ -310,7 +303,7 @@ class Tabs extends React.Component {
     const indicator = (
       <TabIndicator
         style={this.state.indicatorStyle}
-        className={indicatorClassName}
+        className={classes.indicator}
         color={indicatorColor}
       />
     );
@@ -375,10 +368,6 @@ Tabs.propTypes = {
    */
   action: PropTypes.func,
   /**
-   * The CSS class name of the scroll button elements.
-   */
-  buttonClassName: PropTypes.string,
-  /**
    * If `true`, the tabs will be centered.
    * This property is intended for large views.
    */
@@ -400,10 +389,6 @@ Tabs.propTypes = {
    * This property is intended for small views, like on mobile.
    */
   fullWidth: PropTypes.bool,
-  /**
-   * The CSS class name of the indicator element.
-   */
-  indicatorClassName: PropTypes.string,
   /**
    * Determines the color of the indicator.
    */

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -48,14 +48,12 @@ function TextField(props) {
     FormHelperTextProps,
     fullWidth,
     helperText,
-    helperTextClassName,
     id,
     InputLabelProps,
     inputProps,
     InputProps,
     inputRef,
     label,
-    labelClassName,
     multiline,
     name,
     onChange,
@@ -108,7 +106,7 @@ function TextField(props) {
       {...other}
     >
       {label && (
-        <InputLabel htmlFor={id} className={labelClassName} {...InputLabelProps}>
+        <InputLabel htmlFor={id} {...InputLabelProps}>
           {label}
         </InputLabel>
       )}
@@ -120,7 +118,7 @@ function TextField(props) {
         InputComponent
       )}
       {helperText && (
-        <FormHelperText className={helperTextClassName} id={helperTextId} {...FormHelperTextProps}>
+        <FormHelperText id={helperTextId} {...FormHelperTextProps}>
           {helperText}
         </FormHelperText>
       )}
@@ -173,10 +171,6 @@ TextField.propTypes = {
    */
   helperText: PropTypes.node,
   /**
-   * The CSS class name of the helper text element.
-   */
-  helperTextClassName: PropTypes.string,
-  /**
    * The id of the `input` element.
    * Use that property to make `label` and `helperText` accessible for screen readers.
    */
@@ -201,10 +195,6 @@ TextField.propTypes = {
    * The label content.
    */
   label: PropTypes.node,
-  /**
-   * The CSS class name of the label element.
-   */
-  labelClassName: PropTypes.string,
   /**
    * If `dense` or `normal`, will adjust vertical spacing of this and contained components.
    */

--- a/src/TextField/TextField.spec.js
+++ b/src/TextField/TextField.spec.js
@@ -71,8 +71,8 @@ describe('<TextField />', () => {
         assert.strictEqual(wrapper.childAt(0).type(), InputLabel);
       });
 
-      it('should pass labelClassName to the InputLabel as className', () => {
-        wrapper.setProps({ labelClassName: 'foo' });
+      it('should apply the className to the InputLabel', () => {
+        wrapper.setProps({ InputLabelProps: { className: 'foo' } });
         assert.strictEqual(wrapper.find(InputLabel).hasClass('foo'), true);
       });
 
@@ -94,8 +94,8 @@ describe('<TextField />', () => {
         assert.strictEqual(wrapper.childAt(1).type(), FormHelperText);
       });
 
-      it('should pass helperTextClassName to the FormHelperText as className', () => {
-        wrapper.setProps({ helperTextClassName: 'foo' });
+      it('should apply the className to the FormHelperText', () => {
+        wrapper.setProps({ FormHelperTextProps: { className: 'foo' } });
         assert.strictEqual(wrapper.find(FormHelperText).hasClass('foo'), true);
       });
 

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -86,11 +86,12 @@ describe('<MuiThemeProvider />', () => {
       assert.notStrictEqual(markup.match('Hello World'), null);
       assert.strictEqual(sheetsRegistry.registry.length, 3);
       assert.strictEqual(sheetsRegistry.toString().length > 4000, true);
-      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-18');
+      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-19');
       assert.deepEqual(
         sheetsRegistry.registry[1].classes,
         {
           disabled: 'MuiButtonBase-disabled-17',
+          keyboardFocused: 'MuiButtonBase-keyboardFocused-18',
           root: 'MuiButtonBase-root-16',
         },
         'the class names should be deterministic',


### PR DESCRIPTION
The `classes` is the standardized way to customize the className of the component.
We do no longer need to expose a long list of `XXXClassName` properties.
The next important step in this story is to have the classes key documented.
For instance, what is the `keybordFocused` key for?
Right now, people have to either look at the implementation or the behavior in their browser.
It's not ideal.

### Breaking change

These properties were introduced before `classes`. Using a single pattern makes things more predictable and easier to work with.

```diff
-<Tabs buttonClassName="foo" indicatorClassName="bar" />
+<Tabs classes={{ scrollButtons: 'foo', indicator: 'bar' }} />
```

```diff
-<TextField labelClassName="foo" helperTextClassName="bar" />
+<TextField InputLabelProps={{ className: 'foo' }} FormHelperTextProps={{ className: 'bar' }} />
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
