### PR TITLE
[Snackbar] Rename SnackbarContentProps

### DIFF
--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -75,7 +75,7 @@ class Notifications extends React.Component {
       <Snackbar
         key={message.id}
         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
-        SnackbarContentProps={{ 'aria-describedby': 'notification-message' }}
+        ContentProps={{ 'aria-describedby': 'notification-message' }}
         message={
           <span id="notification-message" dangerouslySetInnerHTML={{ __html: message.text }} />
         }

--- a/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
+++ b/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
@@ -73,7 +73,7 @@ class ConsecutiveSnackbars extends React.Component {
           autoHideDuration={6000}
           onClose={this.handleClose}
           onExited={this.handleExited}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">{message}</span>}

--- a/docs/src/pages/demos/snackbars/DirectionSnackbar.js
+++ b/docs/src/pages/demos/snackbars/DirectionSnackbar.js
@@ -44,7 +44,7 @@ class DirectionSnackbar extends React.Component {
           open={this.state.open}
           onClose={this.handleClose}
           transition={this.state.transition}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">I love snacks</span>}

--- a/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.js
+++ b/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.js
@@ -96,7 +96,7 @@ class FabIntegrationSnackbar extends React.Component {
             open={open}
             autoHideDuration={4000}
             onClose={this.handleClose}
-            SnackbarContentProps={{
+            ContentProps={{
               'aria-describedby': 'snackbar-fab-message-id',
               className: classes.snackbarContent,
             }}

--- a/docs/src/pages/demos/snackbars/FadeSnackbar.js
+++ b/docs/src/pages/demos/snackbars/FadeSnackbar.js
@@ -24,7 +24,7 @@ class FadeSnackbar extends React.Component {
           open={this.state.open}
           onClose={this.handleClose}
           transition={Fade}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">I love snacks</span>}

--- a/docs/src/pages/demos/snackbars/PositionedSnackbar.js
+++ b/docs/src/pages/demos/snackbars/PositionedSnackbar.js
@@ -43,7 +43,7 @@ class PositionedSnackbar extends React.Component {
           anchorOrigin={{ vertical, horizontal }}
           open={open}
           onClose={this.handleClose}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">I love snacks</span>}

--- a/docs/src/pages/demos/snackbars/SimpleSnackbar.js
+++ b/docs/src/pages/demos/snackbars/SimpleSnackbar.js
@@ -43,7 +43,7 @@ class SimpleSnackbar extends React.Component {
           open={this.state.open}
           autoHideDuration={6000}
           onClose={this.handleClose}
-          SnackbarContentProps={{
+          ContentProps={{
             'aria-describedby': 'message-id',
           }}
           message={<span id="message-id">Note archived</span>}

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -13,6 +13,7 @@ export interface DialogProps
   PaperProps?: Partial<PaperProps>;
   transition?: React.ReactType;
   transitionDuration?: TransitionProps['timeout'];
+  TransitionProps?: TransitionProps;
 }
 
 export type DialogClassKey =

--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -33,6 +33,7 @@ export interface PopoverProps
   transformOrigin?: PopoverOrigin;
   transition?: React.ReactType;
   transitionDuration?: TransitionProps['timeout'] | 'auto';
+  TransitionProps?: TransitionProps;
 }
 
 export type PopoverClassKey = 'paper';

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StandardProps } from '..';
-import { SnackbarContentProps } from '.';
+import { ContentProps } from '.';
 import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
 
 export type SnackBarOrigin = {
@@ -16,6 +16,7 @@ export interface SnackbarProps
   action?: React.ReactElement<any> | React.ReactElement<any>[];
   anchorOrigin?: SnackBarOrigin;
   autoHideDuration?: number;
+  ContentProps?: Partial<ContentProps>;
   disableWindowBlurListener?: boolean;
   message?: React.ReactElement<any>;
   onClose?: (event: React.SyntheticEvent<any>, reason: string) => void;
@@ -23,9 +24,9 @@ export interface SnackbarProps
   onMouseLeave?: React.MouseEventHandler<any>;
   open: boolean;
   resumeHideDuration?: number;
-  SnackbarContentProps?: Partial<SnackbarContentProps>;
   transition?: React.ReactType;
   transitionDuration?: TransitionProps['timeout'];
+  TransitionProps?: TransitionProps;
 }
 
 export type SnackbarClassKey =

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -194,6 +194,7 @@ class Snackbar extends React.Component {
       children,
       classes,
       className,
+      ContentProps,
       disableWindowBlurListener,
       message,
       onClose,
@@ -207,7 +208,6 @@ class Snackbar extends React.Component {
       onMouseLeave,
       open,
       resumeHideDuration,
-      SnackbarContentProps,
       transition: TransitionProp,
       transitionDuration,
       TransitionProps,
@@ -249,9 +249,7 @@ class Snackbar extends React.Component {
             direction={vertical === 'top' ? 'down' : 'up'}
             {...TransitionProps}
           >
-            {children || (
-              <SnackbarContent message={message} action={action} {...SnackbarContentProps} />
-            )}
+            {children || <SnackbarContent message={message} action={action} {...ContentProps} />}
           </TransitionProp>
         </div>
       </ClickAwayListener>
@@ -294,6 +292,10 @@ Snackbar.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * Properties applied to the `SnackbarContent` element.
+   */
+  ContentProps: PropTypes.object,
   /**
    * If `true`, the `autoHideDuration` timer will expire even if the window is not focused.
    */
@@ -363,10 +365,6 @@ Snackbar.propTypes = {
    * we default to `autoHideDuration / 2` ms.
    */
   resumeHideDuration: PropTypes.number,
-  /**
-   * Properties applied to the `SnackbarContent` element.
-   */
-  SnackbarContentProps: PropTypes.object,
   /**
    * Transition component.
    */

--- a/packages/material-ui/src/Snackbar/SnackbarContent.d.ts
+++ b/packages/material-ui/src/Snackbar/SnackbarContent.d.ts
@@ -2,13 +2,13 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
 
-export interface SnackbarContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
+export interface ContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
   action?: React.ReactElement<any>;
   message: React.ReactElement<any> | string;
 }
 
 export type SnackbarContentClassKey = 'root' | 'message' | 'action';
 
-declare const SnackbarContent: React.ComponentType<SnackbarContentProps>;
+declare const SnackbarContent: React.ComponentType<ContentProps>;
 
 export default SnackbarContent;

--- a/packages/material-ui/src/Stepper/StepContent.d.ts
+++ b/packages/material-ui/src/Stepper/StepContent.d.ts
@@ -14,6 +14,7 @@ export interface StepContentProps
   orientation?: Orientation;
   transition?: React.ComponentType<TransitionProps>;
   transitionDuration?: TransitionProps['timeout'] | 'auto';
+  TransitionProps?: TransitionProps;
 }
 
 export type StepContentClasskey = 'root' | 'last' | 'transition';

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -573,7 +573,7 @@ const SnackbarTest = () => (
       open={true}
       autoHideDuration={6e3}
       onClose={event => log(event)}
-      SnackbarContentProps={
+      ContentProps={
         {
           // 'aria-describedby': 'message-id',
           // ^ will work once https://github.com/DefinitelyTyped/DefinitelyTyped/pull/22582 is merged.

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -17,6 +17,7 @@ filename: /packages/material-ui/src/Snackbar/Snackbar.js
 | <span class="prop-name">autoHideDuration</span> | <span class="prop-type">number |  | The number of milliseconds to wait before automatically calling the `onClose` function. `onClose` should then set the state of the `open` prop to hide the Snackbar. This behavior is disabled by default with the `null` value. |
 | <span class="prop-name">children</span> | <span class="prop-type">element |  | If you wish the take control over the children of the component you can use this property. When used, you replace the `SnackbarContent` component with the children. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Useful to extend the style applied to components. |
+| <span class="prop-name">ContentProps</span> | <span class="prop-type">object |  | Properties applied to the `SnackbarContent` element. |
 | <span class="prop-name">disableWindowBlurListener</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the `autoHideDuration` timer will expire even if the window is not focused. |
 | <span class="prop-name">key</span> | <span class="prop-type">any |  | When displaying multiple consecutive Snackbars from a parent rendering a single &lt;Snackbar/>, add the key property to ensure independent treatment of each message. e.g. &lt;Snackbar key={message} />, otherwise, the message may update-in-place and features such as autoHideDuration may be canceled. |
 | <span class="prop-name">message</span> | <span class="prop-type">node |  | The message to display. |
@@ -29,7 +30,6 @@ filename: /packages/material-ui/src/Snackbar/Snackbar.js
 | <span class="prop-name">onExiting</span> | <span class="prop-type">func |  | Callback fired when the transition is exiting. |
 | <span class="prop-name">open</span> | <span class="prop-type">bool |  | If true, `Snackbar` is open. |
 | <span class="prop-name">resumeHideDuration</span> | <span class="prop-type">number |  | The number of milliseconds to wait before dismissing after user interaction. If `autoHideDuration` property isn't specified, it does nothing. If `autoHideDuration` property is specified but `resumeHideDuration` isn't, we default to `autoHideDuration / 2` ms. |
-| <span class="prop-name">SnackbarContentProps</span> | <span class="prop-type">object |  | Properties applied to the `SnackbarContent` element. |
 | <span class="prop-name">transition</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">Slide</span> | Transition component. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |


### PR DESCRIPTION
### Breaking change

This change is for consistency with the other components. No need to repeat the component name in the property.

```jsx
       <Snackbar
-        SnackbarContentProps={{ 'aria-describedby': 'notification-message' }}
+        ContentProps={{ 'aria-describedby': 'notification-message' }}
```