### PR TITLE
[docs] Fix the sorted table demo size

### DIFF
--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -168,7 +168,7 @@ const styles = theme => ({
     marginTop: theme.spacing.unit * 3,
   },
   table: {
-    minWidth: 800,
+    minWidth: 750,
   },
   tableWrapper: {
     overflowX: 'auto',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Via https://github.com/mui-org/material-ui/pull/10871#issuecomment-377792464

Before:
![image](https://user-images.githubusercontent.com/5544859/38175079-3313d5a6-35d7-11e8-836e-b1c53aca9a53.png)

After:
![image](https://user-images.githubusercontent.com/5544859/38175082-3cbc28c4-35d7-11e8-9bf7-6ab93414b0ca.png)

I think that a minimum width of 750px is still reasonable for this demo.