### PR TITLE
[core] Reduce the size of the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
     "fg-loadcss": "^2.0.1",
     "file-loader": "^1.1.5",
     "flow-bin": "0.62.0",
-    "flow-copy-source": "^1.2.1",
     "flow-typed": "^2.2.3",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",

--- a/packages/material-ui/scripts/copy-files.js
+++ b/packages/material-ui/scripts/copy-files.js
@@ -2,7 +2,6 @@
 
 import path from 'path';
 import fse from 'fs-extra';
-import flowCopySource from 'flow-copy-source';
 import glob from 'glob';
 
 async function copyFile(file) {
@@ -69,9 +68,6 @@ async function run() {
     typescriptCopy(from, path.resolve(__dirname, '../build')),
     typescriptCopy(from, path.resolve(__dirname, '../build/es')),
   ]);
-
-  // Flow
-  flowCopySource(['src'], 'build', { verbose: true, ignore: '**/*.spec.js' });
 }
 
 run();

--- a/packages/material-ui/src/Tabs/Tab.js
+++ b/packages/material-ui/src/Tabs/Tab.js
@@ -108,7 +108,7 @@ class Tab extends React.Component {
     }
   }
 
-  handleChange = (event: SyntheticEvent<>) => {
+  handleChange = event => {
     const { onChange, value, onClick } = this.props;
 
     if (onChange) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2083,7 +2083,7 @@ chokidar@^1.4.1, chokidar@^1.6.1:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.0, chokidar@^2.0.2:
+chokidar@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.3.tgz#dcbd4f6cbb2a55b4799ba8a840ac527e5f4b1176"
   dependencies:
@@ -4150,16 +4150,6 @@ flow-bin@0.62.0:
   version "0.62.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.62.0.tgz#14bca669a6e3f95c0bc0c2d1eb55ec4e98cb1d83"
 
-flow-copy-source@^1.2.1:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/flow-copy-source/-/flow-copy-source-1.3.0.tgz#591b153f5c01e8fc566c64a97290ea9103b7f1ea"
-  dependencies:
-    chokidar "^2.0.0"
-    fs-extra "^5.0.0"
-    glob "^7.0.0"
-    kefir "^3.7.3"
-    yargs "^11.0.0"
-
 flow-parser@^0.*:
   version "0.69.0"
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.69.0.tgz#378b5128d6d0b554a8b2f16a4ca3e1ab9649f00e"
@@ -4548,7 +4538,7 @@ glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
 
-glob@7.1.2, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2:
+glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -5973,12 +5963,6 @@ karma@^2.0.0:
     source-map "^0.6.1"
     tmp "0.0.33"
     useragent "2.2.1"
-
-kefir@^3.7.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/kefir/-/kefir-3.8.3.tgz#8e0ab10084ed8a01cbb5d4f7f18a0b859f7b9bd9"
-  dependencies:
-    symbol-observable "1.0.4"
 
 kew@^0.7.0:
   version "0.7.0"


### PR DESCRIPTION
The flow support moved to flow-typed some month ago. We can reduce the size of the npm package and the confusion by not shipping any `.js.flow` file. Thanks @rosskevin for raising the problem 💯.
For instance: https://unpkg.com/material-ui@1.0.0-beta.43/ButtonBase/ButtonBase.js.flow.