### PR TITLE
[docs] Selection control, customization example

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -116,7 +116,8 @@ Bronze Sponsors are those who have pledged $100/month to $250/month to Material-
 | Olivier Baumann | Linus Gubenis | Scott Fortmann-Roe | Yosmany García Alfonso | cocoanton |
 | Hong Yuan | Lucas Nascimento | the-noob | Thomas Hermann | Diana-Alina Olaru |
 | Daniel Faust | David Langheiter | LocalMonero | Adam Wells | Vincent Bouzeran |
-| Ashwin Hegde | Eric Schultz | Conor Dunk | Jerome Wilson |
+| Ashwin Hegde | Eric Schultz | Conor Dunk | Jerome Wilson | Greenlink |
+| Jolse Maginnis |
 
 #### via [OpenCollective](https://opencollective.com/material-ui)
 

--- a/docs/src/pages/demos/pickers/pickers.md
+++ b/docs/src/pages/demos/pickers/pickers.md
@@ -13,9 +13,9 @@ components: TextField
 
 We are currently falling back to **native input controls**.
 If you are interested in implementing or have implemented a rich Material Design Picker with an awesome UX, please, let us know on [#4787](https://github.com/mui-org/material-ui/issues/4787) and [#4796](https://github.com/mui-org/material-ui/issues/4796)! We could add a link to or a demo of your project in the documentation.
-Here are some components that are promising:
-- [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker)
+Here are some components that are **promising**:
 - [material-ui-pickers](https://github.com/dmtrKovalenko/material-ui-pickers)
+- [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker)
 
 ## Date pickers
 

--- a/docs/src/pages/demos/selection-controls/CheckboxLabels.js
+++ b/docs/src/pages/demos/selection-controls/CheckboxLabels.js
@@ -4,10 +4,19 @@ import { withStyles } from 'material-ui/styles';
 import green from 'material-ui/colors/green';
 import { FormGroup, FormControlLabel } from 'material-ui/Form';
 import Checkbox from 'material-ui/Checkbox';
+import CheckBoxOutlineBlankIcon from 'material-ui-icons/CheckBoxOutlineBlank';
+import CheckBoxIcon from 'material-ui-icons/CheckBox';
 
 const styles = {
   checked: {
     color: green[500],
+  },
+  size: {
+    width: 40,
+    height: 40,
+  },
+  sizeIcon: {
+    fontSize: 20,
   },
 };
 
@@ -79,6 +88,17 @@ class CheckboxLabels extends React.Component {
             />
           }
           label="Custom color"
+        />
+        <FormControlLabel
+          control={
+            <Checkbox
+              className={classes.size}
+              icon={<CheckBoxOutlineBlankIcon className={classes.sizeIcon} />}
+              checkedIcon={<CheckBoxIcon className={classes.sizeIcon} />}
+              value="checkedH"
+            />
+          }
+          label="Custom size"
         />
       </FormGroup>
     );

--- a/docs/src/pages/demos/selection-controls/RadioButtons.js
+++ b/docs/src/pages/demos/selection-controls/RadioButtons.js
@@ -3,10 +3,19 @@ import PropTypes from 'prop-types';
 import { withStyles } from 'material-ui/styles';
 import green from 'material-ui/colors/green';
 import Radio from 'material-ui/Radio';
+import RadioButtonUncheckedIcon from 'material-ui-icons/RadioButtonUnchecked';
+import RadioButtonCheckedIcon from 'material-ui-icons/RadioButtonChecked';
 
 const styles = {
   checked: {
     color: green[500],
+  },
+  size: {
+    width: 40,
+    height: 40,
+  },
+  sizeIcon: {
+    fontSize: 20,
   },
 };
 
@@ -55,6 +64,17 @@ class RadioButtons extends React.Component {
           color="default"
           name="radio-button-demo"
           aria-label="D"
+        />
+        <Radio
+          checked={this.state.selectedValue === 'e'}
+          onChange={this.handleChange}
+          value="e"
+          color="default"
+          name="radio-button-demo"
+          aria-label="E"
+          className={classes.size}
+          icon={<RadioButtonUncheckedIcon className={classes.sizeIcon} />}
+          checkedIcon={<RadioButtonCheckedIcon className={classes.sizeIcon} />}
         />
       </div>
     );

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -13,12 +13,12 @@ filename: /src/Checkbox/Checkbox.js
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">checked</span> | <span class="prop-type">union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br> |  | If `true`, the component is checked. |
-| <span class="prop-name">checkedIcon</span> | <span class="prop-type">node |  | The icon to display when the component is checked. |
+| <span class="prop-name">checkedIcon</span> | <span class="prop-type">node | <span class="prop-default">&lt;CheckBoxIcon /></span> | The icon to display when the component is checked. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br> | <span class="prop-default">'secondary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool |  | If `true`, the switch will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool |  | If `true`, the ripple effect will be disabled. |
-| <span class="prop-name">icon</span> | <span class="prop-type">node |  | The icon to display when the component is unchecked. |
+| <span class="prop-name">icon</span> | <span class="prop-type">node | <span class="prop-default">&lt;CheckBoxOutlineBlankIcon /></span> | The icon to display when the component is unchecked. |
 | <span class="prop-name">id</span> | <span class="prop-type">string |  | The id of the `input` element. |
 | <span class="prop-name">indeterminate</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the component appears indeterminate. |
 | <span class="prop-name">indeterminateIcon</span> | <span class="prop-type">node | <span class="prop-default">&lt;IndeterminateCheckBoxIcon /></span> | The icon to display when the component is indeterminate. |

--- a/src/Checkbox/Checkbox.d.ts
+++ b/src/Checkbox/Checkbox.d.ts
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 
-export interface CheckboxProps extends StandardProps<SwitchBaseProps, CheckboxClassKey, 'color'> {
+export interface CheckboxProps extends StandardProps<SwitchBaseProps, CheckboxClassKey, 'checkedIcon' | 'color' | 'icon'> {
+  checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
+  icon?: React.ReactNode;
 }
 
 export type CheckboxClassKey = SwitchBaseClassKey | 'checkedPrimary' | 'checkedSecondary';

--- a/src/Checkbox/Checkbox.js
+++ b/src/Checkbox/Checkbox.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import SwitchBase from '../internal/SwitchBase';
+import CheckBoxOutlineBlankIcon from '../internal/svg-icons/CheckBoxOutlineBlank';
+import CheckBoxIcon from '../internal/svg-icons/CheckBox';
 import IndeterminateCheckBoxIcon from '../internal/svg-icons/IndeterminateCheckBox';
 import { capitalize } from '../utils/helpers';
 import withStyles from '../styles/withStyles';
@@ -109,7 +111,9 @@ Checkbox.propTypes = {
 };
 
 Checkbox.defaultProps = {
+  checkedIcon: <CheckBoxIcon />,
   color: 'secondary',
+  icon: <CheckBoxOutlineBlankIcon />,
   indeterminate: false,
   indeterminateIcon: <IndeterminateCheckBoxIcon />,
 };

--- a/src/Checkbox/Checkbox.spec.js
+++ b/src/Checkbox/Checkbox.spec.js
@@ -20,17 +20,19 @@ describe('<Checkbox />', () => {
     mount.cleanUp();
   });
 
-  describe('styleSheet', () => {
-    it('should have the classes required for Checkbox', () => {
-      assert.strictEqual(typeof classes.default, 'string');
-      assert.strictEqual(typeof classes.checked, 'string');
-      assert.strictEqual(typeof classes.disabled, 'string');
-    });
+  it('should have the classes required for Checkbox', () => {
+    assert.strictEqual(typeof classes.default, 'string');
+    assert.strictEqual(typeof classes.checked, 'string');
+    assert.strictEqual(typeof classes.disabled, 'string');
   });
 
   it('should render a div with a SwitchBase', () => {
     const wrapper = shallow(<Checkbox />);
     assert.strictEqual(wrapper.type(), SwitchBase);
+  });
+
+  it('should mount without issue', () => {
+    mount(<Checkbox checked />);
   });
 
   describe('prop: indeterminate', () => {

--- a/src/Radio/Radio.d.ts
+++ b/src/Radio/Radio.d.ts
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 
-export interface RadioProps extends StandardProps<SwitchBaseProps, RadioClassKey, 'color'> {
+export interface RadioProps extends StandardProps<SwitchBaseProps, RadioClassKey, 'checkedIcon' | 'color' | 'icon'> {
+  checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
+  icon?: React.ReactNode;
 }
 
 export type RadioClassKey = SwitchBaseClassKey | 'checkedPrimary' | 'checkedSecondary';

--- a/src/Radio/Radio.js
+++ b/src/Radio/Radio.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import SwitchBase from '../internal/SwitchBase';
-import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
 import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
+import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
 import { capitalize } from '../utils/helpers';
 import withStyles from '../styles/withStyles';
 

--- a/src/Switch/Switch.d.ts
+++ b/src/Switch/Switch.d.ts
@@ -2,8 +2,10 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 
-export interface SwitchProps extends StandardProps<SwitchBaseProps, SwitchClassKey, 'color'> {
+export interface SwitchProps extends StandardProps<SwitchBaseProps, SwitchClassKey, 'checkedIcon' | 'color' | 'icon'> {
+  checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
+  icon?: React.ReactNode;
 }
 
 export type SwitchClassKey =

--- a/src/internal/SwitchBase.d.ts
+++ b/src/internal/SwitchBase.d.ts
@@ -5,11 +5,11 @@ import { IconButtonProps } from '../IconButton';
 export interface SwitchBaseProps
   extends StandardProps<IconButtonProps, SwitchBaseClassKey, 'onChange'> {
   checked?: boolean | string;
-  checkedIcon?: React.ReactNode;
+  checkedIcon: React.ReactNode;
   defaultChecked?: boolean;
   disabled?: boolean;
   disableRipple?: boolean;
-  icon?: React.ReactNode;
+  icon: React.ReactNode;
   indeterminate?: boolean;
   indeterminateIcon?: React.ReactNode;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;

--- a/src/internal/SwitchBase.js
+++ b/src/internal/SwitchBase.js
@@ -3,8 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import CheckBoxOutlineBlankIcon from '../internal/svg-icons/CheckBoxOutlineBlank';
-import CheckBoxIcon from '../internal/svg-icons/CheckBox';
 import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';
 
@@ -138,7 +136,7 @@ SwitchBase.propTypes = {
   /**
    * The icon to display when the component is checked.
    */
-  checkedIcon: PropTypes.node,
+  checkedIcon: PropTypes.node.isRequired,
   /**
    * Useful to extend the style applied to components.
    */
@@ -162,7 +160,7 @@ SwitchBase.propTypes = {
   /**
    * The icon to display when the component is unchecked.
    */
-  icon: PropTypes.node,
+  icon: PropTypes.node.isRequired,
   /**
    * The id of the `input` element.
    */
@@ -209,8 +207,6 @@ SwitchBase.propTypes = {
 };
 
 SwitchBase.defaultProps = {
-  checkedIcon: <CheckBoxIcon />,
-  icon: <CheckBoxOutlineBlankIcon />,
   type: 'checkbox',
 };
 

--- a/src/internal/SwitchBase.spec.js
+++ b/src/internal/SwitchBase.spec.js
@@ -22,7 +22,7 @@ function assertIsChecked(wrapper) {
 
   const label = iconButton.childAt(0);
   const icon = label.childAt(0);
-  assert.strictEqual(icon.is('pure(CheckBox)'), true, 'should be the CheckBox icon');
+  assert.strictEqual(icon.is('h2'), true, 'should be the checked icon');
 }
 
 function assertIsNotChecked(wrapper) {
@@ -39,11 +39,7 @@ function assertIsNotChecked(wrapper) {
 
   const label = iconButton.childAt(0);
   const icon = label.childAt(0);
-  assert.strictEqual(
-    icon.is('pure(CheckBoxOutlineBlank)'),
-    true,
-    'should be the CheckBoxOutlineBlank icon',
-  );
+  assert.strictEqual(icon.is('h1'), true, 'should be the icon');
 }
 
 describe('<SwitchBase />', () => {
@@ -51,12 +47,16 @@ describe('<SwitchBase />', () => {
   let mount;
   let classes;
   let SwitchBaseNaked;
+  const defaultProps = {
+    icon: <h1>h1</h1>,
+    checkedIcon: <h2>h2</h2>,
+  };
 
   before(() => {
     SwitchBaseNaked = unwrap(SwitchBase);
     shallow = createShallow({ dive: true });
     mount = createMount();
-    classes = getClasses(<SwitchBase />);
+    classes = getClasses(<SwitchBase {...defaultProps} />);
   });
 
   after(() => {
@@ -64,17 +64,13 @@ describe('<SwitchBase />', () => {
   });
 
   it('should render an IconButton', () => {
-    const wrapper = shallow(<SwitchBase />);
+    const wrapper = shallow(<SwitchBase {...defaultProps} />);
     assert.strictEqual(wrapper.type(), IconButton);
   });
 
   it('should render an icon and input inside the button by default', () => {
-    const wrapper = shallow(<SwitchBase />);
-    assert.strictEqual(
-      wrapper.childAt(0).is('pure(CheckBoxOutlineBlank)'),
-      true,
-      'should be an SVG icon',
-    );
+    const wrapper = shallow(<SwitchBase {...defaultProps} />);
+    assert.strictEqual(wrapper.childAt(0).is('h1'), true, 'should be the icon');
     assert.strictEqual(
       wrapper.childAt(1).is('input[type="checkbox"]'),
       true,
@@ -83,24 +79,24 @@ describe('<SwitchBase />', () => {
   });
 
   it('should have a ripple by default', () => {
-    const wrapper = shallow(<SwitchBase />);
+    const wrapper = shallow(<SwitchBase {...defaultProps} />);
     assert.strictEqual(wrapper.props().disableRipple, undefined);
   });
 
   it('should pass disableRipple={true} to IconButton', () => {
-    const wrapper = shallow(<SwitchBase disableRipple />);
+    const wrapper = shallow(<SwitchBase {...defaultProps} disableRipple />);
     assert.strictEqual(wrapper.props().disableRipple, true, 'should set disableRipple to true');
   });
 
   // className is put on the root node, this is a special case!
   it('should render with the user and root classes', () => {
-    const wrapper = shallow(<SwitchBase className="woofSwitchBase" />);
+    const wrapper = shallow(<SwitchBase {...defaultProps} className="woofSwitchBase" />);
     assert.strictEqual(wrapper.hasClass('woofSwitchBase'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should spread custom props on the root node', () => {
-    const wrapper = shallow(<SwitchBase data-my-prop="woofSwitchBase" />);
+    const wrapper = shallow(<SwitchBase {...defaultProps} data-my-prop="woofSwitchBase" />);
     assert.strictEqual(
       wrapper.props()['data-my-prop'],
       'woofSwitchBase',
@@ -109,7 +105,7 @@ describe('<SwitchBase />', () => {
   });
 
   it('should pass tabIndex to the input so it can be taken out of focus rotation', () => {
-    const wrapper = shallow(<SwitchBase tabIndex={-1} />);
+    const wrapper = shallow(<SwitchBase {...defaultProps} tabIndex={-1} />);
     const input = wrapper.find('input');
     assert.strictEqual(input.props().tabIndex, -1);
   });
@@ -117,7 +113,7 @@ describe('<SwitchBase />', () => {
   it('should pass value, disabled, checked, and name to the input', () => {
     const props = { name: 'gender', disabled: true, value: 'male' };
 
-    const wrapper = shallow(<SwitchBase {...props} />);
+    const wrapper = shallow(<SwitchBase {...defaultProps} {...props} />);
     const input = wrapper.find('input');
 
     Object.keys(props).forEach(n => {
@@ -126,14 +122,16 @@ describe('<SwitchBase />', () => {
   });
 
   it('should disable the components, and render the IconButton with the disabled className', () => {
-    const wrapper = shallow(<SwitchBase disabled />);
+    const wrapper = shallow(<SwitchBase {...defaultProps} disabled />);
     assert.strictEqual(wrapper.props().disabled, true, 'should disable the root node');
     assert.strictEqual(wrapper.childAt(1).props().disabled, true, 'should disable the input node');
   });
 
   it('should apply the custom disabled className when disabled', () => {
     const disabledClassName = 'foo';
-    const wrapperA = shallow(<SwitchBase disabled classes={{ disabled: disabledClassName }} />);
+    const wrapperA = shallow(
+      <SwitchBase {...defaultProps} disabled classes={{ disabled: disabledClassName }} />,
+    );
 
     assert.strictEqual(
       wrapperA.hasClass(disabledClassName),
@@ -157,6 +155,7 @@ describe('<SwitchBase />', () => {
     beforeEach(() => {
       wrapper = mount(
         <SwitchBaseNaked
+          {...defaultProps}
           classes={{
             checked: 'test-class-checked',
           }}
@@ -189,7 +188,7 @@ describe('<SwitchBase />', () => {
 
   describe('prop: defaultChecked', () => {
     it('should work uncontrolled', () => {
-      const wrapper = mount(<SwitchBaseNaked classes={{}} defaultChecked />);
+      const wrapper = mount(<SwitchBaseNaked {...defaultProps} classes={{}} defaultChecked />);
       wrapper
         .find('input')
         .instance()
@@ -205,6 +204,7 @@ describe('<SwitchBase />', () => {
     beforeEach(() => {
       wrapper = mount(
         <SwitchBaseNaked
+          {...defaultProps}
           classes={{
             checked: 'test-class-checked',
           }}
@@ -243,7 +243,7 @@ describe('<SwitchBase />', () => {
 
   describe('prop: icon', () => {
     it('should render an Icon', () => {
-      const wrapper = shallow(<SwitchBase icon={<Icon>heart</Icon>} />);
+      const wrapper = shallow(<SwitchBase {...defaultProps} icon={<Icon>heart</Icon>} />);
       assert.strictEqual(wrapper.childAt(0).is(Icon), true);
     });
   });
@@ -257,7 +257,9 @@ describe('<SwitchBase />', () => {
 
     it('should call onChange exactly once with event', () => {
       const onChangeSpy = spy();
-      const wrapper = mount(<SwitchBaseNaked classes={{}} onChange={onChangeSpy} />);
+      const wrapper = mount(
+        <SwitchBaseNaked {...defaultProps} classes={{}} onChange={onChangeSpy} />,
+      );
       const instance = wrapper.instance();
       instance.handleInputChange(event);
 
@@ -272,7 +274,12 @@ describe('<SwitchBase />', () => {
         const checked = true;
         const onChangeSpy = spy();
         const wrapper = mount(
-          <SwitchBaseNaked classes={{}} checked={checked} onChange={onChangeSpy} />,
+          <SwitchBaseNaked
+            {...defaultProps}
+            classes={{}}
+            checked={checked}
+            onChange={onChangeSpy}
+          />,
         );
         const instance = wrapper.instance();
         instance.handleInputChange(event);
@@ -293,7 +300,7 @@ describe('<SwitchBase />', () => {
 
       before(() => {
         onChangeSpy = spy();
-        wrapper = mount(<SwitchBaseNaked classes={{}} onChange={onChangeSpy} />);
+        wrapper = mount(<SwitchBaseNaked {...defaultProps} classes={{}} onChange={onChangeSpy} />);
         checkedMock = true;
         const instance = wrapper.instance();
         wrapper.setState({ checked: checkedMock });
@@ -315,19 +322,21 @@ describe('<SwitchBase />', () => {
 
     describe('prop: inputProps', () => {
       it('should be able to add aria', () => {
-        const wrapper2 = shallow(<SwitchBase inputProps={{ 'aria-label': 'foo' }} />);
+        const wrapper2 = shallow(
+          <SwitchBase {...defaultProps} inputProps={{ 'aria-label': 'foo' }} />,
+        );
         assert.strictEqual(wrapper2.find('input').props()['aria-label'], 'foo');
       });
     });
 
     describe('prop: id', () => {
       it('should be able to add id to a checkbox input', () => {
-        const wrapper2 = shallow(<SwitchBase type="checkbox" id="foo" />);
+        const wrapper2 = shallow(<SwitchBase {...defaultProps} type="checkbox" id="foo" />);
         assert.strictEqual(wrapper2.find('input').props().id, 'foo');
       });
 
       it('should be able to add id to a radio input', () => {
-        const wrapper2 = shallow(<SwitchBase type="radio" id="foo" />);
+        const wrapper2 = shallow(<SwitchBase {...defaultProps} type="radio" id="foo" />);
         assert.strictEqual(wrapper2.find('input').props().id, 'foo');
       });
     });
@@ -343,7 +352,7 @@ describe('<SwitchBase />', () => {
     }
 
     beforeEach(() => {
-      wrapper = shallow(<SwitchBase />);
+      wrapper = shallow(<SwitchBase {...defaultProps} />);
     });
 
     describe('enabled', () => {


### PR DESCRIPTION
- Add example of size customization
- Reduce the size of the Radio and Switch components
- Add the new backers


Closes #10781