### PR TITLE
[docs] Update npm downloads badge to point to @material-ui/core

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [React](http://facebook.github.io/react/) components that implement [Google's Material Design](https://www.google.com/design/spec/material-design/introduction.html).
 
 [![npm package](https://img.shields.io/npm/v/@material-ui/core/latest.svg)](https://www.npmjs.com/package/@material-ui/core)
-[![npm download](https://img.shields.io/npm/dm/@material-ui/core.svg)](https://www.npmjs.com/package/@material-ui/core)
+[![npm downloads](https://img.shields.io/npm/dm/@material-ui/core.svg)](https://www.npmjs.com/package/@material-ui/core)
 [![CircleCI](https://img.shields.io/circleci/project/github/mui-org/material-ui/v1-beta.svg)](https://circleci.com/gh/mui-org/material-ui/tree/v1-beta)
 [![Gitter](https://img.shields.io/badge/gitter-join%20chat-f81a65.svg)](https://gitter.im/callemall/material-ui?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Coverage Status](https://img.shields.io/codecov/c/github/mui-org/material-ui/v1-beta.svg)](https://codecov.io/gh/mui-org/material-ui/branch/v1-beta)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [React](http://facebook.github.io/react/) components that implement [Google's Material Design](https://www.google.com/design/spec/material-design/introduction.html).
 
 [![npm package](https://img.shields.io/npm/v/@material-ui/core/latest.svg)](https://www.npmjs.com/package/@material-ui/core)
-[![npm download](https://img.shields.io/npm/dm/material-ui.svg)](https://www.npmjs.com/package/material-ui)
+[![npm download](https://img.shields.io/npm/dm/@material-ui/core.svg)](https://www.npmjs.com/package/@material-ui/core)
 [![CircleCI](https://img.shields.io/circleci/project/github/mui-org/material-ui/v1-beta.svg)](https://circleci.com/gh/mui-org/material-ui/tree/v1-beta)
 [![Gitter](https://img.shields.io/badge/gitter-join%20chat-f81a65.svg)](https://gitter.im/callemall/material-ui?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Coverage Status](https://img.shields.io/codecov/c/github/mui-org/material-ui/v1-beta.svg)](https://codecov.io/gh/mui-org/material-ui/branch/v1-beta)

--- a/docs/src/pages/getting-started/comparison/comparison.md
+++ b/docs/src/pages/getting-started/comparison/comparison.md
@@ -20,7 +20,7 @@ We cover the following libraries:
 ## Material-UI
 
 ![stars](https://img.shields.io/github/stars/mui-org/material-ui.svg?style=social&label=Stars)
-![npm](https://img.shields.io/npm/dm/material-ui.svg)
+![npm downloads](https://img.shields.io/npm/dm/@material-ui/core.svg)
 
 We'll try very hard to avoid bias, although as the core team, we obviously like Material-UI a lot ❤️.
 There are some problems we think it solves better than anything else out there; if we didn’t believe that, we wouldn’t be working on it 😄.
@@ -30,7 +30,7 @@ We do want to be fair and accurate though, so where other libraries offer signif
 ## Material Design Lite (MDL)
 
 ![stars](https://img.shields.io/github/stars/google/material-design-lite.svg?style=social&label=Stars)
-![npm](https://img.shields.io/npm/dm/material-design-lite.svg)
+![npm downloads](https://img.shields.io/npm/dm/material-design-lite.svg)
 
 Material Design Lite, while a very well-thought-out Material Design implementation,
 was primarily maintained by Developer Relations at Google.
@@ -44,7 +44,7 @@ and towards the goal of a canonical Material Design implementation for the entir
 ## Material Components Web (MDC-web)
 
 ![stars](https://img.shields.io/github/stars/material-components/material-components-web.svg?style=social&label=Stars)
-![npm](https://img.shields.io/npm/dm/material-components-web.svg)
+![npm downloads](https://img.shields.io/npm/dm/material-components-web.svg)
 
 We are very happy to see this project supported by Google and its design team.
 It sends a clear signal that the [Material Design specification](https://material.io/design/) is
@@ -112,7 +112,7 @@ The **less** time you spend on a single contribution, the **more** contributions
 ## Materialize
 
 ![stars](https://img.shields.io/github/stars/Dogfalo/materialize.svg?style=social&label=Stars)
-![npm](https://img.shields.io/npm/dm/materialize-css.svg)
+![npm downloads](https://img.shields.io/npm/dm/materialize-css.svg)
 
 ### Browser support
 
@@ -129,7 +129,7 @@ We explain why in the [MDC-web section](#styling-solution) above.
 ## React Toolbox
 
 ![stars](https://img.shields.io/github/stars/react-toolbox/react-toolbox.svg?style=social&label=Stars)
-![npm](https://img.shields.io/npm/dm/react-toolbox.svg)
+![npm downloads](https://img.shields.io/npm/dm/react-toolbox.svg)
 
 ### Styling solution
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

The current badge is pointing to the deprecated project on npm: https://www.npmjs.com/package/material-ui

This updates the badge to the new `@material-ui/core` project.

Note: Currently the download count on the old badge is 855k/month, and the new badge is showing 52k/month

### Before
<img width="956" alt="screen shot 2018-05-25 at 2 21 41 pm" src="https://user-images.githubusercontent.com/120596/40566769-1c6d5b0e-6027-11e8-8242-e76f1d8df8d2.png">

(pointing to https://www.npmjs.com/package/material-ui)

### After
<img width="960" alt="screen shot 2018-05-25 at 2 21 27 pm" src="https://user-images.githubusercontent.com/120596/40566768-1b50936c-6027-11e8-85d5-4d74d5ea0818.png">

(pointing to https://www.npmjs.com/package/@material-ui/core)