### PR TITLE
[core] Add a components property

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -115,8 +115,6 @@ that **are needed for the stable version**:
 +import Button from '@material-ui/core/Button';
 ```
 
-- [ ] Look into the Render Props API over the Component Injection API. This one is an area of investigation. For instance, there is potential for simplifying the customization of the transitions.
-
 These breaking changes will be spread into different releases over the next few months to make the upgrade path as smooth as possible.
 Not only does the Material-UI project have to be upgraded for each breaking change,
 but we also have to upgrade our own projects.

--- a/docs/src/modules/components/AppWrapper.js
+++ b/docs/src/modules/components/AppWrapper.js
@@ -29,29 +29,6 @@ function uiThemeSideEffect(uiTheme) {
 }
 
 class AppWrapper extends React.Component {
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (typeof prevState.pageContext === 'undefined') {
-      return {
-        prevProps: nextProps,
-        pageContext: nextProps.pageContext || getPageContext(),
-      };
-    }
-
-    const { prevProps } = prevState;
-
-    if (
-      nextProps.uiTheme.paletteType !== prevProps.uiTheme.paletteType ||
-      nextProps.uiTheme.direction !== prevProps.uiTheme.direction
-    ) {
-      return {
-        prevProps: nextProps,
-        pageContext: updatePageContext(nextProps.uiTheme),
-      };
-    }
-
-    return null;
-  }
-
   state = {};
 
   componentDidMount() {
@@ -95,6 +72,29 @@ class AppWrapper extends React.Component {
     );
   }
 }
+
+AppWrapper.getDerivedStateFromProps = (nextProps, prevState) => {
+  if (typeof prevState.pageContext === 'undefined') {
+    return {
+      prevProps: nextProps,
+      pageContext: nextProps.pageContext || getPageContext(),
+    };
+  }
+
+  const { prevProps } = prevState;
+
+  if (
+    nextProps.uiTheme.paletteType !== prevProps.uiTheme.paletteType ||
+    nextProps.uiTheme.direction !== prevProps.uiTheme.direction
+  ) {
+    return {
+      prevProps: nextProps,
+      pageContext: updatePageContext(nextProps.uiTheme),
+    };
+  }
+
+  return null;
+};
 
 AppWrapper.propTypes = {
   children: PropTypes.node.isRequired,

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -75,7 +75,7 @@ class Notifications extends React.Component {
       <Snackbar
         key={message.id}
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-        SnackbarContentProps={{ 'aria-describedby': 'notification-message' }}
+        ContentProps={{ 'aria-describedby': 'notification-message' }}
         message={
           <span id="notification-message" dangerouslySetInnerHTML={{ __html: message.text }} />
         }

--- a/docs/src/pages/demos/dialogs/AlertDialogSlide.js
+++ b/docs/src/pages/demos/dialogs/AlertDialogSlide.js
@@ -31,7 +31,7 @@ class AlertDialogSlide extends React.Component {
         <Button onClick={this.handleClickOpen}>Slide in alert dialog</Button>
         <Dialog
           open={this.state.open}
-          transition={Transition}
+          components={{ Transition }}
           keepMounted
           onClose={this.handleClose}
           aria-labelledby="alert-dialog-slide-title"

--- a/docs/src/pages/demos/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/demos/dialogs/FullScreenDialog.js
@@ -47,7 +47,7 @@ class FullScreenDialog extends React.Component {
           fullScreen
           open={this.state.open}
           onClose={this.handleClose}
-          transition={Transition}
+          components={{ Transition }}
         >
           <AppBar className={classes.appBar}>
             <Toolbar>

--- a/docs/src/pages/demos/menus/FadeMenu.js
+++ b/docs/src/pages/demos/menus/FadeMenu.js
@@ -33,7 +33,7 @@ class FadeMenu extends React.Component {
           anchorEl={anchorEl}
           open={Boolean(anchorEl)}
           onClose={this.handleClose}
-          transition={Fade}
+          components={{ Transition: Fade }}
         >
           <MenuItem onClick={this.handleClose}>Profile</MenuItem>
           <MenuItem onClick={this.handleClose}>My account</MenuItem>

--- a/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
+++ b/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
@@ -73,7 +73,7 @@ class ConsecutiveSnackbars extends React.Component {
           autoHideDuration={6000}
           onClose={this.handleClose}
           onExited={this.handleExited}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">{message}</span>}

--- a/docs/src/pages/demos/snackbars/DirectionSnackbar.js
+++ b/docs/src/pages/demos/snackbars/DirectionSnackbar.js
@@ -22,11 +22,11 @@ function TransitionDown(props) {
 class DirectionSnackbar extends React.Component {
   state = {
     open: false,
-    transition: null,
+    Transition: null,
   };
 
-  handleClick = transition => () => {
-    this.setState({ open: true, transition });
+  handleClick = Transition => () => {
+    this.setState({ open: true, Transition });
   };
 
   handleClose = () => {
@@ -43,8 +43,8 @@ class DirectionSnackbar extends React.Component {
         <Snackbar
           open={this.state.open}
           onClose={this.handleClose}
-          transition={this.state.transition}
-          SnackbarContentProps={{
+          components={{ Transition: this.state.Transition }}
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">I love snacks</span>}

--- a/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.js
+++ b/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.js
@@ -96,7 +96,7 @@ class FabIntegrationSnackbar extends React.Component {
             open={open}
             autoHideDuration={4000}
             onClose={this.handleClose}
-            SnackbarContentProps={{
+            ContentProps={{
               'aria-describedby': 'snackbar-fab-message-id',
               className: classes.snackbarContent,
             }}

--- a/docs/src/pages/demos/snackbars/FadeSnackbar.js
+++ b/docs/src/pages/demos/snackbars/FadeSnackbar.js
@@ -23,8 +23,8 @@ class FadeSnackbar extends React.Component {
         <Snackbar
           open={this.state.open}
           onClose={this.handleClose}
-          transition={Fade}
-          SnackbarContentProps={{
+          components={{ Transition: Fade }}
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">I love snacks</span>}

--- a/docs/src/pages/demos/snackbars/PositionedSnackbar.js
+++ b/docs/src/pages/demos/snackbars/PositionedSnackbar.js
@@ -43,7 +43,7 @@ class PositionedSnackbar extends React.Component {
           anchorOrigin={{ vertical, horizontal }}
           open={open}
           onClose={this.handleClose}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">I love snacks</span>}

--- a/docs/src/pages/demos/snackbars/SimpleSnackbar.js
+++ b/docs/src/pages/demos/snackbars/SimpleSnackbar.js
@@ -43,7 +43,7 @@ class SimpleSnackbar extends React.Component {
           open={this.state.open}
           autoHideDuration={6000}
           onClose={this.handleClose}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">Note archived</span>}

--- a/docs/src/pages/demos/tables/CustomPaginationActionsTable.js
+++ b/docs/src/pages/demos/tables/CustomPaginationActionsTable.js
@@ -180,7 +180,9 @@ class CustomPaginationActionsTable extends React.Component {
                   page={page}
                   onChangePage={this.handleChangePage}
                   onChangeRowsPerPage={this.handleChangeRowsPerPage}
-                  Actions={TablePaginationActionsWrapped}
+                  components={{
+                    Actions: TablePaginationActionsWrapped,
+                  }}
                 />
               </TableRow>
             </TableFooter>

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -5,9 +5,10 @@ import ReactDOM from 'react-dom';
 import keycode from 'keycode';
 import { withStyles } from 'material-ui/styles';
 import Zoom from 'material-ui/transitions/Zoom';
-import { duration } from 'material-ui/styles/transitions';
 import Button from 'material-ui/Button';
 import { isMuiElement } from 'material-ui/utils/reactHelpers';
+import { duration } from 'material-ui/styles/transitions';
+import { getComponents } from 'material-ui/utils/helpers';
 
 const styles = theme => ({
   root: {
@@ -24,6 +25,10 @@ const styles = theme => ({
     transition: 'top 0s linear 0.2s',
   },
 });
+
+const defaultComponents = {
+  Transition: Zoom,
+};
 
 class SpeedDial extends React.Component {
   state = {
@@ -91,6 +96,7 @@ class SpeedDial extends React.Component {
       children: childrenProp,
       classes,
       className: classNameProp,
+      components: componentsProp,
       hidden,
       icon: iconProp,
       onClick,
@@ -98,10 +104,12 @@ class SpeedDial extends React.Component {
       onKeyDown,
       open,
       openIcon,
-      transition: Transition,
       transitionDuration,
+      TransitionProps,
       ...other
     } = this.props;
+
+    const components = getComponents(defaultComponents, this.props);
 
     // Filter the label for valid id characters.
     const id = ariaLabel.replace(/^[^a-z]+|[^\w:.-]+/gi, '');
@@ -136,7 +144,13 @@ class SpeedDial extends React.Component {
 
     return (
       <div className={classNames(classes.root, classNameProp)} {...other}>
-        <Transition in={!hidden} timeout={transitionDuration} mountOnEnter unmountOnExit>
+        <components.Transition
+          in={!hidden}
+          timeout={transitionDuration}
+          mountOnEnter
+          unmountOnExit
+          {...TransitionProps}
+        >
           <Button
             variant="fab"
             color="primary"
@@ -154,7 +168,7 @@ class SpeedDial extends React.Component {
           >
             {icon()}
           </Button>
-        </Transition>
+        </components.Transition>
         <div
           id={`${id}-actions`}
           className={classNames(classes.actions, { [classes.actionsClosed]: !open })}
@@ -192,6 +206,12 @@ SpeedDial.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * The components injection property.
+   */
+  components: PropTypes.shape({
+    Transition: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  }),
+  /**
    * If `true`, the SpeedDial will be hidden.
    */
   hidden: PropTypes.bool,
@@ -224,10 +244,6 @@ SpeedDial.propTypes = {
    */
   openIcon: PropTypes.node,
   /**
-   * Transition component.
-   */
-  transition: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    */
@@ -235,15 +251,16 @@ SpeedDial.propTypes = {
     PropTypes.number,
     PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
   ]),
+  /**
+   * Properties applied to the `Transition` element.
+   */
+  TransitionProps: PropTypes.object,
 };
 
 SpeedDial.defaultProps = {
+  components: defaultComponents,
+  transitionDuration: { enter: duration.enteringScreen, exit: duration.leavingScreen },
   hidden: false,
-  transition: Zoom,
-  transitionDuration: {
-    enter: duration.enteringScreen,
-    exit: duration.leavingScreen,
-  },
 };
 
 export default withStyles(styles)(SpeedDial);

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -50,28 +50,6 @@ export const styles = {
  * It contains a load of style reset and some focus/ripple logic.
  */
 class ButtonBase extends React.Component {
-  static getDerivedStateFromProps(nextProps, prevState) {
-    if (typeof prevState.focusVisible === 'undefined') {
-      return {
-        focusVisible: false,
-        lastDisabled: nextProps.disabled,
-      };
-    }
-
-    // The blur won't fire when the disabled state is set on a focused input.
-    // We need to book keep the focused state manually.
-    if (!prevState.prevState && nextProps.disabled && prevState.focusVisible) {
-      return {
-        focusVisible: false,
-        lastDisabled: nextProps.disabled,
-      };
-    }
-
-    return {
-      lastDisabled: nextProps.disabled,
-    };
-  }
-
   state = {};
 
   componentDidMount() {
@@ -294,6 +272,28 @@ class ButtonBase extends React.Component {
     );
   }
 }
+
+ButtonBase.getDerivedStateFromProps = (nextProps, prevState) => {
+  if (typeof prevState.focusVisible === 'undefined') {
+    return {
+      focusVisible: false,
+      lastDisabled: nextProps.disabled,
+    };
+  }
+
+  // The blur won't fire when the disabled state is set on a focused input.
+  // We need to book keep the focused state manually.
+  if (!prevState.prevState && nextProps.disabled && prevState.focusVisible) {
+    return {
+      focusVisible: false,
+      lastDisabled: nextProps.disabled,
+    };
+  }
+
+  return {
+    lastDisabled: nextProps.disabled,
+  };
+};
 
 ButtonBase.propTypes = {
   /**

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -28,7 +28,8 @@ export const styles = theme => {
       transition: theme.transitions.create(['background-color', 'box-shadow']),
       // label will inherit this from root, then `clickable` class overrides this for both
       cursor: 'default',
-      outline: 'none', // No outline on focused element in Chrome (as triggered by tabIndex prop)
+      // We disable the focus ring for mouse, touch and keyboard users.
+      outline: 'none',
       border: 'none', // Remove `button` border
       padding: 0, // Remove `button` padding
     },

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
-import { capitalize } from '../utils/helpers';
+import { capitalize, getComponents } from '../utils/helpers';
 import Modal from '../Modal';
 import Fade from '../transitions/Fade';
 import { duration } from '../styles/transitions';
@@ -23,9 +23,7 @@ export const styles = theme => ({
     position: 'relative',
     maxHeight: '90vh',
     overflowY: 'auto', // Fix IE11 issue, to remove at some point.
-    '&:focus': {
-      outline: 'none',
-    },
+    outline: 'none',
   },
   paperWidthXs: {
     maxWidth: Math.max(theme.breakpoints.values.xs, 360),
@@ -49,6 +47,10 @@ export const styles = theme => ({
   },
 });
 
+const defaultComponents = {
+  Transition: Fade,
+};
+
 /**
  * Dialogs are overlaid modal paper based components with a backdrop.
  */
@@ -58,6 +60,7 @@ function Dialog(props) {
     children,
     classes,
     className,
+    components: componentsProp,
     disableBackdropClick,
     disableEscapeKeyDown,
     fullScreen,
@@ -74,10 +77,12 @@ function Dialog(props) {
     onExiting,
     open,
     PaperProps,
-    transition: TransitionProp,
     transitionDuration,
+    TransitionProps,
     ...other
   } = props;
+
+  const components = getComponents(defaultComponents, props);
 
   return (
     <Modal
@@ -95,7 +100,7 @@ function Dialog(props) {
       role="dialog"
       {...other}
     >
-      <TransitionProp
+      <components.Transition
         appear
         in={open}
         timeout={transitionDuration}
@@ -105,6 +110,7 @@ function Dialog(props) {
         onExit={onExit}
         onExiting={onExiting}
         onExited={onExited}
+        {...TransitionProps}
       >
         <Paper
           data-mui-test="Dialog"
@@ -118,7 +124,7 @@ function Dialog(props) {
         >
           {children}
         </Paper>
-      </TransitionProp>
+      </components.Transition>
     </Modal>
   );
 }
@@ -140,6 +146,12 @@ Dialog.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The components injection property.
+   */
+  components: PropTypes.shape({
+    Transition: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  }),
   /**
    * If `true`, clicking the backdrop will not fire the `onClose` callback.
    */
@@ -222,15 +234,19 @@ Dialog.propTypes = {
     PropTypes.number,
     PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
   ]),
+  /**
+   * Properties applied to the `Transition` element.
+   */
+  TransitionProps: PropTypes.object,
 };
 
 Dialog.defaultProps = {
+  components: defaultComponents,
   disableBackdropClick: false,
   disableEscapeKeyDown: false,
   fullScreen: false,
   fullWidth: false,
   maxWidth: 'sm',
-  transition: Fade,
   transitionDuration: { enter: duration.enteringScreen, exit: duration.leavingScreen },
 };
 

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -28,7 +28,7 @@ describe('<Dialog />', () => {
   it('should render a Modal with transition', () => {
     const Transition = props => <div className="cloned-element-class" {...props} />;
     const wrapper = shallow(
-      <Dialog {...defaultProps} transition={Transition}>
+      <Dialog {...defaultProps} components={{ Transition }}>
         foo
       </Dialog>,
     );

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -43,9 +43,7 @@ export const styles = theme => ({
     // We disable the focus ring for mouse, touch and keyboard users.
     // At some point, it would be better to keep it for keyboard users.
     // :focus-ring CSS pseudo-class will help.
-    '&:focus': {
-      outline: 'none',
-    },
+    outline: 'none',
   },
   paperAnchorLeft: {
     left: 0,
@@ -83,7 +81,7 @@ export const styles = theme => ({
   paperAnchorDockedBottom: {
     borderTop: `1px solid ${theme.palette.divider}`,
   },
-  modal: {}, // Just here so people can override the style.
+  modal: {},
 });
 
 /**

--- a/packages/material-ui/src/Input/Textarea.js
+++ b/packages/material-ui/src/Input/Textarea.js
@@ -22,6 +22,7 @@ export const styles = {
     boxSizing: 'border-box',
     lineHeight: 'inherit',
     border: 'none',
+    // We disable the focus ring for mouse, touch and keyboard users.
     outline: 'none',
     background: 'transparent',
   },

--- a/packages/material-ui/src/List/ListItem.d.ts
+++ b/packages/material-ui/src/List/ListItem.d.ts
@@ -10,7 +10,9 @@ export interface ListItemProps
     > {
   button?: boolean;
   component?: React.ReactType<ListItemProps>;
-  ContainerComponent?: React.ReactType<React.HTMLAttributes<HTMLDivElement>>;
+  components: {
+    Container?: React.ReactType<React.HTMLAttributes<HTMLDivElement>>;
+  };
   ContainerProps?: React.HTMLAttributes<HTMLDivElement>;
   dense?: boolean;
   disabled?: boolean;

--- a/packages/material-ui/src/List/ListItem.js
+++ b/packages/material-ui/src/List/ListItem.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import ButtonBase from '../ButtonBase';
 import { isMuiElement } from '../utils/reactHelpers';
+import { getComponents } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -58,6 +59,10 @@ export const styles = theme => ({
   },
 });
 
+const defaultComponents = {
+  Container: 'li',
+};
+
 class ListItem extends React.Component {
   getChildContext() {
     return {
@@ -72,7 +77,7 @@ class ListItem extends React.Component {
       classes,
       className: classNameProp,
       component: componentProp,
-      ContainerComponent,
+      components: componentsProp,
       ContainerProps: { className: ContainerClassName, ...ContainerProps } = {},
       dense,
       disabled,
@@ -80,6 +85,8 @@ class ListItem extends React.Component {
       divider,
       ...other
     } = this.props;
+
+    const components = getComponents(defaultComponents, this.props);
 
     const isDense = dense || this.context.dense || false;
     const children = React.Children.toArray(childrenProp);
@@ -114,7 +121,7 @@ class ListItem extends React.Component {
       Component = !componentProps.component && !componentProp ? 'div' : Component;
 
       // Avoid nesting of li > li.
-      if (ContainerComponent === 'li') {
+      if (components.Container === 'li') {
         if (Component === 'li') {
           Component = 'div';
         } else if (componentProps.component === 'li') {
@@ -123,13 +130,13 @@ class ListItem extends React.Component {
       }
 
       return (
-        <ContainerComponent
+        <components.Container
           className={classNames(classes.container, ContainerClassName)}
           {...ContainerProps}
         >
           <Component {...componentProps}>{children}</Component>
           {children.pop()}
-        </ContainerComponent>
+        </components.Container>
       );
     }
 
@@ -161,9 +168,12 @@ ListItem.propTypes = {
    */
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   /**
-   * The container component. Useful when a `ListItemSecondaryAction` is rendered.
+   * The components injection property.
+   * `Container` is useful when a `ListItemSecondaryAction` is rendered.
    */
-  ContainerComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  components: PropTypes.shape({
+    Container: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  }),
   /**
    * Properties applied to the container element when the component
    * is used to display a `ListItemSecondaryAction`.
@@ -189,7 +199,7 @@ ListItem.propTypes = {
 
 ListItem.defaultProps = {
   button: false,
-  ContainerComponent: 'li',
+  components: defaultComponents,
   dense: false,
   disabled: false,
   disableGutters: false,

--- a/packages/material-ui/src/List/ListItem.test.js
+++ b/packages/material-ui/src/List/ListItem.test.js
@@ -135,9 +135,9 @@ describe('<ListItem />', () => {
       assert.strictEqual(wrapper.childAt(0).type(), ButtonBase);
     });
 
-    it('should accept a ContainerComponent property', () => {
+    it('should accept a components property', () => {
       const wrapper = shallow(
-        <ListItem ContainerComponent="div">
+        <ListItem components={{ Container: 'div' }}>
           <ListItemText primary="primary" />
           <ListItemSecondaryAction />
         </ListItem>,

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -8,8 +8,10 @@ export interface ModalProps
       React.HtmlHTMLAttributes<HTMLDivElement> & Partial<PortalProps>,
       ModalClassKey
     > {
-  BackdropComponent?: React.ReactType<BackdropProps>;
   BackdropProps?: Partial<BackdropProps>;
+  components?: {
+    Backdrop: React.ReactType<BackdropProps>;
+  };
   disableAutoFocus?: boolean;
   disableBackdropClick?: boolean;
   disableEnforceFocus?: boolean;

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StandardProps } from '..';
-import { SnackbarContentProps } from '.';
+import { ContentProps } from '.';
 import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
 
 export type SnackBarOrigin = {
@@ -23,7 +23,7 @@ export interface SnackbarProps
   onMouseLeave?: React.MouseEventHandler<any>;
   open: boolean;
   resumeHideDuration?: number;
-  SnackbarContentProps?: Partial<SnackbarContentProps>;
+  ContentProps?: Partial<ContentProps>;
   transition?: React.ReactType;
   transitionDuration?: TransitionProps['timeout'];
 }

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -365,7 +365,7 @@ describe('<Snackbar />', () => {
   describe('prop: transition', () => {
     it('should render a Snackbar with transition', () => {
       const Transition = props => <div className="cloned-element-class" {...props} />;
-      const wrapper = shallow(<Snackbar open transition={Transition} />);
+      const wrapper = shallow(<Snackbar open components={{ Transition }} />);
       assert.strictEqual(
         wrapper.find(Transition).length,
         1,

--- a/packages/material-ui/src/Snackbar/SnackbarContent.d.ts
+++ b/packages/material-ui/src/Snackbar/SnackbarContent.d.ts
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
 
-export interface SnackbarContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
+export interface ContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
   action?: React.ReactElement<any>;
   message: React.ReactElement<any> | string;
 }
 
 export type SnackbarContentClassKey = 'root' | 'message' | 'action';
 
-declare const SnackbarContent: React.ComponentType<SnackbarContentProps>;
+declare const SnackbarContent: React.ComponentType<ContentProps>;
 
 export default SnackbarContent;

--- a/packages/material-ui/src/Stepper/StepContent.js
+++ b/packages/material-ui/src/Stepper/StepContent.js
@@ -4,6 +4,7 @@ import warning from 'warning';
 import classNames from 'classnames';
 import Collapse from '../transitions/Collapse';
 import withStyles from '../styles/withStyles';
+import { getComponents } from '../utils/helpers';
 
 export const styles = theme => ({
   root: {
@@ -21,6 +22,10 @@ export const styles = theme => ({
   transition: {},
 });
 
+const defaultComponents = {
+  Transition: Collapse,
+};
+
 function StepContent(props) {
   const {
     active,
@@ -29,11 +34,12 @@ function StepContent(props) {
     classes,
     className,
     completed,
+    components: componentsProp,
     last,
     optional,
     orientation,
-    transition: Transition,
     transitionDuration,
+    TransitionProps,
     ...other
   } = props;
 
@@ -42,16 +48,19 @@ function StepContent(props) {
     'Material-UI: <StepContent /> is only designed for use with the vertical stepper.',
   );
 
+  const components = getComponents(defaultComponents, props);
+
   return (
     <div className={classNames(classes.root, { [classes.last]: last }, className)} {...other}>
-      <Transition
+      <components.Transition
         in={active}
         className={classes.transition}
         timeout={transitionDuration}
         unmountOnExit
+        {...TransitionProps}
       >
         {children}
-      </Transition>
+      </components.Transition>
     </div>
   );
 }
@@ -84,6 +93,12 @@ StepContent.propTypes = {
    */
   completed: PropTypes.bool,
   /**
+   * The components injection property.
+   */
+  components: PropTypes.shape({
+    Transition: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  }),
+  /**
    * @ignore
    */
   last: PropTypes.bool,
@@ -97,10 +112,6 @@ StepContent.propTypes = {
    */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   /**
-   * Collapse component.
-   */
-  transition: PropTypes.func,
-  /**
    * Adjust the duration of the content expand transition.
    * Passed as a property to the transition component.
    *
@@ -111,10 +122,14 @@ StepContent.propTypes = {
     PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
     PropTypes.oneOf(['auto']),
   ]),
+  /**
+   * Properties applied to the `Transition` element.
+   */
+  TransitionProps: PropTypes.object,
 };
 
 StepContent.defaultProps = {
-  transition: Collapse,
+  components: defaultComponents,
   transitionDuration: 'auto',
 };
 

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -28,13 +28,6 @@ export function reset() {
 }
 
 class SwipeableDrawer extends React.Component {
-  static getDerivedStateFromProps() {
-    // Reset the maybeSwiping state everytime we receive new properties.
-    return {
-      maybeSwiping: false,
-    };
-  }
-
   state = {};
 
   componentDidMount() {
@@ -354,6 +347,13 @@ class SwipeableDrawer extends React.Component {
     );
   }
 }
+
+SwipeableDrawer.getDerivedStateFromProps = () => {
+  // Reset the maybeSwiping state everytime we receive new properties.
+  return {
+    maybeSwiping: false,
+  };
+};
 
 SwipeableDrawer.propTypes = {
   /**

--- a/packages/material-ui/src/Table/TablePagination.d.ts
+++ b/packages/material-ui/src/Table/TablePagination.d.ts
@@ -13,7 +13,6 @@ export interface LabelDisplayedRowsArgs {
 
 export interface TablePaginationProps
   extends StandardProps<TablePaginationBaseProps, TablePaginationClassKey> {
-  Actions?: React.ReactType<TablePaginationBaseProps>;
   backIconButtonProps?: Partial<IconButtonProps>;
   component?: React.ReactType<TablePaginationBaseProps>;
   count: number;

--- a/packages/material-ui/src/Table/TablePagination.js
+++ b/packages/material-ui/src/Table/TablePagination.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import withStyles from '../styles/withStyles';
+import { getComponents } from '../utils/helpers';
 import Input from '../Input';
 import { MenuItem } from '../Menu';
 import Select from '../Select';
@@ -51,7 +52,12 @@ export const styles = theme => ({
     color: theme.palette.text.secondary,
     marginLeft: theme.spacing.unit * 2.5,
   },
+  menuItem: {},
 });
+
+const defaultComponents = {
+  Actions: TablePaginationActions,
+};
 
 /**
  * A `TableCell` based component for placing inside `TableFooter` for pagination.
@@ -69,11 +75,11 @@ class TablePagination extends React.Component {
 
   render() {
     const {
-      Actions,
       backIconButtonProps,
       classes,
       colSpan: colSpanProp,
       component: Component,
+      components: componentsProp,
       count,
       labelDisplayedRows,
       labelRowsPerPage,
@@ -88,6 +94,8 @@ class TablePagination extends React.Component {
     } = this.props;
 
     let colSpan;
+
+    const components = getComponents(defaultComponents, this.props);
 
     if (Component === TableCell || Component === 'td') {
       colSpan = colSpanProp || 1000; // col-span over everything
@@ -115,7 +123,11 @@ class TablePagination extends React.Component {
               {...SelectProps}
             >
               {rowsPerPageOptions.map(rowsPerPageOption => (
-                <MenuItem key={rowsPerPageOption} value={rowsPerPageOption}>
+                <MenuItem
+                  className={classes.menuItem}
+                  key={rowsPerPageOption}
+                  value={rowsPerPageOption}
+                >
                   {rowsPerPageOption}
                 </MenuItem>
               ))}
@@ -129,7 +141,7 @@ class TablePagination extends React.Component {
               page,
             })}
           </Typography>
-          <Actions
+          <components.Actions
             className={classes.actions}
             backIconButtonProps={backIconButtonProps}
             count={count}
@@ -145,11 +157,6 @@ class TablePagination extends React.Component {
 }
 
 TablePagination.propTypes = {
-  /**
-   * The component used for displaying the actions.
-   * Either a string to use a DOM element or a component.
-   */
-  Actions: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   /**
    * Properties applied to the back arrow `IconButton` component.
    */
@@ -167,6 +174,12 @@ TablePagination.propTypes = {
    * Either a string to use a DOM element or a component.
    */
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  /**
+   * The components injection property.
+   */
+  components: PropTypes.shape({
+    Actions: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  }),
   /**
    * The total number of rows.
    */
@@ -217,8 +230,8 @@ TablePagination.propTypes = {
 };
 
 TablePagination.defaultProps = {
-  Actions: TablePaginationActions,
   component: TableCell,
+  components: defaultComponents,
   labelDisplayedRows: ({ from, to, count }) => `${from}-${to} of ${count}`,
   labelRowsPerPage: 'Rows per page:',
   rowsPerPageOptions: [5, 10, 25],

--- a/packages/material-ui/src/Table/TableRow.js
+++ b/packages/material-ui/src/Table/TableRow.js
@@ -9,19 +9,18 @@ export const styles = theme => ({
     display: 'table-row',
     height: 48,
     verticalAlign: 'middle',
-    '&:focus': {
-      outline: 'none',
-    },
+    // We disable the focus ring for mouse, touch and keyboard users.
+    outline: 'none',
     '&$selected': {
       backgroundColor:
         theme.palette.type === 'light'
-          ? 'rgba(0, 0, 0, 0.04)' // grey[100]
+          ? 'rgba(0, 0, 0, 0.04)' // grey[100] but with opacity
           : 'rgba(255, 255, 255, 0.08)',
     },
     '&$hover:hover': {
       backgroundColor:
         theme.palette.type === 'light'
-          ? 'rgba(0, 0, 0, 0.07)' // grey[200]
+          ? 'rgba(0, 0, 0, 0.07)' // grey[200] but with opacity
           : 'rgba(255, 255, 255, 0.14)',
     },
   },

--- a/packages/material-ui/src/utils/helpers.js
+++ b/packages/material-ui/src/utils/helpers.js
@@ -62,3 +62,13 @@ export function createChainedFunction(...funcs: Array<any>) {
     () => {},
   );
 }
+
+export function getComponents(defaultComponents, props) {
+  return {
+    ...defaultComponents,
+    ...Object.keys(props.components || {}).reduce((accumulator, key) => {
+      accumulator[key] = props.components[key];
+      return accumulator;
+    }, {}),
+  };
+}

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -450,7 +450,7 @@ const ListTest = () => (
         </ListItemSecondaryAction>
       </ListItem>
     ))}
-    <ListItem ContainerComponent="div" ContainerProps={{ className: 'demo' }}>
+    <ListItem components={{ Container: 'div' }} ContainerProps={{ className: 'demo' }}>
       an item
     </ListItem>
   </List>
@@ -573,7 +573,7 @@ const SnackbarTest = () => (
       open={true}
       autoHideDuration={6e3}
       onClose={event => log(event)}
-      SnackbarContentProps={
+      ContentProps={
         {
           // 'aria-describedby': 'message-id',
           // ^ will work once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22582 is merged.

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -14,6 +14,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children *</span> | <span class="prop-type">node |  | Dialog children, usually the included sub-components. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">components</span> | <span class="prop-type">{Transition?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>} | <span class="prop-default">{  Transition: Fade,}</span> | The components injection property. |
 | <span class="prop-name">disableBackdropClick</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, clicking the backdrop will not fire the `onClose` callback. |
 | <span class="prop-name">disableEscapeKeyDown</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, hitting escape will not fire the `onClose` callback. |
 | <span class="prop-name">fullScreen</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the dialog will be full-screen |
@@ -30,8 +31,9 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | <span class="prop-name">onExiting</span> | <span class="prop-type">func |  | Callback fired when the dialog is exiting. |
 | <span class="prop-name required">open *</span> | <span class="prop-type">bool |  | If `true`, the Dialog is open. |
 | <span class="prop-name">PaperProps</span> | <span class="prop-type">object |  | Properties applied to the `Paper` element. |
-| <span class="prop-name">transition</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">Fade</span> | Transition component. |
+| <span class="prop-name">transition</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> |  | Transition component. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/List/ListItem.js
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> |  | The component used for the root node. Either a string to use a DOM element or a component. By default, it's a `li` when `button` is `false` and a `div` when `button` is `true`. |
-| <span class="prop-name">ContainerComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'li'</span> | The container component. Useful when a `ListItemSecondaryAction` is rendered. |
+| <span class="prop-name">components</span> | <span class="prop-type">{Container?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>} | <span class="prop-default">{  Container: 'li',}</span> | The components injection property. `Container` is useful when a `ListItemSecondaryAction` is rendered. |
 | <span class="prop-name">ContainerProps</span> | <span class="prop-type">object |  | Properties applied to the container element when the component is used to display a `ListItemSecondaryAction`. |
 | <span class="prop-name">dense</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, compact vertical padding designed for keyboard and mouse input will be used. |
 | <span class="prop-name">disableGutters</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the left and right padding is removed. |

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -12,10 +12,10 @@ filename: /packages/material-ui/src/Modal/Modal.js
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">BackdropComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">Backdrop</span> | A backdrop component. Useful for custom backdrop rendering. |
 | <span class="prop-name">BackdropProps</span> | <span class="prop-type">object |  | Properties applied to the `Backdrop` element. |
 | <span class="prop-name">children</span> | <span class="prop-type">element |  | A single child content element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">components</span> | <span class="prop-type">{Backdrop?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>} | <span class="prop-default">{  Backdrop,}</span> | The components injection property. |
 | <span class="prop-name">container</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br> |  | A node, component instance, or function that returns either. The `container` will have the portal children appended to it. |
 | <span class="prop-name">disableAutoFocus</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the modal will not automatically shift focus to itself when it opens, and replace it to the last focused element when it closes. This also works correctly with any modal children that have the `disableAutoFocus` prop.<br>Generally this should never be set to `true` as it makes the modal less accessible to assistive technologies, like screen readers. |
 | <span class="prop-name">disableBackdropClick</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, clicking the backdrop will not fire any callback. |

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -19,6 +19,7 @@ filename: /packages/material-ui/src/Popover/Popover.js
 | <span class="prop-name">anchorReference</span> | <span class="prop-type">enum:&nbsp;'anchorEl'&nbsp;&#124;<br>&nbsp;'anchorPosition'&nbsp;&#124;<br>&nbsp;'none'<br> | <span class="prop-default">'anchorEl'</span> |  |
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">components</span> | <span class="prop-type">{Transition?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>} | <span class="prop-default">{  Transition: Grow,}</span> | The components injection property. |
 | <span class="prop-name">container</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br> |  | A node, component instance, or function that returns either. The `container` will passed to the Modal component. By default, it's using the body of the anchorEl's top-level document object, so it's simply `document.body` most of the time. |
 | <span class="prop-name">elevation</span> | <span class="prop-type">number | <span class="prop-default">8</span> | The elevation of the popover. |
 | <span class="prop-name">getContentAnchorEl</span> | <span class="prop-type">func |  | This function is called in order to retrieve the content anchor element. It's the opposite of the `anchorEl` property. The content anchor element should be an element inside the popover. It's used to correctly scroll and set the position of the popover. The positioning strategy tries to make the content anchor element just above the anchor element. |
@@ -33,8 +34,8 @@ filename: /packages/material-ui/src/Popover/Popover.js
 | <span class="prop-name required">open *</span> | <span class="prop-type">bool |  | If `true`, the popover is visible. |
 | <span class="prop-name">PaperProps</span> | <span class="prop-type">object |  | Properties applied to the `Paper` element. |
 | <span class="prop-name">transformOrigin</span> | <span class="prop-type">{horizontal?: union:&nbsp;number&nbsp;&#124;<br>&nbsp;enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'center'&nbsp;&#124;<br>&nbsp;'right'<br><br>, vertical?: union:&nbsp;number&nbsp;&#124;<br>&nbsp;enum:&nbsp;'top'&nbsp;&#124;<br>&nbsp;'center'&nbsp;&#124;<br>&nbsp;'bottom'<br><br>} | <span class="prop-default">{  vertical: 'top',  horizontal: 'left',}</span> | This is the point on the popover which will attach to the anchor's origin.<br>Options: vertical: [top, center, bottom, x(px)]; horizontal: [left, center, right, x(px)]. |
-| <span class="prop-name">transition</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">Grow</span> | Transition component. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">'auto'</span> | Set to 'auto' to automatically calculate transition time based on height. |
+| <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -15,8 +15,10 @@ filename: /packages/material-ui/src/Snackbar/Snackbar.js
 | <span class="prop-name">action</span> | <span class="prop-type">node |  | The action to display. |
 | <span class="prop-name">anchorOrigin</span> | <span class="prop-type">{horizontal?: union:&nbsp;number&nbsp;&#124;<br>&nbsp;enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'center'&nbsp;&#124;<br>&nbsp;'right'<br><br>, vertical?: union:&nbsp;number&nbsp;&#124;<br>&nbsp;enum:&nbsp;'top'&nbsp;&#124;<br>&nbsp;'center'&nbsp;&#124;<br>&nbsp;'bottom'<br><br>} | <span class="prop-default">{  vertical: 'bottom',  horizontal: 'center',}</span> | The anchor of the `Snackbar`. |
 | <span class="prop-name">autoHideDuration</span> | <span class="prop-type">number |  | The number of milliseconds to wait before automatically calling the `onClose` function. `onClose` should then set the state of the `open` prop to hide the Snackbar. This behavior is disabled by default with the `null` value. |
-| <span class="prop-name">children</span> | <span class="prop-type">element |  | If you wish the take control over the children of the component you can use this property. When used, you replace the `SnackbarContent` component with the children. |
+| <span class="prop-name">children</span> | <span class="prop-type">element |  | If you wish the take control over the children of the component you can use this property. When used, you replace the `Content` component with the children. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">components</span> | <span class="prop-type">{Content?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>, Transition?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>} | <span class="prop-default">{  Content: SnackbarContent,  Transition: Slide,}</span> | The components injection property. |
+| <span class="prop-name">ContentProps</span> | <span class="prop-type">object |  | Properties applied to the `Content` element. |
 | <span class="prop-name">disableWindowBlurListener</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the `autoHideDuration` timer will expire even if the window is not focused. |
 | <span class="prop-name">key</span> | <span class="prop-type">any |  | When displaying multiple consecutive Snackbars from a parent rendering a single &lt;Snackbar/>, add the key property to ensure independent treatment of each message. e.g. &lt;Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled. |
 | <span class="prop-name">message</span> | <span class="prop-type">node |  | The message to display. |
@@ -29,9 +31,8 @@ filename: /packages/material-ui/src/Snackbar/Snackbar.js
 | <span class="prop-name">onExiting</span> | <span class="prop-type">func |  | Callback fired when the transition is exiting. |
 | <span class="prop-name">open</span> | <span class="prop-type">bool |  | If true, `Snackbar` is open. |
 | <span class="prop-name">resumeHideDuration</span> | <span class="prop-type">number |  | The number of milliseconds to wait before dismissing after user interaction. If `autoHideDuration` property isn't specified, it does nothing. If `autoHideDuration` property is specified but `resumeHideDuration` isn't, we default to `autoHideDuration / 2` ms. |
-| <span class="prop-name">SnackbarContentProps</span> | <span class="prop-type">object |  | Properties applied to the `SnackbarContent` element. |
-| <span class="prop-name">transition</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">Slide</span> | Transition component. |
-| <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -14,8 +14,9 @@ filename: /packages/material-ui/src/Stepper/StepContent.js
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | Step content. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
-| <span class="prop-name">transition</span> | <span class="prop-type">func | <span class="prop-default">Collapse</span> | Collapse component. |
+| <span class="prop-name">components</span> | <span class="prop-type">{Transition?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>} | <span class="prop-default">{  Transition: Collapse,}</span> | The components injection property. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">'auto'</span> | Adjust the duration of the content expand transition. Passed as a property to the transition component.<br>Set to 'auto' to automatically calculate transition time based on height. |
+| <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -12,10 +12,10 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">Actions</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">TablePaginationActions</span> | The component used for displaying the actions. Either a string to use a DOM element or a component. |
 | <span class="prop-name">backIconButtonProps</span> | <span class="prop-type">object |  | Properties applied to the back arrow `IconButton` component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">TableCell</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">components</span> | <span class="prop-type">{Actions?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>, MenuItem?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>} | <span class="prop-default">{  Actions: TablePaginationActions,  MenuItem,}</span> | The components injection property. |
 | <span class="prop-name required">count *</span> | <span class="prop-type">number |  | The total number of rows. |
 | <span class="prop-name">labelDisplayedRows</span> | <span class="prop-type">func | <span class="prop-default">({ from, to, count }) => `${from}-${to} of ${count}`</span> | Useful to customize the displayed rows label. |
 | <span class="prop-name">labelRowsPerPage</span> | <span class="prop-type">node | <span class="prop-default">'Rows per page:'</span> | Useful to customize the rows per page label. Invoked with a `{ from, to, count, page }` object. |

--- a/pages/lab/api/speed-dial.md
+++ b/pages/lab/api/speed-dial.md
@@ -16,13 +16,14 @@ filename: /packages/material-ui-lab/src/SpeedDial/SpeedDial.js
 | <span class="prop-name">ButtonProps</span> | <span class="prop-type">object |  | Properties applied to the `Button` element. |
 | <span class="prop-name required">children *</span> | <span class="prop-type">node |  | SpeedDialActions to display when the SpeedDial is `open`. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">components</span> | <span class="prop-type">{Transition?: union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br>} | <span class="prop-default">{  Transition: Zoom,}</span> | The components injection property. |
 | <span class="prop-name">hidden</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the SpeedDial will be hidden. |
 | <span class="prop-name required">icon *</span> | <span class="prop-type">element |  | The icon to display in the SpeedDial Floating Action Button. The `SpeedDialIcon` component provides a default Icon with animation. |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object, key: string) => void`<br>*event:* The event source of the callback<br>*key:* The key pressed |
 | <span class="prop-name required">open *</span> | <span class="prop-type">bool |  | If `true`, the SpeedDial is open. |
 | <span class="prop-name">openIcon</span> | <span class="prop-type">node |  | The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open. |
-| <span class="prop-name">transition</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">Zoom</span> | Transition component. |
-| <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 


### PR DESCRIPTION
- Closes #10720. People can use the `classes.menuItem` customization point to mess around. We can potentially add `components.MenuItem` in the future.
- Closes #10476. We keep the `xxxProps` properties as they are quite handy for simple configuration. We introduce a `components?: Object` property that can be used for all sort of customization. It's underused right now. But It should allow us to grow in the future stable releases. Also, it's providing some symetry with the `classes` property. Hopefully, it's simpler to understand this way.

I couldn't find a clean way to support the render prop pattern :/. Let's try again in the future. This shouldn't require breaking changes. 

### Breaking change

```diff
-<ListItem ContainerComponent="div">
+<ListItem components={{ Container: 'div' }}>
```