### PR TITLE
Fixed an issue `Cannot read property 'refs' of undefined`

### DIFF
--- a/src/styles/withStyles.js
+++ b/src/styles/withStyles.js
@@ -196,6 +196,10 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
       const stylesCreatorSaved = this.stylesCreatorSaved;
       const sheetManager = this.sheetsManager.get(stylesCreatorSaved);
       const sheetManagerTheme = sheetManager.get(theme);
+          
+      if (!sheetManagerTheme) {
+        return;
+      }
 
       sheetManagerTheme.refs -= 1;
 


### PR DESCRIPTION
This issue occurs when saving a change with react-hot-loader v3 (possibly also v4) from within a component wrapped in `MuiThemeProvider`. An example would be:

```js
<MuiThemeProvider theme={muiTheme}>
  <SiteLayout>
    <Overview />
  </SiteLayout>
</MuiThemeProvider>
```

Anytime something is wrapped with `withStyles` up the chain, this error will be displayed.

The conditional check stops the error from showing up, but may not actually fix anything. From what I've seen locally, everything works as I'd expect when returning after `sheetManagerTheme` is `undefined`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
