### PR TITLE
[docs] Update Wertarbyte components link

### DIFF
--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -13,7 +13,7 @@ Feel free to submit a pull-request to add more projects; we will accept them if 
 - [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker) A TimePicker for Material-UI.
 - [mui-datatables](https://github.com/gregnb/mui-datatables) Responsive data tables for Material-UI with filtering, sorting, search and more.
 - [mui-downshift](https://github.com/techniq/mui-downshift) Thin layer over paypal's downshift to use Material-UI visual components.
-- [Wertarbyte](https://next.mui.wertarbyte.com/) Wertarbyte are using Material-UI for many of their projects. This is a collection of complementary components they have built.
+- [Wertarbyte](https://mui.wertarbyte.com/) Wertarbyte are using Material-UI for many of their projects. This is a collection of complementary components they have built.
 
 ## Complementary Projects
 


### PR DESCRIPTION
Now that v1.0.0 is not really "next" anymore, we have updated our domains.

~~PR for the 0.x link is incoming, too…~~