### PR TITLE
Enable transparency manipulation

### DIFF
--- a/src/styles/colorManipulator.js
+++ b/src/styles/colorManipulator.js
@@ -228,3 +228,30 @@ export function lighten(color: string, coefficient: number) {
 
   return recomposeColor(color);
 }
+
+/**
+ * Opacifies a color.
+ *
+ * @param {string} color - CSS color, i.e. one of: #nnn, #nnnnnn, rgb(), rgba(), hsl(), hsla()
+ * @param {number} alpha - number between 0.0 (fully transparent) and 1.0 (fully opaque)
+ * @returns {string} A CSS color string. Hex input values are returned as rgba
+ */
+export function opacify(color: string, alpha: number) {
+   warning(color, `Material-UI: missing color argument in opacify(${color}, ${alpha}).`);
+  
+    if (!color) return color;
+
+    color = decomposeColor(color);
+    alpha = clamp(alpha);
+
+    if(color.type === 'hsl'){
+            color.type = 'hsla';
+    } else {
+        if(color.type === 'rgb'){
+            color.type = 'rgba';
+        }
+    }
+    color.values[3] = alpha;
+
+    return recomposeColor(color);
+}


### PR DESCRIPTION
I ran into trouble when manipulating colors across themes. I use the same primary color(deepOrange) for my light and dark themes, but when trying to blend them with their respective backgrounds it looked messy and required unnecessary coloring logic. Following the same philosophy of lighten/darken, opacify allows blending the palette with the rest of the theme in a simple manner, e.g.: opacify(lighten(theme.palette.primary.light, 0.75), 0.2).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
