### PR TITLE
[Table] Fix Typescript classes support

### DIFF
--- a/packages/material-ui-codemod/src/v1.0.0/import-path.test.js
+++ b/packages/material-ui-codemod/src/v1.0.0/import-path.test.js
@@ -45,7 +45,7 @@ describe('@material-ui/codemod', () => {
           trim(expected),
           'The transformed version should be correct',
         );
-      })
+      });
     });
   });
 });

--- a/packages/material-ui-codemod/src/v1.0.0/import-path.test/actual.js
+++ b/packages/material-ui-codemod/src/v1.0.0/import-path.test/actual.js
@@ -1,22 +1,43 @@
-import React from 'react'
-import { withStyles } from 'material-ui/styles'
+import React from 'react';
+import { withStyles } from 'material-ui/styles';
 import { MenuItem } from 'material-ui/Menu';
 import MuiTabs, { Tab } from 'material-ui/Tabs';
 import BottomNavigation, { BottomNavigationAction } from 'material-ui/BottomNavigation';
 import Card, { CardActions, CardContent } from 'material-ui/Card';
 import { CardHeader, CardMedia } from 'material-ui/Card';
 import MuiCollapse from 'material-ui/transitions/Collapse';
-import List, { ListItemIcon, ListItem, ListItemAvatar, ListItemText, ListItemSecondaryAction } from 'material-ui/List';
+import List, {
+  ListItemIcon,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  ListItemSecondaryAction,
+} from 'material-ui/List';
 import Dialog, { DialogTitle } from 'material-ui/Dialog';
-import { withMobileDialog, DialogActions, DialogContent, DialogContentText } from 'material-ui/Dialog';
+import {
+  withMobileDialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+} from 'material-ui/Dialog';
 import Slide from 'material-ui/transitions/Slide';
 import Radio, { RadioGroup } from 'material-ui/Radio';
 import { FormControlLabel } from 'material-ui/Form';
-import ExpansionPanel, { ExpansionPanelSummary, ExpansionPanelDetails, ExpansionPanelActions } from 'material-ui/ExpansionPanel';
+import ExpansionPanel, {
+  ExpansionPanelSummary,
+  ExpansionPanelDetails,
+  ExpansionPanelActions,
+} from 'material-ui/ExpansionPanel';
 import GridList, { GridListTile } from 'material-ui/GridList';
 import { CircularProgress } from 'material-ui/Progress';
 import { LinearProgress as MuiLinearProgress } from 'material-ui/Progress';
