### PR TITLE
Card should not set overflow:hidden

### DIFF
--- a/packages/material-ui/src/Card/Card.js
+++ b/packages/material-ui/src/Card/Card.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 
 export const styles = {
   root: {
-    zIndex: 1
+    zIndex: 1,
   },
 };
 

--- a/packages/material-ui/src/Card/Card.js
+++ b/packages/material-ui/src/Card/Card.js
@@ -8,7 +8,7 @@ import withStyles from '../styles/withStyles';
 
 export const styles = {
   root: {
-    overflow: 'hidden',
+    zIndex: 1
   },
 };
 


### PR DESCRIPTION
Because "https://creativetimofficial.github.io/material-dashboard-react/#/dashboard headers" looking bad with latest version.

![may-24-2018 14-14-19](https://user-images.githubusercontent.com/282104/40482568-f048afa2-5f5d-11e8-9aff-abdfcc7099ce.gif)


Similiar to https://github.com/mui-org/material-ui/issues/2623. 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
