### PR TITLE
[core] Do not include polyfills in the ES modules build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": ["./scripts/material-ui-babel-preset", "@babel/preset-stage-1", "@babel/preset-react"],
-  "plugins": ["@babel/plugin-transform-object-assign", "@babel/transform-runtime"],
+  "plugins": ["@babel/plugin-transform-object-assign"],
   "env": {
     "coverage": {
       "plugins": [
@@ -61,6 +61,7 @@
         ],
         "transform-react-constant-elements",
         "transform-dev-warning",
+        "@babel/transform-runtime",
         "@babel/plugin-transform-flow-strip-types",
         ["react-remove-properties", { "properties": ["data-mui-test"] }],
         ["transform-react-remove-prop-types", { "mode": "remove" }]
@@ -70,6 +71,10 @@
       "plugins": [
         "transform-react-constant-elements",
         "transform-dev-warning",
+        ["@babel/transform-runtime", {
+          "polyfill": false,
+          "useBuiltIns": true
+        }],
         "@babel/plugin-transform-flow-strip-types",
         ["react-remove-properties", { "properties": ["data-mui-test"] }],
         [
@@ -84,6 +89,7 @@
       "plugins": [
         "transform-react-constant-elements",
         "transform-dev-warning",
+        "@babel/transform-runtime",
         "@babel/plugin-transform-flow-strip-types",
         ["react-remove-properties", { "properties": ["data-mui-test"] }],
         [

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -61,5 +61,8 @@ All the non-official syntax is transpiled to the [ECMA-262 standard](https://www
 This can be used to make separate bundles targeting different browsers.
 Older browsers will require more JavaScript features to be transpiled,
 which increases the size of the bundle.
+No polyfills are included for ES2015 runtime features. IE11+ and evergreen browsers support all the
+necessary features. If you need support for other browsers, consider using
+[`@babel/polyfill`](https://npmjs.com/package/@babel/polyfill).
 
 ⚠️ In order to minimize duplication of code is users' bundles, we **strongly discourage** library authors from using the `/es` folder.


### PR DESCRIPTION
This patch adds two options to the `@babel/transform-runtime` plugin for the `/es` build:
 - `polyfill: false` removes polyfill imports for new ES runtime features
 - `useBuiltIns: true` uses Babel helpers that do not include polyfills for new ES runtime features—otherwise, polyfills for things like `Object.defineProperty` and `Symbol` would be included by helpers for class properties and `typeof`

I used the [eslint-plugin-compat](https://www.npmjs.com/package/eslint-plugin-compat) plugin locally to check which polyfills were needed, but it looks like even IE11 supports everything Material-UI uses. (I thought it didn't have `Map`, but it does!—just except the iterator features)
That means that we don't really need the polyfills for any of the officially supported browsers. I think we could safely drop them from the `/` CJS build as well later. It would be best to add the compat plugin then tho so that it won't accidentally break in the future, it could be done in a follow up PR. Adding that plugin is a bit of work because tests and `scripts/**` have to be excluded and I'm not sure how to do that yet, so I didn't do it here.

Closes #11318