### PR TITLE
[typescript] add inline style prop to transition

### DIFF
--- a/src/transitions/transition.d.ts
+++ b/src/transitions/transition.d.ts
@@ -21,6 +21,7 @@ export type TransitionKeys =
   | 'addEndListener'
   | TransitionHandlerKeys;
 export interface TransitionProps
-  extends TransitionActions, Partial<Pick<_TransitionProps, TransitionKeys>> {
+  extends TransitionActions,
+    Partial<Pick<_TransitionProps, TransitionKeys>> {
   style?: CSSProperties;
 }

--- a/src/transitions/transition.d.ts
+++ b/src/transitions/transition.d.ts
@@ -2,7 +2,7 @@ import {
   TransitionProps as _TransitionProps,
   TransitionActions,
 } from 'react-transition-group/Transition';
-import { TransitionEventHandler } from 'react';
+import { TransitionEventHandler, CSSProperties } from 'react';
 
 export type TransitionHandlerKeys =
   | 'onEnter'
@@ -21,5 +21,6 @@ export type TransitionKeys =
   | 'addEndListener'
   | TransitionHandlerKeys;
 export interface TransitionProps
-  extends TransitionActions,
-    Partial<Pick<_TransitionProps, TransitionKeys>> {}
+  extends TransitionActions, Partial<Pick<_TransitionProps, TransitionKeys>> {
+  style?: CSSProperties;
+}


### PR DESCRIPTION
This PR adds the `style` prop back into the `transition` TypeScript declarations (the `style` prop was removed in #10129). 

This allows TypeScript users to pass inline styles to transition components like `<Fade/>` without compiler errors. This is useful because it allows you to do things like delaying a transition (as shown in the transition [docs](https://material-ui-next.com/utils/transitions/#zoom)).
