### PR TITLE
[CssBaseline] Rename from Reboot

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -119,7 +119,7 @@ It's already the default behavior of the `Icon` component. You will still be abl
   +<Tabs classes={{ scrollButtons: 'buttonClassName', indicator: 'indicatorClassName' }} />
   ```
 
-- [ ] Rename `Reboot` to `CssBaseline` [#10233](https://github.com/mui-org/material-ui/issues/10233).
+- [x] Rename `Reboot` to `CssBaseline` [#10233](https://github.com/mui-org/material-ui/issues/10233).
   The new wording should clarify the purpose of the component. For instance, it's not about adding JavaScript polyfills.
 
    ```diff

--- a/docs/src/modules/components/AppWrapper.js
+++ b/docs/src/modules/components/AppWrapper.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { MuiThemeProvider } from 'material-ui/styles';
-import Reboot from 'material-ui/Reboot';
+import CssBaseline from 'material-ui/CssBaseline';
 import JssProvider from 'react-jss/lib/JssProvider';
 import polyfill from 'react-lifecycles-compat';
 import getPageContext, { getTheme } from 'docs/src/modules/styles/getPageContext';
@@ -86,7 +86,7 @@ class AppWrapper extends React.Component {
         generateClassName={pageContext.generateClassName}
       >
         <MuiThemeProvider theme={pageContext.theme} sheetsManager={pageContext.sheetsManager}>
-          <Reboot />
+          <CssBaseline />
           <AppFrame>{children}</AppFrame>
           <GoogleTag />
         </MuiThemeProvider>

--- a/docs/src/pages/style/css-baseline/css-baseline.md
+++ b/docs/src/pages/style/css-baseline/css-baseline.md
@@ -1,19 +1,19 @@
 ---
-components: Reboot
+components: CssBaseline
 ---
 
-# Reboot
+# CssBaseline
 
 You might be familiar with [normalize.css](https://github.com/necolas/normalize.css), a collection of HTML element and attribute style-normalizations.
-Material-UI provides a `Reboot` component to kickstart an elegant, consistent, and simple baseline to build upon.
+Material-UI provides a `CssBaseline` component to kickstart an elegant, consistent, and simple baseline to build upon.
 
 ```jsx
-import Reboot from 'material-ui/Reboot';
+import CssBaseline from 'material-ui/CssBaseline';
 
 function MyApp() {
   return (
     <div>
-      <Reboot />
+      <CssBaseline />
       {/* The rest of your application */}
     </div>
   );
@@ -33,7 +33,7 @@ The `<html>` and `<body>` elements are updated to provide better page-wide defau
 ### Layout
 
 - `box-sizing` is set globally on the `<html>` element to `border-box`.
-Every element—including `*::before` and `*::after` are declared to inherit this property, 
+Every element—including `*::before` and `*::after` are declared to inherit this property,
 which ensures that the declared width of the element is never exceeded due to padding or border.
 
 ### Typography

--- a/pages/api/css-baseline.js
+++ b/pages/api/css-baseline.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import withRoot from 'docs/src/modules/components/withRoot';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
-import markdown from './reboot.md';
+import markdown from './css-baseline.md';
 
 function Page() {
   return <MarkdownDocs markdown={markdown} />;

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -1,10 +1,10 @@
 ---
-filename: /src/Reboot/Reboot.js
+filename: /src/CssBaseline/CssBaseline.js
 ---
 
 <!--- This documentation is automatically generated, do not try to edit it. -->
 
-# Reboot
+# CssBaseline
 
 Kickstart an elegant, consistent, and simple baseline to build upon.
 
@@ -18,5 +18,5 @@ Any other properties supplied will be [spread to the root element](/guides/api#s
 
 ## Demos
 
-- [Reboot](/style/reboot)
+- [Css Baseline](/style/css-baseline)
 

--- a/pages/style/css-baseline.js
+++ b/pages/style/css-baseline.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import withRoot from 'docs/src/modules/components/withRoot';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
-import markdown from 'docs/src/pages/style/reboot/reboot.md';
+import markdown from 'docs/src/pages/style/css-baseline/css-baseline.md';
 
 function Page() {
   return <MarkdownDocs markdown={markdown} />;

--- a/src/CssBaseline/CssBaseline.d.ts
+++ b/src/CssBaseline/CssBaseline.d.ts
@@ -1,0 +1,9 @@
+import * as React from 'react';
+
+export interface CssBaselineProps {
+  children?: React.ReactElement<any>;
+}
+
+declare const CssBaseline: React.ComponentType<CssBaselineProps>;
+
+export default CssBaseline;

--- a/src/CssBaseline/CssBaseline.js
+++ b/src/CssBaseline/CssBaseline.js
@@ -29,13 +29,13 @@ const styles = theme => ({
 /**
  * Kickstart an elegant, consistent, and simple baseline to build upon.
  */
-class Reboot extends React.Component {
+class CssBaseline extends React.Component {
   render() {
     return this.props.children;
   }
 }
 
-Reboot.propTypes = {
+CssBaseline.propTypes = {
   /**
    * You can only provide a single element with react@15, a node with react@16.
    */
@@ -46,10 +46,10 @@ Reboot.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-Reboot.propTypes = exactProp(Reboot.propTypes, 'Reboot');
+CssBaseline.propTypes = exactProp(CssBaseline.propTypes, 'CssBaseline');
 
-Reboot.defaultProps = {
+CssBaseline.defaultProps = {
   children: null,
 };
 
-export default withStyles(styles, { name: 'MuiReboot' })(Reboot);
+export default withStyles(styles, { name: 'MuiCssBaseline' })(CssBaseline);

--- a/src/CssBaseline/CssBaseline.spec.js
+++ b/src/CssBaseline/CssBaseline.spec.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow } from '../test-utils';
-import Reboot from './Reboot';
+import CssBaseline from './CssBaseline';
 
-describe('<Reboot />', () => {
+describe('<CssBaseline />', () => {
   let shallow;
 
   before(() => {
@@ -11,15 +11,15 @@ describe('<Reboot />', () => {
   });
 
   it('should render nothing', () => {
-    const wrapper = shallow(<Reboot />);
+    const wrapper = shallow(<CssBaseline />);
     assert.strictEqual(wrapper.children().length, 0, 'should have no children');
   });
 
   it('should render a div with the root class', () => {
     const wrapper = shallow(
-      <Reboot>
+      <CssBaseline>
         <div />
-      </Reboot>,
+      </CssBaseline>,
     );
     assert.strictEqual(wrapper.name(), 'div');
   });

--- a/src/CssBaseline/index.d.ts
+++ b/src/CssBaseline/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './CssBaseline';
+export * from './CssBaseline';

--- a/src/CssBaseline/index.js
+++ b/src/CssBaseline/index.js
@@ -1,0 +1,1 @@
+export { default } from './CssBaseline';

--- a/src/Reboot/Reboot.d.ts
+++ b/src/Reboot/Reboot.d.ts
@@ -1,9 +1,0 @@
-import * as React from 'react';
-
-export interface RebootProps {
-  children?: React.ReactElement<any>;
-}
-
-declare const Reboot: React.ComponentType<RebootProps>;
-
-export default Reboot;

--- a/src/Reboot/index.d.ts
+++ b/src/Reboot/index.d.ts
@@ -1,2 +1,0 @@
-export { default } from './Reboot';
-export * from './Reboot';

--- a/src/Reboot/index.js
+++ b/src/Reboot/index.js
@@ -1,1 +1,0 @@
-export { default } from './Reboot';

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -63,6 +63,7 @@ export { default as Card, CardActions, CardContent, CardHeader, CardMedia } from
 export { default as Checkbox } from './Checkbox';
 export { default as Chip } from './Chip';
 export { default as ClickAwayListener } from './utils/ClickAwayListener';
+export { default as CssBaseline } from './CssBaseline';
 export {
   default as Dialog,
   DialogActions,
@@ -102,7 +103,6 @@ export { default as Popover } from './Popover';
 export { default as Portal } from './Portal';
 export { CircularProgress, LinearProgress } from './Progress';
 export { default as Radio, RadioGroup } from './Radio';
-export { default as Reboot } from './Reboot';
 export { default as Select } from './Select';
 export { default as Snackbar, SnackbarContent } from './Snackbar';
 export { default as Stepper, Step, StepButton, StepContent, StepIcon, StepLabel } from './Stepper';

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ export { default as Card, CardActions, CardContent, CardHeader, CardMedia } from
 export { default as Checkbox } from './Checkbox';
 export { default as Chip } from './Chip';
 export { default as ClickAwayListener } from './utils/ClickAwayListener';
+export { default as CssBaseline } from './CssBaseline';
 export {
   default as Dialog,
   DialogActions,
@@ -50,7 +51,6 @@ export { default as Popover } from './Popover';
 export { default as Portal } from './Portal';
 export { CircularProgress, LinearProgress } from './Progress';
 export { default as Radio, RadioGroup } from './Radio';
-export { default as Reboot } from './Reboot';
 export { default as Select } from './Select';
 export { default as Snackbar, SnackbarContent } from './Snackbar';
 export { default as Stepper, Step, StepButton, StepIcon, StepContent, StepLabel } from './Stepper';


### PR DESCRIPTION
Closes #10233 

### Breaking change

The new wording should clarify the purpose of the component. For instance, it's not about adding JavaScript polyfills.

```diff
-<Reboot />
+<CssBaseline />
```
