### PR TITLE
[theme] Expose augmentColor for colors outside the palette

### DIFF
--- a/src/styles/createPalette.d.ts
+++ b/src/styles/createPalette.d.ts
@@ -77,6 +77,7 @@ export interface PaletteOptions {
   action?: Partial<TypeAction>;
   background?: Partial<TypeBackground>;
   getContrastText?: (color: string) => string;
+  augmentColor?(color: PaletteColorOptions, mainShade: number | string, lightShade: number | string, darkShade: number | string): void;
 }
 
 //export type PaletteOptions = DeepPartial<Palette>;

--- a/src/styles/createPalette.d.ts
+++ b/src/styles/createPalette.d.ts
@@ -59,7 +59,13 @@ export interface Palette {
   divider: string;
   action: TypeAction;
   background: TypeBackground;
-  getContrastText: (color: string) => string;
+  getContrastText: (background: string) => string;
+  augmentColor: (
+    color: string,
+    mainShade: number | string,
+    lightShade: number | string,
+    darkShade: number | string,
+  ) => void;
 }
 
 type PartialTypeObject = { [P in keyof TypeObject]?: Partial<TypeObject[P]> };
@@ -76,19 +82,9 @@ export interface PaletteOptions {
   divider?: string;
   action?: Partial<TypeAction>;
   background?: Partial<TypeBackground>;
-  getContrastText?: (color: string) => string;  
+  getContrastText?: (background: string) => string;
 }
 
 //export type PaletteOptions = DeepPartial<Palette>;
-
-export function getContrastText(color: string): string;
-
-export function augmentColor(
-  color: PaletteColorOptions,
-  mainShade: number | string,
-  lightShade: number | string,
-  darkShade: number | string,
-  tonalOffset: number,
-  contrastThreshold: number): void;
 
 export default function createPalette(palette: PaletteOptions): Palette;

--- a/src/styles/createPalette.d.ts
+++ b/src/styles/createPalette.d.ts
@@ -76,10 +76,18 @@ export interface PaletteOptions {
   divider?: string;
   action?: Partial<TypeAction>;
   background?: Partial<TypeBackground>;
-  getContrastText?: (color: string) => string;
-  augmentColor?(color: PaletteColorOptions, mainShade: number | string, lightShade: number | string, darkShade: number | string): void;
+  getContrastText?: (color: string) => string;  
 }
 
 //export type PaletteOptions = DeepPartial<Palette>;
+
+export function getContrastText(color: string): string;
+
+export function augmentColor(
+  color: PaletteColorOptions,
+  mainShade: number | string,
+  lightShade: number | string,
+  darkShade: number | string,
+  tonalOffset: number): void;
 
 export default function createPalette(palette: PaletteOptions): Palette;

--- a/src/styles/createPalette.d.ts
+++ b/src/styles/createPalette.d.ts
@@ -88,6 +88,7 @@ export function augmentColor(
   mainShade: number | string,
   lightShade: number | string,
   darkShade: number | string,
-  tonalOffset: number): void;
+  tonalOffset: number,
+  contrastThreshold: number): void;
 
 export default function createPalette(palette: PaletteOptions): Palette;

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -76,6 +76,41 @@ function addLightOrDark(intent, direction, shade, tonalOffset) {
   }
 }
 
