### PR TITLE
[typings] Fix `mixins.gutter` signature (argument is optional)

### DIFF
--- a/src/styles/createMixins.d.ts
+++ b/src/styles/createMixins.d.ts
@@ -1,9 +1,11 @@
+import * as React from 'react';
+
 import { Breakpoints } from './createBreakpoints';
 import { Spacing } from './spacing';
 import { StyleRules } from '../styles';
 
 export interface Mixins {
-  gutters: (styles: React.CSSProperties) => React.CSSProperties;
+  gutters: (styles?: React.CSSProperties) => React.CSSProperties;
   toolbar: React.CSSProperties;
   // ... use interface declaration merging to add custom mixins
 }


### PR DESCRIPTION
This bugged me for a while now. This PR basically adds a `?`! Crazy isn' it! 🙂
