### PR TITLE
[docs] Add missing word to documentation

### DIFF
--- a/docs/src/pages/guides/testing/testing.md
+++ b/docs/src/pages/guides/testing/testing.md
@@ -10,7 +10,7 @@ To learn more about our internal tests, you can have a look at the [README](http
 
 ## Userspace
 
-What about writing tests in userspace? The Material-UI styling infrastructure uses some helper functions built on top of [enzyme](https://github.com/airbnb/enzyme) to make the process easier, which we exposing. You can take advantage of them if you so choose.
+What about writing tests in userspace? The Material-UI styling infrastructure uses some helper functions built on top of [enzyme](https://github.com/airbnb/enzyme) to make the process easier, which we are exposing. You can take advantage of them if you so choose.
 
 ### Shallow rendering
 


### PR DESCRIPTION
Just had a look over the docs for v1.
v1 is great work!
This small error needs to be fixed so v1 is even greater.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
