### PR TITLE
[typescript] Make react-popper a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "react-dom": "^16.2.0",
     "react-inspector": "^2.2.2",
     "react-number-format": "^3.0.2",
+    "react-popper": "^0.10.0",
     "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -32,7 +32,8 @@
   },
   "peerDependencies": {
     "react": "^15.3.0 || ^16.0.0",
-    "react-dom": "^15.3.0 || ^16.0.0"
+    "react-dom": "^15.3.0 || ^16.0.0",
+    "react-popper": "^0.10.0"
   },
   "dependencies": {
     "@types/jss": "^9.3.0",
@@ -57,7 +58,6 @@
     "react-event-listener": "^0.5.1",
     "react-jss": "^8.1.0",
     "react-lifecycles-compat": "^3.0.0",
-    "react-popper": "^0.10.0",
     "react-scrollbar-size": "^2.0.2",
     "react-transition-group": "^2.2.1",
     "recompose": "^0.26.0 || ^0.27.0",


### PR DESCRIPTION
In `Tooltip/Tooltip.d.ts` you `import 'react-popper'` and then expose the imported `IPopperProps` interface through the exported `TooltipProps`.

You are only allowed to expose imported properties of peer dependencies, not regular dependencies. This causes issues when trying to use `material-ui` with a typescript project such as this: https://github.com/mui-org/material-ui/issues/11266