### PR TITLE
[typescript] Fix withStyles edge cases, require TS 2.8

### DIFF
--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -1,7 +1,7 @@
 # TypeScript
 
 You can add static typing to JavaScript to improve developer productivity and code quality thanks to [TypeScript](https://www.typescriptlang.org/).
-Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/v1-beta/examples/create-react-app-with-typescript) example.
+Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/v1-beta/examples/create-react-app-with-typescript) example. A minimum version of TypeScript 2.8 is required.
 
 ## Usage of `withStyles`
 

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -40,14 +40,13 @@ export interface Color {
  */
 
 /** @internal */
-type Diff<T extends string, U extends string> = ({ [P in T]: P } &
-  { [P in U]: never } & { [x: string]: never })[T];
-
-/** @internal */
-export type Omit<T, K extends keyof T> = Pick<T, Diff<keyof T, K>>;
+export type Omit<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
 
 /** @internal */
 export type ConsistentWith<O> = Partial<O> & Record<string, any>;
+
+/** @internal */
+export type Replace<T, U> = (U extends Pick<T, keyof T & keyof U> ? T : Omit<T, keyof U>) & U;
 
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -46,7 +46,7 @@ export type Omit<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
 export type ConsistentWith<O> = Partial<O> & Record<string, any>;
 
 /** @internal */
-export type Replace<T, U> = (U extends Pick<T, keyof T & keyof U> ? T : Omit<T, keyof U>) & U;
+export type Overwrite<T, U> = (U extends Pick<T, keyof T & keyof U> ? T : Omit<T, keyof U>) & U;
 
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -49,7 +49,7 @@ export type Omit<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
 export type ConsistentWith<T, U> = Pick<U, keyof T & keyof U>;
 
 /**
- * Like `T & U`, but using the value type from `U` where their properties overlap.
+ * Like `T & U`, but using the value types from `U` where their properties overlap.
  *
  * @internal
  */

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -35,11 +35,6 @@ export interface Color {
 }
 
 /**
- * Utilies types based on:
- * https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
- */
-
-/**
  * Remove properties `K` from `T`.
  *
  * @internal

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -7,11 +7,10 @@ export { StyledComponentProps };
  * certain `classes`, on which one can also set a top-level `className` and inline
  * `style`.
  */
-export type StandardProps<C, ClassKey extends string, Removals extends keyof C = never> = Omit<
-  C & { classes: any },
-  'classes' | Removals
-> &
-  StyledComponentProps<ClassKey> & {
+export type StandardProps<C, ClassKey extends string, Removals extends keyof C = never> =
+  & Omit<C, 'classes' | Removals>
+  & StyledComponentProps<ClassKey>
+  & {
     className?: string;
     style?: React.CSSProperties;
   };

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -41,19 +41,19 @@ export interface Color {
 export type Omit<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
 
 /**
- * `T extends ConsistentWith<U>` means that where `T` has overlapping properties with
+ * `T extends ConsistentWith<T, U>` means that where `T` has overlapping properties with
  * `U`, their value types do not conflict.
  *
  * @internal
  */
-export type ConsistentWith<O> = Partial<O> & Record<string, any>;
+export type ConsistentWith<T, U> = Pick<U, keyof T & keyof U>;
 
 /**
  * Like `T & U`, but using the value type from `U` where their properties overlap.
  *
  * @internal
  */
-export type Overwrite<T, U> = (U extends Pick<T, keyof T & keyof U> ? T : Omit<T, keyof U>) & U;
+export type Overwrite<T, U> = (U extends ConsistentWith<U, T> ? T : Omit<T, keyof U>) & U;
 
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -39,13 +39,26 @@ export interface Color {
  * https://github.com/Microsoft/TypeScript/issues/12215#issuecomment-307871458
  */
 
-/** @internal */
+/**
+ * Remove properties `K` from `T`.
+ *
+ * @internal
+ */
 export type Omit<T, K extends string> = Pick<T, Exclude<keyof T, K>>;
 
-/** @internal */
+/**
+ * `T extends ConsistentWith<U>` means that where `T` has overlapping properties with
+ * `U`, their value types do not conflict.
+ *
+ * @internal
+ */
 export type ConsistentWith<O> = Partial<O> & Record<string, any>;
 
-/** @internal */
+/**
+ * Like `T & U`, but using the value type from `U` where their properties overlap.
+ *
+ * @internal
+ */
 export type Overwrite<T, U> = (U extends Pick<T, keyof T & keyof U> ? T : Omit<T, keyof U>) & U;
 
 export namespace PropTypes {

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WithTheme } from '../styles/withTheme';
-import { ConsistentWith } from '..';
+import { ConsistentWith, Replace } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 
@@ -49,10 +49,7 @@ export default function withStyles<ClassKey extends string>(
   style: StyleRules<ClassKey> | StyleRulesCallback<ClassKey>,
   options?: WithStylesOptions,
 ): {
-  (component: React.ComponentType<WithStyles<ClassKey>>): React.ComponentType<
-    StyledComponentProps<ClassKey>
-  >;
   <P extends ConsistentWith<StyledComponentProps<ClassKey>>>(
     component: React.ComponentType<P & WithStyles<ClassKey>>,
-  ): React.ComponentType<P & StyledComponentProps<ClassKey>>;
+  ): React.ComponentType<Replace<P, StyledComponentProps<ClassKey>>>;
 };

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -49,7 +49,7 @@ export default function withStyles<ClassKey extends string>(
   style: StyleRules<ClassKey> | StyleRulesCallback<ClassKey>,
   options?: WithStylesOptions,
 ): {
-  <P extends ConsistentWith<StyledComponentProps<ClassKey>>>(
+  <P extends ConsistentWith<P, StyledComponentProps<ClassKey>>>(
     component: React.ComponentType<P & WithStyles<ClassKey>>,
   ): React.ComponentType<Overwrite<P, StyledComponentProps<ClassKey>>>;
 };

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WithTheme } from '../styles/withTheme';
-import { ConsistentWith, Replace } from '..';
+import { ConsistentWith, Overwrite } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 
@@ -51,5 +51,5 @@ export default function withStyles<ClassKey extends string>(
 ): {
   <P extends ConsistentWith<StyledComponentProps<ClassKey>>>(
     component: React.ComponentType<P & WithStyles<ClassKey>>,
-  ): React.ComponentType<Replace<P, StyledComponentProps<ClassKey>>>;
+  ): React.ComponentType<Overwrite<P, StyledComponentProps<ClassKey>>>;
 };

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -5,7 +5,7 @@ export interface WithTheme {
   theme: Theme;
 }
 
-declare const withTheme: () => <P extends ConsistentWith<WithTheme>>(
+declare const withTheme: () => <P extends ConsistentWith<P, WithTheme>>(
   component: React.ComponentType<P & WithTheme>,
 ) => React.ComponentClass<P>;
 

--- a/packages/material-ui/src/utils/withWidth.d.ts
+++ b/packages/material-ui/src/utils/withWidth.d.ts
@@ -1,5 +1,5 @@
 import { Breakpoint } from '../styles/createBreakpoints';
-import { ConsistentWith, Replace } from '..';
+import { ConsistentWith, Overwrite } from '..';
 
 export interface WithWidthOptions {
   resizeInterval: number;
@@ -25,4 +25,4 @@ export default function withWidth(
   options?: WithWidthOptions,
 ): <P extends ConsistentWith<WithWidthProps>>(
   component: React.ComponentType<P & WithWidthProps>,
-) => React.ComponentClass<Replace<P, Partial<WithWidthProps>>>;
+) => React.ComponentClass<Overwrite<P, Partial<WithWidthProps>>>;

--- a/packages/material-ui/src/utils/withWidth.d.ts
+++ b/packages/material-ui/src/utils/withWidth.d.ts
@@ -1,5 +1,5 @@
 import { Breakpoint } from '../styles/createBreakpoints';
-import { ConsistentWith } from '..';
+import { ConsistentWith, Replace } from '..';
 
 export interface WithWidthOptions {
   resizeInterval: number;
@@ -25,4 +25,4 @@ export default function withWidth(
   options?: WithWidthOptions,
 ): <P extends ConsistentWith<WithWidthProps>>(
   component: React.ComponentType<P & WithWidthProps>,
-) => React.ComponentClass<P & Partial<WithWidthProps>>;
+) => React.ComponentClass<Replace<P, Partial<WithWidthProps>>>;

--- a/packages/material-ui/src/utils/withWidth.d.ts
+++ b/packages/material-ui/src/utils/withWidth.d.ts
@@ -23,6 +23,6 @@ export function isWidthUp(
 
 export default function withWidth(
   options?: WithWidthOptions,
-): <P extends ConsistentWith<WithWidthProps>>(
+): <P extends ConsistentWith<P, WithWidthProps>>(
   component: React.ComponentType<P & WithWidthProps>,
 ) => React.ComponentClass<Overwrite<P, Partial<WithWidthProps>>>;

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -232,3 +232,65 @@ withStyles<'listItem' | 'guttered'>(theme => ({
 
   const ListItemContent = withStyles({ x: {}, y: {} })<FooProps>(props => <div />);
 }
+
+{ // https://github.com/mui-org/material-ui/issues/11109
+  // The real test here is with "strictFunctionTypes": false,
+  // but we don't have a way currently to test under varying
+  // TypeScript configurations.
+  interface IStyle {
+    content: any;
+  }
+  
+  interface IComponentProps {
+    caption: string;
+  }
+  
+  type ComponentProps = IComponentProps & WithStyles<'content'>;
+  
+  const decorate = withStyles((theme): IStyle => ({
+    content: {
+      margin: 4
+    }
+  }));
+  
+  const Component = (props: ComponentProps) => {
+    return <div className={props.classes.content}>Hello {props.caption}</div>
+  }
+  
+  const StyledComponent = decorate(Component);
+  
+  class App extends React.Component {
+    public render() {
+      return (
+        <div className="App">
+          <StyledComponent caption="Developer" />
+        </div>
+      );
+    }
+  }
+
+  <App />;
+}
+
+{ // https://github.com/mui-org/material-ui/issues/11191
+  const decorate = withStyles<classList>((theme) => ({
+    main: {}
+  }));
+
+  type classList =
+    | 'main';
+
+  interface IProps {
+    someProp?: string;
+  }
+
+  class SomeComponent extends React.PureComponent<IProps & WithStyles<classList>> {
+    render() {
+      return <div />
+    }
+  }
+
+  const DecoratedSomeComponent = decorate(SomeComponent); // note that I don't specify a generic type here
+
+  <DecoratedSomeComponent someProp="hello world" />;
+}


### PR DESCRIPTION
Fixes #11109.
Fixes #11191.

This employs conditional types to define an `Overwrite` type operator which resolves the edge cases around `withStyles`, without destroying the integrity of props that are specified as a union. This means requiring a minimum TypeScript version of 2.8.