### PR TITLE
[SpeedDial] Add an option to make actions tooltip always visible

### DIFF
--- a/docs/src/pages/lab/speed-dial/SpeedDialTooltipOpen.js
+++ b/docs/src/pages/lab/speed-dial/SpeedDialTooltipOpen.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import Button from 'material-ui/Button';
+import SpeedDial from '@material-ui/lab/SpeedDial';
+import SpeedDialIcon from '@material-ui/lab/SpeedDialIcon';
+import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
+import ContentCopyIcon from '@material-ui/icons/ContentCopy';
+import SaveIcon from '@material-ui/icons/Save';
+import PrintIcon from '@material-ui/icons/Print';
+import ShareIcon from '@material-ui/icons/Share';
+import DeleteIcon from '@material-ui/icons/Delete';
+
+const styles = theme => ({
+  root: {
+    height: 380,
+  },
+  speedDial: {
+    position: 'absolute',
+    bottom: theme.spacing.unit * 2,
+    right: theme.spacing.unit * 3,
+  },
+});
+
+const actions = [
+  { icon: <ContentCopyIcon />, name: 'Copy' },
+  { icon: <SaveIcon />, name: 'Save' },
+  { icon: <PrintIcon />, name: 'Print' },
+  { icon: <ShareIcon />, name: 'Share' },
+  { icon: <DeleteIcon />, name: 'Delete' },
+];
+
+class SpeedDialTooltipOpen extends React.Component {
+  state = {
+    open: false,
+    hidden: false,
+  };
+
+  handleVisibility = () => {
+    this.setState({
+      open: false,
+      hidden: !this.state.hidden,
+    });
+  };
+
+  handleClick = () => {
+    this.setState({
+      open: !this.state.open,
+    });
+  };
+
+  handleOpen = () => {
+    if (!this.state.hidden) {
+      this.setState({
+        open: true,
+      });
+    }
+  };
+
+  handleClose = () => {
+    this.setState({
+      open: false,
+    });
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { hidden, open } = this.state;
+
+    let isTouch;
+    if (typeof document !== 'undefined') {
+      isTouch = 'ontouchstart' in document.documentElement;
+    }
+
+    return (
+      <div className={classes.root}>
+        <Button onClick={this.handleVisibility}>Toggle Speed Dial</Button>
+        <SpeedDial
+          ariaLabel="SpeedDial example"
+          className={classes.speedDial}
+          hidden={hidden}
+          icon={<SpeedDialIcon />}
+          onBlur={this.handleClose}
+          onClick={this.handleClick}
+          onClose={this.handleClose}
+          onFocus={isTouch ? undefined : this.handleOpen}
+          onMouseEnter={isTouch ? undefined : this.handleOpen}
+          onMouseLeave={this.handleClose}
+          open={open}
+        >
+          {actions.map(action => (
+            <SpeedDialAction
+              key={action.name}
+              icon={action.icon}
+              tooltipTitle={action.name}
+              tooltipAlwaysOpen
+              onClick={this.handleClick}
+            />
+          ))}
+        </SpeedDial>
+      </div>
+    );
+  }
+}
+
+SpeedDialTooltipOpen.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(SpeedDialTooltipOpen);

--- a/docs/src/pages/lab/speed-dial/speed-dial.md
+++ b/docs/src/pages/lab/speed-dial/speed-dial.md
@@ -12,3 +12,7 @@ You can provide an alternate icon for the closed and open states using the `icon
 of the `SpeedDialIcon` component.
 
 {{"demo": "pages/lab/speed-dial/OpenIconSpeedDial.js"}}
+
+Actions tooltip can be set to always visible to prevent long press on mobile platform.
+
+{{"demo": "pages/lab/speed-dial/SpeedDialTooltipOpen.js"}}

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -118,7 +118,7 @@ SpeedDialAction.propTypes = {
    */
   open: PropTypes.bool,
   /**
-   * Label to display in the tooltip.
+   * Make the tooltip always visible.
    */
   tooltipAlwaysOpen: PropTypes.bool,
   /**
@@ -130,6 +130,7 @@ SpeedDialAction.propTypes = {
 SpeedDialAction.defaultProps = {
   delay: 0,
   open: false,
+  tooltipAlwaysOpen: false,
 };
 
 export default withStyles(styles)(SpeedDialAction);

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -46,6 +46,7 @@ class SpeedDialAction extends React.Component {
       id,
       onClick,
       open,
+      tooltipAlwaysOpen,
       tooltipTitle,
       ...other
     } = this.props;
@@ -58,7 +59,7 @@ class SpeedDialAction extends React.Component {
         placement="left"
         onClose={this.handleTooltipClose}
         onOpen={this.handleTooltipOpen}
-        open={open && this.state.tooltipOpen}
+        open={open && (tooltipAlwaysOpen || this.state.tooltipOpen)}
         {...other}
       >
         <Button
@@ -116,6 +117,10 @@ SpeedDialAction.propTypes = {
    * @ignore
    */
   open: PropTypes.bool,
+  /**
+   * Label to display in the tooltip.
+   */
+  tooltipAlwaysOpen: PropTypes.bool,
   /**
    * Label to display in the tooltip.
    */

--- a/pages/lab/speed-dial.js
+++ b/pages/lab/speed-dial.js
@@ -19,7 +19,14 @@ module.exports = require('fs')
           js: require('docs/src/pages/lab/speed-dial/OpenIconSpeedDial').default,
           raw: preval`
 module.exports = require('fs')
-  .readFileSync(require.resolve('docs/src/pages/lab/speed-dial/OpenIconSpeedDial'), 'utf8')
+  .readFileSync(require.resolve('docs/src/pages/lab/speed-dial/SpeedDialTooltipOpen'), 'utf8')
+`,
+        },
+        'pages/lab/speed-dial/SpeedDialTooltipOpen.js': {
+          js: require('docs/src/pages/lab/speed-dial/SpeedDialTooltipOpen').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/lab/speed-dial/SpeedDialTooltipOpen'), 'utf8')
 `,
         },
       }}


### PR DESCRIPTION
Added a prop to the SpeedDialAction component to make it possible to have tooltips always visible
