### PR TITLE
[Tooltip] Minor fixes

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -7,7 +7,7 @@
   {
     "name": "The size of the whole library.",
     "path": "build/index.js",
-    "limit": "100.2 KB"
+    "limit": "100.3 KB"
   },
   {
     "name": "The main bundle of the documentation",

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -39,6 +39,7 @@ This property accepts the following keys:
 - `popper`
 - `open`
 - `tooltip`
+- `touch`
 - `tooltipPlacementLeft`
 - `tooltipPlacementRight`
 - `tooltipPlacementTop`

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -239,6 +239,8 @@ class Tooltip extends React.Component {
       childrenProps.onTouchStart(event);
     }
 
+    clearTimeout(this.leaveTimer);
+    clearTimeout(this.closeTimer);
     clearTimeout(this.touchTimer);
     event.persist();
     this.touchTimer = setTimeout(() => {

--- a/src/Tooltip/Tooltip.js
+++ b/src/Tooltip/Tooltip.js
@@ -37,20 +37,25 @@ export const styles = theme => ({
     transform: 'scale(0)',
     transition: theme.transitions.create(['opacity', 'transform'], {
       duration: theme.transitions.duration.shortest,
+      easing: theme.transitions.easing.easeIn,
     }),
     minHeight: 0,
-    padding: theme.spacing.unit,
-    fontSize: theme.typography.pxToRem(14),
-    lineHeight: `${theme.typography.round(16 / 14)}em`,
-    [theme.breakpoints.up('sm')]: {
-      padding: `${theme.spacing.unit / 2}px ${theme.spacing.unit}px`,
-      fontSize: theme.typography.pxToRem(10),
-      lineHeight: `${theme.typography.round(14 / 10)}em`,
-    },
+    padding: `${theme.spacing.unit / 2}px ${theme.spacing.unit}px`,
+    fontSize: theme.typography.pxToRem(10),
+    lineHeight: `${theme.typography.round(14 / 10)}em`,
     '&$open': {
       opacity: 0.9,
       transform: 'scale(1)',
+      transition: theme.transitions.create(['opacity', 'transform'], {
+        duration: theme.transitions.duration.shortest,
+        easing: theme.transitions.easing.easeOut,
+      }),
     },
+  },
+  touch: {
+    padding: `${theme.spacing.unit}px ${theme.spacing.unit * 2}px`,
+    fontSize: theme.typography.pxToRem(14),
+    lineHeight: `${theme.typography.round(16 / 14)}em`,
   },
   tooltipPlacementLeft: {
     transformOrigin: 'right center',
@@ -128,12 +133,15 @@ class Tooltip extends React.Component {
   componentWillUnmount() {
     clearTimeout(this.enterTimer);
     clearTimeout(this.leaveTimer);
+    clearTimeout(this.touchTimer);
+    clearTimeout(this.closeTimer);
     this.handleResize.cancel();
   }
 
   enterTimer = null;
   leaveTimer = null;
   touchTimer = null;
+  closeTimer = null;
   isControlled = null;
   popper = null;
   children = null;
@@ -208,8 +216,6 @@ class Tooltip extends React.Component {
   };
 
   handleClose = event => {
-    this.ignoreNonTouchEvents = false;
-
     if (!this.isControlled) {
       this.setState({ open: false });
     }
@@ -217,6 +223,11 @@ class Tooltip extends React.Component {
     if (this.props.onClose) {
       this.props.onClose(event, false);
     }
+
+    clearTimeout(this.closeTimer);
+    this.closeTimer = setTimeout(() => {
+      this.ignoreNonTouchEvents = false;
+    }, this.props.theme.transitions.duration.shortest);
   };
 
   handleTouchStart = event => {
@@ -355,6 +366,7 @@ class Tooltip extends React.Component {
                     className={classNames(
                       classes.tooltip,
                       { [classes.open]: open },
+                      { [classes.touch]: this.ignoreNonTouchEvents },
                       classes[`tooltipPlacement${capitalize(actualPlacement)}`],
                     )}
                   >


### PR DESCRIPTION
- Correct the mobile tooltip padding

<img width="444" alt="image" src="https://user-images.githubusercontent.com/357702/38577561-3381a6de-3cf9-11e8-8db8-d35c8c5bd7f1.png">

Before:
<img width="320" alt="image" src="https://user-images.githubusercontent.com/357702/38780301-5c4cb4ce-40cc-11e8-9fa5-5094fc61614c.png">


After:
<img width="320" alt="image" src="https://user-images.githubusercontent.com/357702/38780285-0a33d2ee-40cc-11e8-919b-e183452b5b5b.png">


- Apply mobile tooltip sizing when touched to support large format touch devices
- Use the correct enter end exit transitions

<img width="772" alt="image" src="https://user-images.githubusercontent.com/357702/38577597-44986ca0-3cf9-11e8-983f-81f2b17852d2.png">


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
