### PR TITLE
[docs] Add a changelog page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## HEAD
+Material-UI strictly follows [Semantic Versioning 2.0.0](http://semver.org/).
 
-Changes. Changes everywhere!
+#### Release Schedule
+
+- Weekly release: patch or minor version at the end of every week for routine bugfix or new features (anytime for urgent bugfix).
+- Major version release is not included in this schedule for breaking change and new features.
 
 ## 1.1.0
 ###### *May 26, 2018*

--- a/docs/src/modules/components/withRoot.js
+++ b/docs/src/modules/components/withRoot.js
@@ -199,15 +199,6 @@ const pages = [
         pathname: '/discover-more/vision',
       },
       {
-        pathname: '/discover-more/roadmap',
-      },
-      {
-        pathname: '/discover-more/governance',
-      },
-      {
-        pathname: '/discover-more/team',
-      },
-      {
         pathname: '/discover-more/backers',
         title: 'Sponsors & Backers',
       },
@@ -215,10 +206,22 @@ const pages = [
         pathname: '/discover-more/community',
       },
       {
+        pathname: '/discover-more/related-projects',
+      },
+      {
         pathname: '/discover-more/showcase',
       },
       {
-        pathname: '/discover-more/related-projects',
+        pathname: '/discover-more/roadmap',
+      },
+      {
+        pathname: '/discover-more/changelog',
+      },
+      {
+        pathname: '/discover-more/team',
+      },
+      {
+        pathname: '/discover-more/governance',
       },
     ],
   },

--- a/docs/src/pages/discover-more/changelog/changelog.md
+++ b/docs/src/pages/discover-more/changelog/changelog.md
@@ -1,0 +1,3 @@
+# Changelog
+
+All notable changes are described on the [CHANGELOG.md file](https://github.com/mui-org/material-ui/blob/master/CHANGELOG.md).

--- a/docs/src/pages/discover-more/changelog/changelog.md
+++ b/docs/src/pages/discover-more/changelog/changelog.md
@@ -1,3 +1,3 @@
 # Changelog
 
-All notable changes are described on the [CHANGELOG.md file](https://github.com/mui-org/material-ui/blob/master/CHANGELOG.md).
+All notable changes are described in the [CHANGELOG.md file](https://github.com/mui-org/material-ui/blob/master/CHANGELOG.md).

--- a/pages/discover-more/changelog.js
+++ b/pages/discover-more/changelog.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from 'docs/src/pages/discover-more/changelog/changelog.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default withRoot(Page);


### PR DESCRIPTION
So people can use the documentation search bar to find the changelog.

![capture d ecran 2018-05-27 a 13 09 13](https://user-images.githubusercontent.com/3165635/40585225-32db48ae-61af-11e8-81b2-ec5fa7f67933.png)
