### PR TITLE
[docs] Better API spread section

### DIFF
--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -41,6 +41,38 @@ const rootDirectory = path.resolve(__dirname, '../../');
 const docsApiDirectory = path.resolve(rootDirectory, args[3]);
 const theme = createMuiTheme();
 
+const inheritedComponentRegexp = /\/\/ @inheritedComponent (.*)/;
+
+function getInheritance(src) {
+  const inheritedComponent = src.match(inheritedComponentRegexp);
+
+  if (!inheritedComponent) {
+    return null;
+  }
+
+  const component = inheritedComponent[1];
+  let pathname;
+
+  switch (component) {
+    case 'Transition':
+      pathname = 'https://reactcommunity.org/react-transition-group/#Transition';
+      break;
+
+    case 'EventListener':
+      pathname = 'https://github.com/oliviertassinari/react-event-listener';
+      break;
+
+    default:
+      pathname = `/api/${kebabCase(component)}`;
+      break;
+  }
+
+  return {
+    component,
+    pathname,
+  };
+}
+
 function buildDocs(options) {
   const { component: componentObject, pagesMarkdown } = options;
   const src = readFileSync(componentObject.filename, 'utf8');
@@ -72,17 +104,19 @@ function buildDocs(options) {
     throw err;
   }
 
+  // if (reactAPI.name !== 'Select') {
+  //   return;
+  // }
+
   reactAPI.name = path.parse(componentObject.filename).name;
   reactAPI.styles = styles;
   reactAPI.pagesMarkdown = pagesMarkdown;
   reactAPI.src = src;
 
-  // if (reactAPI.name !== 'Select') {
-  //   return;
-  // }
-
   // Relative location in the file system.
   reactAPI.filename = componentObject.filename.replace(rootDirectory, '');
+  reactAPI.inheritance = getInheritance(src);
+
   let markdown;
   try {
     markdown = generateMarkdown(reactAPI);

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -7,7 +7,7 @@ import withTheme from '../styles/withTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
 
 function getScale(value) {
-  return `scale(${value}, ${value ** 2})`;
+  return `scale(${value}, ${Math.pow(value, 2)})`;
 }
 
 const styles = {

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -17,7 +17,7 @@ filename: /packages/material-ui/src/AppBar/AppBar.js
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br> | <span class="prop-default">'primary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">position</span> | <span class="prop-type">enum:&nbsp;'fixed'&nbsp;&#124;<br>&nbsp;'absolute'&nbsp;&#124;<br>&nbsp;'sticky'&nbsp;&#124;<br>&nbsp;'static'<br> | <span class="prop-default">'fixed'</span> | The positioning type. The behavior of the different options is described [here](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning). Note: `sticky` is not universally supported and will fall back to `static` when unavailable. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Paper](/api/paper)).
 
 ## CSS API
 
@@ -43,6 +43,7 @@ you need to use the following style sheet name: `MuiAppBar`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -21,7 +21,7 @@ filename: /packages/material-ui/src/Avatar/Avatar.js
 | <span class="prop-name">src</span> | <span class="prop-type">string |  | The `src` attribute for the `img` element. |
 | <span class="prop-name">srcSet</span> | <span class="prop-type">string |  | The `srcSet` attribute for the `img` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/backdrop.md
+++ b/pages/api/backdrop.md
@@ -17,7 +17,7 @@ filename: /packages/material-ui/src/Backdrop/Backdrop.js
 | <span class="prop-name required">open *</span> | <span class="prop-type">bool |  | If `true`, the backdrop is open. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> |  | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/Badge/Badge.js
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'error'<br> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'span'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/BottomNavigationAction/BottomNavigationActio
 | <span class="prop-name">showLabel</span> | <span class="prop-type">bool |  | If `true`, the BottomNavigationAction will show its label. |
 | <span class="prop-name">value</span> | <span class="prop-type">any |  | You can provide your own value. Otherwise, we fallback to the child position index. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([ButtonBase](/api/button-base)).
 
 ## CSS API
 
@@ -41,6 +41,7 @@ you need to use the following style sheet name: `MuiBottomNavigationAction`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/BottomNavigation/BottomNavigation.js
 | <span class="prop-name">showLabels</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, all `BottomNavigationAction`s will show their labels. By default, only the selected `BottomNavigationAction` will show its label. |
 | <span class="prop-name">value</span> | <span class="prop-type">any |  | The value of the currently selected `BottomNavigationAction`. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -27,7 +27,7 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">onFocusVisible</span> | <span class="prop-type">func |  | Callback fired when the component is focused with a keyboard. We trigger a `onFocus` callback too. |
 | <span class="prop-name">TouchRippleProps</span> | <span class="prop-type">object |  | Properties applied to the `TouchRipple` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -25,7 +25,7 @@ filename: /packages/material-ui/src/Button/Button.js
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'flat'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'raised'&nbsp;&#124;<br>&nbsp;'fab'<br> | <span class="prop-default">'flat'</span> | The type of button. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([ButtonBase](/api/button-base)).
 
 ## CSS API
 
@@ -59,6 +59,7 @@ you need to use the following style sheet name: `MuiButton`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/CardActions/CardActions.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">disableActionSpacing</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the card actions do not have additional margin. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/card-content.md
+++ b/pages/api/card-content.md
@@ -15,7 +15,7 @@ filename: /packages/material-ui/src/CardContent/CardContent.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/card-header.md
+++ b/pages/api/card-header.md
@@ -19,7 +19,7 @@ filename: /packages/material-ui/src/CardHeader/CardHeader.js
 | <span class="prop-name">subheader</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">title</span> | <span class="prop-type">node |  | The content of the Card Title. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -17,7 +17,7 @@ filename: /packages/material-ui/src/CardMedia/CardMedia.js
 | <span class="prop-name">image</span> | <span class="prop-type">string |  | Image to be displayed as a background image. Either `image` or `src` prop must be specified. Note that caller must specify height otherwise the image will not be visible. |
 | <span class="prop-name">src</span> | <span class="prop-type">string |  | An alias for `image` property. Available only with media components. Media components: `video`, `audio`, `picture`, `iframe`, `img`. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/card.md
+++ b/pages/api/card.md
@@ -15,7 +15,7 @@ filename: /packages/material-ui/src/Card/Card.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">raised</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the card will use raised styling. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Paper](/api/paper)).
 
 ## CSS API
 
@@ -34,6 +34,7 @@ you need to use the following style sheet name: `MuiCard`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -28,7 +28,7 @@ filename: /packages/material-ui/src/Checkbox/Checkbox.js
 | <span class="prop-name">type</span> | <span class="prop-type">string |  | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">string |  | The value of the component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -19,7 +19,7 @@ Chips represent complex entities in small blocks, such as a contact.
 | <span class="prop-name">label</span> | <span class="prop-type">node |  | The content of the label. |
 | <span class="prop-name">onDelete</span> | <span class="prop-type">func |  | Callback function fired when the delete icon is clicked. If set, the delete icon will be shown. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -23,7 +23,7 @@ attribute to `true` on that region until it has finished loading.
 | <span class="prop-name">value</span> | <span class="prop-type">number | <span class="prop-default">0</span> | The value of the progress indicator for the determinate and static variants. Value between 0 and 100. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'determinate'&nbsp;&#124;<br>&nbsp;'indeterminate'&nbsp;&#124;<br>&nbsp;'static'<br> | <span class="prop-default">'indeterminate'</span> | The variant of progress indicator. Use indeterminate when there is no progress value. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -17,9 +17,10 @@ Listen for click events that are triggered outside of the component children.
 | <span class="prop-name required">onClickAway *</span> | <span class="prop-type">func |  |  |
 | <span class="prop-name">touchEvent</span> | <span class="prop-type">enum:&nbsp;'onTouchStart'&nbsp;&#124;<br>&nbsp;'onTouchEnd'&nbsp;&#124;<br>&nbsp;false<br> | <span class="prop-default">'onTouchEnd'</span> |  |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([EventListener](https://github.com/oliviertassinari/react-event-listener)).
 
 ## Inheritance
 
 The properties of the [EventListener](https://github.com/oliviertassinari/react-event-listener) component, from react-event-listener, are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -21,7 +21,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">duration.standard</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## CSS API
 
@@ -43,6 +43,7 @@ you need to use the following style sheet name: `MuiCollapse`.
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -14,7 +14,7 @@ Kickstart an elegant, consistent, and simple baseline to build upon.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node | <span class="prop-default">null</span> | You can wrap a node. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/DialogActions/DialogActions.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">disableActionSpacing</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the dialog actions do not have additional margin. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -15,7 +15,7 @@ filename: /packages/material-ui/src/DialogContentText/DialogContentText.js
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Typography](/api/typography)).
 
 ## CSS API
 
@@ -34,4 +34,5 @@ you need to use the following style sheet name: `MuiDialogContentText`.
 ## Inheritance
 
 The properties of the [Typography](/api/typography) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 

--- a/pages/api/dialog-content.md
+++ b/pages/api/dialog-content.md
@@ -15,7 +15,7 @@ filename: /packages/material-ui/src/DialogContent/DialogContent.js
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/dialog-title.md
+++ b/pages/api/dialog-title.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/DialogTitle/DialogTitle.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">disableTypography</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the children won't be wrapped by a typography component. For instance, this can be useful to render an h4 instead of the default h2. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -34,7 +34,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Modal](/api/modal)).
 
 ## CSS API
 
@@ -59,6 +59,7 @@ you need to use the following style sheet name: `MuiDialog`.
 ## Inheritance
 
 The properties of the [Modal](/api/modal) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/Divider/Divider.js
 | <span class="prop-name">inset</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the divider will be indented. |
 | <span class="prop-name">light</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the divider will have a lighter color. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -25,7 +25,7 @@ when `variant="temporary"` is set.
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br> | <span class="prop-default">'temporary'</span> | The variant of drawer. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/expansion-panel-actions.md
+++ b/pages/api/expansion-panel-actions.md
@@ -15,7 +15,7 @@ filename: /packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.
 | <span class="prop-name required">children *</span> | <span class="prop-type">node |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/expansion-panel-details.md
+++ b/pages/api/expansion-panel-details.md
@@ -15,7 +15,7 @@ filename: /packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.
 | <span class="prop-name required">children *</span> | <span class="prop-type">node |  | The content of the expansion panel details. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node |  | The icon to display as the expand indicator. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([ButtonBase](/api/button-base)).
 
 ## CSS API
 
@@ -40,6 +40,7 @@ you need to use the following style sheet name: `MuiExpansionPanelSummary`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/expansion-panel.md
+++ b/pages/api/expansion-panel.md
@@ -20,7 +20,7 @@ filename: /packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
 | <span class="prop-name">expanded</span> | <span class="prop-type">bool |  | If `true`, expands the panel, otherwise collapse it. Setting this prop enables control over the panel. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |  | Callback fired when the expand/collapse state is changed.<br><br>**Signature:**<br>`function(event: object, expanded: boolean) => void`<br>*event:* The event source of the callback<br>*expanded:* The `expanded` state of the panel |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Paper](/api/paper)).
 
 ## CSS API
 
