### PR TITLE
[withStyles] Support createRef()

### DIFF
--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -42,7 +42,7 @@ export interface WithStyles<ClassKey extends string = string> extends Partial<Wi
 
 export interface StyledComponentProps<ClassKey extends string = string> {
   classes?: Partial<ClassNameMap<ClassKey>>;
-  innerRef?: React.Ref<any>;
+  innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
 export default function withStyles<ClassKey extends string>(

--- a/packages/material-ui/src/styles/withStyles.js
+++ b/packages/material-ui/src/styles/withStyles.js
@@ -313,7 +313,7 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
     /**
      * Use that property to pass a ref callback to the decorated component.
      */
-    innerRef: PropTypes.func,
+    innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   };
 
   WithStyles.contextTypes = {


### PR DESCRIPTION
This fixes the prop types for `{innerRef}` when the passed value is the result of `createRef()`.
