### PR TITLE
[TextField] Increase shrunk label width to match 100% input width

### DIFF
--- a/packages/material-ui/src/Input/InputLabel.js
+++ b/packages/material-ui/src/Input/InputLabel.js
@@ -24,6 +24,7 @@ export const styles = theme => ({
   shrink: {
     transform: 'translate(0, 1.5px) scale(0.75)',
     transformOrigin: 'top left',
+    width: '133.33%',
   },
   animated: {
     transition: theme.transitions.create('transform', {


### PR DESCRIPTION
## Description of issue

Input label is shrunk using CSS `scale`. The 100% default width of that label makes it smaller than full input width. 

## Solution in this PR

Increasing accordingly the shrunk input label `width` let it occupy as much space as possible,
avoiding in some case the wrapping of text (which is very inelegant in this component).

## Side effects / misc

The width being increased, it means there is an inconsistency between unshrunk label unwrapped text capacity, and the shrunk one. It means that some text that is not wrapping when shrunk, would wrap when label is not shrunk.

I think that side effect is less problematic than the gain of this PR.

For example, many time the label is used in different ways when user started typing (hence in a shrunk state) : error state, display total of a sum, display additional information. Hence the benefit from having more space in this area - at least up to the parent input 100% width.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
