### PR TITLE
[ButtonBase] Fix React propTypes buttonRef warning

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
@@ -8,7 +8,7 @@ export interface ButtonBaseProps
       ButtonBaseClassKey
     > {
   action?: (actions: ButtonBaseActions) => void;
-  buttonRef?: React.Ref<any>;
+  buttonRef?: React.Ref<any> | React.RefObject<any>;
   centerRipple?: boolean;
   component?: React.ReactType<ButtonBaseProps>;
   disableRipple?: boolean;

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -318,7 +318,7 @@ ButtonBase.propTypes = {
   /**
    * Use that property to pass a ref callback to the native button component.
    */
-  buttonRef: PropTypes.func,
+  buttonRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * If `true`, the ripples will be centered.
    * They won't start at the cursor interaction position.

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -15,7 +15,7 @@ It contains a load of style reset and some focus/ripple logic.
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">action</span> | <span class="prop-type">func |  | Callback fired when the component mounts. This is useful when you want to trigger an action programmatically. It currently only supports `focusVisible()` action.<br><br>**Signature:**<br>`function(actions: object) => void`<br>*actions:* This object contains all possible actions that can be triggered programmatically. |
-| <span class="prop-name">buttonRef</span> | <span class="prop-type">func |  | Use that property to pass a ref callback to the native button component. |
+| <span class="prop-name">buttonRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |  | Use that property to pass a ref callback to the native button component. |
 | <span class="prop-name">centerRipple</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |


### PR DESCRIPTION
Fix issue with `buttonRef` mentioned in #11486 follow idea in: #11293 

Closes #11486