### PR TITLE
[StepConnector] Add to default export from @material-ui/core

### DIFF
--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -151,6 +151,7 @@ export { default as Snackbar } from './Snackbar';
 export { default as SnackbarContent } from './SnackbarContent';
 export { default as Step } from './Step';
 export { default as StepButton } from './StepButton';
+export { default as StepConnector } from './StepConnector';
 export { default as StepContent } from './StepContent';
 export { default as StepIcon } from './StepIcon';
 export { default as StepLabel } from './StepLabel';

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -84,6 +84,7 @@ export { default as Snackbar } from './Snackbar';
 export { default as SnackbarContent } from './SnackbarContent';
 export { default as Step } from './Step';
 export { default as StepButton } from './StepButton';
+export { default as StepConnector } from './StepConnector';
 export { default as StepContent } from './StepContent';
 export { default as StepIcon } from './StepIcon';
 export { default as StepLabel } from './StepLabel';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
In the beta version was the ability to export StepConnector. In version 1.0, it disappeared. I added this feature.