### PR TITLE
[MenuItem] Ability to override List style for nested menuItems

### DIFF
--- a/src/MenuItem/MenuItem.js
+++ b/src/MenuItem/MenuItem.js
@@ -117,6 +117,11 @@ class MenuItem extends Component {
      */
     menuItems: PropTypes.node,
     /**
+     * Override the inline-styles of the nested `List`.
+     * This will only affect the component if `menuItems` are specified.
+     */
+    nestedListStyle: PropTypes.object,
+    /**
      * Callback function fired when the menu item is clicked.
      *
      * @param {object} event Click event targeting the menu item.
@@ -249,6 +254,7 @@ class MenuItem extends Component {
       insetChildren,
       leftIcon,
       menuItems,
+      nestedListStyle,
       rightIcon,
       secondaryText,
       style,
@@ -303,7 +309,12 @@ class MenuItem extends Component {
           useLayerForClickAway={false}
           onRequestClose={this.handleRequestClose}
         >
-          <Menu desktop={desktop} disabled={disabled} style={nestedMenuStyle}>
+          <Menu
+            desktop={desktop}
+            disabled={disabled}
+            listStyle={nestedListStyle}
+            style={nestedMenuStyle}
+          >
             {React.Children.map(menuItems, this.cloneMenuItem)}
           </Menu>
         </Popover>


### PR DESCRIPTION
Currently you can ovverride the styling of `List` within `Menu`, however this is not possible for nested menus (in the case of adding the `menuItems` property to a `MenuItem`.

With this PR you can now pass in a `nestedListStyle` object property to `MenuItem` to override the default styling on submenus, as is possible with specifying `listStyle` on a `Menu` in regular (non-submenu) usage.
