### PR TITLE
[ListItemText] Fix invalid ListItemText 'children'  proptype

### DIFF
--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -12,7 +12,7 @@ filename: /src/List/ListItemText.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">children</span> | <span class="prop-type">element |  | Alias for the `primary` property. |
+| <span class="prop-name">children</span> | <span class="prop-type">node |  | Alias for the `primary` property. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">disableTypography</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the children won't be wrapped by a typography component. For instance, that can be useful to can render an h4 instead of a |
 | <span class="prop-name">inset</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the children will be indented. This should be used if there is no left avatar or left icon. |

--- a/src/List/ListItemText.js
+++ b/src/List/ListItemText.js
@@ -96,7 +96,7 @@ ListItemText.propTypes = {
   /**
    * Alias for the `primary` property.
    */
-  children: PropTypes.element,
+  children: PropTypes.node,
   /**
    * Useful to extend the style applied to components.
    */


### PR DESCRIPTION
## Description

Closes #10921 

An incorrect PropType on `ListItemText` `children` (was `element`) prevented passing a string (used as an alternative to the `primary` prop).

## Changes

- Fix incorrect PropType on `ListItemText` (changed `children` to `node`)
- Update documentation

