### PR TITLE
[StepLabel] Allow StepIcon customization

### DIFF
--- a/packages/material-ui/src/StepLabel/StepLabel.d.ts
+++ b/packages/material-ui/src/StepLabel/StepLabel.d.ts
@@ -15,6 +15,7 @@ export interface StepLabelProps
   last?: boolean;
   optional?: React.ReactNode;
   orientation?: Orientation;
+  stepIconProps?: object;
 }
 
 export type StepLabelClasskey =

--- a/packages/material-ui/src/StepLabel/StepLabel.d.ts
+++ b/packages/material-ui/src/StepLabel/StepLabel.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { Orientation } from '../Stepper';
 import { StepButtonIcon } from '../StepButton';
+import { StepIconProps } from '../StepIcon';
 
 export interface StepLabelProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, StepLabelClasskey> {
@@ -15,7 +16,7 @@ export interface StepLabelProps
   last?: boolean;
   optional?: React.ReactNode;
   orientation?: Orientation;
-  StepIconProps?: object;
+  StepIconProps?: Partial<StepIconProps>;
 }
 
 export type StepLabelClasskey =

--- a/packages/material-ui/src/StepLabel/StepLabel.d.ts
+++ b/packages/material-ui/src/StepLabel/StepLabel.d.ts
@@ -15,7 +15,7 @@ export interface StepLabelProps
   last?: boolean;
   optional?: React.ReactNode;
   orientation?: Orientation;
-  stepIconProps?: object;
+  StepIconProps?: object;
 }
 
 export type StepLabelClasskey =

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -66,7 +66,7 @@ function StepLabel(props) {
     last,
     optional,
     orientation,
-    stepIconProps,
+    StepIconProps,
     ...other
   } = props;
 
@@ -96,7 +96,7 @@ function StepLabel(props) {
             error={error}
             icon={icon}
             alternativeLabel={alternativeLabel}
-            {...stepIconProps}
+            {...StepIconProps}
           />
         </span>
       )}
@@ -176,7 +176,7 @@ StepLabel.propTypes = {
   /**
    *  The properties passed to the child <StepIcon />.
    */
-  stepIconProps: PropTypes.object,
+  StepIconProps: PropTypes.object,
 };
 
 StepLabel.defaultProps = {

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -95,7 +95,6 @@ function StepLabel(props) {
             active={active}
             error={error}
             icon={icon}
-            alternativeLabel={alternativeLabel}
             {...StepIconProps}
           />
         </span>
@@ -174,7 +173,7 @@ StepLabel.propTypes = {
    */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   /**
-   *  The properties passed to the child <StepIcon />.
+   * Properties applied to the `StepIcon` element.
    */
   StepIconProps: PropTypes.object,
 };

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -66,6 +66,7 @@ function StepLabel(props) {
     last,
     optional,
     orientation,
+    stepIconProps,
     ...other
   } = props;
 
@@ -89,7 +90,14 @@ function StepLabel(props) {
             [classes.alternativeLabel]: alternativeLabel,
           })}
         >
-          <StepIcon completed={completed} active={active} error={error} icon={icon} />
+          <StepIcon
+            completed={completed}
+            active={active}
+            error={error}
+            icon={icon}
+            alternativeLabel={alternativeLabel}
+            {...stepIconProps}
+          />
         </span>
       )}
       <span className={classes.labelContainer}>
@@ -165,6 +173,10 @@ StepLabel.propTypes = {
    * @ignore
    */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
+   *  The properties passed to the child <StepIcon />.
+   */
+  stepIconProps: PropTypes.object,
 };
 
 StepLabel.defaultProps = {

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -44,8 +44,9 @@ describe('<StepLabel />', () => {
     });
 
     it('renders <StepIcon>', () => {
+      const stepIconProps = { prop1: 'value1', prop2: 'value2' };
       const wrapper = shallow(
-        <StepLabel icon={1} active completed alternativeLabel>
+        <StepLabel icon={1} active completed alternativeLabel stepIconProps={stepIconProps}>
           Step One
         </StepLabel>,
       );
@@ -53,6 +54,8 @@ describe('<StepLabel />', () => {
       assert.strictEqual(stepIcon.length, 1, 'should have an <StepIcon />');
       const props = stepIcon.props();
       assert.strictEqual(props.icon, 1, 'should set icon');
+      assert.strictEqual(props.prop1, 'value1', 'should have inherited custom prop1');
+      assert.strictEqual(props.prop2, 'value2', 'should have inherited custom prop2');
     });
   });
 

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -46,7 +46,7 @@ describe('<StepLabel />', () => {
     it('renders <StepIcon>', () => {
       const stepIconProps = { prop1: 'value1', prop2: 'value2' };
       const wrapper = shallow(
-        <StepLabel icon={1} active completed alternativeLabel stepIconProps={stepIconProps}>
+        <StepLabel icon={1} active completed alternativeLabel StepIconProps={stepIconProps}>
           Step One
         </StepLabel>,
       );

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/StepLabel/StepLabel.js
 | <span class="prop-name">error</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node |  | Override the default icon. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node |  | The optional node to display. |
-| <span class="prop-name">stepIconProps</span> | <span class="prop-type">object |  | The properties passed to the child `StepIcon`. |
+| <span class="prop-name">StepIconProps</span> | <span class="prop-type">object |  | The properties passed to the child `StepIcon`. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -18,6 +18,7 @@ filename: /packages/material-ui/src/StepLabel/StepLabel.js
 | <span class="prop-name">error</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node |  | Override the default icon. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node |  | The optional node to display. |
+| <span class="prop-name">stepIconProps</span> | <span class="prop-type">object |  | The properties passed to the child `StepIcon`. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/StepLabel/StepLabel.js
 | <span class="prop-name">error</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node |  | Override the default icon. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node |  | The optional node to display. |
-| <span class="prop-name">StepIconProps</span> | <span class="prop-type">object |  | The properties passed to the child `StepIcon`. |
+| <span class="prop-name">StepIconProps</span> | <span class="prop-type">object |  | Properties applied to the `StepIcon` element. |
 
 Any other properties supplied will be [spread to the root element](/guides/api#spread).
 


### PR DESCRIPTION
Hi,

First pull-request ever, please send constructive criticism ;)

This follows #11329 and option 2 of what was suggested:

- Allows <StepLabel > to have a stepIconProps property to be passed to its child <StepIcon />

Closes #11329