### PR TITLE
[TablePagination] Allow the override of the action buttons

### DIFF
--- a/packages/material-ui/src/Table/TablePagination.d.ts
+++ b/packages/material-ui/src/Table/TablePagination.d.ts
@@ -37,7 +37,8 @@ export type TablePaginationClassKey =
   | 'caption'
   | 'input'
   | 'selectRoot'
-  | 'select';
+  | 'select'
+  | 'actions';
 
 declare const TablePagination: React.ComponentType<TablePaginationProps>;
 

--- a/packages/material-ui/src/Table/TablePagination.js
+++ b/packages/material-ui/src/Table/TablePagination.js
@@ -130,6 +130,7 @@ class TablePagination extends React.Component {
             })}
           </Typography>
           <Actions
+            classes={{ root: classes.actions }}
             backIconButtonProps={backIconButtonProps}
             count={count}
             nextIconButtonProps={nextIconButtonProps}

--- a/packages/material-ui/src/Table/TablePagination.js
+++ b/packages/material-ui/src/Table/TablePagination.js
@@ -130,7 +130,7 @@ class TablePagination extends React.Component {
             })}
           </Typography>
           <Actions
-            classes={{ root: classes.actions }}
+            className={classes.actions}
             backIconButtonProps={backIconButtonProps}
             count={count}
             nextIconButtonProps={nextIconButtonProps}

--- a/packages/material-ui/src/Table/TablePaginationActions.js
+++ b/packages/material-ui/src/Table/TablePaginationActions.js
@@ -20,7 +20,6 @@ class TablePaginationActions extends React.Component {
   render() {
     const {
       backIconButtonProps,
-      classes,
       count,
       nextIconButtonProps,
       onChangePage,
@@ -31,7 +30,7 @@ class TablePaginationActions extends React.Component {
     } = this.props;
 
     return (
-      <div className={classes.root} {...other}>
+      <div {...other}>
         <IconButton
           onClick={this.handleBackButtonClick}
           disabled={page === 0}
@@ -56,10 +55,6 @@ TablePaginationActions.propTypes = {
    * Properties applied to the back arrow `IconButton` element.
    */
   backIconButtonProps: PropTypes.object,
-  /**
-   * Useful to extend the style applied to components.
-   */
-  classes: PropTypes.object.isRequired,
   /**
    * The total number of rows.
    */

--- a/packages/material-ui/src/Table/TablePaginationActions.js
+++ b/packages/material-ui/src/Table/TablePaginationActions.js
@@ -2,16 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
-import withStyles from '../styles/withStyles';
+import withTheme from '../styles/withTheme';
 import IconButton from '../IconButton';
-
-export const styles = theme => ({
-  root: {
-    flexShrink: 0,
-    color: theme.palette.text.secondary,
-    marginLeft: theme.spacing.unit * 2.5,
-  },
-});
 
 /**
  * @ignore - internal component.
@@ -97,4 +89,4 @@ TablePaginationActions.propTypes = {
   theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles, { withTheme: true })(TablePaginationActions);
+export default withTheme()(TablePaginationActions);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #10607.

Moved `TablePaginationActions` styles to `TablePagination`.

Note: `TablePagination.js` already had an `actions` stylesheet with the same styles that were in `TablePaginationActions`

https://github.com/mui-org/material-ui/blob/bbbc7a57a26673f9304275f2444a445b56ac4f71/src/Table/TablePagination.js#L48-L51 