### PR TITLE
Clear autocomplete input value

### DIFF
--- a/src/AutoComplete/AutoComplete.js
+++ b/src/AutoComplete/AutoComplete.js
@@ -538,7 +538,7 @@ class AutoComplete extends Component {
           {...other}
           // value and onChange are idiomatic properties often leaked.
           // We prevent their overrides in order to reduce potential bugs.
-          value={searchText}
+          value={searchText || ''}
           onChange={this.handleChange}
         />
         <Popover


### PR DESCRIPTION
I have faced the following behavior with the autocomplete component : 
After selecting the item , the text input does not clear itself 

![cap](https://user-images.githubusercontent.com/19166511/38805872-bf21f09a-4177-11e8-871c-d50e27b21329.png)

The expected behavior would be : 

![cap1](https://user-images.githubusercontent.com/19166511/38805937-f835890a-4177-11e8-908b-46e24aae05d9.png)

This pull request aims to allow clearing the autocomplete input text value after successful insertion.
