### PR TITLE
[TextField] change underline approach to prevent browser zoom issue

### DIFF
--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -78,12 +78,11 @@ export const styles = theme => {
     disabled: {},
     underline: {
       '&:after': {
-        backgroundColor: theme.palette.primary[light ? 'dark' : 'light'],
+        borderBottom: `2px solid ${theme.palette.primary[light ? 'dark' : 'light']}`,
         left: 0,
         bottom: 0,
         // Doing the other way around crash on IE11 "''" https://github.com/cssinjs/jss/issues/242
         content: '""',
-        height: 2,
         position: 'absolute',
         right: 0,
         transform: 'scaleX(0)',
@@ -97,33 +96,28 @@ export const styles = theme => {
         transform: 'scaleX(1)',
       },
       '&$error:after': {
-        backgroundColor: theme.palette.error.main,
+        borderBottomColor: theme.palette.error.main,
         transform: 'scaleX(1)', // error is always underlined in red
       },
       '&:before': {
-        backgroundColor: bottomLineColor,
+        borderBottom: `1px solid ${bottomLineColor}`,
         left: 0,
         bottom: 0,
         // Doing the other way around crash on IE11 "''" https://github.com/cssinjs/jss/issues/242
-        content: '""',
-        height: 1,
+        content: '"need text here to prevent subpixel zoom issue"',
+        color: 'transparent',
         position: 'absolute',
         right: 0,
-        transition: theme.transitions.create('background-color', {
+        transition: theme.transitions.create('border-bottom-color', {
           duration: theme.transitions.duration.shorter,
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      '&:hover:not($disabled):before': {
-        backgroundColor: theme.palette.text.primary,
-        height: 2,
+      '&:hover:not($disabled):not($focused):not($error):before': {
+        borderBottom: `2px solid ${theme.palette.text.primary}`,
       },
       '&$disabled:before': {
-        background: 'transparent',
-        backgroundImage: `linear-gradient(to right, ${bottomLineColor} 33%, transparent 0%)`,
-        backgroundPosition: 'left top',
-        backgroundRepeat: 'repeat-x',
-        backgroundSize: '5px 1px',
+        borderBottom: `2px dotted ${bottomLineColor}`,
       },
     },
     error: {},


### PR DESCRIPTION
If you use the browser zoom capability to shrink the elements on the page, the underline of the TextField will disappear at times.  The times that the underline disappears seems to be a function of the length of the underline, the label length, and the screen resolution.  Wide TextFields seem to have the issue earlier in zooming to a lower percentage.

Using Windows 10 and Chrome and Firefox I am able to reproduce the issue using the demo page.  https://material-ui-next.com/demos/text-fields/   As you reduce the size of the page elements you should be able to notice some of the underlines disappearing.  From what I can tell, the issue appears to be a sub pixel calculation that is causing the browsers not to display the underline.  I made a switch to using border-bottom and removing the height attribute to ensure the underline stays visible at all zoom levels.

The team I work with uses wide TextFields and see this issue appear frequently, so I decided to try and fix it.