### PR TITLE
[typescript] add sample with return types

### DIFF
--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -109,7 +109,7 @@ type Props = {
    someProp: string;
 };
 
-type PropsWithStyles = Props & WithStyles<"one" | "two">;
+type PropsWithStyles = Props & WithStyles<keyof ReturnType<typeof styles>>;
 
 const Component: React.SFC<PropsWithStyles> = ({
   classes,


### PR DESCRIPTION
With [typescript 2.8+](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html) **ReturnType** feature could by used.