@@ -41,6 +41,7 @@ you need to use the following style sheet name: `MuiExpansionPanel`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -17,11 +17,12 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -23,7 +23,7 @@ Use this component if you want to display an extra label.
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">value</span> | <span class="prop-type">string |  | The value of the component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -28,7 +28,7 @@ This context is used by the following components:
 | <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'none'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'normal'<br> | <span class="prop-default">'none'</span> | If `dense` or `normal`, will adjust vertical spacing of this and contained components. |
 | <span class="prop-name">required</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the label will indicate that the input is required. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/form-group.md
+++ b/pages/api/form-group.md
@@ -18,7 +18,7 @@ For the `Radio`, you should be using the `RadioGroup` component instead of this 
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">row</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Display group of elements in a compact row. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -19,7 +19,7 @@ filename: /packages/material-ui/src/FormHelperText/FormHelperText.js
 | <span class="prop-name">error</span> | <span class="prop-type">bool |  | If `true`, helper text should be displayed in an error state. |
 | <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'<br> |  | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -20,7 +20,7 @@ filename: /packages/material-ui/src/FormLabel/FormLabel.js
 | <span class="prop-name">focused</span> | <span class="prop-type">bool |  | If `true`, the input of this label is focused (used by `FormGroup` components). |
 | <span class="prop-name">required</span> | <span class="prop-type">bool |  | If `true`, the label will indicate that the input is required. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -19,7 +19,7 @@ filename: /packages/material-ui/src/GridListTileBar/GridListTileBar.js
 | <span class="prop-name">title</span> | <span class="prop-type">node |  | Title to be displayed on tile. |
 | <span class="prop-name">titlePosition</span> | <span class="prop-type">enum:&nbsp;'top'&nbsp;&#124;<br>&nbsp;'bottom'<br> | <span class="prop-default">'bottom'</span> | Position of the title bar. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/GridListTile/GridListTile.js
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'li'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">rows</span> | <span class="prop-type">number | <span class="prop-default">1</span> | Height of the tile in number of grid cells. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/grid-list.md
+++ b/pages/api/grid-list.md
@@ -19,7 +19,7 @@ filename: /packages/material-ui/src/GridList/GridList.js
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'ul'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">spacing</span> | <span class="prop-type">number | <span class="prop-default">4</span> | Number of px for the spacing between tiles. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -30,7 +30,7 @@ filename: /packages/material-ui/src/Grid/Grid.js
 | <span class="prop-name">xs</span> | <span class="prop-type">enum:&nbsp;false, true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br> | <span class="prop-default">false</span> | Defines the number of grids the component is going to use. It's applied for all the screen sizes with the lowest priority. |
 | <span class="prop-name">zeroMinWidth</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, it sets `min-width: 0` on the item. Refer to the limitations section of the documentation to better understand the use case. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -17,11 +17,12 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool |  | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">'auto'</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/hidden.md
