### PR TITLE
[TextField] Apply onFocus and onBlur on the input

### DIFF
--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -6,7 +6,7 @@ filename: /src/Form/FormControl.js
 
 # FormControl
 
-Provides context such as dirty/focused/error/required for form inputs.
+Provides context such as filled/focused/error/required for form inputs.
 Relying on the context provides high flexibilty and ensures that the state always stay
 consitent across the children of the `FormControl`.
 This context is used by the following components:

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -30,8 +30,6 @@ filename: /src/Input/Input.js
 | <span class="prop-name">multiline</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, a textarea element will be rendered. |
 | <span class="prop-name">name</span> | <span class="prop-type">string |  | Name attribute of the `input` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |  | Callback fired when the value is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
-| <span class="prop-name">onClean</span> | <span class="prop-type">func |  | TODO |
-| <span class="prop-name">onDirty</span> | <span class="prop-type">func |  | TODO |
 | <span class="prop-name">placeholder</span> | <span class="prop-type">string |  | The short hint displayed in the input before the user enters a value. |
 | <span class="prop-name">rows</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | Number of rows to display when multiline option is set to true. |
 | <span class="prop-name">rowsMax</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | Maximum number of rows to display when multiline option is set to true. |

--- a/src/Form/FormControl.js
+++ b/src/Form/FormControl.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { isEmpty, isAdornedStart } from '../Input/Input';
+import { isFilled, isAdornedStart } from '../Input/Input';
 import { capitalize } from '../utils/helpers';
 import { isMuiElement } from '../utils/reactHelpers';
 
