### PR TITLE
[chip] only transition the CSS properties we need

### DIFF
--- a/docs/src/pages/demos/buttons/CustomizedButtons.js
+++ b/docs/src/pages/demos/buttons/CustomizedButtons.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
 import { withStyles, MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
 import Button from 'material-ui/Button';
 import purple from 'material-ui/colors/purple';
@@ -58,10 +59,7 @@ function CustomizedInputs(props) {
       <Button
         variant="raised"
         color="primary"
-        className={classes.margin}
-        classes={{
-          root: classes.cssRoot,
-        }}
+        className={classNames(classes.margin, classes.cssRoot)}
       >
         Custom CSS
       </Button>
@@ -73,11 +71,8 @@ function CustomizedInputs(props) {
       <Button
         variant="raised"
         color="primary"
-        className={classes.margin}
         disableRipple
-        classes={{
-          root: classes.bootstrapRoot,
-        }}
+        className={classNames(classes.margin, classes.bootstrapRoot)}
       >
         Bootstrap
       </Button>

--- a/src/Chip/Chip.js
+++ b/src/Chip/Chip.js
@@ -25,7 +25,7 @@ export const styles = theme => {
       backgroundColor,
       borderRadius: height / 2,
       whiteSpace: 'nowrap',
-      transition: theme.transitions.create(),
+      transition: theme.transitions.create(['background-color', 'box-shadow']),
       // label will inherit this from root, then `clickable` class overrides this for both
       cursor: 'default',
       outline: 'none', // No outline on focused element in Chrome (as triggered by tabIndex prop)


### PR DESCRIPTION
By chance, I have discovered that the chip transition all the CSS properties. I don't think it's a nice default. It's unpredictable. Instead, I follow the button approach:
https://github.com/mui-org/material-ui/blob/2c6c15e41b1a7f528e226c1a6819c327c2daa056/src/Button/Button.js#L21