### PR TITLE
[core] Enable loose mode for staged featues

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,19 +1,13 @@
 {
   "presets": [
     "./scripts/material-ui-babel-preset",
-    "@babel/preset-stage-1",
+    ["@babel/preset-stage-1", { "loose": true }],
     "@babel/preset-react",
     "@babel/flow"
   ],
   "plugins": [
     "@babel/plugin-transform-object-assign",
-    [
-      "@babel/transform-runtime",
-      {
-        "polyfill": false,
-        "useBuiltIns": true
-      }
-    ]
+    ["@babel/transform-runtime", { "polyfill": false, "useBuiltIns": true }]
   ],
   "env": {
     "coverage": {

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -21,13 +21,13 @@ module.exports = [
     name: 'The initial cost people pay for using one component',
     webpack: true,
     path: 'packages/material-ui/build/Paper/index.js',
-    limit: '18.0 KB',
+    limit: '17.7 KB',
   },
   {
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '97.1 KB',
+    limit: '95.8 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/packages/material-ui/.size-snapshot.json
+++ b/packages/material-ui/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "build/umd/material-ui.development.js": {
-    "bundled": 1041596,
-    "minified": 382040,
-    "gzipped": 96691
+    "bundled": 1005468,
+    "minified": 364958,
+    "gzipped": 95541
   },
   "build/umd/material-ui.production.min.js": {
-    "bundled": 872259,
-    "minified": 340866,
-    "gzipped": 87410
+    "bundled": 836136,
+    "minified": 323784,
+    "gzipped": 86321
   },
   "build/dist/material-ui.esm.js": {
-    "bundled": 613312,
-    "minified": 303359,
-    "gzipped": 63808,
+    "bundled": 579128,
+    "minified": 281957,
+    "gzipped": 62887,
     "treeshaked": {
-      "rollup": 211331,
-      "webpack": 218868
+      "rollup": 194465,
+      "webpack": 201568
     }
   }
 }

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -24,7 +24,7 @@
     "build:es2015": "cross-env NODE_ENV=production babel ./src --out-dir ./build --ignore *.test.js",
     "build:es2015modules": "cross-env NODE_ENV=production BABEL_ENV=modules babel ./src/index.js --out-file ./build/index.es.js",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel ./src --out-dir ./build/es --ignore *.test.js",
-    "build:umd": "cross-env NODE_ENV=production BABEL_ENV=production-umd rollup -c scripts/rollup.config.js && rimraf dist/material-ui.esm.js",
+    "build:umd": "BABEL_ENV=production-umd rollup -c scripts/rollup.config.js && rimraf dist/material-ui.esm.js",
     "build:copy-files": "babel-node ./scripts/copy-files.js",
     "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:es && yarn build:umd && yarn build:copy-files",
     "release": "yarn build && npm publish build"


### PR DESCRIPTION
By default babel tries to fit better in spec. But most of restrictions
just do not affect usual code. This diff enables loose mode for `stage-1`
preset. As a result babel requires less actions and less helpers.

🚀 We saved here ~17KB of the code which is parsed with browser. And ~1KB of
gzip space because a lot of stuff was a duplication.