### PR TITLE
[SwipeableDrawer] Add a blocking div to the edge of the screen

### DIFF
--- a/.size-limit
+++ b/.size-limit
@@ -7,13 +7,13 @@
   {
     "name": "The size of the whole library.",
     "path": "build/index.js",
-    "limit": "100.2 KB"
+    "limit": "100.6 KB"
   },
   {
     "name": "The main bundle of the documentation",
     "webpack": false,
     "path": ".next/main.js",
-    "limit": "184 KB"
+    "limit": "185 KB"
   },
   {
     "name": "The home page of the documentation",

--- a/src/SwipeableDrawer/SwipeArea.js
+++ b/src/SwipeableDrawer/SwipeArea.js
@@ -6,14 +6,14 @@ import { capitalize } from '../utils/helpers';
 import { isHorizontal } from '../Drawer/Drawer';
 
 export const styles = theme => ({
-  discovery: {
+  root: {
     position: 'fixed',
     top: 0,
+    left: 0,
     height: '100vh',
     zIndex: theme.zIndex.drawer - 1,
   },
   discoveryAnchorLeft: {
-    left: 0,
     right: 'auto',
   },
   discoveryAnchorRight: {
@@ -21,25 +21,31 @@ export const styles = theme => ({
     right: 0,
   },
   discoveryAnchorTop: {
-    top: 0,
-    left: 0,
     bottom: 'auto',
     right: 0,
   },
   discoveryAnchorBottom: {
     top: 'auto',
-    left: 0,
     bottom: 0,
     right: 0,
   },
 });
 
+/**
+ * @ignore - internal component.
+ */
 function SwipeArea(props) {
-  const { anchor, classes, swipeAreaWidth } = props;
+  const {
+    anchor,
+    classes,
+    swipeAreaWidth,
+    ...other
+  } = props;
 
   return (
     <div
-      className={classNames(classes.discovery, classes[`discoveryAnchor${capitalize(anchor)}`])}
+      {...other}
+      className={classNames(classes.root, classes[`discoveryAnchor${capitalize(anchor)}`])}
       style={{
         [isHorizontal(props) ? 'width' : 'height']: swipeAreaWidth,
       }}

--- a/src/SwipeableDrawer/SwipeArea.js
+++ b/src/SwipeableDrawer/SwipeArea.js
@@ -35,12 +35,7 @@ export const styles = theme => ({
  * @ignore - internal component.
  */
 function SwipeArea(props) {
-  const {
-    anchor,
-    classes,
-    swipeAreaWidth,
-    ...other
-  } = props;
+  const { anchor, classes, swipeAreaWidth, ...other } = props;
 
   return (
     <div

--- a/src/SwipeableDrawer/SwipeArea.js
+++ b/src/SwipeableDrawer/SwipeArea.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import withStyles from '../styles/withStyles';
+import { capitalize } from '../utils/helpers';
+import { isHorizontal } from '../Drawer/Drawer';
+
+export const styles = theme => ({
+  discovery: {
+    position: 'fixed',
+    top: 0,
+    height: '100vh',
+    zIndex: theme.zIndex.drawer - 1,
+  },
+  discoveryAnchorLeft: {
+    left: 0,
+    right: 'auto',
+  },
+  discoveryAnchorRight: {
+    left: 'auto',
+    right: 0,
+  },
+  discoveryAnchorTop: {
+    top: 0,
+    left: 0,
+    bottom: 'auto',
+    right: 0,
+  },
+  discoveryAnchorBottom: {
+    top: 'auto',
+    left: 0,
+    bottom: 0,
+    right: 0,
+  },
+});
+
+function SwipeArea(props) {
+  const { anchor, classes, swipeAreaWidth } = props;
+
+  return (
+    <div
+      className={classNames(classes.discovery, classes[`discoveryAnchor${capitalize(anchor)}`])}
+      style={{
+        [isHorizontal(props) ? 'width' : 'height']: swipeAreaWidth,
+      }}
+    />
+  );
+}
+
+SwipeArea.propTypes = {
+  /**
+   * Side on which to attach the discovery area.
+   */
+  anchor: PropTypes.oneOf(['left', 'top', 'right', 'bottom']).isRequired,
+  /**
+   * @ignore
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * The width of the left most (or right most) area in pixels where the
+   * drawer can be swiped open from.
+   */
+  swipeAreaWidth: PropTypes.number.isRequired,
+};
+
+export default withStyles(styles)(SwipeArea);

--- a/src/SwipeableDrawer/SwipeArea.js
+++ b/src/SwipeableDrawer/SwipeArea.js
@@ -39,11 +39,11 @@ function SwipeArea(props) {
 
   return (
     <div
-      {...other}
       className={classNames(classes.root, classes[`discoveryAnchor${capitalize(anchor)}`])}
       style={{
         [isHorizontal(props) ? 'width' : 'height']: swipeAreaWidth,
       }}
+      {...other}
     />
   );
 }

--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -351,7 +351,8 @@ class SwipeableDrawer extends React.Component {
           {...other}
         />
         {!disableDiscovery &&
-          !disableSwipeToOpen && (
+          !disableSwipeToOpen &&
+          variant === 'temporary' && (
             <SwipeArea anchor={other.anchor} swipeAreaWidth={swipeAreaWidth} />
           )}
       </Fragment>

--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -9,6 +9,7 @@ import Drawer, { getAnchor, isHorizontal } from '../Drawer/Drawer';
 import { duration } from '../styles/transitions';
 import withTheme from '../styles/withTheme';
 import { getTransitionProps } from '../transitions/utils';
+import SwipeArea from './SwipeArea';
 
 // This value is closed to what browsers are using internally to
 // trigger a native scroll.
@@ -330,22 +331,28 @@ class SwipeableDrawer extends React.Component {
     const { maybeSwiping } = this.state;
 
     return (
-      <Drawer
-        open={variant === 'temporary' && maybeSwiping ? true : open}
-        variant={variant}
-        ModalProps={{
-          BackdropProps: {
-            ...BackdropProps,
-            ref: this.handleBackdropRef,
-          },
-          ...ModalPropsProp,
-        }}
-        PaperProps={{
-          ...PaperProps,
-          ref: this.handlePaperRef,
-        }}
-        {...other}
-      />
+      <div>
+        <Drawer
+          open={variant === 'temporary' && maybeSwiping ? true : open}
+          variant={variant}
+          ModalProps={{
+            BackdropProps: {
+              ...BackdropProps,
+              ref: this.handleBackdropRef,
+            },
+            ...ModalPropsProp,
+          }}
+          PaperProps={{
+            ...PaperProps,
+            ref: this.handlePaperRef,
+          }}
+          {...other}
+        />
+        {!disableDiscovery &&
+          !disableSwipeToOpen && (
+            <SwipeArea anchor={other.anchor} swipeAreaWidth={swipeAreaWidth} />
+          )}
+      </div>
     );
   }
 }

--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -11,6 +11,8 @@ import withTheme from '../styles/withTheme';
 import { getTransitionProps } from '../transitions/utils';
 import SwipeArea from './SwipeArea';
 
+const Fragment = React.Fragment || 'div';
+
 // This value is closed to what browsers are using internally to
 // trigger a native scroll.
 const UNCERTAINTY_THRESHOLD = 3; // px
@@ -331,7 +333,7 @@ class SwipeableDrawer extends React.Component {
     const { maybeSwiping } = this.state;
 
     return (
-      <div>
+      <Fragment>
         <Drawer
           open={variant === 'temporary' && maybeSwiping ? true : open}
           variant={variant}
@@ -352,7 +354,7 @@ class SwipeableDrawer extends React.Component {
           !disableSwipeToOpen && (
             <SwipeArea anchor={other.anchor} swipeAreaWidth={swipeAreaWidth} />
           )}
-      </div>
+      </Fragment>
     );
   }
 }

--- a/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -2,10 +2,11 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import ReactDOM from 'react-dom';
-import { createShallow, createMount, unwrap } from '../test-utils';
+import { createMount, unwrap } from '../test-utils';
 import Paper from '../Paper';
 import Drawer from '../Drawer';
 import SwipeableDrawer, { reset } from './SwipeableDrawer';
+import SwipeArea from './SwipeArea';
 import createMuiTheme from '../styles/createMuiTheme';
 
 function fireBodyMouseEvent(name, properties) {
@@ -19,12 +20,10 @@ function fireBodyMouseEvent(name, properties) {
 
 describe('<SwipeableDrawer />', () => {
   const SwipeableDrawerNaked = unwrap(SwipeableDrawer);
-  let shallow;
   let mount;
   let findDOMNodeStub;
 
   before(() => {
-    shallow = createShallow({ dive: true });
     mount = createMount();
     // mock the drawer DOM node, since jsdom doesn't do layouting but its size is required
     const findDOMNode = ReactDOM.findDOMNode;
@@ -42,9 +41,60 @@ describe('<SwipeableDrawer />', () => {
     mount.cleanUp();
   });
 
-  it('should render a Drawer', () => {
-    const wrapper = shallow(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open={false} />);
-    assert.strictEqual(wrapper.type(), Drawer);
+  it('should render a div with a Drawer and a SwipeArea', () => {
+    const wrapper = mount(
+      <SwipeableDrawerNaked
+        onOpen={() => {}}
+        onClose={() => {}}
+        open={false}
+        theme={createMuiTheme()}
+      />,
+    );
+    assert.strictEqual(wrapper.childAt(0).type(), 'div');
+    assert.strictEqual(
+      wrapper
+        .childAt(0)
+        .childAt(0)
+        .type(),
+      Drawer,
+    );
+    assert.strictEqual(
+      wrapper
+        .childAt(0)
+        .childAt(1)
+        .type(),
+      SwipeArea,
+    );
+    wrapper.unmount();
+  });
+
+  it('should hide the SwipeArea if swipe to open is disabled', () => {
+    const wrapper = mount(
+      <SwipeableDrawerNaked
+        onOpen={() => {}}
+        onClose={() => {}}
+        open={false}
+        theme={createMuiTheme()}
+        disableSwipeToOpen
+      />,
+    );
+    assert.strictEqual(wrapper.childAt(0).type(), 'div');
+    assert.strictEqual(wrapper.childAt(0).children().length, 1);
+    wrapper.unmount();
+  });
+
+  it('should hide the SwipeArea if discovery is disabled', () => {
+    const wrapper = mount(
+      <SwipeableDrawerNaked
+        onOpen={() => {}}
+        onClose={() => {}}
+        open={false}
+        theme={createMuiTheme()}
+        disableDiscovery
+      />,
+    );
+    assert.strictEqual(wrapper.childAt(0).type(), 'div');
+    assert.strictEqual(wrapper.childAt(0).children().length, 1);
     wrapper.unmount();
   });
 

--- a/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -41,7 +41,7 @@ describe('<SwipeableDrawer />', () => {
     mount.cleanUp();
   });
 
-  it('should render a div with a Drawer and a SwipeArea', () => {
+  it('should render a Drawer and a SwipeArea', () => {
     const wrapper = mount(
       <SwipeableDrawerNaked
         onOpen={() => {}}
@@ -50,21 +50,25 @@ describe('<SwipeableDrawer />', () => {
         theme={createMuiTheme()}
       />,
     );
-    assert.strictEqual(wrapper.childAt(0).type(), 'div');
-    assert.strictEqual(
-      wrapper
-        .childAt(0)
-        .childAt(0)
-        .type(),
-      Drawer,
-    );
-    assert.strictEqual(
-      wrapper
-        .childAt(0)
-        .childAt(1)
-        .type(),
-      SwipeArea,
-    );
+    if (React.Fragment) {
+      assert.strictEqual(wrapper.childAt(0).type(), Drawer);
+      assert.strictEqual(wrapper.childAt(1).type(), SwipeArea);
+    } else {
+      assert.strictEqual(
+        wrapper
+          .childAt(0)
+          .childAt(0)
+          .type(),
+        Drawer,
+      );
+      assert.strictEqual(
+        wrapper
+          .childAt(0)
+          .childAt(1)
+          .type(),
+        SwipeArea,
+      );
+    }
     wrapper.unmount();
   });
 
@@ -78,8 +82,7 @@ describe('<SwipeableDrawer />', () => {
         disableSwipeToOpen
       />,
     );
-    assert.strictEqual(wrapper.childAt(0).type(), 'div');
-    assert.strictEqual(wrapper.childAt(0).children().length, 1);
+    assert.strictEqual(wrapper.children().length, 1);
     wrapper.unmount();
   });
 
@@ -93,8 +96,7 @@ describe('<SwipeableDrawer />', () => {
         disableDiscovery
       />,
     );
-    assert.strictEqual(wrapper.childAt(0).type(), 'div');
-    assert.strictEqual(wrapper.childAt(0).children().length, 1);
+    assert.strictEqual(wrapper.children().length, 1);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
This adds a blocking `div` so that swiping/discovery touches don't get "through" the swipe area.

With the new `SwipeArea` in place, the discovery logic could be simplified later. Also, adding a delay for discovery later should be easier.

Closes #10862 

Note: This, once again, increases the size a bit. :disappointed: I'll work on bringing the size down in future PRs.