### PR TITLE
[docs] Clarify discrepancies from default theme

### DIFF
--- a/docs/src/pages/customization/default-theme/default-theme.md
+++ b/docs/src/pages/customization/default-theme/default-theme.md
@@ -9,5 +9,8 @@ The theme normalizes implementation by providing default values for palette, dar
 Tip: you can play with the theme object in your console too.
 **We expose a global `theme` variable on all the pages**.
 
+Please take note that the documentation site is using a custom theme. As a result, the demos
+you see here might disagree with the values above.
+
 If you want to learn more about how the theme is assembled, take a look at [`material-ui/style/createMuiTheme.js`](https://github.com/mui-org/material-ui/blob/v1-beta/src/styles/createMuiTheme.js),
 and the related imports which `createMuiTheme` uses.

--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -98,6 +98,12 @@ Usage:
 </RootRef>
 ```
 
+## Why are the colors I am seeing different from what I see here?
+
+The documentation site is using a custom theme. Hence, the color palette is
+different from the default theme that Material-UI ships. Please refer to [this
+page](/customization/themes) to learn about theme customization.
+
 ## Material-UI is awesome. How can I support the project?
 
 There are many ways to support Material-UI:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR addresses the confusion reported in #9857 by clarifying in the documentation that the documentation site is not using the default theme.