### PR TITLE
[SwipeableDrawer] Prevent interaction with the drawer content if no opened

### DIFF
--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -340,6 +340,7 @@ class SwipeableDrawer extends React.Component {
           }}
           PaperProps={{
             ...PaperProps,
+            style: { pointerEvents: variant === 'temporary' && !open ? 'none' : '' },
             ref: this.handlePaperRef,
           }}
           {...other}


### PR DESCRIPTION
Disabling pointer events when the drawer is not open (e.g. swiping) fixes clicking in discovery mode and also prevents accidentially clicking something while swiping (which is annoying).

I used the paper's `style` attribute because passing classes down into the "inherited" component would break just inheriting the classes. The same reason why I introduced `SwipeArea` instead of making that component inline. :confused: I'm curious if there is a better solution, so please tell me! :+1: 

Fixes #10844 

Edit: Better (= no inline-style) way: We could add `pointerEvents: 'none'` in the drawer, using another style classname for the `Paper` element. That, however, would put a fix for the SwipeableDrawer into the drawer.