### PR TITLE
[DialogContentText] Extend the Typography component

### DIFF
--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -31,3 +31,7 @@ If using the `overrides` key of the theme as documented
 [here](/customization/themes#customizing-all-instances-of-a-component-type),
 you need to use the following style sheet name: `MuiDialogContentText`.
 
+## Inheritance
+
+The properties of the [Typography](/api/typography) component are also available.
+

--- a/src/Dialog/DialogContentText.js
+++ b/src/Dialog/DialogContentText.js
@@ -1,13 +1,14 @@
+// @inheritedComponent Typography
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
+import Typography from '../Typography';
 
 export const styles = theme => ({
   root: {
-    ...theme.typography.subheading,
     color: theme.palette.text.secondary,
-    margin: 0,
   },
 });
 
@@ -15,9 +16,14 @@ function DialogContentText(props) {
   const { children, classes, className, ...other } = props;
 
   return (
-    <p className={classNames(classes.root, className)} {...other}>
+    <Typography
+      component="p"
+      variant="subheading"
+      className={classNames(classes.root, className)}
+      {...other}
+    >
       {children}
-    </p>
+    </Typography>
   );
 }
 


### PR DESCRIPTION
The `DialogContentText` is meant to display text. With this change, you have access to the extra properties of the `Typography` component, like `align`.