### PR TITLE
[InputLabel] Rename FormControlClasses property

### DIFF
--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -18,7 +18,7 @@ filename: /src/Input/InputLabel.js
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool |  | If `true`, apply disabled class. |
 | <span class="prop-name">error</span> | <span class="prop-type">bool |  | If `true`, the label will be displayed in an error state. |
 | <span class="prop-name">focused</span> | <span class="prop-type">bool |  | If `true`, the input of this label is focused. |
-| <span class="prop-name">FormControlClasses</span> | <span class="prop-type">object |  | `classes` property applied to the `FormControl` element. |
+| <span class="prop-name">FormLabelClasses</span> | <span class="prop-type">object |  | `classes` property applied to the `FormLabel` element. |
 | <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'<br> |  | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
 | <span class="prop-name">required</span> | <span class="prop-type">bool |  | if `true`, the label will indicate that the input is required. |
 | <span class="prop-name">shrink</span> | <span class="prop-type">bool |  | If `true`, the label is shrunk. |

--- a/src/Input/InputLabel.d.ts
+++ b/src/Input/InputLabel.d.ts
@@ -7,7 +7,7 @@ export interface InputLabelProps extends StandardProps<FormLabelProps, InputLabe
   disableAnimation?: boolean;
   disabled?: boolean;
   error?: boolean;
-  FormControlClasses?: Partial<ClassNameMap<FormLabelClassKey>>;
+  FormLabelClasses?: Partial<ClassNameMap<FormLabelClassKey>>;
   focused?: boolean;
   required?: boolean;
   shrink?: boolean;

--- a/src/Input/InputLabel.js
+++ b/src/Input/InputLabel.js
@@ -39,7 +39,7 @@ function InputLabel(props, context) {
     classes,
     className: classNameProp,
     disableAnimation,
-    FormControlClasses,
+    FormLabelClasses,
     margin: marginProp,
     shrink: shrinkProp,
     ...other
@@ -69,7 +69,7 @@ function InputLabel(props, context) {
   );
 
   return (
-    <FormLabel data-shrink={shrink} className={className} classes={FormControlClasses} {...other}>
+    <FormLabel data-shrink={shrink} className={className} classes={FormLabelClasses} {...other}>
       {children}
     </FormLabel>
   );
@@ -105,9 +105,9 @@ InputLabel.propTypes = {
    */
   focused: PropTypes.bool,
   /**
-   * `classes` property applied to the `FormControl` element.
+   * `classes` property applied to the `FormLabel` element.
    */
-  FormControlClasses: PropTypes.object,
+  FormLabelClasses: PropTypes.object,
   /**
    * If `dense`, will adjust vertical spacing. This is normally obtained via context from
    * FormControl.

--- a/src/Input/InputLabel.spec.js
+++ b/src/Input/InputLabel.spec.js
@@ -30,9 +30,9 @@ describe('<InputLabel />', () => {
     assert.strictEqual(wrapper.hasClass(classes.animated), false);
   });
 
-  describe('prop: FormControlClasses', () => {
+  describe('prop: FormLabelClasses', () => {
     it('should be able to change the FormLabel style', () => {
-      const wrapper = shallow(<InputLabel FormControlClasses={{ foo: 'bar' }}>Foo</InputLabel>);
+      const wrapper = shallow(<InputLabel FormLabelClasses={{ foo: 'bar' }}>Foo</InputLabel>);
       assert.strictEqual(wrapper.props().classes.foo, 'bar');
     });
   });


### PR DESCRIPTION
### Breaking change

I have completely fucked up in #8108. The property isn't applied on a `FormControl` but on a `FormLabel` component.

```diff
-<InputLabel FormControlClasses={classes} />
+<InputLabel FormLabelClasses={classes} />
```