+export function getContrastText(background) {
+  // Use the same logic as
+  // Bootstrap: https://github.com/twbs/bootstrap/blob/1d6e3710dd447de1a200f29e8fa521f8a0908f70/scss/_functions.scss#L59
+  // and material-components-web https://github.com/material-components/material-components-web/blob/ac46b8863c4dab9fc22c4c662dc6bd1b65dd652f/packages/mdc-theme/_functions.scss#L54
+  const contrastText =
+    getContrastRatio(background, dark.text.primary) >= contrastThreshold
+      ? dark.text.primary
+      : light.text.primary;
+
+  if (process.env.NODE_ENV !== 'production') {
+    const contrast = getContrastRatio(background, contrastText);
+    warning(
+      contrast >= 3,
+      [
+        `Material-UI: the contrast ratio of ${contrast}:1 for ${contrastText} on ${background}`,
+        'falls below the WACG recommended absolute minimum contrast ratio of 3:1.',
+        'https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast',
+      ].join('\n'),
+    );
+  }
+
+  return contrastText;
+}
+
+export function augmentColor(color, mainShade, lightShade, darkShade, tonalOffset) {
+  if (!color.main && color[mainShade]) {
+    color.main = color[mainShade];
+  }
+  addLightOrDark(color, 'light', lightShade, tonalOffset);
+  addLightOrDark(color, 'dark', darkShade, tonalOffset);
+  if (!color.contrastText) {
+    color.contrastText = getContrastText(color.main);
+  }
+}
+
 export default function createPalette(palette: Object) {
   const {
     primary = {
@@ -99,44 +134,9 @@ export default function createPalette(palette: Object) {
     ...other
   } = palette;
 
-  function getContrastText(background) {
-    // Use the same logic as
-    // Bootstrap: https://github.com/twbs/bootstrap/blob/1d6e3710dd447de1a200f29e8fa521f8a0908f70/scss/_functions.scss#L59
-    // and material-components-web https://github.com/material-components/material-components-web/blob/ac46b8863c4dab9fc22c4c662dc6bd1b65dd652f/packages/mdc-theme/_functions.scss#L54
-    const contrastText =
-      getContrastRatio(background, dark.text.primary) >= contrastThreshold
-        ? dark.text.primary
-        : light.text.primary;
-
-    if (process.env.NODE_ENV !== 'production') {
-      const contrast = getContrastRatio(background, contrastText);
-      warning(
-        contrast >= 3,
-        [
-          `Material-UI: the contrast ratio of ${contrast}:1 for ${contrastText} on ${background}`,
-          'falls below the WACG recommended absolute minimum contrast ratio of 3:1.',
-          'https://www.w3.org/TR/2008/REC-WCAG20-20081211/#visual-audio-contrast-contrast',
-        ].join('\n'),
-      );
-    }
-
-    return contrastText;
-  }
-
-  function augmentColor(color, mainShade, lightShade, darkShade) {
-    if (!color.main && color[mainShade]) {
-      color.main = color[mainShade];
-    }
-    addLightOrDark(color, 'light', lightShade, tonalOffset);
-    addLightOrDark(color, 'dark', darkShade, tonalOffset);
-    if (!color.contrastText) {
-      color.contrastText = getContrastText(color.main);
-    }
-  }
-
-  augmentColor(primary, 500, 300, 700);
-  augmentColor(secondary, 'A400', 'A200', 'A700');
-  augmentColor(error, 500, 300, 700);
+  augmentColor(primary, 500, 300, 700, tonalOffset);
+  augmentColor(secondary, 'A400', 'A200', 'A700', tonalOffset);
+  augmentColor(error, 500, 300, 700, tonalOffset);
 
   const types = { dark, light };
 
@@ -160,9 +160,8 @@ export default function createPalette(palette: Object) {
       // the text.
       contrastThreshold,
       // Take a background color and return the color of the text to maximize the contrast.
+      // NOTE: This should be deprecated in favor to getContrastText exported - lines 79 - 101
       getContrastText,
-      // Take a color and set its light, dark and contrastText color
-      augmentColor,
       // Used by the functions below to shift a color's luminance by approximately
       // two indexes within its tonal palette.
       // E.g., shift from Red 500 to Red 300 or Red 700.

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -161,6 +161,8 @@ export default function createPalette(palette: Object) {
       contrastThreshold,
       // Take a background color and return the color of the text to maximize the contrast.
       getContrastText,
+      // Take a color and set its light, dark and contrastText color
+      augmentColor,
       // Used by the functions below to shift a color's luminance by approximately
       // two indexes within its tonal palette.
       // E.g., shift from Red 500 to Red 300 or Red 700.

--- a/src/styles/createPalette.js
+++ b/src/styles/createPalette.js
@@ -76,7 +76,7 @@ function addLightOrDark(intent, direction, shade, tonalOffset) {
   }
 }
 
-export function getContrastText(background) {
+export function getContrastText(background, contrastThreshold) {
   // Use the same logic as
   // Bootstrap: https://github.com/twbs/bootstrap/blob/1d6e3710dd447de1a200f29e8fa521f8a0908f70/scss/_functions.scss#L59
   // and material-components-web https://github.com/material-components/material-components-web/blob/ac46b8863c4dab9fc22c4c662dc6bd1b65dd652f/packages/mdc-theme/_functions.scss#L54
@@ -100,7 +100,7 @@ export function getContrastText(background) {
   return contrastText;
 }
 
-export function augmentColor(color, mainShade, lightShade, darkShade, tonalOffset) {
+export function augmentColor(color, mainShade, lightShade, darkShade, tonalOffset, contrastThreshold) {
   if (!color.main && color[mainShade]) {
     color.main = color[mainShade];
   }
@@ -134,9 +134,9 @@ export default function createPalette(palette: Object) {
     ...other
   } = palette;
 
-  augmentColor(primary, 500, 300, 700, tonalOffset);
-  augmentColor(secondary, 'A400', 'A200', 'A700', tonalOffset);
-  augmentColor(error, 500, 300, 700, tonalOffset);
+  augmentColor(primary, 500, 300, 700, tonalOffset, contrastThreshold);
+  augmentColor(secondary, 'A400', 'A200', 'A700', tonalOffset, contrastThreshold);
+  augmentColor(error, 500, 300, 700, tonalOffset, contrastThreshold);
 
   const types = { dark, light };
 


### PR DESCRIPTION
Also expose getContrastText as individual function without need to instantiate createPalette (this is necessary because augmentColor use it).

For my current project this is necessary, for now I copied this function in my mui theme file configuration.

Sorry for my English :D

---

Closes #10499