### PR TITLE
[lab] [SpeedDial] [typescript] Added type definitions to lab, so SpeedDial can be use with TypeScript project

### DIFF
--- a/packages/material-ui-lab/scripts/copy-files.js
+++ b/packages/material-ui-lab/scripts/copy-files.js
@@ -2,11 +2,18 @@
 
 import path from 'path';
 import fse from 'fs-extra';
+import glob from 'glob';
 
 async function copyFile(file) {
   const buildPath = path.resolve(__dirname, '../build/', path.basename(file));
   await fse.copy(file, buildPath);
   console.log(`Copied ${file} to ${buildPath}`);
+}
+
+function typescriptCopy(from, to) {
+  const files = glob.sync('**/*.d.ts', { cwd: from });
+  const cmds = files.map(file => fse.copy(path.resolve(from, file), path.resolve(to, file)));
+  return Promise.all(cmds);
 }
 
 async function createPackageFile() {
@@ -48,6 +55,13 @@ async function run() {
   await ['README.md', '../../LICENSE'].map(file => copyFile(file));
   const packageData = await createPackageFile();
   await addLicense(packageData);
+
+  // TypeScript
+  const from = path.resolve(__dirname, '../src');
+  await Promise.all([
+    typescriptCopy(from, path.resolve(__dirname, '../build')),
+    typescriptCopy(from, path.resolve(__dirname, '../build/es')),
+  ]);
 }
 
 run();

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
@@ -1,0 +1,27 @@
+import * as React from "react";
+import { StandardProps } from "../../../material-ui/src";
+import { ButtonProps } from "../../../material-ui/src/Button";
+import { TransitionProps } from "react-transition-group/Transition";
+import { TransitionHandlerProps } from "../../../material-ui/src/transitions/transition";
+
+export interface SpeedDialProps extends StandardProps<React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>, SpeedDialClassKey> {
+    ariaLabel: string;
+    ButtonProps?: Partial<ButtonProps>;
+    hidden?: boolean;
+    icon: React.ReactNode;
+    onClose?: React.ReactEventHandler<{}>;
+    open: boolean;
+    openIcon?: React.ReactNode;
+    TransitionComponent?: React.ReactType;
+    transitionDuration?: TransitionProps["timeout"];
+    TransitionProps?: TransitionProps;
+}
+
+export type SpeedDialClassKey =
+    | "root"
+    | "actions"
+    | "actionsClosed";
+
+declare const SpeedDial: React.ComponentType<SpeedDialProps>;
+
+export default SpeedDial;

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { StandardProps } from "../../../material-ui/src";
-import { ButtonProps } from "../../../material-ui/src/Button";
+import { StandardProps } from "@material-ui/core";
+import { ButtonProps } from "@material-ui/core/Button";
 import { TransitionProps } from "react-transition-group/Transition";
-import { TransitionHandlerProps } from "../../../material-ui/src/transitions/transition";
+import { TransitionHandlerProps } from "@material-ui/core/transitions/transition";
 
 export interface SpeedDialProps extends StandardProps<React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>, SpeedDialClassKey> {
     ariaLabel: string;

--- a/packages/material-ui-lab/src/SpeedDial/index.d.ts
+++ b/packages/material-ui-lab/src/SpeedDial/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from "./SpeedDial";
+export * from "./SpeedDial";

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -15,6 +15,6 @@ export type SpeedDialActionClassKey =
     | "button"
     | "buttonClosed";
 
-declare const SpeedDialAction: React.ComponentType<any>;
+declare const SpeedDialAction: React.ComponentType<SpeedDialActionProps>;
 
 export default SpeedDialAction;

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from "../../../material-ui/src";
 import { ButtonProps } from "../../../material-ui/src/Button";
 import { TooltipProps } from "../../../material-ui/src/Tooltip";
 
-export interface SpeedDialActionProps extends StandardProps<ButtonProps & TooltipProps, SpeedDialActionClassKey> {
+export interface SpeedDialActionProps extends StandardProps<ButtonProps & Partial<TooltipProps>, SpeedDialActionClassKey> {
     ButtonProps?: Partial<ButtonProps>;
     delay?: number;
     icon: React.ReactNode;

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+import { StandardProps } from "../../../material-ui/src";
+import { ButtonProps } from "../../../material-ui/src/Button";
+import { TooltipProps } from "../../../material-ui/src/Tooltip";
+
+export interface SpeedDialActionProps extends StandardProps<ButtonProps & TooltipProps, SpeedDialActionClassKey> {
+    ButtonProps?: Partial<ButtonProps>;
+    delay?: number;
+    icon: React.ReactNode;
+    tooltipTitle?: React.ReactNode;
+}
+
+export type SpeedDialActionClassKey =
+    | "root"
+    | "button"
+    | "buttonClosed";
+
+declare const SpeedDialAction: React.ComponentType<any>;
+
+export default SpeedDialAction;

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { StandardProps } from "../../../material-ui/src";
-import { ButtonProps } from "../../../material-ui/src/Button";
-import { TooltipProps } from "../../../material-ui/src/Tooltip";
+import { StandardProps } from "@material-ui/core";
+import { ButtonProps } from "@material-ui/core/Button";
+import { TooltipProps } from "@material-ui/core/Tooltip";
 
 export interface SpeedDialActionProps extends StandardProps<ButtonProps & Partial<TooltipProps>, SpeedDialActionClassKey> {
     ButtonProps?: Partial<ButtonProps>;

--- a/packages/material-ui-lab/src/SpeedDialAction/index.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from "./SpeedDialAction";
+export * from "./SpeedDialAction";

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { StandardProps } from "../../../material-ui/src";
+import { StandardProps } from "@material-ui/core";
 
 export interface SpeedDialIconProps extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, SpeedDialIconClassKey> {
     icon?: React.ReactNode;

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { StandardProps } from "../../../material-ui/src";
+
+export interface SpeedDialIconProps extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, SpeedDialIconClassKey> {
+    icon?: React.ReactNode;
+    openIcon?: React.ReactNode;
+}
+
+export type SpeedDialIconClassKey =
+    | "root"
+    | "icon"
+    | "iconOpen"
+    | "iconWithOpenIconOpen"
+    | "openIcon"
+    | "openIconOpen";
+
+declare const SpeedDialIcon: React.ComponentType<SpeedDialIconProps>;
+
+export default SpeedDialIcon;

--- a/packages/material-ui-lab/src/SpeedDialIcon/index.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialIcon/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from "./SpeedDialIcon";
+export * from "./SpeedDialIcon";

--- a/packages/material-ui-lab/src/index.d.ts
+++ b/packages/material-ui-lab/src/index.d.ts
@@ -1,0 +1,3 @@
+export { default as SpeedDial } from './SpeedDial';
+export { default as SpeedDialAction } from './SpeedDialAction';
+export { default as SpeedDialIcon } from './SpeedDialIcon';


### PR DESCRIPTION
I was trying to use the SpeedDial component in a TypeScript project and I saw it didn't have type definitions. I decided to add them, even if the lab part of Material-UI is a work in progress (at least the base will be there).