### PR TITLE
[Table] Fix EnhancedTable example to not scroll TablePagination

### DIFF
--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -5,7 +5,6 @@ import { withStyles } from 'material-ui/styles';
 import Table, {
   TableBody,
   TableCell,
-  TableFooter,
   TableHead,
   TablePagination,
   TableRow,
@@ -168,7 +167,7 @@ const styles = theme => ({
     marginTop: theme.spacing.unit * 3,
   },
   table: {
-    minWidth: 800,
+    minWidth: 1020,
   },
   tableWrapper: {
     overflowX: 'auto',
@@ -306,26 +305,22 @@ class EnhancedTable extends React.Component {
                 </TableRow>
               )}
             </TableBody>
-            <TableFooter>
-              <TableRow>
-                <TablePagination
-                  colSpan={6}
-                  count={data.length}
-                  rowsPerPage={rowsPerPage}
-                  page={page}
-                  backIconButtonProps={{
-                    'aria-label': 'Previous Page',
-                  }}
-                  nextIconButtonProps={{
-                    'aria-label': 'Next Page',
-                  }}
-                  onChangePage={this.handleChangePage}
-                  onChangeRowsPerPage={this.handleChangeRowsPerPage}
-                />
-              </TableRow>
-            </TableFooter>
           </Table>
         </div>
+        <TablePagination
+          component="div"
+          count={data.length}
+          rowsPerPage={rowsPerPage}
+          page={page}
+          backIconButtonProps={{
+            'aria-label': 'Previous Page',
+          }}
+          nextIconButtonProps={{
+            'aria-label': 'Next Page',
+          }}
+          onChangePage={this.handleChangePage}
+          onChangeRowsPerPage={this.handleChangeRowsPerPage}
+        />
       </Paper>
     );
   }

--- a/docs/src/pages/demos/tables/tables.md
+++ b/docs/src/pages/demos/tables/tables.md
@@ -21,9 +21,9 @@ A simple example with no frills.
 
 ## Sorting & Selecting
 
-This example demonstrates the use `Checkbox` and clickable rows for selection with a `Toolbar`.
+This example demonstrates the use of `Checkbox` and clickable rows for selection, with a custom `Toolbar`. It uses the `TableSortLabel` component to help style column headings.
 
-It uses the `TableSortLabel` component to help style column headings.
+The Table has been given a fixed width to demonstrate horizontal scrolling. In order to prevent the pagination controls from scrolling, the TablePagination component is used outside of the Table. (The ['Custom Table Pagination Action' example](#custom-table-pagination-action) below shows the pagination within the TableFooter.)
 
 {{"demo": "pages/demos/tables/EnhancedTable.js"}}
 

--- a/src/Table/TablePagination.js
+++ b/src/Table/TablePagination.js
@@ -13,6 +13,7 @@ import TablePaginationActions from './TablePaginationActions';
 
 export const styles = theme => ({
   root: {
+    fontSize: theme.typography.pxToRem(12),
     // Increase the specificity to override TableCell.
     '&:last-child': {
       padding: 0,


### PR DESCRIPTION
Also make the scrollability of the table more obvious (at the expense of even more exaggerated column widths), and update the docs wording.
