### PR TITLE
[docs] Remove reference to props to retrieve classname

### DIFF
--- a/docs/src/pages/demos/tooltips/SimpleTooltips.js
+++ b/docs/src/pages/demos/tooltips/SimpleTooltips.js
@@ -35,7 +35,7 @@ function SimpleTooltips(props) {
       <br />
       <br />
       <Tooltip title="FAB 'position: absolute;'">
-        <Button variant="fab" color="secondary" className={props.classes.absolute}>
+        <Button variant="fab" color="secondary" className={classes.absolute}>
           <AddIcon />
         </Button>
       </Tooltip>


### PR DESCRIPTION
`classes` was already destructured from the `props` so there is no need to reference it here to retrieve the `classes.absolute` class name.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
