### PR TITLE
[Input] fix setState warning

### DIFF
--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -229,9 +229,6 @@ class Input extends React.Component {
     super(props, context);
 
     this.isControlled = props.value != null;
-    if (this.isControlled) {
-      this.checkDirty(props);
-    }
   }
 
   state = {


### PR DESCRIPTION
Remove the call to checkDirty in the constructor to avoid setState warnings from calling setState in the constructor. Removing it should not matter, as the same logic is run in componentDidMount.

```Warning: setState(...): Cannot update during an existing state transition (such as within `render` or another component’s constructor). Render methods should be a pure function of props and state; constructor side-effects are an anti-pattern, but can be moved to `componentWillMount`.```