### PR TITLE
[FormControlLabel] Enable disabled label CSS modifications

### DIFF
--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -32,6 +32,7 @@ This property accepts the following keys:
 - `root`
 - `disabled`
 - `label`
+- `labelDisabled`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/src/Form/FormControlLabel.js)

--- a/src/Form/FormControlLabel.d.ts
+++ b/src/Form/FormControlLabel.d.ts
@@ -17,7 +17,7 @@ export interface FormControlLabelProps
   value?: string;
 }
 
-export type FormControlLabelClassKey = 'root' | 'disabled' | 'label';
+export type FormControlLabelClassKey = 'root' | 'disabled' | 'label' | 'labelDisabled';
 
 declare const FormControlLabel: React.ComponentType<FormControlLabelProps>;
 

--- a/src/Form/FormControlLabel.js
+++ b/src/Form/FormControlLabel.js
@@ -19,10 +19,12 @@ export const styles = theme => ({
     marginRight: theme.spacing.unit * 2, // used for row presentation of radio/checkbox
   },
   disabled: {
-    color: theme.palette.text.disabled,
     cursor: 'default',
   },
   label: {},
+  labelDisabled: {
+    color: theme.palette.text.disabled,
+  },
 });
 
 /**
@@ -77,7 +79,10 @@ function FormControlLabel(props, context) {
         value: control.props.value || value,
         inputRef: control.props.inputRef || inputRef,
       })}
-      <Typography component="span" className={classes.label}>
+      <Typography
+        component="span"
+        className={classNames(classes.label, { [classes.labelDisabled]: disabled })}
+      >
         {label}
       </Typography>
     </label>

--- a/src/Form/FormControlLabel.spec.js
+++ b/src/Form/FormControlLabel.spec.js
@@ -30,6 +30,7 @@ describe('FormControlLabel', () => {
   describe('prop: disabled', () => {
     it('should disable everything', () => {
       const wrapper = shallow(<FormControlLabel label="Pizza" disabled control={<div />} />);
+      const label = wrapper.childAt(1);
       assert.strictEqual(
         wrapper.hasClass(classes.disabled),
         true,
@@ -37,10 +38,12 @@ describe('FormControlLabel', () => {
       );
       assert.strictEqual(wrapper.hasClass(classes.disabled), true);
       assert.strictEqual(wrapper.find('div').props().disabled, true);
+      assert.strictEqual(label.hasClass(classes.labelDisabled), true);
     });
 
     it('should disable everything', () => {
       const wrapper = shallow(<FormControlLabel label="Pizza" control={<div disabled />} />);
+      const label = wrapper.childAt(1);
       assert.strictEqual(
         wrapper.hasClass(classes.disabled),
         true,
@@ -48,6 +51,7 @@ describe('FormControlLabel', () => {
       );
       assert.strictEqual(wrapper.hasClass(classes.disabled), true);
       assert.strictEqual(wrapper.find('div').props().disabled, true);
+      assert.strictEqual(label.hasClass(classes.labelDisabled), true);
     });
   });
 


### PR DESCRIPTION
Move disabled label color definition from root component to the label.

Add `labelDisabled` CSS API property.

Fixes #10822