### PR TITLE
[SwipeableDrawer] Simplify isSwiping logic

### DIFF
--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -72,7 +72,7 @@ class SwipeableDrawer extends React.Component {
 
     return Math.min(
       Math.max(
-        this.isSwiping === 'closing' ? start - current : this.getMaxTranslate() + start - current,
+        this.props.open && this.isSwiping ? start - current : this.getMaxTranslate() + start - current,
         0,
       ),
       this.getMaxTranslate(),
@@ -188,7 +188,7 @@ class SwipeableDrawer extends React.Component {
         : event.touches[0].clientY;
 
     // We don't know yet.
-    if (this.isSwiping === undefined) {
+    if (this.isSwiping == null) {
       const dx = Math.abs(currentX - this.startX);
       const dy = Math.abs(currentY - this.startY);
 
@@ -205,10 +205,8 @@ class SwipeableDrawer extends React.Component {
         isSwiping === true ||
         (horizontalSwipe ? dy > UNCERTAINTY_THRESHOLD : dx > UNCERTAINTY_THRESHOLD)
       ) {
-        if (isSwiping) {
-          this.isSwiping = this.props.open ? 'closing' : 'opening';
-        } else {
-          this.isSwiping = false;
+        this.isSwiping = isSwiping;
+        if (!isSwiping) {
           this.handleBodyTouchEnd(event);
           return;
         }
@@ -228,7 +226,7 @@ class SwipeableDrawer extends React.Component {
       }
     }
 
-    if (this.isSwiping === undefined) {
+    if (!this.isSwiping) {
       return;
     }
 
@@ -243,8 +241,8 @@ class SwipeableDrawer extends React.Component {
     this.setState({ maybeSwiping: false });
 
     // The swipe wasn't started.
-    if (this.isSwiping !== 'opening' && this.isSwiping !== 'closing') {
-      this.isSwiping = undefined;
+    if (!this.isSwiping) {
+      this.isSwiping = null;
       return;
     }
 
@@ -266,7 +264,7 @@ class SwipeableDrawer extends React.Component {
     // We have to open or close after setting swiping to null,
     // because only then CSS transition is enabled.
     if (translateRatio > 0.5) {
-      if (this.isSwiping === 'opening') {
+      if (this.isSwiping && !this.props.open) {
         // Reset the position, the swipe was aborted.
         this.setPosition(this.getMaxTranslate(), {
           mode: 'enter',
@@ -274,7 +272,7 @@ class SwipeableDrawer extends React.Component {
       } else {
         this.props.onClose();
       }
-    } else if (this.isSwiping === 'opening') {
+    } else if (this.isSwiping && !this.props.open) {
       this.props.onOpen();
     } else {
       // Reset the position, the swipe was aborted.
@@ -283,12 +281,12 @@ class SwipeableDrawer extends React.Component {
       });
     }
 
-    this.isSwiping = undefined;
+    this.isSwiping = null;
   };
 
   backdrop = null;
   paper = null;
-  isSwiping = undefined;
+  isSwiping = null;
   startX = null;
   startY = null;
 

--- a/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.js
@@ -69,12 +69,8 @@ class SwipeableDrawer extends React.Component {
 
   getTranslate(current) {
     const start = isHorizontal(this.props) ? this.startX : this.startY;
-
     return Math.min(
-      Math.max(
-        this.props.open && this.isSwiping ? start - current : this.getMaxTranslate() + start - current,
-        0,
-      ),
+      Math.max(this.props.open ? start - current : this.getMaxTranslate() + start - current, 0),
       this.getMaxTranslate(),
     );
   }

--- a/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -152,7 +152,7 @@ describe('<SwipeableDrawer />', () => {
           fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
           assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
-          assert.strictEqual(instance.isSwiping, 'opening', 'should be opening');
+          assert.strictEqual(instance.isSwiping, true, 'should be swiping');
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[2]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[2]] });
           assert.strictEqual(handleOpen.callCount, 1, 'should call onOpen');
@@ -169,7 +169,7 @@ describe('<SwipeableDrawer />', () => {
           fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
           assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
-          assert.strictEqual(instance.isSwiping, 'closing', 'should be closing');
+          assert.strictEqual(instance.isSwiping, true, 'should be swiping');
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[2]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[2]] });
           assert.strictEqual(handleClose.callCount, 1, 'should call onClose');
@@ -187,7 +187,7 @@ describe('<SwipeableDrawer />', () => {
           fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
           assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
-          assert.strictEqual(instance.isSwiping, 'opening', 'should be opening');
+          assert.strictEqual(instance.isSwiping, true, 'should be swiping');
           fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[1]] });
           assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
         });
@@ -199,7 +199,7 @@ describe('<SwipeableDrawer />', () => {
           fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
           assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
-          assert.strictEqual(instance.isSwiping, 'closing', 'should be closing');
+          assert.strictEqual(instance.isSwiping, true, 'should be swiping');
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[1]] });
           assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
         });
@@ -227,7 +227,7 @@ describe('<SwipeableDrawer />', () => {
               ],
             });
           }
-          assert.strictEqual(instance.isSwiping, undefined, 'should not be swiping');
+          assert.strictEqual(instance.isSwiping, null, 'should not be swiping');
         });
 
         it('should slide in a bit when touching near the edge', () => {
@@ -287,13 +287,13 @@ describe('<SwipeableDrawer />', () => {
     });
 
     it('should wait for a clear signal to determin this.isSwiping', () => {
-      assert.strictEqual(instance.isSwiping, undefined);
+      assert.strictEqual(instance.isSwiping, null);
       fireBodyMouseEvent('touchstart', { touches: [{ pageX: 0, clientY: 0 }] });
-      assert.strictEqual(instance.isSwiping, undefined);
+      assert.strictEqual(instance.isSwiping, null);
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 3, clientY: 0 }] });
-      assert.strictEqual(instance.isSwiping, undefined);
+      assert.strictEqual(instance.isSwiping, null);
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 10, clientY: 0 }] });
-      assert.strictEqual(instance.isSwiping, 'opening');
+      assert.strictEqual(instance.isSwiping, true);
     });
 
     it('removes event listeners on unmount', () => {


### PR DESCRIPTION
This simplifies the `isSwiping` logic without changing the behavior of the swipeable drawer. `isSwiping` is now either `true`, `false` or `null`, instead of `'opening'`, `'closing'` and `undefined`.