### PR TITLE
[Buttton] Simplify the size implementation

### DIFF
--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -44,6 +44,7 @@ This property accepts the following keys:
 - `fab`
 - `mini`
 - `sizeSmall`
+- `sizeMedium`
 - `sizeLarge`
 - `fullWidth`
 

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -29,6 +29,7 @@ export type ButtonClassKey =
   | 'raisedSecondary'
   | 'fab'
   | 'sizeSmall'
+  | 'sizeMedium'
   | 'sizeLarge'
   | 'fullWidth';
 

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -13,9 +13,6 @@ export const styles = theme => ({
     ...theme.typography.button,
     lineHeight: '1.4em', // Improve readability for multiline button.
     boxSizing: 'border-box',
-    minWidth: theme.spacing.unit * 11,
-    minHeight: 36,
-    padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`,
     borderRadius: 2,
     color: theme.palette.text.primary,
     transition: theme.transitions.create(['background-color', 'box-shadow'], {
@@ -135,6 +132,11 @@ export const styles = theme => ({
     minHeight: 32,
     fontSize: theme.typography.pxToRem(13),
   },
+  sizeMedium: {
+    padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`,
+    minWidth: theme.spacing.unit * 11,
+    minHeight: 36,
+  },
   sizeLarge: {
     padding: `${theme.spacing.unit}px ${theme.spacing.unit * 3}px`,
     minWidth: theme.spacing.unit * 14,
@@ -166,6 +168,7 @@ function Button(props) {
   const flat = !raised && !fab;
   const className = classNames(
     classes.root,
+    classes[`size${capitalize(size)}`],
     {
       [classes.raised]: raised || fab,
       [classes.fab]: fab,
@@ -175,7 +178,6 @@ function Button(props) {
       [classes.flatSecondary]: flat && color === 'secondary',
       [classes.raisedPrimary]: !flat && color === 'primary',
       [classes.raisedSecondary]: !flat && color === 'secondary',
-      [classes[`size${capitalize(size)}`]]: size !== 'medium',
       [classes.disabled]: disabled,
       [classes.fullWidth]: fullWidth,
     },

--- a/src/styles/MuiThemeProvider.spec.js
+++ b/src/styles/MuiThemeProvider.spec.js
@@ -86,13 +86,13 @@ describe('<MuiThemeProvider />', () => {
       assert.notStrictEqual(markup.match('Hello World'), null);
       assert.strictEqual(sheetsRegistry.registry.length, 3);
       assert.strictEqual(sheetsRegistry.toString().length > 4000, true);
-      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-19');
+      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-20');
       assert.deepEqual(
         sheetsRegistry.registry[1].classes,
         {
-          disabled: 'MuiButtonBase-disabled-17',
-          keyboardFocused: 'MuiButtonBase-keyboardFocused-18',
-          root: 'MuiButtonBase-root-16',
+          disabled: 'MuiButtonBase-disabled-18',
+          keyboardFocused: 'MuiButtonBase-keyboardFocused-19',
+          root: 'MuiButtonBase-root-17',
         },
         'the class names should be deterministic',
       );


### PR DESCRIPTION
Bootstrap merge the default style with the root style. However, I believe they do such for reducing the number of classes people have to apply, in our case, we have another level of abstraction: the React components. Having a specific class name for the medium size makes thing more straightforward.