### PR TITLE
[Button] Fix types

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "devDependencies": {
     "@types/enzyme": "^3.1.4",
     "@types/react": "16.3.4",
+    "@types/react-router-dom": "^4.2.6",
     "app-module-path": "^2.2.0",
     "argos-cli": "^0.0.9",
     "autoprefixer": "^8.0.0",

--- a/src/Button/Button.d.ts
+++ b/src/Button/Button.d.ts
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { StandardProps, PropTypes } from '..';
 import { ButtonBaseProps, ButtonBaseClassKey } from '../ButtonBase';
+import { Link } from 'react-router-dom';
 
 export interface ButtonProps extends StandardProps<ButtonBaseProps, ButtonClassKey, 'component'> {
   color?: PropTypes.Color;
-  component?: React.ReactType<ButtonProps>;
+  component?: React.ReactType<ButtonProps> | Link;
+  to?: string;
   disabled?: boolean;
   disableFocusRipple?: boolean;
   disableRipple?: boolean;

--- a/yarn.lock
+++ b/yarn.lock
@@ -107,6 +107,10 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.6.2.tgz#12cfaba693ba20f114ed5765467ff25fdf67ddb0"
+
 "@types/jss@^9.3.0":
   version "9.5.1"
   resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.1.tgz#b98788a235fc9b6c592ba83547c000b10d00ef2e"
@@ -120,6 +124,21 @@
 "@types/node@*":
   version "9.6.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.1.tgz#e2d374ef15b315b48e7efc308fa1a7cd51faa06c"
+
+"@types/react-router-dom@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.2.6.tgz#9f7eb3c0e6661a9607d878ff8675cc4ea95cd276"
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "4.0.23"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.0.23.tgz#d0509dcbdb1c686aed8f3d5cb186f42e5fbe7c2a"
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react-transition-group@^2.0.6":
   version "2.0.7"


### PR DESCRIPTION
Basic examples of Button documentation are not working with Typescript, e.g.:

```
import { Link } from 'react-router-dom'
import Button from 'material-ui/Button';

<Button component={Link} to="/open-collective">
  Link
</Button>
```

It's because Button.d.ts doesn't contain property `to` and `component` property doesn't allow `Link` type (I think it's most popular component here). Please accept PR to fix it.