+++ b/pages/api/hidden.md
@@ -27,7 +27,7 @@ Responsively hides children based on the selected implementation.
 | <span class="prop-name">xsDown</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If true, screens this size and down will be hidden. |
 | <span class="prop-name">xsUp</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If true, screens this size and up will be hidden. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -19,7 +19,7 @@ regarding the available icon options.
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool |  | If `true`, the ripple will be disabled. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([ButtonBase](/api/button-base)).
 
 ## CSS API
 
@@ -43,6 +43,7 @@ you need to use the following style sheet name: `MuiIconButton`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/Icon/Icon.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'inherit', 'primary', 'secondary', 'action', 'error', 'disabled'<br> | <span class="prop-default">'inherit'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/input-adornment.md
+++ b/pages/api/input-adornment.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/InputAdornment/InputAdornment.js
 | <span class="prop-name">disableTypography</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If children is a string then disable wrapping in a Typography component. |
 | <span class="prop-name">position</span> | <span class="prop-type">enum:&nbsp;'start'&nbsp;&#124;<br>&nbsp;'end'<br> |  | The position this adornment should appear relative to the `Input`. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -23,7 +23,7 @@ filename: /packages/material-ui/src/InputLabel/InputLabel.js
 | <span class="prop-name">required</span> | <span class="prop-type">bool |  | if `true`, the label will indicate that the input is required. |
 | <span class="prop-name">shrink</span> | <span class="prop-type">bool |  | If `true`, the label is shrunk. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([FormLabel](/api/form-label)).
 
 ## CSS API
 
