### PR TITLE
[material-ui-icons] Reduce code duplication

### DIFF
--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -8,8 +8,6 @@ import Mustache from 'mustache';
 import glob from 'glob';
 import mkdirp from 'mkdirp';
 
-const SVG_ICON_RELATIVE_REQUIRE = '../../SvgIcon';
-const SVG_ICON_ABSOLUTE_REQUIRE = 'material-ui/SvgIcon';
 const RENAME_FILTER_DEFAULT = './filters/rename/default';
 const RENAME_FILTER_MUI = './filters/rename/material-design-icons';
 
@@ -32,7 +30,7 @@ function pascalCase(destPath) {
   return className;
 }
 
-function getJsxString(svgPath, destPath, options) {
+function getJsxString(svgPath, destPath) {
   const className = pascalCase(destPath);
 
   console.log(`  ${className}`);
@@ -54,12 +52,7 @@ function getJsxString(svgPath, destPath, options) {
   paths = paths.replace(/\s?fill=".*?"/g, '');
   paths = paths.replace(/"\/>/g, '" />');
 
-  // Node acts weird if we put this directly into string concatenation
-  const muiRequireStmt =
-    options.muiRequire === 'relative' ? SVG_ICON_RELATIVE_REQUIRE : SVG_ICON_ABSOLUTE_REQUIRE;
-
   return Mustache.render(template, {
-    muiRequireStmt,
     paths,
     className,
   });
@@ -81,7 +74,7 @@ function processFile(svgPath, destPath, options) {
     console.log(`Making dir: ${outputFileDir}`);
     mkdirp.sync(outputFileDir);
   }
-  const fileString = getJsxString(svgPath, destPath, options);
+  const fileString = getJsxString(svgPath, destPath);
   const absDestPath = path.join(options.outputDir, destPath);
   fs.writeFileSync(absDestPath, fileString);
 }
@@ -137,7 +130,6 @@ function parseArgs() {
 function main(options, callback) {
   let originalWrite; // todo, add winston / other logging tool
 
-  options.muiRequire = options.muiRequire || 'absolute';
   options.glob = options.glob || '/**/*.svg';
   options.innerPath = options.innerPath || '';
   options.renameFilter = options.renameFilter || RENAME_FILTER_DEFAULT;
@@ -199,8 +191,6 @@ export default {
   processFile,
   processIndex,
   main,
-  SVG_ICON_RELATIVE_REQUIRE,
-  SVG_ICON_ABSOLUTE_REQUIRE,
   RENAME_FILTER_DEFAULT,
   RENAME_FILTER_MUI,
 };

--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -4,16 +4,16 @@ import SvgIcon from 'material-ui/SvgIcon';
 
 const SvgIconCustom = global.__MUI_SvgIcon__ || SvgIcon;
 
-const createSvgIcon = path => displayName => {
+function createSvgIcon(path, displayName) {
   let Icon = props => (
     <SvgIconCustom {...props}>
       {path}
     </SvgIconCustom>
   );
 
+  Icon.displayName = displayName;
   Icon = pure(Icon);
   Icon.muiName = 'SvgIcon';
-  Icon.displayName = displayName;
 
   return Icon;
 };

--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import pure from 'recompose/pure';
+import SvgIcon from 'material-ui/SvgIcon';
+
+const SvgIconCustom = global.__MUI_SvgIcon__ || SvgIcon;
+
+const createSvgIcon = path => displayName => {
+  let Icon = props => (
+    <SvgIconCustom {...props}>
+      {path}
+    </SvgIconCustom>
+  );
+
+  Icon = pure(Icon);
+  Icon.muiName = 'SvgIcon';
+  Icon.displayName = displayName;
+
+  return Icon;
+};
+
+export default createSvgIcon;

--- a/packages/material-ui-icons/test/fixtures/material-design-icons/expected/Accessibility.js
+++ b/packages/material-ui-icons/test/fixtures/material-design-icons/expected/Accessibility.js
@@ -1,15 +1,6 @@
 import React from 'react';
-import pure from 'recompose/pure';
-import SvgIcon from 'material-ui/SvgIcon';
+import createSvgIcon from './utils/createSvgIcon';
 
-const SvgIconCustom = global.__MUI_SvgIcon__ || SvgIcon;
-
-let Accessibility = props =>
-  <SvgIconCustom {...props}>
-    <path d="M12 2c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm9 7h-6v13h-2v-6h-2v6H9V9H3V7h18v2z" />
-  </SvgIconCustom>;
-
-Accessibility = pure(Accessibility);
-Accessibility.muiName = 'SvgIcon';
-
-export default Accessibility;
+export default createSvgIcon(
+  <g><path d="M12 2c1.1 0 2 .9 2 2s-.9 2-2 2-2-.9-2-2 .9-2 2-2zm9 7h-6v13h-2v-6h-2v6H9V9H3V7h18v2z" /></g>
+, 'Accessibility');

--- a/packages/material-ui-icons/test/index.test.js
+++ b/packages/material-ui-icons/test/index.test.js
@@ -149,70 +149,8 @@ describe('--svg-dir, --innerPath, --fileSuffix', () => {
       assert.strictEqual(fs.existsSync(actualFilePath), true);
 
       const actualFileData = fs.readFileSync(actualFilePath, { encoding: 'utf8' });
-      assert.include(actualFileData, builder.SVG_ICON_ABSOLUTE_REQUIRE);
+      assert.include(actualFileData, "import createSvgIcon from './utils/createSvgIcon'");
       done();
-    });
-  });
-});
-
-describe('--mui-require', () => {
-  const options = {
-    svgDir: MUI_ICONS_SVG_DIR,
-    innerPath: '/svg/production/',
-    glob: '/**/production/*_24px.svg',
-    disableLog: DISABLE_LOG,
-    renameFilter: builder.RENAME_FILTER_MUI,
-    outputDir: null,
-  };
-  let tempPath;
-  let actualFilePath;
-
-  before(() => {
-    tempPath = temp.mkdirSync();
-    actualFilePath = path.join(tempPath, 'Accessibility.js');
-    options.outputDir = tempPath;
-  });
-
-  after(() => {
-    temp.cleanupSync();
-  });
-
-  describe('absolute', () => {
-    it('default should be absolute', done => {
-      builder.main(options, () => {
-        assert.strictEqual(fs.lstatSync(tempPath).isDirectory(), true);
-        assert.strictEqual(fs.existsSync(actualFilePath), true);
-
-        const actualFileData = fs.readFileSync(actualFilePath, { encoding: 'utf8' });
-        assert.include(actualFileData, builder.SVG_ICON_ABSOLUTE_REQUIRE);
-        done();
-      });
-    });
-
-    it('should load SvgIcon as absolute', done => {
-      const absoluteOptions = { ...options, muiRequire: 'absolute' };
-      builder.main(absoluteOptions, () => {
-        assert.strictEqual(fs.lstatSync(tempPath).isDirectory(), true);
-        assert.strictEqual(fs.existsSync(actualFilePath), true);
-
-        const actualFileData = fs.readFileSync(actualFilePath, { encoding: 'utf8' });
-        assert.include(actualFileData, builder.SVG_ICON_ABSOLUTE_REQUIRE);
-        done();
-      });
-    });
-  });
-
-  describe('relative', () => {
-    it('should load SvgIcon as relative', done => {
-      const relativeOptions = { ...options, muiRequire: 'relative' };
-      builder.main(relativeOptions, () => {
-        assert.strictEqual(fs.lstatSync(tempPath).isDirectory(), true);
-        assert.strictEqual(fs.existsSync(actualFilePath), true);
-
-        const actualFileData = fs.readFileSync(actualFilePath, { encoding: 'utf8' });
-        assert.include(actualFileData, builder.SVG_ICON_RELATIVE_REQUIRE);
-        done();
-      });
     });
   });
 });

--- a/packages/material-ui-icons/tpl/SvgIcon.js
+++ b/packages/material-ui-icons/tpl/SvgIcon.js
@@ -2,7 +2,5 @@ import React from 'react';
 import createSvgIcon from './utils/createSvgIcon';
 
 export default createSvgIcon(
-  <g>
-    {{{paths}}}
-  </g>
-)('{{className}}');
+  <g>{{{paths}}}</g>
+, '{{className}}');

--- a/packages/material-ui-icons/tpl/SvgIcon.js
+++ b/packages/material-ui-icons/tpl/SvgIcon.js
@@ -1,15 +1,8 @@
 import React from 'react';
-import pure from 'recompose/pure';
-import SvgIcon from '{{{ muiRequireStmt }}}';
+import createSvgIcon from './utils/createSvgIcon';
 
-const SvgIconCustom = global.__MUI_SvgIcon__ || SvgIcon;
-
-let {{className}} = props =>
-  <SvgIconCustom {...props}>
+export default createSvgIcon(
+  <g>
     {{{paths}}}
-  </SvgIconCustom>;
-
-{{className}} = pure({{className}});
-{{className}}.muiName = 'SvgIcon';
-
-export default {{className}};
+  </g>
+)('{{className}}');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes #10900 

I've added [`withSvgIcon` file](https://github.com/cherniavskii/material-ui/blob/04a55d567acd86d23d4ffcb39fb9ccb125ff2f61/packages/material-ui-icons/src/components/withSvgIcon.js) (not sure about name, maybe it should be named `createSvgIcon`?).
It receives `path` and `displayName`, and returns pure react component.