### PR TITLE
props rearranged

### DIFF
--- a/docs/src/pages/demos/snackbars/DirectionSnackbar.js
+++ b/docs/src/pages/demos/snackbars/DirectionSnackbar.js
@@ -4,19 +4,19 @@ import Snackbar from '@material-ui/core/Snackbar';
 import Slide from '@material-ui/core/Slide';
 
 function TransitionLeft(props) {
-  return <Slide direction="left" {...props} />;
+  return <Slide {...props} direction="left" />;
 }
 
 function TransitionUp(props) {
-  return <Slide direction="up" {...props} />;
+  return <Slide {...props} direction="up" />;
 }
 
 function TransitionRight(props) {
-  return <Slide direction="right" {...props} />;
+  return <Slide {...props} direction="right" />;
 }
 
 function TransitionDown(props) {
-  return <Slide direction="down" {...props} />;
+  return <Slide {...props} direction="down" />;
 }
 
 class DirectionSnackbar extends React.Component {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
[Snackbar] Snackbar transitions demo doesn't work anymore because of direction prop override #11371 

I have changed the override order of the props. First contribution. Thanks!