### PR TITLE
Don't close snackbar when prop.open is provided

### DIFF
--- a/src/Snackbar/Snackbar.js
+++ b/src/Snackbar/Snackbar.js
@@ -174,7 +174,7 @@ class Snackbar extends Component {
 
     if (this.props.open !== null && this.props.onRequestClose) {
       this.props.onRequestClose(Snackbar.reasons.CLICKAWAY);
-    } else {
+    } else if(this.props.open === null || this.props.open === undefined){
       this.setState({open: false});
     }
   };
@@ -188,7 +188,7 @@ class Snackbar extends Component {
       this.timerAutoHideId = setTimeout(() => {
         if (this.props.open !== null && this.props.onRequestClose) {
           this.props.onRequestClose(Snackbar.reasons.TIMEOUT);
-        } else {
+        } else if(this.props.open === null || this.props.open === undefined) {
           this.setState({open: false});
         }
       }, autoHideDuration);


### PR DESCRIPTION
My snackbar closed even though I provided the open prop.
But i only wanted the snackbar to close on actionClick not on request close.
But still it would close automatically even though my open was still true. 
I had to stumb `onRequestClose={(r) => {}}` to make it work.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