@@ -46,6 +46,7 @@ you need to use the following style sheet name: `MuiInputLabel`.
 ## Inheritance
 
 The properties of the [FormLabel](/api/form-label) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -37,7 +37,7 @@ filename: /packages/material-ui/src/Input/Input.js
 | <span class="prop-name">type</span> | <span class="prop-type">string | <span class="prop-default">'text'</span> | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;arrayOf<br> |  | The input value, required for a controlled component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -22,7 +22,7 @@ attribute to `true` on that region until it has finished loading.
 | <span class="prop-name">valueBuffer</span> | <span class="prop-type">number |  | The value for the buffer variant. Value between 0 and 100. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'determinate'&nbsp;&#124;<br>&nbsp;'indeterminate'&nbsp;&#124;<br>&nbsp;'buffer'&nbsp;&#124;<br>&nbsp;'query'<br> | <span class="prop-default">'indeterminate'</span> | The variant of progress indicator. Use indeterminate or query when there is no progress value. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -15,7 +15,7 @@ It's a simple wrapper to apply the `dense` mode styles to `Avatar`.
 | <span class="prop-name required">children *</span> | <span class="prop-type">element |  | The content of the component, normally `Avatar`. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -15,7 +15,7 @@ A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
 | <span class="prop-name required">children *</span> | <span class="prop-type">element |  | The content of the component, normally `Icon`, `SvgIcon`, or a `@material-ui/icons` SVG icon element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/list-item-secondary-action.md
