### PR TITLE
[Snackbar] Add a consecutive demo

### DIFF
--- a/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
+++ b/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
@@ -1,0 +1,107 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "material-ui/styles";
+import Button from "material-ui/Button";
+import Snackbar from "material-ui/Snackbar";
+import IconButton from "material-ui/IconButton";
+import CloseIcon from "@material-ui/icons/Close";
+
+const styles = theme => ({
+  close: {
+    width: theme.spacing.unit * 4,
+    height: theme.spacing.unit * 4
+  }
+});
+
+class ConsecutiveSnackbars extends React.Component {
+  state = {
+    open: false,
+    messageInfo: {}
+  };
+
+  queue = [];
+
+  handleClick = message => () => {
+    const messageInfo = {
+      message,
+      key: new Date().getTime()
+    };
+    this.queue.push(messageInfo);
+    if (this.state.open) {
+      // immediately begin dismissing current message
+      // to start showing new one
+      this.setState({ open: false });
+    } else {
+      this.processQueue();
+    }
+  };
+
+  processQueue = () => {
+    if (this.queue.length) {
+      const messageInfo = this.queue.shift();
+      this.setState({ messageInfo, open: true });
+    }
+  };
+
+  handleClose = (event, reason) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+    this.setState({ open: false });
+  };
+
+  handleExited = () => {
+    this.processQueue();
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { message, key } = this.state.messageInfo;
+    return (
+      <div>
+        <Button onClick={this.handleClick("message a")}>Show message A</Button>
+        <Button onClick={this.handleClick("message b")}>Show message B</Button>
+        <Snackbar
+          key={key}
+          anchorOrigin={{
+            vertical: "bottom",
+            horizontal: "left"
+          }}
+          open={this.state.open}
+          autoHideDuration={6000}
+          onClose={this.handleClose}
+          onExited={this.handleExited}
+          SnackbarContentProps={{
+            "aria-describedby": "message-id"
+          }}
+          message={<span id="message-id">{message}</span>}
+          action={[
+            <Button
+              key="undo"
+              color="secondary"
+              size="small"
+              onClick={this.handleClose}
+            >
+              UNDO
+            </Button>,
+            <IconButton
+              key="close"
+              aria-label="Close"
+              color="inherit"
+              className={classes.close}
+              onClick={this.handleClose}
+            >
+              <CloseIcon />
+            </IconButton>
+          ]}
+        />
+      </div>
+    );
+  }
+}
+
+ConsecutiveSnackbars.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+
+export default withStyles(styles)(ConsecutiveSnackbars);

--- a/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
+++ b/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
@@ -1,32 +1,32 @@
-import React from "react";
-import PropTypes from "prop-types";
-import { withStyles } from "material-ui/styles";
-import Button from "material-ui/Button";
-import Snackbar from "material-ui/Snackbar";
-import IconButton from "material-ui/IconButton";
-import CloseIcon from "@material-ui/icons/Close";
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from 'material-ui/styles';
+import Button from 'material-ui/Button';
+import Snackbar from 'material-ui/Snackbar';
+import IconButton from 'material-ui/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
 
 const styles = theme => ({
   close: {
     width: theme.spacing.unit * 4,
-    height: theme.spacing.unit * 4
-  }
+    height: theme.spacing.unit * 4,
+  },
 });
 
 class ConsecutiveSnackbars extends React.Component {
   state = {
     open: false,
-    messageInfo: {}
+    messageInfo: {},
   };
 
   queue = [];
 
   handleClick = message => () => {
-    const messageInfo = {
+    this.queue.push({
       message,
-      key: new Date().getTime()
-    };
-    this.queue.push(messageInfo);
+      key: new Date().getTime(),
+    });
+
     if (this.state.open) {
       // immediately begin dismissing current message
       // to start showing new one
@@ -37,9 +37,11 @@ class ConsecutiveSnackbars extends React.Component {
   };
 
   processQueue = () => {
-    if (this.queue.length) {
-      const messageInfo = this.queue.shift();
-      this.setState({ messageInfo, open: true });
+    if (this.queue.length > 0) {
+      this.setState({
+        messageInfo: this.queue.shift(),
+        open: true,
+      });
     }
   };
 
@@ -59,29 +61,24 @@ class ConsecutiveSnackbars extends React.Component {
     const { message, key } = this.state.messageInfo;
     return (
       <div>
-        <Button onClick={this.handleClick("message a")}>Show message A</Button>
-        <Button onClick={this.handleClick("message b")}>Show message B</Button>
+        <Button onClick={this.handleClick('message a')}>Show message A</Button>
+        <Button onClick={this.handleClick('message b')}>Show message B</Button>
         <Snackbar
           key={key}
           anchorOrigin={{
-            vertical: "bottom",
-            horizontal: "left"
+            vertical: 'bottom',
+            horizontal: 'left',
           }}
           open={this.state.open}
           autoHideDuration={6000}
           onClose={this.handleClose}
           onExited={this.handleExited}
           SnackbarContentProps={{
-            "aria-describedby": "message-id"
+            'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">{message}</span>}
           action={[
-            <Button
-              key="undo"
-              color="secondary"
-              size="small"
-              onClick={this.handleClose}
-            >
+            <Button key="undo" color="secondary" size="small" onClick={this.handleClose}>
               UNDO
             </Button>,
             <IconButton
@@ -92,7 +89,7 @@ class ConsecutiveSnackbars extends React.Component {
               onClick={this.handleClose}
             >
               <CloseIcon />
-            </IconButton>
+            </IconButton>,
           ]}
         />
       </div>
@@ -101,7 +98,7 @@ class ConsecutiveSnackbars extends React.Component {
 }
 
 ConsecutiveSnackbars.propTypes = {
-  classes: PropTypes.object.isRequired
+  classes: PropTypes.object.isRequired,
 };
 
 export default withStyles(styles)(ConsecutiveSnackbars);

--- a/docs/src/pages/demos/snackbars/snackbars.md
+++ b/docs/src/pages/demos/snackbars/snackbars.md
@@ -48,3 +48,9 @@ Use a different transition all together.
 Move the floating action button vertically to accommodate the snackbar height.
 
 {{"demo": "pages/demos/snackbars/FabIntegrationSnackbar.js"}}
+
+### Consecutive Snackbars
+
+Per [Google's guidelines](https://material.io/guidelines/components/snackbars-toasts.html#snackbars-toasts-usage), when a second snackbar is triggered while the first is displayed, the first should start the contraction motion downwards before the second one animates upwards.
+
+{{"demo": "pages/demos/snackbars/ConsecutiveSnackbars.js"}}

--- a/pages/demos/snackbars.js
+++ b/pages/demos/snackbars.js
@@ -50,6 +50,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/snackbars/FabIntegrationSnackbar'), 'utf8')
 `,
         },
+        'pages/demos/snackbars/ConsecutiveSnackbars.js': {
+          js: require('docs/src/pages/demos/snackbars/ConsecutiveSnackbars').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/snackbars/ConsecutiveSnackbars'), 'utf8')
+`,
+        },
       }}
     />
   );


### PR DESCRIPTION
Add a demo for consecutive snackbars per Google's [usage guidelines](https://material.io/guidelines/components/snackbars-toasts.html#snackbars-toasts-usage). Instead of immediately replacing a visible snackbar, when a second snackbar is triggered, the first one should start the contraction motion downwards before the second one animates upwards.
