### PR TITLE
Fix SpeedDials pressed twice on mobile

### DIFF
--- a/docs/src/pages/lab/speed-dial/SpeedDials.js
+++ b/docs/src/pages/lab/speed-dial/SpeedDials.js
@@ -67,6 +67,11 @@ class SpeedDials extends React.Component {
     const { classes } = this.props;
     const { hidden, open } = this.state;
 
+    let isTouch;
+    if (typeof document !== 'undefined') {
+      isTouch = 'ontouchstart' in document.documentElement;
+    }
+
     return (
       <div className={classes.root}>
         <Button onClick={this.handleVisibility}>Toggle Speed Dial</Button>
@@ -78,8 +83,8 @@ class SpeedDials extends React.Component {
           onBlur={this.handleClose}
           onClick={this.handleClick}
           onClose={this.handleClose}
-          onFocus={this.handleOpen}
-          onMouseEnter={this.handleOpen}
+          onFocus={isTouch ? undefined : this.handleOpen}
+          onMouseEnter={isTouch ? undefined : this.handleOpen}
           onMouseLeave={this.handleClose}
           open={open}
         >


### PR DESCRIPTION
This is a possible fix for issue #10684

## Description
Currently in docs, the tapping on `SpeedDial` button will trigger `onMouseEnter` and `onFocus` in mobile before calling `onClick`, i.e. the `open` state transitions from

```false (initial state) > true (onMouseEnter) > true (onFocus) > false (onClick toggle)```

## Solution
Need to know whether page is opened in touch screen. It can be checked through
```js
if (typeof document !== 'undefined') {
   isTouch = 'ontouchstart' in document.documentElement;
}
```

and set the `SpeedDial` props
```js
<SpeedDial
  onFocus={isTouch ? undefined : this.handleOpen}
  onMouseEnter={isTouch ? undefined : this.handleOpen}
>
```

__Really appreciate for a review!__