### PR TITLE
[icons] Remove deadcode

### DIFF
--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -2,13 +2,11 @@ import React from 'react';
 import pure from 'recompose/pure';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
-const SvgIconCustom = typeof global !== 'undefined' && global.__MUI_SvgIcon__ || SvgIcon;
-
 function createSvgIcon(path, displayName) {
   let Icon = props => (
-    <SvgIconCustom {...props}>
+    <SvgIcon {...props}>
       {path}
-    </SvgIconCustom>
+    </SvgIcon>
   );
 
   Icon.displayName = displayName;


### PR DESCRIPTION
This logic should no longer be needed given material-ui v0.x and material-ui v1 are published under two different packages.

Closes #9469 