### PR TITLE
[docs] Prepare the v1 release

### DIFF
--- a/docs/src/pages/versions/LatestVersion.js
+++ b/docs/src/pages/versions/LatestVersion.js
@@ -22,7 +22,7 @@ function LatestVersion(props) {
         <TableBody>
           <TableRow>
             <TableCell padding="dense">
-              <Typography>v1-beta branch</Typography>
+              <Typography>master branch</Typography>
             </TableCell>
             <TableCell padding="dense">
               <Typography

--- a/docs/src/pages/versions/StableVersions.js
+++ b/docs/src/pages/versions/StableVersions.js
@@ -56,7 +56,11 @@ class StableVersions extends React.Component {
     const VERSIONS = [
       {
         url: 'https://material-ui-next.com',
-        semver: process.env.LIB_VERSION,
+        semver: `v${process.env.LIB_VERSION}`,
+      },
+      {
+        url: 'https://v0.material-ui.com',
+        semver: 'v0.20.1',
       },
     ];
 
@@ -85,7 +89,7 @@ class StableVersions extends React.Component {
                         <Link
                           {...props2}
                           variant="secondary"
-                          href={`${GITHUB_RELEASE_BASE_URL}v${version.semver}`}
+                          href={`${GITHUB_RELEASE_BASE_URL}${version.semver}`}
                         />
                       )}
                     >

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -1,8 +1,8 @@
 # Material-UI Versions
 
-## Beta versions
+## Stable versions
 
-The most recent beta version is recommended in production.
+The most recent version is recommended in production.
 
 {{"demo": "pages/versions/StableVersions.js", "hideHeader": true}}
 


### PR DESCRIPTION
This time, it's the version page.

![capture d ecran 2018-05-10 a 15 31 04](https://user-images.githubusercontent.com/3165635/39872137-4bbdb46a-5467-11e8-8ebe-31203f087085.png)

