### PR TITLE
[Switch,Radio] Updated 'secondary' property spelling

### DIFF
--- a/packages/material-ui/src/Radio/Radio.d.ts
+++ b/packages/material-ui/src/Radio/Radio.d.ts
@@ -9,7 +9,7 @@ export interface RadioProps
   icon?: React.ReactNode;
 }
 
-export type RadioClassKey = SwitchBaseClassKey | 'colorPrimary' | 'colorSecondery';
+export type RadioClassKey = SwitchBaseClassKey | 'colorPrimary' | 'colorSecondary';
 
 declare const Radio: React.ComponentType<RadioProps>;
 

--- a/packages/material-ui/src/Switch/Switch.d.ts
+++ b/packages/material-ui/src/Switch/Switch.d.ts
@@ -16,7 +16,7 @@ export type SwitchClassKey =
   | 'iconChecked'
   | 'switchBase'
   | 'colorPrimary'
-  | 'colorSecondery';
+  | 'colorSecondary';
 
 declare const Switch: React.ComponentType<SwitchProps>;
 


### PR DESCRIPTION
Hi,
This fixes the open issue #11418 about the property spellings in the Switch & Radio components.

Closes #11418