### PR TITLE
[Grid] Allow shrink in items so text will wrap by default

### DIFF
--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -92,7 +92,7 @@ export const styles = theme => ({
   },
   item: {
     boxSizing: 'border-box',
-    flex: '0 0 auto',
+    flex: '0 1 auto', // Allow shrink so text will wrap in items by default.
     margin: '0', // For instance, it's useful when used with a `figure` element.
   },
   zeroMinWidth: {

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -92,7 +92,6 @@ export const styles = theme => ({
   },
   item: {
     boxSizing: 'border-box',
-    flex: '0 1 auto', // Allow shrink so text will wrap in items by default.
     margin: '0', // For instance, it's useful when used with a `figure` element.
   },
   zeroMinWidth: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Simple change to allow flexbox shrink in Grid items, which will let text wrap by default (just like standard flexbox behavior).
