### PR TITLE
[docs] Improve server-rendering, replace render by hydrate

### DIFF
--- a/docs/src/pages/guides/server-rendering/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering.md
@@ -30,7 +30,6 @@ If you're unfamiliar with Express or middleware, just know that our handleRender
 `server.js`
 
 ```js
-import path from 'path';
 import express from 'express';
 import React from 'react';
 import App from './App';
@@ -133,7 +132,7 @@ Let's take a look at our client file:
 
 ```jsx
 import React from 'react';
-import { render } from 'react-dom';
+import { hydrate } from 'react-dom';
 import { MuiThemeProvider, createMuiTheme } from 'material-ui/styles';
 import { green, red } from 'material-ui/colors';
 import App from './App';
@@ -161,7 +160,7 @@ const theme = createMuiTheme({
   },
 });
 
-render(
+hydrate(
   <MuiThemeProvider theme={theme}>
     <Main />
   </MuiThemeProvider>,


### PR DESCRIPTION
Replace render by hydrate to improve performance when JS client is loaded and avoid deprecation warning from React 16. (Render will be removed in React v17)
I also removed path import which was not used.

Source : https://stackoverflow.com/questions/46516395/whats-the-difference-between-hydrate-and-render-in-react-16

https://reactjs.org/docs/react-dom.html
> Using ReactDOM.render() to hydrate a server-rendered container is deprecated and will be removed in React 17. Use hydrate() instead

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
