### PR TITLE
[Popover] fix max height issue in some mobile browsers

### DIFF
--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -23,7 +23,7 @@ export const styles = {
     // specZ: The maximum height of a simple menu should be one or more rows less than the view
     // height. This ensures a tappable area outside of the simple menu with which to dismiss
     // the menu.
-    maxHeight: 'calc(100vh - 96px)',
+    maxHeight: 'calc(100% - 96px)',
     // Add iOS momentum scrolling.
     WebkitOverflowScrolling: 'touch',
   },

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -75,8 +75,8 @@ export const styles = {
     // It's most likely on issue on userland.
     minWidth: 16,
     minHeight: 16,
-    maxWidth: 'calc(100vw - 32px)',
-    maxHeight: 'calc(100vh - 32px)',
+    maxWidth: 'calc(100% - 32px)',
+    maxHeight: 'calc(100% - 32px)',
     // We disable the focus ring for mouse, touch and keyboard users.
     outline: 'none',
   },


### PR DESCRIPTION
Viewport height is taller than the visible part of the document in some mobile browsers.
https://nicolas-hoizey.com/2015/02/viewport-height-is-taller-than-the-visible-part-of-the-document-in-some-mobile-browsers.html

Before:
![screenshot_20180512-132154](https://user-images.githubusercontent.com/5795996/39956884-6c7ab4ae-55e9-11e8-807e-70840b59e350.png)

After:
![screenshot_20180512-133052](https://user-images.githubusercontent.com/5795996/39956893-90af3d4a-55e9-11e8-9619-d82b1424eb5d.png)
