### PR TITLE
[SwipeableDrawer] Only listen on touchStart events of the swipe area for opening

### DIFF
--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -138,7 +138,7 @@ class Drawer extends React.Component {
       );
     }
 
-    const slidingDrawer = (
+    const slidingDrawer = other.disableSlide ? drawer : (
       <Slide
         in={open}
         direction={oppositeDirection[anchor]}

--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -35,13 +35,13 @@ export const styles = theme => ({
  * @ignore - internal component.
  */
 function SwipeArea(props) {
-  const { anchor, classes, swipeAreaWidth, ...other } = props;
+  const { anchor, classes, width, ...other } = props;
 
   return (
     <div
       className={classNames(classes.root, classes[`discoveryAnchor${capitalize(anchor)}`])}
       style={{
-        [isHorizontal(props) ? 'width' : 'height']: swipeAreaWidth,
+        [isHorizontal(props) ? 'width' : 'height']: width,
       }}
       {...other}
     />
@@ -58,10 +58,9 @@ SwipeArea.propTypes = {
    */
   classes: PropTypes.object.isRequired,
   /**
-   * The width of the left most (or right most) area in pixels where the
-   * drawer can be swiped open from.
+   * The width, in pixels, of area where the drawer can be swiped open from.
    */
-  swipeAreaWidth: PropTypes.number.isRequired,
+  width: PropTypes.number.isRequired,
 };
 
 export default withStyles(styles)(SwipeArea);

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -76,9 +76,7 @@ class SwipeableDrawer extends React.Component {
     );
   }
 
-  setPosition(translate, options = {}) {
-    const { mode = null, changeTransition = true } = options;
-
+  setPosition(translate, mode = null) {
     const anchor = getAnchor(this.props);
     const rtlTranslateMultiplier = ['right', 'bottom'].indexOf(anchor) !== -1 ? 1 : -1;
     const transform = isHorizontal(this.props)
@@ -104,19 +102,14 @@ class SwipeableDrawer extends React.Component {
       );
     }
 
-    if (changeTransition) {
-      drawerStyle.webkitTransition = transition;
-      drawerStyle.transition = transition;
-    }
+    drawerStyle.webkitTransition = transition;
+    drawerStyle.transition = transition;
 
     if (!this.props.disableBackdropTransition) {
       const backdropStyle = this.backdrop.style;
       backdropStyle.opacity = 1 - translate / this.getMaxTranslate();
-
-      if (changeTransition) {
-        backdropStyle.webkitTransition = transition;
-        backdropStyle.transition = transition;
-      }
+      backdropStyle.webkitTransition = transition;
+      backdropStyle.transition = transition;
     }
   }
 
@@ -148,12 +141,9 @@ class SwipeableDrawer extends React.Component {
     // the ref may be null when a parent component updates while swiping
     if (!open && this.paper) {
       // setting the position twice ensures that the drawer animates correctly for discovery
-      this.setPosition(this.getMaxTranslate() + 20, { changeTransition: true });
+      this.setPosition(this.getMaxTranslate() + 20);
       if (!disableDiscovery) {
-        this.setPosition(this.getMaxTranslate() - swipeAreaWidth, {
-          changeTransition: true,
-          mode: 'enter'
-        });
+        this.setPosition(this.getMaxTranslate() - swipeAreaWidth, 'enter');
       }
     }
     this.setState({ maybeSwiping: true });
@@ -259,29 +249,17 @@ class SwipeableDrawer extends React.Component {
     if (translateRatio > 0.5) {
       if (this.isSwiping && !this.props.open) {
         // Reset the position, the swipe was aborted.
-        this.setPosition(this.getMaxTranslate(), {
-          mode: 'exit',
-          changeTransition: true,
-        });
+        this.setPosition(this.getMaxTranslate(), 'exit');
       } else {
-        this.setPosition(this.getMaxTranslate(), {
-          mode: 'exit',
-          changeTransition: true,
-        });
+        this.setPosition(this.getMaxTranslate(), 'exit');
         this.props.onClose();
       }
     } else if (this.isSwiping && !this.props.open) {
-      this.setPosition(0, {
-        mode: 'enter',
-        changeTransition: true,
-      });
+      this.setPosition(0, 'enter');
       this.props.onOpen();
     } else {
       // Reset the position, the swipe was aborted.
-      this.setPosition(0, {
-        mode: 'enter',
-        changeTransition: true,
-      });
+      this.setPosition(0, 'enter');
     }
     this.setState({ maybeSwiping: false });
 
@@ -289,9 +267,7 @@ class SwipeableDrawer extends React.Component {
   };
 
   handleBackdropClick = () => {
-    this.setPosition(this.getMaxTranslate(), {
-      mode: 'exit'
-    });
+    this.setPosition(this.getMaxTranslate(), 'exit');
     this.props.onClose();
   }
 

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -341,7 +341,7 @@ class SwipeableDrawer extends React.Component {
           variant === 'temporary' && (
             <SwipeArea
               anchor={other.anchor}
-              swipeAreaWidth={swipeAreaWidth}
+              width={swipeAreaWidth}
               onTouchStart={this.handleTouchStart}
             />
           )}


### PR DESCRIPTION
This PR does not only simplify the detection logic of opening swipes but also fixes a bug where you would swipe open (or discover) a drawer even if there are elements on top of it (e.g. Dialogs) because the open swipe used to listen to the `body`'s events.

It requires re-testing on Safari, I don't have any :apple: devices at hand.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
