### PR TITLE
fix: make icons inherit font size

### DIFF
--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -7,7 +7,7 @@ import { capitalize } from '../utils/helpers';
 export const styles = theme => ({
   root: {
     userSelect: 'none',
-    fontSize: 24,
+    fontSize: 'inherit',
     width: '1em',
     height: '1em',
     // Chrome fix for https://bugs.chromium.org/p/chromium/issues/detail?id=820541

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -7,7 +7,8 @@ import { capitalize } from '../utils/helpers';
 export const styles = theme => ({
   root: {
     userSelect: 'none',
-    fontSize: 24,
+    fontSize: 'inherit',
+    verticalAlign: 'middle',
     width: '1em',
     height: '1em',
     display: 'inline-block',


### PR DESCRIPTION
fix #11493

This might cause a visual regression, but the current behavior isn't really correct.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
