### PR TITLE
[Badge] Export radius from badge to allow custom badge location

### DIFF
--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import { capitalize } from '../utils/helpers';
 
-const RADIUS = 12;
+export const RADIUS = 12;
 
 export const styles = theme => ({
   root: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

How would you feel about this?

My use case: I want to put the badge on the left top corner, instead of the right top corner. I'd like to be able to import `RADIUS` instead of hardcoding it. I'm using overrides with `classes`.

Example (shortened for brevity, might not work as is):

```
import React from 'react';
import PropTypes from 'prop-types';
import Badge from 'material-ui/Badge';
import Icon from '@material-ui/icons/InsertComment';
import { withStyles } from 'material-ui/styles';

// NOTE: ideally we would import it from Badge instead.
const RADIUS = 12;

const styles = theme => ({
  badge: {
    right: 0,
    left: -RADIUS,
  },
});

const MyBadge = ({ classes }) => {
  return (
    <Badge
      badgeContent={2}
      color="secondary"
      classes={{ badge: classes.badge }}
    >
      <Icon className={classes.icon} />
    </Badge>
  );
};

MyBadge.propTypes = {
  classes: PropTypes.object.isRequired,
};

export default withStyles(styles)(MyBadge);
```