-import { FormLabel, FormControl, FormGroup, FormControlLabel, FormHelperText } from 'material-ui/Form';
+import {
+  FormLabel,
+  FormControl,
+  FormGroup,
+  FormControlLabel,
+  FormHelperText,
+} from 'material-ui/Form';
 import Fade from 'material-ui/transitions/Fade';
 import Stepper, { Step, StepButton, StepContent } from 'material-ui/Stepper';
 import Table, {

--- a/packages/material-ui-codemod/src/v1.0.0/import-path.test/expected.js
+++ b/packages/material-ui-codemod/src/v1.0.0/import-path.test/expected.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import { withStyles } from 'material-ui/styles'
+import React from 'react';
+import { withStyles } from 'material-ui/styles';
 import MenuItem from 'material-ui/MenuItem';
 import Tab from 'material-ui/Tab';
 import MuiTabs from 'material-ui/Tabs';

--- a/packages/material-ui/src/Table/TableBody.d.ts
+++ b/packages/material-ui/src/Table/TableBody.d.ts
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import { StandardProps } from '..';
 
-export interface TableBodyProps extends TableBodyBaseProps {
+export interface TableBodyProps extends StandardProps<TableBodyBaseProps, TableBodyClassKey> {
   component?: React.ReactType<TableBodyBaseProps>;
 }
+
+export type TableBodyClassKey = 'root';
 
 export type TableBodyBaseProps = React.HTMLAttributes<HTMLTableSectionElement>;
 

--- a/packages/material-ui/src/Table/TableBody.test.js
+++ b/packages/material-ui/src/Table/TableBody.test.js
@@ -2,14 +2,16 @@
 
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from '../test-utils';
+import { createShallow, getClasses } from '../test-utils';
 import TableBody from './TableBody';
 
 describe('<TableBody />', () => {
   let shallow;
+  let classes;
 
   before(() => {
     shallow = createShallow({ dive: true });
+    classes = getClasses(<TableBody>foo</TableBody>);
   });
 
   it('should render a tbody', () => {
@@ -22,9 +24,10 @@ describe('<TableBody />', () => {
     assert.strictEqual(wrapper.name(), 'div');
   });
 
-  it('should render with the user and class', () => {
+  it('should render with the user and root class', () => {
     const wrapper = shallow(<TableBody className="woofTableBody">foo</TableBody>);
     assert.strictEqual(wrapper.hasClass('woofTableBody'), true);
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render children', () => {

--- a/packages/material-ui/src/Table/TableHead.d.ts
+++ b/packages/material-ui/src/Table/TableHead.d.ts
@@ -1,8 +1,11 @@
 import * as React from 'react';
+import { StandardProps } from '..';
 
-export interface TableHeadProps extends TableHeadBaseProps {
+export interface TableHeadProps extends StandardProps<TableHeadBaseProps, TableHeadClassKey> {
   component?: React.ReactType<TableHeadBaseProps>;
 }
+
+export type TableHeadClassKey = 'root';
 
 export type TableHeadBaseProps = React.HTMLAttributes<HTMLTableSectionElement>;
 

--- a/packages/material-ui/src/Table/TableHead.test.js
+++ b/packages/material-ui/src/Table/TableHead.test.js
@@ -9,7 +9,7 @@ describe('<TableHead />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    classes = getClasses(<TableHead />);
+    classes = getClasses(<TableHead>foo</TableHead>);
   });
 
   it('should render a thead', () => {

--- a/packages/material-ui/src/Table/TableHead.test.js
+++ b/packages/material-ui/src/Table/TableHead.test.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow } from '../test-utils';
+import { createShallow, getClasses } from '../test-utils';
 import TableHead from './TableHead';
 
 describe('<TableHead />', () => {
   let shallow;
+  let classes;
 
   before(() => {
     shallow = createShallow({ dive: true });
+    classes = getClasses(<TableHead />);
   });
 
   it('should render a thead', () => {
@@ -20,9 +22,10 @@ describe('<TableHead />', () => {
     assert.strictEqual(wrapper.name(), 'div');
   });
 
-  it('should render with the user class', () => {
+  it('should render with the user and root class', () => {
     const wrapper = shallow(<TableHead className="woofTableHead">foo</TableHead>);
     assert.strictEqual(wrapper.hasClass('woofTableHead'), true);
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render children', () => {

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -660,7 +660,7 @@ const StepperTest = () =>
   };
 
 const TableTest = () => {
-  const styles: StyleRulesCallback<'paper'> = theme => {
+  const styles: StyleRulesCallback<'paper' | 'thead'> = theme => {
     const backgroundColor: string = theme.palette.secondary.light;
     return {
       paper: {
@@ -669,6 +669,9 @@ const TableTest = () => {
         backgroundColor,
         overflowX: 'auto',
       },
+      thead: {
+        backgroundColor
+      }
     };
   };
 
@@ -686,13 +689,13 @@ const TableTest = () => {
     createData('Gingerbread', 356, 16.0, 49, 3.9),
   ];
 
-  function BasicTable(props: WithStyles<'paper'>) {
+  function BasicTable(props: WithStyles<'paper' | 'thead'>) {
     const classes = props.classes;
 
     return (
       <Paper className={classes.paper}>
         <Table>
-          <TableHead>
+          <TableHead classes={{root: classes.thead}}>
             <TableRow>
               <TableCell>Dessert (100g serving)</TableCell>
               <TableCell numeric>Calories</TableCell>

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -660,7 +660,7 @@ const StepperTest = () =>
   };
 
 const TableTest = () => {
-  const styles: StyleRulesCallback<'paper' | 'thead'> = theme => {
+  const styles: StyleRulesCallback<'paper'> = theme => {
     const backgroundColor: string = theme.palette.secondary.light;
     return {
       paper: {
@@ -668,9 +668,6 @@ const TableTest = () => {
         marginTop: theme.spacing.unit * 3,
         backgroundColor,
         overflowX: 'auto',
-      },
-      thead: {
-        backgroundColor
       }
     };
   };
@@ -689,13 +686,13 @@ const TableTest = () => {
     createData('Gingerbread', 356, 16.0, 49, 3.9),
   ];
 
-  function BasicTable(props: WithStyles<'paper' | 'thead'>) {
+  function BasicTable(props: WithStyles<'paper'>) {
     const classes = props.classes;
 
     return (
       <Paper className={classes.paper}>
         <Table>
-          <TableHead classes={{root: classes.thead}}>
+          <TableHead>
             <TableRow>
               <TableCell>Dessert (100g serving)</TableCell>
               <TableCell numeric>Calories</TableCell>

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -55,7 +55,9 @@ import {
   Table,
   TableBody,
   TableCell,
+  TableFooter,
   TableHead,
+  TablePagination,
   TableRow,
   Tabs,
   TextField,
@@ -668,7 +670,7 @@ const TableTest = () => {
         marginTop: theme.spacing.unit * 3,
         backgroundColor,
         overflowX: 'auto',
-      }
+      },
     };
   };
 
@@ -692,7 +694,7 @@ const TableTest = () => {
     return (
       <Paper className={classes.paper}>
         <Table>
-          <TableHead>
+          <TableHead classes={{ root: 'foo' }}>
             <TableRow>
               <TableCell>Dessert (100g serving)</TableCell>
               <TableCell numeric>Calories</TableCell>
@@ -714,6 +716,11 @@ const TableTest = () => {
               );
             })}
           </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TablePagination count={2} rowsPerPage={1} page={1} onChangePage={() => {}} />
+            </TableRow>
+          </TableFooter>
         </Table>
       </Paper>
     );


### PR DESCRIPTION
Update typing definition for `TableBody`, `TableHead` to fix the issue raised in: #11182.

In this PR:

- Update `TableBodyProps` and `TableHeadProps`
- Add tests to check for root class being rendered with the component

Closes #11182