### PR TITLE
Enhanced type defintion for withStyles

### DIFF
--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -44,4 +44,4 @@ export default function withStyles<ClassKey extends string>(
   options?: WithStylesOptions,
 ): <P extends WithStyles<ClassKey>>(
   component: React.ComponentType<P>,
-) => React.ComponentType<Omit<P, keyof StyledComponentProps<ClassKey>>>;
+) => React.ComponentType<Omit<P, keyof WithStyles<ClassKey>> & StyledComponentProps<ClassKey>>;

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -41,6 +41,6 @@ export interface StyledComponentProps<ClassKey extends string = string> {
 export default function withStyles<ClassKey extends string>(
   style: StyleRules<ClassKey> | StyleRulesCallback<ClassKey>,
   options?: WithStylesOptions,
-): <P>(
-  component: React.ComponentType<P & WithStyles<ClassKey>>,
-) => React.ComponentType<P & StyledComponentProps<ClassKey>>;
+): <P extends WithStyles<ClassKey>>(
+  component: React.ComponentType<P>,
+) => React.ComponentType<Omit<P, keyof StyledComponentProps<ClassKey>>>;

--- a/src/styles/withStyles.d.ts
+++ b/src/styles/withStyles.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Theme } from './createMuiTheme';
+import { Omit } from '..'
 
 /**
  * This is basically the API of JSS. It defines a Map<string, CSS>,

--- a/src/styles/withTheme.d.ts
+++ b/src/styles/withTheme.d.ts
@@ -1,11 +1,12 @@
 import { Theme } from './createMuiTheme';
+import { Omit } from '..'
 
 export interface WithTheme {
   theme: Theme;
 }
 
-declare const withTheme: () => <P>(
-  component: React.ComponentType<P & WithTheme>,
-) => React.ComponentClass<P>;
+declare const withTheme: () => <P extends WithTheme>(
+  component: React.ComponentType<P>,
+) => React.ComponentClass<Omit<P, keyof WithTheme>>;
 
 export default withTheme;

--- a/test/typescript/components.spec.tsx
+++ b/test/typescript/components.spec.tsx
@@ -665,7 +665,7 @@ const TableTest = () => {
     );
   }
 
-  return withStyles(styles)<{}>(BasicTable);
+  return withStyles(styles)(BasicTable);
 };
 
 const TabsTest = () => {

--- a/test/typescript/styles.spec.tsx
+++ b/test/typescript/styles.spec.tsx
@@ -28,7 +28,7 @@ const styles: StyleRulesCallback<'root'> = ({ palette, spacing }) => ({
   },
 });
 
-const StyledExampleOne = withStyles(styles)<ComponentProps>(({ classes, text }) => (
+const StyledExampleOne = withStyles(styles)(({ classes, text }) => (
   <div className={classes.root}>{text}</div>
 ));
 <StyledExampleOne text="I am styled!" />;
@@ -57,7 +57,7 @@ const ComponentWithChildren: React.SFC<WithStyles<ComponentClassNames>> = ({
   children,
 }) => <div className={classes.root}>{children}</div>;
 
-const StyledExampleThree = withStyles(styleRule)<{}>(ComponentWithChildren);
+const StyledExampleThree = withStyles(styleRule)(ComponentWithChildren);
 <StyledExampleThree />;
 
 // Also works with a plain object

--- a/test/typescript/styling-comparison.spec.tsx
+++ b/test/typescript/styling-comparison.spec.tsx
@@ -16,7 +16,7 @@ interface Props {
   variant: TypographyProps['variant'];
 }
 
-const DecoratedSFC = decorate<Props>(({ text, variant, color, classes }) => (
+const DecoratedSFC = decorate(({ text, variant, color, classes }) => (
   <Typography variant={variant} color={color} classes={classes}>
     {text}
   </Typography>
@@ -35,7 +35,7 @@ const DecoratedClass = decorate(
   },
 );
 
-const DecoratedNoProps = decorate<{}>(
+const DecoratedNoProps = decorate(
   class extends React.Component<WithStyles<'root'>> {
     render() {
       return <Typography classes={this.props.classes}>Hello, World!</Typography>;


### PR DESCRIPTION
Enhanced type defintion for withStyles to make it enforce the presence of `StyledComponentProps<ClassKey>` as part of the props in the wrapped component, and not expose the injected props (`StyledComponentProps<ClassKey>` in this case) to the outside world.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
