### PR TITLE
feat: [InputAdornment] add default css overflow: hidden

### DIFF
--- a/src/Input/InputAdornment.js
+++ b/src/Input/InputAdornment.js
@@ -9,6 +9,7 @@ export const styles = theme => ({
     display: 'flex',
     maxHeight: '2em',
     alignItems: 'center',
+    overflow: 'hidden',
   },
   positionStart: {
     marginRight: theme.spacing.unit,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

--- [InputAdornment] add default `overflow: hidden` to prevent layout break when children doesn't fit inside Adornment default height.

Fix issue raised in: #10222 