### PR TITLE
[CardActions] Fix CSS override

### DIFF
--- a/packages/material-ui/src/Card/CardActions.js
+++ b/packages/material-ui/src/Card/CardActions.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import { cloneChildrenWithClassName } from '../utils/reactHelpers';
+import '../Button'; // So we don't have any override priority issue.
 
 export const styles = theme => ({
   root: {

--- a/packages/material-ui/src/Dialog/DialogActions.js
+++ b/packages/material-ui/src/Dialog/DialogActions.js
@@ -7,11 +7,11 @@ import '../Button'; // So we don't have any override priority issue.
 
 export const styles = theme => ({
   root: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
     flex: '0 0 auto',
     margin: `${theme.spacing.unit}px ${theme.spacing.unit / 2}px`,
-    display: 'flex',
-    justifyContent: 'flex-end',
-    alignItems: 'center',
   },
   action: {
     margin: `0 ${theme.spacing.unit / 2}px`,

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanelActions.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanelActions.js
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import { cloneChildrenWithClassName } from '../utils/reactHelpers';
+import '../Button'; // So we don't have any override priority issue.
 
 export const styles = theme => ({
   root: {
     display: 'flex',
-    justifyContent: 'flex-end',
     alignItems: 'center',
+    justifyContent: 'flex-end',
     padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit}px`,
   },
   action: {


### PR DESCRIPTION
This is definitely not the most reliable fix to the problem. The alternative is to introduce an intermediary component to apply the style. It would also save an unpredictable usage of cloneElement. The only advantage of the current approach is to save one DOM node. In the future, if this approach is problematic, we can always fallback to the extra `div` solution. Let's see how that goes.

Closes #11056