### PR TITLE
[core] Add esm bundle to start tracking treeshakability

### DIFF
--- a/packages/material-ui/.size-snapshot.json
+++ b/packages/material-ui/.size-snapshot.json
@@ -1,12 +1,21 @@
 {
   "build/umd/material-ui.development.js": {
-    "bundled": 1059967,
-    "minified": 387105,
-    "gzipped": 98931
+    "bundled": 1060168,
+    "minified": 387193,
+    "gzipped": 99039
   },
   "build/umd/material-ui.production.min.js": {
-    "bundled": 890849,
-    "minified": 346056,
-    "gzipped": 89487
+    "bundled": 890973,
+    "minified": 346112,
+    "gzipped": 89530
+  },
+  "build/dist/material-ui.esm.js": {
+    "bundled": 613335,
+    "minified": 303539,
+    "gzipped": 63852,
+    "treeshaked": {
+      "rollup": 210442,
+      "webpack": 218416
+    }
   }
 }

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -24,7 +24,7 @@
     "build:es2015": "cross-env NODE_ENV=production babel ./src --out-dir ./build --ignore *.test.js",
     "build:es2015modules": "cross-env NODE_ENV=production BABEL_ENV=modules babel ./src/index.js --out-file ./build/index.es.js",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel ./src --out-dir ./build/es --ignore *.test.js",
-    "build:umd": "cross-env NODE_ENV=production BABEL_ENV=production-umd rollup -c scripts/rollup.config.js",
+    "build:umd": "cross-env NODE_ENV=production BABEL_ENV=production-umd rollup -c scripts/rollup.config.js && rimraf dist/material-ui.esm.js",
     "build:copy-files": "babel-node ./scripts/copy-files.js",
     "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:es && yarn build:umd && yarn build:copy-files",
     "release": "yarn build && npm publish build"

--- a/packages/material-ui/scripts/rollup.config.js
+++ b/packages/material-ui/scripts/rollup.config.js
@@ -51,4 +51,11 @@ export default [
       uglify(),
     ],
   },
+
+  {
+    input,
+    output: { file: `build/dist/${name}.esm.js`, format: 'es' },
+    external: id => !id.startsWith('.') && !id.startsWith('/'),
+    plugins: [nodeResolve(), babel(getBabelOptions()), sizeSnapshot()],
+  },
 ];


### PR DESCRIPTION
Size snapshot plugin for esm bundle computes `import {} from 'lib'`
bundles with both rollup and webpack so we can see how much of the code
left after treeshaking and minification.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


P.S. We can force contributors to commit snapshot with `matchSnapshot` option which should fail on CI. Do you want me to take care about this in the next PR?