### PR TITLE
[ExpansionPanelSummary] Add disableRippleIconButton property to ExpansionPanelSummary

### DIFF
--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -14,8 +14,8 @@ filename: /src/ExpansionPanel/ExpansionPanelSummary.js
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the expansion panel summary. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">disableRippleIconButton</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Control the ripple effect in the Icon Button. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node |  | The icon to display as the expand indicator. |
-| <span class="prop-name">disableRippleIconButton</span> | <span class="prop-type">boolean |  | Control the ripple effect in the Icon Button. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -15,6 +15,7 @@ filename: /src/ExpansionPanel/ExpansionPanelSummary.js
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the expansion panel summary. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node |  | The icon to display as the expand indicator. |
+| <span class="prop-name">disableRippleIconButton</span> | <span class="prop-type">boolean |  | Control the ripple effect in the Icon Button. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/src/ExpansionPanel/ExpansionPanelSummary.d.ts
+++ b/src/ExpansionPanel/ExpansionPanelSummary.d.ts
@@ -5,6 +5,7 @@ import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
 export interface ExpansionPanelSummaryProps
   extends StandardProps<ButtonBaseProps, ExpansionPanelSummaryClassKey> {
   disabled?: boolean;
+  disableRippleIconButton?: boolean;
   expanded?: boolean;
   expandIcon?: React.ReactNode;
   onChange?: React.ReactEventHandler<{}>;

--- a/src/ExpansionPanel/ExpansionPanelSummary.js
+++ b/src/ExpansionPanel/ExpansionPanelSummary.js
@@ -88,10 +88,10 @@ class ExpansionPanelSummary extends React.Component {
       classes,
       className,
       disabled,
+      disableRippleIconButton,
       expanded,
       expandIcon,
       onChange,
-      disableRippleIconButton,
       ...other
     } = this.props;
     const { focused } = this.state;
@@ -158,7 +158,6 @@ ExpansionPanelSummary.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
-   * @ignore
    * Control the ripple effect in the Icon Button.
    */
   disableRippleIconButton: PropTypes.bool,

--- a/src/ExpansionPanel/ExpansionPanelSummary.js
+++ b/src/ExpansionPanel/ExpansionPanelSummary.js
@@ -91,6 +91,7 @@ class ExpansionPanelSummary extends React.Component {
       expanded,
       expandIcon,
       onChange,
+      disableRippleIconButton,
       ...other
     } = this.props;
     const { focused } = this.state;
@@ -128,6 +129,7 @@ class ExpansionPanelSummary extends React.Component {
             component="div"
             tabIndex={-1}
             aria-hidden="true"
+            disableRipple={disableRippleIconButton}
           >
             {expandIcon}
           </IconButton>
@@ -157,6 +159,11 @@ ExpansionPanelSummary.propTypes = {
   disabled: PropTypes.bool,
   /**
    * @ignore
+   * Control the ripple effect in the Icon Button.
+   */
+  disableRippleIconButton: PropTypes.bool,
+  /**
+   * @ignore
    * If `true`, expands the summary, otherwise collapse it.
    */
   expanded: PropTypes.bool,
@@ -176,6 +183,7 @@ ExpansionPanelSummary.propTypes = {
 
 ExpansionPanelSummary.defaultProps = {
   disabled: false,
+  disableRippleIconButton: false,
 };
 
 ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';


### PR DESCRIPTION
Actually, We can't disable the ripple effect in the `<IconButton  />` on `<ExpansionPanelSummary />`
By default, it's already supported, but We don't pass in any way this props. 
This PR allows us to control the effect.