+++ b/pages/api/list-item-secondary-action.md
@@ -15,7 +15,7 @@ filename: /packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAct
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | The content of the component, normally an `IconButton` or selection control. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -19,7 +19,7 @@ filename: /packages/material-ui/src/ListItemText/ListItemText.js
 | <span class="prop-name">primary</span> | <span class="prop-type">node |  | The main content element. |
 | <span class="prop-name">secondary</span> | <span class="prop-type">node |  | The secondary content element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -22,7 +22,7 @@ filename: /packages/material-ui/src/ListItem/ListItem.js
 | <span class="prop-name">disableGutters</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the left and right padding is removed. |
 | <span class="prop-name">divider</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, a 1px light border is added to the bottom of the list item. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -19,7 +19,7 @@ filename: /packages/material-ui/src/ListSubheader/ListSubheader.js
 | <span class="prop-name">disableSticky</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the List Subheader will not stick to the top during scroll. |
 | <span class="prop-name">inset</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the List Subheader will be indented. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -19,7 +19,7 @@ filename: /packages/material-ui/src/List/List.js
 | <span class="prop-name">disablePadding</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, vertical padding will be removed from the list. |
 | <span class="prop-name">subheader</span> | <span class="prop-type">node |  | The content of the subheader, normally `ListSubheader`. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -17,7 +17,7 @@ filename: /packages/material-ui/src/MenuItem/MenuItem.js
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'li'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">selected</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Use to apply selected styling. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([ListItem](/api/list-item)).
 
 ## CSS API
 
@@ -37,6 +37,7 @@ you need to use the following style sheet name: `MuiMenuItem`.
 ## Inheritance
 
 The properties of the [ListItem](/api/list-item) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -14,11 +14,12 @@ filename: /packages/material-ui/src/MenuList/MenuList.js
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node |  | MenuList contents, normally `MenuItem`s. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([List](/api/list)).
 
 ## Inheritance
 
 The properties of the [List](/api/list) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -27,7 +27,7 @@ filename: /packages/material-ui/src/Menu/Menu.js
 | <span class="prop-name">PopoverClasses</span> | <span class="prop-type">object |  | `classes` property applied to the `Popover` element. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">'auto'</span> | The length of the transition in `ms`, or 'auto' |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Popover](/api/popover)).
 
 ## CSS API
 
@@ -46,6 +46,7 @@ you need to use the following style sheet name: `MuiMenu`.
 ## Inheritance
 
 The properties of the [Popover](/api/popover) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/mobile-stepper.md
+++ b/pages/api/mobile-stepper.md
@@ -20,7 +20,7 @@ filename: /packages/material-ui/src/MobileStepper/MobileStepper.js
 | <span class="prop-name required">steps *</span> | <span class="prop-type">number |  | The total steps. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'dots'&nbsp;&#124;<br>&nbsp;'progress'<br> | <span class="prop-default">'dots'</span> | The type of mobile stepper to use. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Paper](/api/paper)).
 
 ## CSS API
 
@@ -46,6 +46,7 @@ you need to use the following style sheet name: `MuiMobileStepper`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -31,7 +31,7 @@ filename: /packages/material-ui/src/Modal/Modal.js
 | <span class="prop-name">onRendered</span> | <span class="prop-type">func |  | Callback fired once the children has been mounted into the `container`. It signals that the `open={true}` property took effect. |
 | <span class="prop-name required">open *</span> | <span class="prop-type">bool |  | If `true`, the modal is open. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Portal](/api/portal)).
 
 ## CSS API
 
@@ -51,6 +51,7 @@ you need to use the following style sheet name: `MuiModal`.
 ## Inheritance
 
 The properties of the [Portal](/api/portal) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/mui-theme-provider.md
+++ b/pages/api/mui-theme-provider.md
@@ -19,5 +19,5 @@ This component should preferably be used at **the root of your component tree**.
 | <span class="prop-name">sheetsManager</span> | <span class="prop-type">object |  | The sheetsManager is used to deduplicate style sheet injection in the page. It's deduplicating using the (theme, styles) couple. On the server, you should provide a new instance for each request. |
 | <span class="prop-name required">theme *</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br> |  | A theme object. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -20,7 +20,7 @@ An alternative to `<Select native />` with a much smaller dependency graph.
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |  | Callback function fired when a menu item is selected.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br> |  | The input value. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Input](/api/input)).
 
 ## CSS API
 
