### PR TITLE
Removed unnecessary Partial<> for `style` prop

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,7 +13,7 @@ export type StandardProps<C, ClassKey extends string, Removals extends keyof C =
 > &
   StyledComponentProps<ClassKey> & {
     className?: string;
-    style?: Partial<React.CSSProperties>;
+    style?: React.CSSProperties;
   };
 
 export type PaletteType = 'light' | 'dark';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Since the props of `React.CSSProperties` are all optional, we don't need `Partial<>` around `style`.