### PR TITLE
[Tabs] Fix TabIndicatorProps merge

### DIFF
--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -25,11 +25,20 @@ export const styles = theme => ({
  * @ignore - internal component.
  */
 function TabIndicator(props) {
-  const { classes, className, color, ...other } = props;
+  const { classes, className, color, TabIndicatorStyle, style, ...other } = props;
+
+  const styleProps =
+    Object.keys(TabIndicatorStyle).length !== 0
+      ? {
+          ...TabIndicatorStyle,
+          ...style,
+        }
+      : style;
 
   return (
     <span
       className={classNames(classes.root, classes[`color${capitalize(color)}`], className)}
+      style={styleProps}
       {...other}
     />
   );
@@ -49,7 +58,15 @@ TabIndicator.propTypes = {
    * @ignore
    * The color of the tab indicator.
    */
-  color: PropTypes.oneOf(['primary', 'secondary']),
+  color: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
+  /**
+   * @ignore
+   */
+  style: PropTypes.object,
+  /**
+   * Useful to extend or add custom style to component
+   */
+  TabIndicatorStyle: PropTypes.object,
 };
 
 export default withStyles(styles)(TabIndicator);

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -25,20 +25,11 @@ export const styles = theme => ({
  * @ignore - internal component.
  */
 function TabIndicator(props) {
-  const { classes, className, color, TabIndicatorStyle, style, ...other } = props;
-
-  const styleProps =
-    Object.keys(TabIndicatorStyle).length !== 0
-      ? {
-          ...TabIndicatorStyle,
-          ...style,
-        }
-      : style;
+  const { classes, className, color, ...other } = props;
 
   return (
     <span
       className={classNames(classes.root, classes[`color${capitalize(color)}`], className)}
-      style={styleProps}
       {...other}
     />
   );
@@ -58,15 +49,7 @@ TabIndicator.propTypes = {
    * @ignore
    * The color of the tab indicator.
    */
-  color: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
-  /**
-   * @ignore
-   */
-  style: PropTypes.object,
-  /**
-   * Useful to extend or add custom style to component
-   */
-  TabIndicatorStyle: PropTypes.object,
+  color: PropTypes.oneOf(['primary', 'secondary']),
 };
 
 export default withStyles(styles)(TabIndicator);

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -279,7 +279,7 @@ class Tabs extends React.Component {
       scrollable,
       ScrollButtonComponent,
       scrollButtons,
-      TabIndicatorStyle,
+      TabIndicatorProps = {},
       textColor,
       theme,
       value,
@@ -303,10 +303,13 @@ class Tabs extends React.Component {
 
     const indicator = (
       <TabIndicator
-        style={this.state.indicatorStyle}
         className={classes.indicator}
         color={indicatorColor}
-        TabIndicatorStyle={TabIndicatorStyle}
+        {...TabIndicatorProps}
+        style={{
+          ...this.state.indicatorStyle,
+          ...TabIndicatorProps.style,
+        }}
       />
     );
 
@@ -395,7 +398,7 @@ Tabs.propTypes = {
   /**
    * Determines the color of the indicator.
    */
-  indicatorColor: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
+  indicatorColor: PropTypes.oneOf(['secondary', 'primary']),
   /**
    * Callback fired when the value changes.
    *
@@ -422,7 +425,7 @@ Tabs.propTypes = {
   /**
    * Properties applied to the `TabIndicator` element.
    */
-  TabIndicatorStyle: PropTypes.object,
+  TabIndicatorProps: PropTypes.object,
   /**
    * Determines the color of the `Tab`.
    */
@@ -446,7 +449,6 @@ Tabs.defaultProps = {
   ScrollButtonComponent: TabScrollButton,
   scrollButtons: 'auto',
   textColor: 'inherit',
-  TabIndicatorStyle: {},
 };
 
 export default withStyles(styles, { name: 'MuiTabs', withTheme: true })(Tabs);

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -395,7 +395,7 @@ Tabs.propTypes = {
   /**
    * Determines the color of the indicator.
    */
-  indicatorColor: PropTypes.oneOf(['secondary', 'primary']),
+  indicatorColor: PropTypes.oneOf([PropTypes.string, PropTypes.oneOf(['secondary', 'primary'])]),
   /**
    * Callback fired when the value changes.
    *

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -279,7 +279,7 @@ class Tabs extends React.Component {
       scrollable,
       ScrollButtonComponent,
       scrollButtons,
-      TabIndicatorProps,
+      TabIndicatorStyle,
       textColor,
       theme,
       value,
@@ -306,7 +306,7 @@ class Tabs extends React.Component {
         style={this.state.indicatorStyle}
         className={classes.indicator}
         color={indicatorColor}
-        {...TabIndicatorProps}
+        TabIndicatorStyle={TabIndicatorStyle}
       />
     );
 
@@ -422,7 +422,7 @@ Tabs.propTypes = {
   /**
    * Properties applied to the `TabIndicator` element.
    */
-  TabIndicatorProps: PropTypes.object,
+  TabIndicatorStyle: PropTypes.object,
   /**
    * Determines the color of the `Tab`.
    */
@@ -446,6 +446,7 @@ Tabs.defaultProps = {
   ScrollButtonComponent: TabScrollButton,
   scrollButtons: 'auto',
   textColor: 'inherit',
+  TabIndicatorStyle: {},
 };
 
 export default withStyles(styles, { name: 'MuiTabs', withTheme: true })(Tabs);

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -606,4 +606,15 @@ describe('<Tabs />', () => {
       assert.strictEqual(scrollStub.callCount, 0, 'should not scroll');
     });
   });
+
+  describe('prop: TabIndicatorProps', () => {
+    it('should merge the style', () => {
+      const wrapper = shallow(
+        <Tabs onChange={noop} value={0} TabIndicatorProps={{ style: { backgroundColor: 'green' } }}>
+          <Tab />
+        </Tabs>,
+      );
+      assert.strictEqual(wrapper.find(TabIndicator).props().style.backgroundColor, 'green');
+    });
+  });
 });


### PR DESCRIPTION
<!-- I have reverted the changes and updated my PR, now if anyone wants to modify the TabIndicator they can easily do so like this.

```
<Tabs
   TabIndicatorStyle={{ height: 5, backgroundColor: 'yellow' }}
   value={value}
   onChange={this.handleChange}
>
  <Tab label="Item One" />
  <Tab label="Item Two" />
  <Tab label="Item Three" href="#basic-tabs" />
</Tabs>
```
--!>

Closes #11085