### PR TITLE
[Modal] Prevent IE11 from crashing on modal close

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -194,7 +194,9 @@ class Modal extends React.Component {
     }
 
     if (this.lastFocus) {
-      // Not all elements in IE11 have a focus method
+      // Not all elements in IE11 have a focus method.
+      // Because IE11 market share is low, we accept the restore focus being broken
+      // and we silent the issue.
       if (this.lastFocus.focus) {
         this.lastFocus.focus();
       }

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -194,7 +194,11 @@ class Modal extends React.Component {
     }
 
     if (this.lastFocus) {
-      this.lastFocus.focus();
+      // Not all elements in IE11 have a focus method
+      if (this.lastFocus.focus) {
+        this.lastFocus.focus();
+      }
+
       this.lastFocus = null;
     }
   }


### PR DESCRIPTION
Fixes an IE11 crash I recently encountered. If the element that gets clicked to open a modal is an SVG (a FontAwesome icon in my case), then the whole site crashes on modal close.

This is due to material-ui trying call `.focus()` on the last element with focus before the modal was opened. It turns out that IE11 doesn't provide a `focus` method for `<svg />` elements.

There were a few ways to fix this, but went with a check on modal close, using a focus checking technique found elsewhere in the same file.

I'm not sure how to write a test for this, considering jsdom doesn't emulate IE11. I have tested it myself in Virtualbox, but I doubt that's worth a whole lot.