@@ -43,4 +43,5 @@ you need to use the following style sheet name: `MuiNativeSelect`.
 ## Inheritance
 
 The properties of the [Input](/api/input) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/Paper/Paper.js
 | <span class="prop-name">elevation</span> | <span class="prop-type">number | <span class="prop-default">2</span> | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |
 | <span class="prop-name">square</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, rounded corners are disabled. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -37,7 +37,7 @@ filename: /packages/material-ui/src/Popover/Popover.js
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">'auto'</span> | Set to 'auto' to automatically calculate transition time based on height. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Modal](/api/modal)).
 
 ## CSS API
 
@@ -56,6 +56,7 @@ you need to use the following style sheet name: `MuiPopover`.
 ## Inheritance
 
 The properties of the [Modal](/api/modal) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/portal.md
+++ b/pages/api/portal.md
@@ -19,7 +19,7 @@ and take the control of our destiny.
 | <span class="prop-name">container</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br> |  | A node, component instance, or function that returns either. The `container` will have the portal children appended to it. By default, it uses the body of the top-level document object, so it's simply `document.body` most of the time. |
 | <span class="prop-name">onRendered</span> | <span class="prop-type">func |  | Callback fired once the children has been mounted into the `container`. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -17,11 +17,12 @@ filename: /packages/material-ui/src/RadioGroup/RadioGroup.js
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |  | Callback fired when a radio button is selected.<br><br>**Signature:**<br>`function(event: object, value: string) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`.<br>*value:* The `value` of the selected radio button |
 | <span class="prop-name">value</span> | <span class="prop-type">string |  | Value of the selected radio button. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([FormGroup](/api/form-group)).
 
 ## Inheritance
 
 The properties of the [FormGroup](/api/form-group) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -26,7 +26,7 @@ filename: /packages/material-ui/src/Radio/Radio.js
 | <span class="prop-name">type</span> | <span class="prop-type">string |  | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">string |  | The value of the component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -17,5 +17,5 @@ It's higly inspired by https://github.com/facebook/react/issues/11401#issuecomme
 | <span class="prop-name required">children *</span> | <span class="prop-type">element |  |  |
 | <span class="prop-name required">rootRef *</span> | <span class="prop-type">func |  |  |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -30,7 +30,7 @@ filename: /packages/material-ui/src/Select/Select.js
 | <span class="prop-name">SelectDisplayProps</span> | <span class="prop-type">object |  | Properties applied to the clickable div element. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;arrayOf<br> |  | The input value. This property is required when the `native` property is `false` (default). |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Input](/api/input)).
 
 ## CSS API
 
@@ -53,6 +53,7 @@ you need to use the following style sheet name: `MuiSelect`.
 ## Inheritance
 
 The properties of the [Input](/api/input) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -18,11 +18,12 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool |  | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/snackbar-content.md
+++ b/pages/api/snackbar-content.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/SnackbarContent/SnackbarContent.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">message</span> | <span class="prop-type">node |  | The message to display. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Paper](/api/paper)).
 
 ## CSS API
 
@@ -37,6 +37,7 @@ you need to use the following style sheet name: `MuiSnackbarContent`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -34,7 +34,7 @@ filename: /packages/material-ui/src/Snackbar/Snackbar.js
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -17,7 +17,7 @@ filename: /packages/material-ui/src/StepButton/StepButton.js
 | <span class="prop-name">icon</span> | <span class="prop-type">node |  | The icon displayed by the step label. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node |  | The optional node to display. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([ButtonBase](/api/button-base)).
 
 ## CSS API
 
@@ -38,6 +38,7 @@ you need to use the following style sheet name: `MuiStepButton`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -14,7 +14,7 @@ filename: /packages/material-ui/src/StepConnector/StepConnector.js
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/StepContent/StepContent.js
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">'auto'</span> | Adjust the duration of the content expand transition. Passed as a property to the transition component.<br>Set to 'auto' to automatically calculate transition time based on height. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/StepIcon/StepIcon.js
 | <span class="prop-name">error</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name required">icon *</span> | <span class="prop-type">node |  | The icon displayed by the step label. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -20,7 +20,7 @@ filename: /packages/material-ui/src/StepLabel/StepLabel.js
 | <span class="prop-name">optional</span> | <span class="prop-type">node |  | The optional node to display. |
 | <span class="prop-name">StepIconProps</span> | <span class="prop-type">object |  | Properties applied to the `StepIcon` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/Step/Step.js
 | <span class="prop-name">completed</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as completed. Is passed to child components. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as disabled, will also disable the button if `StepButton` is a child of `Step`. Is passed to child components. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -20,7 +20,7 @@ filename: /packages/material-ui/src/Stepper/Stepper.js
 | <span class="prop-name">nonLinear</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If set the `Stepper` will not assist in controlling steps for linear flow. |
 | <span class="prop-name">orientation</span> | <span class="prop-type">enum:&nbsp;'horizontal'&nbsp;&#124;<br>&nbsp;'vertical'<br> | <span class="prop-default">'horizontal'</span> | The stepper orientation (layout flow direction). |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Paper](/api/paper)).
 
 ## CSS API
 
