### PR TITLE
[BottomNavigationAction] Use default childIndex value only if value undefined

### DIFF
--- a/src/BottomNavigation/BottomNavigation.js
+++ b/src/BottomNavigation/BottomNavigation.js
@@ -30,7 +30,7 @@ function BottomNavigation(props) {
       return null;
     }
 
-    const childValue = child.props.value || childIndex;
+    const childValue = child.props.value === undefined ? childIndex : child.props.value;
     return React.cloneElement(child, {
       selected: childValue === value,
       showLabel: child.props.showLabel !== undefined ? child.props.showLabel : showLabels,

--- a/src/BottomNavigation/BottomNavigation.test.js
+++ b/src/BottomNavigation/BottomNavigation.test.js
@@ -99,8 +99,8 @@ describe('<BottomNavigation />', () => {
     const handleChange = spy();
     const wrapper = mount(
       <BottomNavigation showLabels value={'first'} onChange={handleChange}>
-        <BottomNavigationAction value={'first'} icon={icon} />
-        <BottomNavigationAction value={'second'} icon={icon} />
+        <BottomNavigationAction value="first" icon={icon} />
+        <BottomNavigationAction value="second" icon={icon} />
       </BottomNavigation>,
     );
     wrapper
@@ -117,19 +117,26 @@ describe('<BottomNavigation />', () => {
   it('should handle also empty action value', () => {
     const handleChange = spy();
     const wrapper = mount(
-      <BottomNavigation showLabels value={'val'} onChange={handleChange}>
-        <BottomNavigationAction value={''} icon={icon} />
-        <BottomNavigationAction value={'val'} icon={icon} />
+      <BottomNavigation showLabels value="val" onChange={handleChange}>
+        <BottomNavigationAction value="" icon={icon} />
+        <BottomNavigationAction icon={icon} />
+        <BottomNavigationAction value={null} icon={icon} />
       </BottomNavigation>,
     );
     wrapper
       .find(BottomNavigationAction)
       .at(0)
       .simulate('click');
-    assert.strictEqual(
-      handleChange.args[0][1],
-      '',
-      'should have been called with empty string value',
-    );
+    assert.strictEqual(handleChange.args[0][1], '');
+    wrapper
+      .find(BottomNavigationAction)
+      .at(1)
+      .simulate('click');
+    assert.strictEqual(handleChange.args[1][1], 1);
+    wrapper
+      .find(BottomNavigationAction)
+      .at(2)
+      .simulate('click');
+    assert.strictEqual(handleChange.args[2][1], null);
   });
 });

--- a/src/BottomNavigation/BottomNavigation.test.js
+++ b/src/BottomNavigation/BottomNavigation.test.js
@@ -94,4 +94,42 @@ describe('<BottomNavigation />', () => {
     assert.strictEqual(handleChange.callCount, 1, 'should have been called once');
     assert.strictEqual(handleChange.args[0][1], 1, 'should have been called with value 1');
   });
+
+  it('should use custom action values', () => {
+    const handleChange = spy();
+    const wrapper = mount(
+      <BottomNavigation showLabels value={'first'} onChange={handleChange}>
+        <BottomNavigationAction value={'first'} icon={icon} />
+        <BottomNavigationAction value={'second'} icon={icon} />
+      </BottomNavigation>,
+    );
+    wrapper
+      .find(BottomNavigationAction)
+      .at(1)
+      .simulate('click');
+    assert.strictEqual(
+      handleChange.args[0][1],
+      'second',
+      'should have been called with value second',
+    );
+  });
+
+  it('should handle also empty action value', () => {
+    const handleChange = spy();
+    const wrapper = mount(
+      <BottomNavigation showLabels value={'val'} onChange={handleChange}>
+        <BottomNavigationAction value={''} icon={icon} />
+        <BottomNavigationAction value={'val'} icon={icon} />
+      </BottomNavigation>,
+    );
+    wrapper
+      .find(BottomNavigationAction)
+      .at(0)
+      .simulate('click');
+    assert.strictEqual(
+      handleChange.args[0][1],
+      '',
+      'should have been called with empty string value',
+    );
+  });
 });

--- a/src/Tabs/Tabs.js
+++ b/src/Tabs/Tabs.js
@@ -321,7 +321,7 @@ class Tabs extends React.Component {
         return null;
       }
 
-      const childValue = child.props.value || childIndex;
+      const childValue = child.props.value === undefined ? childIndex : child.props.value;
       this.valueToIndex[childValue] = childIndex;
       const selected = childValue === value;
 


### PR DESCRIPTION
Use default childIndex value for BottomNavigationAction only if value prop is really not defined. Fix: #10935

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
