### PR TITLE
[ButtonBase] More robust button keyboard accessibility

### DIFF
--- a/src/ButtonBase/ButtonBase.js
+++ b/src/ButtonBase/ButtonBase.js
@@ -6,7 +6,7 @@ import keycode from 'keycode';
 import ownerWindow from 'dom-helpers/ownerWindow';
 import { polyfill } from 'react-lifecycles-compat';
 import withStyles from '../styles/withStyles';
-import { listenForFocusKeys, detectKeyboardFocus, focusKeyPressed } from '../utils/keyboardFocus';
+import { listenForFocusKeys, detectKeyboardFocus } from '../utils/keyboardFocus';
 import TouchRipple from './TouchRipple';
 import createRippleHandler from './createRippleHandler';
 
@@ -169,7 +169,6 @@ class ButtonBase extends React.Component {
 
   handleMouseDown = createRippleHandler(this, 'MouseDown', 'start', () => {
     clearTimeout(this.keyboardFocusTimeout);
-    focusKeyPressed(false);
     if (this.state.keyboardFocused) {
       this.setState({ keyboardFocused: false });
     }
@@ -191,8 +190,9 @@ class ButtonBase extends React.Component {
 
   handleBlur = createRippleHandler(this, 'Blur', 'stop', () => {
     clearTimeout(this.keyboardFocusTimeout);
-    focusKeyPressed(false);
-    this.setState({ keyboardFocused: false });
+    if (this.state.keyboardFocused) {
+      this.setState({ keyboardFocused: false });
+    }
   });
 
   handleFocus = event => {

--- a/src/utils/keyboardFocus.js
+++ b/src/utils/keyboardFocus.js
@@ -7,15 +7,8 @@ import ownerDocument from 'dom-helpers/ownerDocument';
 
 const internal = {
   focusKeyPressed: false,
+  keyUpEventTimeout: -1,
 };
-
-export function focusKeyPressed(pressed) {
-  if (typeof pressed !== 'undefined') {
-    internal.focusKeyPressed = Boolean(pressed);
-  }
-
-  return internal.focusKeyPressed;
-}
 
 export function detectKeyboardFocus(instance, element, callback, attempt = 1) {
   warning(instance.keyboardFocusCheckTime, 'Material-UI: missing instance.keyboardFocusCheckTime');
@@ -28,7 +21,7 @@ export function detectKeyboardFocus(instance, element, callback, attempt = 1) {
     const doc = ownerDocument(element);
 
     if (
-      focusKeyPressed() &&
+      internal.focusKeyPressed &&
       (doc.activeElement === element || contains(element, doc.activeElement))
     ) {
       callback();
@@ -47,6 +40,12 @@ function isFocusKey(event) {
 const handleKeyUpEvent = event => {
   if (isFocusKey(event)) {
     internal.focusKeyPressed = true;
+
+    // Let's consider that the user is using a keyboard during a window frame of 1s.
+    clearTimeout(internal.keyUpEventTimeout);
+    internal.keyUpEventTimeout = setTimeout(() => {
+      internal.focusKeyPressed = false;
+    }, 1e3);
   }
 };
 


### PR DESCRIPTION
The previous implementation was depending on the blur / keyUp events timing. It was brittle. For instance, the enter key is triggering the blur event on the keyDown 👍  while the spacing key is triggering the blur event on the keyUp 👎 .

Closes #10960