### PR TITLE
[styles] Fix typings for FontStyle

### DIFF
--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -17,7 +17,7 @@ export type Style = TextStyle | 'button';
 
 export interface FontStyle {
   fontFamily: React.CSSProperties['fontFamily'];
-  fontSize: React.CSSProperties['fontSize'];
+  fontSize: number;
   fontWeightLight: React.CSSProperties['fontWeight'];
   fontWeightRegular: React.CSSProperties['fontWeight'];
   fontWeightMedium: React.CSSProperties['fontWeight'];


### PR DESCRIPTION
Related to this change: https://github.com/mui-org/material-ui/pull/10687/files#diff-87149c57922a594709ba893585864b8fR24
Specifying a font size (say `'18px'` for example) in theme, made the `coef` (and therefor all return values of `pxToRem()`) have `NaN` value.

The linked change is breaking. This change makes it visible for TS users.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
