### PR TITLE
[docs] Make navigation look more like the material guidelines

### DIFF
--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -34,8 +34,7 @@ const styles = theme => ({
     },
   },
   active: {
-    color:
-      theme.palette.type === 'light' ? theme.palette.primary.dark : theme.palette.primary.light,
+    color: theme.palette.primary.main,
     fontWeight: theme.typography.fontWeightMedium,
   },
 });

--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -30,12 +30,13 @@ const styles = theme => ({
     width: '100%',
     fontWeight: theme.typography.fontWeightRegular,
     '&.depth-0': {
-      fontWeight: theme.typography.fontWeightMedium
-    }
+      fontWeight: theme.typography.fontWeightMedium,
+    },
   },
   active: {
-    color: theme.palette.primary.main,
-    fontWeight: theme.typography.fontWeightMedium
+    color:
+      theme.palette.type === 'light' ? theme.palette.primary.dark : theme.palette.primary.light,
+    fontWeight: theme.typography.fontWeightMedium,
   },
 });
 

--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { withStyles } from 'material-ui/styles';
 import { ListItem } from 'material-ui/List';
 import Button from 'material-ui/Button';
@@ -27,10 +28,14 @@ const styles = theme => ({
     justifyContent: 'flex-start',
     textTransform: 'none',
     width: '100%',
-    color: theme.palette.text.secondary,
+    fontWeight: theme.typography.fontWeightRegular,
+    '&.depth-0': {
+      fontWeight: theme.typography.fontWeightMedium
+    }
   },
   active: {
-    color: theme.palette.text.primary,
+    color: theme.palette.primary.main,
+    fontWeight: theme.typography.fontWeightMedium
   },
 });
 
@@ -74,7 +79,7 @@ class AppDrawerNavItem extends React.Component {
             component={props => (
               <Link variant="button" activeClassName={classes.active} href={href} {...props} />
             )}
-            className={classes.buttonLeaf}
+            className={classNames(classes.buttonLeaf, `depth-${depth}`)}
             disableRipple
             onClick={onClick}
             style={style}


### PR DESCRIPTION
This change makes the menu look more like the menu in the material specs, except that there are no top-level leaves in the specs. To distinguish the active "Premium Themes" item from the other, non-active items, I also made top-level leaves have the primary color and medium font weight.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/5544859/37571469-680ac39e-2afd-11e8-86e3-64746fa34a14.png)|![image](https://user-images.githubusercontent.com/5544859/37571507-c3b1c92c-2afd-11e8-8da5-ca3629c3a20c.png)|
|![image](https://user-images.githubusercontent.com/5544859/37571479-7cf8d4f8-2afd-11e8-9fe6-0bb292a2b31e.png)|![image](https://user-images.githubusercontent.com/5544859/37571512-d5308742-2afd-11e8-9094-ee35e3a8a7ec.png)|
|![image](https://user-images.githubusercontent.com/5544859/37571537-314df7d0-2afe-11e8-937a-1c4b1f02ec21.png)|![image](https://user-images.githubusercontent.com/5544859/37571534-256ca6aa-2afe-11e8-966d-7c0e138c4c48.png)|


