### PR TITLE
[ROADMAP] Remove @material/core plan

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,13 +108,6 @@ that **are needed for the stable version**:
   +import ListItem from 'material-ui/ListItem';
   ```
 
-- [ ] Use `@material-ui npm scope name` #9673. The pros have been raised in the linked issue.
-
-```diff
--import Button from 'material-ui/Button';
-+import Button from '@material-ui/core/Button';
-```
-
 - [ ] Look into the Render Props API over the Component Injection API. This one is an area of investigation. For instance, there is potential for simplifying the customization of the transitions.
 
 These breaking changes will be spread into different releases over the next few months to make the upgrade path as smooth as possible.


### PR DESCRIPTION
I'm opening this pull-request so we can debate the change. Feedback welcomed!

### What do you prefer between `material-ui` and `@material-ui/core`?

`material-ui` Pros:
- Simpler to type
- Better "marketing" by keeping the legacy name
- Keep the download stats

`material-ui` Cons:
- Less consistency with the other packages
- Makes the migration from v0.x. to v1 a bit harder
- Reset the download stats

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