@@ -42,6 +42,7 @@ you need to use the following style sheet name: `MuiStepper`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -19,7 +19,7 @@ filename: /packages/material-ui/src/SvgIcon/SvgIcon.js
 | <span class="prop-name">titleAccess</span> | <span class="prop-type">string |  | Provides a human-readable title for the element that contains it. https://www.w3.org/TR/SVG-access/#Equivalent |
 | <span class="prop-name">viewBox</span> | <span class="prop-type">string | <span class="prop-default">'0 0 24 24'</span> | Allows you to redefine what the coordinates without units mean inside an SVG element. For example, if the SVG element is 500 (width) by 200 (height), and you pass viewBox="0 0 50 20", this means that the coordinates inside the SVG will go from the top left corner (0,0) to bottom right (50,20) and each unit will be worth 10px. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -21,11 +21,12 @@ filename: /packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
 | <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Drawer](/api/drawer)).
 
 ## Inheritance
 
 The properties of the [Drawer](/api/drawer) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/switch-base.md
+++ b/pages/api/switch-base.md
@@ -28,7 +28,7 @@ filename: /packages/material-ui/src/internal/SwitchBase.js
 | <span class="prop-name">type</span> | <span class="prop-type">string | <span class="prop-default">'checkbox'</span> | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">string |  | The value of the component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([IconButton](/api/icon-button)).
 
 ## CSS API
 
@@ -50,4 +50,5 @@ you need to use the following style sheet name: `MuiSwitchBase`.
 ## Inheritance
 
 The properties of the [IconButton](/api/icon-button) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -26,7 +26,7 @@ filename: /packages/material-ui/src/Switch/Switch.js
 | <span class="prop-name">type</span> | <span class="prop-type">string |  | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">string |  | The value of the component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui/src/Tab/Tab.js
 | <span class="prop-name">label</span> | <span class="prop-type">node |  | The label element. |
 | <span class="prop-name">value</span> | <span class="prop-type">any |  | You can provide your own value. Otherwise, we fallback to the child position index. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([ButtonBase](/api/button-base)).
 
 ## CSS API
 
@@ -48,6 +48,7 @@ you need to use the following style sheet name: `MuiTab`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/TableBody/TableBody.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'tbody'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -21,7 +21,7 @@ filename: /packages/material-ui/src/TableCell/TableCell.js
 | <span class="prop-name">sortDirection</span> | <span class="prop-type">enum:&nbsp;'asc'&nbsp;&#124;<br>&nbsp;'desc'&nbsp;&#124;<br>&nbsp;false<br> |  | Set aria-sort direction. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'head'&nbsp;&#124;<br>&nbsp;'body'&nbsp;&#124;<br>&nbsp;'footer'<br> |  | Specify the cell type. By default, the TableHead, TableBody or TableFooter parent component set the value. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/TableFooter/TableFooter.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'tfoot'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/TableHead/TableHead.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'thead'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -27,7 +27,7 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 | <span class="prop-name">rowsPerPageOptions</span> | <span class="prop-type">array | <span class="prop-default">[5, 10, 25]</span> | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |
 | <span class="prop-name">SelectProps</span> | <span class="prop-type">object |  | Properties applied to the rows per page `Select` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([TableCell](/api/table-cell)).
 
 ## CSS API
 
@@ -55,6 +55,7 @@ you need to use the following style sheet name: `MuiTablePagination`.
 ## Inheritance
 
 The properties of the [TableCell](/api/table-cell) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -19,7 +19,7 @@ based on the material table element parent (head, body, etc).
 | <span class="prop-name">hover</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the table row will shade on hover. |
 | <span class="prop-name">selected</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the table row will have the selected shading. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -17,7 +17,7 @@ A button based label for placing inside `TableCell` for column sorting.
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">direction</span> | <span class="prop-type">enum:&nbsp;'asc'&nbsp;&#124;<br>&nbsp;'desc'<br> | <span class="prop-default">'desc'</span> | The current sort direction. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([ButtonBase](/api/button-base)).
 
 ## CSS API
 
