### PR TITLE
fixes emptyRows TableRow height

### DIFF
--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -300,7 +300,7 @@ class EnhancedTable extends React.Component {
                 );
               })}
               {emptyRows > 0 && (
-                <TableRow style={{ height: 49 * emptyRows }}>
+                <TableRow style={{ height: 48 * emptyRows }}>
                   <TableCell colSpan={6} />
                 </TableRow>
               )}


### PR DESCRIPTION
When the emptyRows height is set to 49 the footer of the table shifts a bit when empty rows are displayed. When it is set to 48, it does not. See other examples for reference as well where they are 48.