### PR TITLE
[typescript] Make TypographyStyle assignable to CSSProperties, misc other typing fixes

### DIFF
--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -18,11 +18,11 @@ export type Style = TextStyle | 'button';
 
 export interface FontStyle extends Required<{
   fontFamily: CSSProperties['fontFamily'];
-  fontSize: CSSProperties['fontSize'];
+  fontSize: number;
   fontWeightLight: CSSProperties['fontWeight'];
   fontWeightRegular: CSSProperties['fontWeight'];
   fontWeightMedium: CSSProperties['fontWeight'];
-  htmlFontSize?: CSSProperties['fontSize'];
+  htmlFontSize?: number;
 }> {}
 
 export type TypographyStyle =

--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 import { Palette } from './createPalette';
+import { Overwrite, Omit } from '..';
+import { CSSProperties } from './withStyles';
 
 export type TextStyle =
   | 'display1'
@@ -24,15 +26,10 @@ export interface FontStyle {
   htmlFontSize?: number;
 }
 
-export interface TypographyStyle {
-  color?: React.CSSProperties['color'];
-  fontFamily: React.CSSProperties['fontFamily'];
-  fontSize: React.CSSProperties['fontSize'];
-  fontWeight: React.CSSProperties['fontWeight'];
-  letterSpacing?: React.CSSProperties['letterSpacing'];
-  lineHeight?: React.CSSProperties['lineHeight'];
-  textTransform?: React.CSSProperties['textTransform'];
-}
+export type TypographyStyle =
+  & Required<Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>>
+  & Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>
+  ;
 
 export interface TypographyUtils {
   pxToRem: (px: number) => string;

--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -16,14 +16,14 @@ export type TextStyle =
 
 export type Style = TextStyle | 'button';
 
-export interface FontStyle {
+export interface FontStyle extends Required<{
   fontFamily: CSSProperties['fontFamily'];
-  fontSize: number;
+  fontSize: CSSProperties['fontSize'];
   fontWeightLight: CSSProperties['fontWeight'];
   fontWeightRegular: CSSProperties['fontWeight'];
   fontWeightMedium: CSSProperties['fontWeight'];
-  htmlFontSize?: number;
-}
+  htmlFontSize?: CSSProperties['fontSize'];
+}> {}
 
 export type TypographyStyle =
   & Required<Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>>

--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { Palette } from './createPalette';
 import { Overwrite, Omit } from '..';
 import { CSSProperties } from './withStyles';
@@ -18,11 +17,11 @@ export type TextStyle =
 export type Style = TextStyle | 'button';
 
 export interface FontStyle {
-  fontFamily: React.CSSProperties['fontFamily'];
+  fontFamily: CSSProperties['fontFamily'];
   fontSize: number;
-  fontWeightLight: React.CSSProperties['fontWeight'];
-  fontWeightRegular: React.CSSProperties['fontWeight'];
-  fontWeightMedium: React.CSSProperties['fontWeight'];
+  fontWeightLight: CSSProperties['fontWeight'];
+  fontWeightRegular: CSSProperties['fontWeight'];
+  fontWeightMedium: CSSProperties['fontWeight'];
   htmlFontSize?: number;
 }
 

--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -22,13 +22,18 @@ export interface FontStyle extends Required<{
   fontWeightLight: CSSProperties['fontWeight'];
   fontWeightRegular: CSSProperties['fontWeight'];
   fontWeightMedium: CSSProperties['fontWeight'];
-  htmlFontSize?: number;
 }> {}
+
+export interface FontStyleOptions extends Partial<FontStyle> {
+  htmlFontSize?: number;
+}
 
 export type TypographyStyle =
   & Required<Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>>
   & Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>
   ;
+
+export interface TypographyStyleOptions extends Partial<TypographyStyle> {}
 
 export interface TypographyUtils {
   pxToRem: (px: number) => string;
@@ -36,9 +41,7 @@ export interface TypographyUtils {
 
 export type Typography = Record<Style, TypographyStyle> & FontStyle & TypographyUtils;
 
-export type TypographyOptions = Partial<Record<Style, Partial<TypographyStyle>> & FontStyle>;
-
-//export type TypographyOptions = DeepPartial<Typography>;
+export type TypographyOptions = Partial<Record<Style, TypographyStyleOptions> & FontStyleOptions>;
 
 export default function createTypography(
   palette: Palette,

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -13,6 +13,7 @@ import { StyleRulesCallback, StyledComponentProps } from '../../src/styles/withS
 import blue from '../../src/colors/blue';
 import { WithTheme } from '../../src/styles/withTheme';
 import { StandardProps } from '../../src';
+import { TypographyStyle } from '../../src/styles/createTypography';
 
 // Shared types for examples
 type ComponentClassNames = 'root';
@@ -320,4 +321,10 @@ withStyles<'listItem' | 'guttered'>(theme => ({
 
 { // https://github.com/mui-org/material-ui/issues/11312
   withStyles(styles, { name: "MyComponent", index: 0 })(() => <div/>);
+}
+
+{ // https://github.com/mui-org/material-ui/issues/11164
+  const style: StyleRulesCallback = theme => ({
+    text: theme.typography.body2
+  });
 }


### PR DESCRIPTION
Fixes #11164 by using a type alias instead of an interface for `TypographyStyle`.

Also:
- Marks as definite properties on `TypographyStyle` that should always be defined (`fontFamily`, `fontSize`, `fontWeight`, `color`).
- Extract separate types for `FontStyleOptions` and `TypographyStyleOptions`
- Use our custom `CSSProperties` instead of `React.CSSProperties` everywhere.