### PR TITLE
[typescript] Fix DialogContent export

### DIFF
--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -100,7 +100,7 @@ export { default as Collapse } from './Collapse';
 export { default as CssBaseline } from './CssBaseline';
 export { default as Dialog } from './Dialog';
 export { default as DialogActions } from './DialogActions';
-export { default as DialogContent } from './CssBaseline';
+export { default as DialogContent } from './DialogContent';
 export { default as DialogContentText } from './DialogContentText';
 export { default as DialogTitle } from './DialogTitle';
 export { default as Divider } from './Divider';


### PR DESCRIPTION
Fixed the export of DialogContent in index.d.ts.

Closes #11373 