### PR TITLE
[typescript] make Select's onChange prop optional

### DIFF
--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -5,7 +5,8 @@ import { MenuProps } from '../Menu';
 import { SelectInputProps } from './SelectInput';
 
 export interface SelectProps
-  extends StandardProps<InputProps, SelectClassKey, 'value' | 'onChange'> {
+  extends StandardProps<InputProps, SelectClassKey, 'value' | 'onChange'>,
+    Pick<SelectInputProps, 'onChange'> {
   autoWidth?: boolean;
   displayEmpty?: boolean;
   input?: React.ReactNode;
@@ -14,7 +15,6 @@ export interface SelectProps
   native?: boolean;
   onClose?: (event: React.ChangeEvent<{}>) => void;
   onOpen?: (event: React.ChangeEvent<{}>) => void;
-  onChange: SelectInputProps['onChange'];
   open?: boolean;
   renderValue?: (value: SelectProps['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;


### PR DESCRIPTION
This PR is a follow-up to #11012, which caused the `Select` component's `onChange` prop to be required in TypeScript. However, the `SelectInput` component's `onChange` prop is optional. This PR uses a `Pick` to ensure that the `Select` component's `onChange` has exactly the same typing as the `SelectInput`.

