### PR TITLE
[CssBaseline] Add key to theme overrides type definition

### DIFF
--- a/src/CssBaseline/CssBaseline.d.ts
+++ b/src/CssBaseline/CssBaseline.d.ts
@@ -6,4 +6,7 @@ export interface CssBaselineProps {
 
 declare const CssBaseline: React.ComponentType<CssBaselineProps>;
 
+export type CssBaselineClassKey =
+  | '@global';
+
 export default CssBaseline;

--- a/src/styles/overrides.d.ts
+++ b/src/styles/overrides.d.ts
@@ -15,6 +15,7 @@ import { CheckboxClassKey } from '../Checkbox/Checkbox';
 import { ChipClassKey } from '../Chip/Chip';
 import { CircularProgressClassKey } from '../Progress/CircularProgress';
 import { CollapseClassKey } from '../transitions/Collapse';
+import { CssBaselineClassKey } from '../CssBaseline/CssBaseline';
 import { DialogActionsClassKey } from '../Dialog/DialogActions';
 import { DialogClassKey } from '../Dialog/Dialog';
 import { DialogContentClassKey } from '../Dialog/DialogContent';
@@ -107,6 +108,7 @@ type ComponentNameToClassKey = {
   MuiChip: ChipClassKey;
   MuiCircularProgress: CircularProgressClassKey;
   MuiCollapse: CollapseClassKey;
+  MuiCssBaseline: CssBaselineClassKey;
   MuiDialog: DialogClassKey;
   MuiDialogActions: DialogActionsClassKey;
   MuiDialogContent: DialogContentClassKey;


### PR DESCRIPTION
Should fix #11015 (but I have no idea what I'm doing). Followed how other `<Component>ClassKey` were implemented, with the difference of not modifying the `CssBaselineProps` as it doesn't extend from the `StandardProps` as rest of the components.