### PR TITLE
Update material-ui NPM package installation link

### DIFF
--- a/docs/src/pages/getting-started/installation/installation.md
+++ b/docs/src/pages/getting-started/installation/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Material-UI is available as an [npm package](https://www.npmjs.org/package/material-ui).
+Material-UI is available as an [npm package](https://www.npmjs.com/package/material-ui).
 
 ## npm
 
@@ -15,6 +15,7 @@ npm install material-ui@next
 Material-UI was designed with the [Roboto](http://www.google.com/fonts/specimen/Roboto)
 font in mind. So be sure to follow [these instructions](/style/typography#general).
 For instance, via Google Web Fonts:
+
 ```html
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
 ```
@@ -26,6 +27,7 @@ that support them, you must first add the [Material icons](https://material.io/i
 Here are [some instructions](/style/icons#font-icons)
 on how to do so.
 For instance, via Google Web Fonts:
+
 ```html
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 ```


### PR DESCRIPTION
## Description

**Issue:** #10846 

Installation documentation pointed to an incorrect NPM url (used `npmjs.org` instead of `npmjs.com`). This happens for both the `material-ui-next.com` site and the "regular" `material-ui.com` site.

## Changes

- Update the NPM installation link to `npmjs.com` on the `v1-beta` branch

**NOTE:** Another PR will be created for the "regular" branch