### PR TITLE
[docs] Make sure next@6 is working

### DIFF
--- a/examples/nextjs/.babelrc
+++ b/examples/nextjs/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["next/babel"]
+}


### PR DESCRIPTION
I had to add the `.babelrc` to make it work with `next@6.0.0-canary.7`. The warnings are gone. This confirms my analysis. react-hot-loader is to blame for all the warnings.

Closes #11052