### PR TITLE
[StepButton] Allow null to be assigned to icon prop

### DIFF
--- a/packages/material-ui/src/Stepper/StepButton.d.ts
+++ b/packages/material-ui/src/Stepper/StepButton.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { Orientation } from './Stepper';
 import { ButtonBaseProps } from '../ButtonBase';
 
-export type StepButtonIcon = React.ReactElement<any> | string | number;
+export type StepButtonIcon = React.ReactElement<any> | string | number | null;
 
 export interface StepButtonProps extends StandardProps<ButtonBaseProps, StepButtonClasskey> {
   active?: boolean;


### PR DESCRIPTION
Allow `null` to be assigned to `StepButtonIcon` in `StepButton.d.ts`

fixes #11220 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
