### PR TITLE
[Tooltip] Rename disableTriggerX

### DIFF
--- a/docs/src/pages/demos/tooltips/tooltips.md
+++ b/docs/src/pages/demos/tooltips/tooltips.md
@@ -25,4 +25,4 @@ They don’t have directional arrows; instead, they rely on motion emanating fro
 
 The tooltip is normally shown immediately when the user's mouse hovers over the element, and hides immediately when the user's mouse leaves. A delay in showing or hiding the tooltip can be added through the properties `enterDelay` and `leaveDelay`, as shown in the Controlled Tooltips demo above.
 
-On mobile, the tooltip is displayed when the user longpresses the element and hides after a delay of 1500ms. You can disable this feature with the `disableTriggerTouch` property.
+On mobile, the tooltip is displayed when the user longpresses the element and hides after a delay of 1500ms. You can disable this feature with the `disableTouchListener` property.

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -14,9 +14,9 @@ filename: /src/Tooltip/Tooltip.js
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children *</span> | <span class="prop-type">element |  | Tooltip reference element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
-| <span class="prop-name">disableTriggerFocus</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Do not respond to focus events. |
-| <span class="prop-name">disableTriggerHover</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Do not respond to hover events. |
-| <span class="prop-name">disableTriggerTouch</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Do not respond to long press touch events. |
+| <span class="prop-name">disableFocusListener</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Do not respond to focus events. |
+| <span class="prop-name">disableHoverListener</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Do not respond to hover events. |
+| <span class="prop-name">disableTouchListener</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Do not respond to long press touch events. |
 | <span class="prop-name">enterDelay</span> | <span class="prop-type">number | <span class="prop-default">0</span> | The number of milliseconds to wait before showing the tooltip. This property won't impact the enter touch delay (`enterTouchDelay`). |
 | <span class="prop-name">enterTouchDelay</span> | <span class="prop-type">number | <span class="prop-default">1000</span> | The number of milliseconds a user must touch the element before showing the tooltip. |
 | <span class="prop-name">id</span> | <span class="prop-type">string |  | The relationship between the tooltip and the wrapper component is not clear from the DOM. By providing this property, we can use aria-describedby to solve the accessibility issue. |

--- a/src/Tooltip/Tooltip.d.ts
+++ b/src/Tooltip/Tooltip.d.ts
@@ -5,9 +5,9 @@ import { StandardProps } from '..';
 export interface TooltipProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title'> {
   children: React.ReactElement<any>;
-  disableTriggerFocus?: boolean;
-  disableTriggerHover?: boolean;
-  disableTriggerTouch?: boolean;
+  disableFocusListener?: boolean;
+  disableHoverListener?: boolean;
+  disableTouchListener?: boolean;
   enterDelay?: number;
   enterTouchDelay?: number;
   id?: string;

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -252,9 +252,9 @@ class Tooltip extends React.Component {
       children,
       classes,
       className,
-      disableTriggerFocus,
-      disableTriggerHover,
-      disableTriggerTouch,
+      disableFocusListener,
+      disableHoverListener,
+      disableTouchListener,
       enterDelay,
       enterTouchDelay,
       id,
@@ -280,17 +280,17 @@ class Tooltip extends React.Component {
       open = false;
     }
 
-    if (!disableTriggerTouch) {
+    if (!disableTouchListener) {
       childrenProps.onTouchStart = this.handleTouchStart;
       childrenProps.onTouchEnd = this.handleTouchEnd;
     }
 
-    if (!disableTriggerHover) {
+    if (!disableHoverListener) {
       childrenProps.onMouseOver = this.handleEnter;
       childrenProps.onMouseLeave = this.handleLeave;
     }
 
-    if (!disableTriggerFocus) {
+    if (!disableFocusListener) {
       childrenProps.onFocus = this.handleEnter;
       childrenProps.onBlur = this.handleLeave;
     }
@@ -382,15 +382,15 @@ Tooltip.propTypes = {
   /**
    * Do not respond to focus events.
    */
-  disableTriggerFocus: PropTypes.bool,
+  disableFocusListener: PropTypes.bool,
   /**
    * Do not respond to hover events.
    */
-  disableTriggerHover: PropTypes.bool,
+  disableHoverListener: PropTypes.bool,
   /**
    * Do not respond to long press touch events.
    */
-  disableTriggerTouch: PropTypes.bool,
+  disableTouchListener: PropTypes.bool,
   /**
    * The number of milliseconds to wait before showing the tooltip.
    * This property won't impact the enter touch delay (`enterTouchDelay`).
@@ -462,9 +462,9 @@ Tooltip.propTypes = {
 };
 
 Tooltip.defaultProps = {
-  disableTriggerFocus: false,
-  disableTriggerHover: false,
-  disableTriggerTouch: false,
+  disableFocusListener: false,
+  disableHoverListener: false,
+  disableTouchListener: false,
   enterDelay: 0,
   enterTouchDelay: 1000,
   leaveDelay: 0,


### PR DESCRIPTION
### Breaking change:

For consistency with the Web API [removeEventListener](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener) and the Snackbar `disableWindowBlurListener` property.

```diff
<Tooltip
- disableTriggerFocus
- disableTriggerHover
- disableTriggerTouch
+ disableFocusListener
+ disableHoverListener
+ disableTouchListener
/>
```