@@ -40,6 +40,7 @@ you need to use the following style sheet name: `MuiTableSortLabel`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/Table/Table.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'table'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -26,7 +26,7 @@ filename: /packages/material-ui/src/Tabs/Tabs.js
 | <span class="prop-name">textColor</span> | <span class="prop-type">enum:&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'inherit'<br> | <span class="prop-default">'inherit'</span> | Determines the color of the `Tab`. |
 | <span class="prop-name">value</span> | <span class="prop-type">any |  | The value of the currently selected `Tab`. If you don't want any selected `Tab`, you can set this property to `false`. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -64,11 +64,12 @@ For advanced cases, please look at the source of TextField by clicking on the
 | <span class="prop-name">type</span> | <span class="prop-type">string |  | Type attribute of the `Input` element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;arrayOf<br> |  | The value of the `Input` element, required for a controlled component. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([FormControl](/api/form-control)).
 
 ## Inheritance
 
 The properties of the [FormControl](/api/form-control) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui/src/Toolbar/Toolbar.js
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">disableGutters</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, disables gutter padding. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -29,7 +29,7 @@ filename: /packages/material-ui/src/Tooltip/Tooltip.js
 | <span class="prop-name">PopperProps</span> | <span class="prop-type">object |  | Properties applied to the `Popper` element. |
 | <span class="prop-name required">title *</span> | <span class="prop-type">node |  | Tooltip title. Zero-length titles string are never displayed. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/touch-ripple.md
+++ b/pages/api/touch-ripple.md
@@ -15,7 +15,7 @@ filename: /packages/material-ui/src/ButtonBase/TouchRipple.js
 | <span class="prop-name">center</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the ripple starts at the center of the component rather than at the point of interaction. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -23,7 +23,7 @@ filename: /packages/material-ui/src/Typography/Typography.js
 | <span class="prop-name">paragraph</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the text will have a bottom margin. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'display4', 'display3', 'display2', 'display1', 'headline', 'title', 'subheading', 'body2', 'body1', 'caption', 'button'<br> | <span class="prop-default">'body1'</span> | Applies the theme typography styles. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## CSS API
 

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -18,11 +18,12 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
 
 ## Demos
 

--- a/pages/lab/api/slider.md
+++ b/pages/lab/api/slider.md
@@ -24,7 +24,7 @@ filename: /packages/material-ui-lab/src/Slider/Slider.js
 | <span class="prop-name">value</span> | <span class="prop-type">number | <span class="prop-default">50</span> | The value of the slider. |
 | <span class="prop-name">vertical</span> | <span class="prop-type">bool |  | If `true`, the slider will be vertical. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/lab/api/speed-dial-action.md
+++ b/pages/lab/api/speed-dial-action.md
@@ -18,7 +18,7 @@ filename: /packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
 | <span class="prop-name required">icon *</span> | <span class="prop-type">node |  | The Icon to display in the SpeedDial Floating Action Button. |
 | <span class="prop-name">tooltipTitle</span> | <span class="prop-type">node |  | Label to display in the tooltip. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/lab/api/speed-dial-icon.md
+++ b/pages/lab/api/speed-dial-icon.md
@@ -16,7 +16,7 @@ filename: /packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.js
 | <span class="prop-name">icon</span> | <span class="prop-type">node |  | The icon to display in the SpeedDial Floating Action Button. |
 | <span class="prop-name">openIcon</span> | <span class="prop-type">node |  | The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 

--- a/pages/lab/api/speed-dial.md
+++ b/pages/lab/api/speed-dial.md
@@ -25,7 +25,7 @@ filename: /packages/material-ui-lab/src/SpeedDial/SpeedDial.js
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{enter?: number, exit?: number}<br> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |  | Properties applied to the `Transition` element. |
 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element (native element).
 
 ## Demos
 


### PR DESCRIPTION
Closes #10393

```diff 
-Any other properties supplied will be [spread to the root element](/guides/api#spread).
+Any other properties supplied will be [spread to](#inheritance) the root element ([Paper](/api/paper)).
 ```