### PR TITLE
[Table] Remove overflow

### DIFF
--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -10,7 +10,6 @@ export const styles = theme => ({
     width: '100%',
     borderCollapse: 'collapse',
     borderSpacing: 0,
-    overflow: 'hidden',
   },
 });
 


### PR DESCRIPTION
The overflow hidden style is preventing the sticky position to work.
I can't think of a good motivation for having this style by default.
Let's remove it.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