@@ -31,7 +31,7 @@ export const styles = theme => ({
 });
 
 /**
- * Provides context such as dirty/focused/error/required for form inputs.
+ * Provides context such as filled/focused/error/required for form inputs.
  * Relying on the context provides high flexibilty and ensures that the state always stay
  * consitent across the children of the `FormControl`.
  * This context is used by the following components:
@@ -53,8 +53,8 @@ class FormControl extends React.Component {
           return;
         }
 
-        if (isEmpty(child.props, true)) {
-          this.state.dirty = true;
+        if (isFilled(child.props, true)) {
+          this.state.filled = true;
         }
 
         const input = isMuiElement(child, ['Select']) ? child.props.input : child;
@@ -68,27 +68,27 @@ class FormControl extends React.Component {
 
   state = {
     adornedStart: false,
-    dirty: false,
+    filled: false,
     focused: false,
   };
 
   getChildContext() {
     const { disabled, error, required, margin } = this.props;
-    const { adornedStart, dirty, focused } = this.state;
+    const { adornedStart, filled, focused } = this.state;
 
     return {
       muiFormControl: {
         adornedStart,
-        dirty,
         disabled,
         error,
+        filled,
         focused,
         margin,
-        required,
-        onDirty: this.handleDirty,
-        onClean: this.handleClean,
-        onFocus: this.handleFocus,
         onBlur: this.handleBlur,
+        onEmpty: this.handleClean,
+        onFilled: this.handleDirty,
+        onFocus: this.handleFocus,
+        required,
       },
     };
   }
@@ -111,14 +111,14 @@ class FormControl extends React.Component {
   };
 
   handleDirty = () => {
-    if (!this.state.dirty) {
-      this.setState({ dirty: true });
+    if (!this.state.filled) {
+      this.setState({ filled: true });
     }
   };
 
   handleClean = () => {
-    if (this.state.dirty) {
-      this.setState({ dirty: false });
+    if (this.state.filled) {
+      this.setState({ filled: false });
     }
   };
 

--- a/src/Form/FormControl.spec.js
+++ b/src/Form/FormControl.spec.js
@@ -63,8 +63,8 @@ describe('<FormControl />', () => {
       wrapper = shallow(<FormControl />);
     });
 
-    it('should not be dirty initially', () => {
-      assert.strictEqual(wrapper.state().dirty, false);
+    it('should not be filled initially', () => {
+      assert.strictEqual(wrapper.state().filled, false);
     });
 
     it('should not be focused initially', () => {
@@ -80,22 +80,22 @@ describe('<FormControl />', () => {
   });
 
   describe('input', () => {
-    it('should be dirty with a value', () => {
+    it('should be filled with a value', () => {
       const wrapper = shallow(
         <FormControl>
           <Input value="bar" />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().dirty, true);
+      assert.strictEqual(wrapper.state().filled, true);
     });
 
-    it('should be dirty with a defaultValue', () => {
+    it('should be filled with a defaultValue', () => {
       const wrapper = shallow(
         <FormControl>
           <Input defaultValue="bar" />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().dirty, true);
+      assert.strictEqual(wrapper.state().filled, true);
     });
 
     it('should be adorned with an endAdornment', () => {
@@ -151,11 +151,11 @@ describe('<FormControl />', () => {
     });
 
     describe('from state', () => {
-      it('should have the dirty state from the instance', () => {
-        assert.strictEqual(muiFormControlContext.dirty, false);
-        wrapper.setState({ dirty: true });
+      it('should have the filled state from the instance', () => {
+        assert.strictEqual(muiFormControlContext.filled, false);
+        wrapper.setState({ filled: true });
         loadChildContext();
-        assert.strictEqual(muiFormControlContext.dirty, true);
+        assert.strictEqual(muiFormControlContext.filled, true);
       });
 
       it('should have the focused state from the instance', () => {
@@ -197,27 +197,27 @@ describe('<FormControl />', () => {
     });
 
     describe('callbacks', () => {
-      describe('onDirty', () => {
-        it('should set the dirty state', () => {
-          assert.strictEqual(muiFormControlContext.dirty, false);
-          muiFormControlContext.onDirty();
+      describe('onFilled', () => {
+        it('should set the filled state', () => {
+          assert.strictEqual(muiFormControlContext.filled, false);
+          muiFormControlContext.onFilled();
           loadChildContext();
-          assert.strictEqual(muiFormControlContext.dirty, true);
-          muiFormControlContext.onDirty();
-          assert.strictEqual(muiFormControlContext.dirty, true);
+          assert.strictEqual(muiFormControlContext.filled, true);
+          muiFormControlContext.onFilled();
+          assert.strictEqual(muiFormControlContext.filled, true);
         });
       });
 
-      describe('onClean', () => {
-        it('should clean the dirty state', () => {
-          muiFormControlContext.onDirty();
+      describe('onEmpty', () => {
+        it('should clean the filled state', () => {
+          muiFormControlContext.onFilled();
           loadChildContext();
-          assert.strictEqual(muiFormControlContext.dirty, true);
-          muiFormControlContext.onClean();
+          assert.strictEqual(muiFormControlContext.filled, true);
+          muiFormControlContext.onEmpty();
           loadChildContext();
-          assert.strictEqual(muiFormControlContext.dirty, false);
-          muiFormControlContext.onClean();
-          assert.strictEqual(muiFormControlContext.dirty, false);
+          assert.strictEqual(muiFormControlContext.filled, false);
+          muiFormControlContext.onEmpty();
+          assert.strictEqual(muiFormControlContext.filled, false);
         });
       });
 

--- a/src/Input/Input.d.ts
+++ b/src/Input/Input.d.ts
@@ -30,8 +30,6 @@ export interface InputProps
   startAdornment?: React.ReactNode;
   type?: string;
   value?: Array<string | number> | string | number;
-  onClean?: () => void;
-  onDirty?: () => void;
   /**
    * `onChange`, `onKeyUp` + `onKeyDown` are applied to the inner `InputComponent`,
    * which by default is an input or textarea. Since these handlers differ from the

--- a/src/Input/Input.js
+++ b/src/Input/Input.js
@@ -21,7 +21,7 @@ export function hasValue(value) {
 // @param SSR
 // @returns {boolean} False when not present or empty string.
 //                    True when any number or string with length.
-export function isEmpty(obj, SSR = false) {
+export function isFilled(obj, SSR = false) {
   return (
     obj &&
     ((hasValue(obj.value) && obj.value !== '') ||
@@ -329,21 +329,21 @@ class Input extends React.Component {
   checkDirty(obj) {
     const { muiFormControl } = this.context;
 
-    if (isEmpty(obj)) {
-      if (muiFormControl && muiFormControl.onDirty) {
-        muiFormControl.onDirty();
+    if (isFilled(obj)) {
+      if (muiFormControl && muiFormControl.onFilled) {
+        muiFormControl.onFilled();
       }
-      if (this.props.onDirty) {
-        this.props.onDirty();
+      if (this.props.onFilled) {
+        this.props.onFilled();
       }
       return;
     }
 
-    if (muiFormControl && muiFormControl.onClean) {
-      muiFormControl.onClean();
+    if (muiFormControl && muiFormControl.onEmpty) {
+      muiFormControl.onEmpty();
     }
-    if (this.props.onClean) {
-      this.props.onClean();
+    if (this.props.onEmpty) {
+      this.props.onEmpty();
     }
   }
 
@@ -368,8 +368,8 @@ class Input extends React.Component {
       name,
       onBlur,
       onChange,
-      onClean,
-      onDirty,
+      onEmpty,
+      onFilled,
       onFocus,
       onKeyDown,
       onKeyUp,
@@ -561,13 +561,13 @@ Input.propTypes = {
    */
   onChange: PropTypes.func,
   /**
-   * TODO
+   * @ignore
    */
