### PR TITLE
[typescript] Fix color type in augmentColor function

### DIFF
--- a/packages/material-ui/src/styles/createPalette.d.ts
+++ b/packages/material-ui/src/styles/createPalette.d.ts
@@ -61,7 +61,7 @@ export interface Palette {
   background: TypeBackground;
   getContrastText: (background: string) => string;
   augmentColor: (
-    color: string,
+    color: SimplePaletteColorOptions,
     mainShade: number | string,
     lightShade: number | string,
     darkShade: number | string,


### PR DESCRIPTION
In createPalette.d.ts file the function augmentColor (line 63) receive "color" argument as string but the correct Type should be SimplePaletteColorOptions.
