### PR TITLE
[Select] Update onChange props definition to match with SelectInput

### DIFF
--- a/src/Select/Select.d.ts
+++ b/src/Select/Select.d.ts
@@ -2,8 +2,9 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { InputProps } from '../Input';
 import { MenuProps } from '../Menu';
+import { SelectInputProps } from './SelectInput';
 
-export interface SelectProps extends StandardProps<InputProps, SelectClassKey, 'value'> {
+export interface SelectProps extends StandardProps<InputProps, SelectClassKey, 'value' | 'onChange'> {
   autoWidth?: boolean;
   displayEmpty?: boolean;
   input?: React.ReactNode;
@@ -12,6 +13,7 @@ export interface SelectProps extends StandardProps<InputProps, SelectClassKey, '
   native?: boolean;
   onClose?: (event: React.ChangeEvent<{}>) => void;
   onOpen?: (event: React.ChangeEvent<{}>) => void;
+  onChange: SelectInputProps['onChange'];
   open?: boolean;
   renderValue?: (value: SelectProps['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;

--- a/src/Select/SelectInput.d.ts
+++ b/src/Select/SelectInput.d.ts
@@ -14,7 +14,7 @@ export interface SelectInputProps extends StandardProps<{}, SelectInputClassKey>
   name?: string;
   native: boolean;
   onBlur?: React.FocusEventHandler<any>;
-  onChange?: (event: React.ChangeEvent<{}>, child: React.ReactNode) => void;
+  onChange?: (event: React.ChangeEvent<HTMLSelectElement>, child: React.ReactNode) => void;
   onClose?: (event: React.ChangeEvent<{}>) => void;
   onFocus?: React.FocusEventHandler<any>;
   onOpen?: (event: React.ChangeEvent<{}>) => void;


### PR DESCRIPTION
Update `SelectProps` and `SelectInputProps` `onChange` type definition to address the issue.
Closes #10682

