### PR TITLE
[ButtonBase] Simpler global focus visible style override

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -41,6 +41,7 @@ export const styles = {
     },
   },
   disabled: {},
+  focusVisible: {},
 };
 
 /**
@@ -242,6 +243,7 @@ class ButtonBase extends React.Component {
       classes.root,
       {
         [classes.disabled]: disabled,
+        [classes.focusVisible]: this.state.focusVisible,
         [focusVisibleClassName]: this.state.focusVisible,
       },
       classNameProp,

--- a/packages/material-ui/src/styles/MuiThemeProvider.test.js
+++ b/packages/material-ui/src/styles/MuiThemeProvider.test.js
@@ -86,11 +86,12 @@ describe('<MuiThemeProvider />', () => {
       assert.notStrictEqual(markup.match('Hello World'), null);
       assert.strictEqual(sheetsRegistry.registry.length, 3);
       assert.strictEqual(sheetsRegistry.toString().length > 4000, true);
-      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-18');
+      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-19');
       assert.deepEqual(
         sheetsRegistry.registry[1].classes,
         {
           disabled: 'MuiButtonBase-disabled-17',
+          focusVisible: 'MuiButtonBase-focusVisible-18',
           root: 'MuiButtonBase-root-16',
         },
         'the class names should be deterministic',

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -34,6 +34,7 @@ You can override all the class names injected by Material-UI thanks to the `clas
 This property accepts the following keys:
 - `root`
 - `disabled`
+- `focusVisible`
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/v1-beta/packages/material-ui/src/ButtonBase/ButtonBase.js)


### PR DESCRIPTION
Add the global override back:
```jsx
  const theme = createMuiTheme({
    overrides: {
      MuiButtonBase: {
        focusVisible: {
          outline: 'thick double green',
        },
      },
    },
  });
```

Solves @z-ax concern: https://github.com/mui-org/material-ui/issues/10976#issuecomment-383915833.