### PR TITLE
[Input] Allow div props on InputAdornment in TypeScript

### DIFF
--- a/packages/material-ui/src/Input/InputAdornment.d.ts
+++ b/packages/material-ui/src/Input/InputAdornment.d.ts
@@ -1,11 +1,8 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 
-export interface InputAdornmentProps 
-  extends StandardProps<
-      React.HTMLAttributes<HTMLDivElement>,
-      InputAdornmentClassKey
-    > {
+export interface InputAdornmentProps
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, InputAdornmentClassKey> {
   component?: React.ReactType<InputAdornmentProps>;
   disableTypography?: boolean;
   position: 'start' | 'end';

--- a/packages/material-ui/src/Input/InputAdornment.d.ts
+++ b/packages/material-ui/src/Input/InputAdornment.d.ts
@@ -1,7 +1,11 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 
-export interface InputAdornmentProps extends StandardProps<{}, InputAdornmentClassKey> {
+export interface InputAdornmentProps 
+  extends StandardProps<
+      React.HTMLAttributes<HTMLDivElement>,
+      InputAdornmentClassKey
+    > {
   component?: React.ReactType<InputAdornmentProps>;
   disableTypography?: boolean;
   position: 'start' | 'end';

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -49,9 +49,9 @@ export default function withStyles<ClassKey extends string>(
   style: StyleRules<ClassKey> | StyleRulesCallback<ClassKey>,
   options?: WithStylesOptions,
 ): {
-  (
-    component: React.ComponentType<WithStyles<ClassKey>>,
-  ): React.ComponentType<StyledComponentProps<ClassKey>>;
+  (component: React.ComponentType<WithStyles<ClassKey>>): React.ComponentType<
+    StyledComponentProps<ClassKey>
+  >;
   <P extends ConsistentWith<WithStyles<ClassKey>>>(
     component: React.ComponentType<P & WithStyles<ClassKey>>,
   ): React.ComponentType<P & StyledComponentProps<ClassKey>>;

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -34,6 +34,7 @@ import {
   Grow,
   IconButton,
   Input,
+  InputAdornment,
   LinearProgress,
   List,
   ListItem,
@@ -784,7 +785,7 @@ const TextFieldTest = () => (
   </div>
 );
 
-const SelectTest = () => {
+const SelectTest = () => (
   <Select input={<Input />} value={10} onChange={e => log(e.currentTarget.value)}>
     <MenuItem value="">
       <em>None</em>
@@ -792,8 +793,12 @@ const SelectTest = () => {
     <MenuItem value={10}>Ten</MenuItem>
     <MenuItem value={20}>Twenty</MenuItem>
     <MenuItem value={30}>Thirty</MenuItem>
-  </Select>;
-};
+  </Select>
+);
+
+const InputAdornmentTest = () => (
+  <InputAdornment position="end" onClick={() => alert('Hello')} />
+);
 
 const ResponsiveComponentTest = () => {
   const ResponsiveComponent = withMobileDialog({

--- a/packages/material-ui/test/typescript/styling-comparison.spec.tsx
+++ b/packages/material-ui/test/typescript/styling-comparison.spec.tsx
@@ -73,4 +73,3 @@ const DecoratedUnionProps = decorate<ArtProps>( // <-- without the type argument
 );
 
 const unionPropElem = <DecoratedUnionProps category="book" author="Twain, Mark" />;
-


### PR DESCRIPTION
The following code in typescript gives a error on onClick that it is not an property in the InputAdornment.
```jsx
<InputAdornment position="end" onClick={() => alert('Hello')}>
  Hello
</InputAdornment>
```
This pr aims to fix that.