-  onClean: PropTypes.func,
+  onEmpty: PropTypes.func,
   /**
-   * TODO
+   * @ignore
    */
-  onDirty: PropTypes.func,
+  onFilled: PropTypes.func,
   /**
    * @ignore
    */

--- a/src/Input/Input.spec.js
+++ b/src/Input/Input.spec.js
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
 import Textarea from './Textarea';
-import Input, { hasValue, isEmpty } from './Input';
+import Input, { hasValue, isFilled } from './Input';
 import InputAdornment from './InputAdornment';
 
 const NakedInput = unwrap(Input);
@@ -145,13 +145,13 @@ describe('<Input />', () => {
     ['', 0].forEach(value => {
       describe(`${typeof value} value`, () => {
         let wrapper;
-        let handleDirty;
-        let handleClean;
+        let handleFilled;
+        let handleEmpty;
 
         before(() => {
-          handleClean = spy();
-          handleDirty = spy();
-          wrapper = shallow(<Input value={value} onDirty={handleDirty} onClean={handleClean} />);
+          handleEmpty = spy();
+          handleFilled = spy();
+          wrapper = shallow(<Input value={value} onFilled={handleFilled} onEmpty={handleEmpty} />);
         });
 
         it('should check that the component is controlled', () => {
@@ -159,26 +159,26 @@ describe('<Input />', () => {
           assert.strictEqual(instance.isControlled, true, 'isControlled should return true');
         });
 
-        // don't test number because zero is a dirty state, whereas '' is not
+        // don't test number because zero is a empty state, whereas '' is not
         if (typeof value !== 'number') {
-          it('should have called the handleClean callback', () => {
-            assert.strictEqual(handleClean.callCount, 1, 'should have called the onClean cb');
+          it('should have called the handleEmpty callback', () => {
+            assert.strictEqual(handleEmpty.callCount, 1, 'should have called the onEmpty cb');
           });
 
-          it('should fire the onDirty callback when dirtied', () => {
-            assert.strictEqual(handleDirty.callCount, 0);
+          it('should fire the onFilled callback when dirtied', () => {
+            assert.strictEqual(handleFilled.callCount, 0);
             wrapper.setProps({ value: typeof value === 'number' ? 2 : 'hello' });
-            assert.strictEqual(handleDirty.callCount, 1, 'should have called the onDirty cb');
+            assert.strictEqual(handleFilled.callCount, 1, 'should have called the onFilled cb');
           });
 
-          it('should fire the onClean callback when dirtied', () => {
+          it('should fire the onEmpty callback when dirtied', () => {
             assert.strictEqual(
-              handleClean.callCount,
+              handleEmpty.callCount,
               1,
-              'should have called the onClean cb once already',
+              'should have called the onEmpty cb once already',
             );
             wrapper.setProps({ value });
-            assert.strictEqual(handleClean.callCount, 2, 'should have called the onClean cb again');
+            assert.strictEqual(handleEmpty.callCount, 2, 'should have called the onEmpty cb again');
           });
         }
       });
@@ -213,14 +213,19 @@ describe('<Input />', () => {
   // uncontrolled only fires for a full mount
   describe('uncontrolled', () => {
     let wrapper;
-    let handleDirty;
-    let handleClean;
+    let handleFilled;
+    let handleEmpty;
 
     before(() => {
-      handleClean = spy();
-      handleDirty = spy();
+      handleEmpty = spy();
+      handleFilled = spy();
       wrapper = mount(
-        <NakedInput classes={{}} onDirty={handleDirty} defaultValue="hell" onClean={handleClean} />,
+        <NakedInput
+          classes={{}}
+          onFilled={handleFilled}
+          defaultValue="hell"
+          onEmpty={handleEmpty}
+        />,
       );
     });
 
@@ -229,19 +234,19 @@ describe('<Input />', () => {
       assert.strictEqual(instance.isControlled, false, 'isControlled should return false');
     });
 
-    it('should fire the onDirty callback when dirtied', () => {
-      assert.strictEqual(handleDirty.callCount, 1, 'should not have called the onDirty cb yet');
+    it('should fire the onFilled callback when dirtied', () => {
+      assert.strictEqual(handleFilled.callCount, 1, 'should not have called the onFilled cb yet');
       wrapper.instance().input.value = 'hello';
       wrapper.find('input').simulate('change');
-      assert.strictEqual(handleDirty.callCount, 2, 'should have called the onDirty cb');
+      assert.strictEqual(handleFilled.callCount, 2, 'should have called the onFilled cb');
     });
 
-    it('should fire the onClean callback when cleaned', () => {
+    it('should fire the onEmpty callback when cleaned', () => {
       // Because of shallow() this hasn't fired since there is no mounting
-      assert.strictEqual(handleClean.callCount, 0, 'should not have called the onClean cb yet');
+      assert.strictEqual(handleEmpty.callCount, 0, 'should not have called the onEmpty cb yet');
       wrapper.instance().input.value = '';
       wrapper.find('input').simulate('change');
-      assert.strictEqual(handleClean.callCount, 1, 'should have called the onClean cb');
+      assert.strictEqual(handleEmpty.callCount, 1, 'should have called the onEmpty cb');
     });
   });
 
@@ -264,37 +269,37 @@ describe('<Input />', () => {
     });
 
     describe('callbacks', () => {
-      let handleDirty;
-      let handleClean;
+      let handleFilled;
+      let handleEmpty;
 
       beforeEach(() => {
-        handleDirty = spy();
-        handleClean = spy();
+        handleFilled = spy();
+        handleEmpty = spy();
         // Mock the input ref
-        wrapper.setProps({ onDirty: handleDirty, onClean: handleClean });
+        wrapper.setProps({ onFilled: handleFilled, onEmpty: handleEmpty });
         wrapper.instance().input = { value: '' };
-        setFormControlContext({ onDirty: spy(), onClean: spy() });
+        setFormControlContext({ onFilled: spy(), onEmpty: spy() });
       });
 
-      it('should fire the onDirty muiFormControl and props callback when dirtied', () => {
+      it('should fire the onFilled muiFormControl and props callback when dirtied', () => {
         wrapper.instance().input.value = 'hello';
         wrapper.find('input').simulate('change');
-        assert.strictEqual(handleDirty.callCount, 1, 'should have called the onDirty props cb');
+        assert.strictEqual(handleFilled.callCount, 1, 'should have called the onFilled props cb');
         assert.strictEqual(
-          muiFormControl.onDirty.callCount,
+          muiFormControl.onFilled.callCount,
           1,
-          'should have called the onDirty muiFormControl cb',
+          'should have called the onFilled muiFormControl cb',
         );
       });
 
-      it('should fire the onClean muiFormControl and props callback when cleaned', () => {
+      it('should fire the onEmpty muiFormControl and props callback when cleaned', () => {
         wrapper.instance().input.value = '';
         wrapper.find('input').simulate('change');
-        assert.strictEqual(handleClean.callCount, 1, 'should have called the onClean props cb');
+        assert.strictEqual(handleEmpty.callCount, 1, 'should have called the onEmpty props cb');
         assert.strictEqual(
-          muiFormControl.onClean.callCount,
+          muiFormControl.onEmpty.callCount,
           1,
-          'should have called the onClean muiFormControl cb',
+          'should have called the onEmpty muiFormControl cb',
         );
       });
     });
@@ -417,23 +422,23 @@ describe('<Input />', () => {
     });
   });
 
-  describe('isEmpty', () => {
+  describe('isFilled', () => {
     [' ', 0].forEach(value => {
       it(`is true for value ${value}`, () => {
-        assert.strictEqual(isEmpty({ value }), true);
+        assert.strictEqual(isFilled({ value }), true);
       });
 
       it(`is true for SSR defaultValue ${value}`, () => {
-        assert.strictEqual(isEmpty({ defaultValue: value }, true), true);
+        assert.strictEqual(isFilled({ defaultValue: value }, true), true);
       });
     });
     [null, undefined, ''].forEach(value => {
       it(`is false for value ${value}`, () => {
-        assert.strictEqual(isEmpty({ value }), false);
+        assert.strictEqual(isFilled({ value }), false);
       });
 
       it(`is false for SSR defaultValue ${value}`, () => {
-        assert.strictEqual(isEmpty({ defaultValue: value }, true), false);
+        assert.strictEqual(isFilled({ defaultValue: value }, true), false);
       });
     });
   });

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -53,7 +53,7 @@ function InputLabel(props, context) {
   let shrink = shrinkProp;
 
   if (typeof shrink === 'undefined' && muiFormControl) {
-    shrink = muiFormControl.dirty || muiFormControl.focused || muiFormControl.adornedStart;
+    shrink = muiFormControl.filled || muiFormControl.focused || muiFormControl.adornedStart;
   }
 
   let margin = marginProp;

--- a/src/Input/InputLabel.spec.js
+++ b/src/Input/InputLabel.spec.js
@@ -65,7 +65,7 @@ describe('<InputLabel />', () => {
       assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
     });
 
-    ['dirty', 'focused'].forEach(state => {
+    ['filled', 'focused'].forEach(state => {
       describe(state, () => {
         beforeEach(() => {
           setFormControlContext({ [state]: true });

--- a/src/Input/Textarea.js
+++ b/src/Input/Textarea.js
@@ -46,7 +46,7 @@ class Textarea extends React.Component {
     super(props, context);
 
     // <Input> expects the components it renders to respond to 'value'
-    // so that it can check whether they are dirty
+    // so that it can check whether they are filled.
     this.value = props.value || props.defaultValue || '';
     this.state = {
       height: Number(props.rows) * ROWS_HEIGHT,

--- a/src/Input/Textarea.spec.js
+++ b/src/Input/Textarea.spec.js
@@ -95,7 +95,7 @@ describe('<Textarea />', () => {
     });
   });
 
-  it('should set dirty', () => {
+  it('should set filled', () => {
     const wrapper = shallow(<Textarea />);
     assert.strictEqual(wrapper.find('textarea').length, 3);
 

--- a/src/Select/SelectInput.js
+++ b/src/Select/SelectInput.js
@@ -5,7 +5,7 @@ import keycode from 'keycode';
 import warning from 'warning';
 import ArrowDropDownIcon from '../internal/svg-icons/ArrowDropDown';
 import Menu from '../Menu/Menu';
-import { isEmpty } from '../Input/Input';
+import { isFilled } from '../Input/Input';
 
 /**
  * @ignore - internal component.
@@ -227,7 +227,7 @@ class SelectInput extends React.Component {
     let computeDisplay = false;
 
     // No need to display any value if the field is empty.
-    if (isEmpty(this.props) || displayEmpty) {
+    if (isFilled(this.props) || displayEmpty) {
       if (renderValue) {
         display = renderValue(value);
       } else {

--- a/src/TextField/TextField.js
+++ b/src/TextField/TextField.js
@@ -56,7 +56,9 @@ function TextField(props) {
     label,
     multiline,
     name,
+    onBlur,
     onChange,
+    onFocus,
     placeholder,
     required,
     rows,
@@ -74,7 +76,7 @@ function TextField(props) {
   );
 
   const helperTextId = helperText && id ? `${id}-helper-text` : undefined;
-  const InputComponent = (
+  const InputElement = (
     <Input
       autoComplete={autoComplete}
       autoFocus={autoFocus}
@@ -89,7 +91,9 @@ function TextField(props) {
       value={value}
       id={id}
       inputRef={inputRef}
+      onBlur={onBlur}
       onChange={onChange}
+      onFocus={onFocus}
       placeholder={placeholder}
       inputProps={inputProps}
       {...InputProps}
@@ -111,11 +115,11 @@ function TextField(props) {
         </InputLabel>
       )}
       {select ? (
-        <Select value={value} input={InputComponent} {...SelectProps}>
+        <Select value={value} input={InputElement} {...SelectProps}>
           {children}
         </Select>
       ) : (
-        InputComponent
+        InputElement
       )}
       {helperText && (
         <FormHelperText id={helperTextId} {...FormHelperTextProps}>
@@ -208,11 +212,19 @@ TextField.propTypes = {
    */
   name: PropTypes.string,
   /**
+   * @ignore
+   */
+  onBlur: PropTypes.func,
+  /**
    * Callback fired when the value is changed.
    *
    * @param {object} event The event source of the callback
    */
   onChange: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onFocus: PropTypes.func,
   /**
    * The short hint displayed in the input before the user enters a value.
    */


### PR DESCRIPTION
- I have forgotten to push the `isDirty -> isFilled` as far as possible: #10704. It's done here.
- It makes more sense to forward the `onFocus` and `onBlur` properties down to the input. By luck, it's also solving: https://github.com/mui-org/material-ui/issues/8990#issuecomment-374393913.