### PR TITLE
[core] Simplify the babel docs config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -35,7 +35,6 @@
       "sourceMaps": "both"
     },
     "docs-development": {
-      "presets": ["next/babel"],
       "plugins": [
         "./scripts/material-ui-babel-preval",
         [
@@ -54,7 +53,6 @@
       ]
     },
     "docs-production": {
-      "presets": ["next/babel"],
       "plugins": [
         "./scripts/material-ui-babel-preval",
         [


### PR DESCRIPTION
The closest the configuration of the documentation can be from the released
modules on npm, the better.

https://github.com/zeit/next.js/blob/57be892d02fa7b4bcf1d49d93e9bc335d2fd8677/.babelrc#L10