### PR TITLE
[Button] Add outlined variant

### DIFF
--- a/docs/src/pages/demos/buttons/OutlinedButtons.js
+++ b/docs/src/pages/demos/buttons/OutlinedButtons.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+
+const styles = theme => ({
+  button: {
+    margin: theme.spacing.unit,
+  },
+});
+
+function doSomething(event) {
+  // eslint-disable-next-line no-console
+  console.log(event.currentTarget.getAttribute('data-something'));
+}
+
+function OutlinedButtons(props) {
+  const { classes } = props;
+  return (
+    <div>
+      <Button variant="outlined" className={classes.button}>Default</Button>
+      <Button color="primary" variant="outlined" className={classes.button}>
+        Primary
+      </Button>
+      <Button color="secondary" variant="outlined" className={classes.button}>
+        Secondary
+      </Button>
+      <Button variant="outlined" disabled className={classes.button}>
+        Disabled
+      </Button>
+      <Button variant="outlined" href="#flat-buttons" className={classes.button}>
+        Link
+      </Button>
+      <Button variant="outlined" disabled href="/" className={classes.button}>
+        Link disabled
+      </Button>
+      <Button variant="outlined" className={classes.button} onClick={doSomething} data-something="here I am">
+        Does something
+      </Button>
+    </div>
+  );
+}
+
+OutlinedButtons.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(OutlinedButtons);

