### PR TITLE
[typescript] allow pseudos on any theme mixins

### DIFF
--- a/packages/material-ui/src/styles/createMixins.d.ts
+++ b/packages/material-ui/src/styles/createMixins.d.ts
@@ -3,10 +3,11 @@ import * as React from 'react';
 import { Breakpoints } from './createBreakpoints';
 import { Spacing } from './spacing';
 import { StyleRules } from '../styles';
+import { CSSProperties } from './withStyles';
 
 export interface Mixins {
-  gutters: (styles?: React.CSSProperties) => React.CSSProperties;
-  toolbar: React.CSSProperties;
+  gutters: (styles?: CSSProperties) => CSSProperties;
+  toolbar: CSSProperties;
   // ... use interface declaration merging to add custom mixins
 }
 

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -168,7 +168,12 @@ const DecoratedComponent = withStyles(styles)(
 <DecoratedComponent text="foo" />;
 
 // Allow nested pseudo selectors
-withStyles<'listItem'>(theme => ({
+withStyles<'listItem' | 'guttered'>(theme => ({
+  guttered: theme.mixins.gutters({
+    '&:hover': {
+      textDecoration: 'none',
+    },
+  }),
   listItem: {
     '&:hover $listItemIcon': {
       visibility: 'inherit',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
#11007 allows specifying pseudo selectors in written jss.  This missed the mixin helpers such as `gutters()`.  Now any mixins use the `CSSProperties` specified in the `withStyles.d.ts`.