### PR TITLE
[examples] Update next.js PWA color

### DIFF
--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -22,7 +22,7 @@ class MyDocument extends Document {
             }
           />
           {/* PWA primary color */}
-          <meta name="theme-color" content={pageContext.theme.palette.primary[500]} />
+          <meta name="theme-color" content={pageContext.theme.palette.primary.main} />
           <link
             rel="stylesheet"
             href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"


### PR DESCRIPTION
The example theme defined in getPageContext has only light, medium, dark defined for the primary palette. As such, in the example, the 500 color used for the PWA theme undefined. This PR just sets it to a defined property.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
