### PR TITLE
[docs] Fix typo

### DIFF
--- a/docs/src/pages/customization/themes/themes.md
+++ b/docs/src/pages/customization/themes/themes.md
@@ -98,7 +98,7 @@ palette: {
   },
   error: {
     light: palette.error[300],
-    main: palette.errorr[500],
+    main: palette.error[500],
     dark: palette.error[700],
     contrastText: getContrastText(palette.error[500]),
   },


### PR DESCRIPTION
Fixed typo of 'errorr' to 'error'.
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