--- a/docs/src/pages/demos/buttons/OutlinedButtons.js
+++ b/docs/src/pages/demos/buttons/OutlinedButtons.js
@@ -18,7 +18,9 @@ function OutlinedButtons(props) {
   const { classes } = props;
   return (
     <div>
-      <Button variant="outlined" className={classes.button}>Default</Button>
+      <Button variant="outlined" className={classes.button}>
+        Default
+      </Button>
       <Button color="primary" variant="outlined" className={classes.button}>
         Primary
       </Button>
@@ -34,7 +36,12 @@ function OutlinedButtons(props) {
       <Button variant="outlined" disabled href="/" className={classes.button}>
         Link disabled
       </Button>
-      <Button variant="outlined" className={classes.button} onClick={doSomething} data-something="here I am">
+      <Button
+        variant="outlined"
+        className={classes.button}
+        onClick={doSomething}
+        data-something="here I am"
+      >
         Does something
       </Button>
     </div>

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -18,6 +18,13 @@ They do not lift, but fill with color on press.
 
 {{"demo": "pages/demos/buttons/FlatButtons.js"}}
 
+## Outlined Buttons
+Outlined buttons are text-only buttons with medium emphasis.
+They behave like flat buttons but have an outline and are typically used for actions that are important, but
+aren’t the primary action in an app.
+
+{{"demo": "pages/demos/buttons/OutlinedButtons.js"}}
+
 ## Raised Buttons
 
 Raised buttons are rectangular-shaped buttons.

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -13,7 +13,7 @@ export interface ButtonProps extends StandardProps<ButtonBaseProps, ButtonClassK
   mini?: boolean;
   size?: 'small' | 'medium' | 'large';
   type?: string;
-  variant?: 'flat' | 'raised' | 'fab';
+  variant?: 'flat' | 'outlined' | 'raised' | 'fab';
 }
 
 export type ButtonClassKey =

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -63,7 +63,9 @@ export const styles = theme => ({
     },
   },
   outlined: {
-    border: `1px solid ${theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'}`,
+    border: `1px solid ${
+      theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+    }`,
     borderRadius: 4,
     '&:hover': {
       backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -67,13 +67,6 @@ export const styles = theme => ({
       theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
     }`,
     borderRadius: 4,
-    '&:hover': {
-      backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: 'transparent',
-      },
-    },
   },
   colorInherit: {
     color: 'inherit',

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -62,6 +62,17 @@ export const styles = theme => ({
       },
     },
   },
+  outlined: {
+    border: `1px solid ${theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'}`,
+    borderRadius: 4,
+    '&:hover': {
+      backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
+  },
   colorInherit: {
     color: 'inherit',
   },
@@ -178,6 +189,7 @@ function Button(props) {
       [classes.flatSecondary]: flat && color === 'secondary',
       [classes.raisedPrimary]: !flat && color === 'primary',
       [classes.raisedSecondary]: !flat && color === 'secondary',
+      [classes.outlined]: variant === 'outlined',
       [classes[`size${capitalize(size)}`]]: size !== 'medium',
       [classes.disabled]: disabled,
       [classes.fullWidth]: fullWidth,
@@ -263,7 +275,7 @@ Button.propTypes = {
   /**
    * The type of button.
    */
-  variant: PropTypes.oneOf(['flat', 'raised', 'fab']),
+  variant: PropTypes.oneOf(['flat', 'outlined', 'raised', 'fab']),
 };
 
 Button.defaultProps = {

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -123,11 +123,7 @@ describe('<Button />', () => {
   });
 
   it('should render an outlined button', () => {
-    const wrapper = shallow(
-      <Button variant="outlined">
-        Hello World
-      </Button>,
-    );
+    const wrapper = shallow(<Button variant="outlined">Hello World</Button>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.outlined), true, 'should have the outlined class');
     assert.strictEqual(wrapper.hasClass(classes.flat), true, 'should have the flat class');

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -126,7 +126,40 @@ describe('<Button />', () => {
     const wrapper = shallow(<Button variant="outlined">Hello World</Button>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.outlined), true, 'should have the outlined class');
-    assert.strictEqual(wrapper.hasClass(classes.flat), true, 'should have the flat class');
+    assert.strictEqual(wrapper.hasClass(classes.raised), false, 'should not have the raised class');
+    assert.strictEqual(wrapper.hasClass(classes.fab), false, 'should not have the fab class');
+  });
+
+  it('should render a primary outlined button', () => {
+    const wrapper = shallow(
+      <Button variant="outlined" color="primary">
+        Hello World
+      </Button>,
+    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass(classes.outlined), true, 'should have the outlined class');
+    assert.strictEqual(
+      wrapper.hasClass(classes.flatPrimary),
+      true,
+      'should have the flatPrimary class',
+    );
+    assert.strictEqual(wrapper.hasClass(classes.raised), false, 'should not have the raised class');
+    assert.strictEqual(wrapper.hasClass(classes.fab), false, 'should not have the fab class');
+  });
+
+  it('should render a secondary outlined button', () => {
+    const wrapper = shallow(
+      <Button variant="outlined" color="secondary">
+        Hello World
+      </Button>,
+    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass(classes.outlined), true, 'should have the outlined class');
+    assert.strictEqual(
+      wrapper.hasClass(classes.flatSecondary),
+      true,
+      'should have the flatSecondary class',
+    );
     assert.strictEqual(wrapper.hasClass(classes.raised), false, 'should not have the raised class');
     assert.strictEqual(wrapper.hasClass(classes.fab), false, 'should not have the fab class');
   });

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -122,6 +122,19 @@ describe('<Button />', () => {
     );
   });
 
+  it('should render an outlined button', () => {
+    const wrapper = shallow(
+      <Button variant="outlined">
+        Hello World
+      </Button>,
+    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass(classes.outlined), true, 'should have the outlined class');
+    assert.strictEqual(wrapper.hasClass(classes.flat), true, 'should have the flat class');
+    assert.strictEqual(wrapper.hasClass(classes.raised), false, 'should not have the raised class');
+    assert.strictEqual(wrapper.hasClass(classes.fab), false, 'should not have the fab class');
+  });
+
   it('should render a floating action button', () => {
     const wrapper = shallow(<Button variant="fab">Hello World</Button>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);

--- a/packages/material-ui/src/styles/MuiThemeProvider.test.js
+++ b/packages/material-ui/src/styles/MuiThemeProvider.test.js
@@ -86,13 +86,13 @@ describe('<MuiThemeProvider />', () => {
       assert.notStrictEqual(markup.match('Hello World'), null);
       assert.strictEqual(sheetsRegistry.registry.length, 3);
       assert.strictEqual(sheetsRegistry.toString().length > 4000, true);
-      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-19');
+      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'MuiTouchRipple-root-20');
       assert.deepEqual(
         sheetsRegistry.registry[1].classes,
         {
-          disabled: 'MuiButtonBase-disabled-17',
-          focusVisible: 'MuiButtonBase-focusVisible-18',
-          root: 'MuiButtonBase-root-16',
+          disabled: 'MuiButtonBase-disabled-18',
+          focusVisible: 'MuiButtonBase-focusVisible-19',
+          root: 'MuiButtonBase-root-17',
         },
         'the class names should be deterministic',
       );

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -23,7 +23,7 @@ filename: /packages/material-ui/src/Button/Button.js
 | <span class="prop-name">href</span> | <span class="prop-type">string |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | <span class="prop-name">mini</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, and `variant` is `'fab'`, will use mini floating action button styling. |
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'flat'&nbsp;&#124;<br>&nbsp;'raised'&nbsp;&#124;<br>&nbsp;'fab'<br> | <span class="prop-default">'flat'</span> | The type of button. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'flat'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'raised'&nbsp;&#124;<br>&nbsp;'fab'<br> | <span class="prop-default">'flat'</span> | The type of button. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 
@@ -35,6 +35,7 @@ This property accepts the following keys:
 - `label`
 - `flatPrimary`
 - `flatSecondary`
+- `outlined`
 - `colorInherit`
 - `raised`
 - `raisedPrimary`

--- a/pages/demos/buttons.js
+++ b/pages/demos/buttons.js
@@ -15,6 +15,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/buttons/FlatButtons'), 'utf8')
 `,
         },
+        'pages/demos/buttons/OutlinedButtons.js': {
+          js: require('docs/src/pages/demos/buttons/OutlinedButtons').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/buttons/OutlinedButtons'), 'utf8')
+`,
+        },
         'pages/demos/buttons/RaisedButtons.js': {
           js: require('docs/src/pages/demos/buttons/RaisedButtons').default,
           raw: preval`


### PR DESCRIPTION
This adds a new `outlined` variant to the `Button`, as [seen here](https://material.io/design/components/buttons.html#outlined-button).

The border and radius matches the specs (yup, 23% opacity…). Unfortunately, there is nothing said about the dark style, so I don't really know which value to put there. It looks pretty good imho. :wink: 

Light:
![image](https://user-images.githubusercontent.com/5544859/39956748-eb12a310-55e6-11e8-829c-345c8cc96a19.png)

Dark:
![image](https://user-images.githubusercontent.com/5544859/39956754-f2b456e0-55e6-11e8-9132-1c86e630c8ef.png)


Related to #11342 and #11284 