### PR TITLE
[docs] Remove devextreme-reactive

### DIFF
--- a/docs/src/pages/demos/tables/tables.md
+++ b/docs/src/pages/demos/tables/tables.md
@@ -39,7 +39,3 @@ custom actions.
 You can customize the look and feel of the table by overriding the styles of the `TableCell` component.
 
 {{"demo": "pages/demos/tables/CustomizedTable.js"}}
-
-## Advanced use cases
-
-For more advanced use cases you might be able to take advantage of [dx-react-grid-material-ui](https://devexpress.github.io/devextreme-reactive/react/grid/). It's a data grid for Material-UI with paging, sorting, filtering, grouping and editing features.


### PR DESCRIPTION
🚨It just came to my attention that `dx-react-grid-material-ui` isn't free software in the modern meaning of the phrase. It's licensed under [a custom license](https://js.devexpress.com/Licensing/). **People have to pay for commercial applications**.

While I'm very happy to see that Material-UI is responsible for a [84% of the success](https://npm-stat.com/charts.html?package=%40devexpress%2Fdx-react-grid-bootstrap3&package=%40devexpress%2Fdx-react-grid-bootstrap4&package=%40devexpress%2Fdx-react-grid-material-ui&from=2017-04-27&to=2018-04-27) of dx-react-grid, I think that we will better of not promoting the link in the current situation and warning about the potential confusion in the next release note:
1. It can be confusing for our users. They would expect us to promote MIT licensed like libraries. It took me 8 months to realized it's not free software: #7824. 
2. There is a business opportunity. It can be leveraged in order to keep Material-UI model sustainable.

cc @kvet and @gsobolev