### PR TITLE
[StepConnector] Exposes the component

### DIFF
--- a/docs/src/pages/demos/steppers/steppers.md
+++ b/docs/src/pages/demos/steppers/steppers.md
@@ -1,5 +1,5 @@
 ---
-components: MobileStepper, Step, StepButton, StepContent, StepIcon, StepLabel, Stepper
+components: MobileStepper, Step, StepButton, StepConnector, StepContent, StepIcon, StepLabel, Stepper
 ---
 
 # Steppers
@@ -75,7 +75,7 @@ You must implement the textual description yourself, however, an example is prov
 
 ### Mobile Stepper - Text with Carousel effect
 
-This demo is very similar to the previous, the difference is the usage of 
+This demo is very similar to the previous, the difference is the usage of
 [react-swipeable-views](https://github.com/oliviertassinari/react-swipeable-views) to make the transition of steps.
 
 {{"demo": "pages/demos/steppers/SwipeableTextMobileStepper.js"}}

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -85,4 +85,4 @@ StepConnector.defaultProps = {
   orientation: 'horizontal',
 };
 
-export default withStyles(styles)(StepConnector);
+export default withStyles(styles, { name: 'MuiStepConnector' })(StepConnector);

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -33,9 +33,6 @@ export const styles = theme => ({
   },
 });
 
-/**
- * @ignore - internal component.
- */
 function StepConnector(props) {
   const { alternativeLabel, className: classNameProp, classes, orientation, ...other } = props;
 

--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -64,6 +64,7 @@ import { SnackbarClassKey } from '../Snackbar';
 import { SnackbarContentClassKey } from '../SnackbarContent';
 import { StepButtonClasskey } from '../StepButton';
 import { StepClasskey } from '../Step';
+import { StepConnectorClasskey } from '../StepConnector';
 import { StepContentClasskey } from '../StepContent';
 import { StepIconClasskey } from '../StepIcon';
 import { StepLabelClasskey } from '../StepLabel';
@@ -156,6 +157,7 @@ type ComponentNameToClassKey = {
   MuiSnackbarContent: SnackbarContentClassKey;
   MuiStep: StepClasskey;
   MuiStepButton: StepButtonClasskey;
+  MuiStepConnector: StepConnectorClasskey;
   MuiStepContent: StepContentClasskey;
   MuiStepIcon: StepIconClasskey;
   MuiStepLabel: StepLabelClasskey;

--- a/packages/material-ui/src/styles/props.d.ts
+++ b/packages/material-ui/src/styles/props.d.ts
@@ -63,6 +63,7 @@ import { SelectProps } from '../Select';
 import { SnackbarContentProps } from '../SnackbarContent';
 import { SnackbarProps } from '../Snackbar';
 import { StepButtonProps } from '../StepButton';
+import { StepConnectorProps } from '../StepConnector';
 import { StepContentProps } from '../StepContent';
 import { StepIconProps } from '../StepIcon';
 import { StepLabelProps } from '../StepLabel';
@@ -153,6 +154,7 @@ type ComponentsPropsList = {
   MuiSnackbarContent: SnackbarContentProps;
   MuiStep: StepProps;
   MuiStepButton: StepButtonProps;
+  MuiStepConnector: StepConnectorProps;
   MuiStepContent: StepContentProps;
   MuiStepIcon: StepIconProps;
   MuiStepLabel: StepLabelProps;

--- a/pages/api/step-connector.js
+++ b/pages/api/step-connector.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './step-connector.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default withRoot(Page);

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -1,0 +1,42 @@
+---
+filename: /packages/material-ui/src/StepConnector/StepConnector.js
+---
+
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# StepConnector
+
+
+
+## Props
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+
+Any other properties supplied will be [spread to the root element](/guides/api#spread).
+
+## CSS API
+
+You can override all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+- `root`
+- `horizontal`
+- `vertical`
+- `alternativeLabel`
+- `line`
+- `lineHorizontal`
+- `lineVertical`
+
+Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/StepConnector/StepConnector.js)
+for more detail.
+
+If using the `overrides` key of the theme as documented
+[here](/customization/themes#customizing-all-instances-of-a-component-type),
+you need to use the following style sheet name: `MuiStepConnector`.
+
+## Demos
+
+- [Steppers](/demos/steppers)
+


### PR DESCRIPTION
This update will allow the StepConnector to be accessed in the theme file.

The motivation for this was for Stepper to support larger icons when using custom icons.

Example changes to theme file for using an icon with 30px width for a vertical stepper:
MuiStepConnector: {
  vertical: {
    marginLeft: '15px'
  }
}