### PR TITLE
[Tabs] Add a TabIndicatorProps property

### DIFF
--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -28,7 +28,7 @@ function TabIndicator(props) {
   const { classes, className, color, style, ...other } = props;
 
   const styleProps =
-    color !== 'primary' || color !== 'secondary'
+    color.toLowerCase() !== 'primary' || color.toLowerCase() !== 'secondary'
       ? {
           backgroundColor: color,
           ...style,
@@ -53,6 +53,10 @@ TabIndicator.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * @ignore
+   */
+  style: PropTypes.object,
   /**
    * @ignore
    * The color of the tab indicator.

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -19,6 +19,9 @@ export const styles = theme => ({
   colorSecondary: {
     backgroundColor: theme.palette.secondary.main,
   },
+  colorOther: color => ({
+    backgroundColor: color,
+  }),
 });
 
 /**
@@ -27,12 +30,10 @@ export const styles = theme => ({
 function TabIndicator(props) {
   const { classes, className, color, ...other } = props;
 
-  return (
-    <span
-      className={classNames(classes.root, classes[`color${capitalize(color)}`], className)}
-      {...other}
-    />
-  );
+  const condition = color !== 'primary' || color !== 'secondary';
+  const colorToApply = condition ? classes.colorOther(color) : classes[`color${capitalize(color)}`];
+
+  return <span className={classNames(classes.root, colorToApply, className)} {...other} />;
 }
 
 TabIndicator.propTypes = {

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -25,20 +25,11 @@ export const styles = theme => ({
  * @ignore - internal component.
  */
 function TabIndicator(props) {
-  const { classes, className, color, tabIndicatorProps, style, ...other } = props;
-
-  const styleProps =
-    Object.keys(tabIndicatorProps).length !== 0
-      ? {
-          ...tabIndicatorProps,
-          ...style,
-        }
-      : style;
+  const { classes, className, color, ...other } = props;
 
   return (
     <span
       className={classNames(classes.root, classes[`color${capitalize(color)}`], className)}
-      style={styleProps}
       {...other}
     />
   );
@@ -57,15 +48,7 @@ TabIndicator.propTypes = {
    * @ignore
    * The color of the tab indicator.
    */
-  color: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
-  /**
-   * @ignore
-   */
-  style: PropTypes.object,
-  /**
-   * Useful to extend or add custom style to component
-   */
-  tabIndicatorProps: PropTypes.object,
+  color: PropTypes.oneOf(['primary', 'secondary']),
 };
 
 export default withStyles(styles)(TabIndicator);

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -55,13 +55,13 @@ TabIndicator.propTypes = {
   className: PropTypes.string,
   /**
    * @ignore
-   */
-  style: PropTypes.object,
-  /**
-   * @ignore
    * The color of the tab indicator.
    */
   color: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
+  /**
+   * @ignore
+   */
+  style: PropTypes.object,
 };
 
 export default withStyles(styles)(TabIndicator);

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -25,12 +25,12 @@ export const styles = theme => ({
  * @ignore - internal component.
  */
 function TabIndicator(props) {
-  const { classes, className, color, style, ...other } = props;
+  const { classes, className, color, tabIndicatorProps, style, ...other } = props;
 
   const styleProps =
-    color.toLowerCase() !== 'primary' || color.toLowerCase() !== 'secondary'
+    Object.keys(tabIndicatorProps).length !== 0
       ? {
-          backgroundColor: color,
+          ...tabIndicatorProps,
           ...style,
         }
       : style;
@@ -62,6 +62,10 @@ TabIndicator.propTypes = {
    * @ignore
    */
   style: PropTypes.object,
+  /**
+   * Useful to extend or add custom style to component
+   */
+  tabIndicatorProps: PropTypes.object,
 };
 
 export default withStyles(styles)(TabIndicator);

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -19,21 +19,29 @@ export const styles = theme => ({
   colorSecondary: {
     backgroundColor: theme.palette.secondary.main,
   },
-  colorOther: color => ({
-    backgroundColor: color,
-  }),
 });
 
 /**
  * @ignore - internal component.
  */
 function TabIndicator(props) {
-  const { classes, className, color, ...other } = props;
+  const { classes, className, color, style, ...other } = props;
 
-  const condition = color !== 'primary' || color !== 'secondary';
-  const colorToApply = condition ? classes.colorOther(color) : classes[`color${capitalize(color)}`];
+  const styleProps =
+    color !== 'primary' || color !== 'secondary'
+      ? {
+          backgroundColor: color,
+          ...style,
+        }
+      : style;
 
-  return <span className={classNames(classes.root, colorToApply, className)} {...other} />;
+  return (
+    <span
+      className={classNames(classes.root, classes[`color${capitalize(color)}`], className)}
+      style={styleProps}
+      {...other}
+    />
+  );
 }
 
 TabIndicator.propTypes = {

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -48,7 +48,7 @@ TabIndicator.propTypes = {
    * @ignore
    * The color of the tab indicator.
    */
-  color: PropTypes.oneOf(['primary', 'secondary']),
+  color: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
 };
 
 export default withStyles(styles)(TabIndicator);

--- a/packages/material-ui/src/Tabs/Tabs.d.ts
+++ b/packages/material-ui/src/Tabs/Tabs.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { ButtonBaseProps } from '../ButtonBase/ButtonBase';
+import { TabIndicatorProps } from './TabIndicator';
 
 export interface TabsProps extends StandardProps<ButtonBaseProps, TabsClassKey, 'onChange'> {
   action?: (actions: TabsActions) => void;
@@ -12,6 +13,7 @@ export interface TabsProps extends StandardProps<ButtonBaseProps, TabsClassKey, 
   scrollable?: boolean;
   ScrollButtonComponent?: React.ReactType;
   scrollButtons?: 'auto' | 'on' | 'off';
+  TabIndicatorProps?: Partial<TabIndicatorProps>;
   textColor?: 'secondary' | 'primary' | 'inherit' | string;
   value: any;
   width?: string;

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -279,6 +279,7 @@ class Tabs extends React.Component {
       scrollable,
       ScrollButtonComponent,
       scrollButtons,
+      tabIndicatorProps,
       textColor,
       theme,
       value,
@@ -305,6 +306,7 @@ class Tabs extends React.Component {
         style={this.state.indicatorStyle}
         className={classes.indicator}
         color={indicatorColor}
+        tabIndicatorProps={tabIndicatorProps}
       />
     );
 
@@ -392,7 +394,7 @@ Tabs.propTypes = {
   /**
    * Determines the color of the indicator.
    */
-  indicatorColor: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
+  indicatorColor: PropTypes.oneOf(['secondary', 'primary']),
   /**
    * Callback fired when the value changes.
    *
@@ -417,6 +419,10 @@ Tabs.propTypes = {
    */
   scrollButtons: PropTypes.oneOf(['auto', 'on', 'off']),
   /**
+   * Determines a custom style for tab indicator
+   */
+  tabIndicatorProps: PropTypes.object,
+  /**
    * Determines the color of the `Tab`.
    */
   textColor: PropTypes.oneOf(['secondary', 'primary', 'inherit']),
@@ -439,6 +445,7 @@ Tabs.defaultProps = {
   ScrollButtonComponent: TabScrollButton,
   scrollButtons: 'auto',
   textColor: 'inherit',
+  tabIndicatorProps: {},
 };
 
 export default withStyles(styles, { name: 'MuiTabs', withTheme: true })(Tabs);

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -279,7 +279,7 @@ class Tabs extends React.Component {
       scrollable,
       ScrollButtonComponent,
       scrollButtons,
-      tabIndicatorProps,
+      TabIndicatorProps,
       textColor,
       theme,
       value,
@@ -306,7 +306,7 @@ class Tabs extends React.Component {
         style={this.state.indicatorStyle}
         className={classes.indicator}
         color={indicatorColor}
-        tabIndicatorProps={tabIndicatorProps}
+        {...TabIndicatorProps}
       />
     );
 
@@ -419,9 +419,9 @@ Tabs.propTypes = {
    */
   scrollButtons: PropTypes.oneOf(['auto', 'on', 'off']),
   /**
-   * Determines a custom style for tab indicator
+   * Properties applied to the `TabIndicator` element.
    */
-  tabIndicatorProps: PropTypes.object,
+  TabIndicatorProps: PropTypes.object,
   /**
    * Determines the color of the `Tab`.
    */
@@ -445,7 +445,6 @@ Tabs.defaultProps = {
   ScrollButtonComponent: TabScrollButton,
   scrollButtons: 'auto',
   textColor: 'inherit',
-  tabIndicatorProps: {},
 };
 
 export default withStyles(styles, { name: 'MuiTabs', withTheme: true })(Tabs);

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -392,7 +392,7 @@ Tabs.propTypes = {
   /**
    * Determines the color of the indicator.
    */
-  indicatorColor: PropTypes.oneOf(['secondary', 'primary']),
+  indicatorColor: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
   /**
    * Callback fired when the value changes.
    *

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -22,6 +22,7 @@ filename: /packages/material-ui/src/Tabs/Tabs.js
 | <span class="prop-name">scrollable</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | True invokes scrolling properties and allow for horizontally scrolling (or swiping) the tab bar. |
 | <span class="prop-name">ScrollButtonComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">TabScrollButton</span> | The component used to render the scroll buttons. |
 | <span class="prop-name">scrollButtons</span> | <span class="prop-type">enum:&nbsp;'auto'&nbsp;&#124;<br>&nbsp;'on'&nbsp;&#124;<br>&nbsp;'off'<br> | <span class="prop-default">'auto'</span> | Determine behavior of scroll buttons when tabs are set to scroll `auto` will only present them on medium and larger viewports `on` will always present them `off` will never present them |
+| <span class="prop-name">TabIndicatorProps</span> | <span class="prop-type">object |  | Properties applied to the `TabIndicator` element. |
 | <span class="prop-name">textColor</span> | <span class="prop-type">enum:&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'inherit'<br> | <span class="prop-default">'inherit'</span> | Determines the color of the `Tab`. |
 | <span class="prop-name">value</span> | <span class="prop-type">any |  | The value of the currently selected `Tab`. If you don't want any selected `Tab`, you can set this property to `false`. |
 


### PR DESCRIPTION
this is an initial commit change, I have just added a prop validation so that indicator color can accept a string also with secondary and primary.

Closes #11085