### PR TITLE
[Grid] Fix TypeScript definitions of class keys

### DIFF
--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -48,8 +48,8 @@ export interface GridProps
 }
 
 export type GridClassKey =
-  | 'typeContainer'
-  | 'typeItem'
+  | 'container'
+  | 'item'
   | 'direction-xs-column'
   | 'direction-xs-column-reverse'
   | 'direction-xs-row-reverse'


### PR DESCRIPTION
This PR fixes the TypeScript definitions for the `<Grid/>` component's class keys. In one of the recent updates, the class keys changed from `typeContainer` to `container` and `typeItem` to `item`, respectively.
