### PR TITLE
[docs] Removed references to Grid's hidden property

### DIFF
--- a/docs/src/pages/layout/hidden/hidden.md
+++ b/docs/src/pages/layout/hidden/hidden.md
@@ -61,6 +61,5 @@ The `only` property can be used in two ways:
 ## Integration with Grid
 
 It is quite common to alter `Grid` at different responsive breakpoints, and in many cases, you want to hide some of those elements.
-For brevity, where you are already using `Grid`, you may specify `Hidden` behaviors as the `hidden` property.
 
 {{"demo": "pages/layout/hidden/GridIntegration.js"}}


### PR DESCRIPTION
The `hidden` property of `Grid` was removed a couple days ago. See: https://github.com/mui-org/material-ui/pull/11348
So the references to it in the docs should be removed as well :)
