### PR TITLE
[Collapse] Fix flicker in Safari 9 when collapse finishes entering

### DIFF
--- a/packages/material-ui/src/transitions/Collapse.js
+++ b/packages/material-ui/src/transitions/Collapse.js
@@ -73,7 +73,10 @@ class Collapse extends React.Component {
   };
 
   handleEntered = node => {
+    const { transitionDuration } = node.style;
+    node.style.transitionDuration = '0s';
     node.style.height = 'auto';
+    node.style.transitionDuration = transitionDuration;
 
     if (this.props.onEntered) {
       this.props.onEntered(node);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
I noticed this on my own project and checked to confirm the issue is happening on the [demo page](https://material-ui-next.com/utils/transitions/). The issue can also be seen on https://material-ui.com Drawer Menu (when expanding any of the sub-navs).

The issue occurs both in the macOS and iOS versions of Safari 9.