### PR TITLE
[Tab] use text.secondary text color for unselected tab

### DIFF
--- a/src/Tabs/Tab.js
+++ b/src/Tabs/Tab.js
@@ -145,6 +145,7 @@ class Tab extends React.Component {
       style: styleProp,
       textColor,
       value,
+      theme,
       ...other
     } = this.props;
 
@@ -182,7 +183,7 @@ class Tab extends React.Component {
     let style = {};
 
     if (textColor !== 'secondary' && textColor !== 'inherit') {
-      style.color = textColor;
+      style.color = selected ? textColor : theme.palette.text.secondary;
     }
 
     style =
@@ -269,6 +270,10 @@ Tab.propTypes = {
     PropTypes.oneOf(['secondary', 'primary', 'inherit']),
   ]),
   /**
+   * @ignore
+   */
+  theme: PropTypes.object.isRequired,
+  /**
    * You can provide your own value. Otherwise, we fallback to the child position index.
    */
   value: PropTypes.any,
@@ -279,4 +284,4 @@ Tab.defaultProps = {
   textColor: 'inherit',
 };
 
-export default withStyles(styles, { name: 'MuiTab' })(Tab);
+export default withStyles(styles, { name: 'MuiTab', withTheme: true })(Tab);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #10997 

Before:
![tab-before](https://user-images.githubusercontent.com/13808724/38670599-7e98aad6-3e49-11e8-9df7-20ca11438a59.png)

After:
![tab-after](https://user-images.githubusercontent.com/13808724/38670603-82f88786-3e49-11e8-9bd0-f692b75fbdbb.png)
