### PR TITLE
Depend directly on CSSType

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -39,6 +39,7 @@
     "@types/react-transition-group": "^2.0.8",
     "brcast": "^3.0.1",
     "classnames": "^2.2.5",
+    "csstype": "^2.5.2",
     "debounce": "^1.1.0",
     "deepmerge": "^2.0.1",
     "dom-helpers": "^3.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3602,7 +3602,7 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.0.0, csstype@^2.2.0:
+csstype@^2.0.0, csstype@^2.2.0, csstype@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.2.tgz#4534308476ceede8fbe148b9b99f9baf1c80fa06"
 


### PR DESCRIPTION
Fixes #11301.

We should depend directly on `csstype` since it is imported in `withStyles.d.ts`, instead of relying on React or JSS to bring it in for us.