### PR TITLE
[material-ui-icons] Check if `global` is defined before trying to use it

### DIFF
--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import pure from 'recompose/pure';
 import SvgIcon from 'material-ui/SvgIcon';
 
-const SvgIconCustom = global.__MUI_SvgIcon__ || SvgIcon;
+const SvgIconCustom = typeof global !== 'undefined' && global.__MUI_SvgIcon__ || SvgIcon;
 
 function createSvgIcon(path, displayName) {
   let Icon = props => (


### PR DESCRIPTION
We're using Rollup to compile our app, and I'm trying to use material-ui v1-beta with it. I simply set up the search paths like so (I'm sure there's a better way):

```sh
ln -s node_modules/material-ui/es material-ui
ln -s node_modules/material-ui-icons/es material-ui-icons
```

This seems to work fine, except for one issue: The material-ui-icons source files all use a `global` variable, which does not exist in the browser.

This pull request updates `packages/material-ui-icons/tpl/SvgIcon.js`, as well as all files built from it, to check whether `global` exists before trying to use it.