### PR TITLE
[typescript] createStyles and InjectedStyles helpers

### DIFF
--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { StyledComponentProps } from './styles';
 export { StyledComponentProps };
+export { createStyles } from './styles';
 
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StyledComponentProps } from './styles';
 export { StyledComponentProps };
-export { createStyles } from './styles';
+export { InjectedStyles, createStyles } from './styles';
 
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -6,6 +6,7 @@ export { colors };
 export {
   createGenerateClassName,
   createMuiTheme,
+  createStyles,
   jssPreset,
   MuiThemeProvider,
   withStyles,

--- a/packages/material-ui/src/styles/createStyles.d.ts
+++ b/packages/material-ui/src/styles/createStyles.d.ts
@@ -1,0 +1,11 @@
+import { CSSProperties, StyleRules } from './withStyles';
+
+/**
+ * This function doesn't really "do anything" at runtime, it's just the identity
+ * function. Its only purpose is to defeat TypeScript's type widening when providing
+ * style rules to `withStyles` which are a function of the `Theme`.
+ *
+ * @param styles a set of style mappings
+ * @returns the same styles that were passed in
+ */
+export default function createStyles<S extends StyleRules>(styles: S): S;

--- a/packages/material-ui/src/styles/createStyles.js
+++ b/packages/material-ui/src/styles/createStyles.js
@@ -1,0 +1,5 @@
+// @flow
+
+export default function createStyles(s: Object) {
+  return s;
+}

--- a/packages/material-ui/src/styles/createStyles.test.js
+++ b/packages/material-ui/src/styles/createStyles.test.js
@@ -1,0 +1,9 @@
+import { assert } from 'chai';
+import { createStyles } from '.';
+
+describe('createStyles', () => {
+  it('is the identity function', () => {
+    const styles = {};
+    assert.strictEqual(createStyles(styles), styles);
+  });
+});

--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -2,6 +2,7 @@ export { default as createGenerateClassName } from './createGenerateClassName';
 export { default as createMuiTheme, Theme, Direction } from './createMuiTheme';
 export { default as jssPreset } from './jssPreset';
 export { default as MuiThemeProvider } from './MuiThemeProvider';
+export { default as createStyles } from './createStyles';
 export {
   default as withStyles,
   WithStyles,

--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -5,6 +5,7 @@ export { default as MuiThemeProvider } from './MuiThemeProvider';
 export { default as createStyles } from './createStyles';
 export {
   default as withStyles,
+  InjectedStyles,
   WithStyles,
   StyleRules,
   StyleRulesCallback,

--- a/packages/material-ui/src/styles/index.js
+++ b/packages/material-ui/src/styles/index.js
@@ -2,5 +2,6 @@ export { default as createGenerateClassName } from './createGenerateClassName';
 export { default as createMuiTheme } from './createMuiTheme';
 export { default as jssPreset } from './jssPreset';
 export { default as MuiThemeProvider } from './MuiThemeProvider';
+export { default as createStyles } from './createStyles';
 export { default as withStyles } from './withStyles';
 export { default as withTheme } from './withTheme';

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -41,6 +41,11 @@ export interface WithStyles<ClassKey extends string = string> extends Partial<Wi
   classes: ClassNameMap<ClassKey>;
 }
 
+export type InjectedStyles<R extends StyleRules | StyleRulesCallback> = WithStyles<
+  R extends StyleRulesCallback<infer K> ? K :
+  R extends StyleRules<infer K> ? K : never
+>;
+
 export interface StyledComponentProps<ClassKey extends string = string> {
   classes?: Partial<ClassNameMap<ClassKey>>;
   innerRef?: React.Ref<any> | React.RefObject<any>;

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  createStyles,
   withStyles,
   WithStyles,
   createMuiTheme,
@@ -22,7 +23,7 @@ interface ComponentProps {
 }
 
 // Example 1
-const styles: StyleRulesCallback<'root'> = ({ palette, spacing }) => ({
+const styles = ({ palette, spacing }: Theme) => ({
   root: {
     padding: spacing.unit,
     backgroundColor: palette.background.default,
@@ -192,7 +193,7 @@ const DecoratedComponent = withStyles(styles)(
 <DecoratedComponent text="foo" />;
 
 // Allow nested pseudo selectors
-withStyles<'listItem' | 'guttered'>(theme => ({
+withStyles(theme => createStyles({
   guttered: theme.mixins.gutters({
     '&:hover': {
       textDecoration: 'none',
@@ -207,8 +208,8 @@ withStyles<'listItem' | 'guttered'>(theme => ({
 
 {
   type ListItemContentClassKey = 'root' | 'iiiinset' | 'row';
-  const styles = withStyles<ListItemContentClassKey>(
-    theme => ({
+  const decorate = withStyles(
+    theme => createStyles({
       // Styled similar to ListItemText
       root: {
         '&:first-child': {
@@ -237,7 +238,7 @@ withStyles<'listItem' | 'guttered'>(theme => ({
     row?: boolean;
   }
 
-  const ListItemContent = styles<ListItemContentProps>(props => {
+  const ListItemContent = decorate<ListItemContentProps>(props => {
     const { children, classes, inset, row } = props;
     return (
       <div className="foo" color="textSecondary">
@@ -298,7 +299,7 @@ withStyles<'listItem' | 'guttered'>(theme => ({
 
 {
   // https://github.com/mui-org/material-ui/issues/11191
-  const decorate = withStyles<classList>(theme => ({
+  const decorate = withStyles(theme => ({
     main: {},
   }));
 

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -2,22 +2,22 @@ import * as React from 'react';
 import {
   createStyles,
   withStyles,
-  WithStyles,
   createMuiTheme,
   MuiThemeProvider,
   Theme,
   withTheme,
   StyleRules,
+  StyleRulesCallback,
+  StyledComponentProps,
+  InjectedStyles,
 } from '../../src/styles';
 import Button from '../../src/Button/Button';
-import { StyleRulesCallback, StyledComponentProps } from '../../src/styles/withStyles';
 import blue from '../../src/colors/blue';
 import { WithTheme } from '../../src/styles/withTheme';
 import { StandardProps } from '../../src';
 import { TypographyStyle } from '../../src/styles/createTypography';
 
 // Shared types for examples
-type ComponentClassNames = 'root';
 interface ComponentProps {
   text: string;
 }
@@ -37,7 +37,7 @@ const StyledExampleOne = withStyles(styles)<ComponentProps>(({ classes, text }) 
 <StyledExampleOne text="I am styled!" />;
 
 // Example 2
-const Component: React.SFC<ComponentProps & WithStyles<ComponentClassNames>> = ({
+const Component: React.SFC<ComponentProps & InjectedStyles<typeof styles>> = ({
   classes,
   text,
 }) => <div className={classes.root}>{text}</div>;
@@ -46,16 +46,16 @@ const StyledExampleTwo = withStyles(styles)(Component);
 <StyledExampleTwo text="I am styled!" />;
 
 // Example 3
-const styleRule: StyleRules<ComponentClassNames> = {
+const styleRule = createStyles({
   root: {
     display: 'flex',
     alignItems: 'stretch',
     height: '100vh',
     width: '100%',
   },
-};
+});
 
-const ComponentWithChildren: React.SFC<WithStyles<ComponentClassNames>> = ({
+const ComponentWithChildren: React.SFC<InjectedStyles<typeof styles>> = ({
   classes,
   children,
 }) => <div className={classes.root}>{children}</div>;
@@ -167,7 +167,7 @@ const ComponentWithTheme = withTheme()(({ theme }) => <div>{theme.spacing.unit}<
 <ComponentWithTheme />;
 
 // withStyles + withTheme
-type AllTheProps = WithTheme & WithStyles<'root'>;
+type AllTheProps = WithTheme & InjectedStyles<typeof styles>;
 
 const AllTheComposition = withTheme()(
   withStyles(styles)(({ theme, classes }: AllTheProps) => (
@@ -181,7 +181,7 @@ const AllTheComposition = withTheme()(
 // due to https://github.com/Microsoft/TypeScript/issues/4881
 //@withStyles(styles)
 const DecoratedComponent = withStyles(styles)(
-  class extends React.Component<ComponentProps & WithStyles<'root'>> {
+  class extends React.Component<ComponentProps & InjectedStyles<typeof styles>> {
     render() {
       const { classes, text } = this.props;
       return <div className={classes.root}>{text}</div>;
@@ -193,7 +193,7 @@ const DecoratedComponent = withStyles(styles)(
 <DecoratedComponent text="foo" />;
 
 // Allow nested pseudo selectors
-withStyles(theme => createStyles({
+withStyles(theme => ({
   guttered: theme.mixins.gutters({
     '&:hover': {
       textDecoration: 'none',
@@ -201,7 +201,7 @@ withStyles(theme => createStyles({
   }),
   listItem: {
     '&:hover $listItemIcon': {
-      visibility: 'inherit',
+      // visibility: 'inherit',
     },
   },
 }));
@@ -262,27 +262,22 @@ withStyles(theme => createStyles({
   // The real test here is with "strictFunctionTypes": false,
   // but we don't have a way currently to test under varying
   // TypeScript configurations.
-  interface IStyle {
-    content: any;
-  }
 
-  interface IComponentProps {
+  interface ComponentProps extends InjectedStyles<typeof styles> {
     caption: string;
   }
 
-  type ComponentProps = IComponentProps & WithStyles<'content'>;
-
-  const decorate = withStyles((theme): IStyle => ({
+  const styles = (theme: Theme) => createStyles({
     content: {
       margin: 4,
     },
-  }));
+  });
 
   const Component = (props: ComponentProps) => {
     return <div className={props.classes.content}>Hello {props.caption}</div>;
   };
 
-  const StyledComponent = decorate(Component);
+  const StyledComponent = withStyles(styles)(Component);
 
   class App extends React.Component {
     public render() {
@@ -299,23 +294,21 @@ withStyles(theme => createStyles({
 
 {
   // https://github.com/mui-org/material-ui/issues/11191
-  const decorate = withStyles(theme => ({
+  const styles = (theme: Theme) => createStyles({
     main: {},
-  }));
+  });
 
-  type classList = 'main';
-
-  interface IProps {
+  interface Props extends InjectedStyles<typeof styles> {
     someProp?: string;
   }
 
-  class SomeComponent extends React.PureComponent<IProps & WithStyles<classList>> {
+  class SomeComponent extends React.PureComponent<Props> {
     render() {
       return <div />;
     }
   }
 
-  const DecoratedSomeComponent = decorate(SomeComponent); // note that I don't specify a generic type here
+  const DecoratedSomeComponent = withStyles(styles)(SomeComponent);
 
   <DecoratedSomeComponent someProp="hello world" />;
 }

--- a/packages/material-ui/test/typescript/styling-comparison.spec.tsx
+++ b/packages/material-ui/test/typescript/styling-comparison.spec.tsx
@@ -1,29 +1,29 @@
 import * as React from 'react';
 import Typography, { TypographyProps } from '../../src/Typography/Typography';
-import { withStyles, WithStyles } from '../../src/styles';
+import { withStyles, InjectedStyles, createStyles, Theme } from '../../src/styles';
 
-const decorate = withStyles(({ palette, spacing }) => ({
+const styles = ({ palette, spacing }: Theme) => createStyles({
   root: {
     padding: spacing.unit,
     backgroundColor: palette.background.default,
     color: palette.primary.dark,
   },
-}));
+})
 
-interface Props {
+interface Props extends InjectedStyles<typeof styles> {
   color: TypographyProps['color'];
   text: string;
   variant: TypographyProps['variant'];
 }
 
-const DecoratedSFC = decorate<Props>(({ text, variant, color, classes }) => (
+const DecoratedSFC = withStyles(styles)(({ text, variant, color, classes }: Props) => (
   <Typography variant={variant} color={color} classes={classes}>
     {text}
   </Typography>
 ));
 
-const DecoratedClass = decorate(
-  class extends React.Component<Props & WithStyles<'root'>> {
+const DecoratedClass = withStyles(styles)(
+  class extends React.Component<Props> {
     render() {
       const { text, variant, color, classes } = this.props;
       return (
@@ -35,8 +35,8 @@ const DecoratedClass = decorate(
   },
 );
 
-const DecoratedNoProps = decorate(
-  class extends React.Component<WithStyles<'root'>> {
+const DecoratedNoProps = withStyles(styles)(
+  class extends React.Component<InjectedStyles<typeof styles>> {
     render() {
       return <Typography classes={this.props.classes}>Hello, World!</Typography>;
     }
@@ -59,8 +59,8 @@ interface Painting {
 
 type ArtProps = Book | Painting;
 
-const DecoratedUnionProps = decorate<ArtProps>( // <-- without the type argument, we'd get a compiler error!
-  class extends React.Component<ArtProps & WithStyles<'root'>> {
+const DecoratedUnionProps = withStyles(styles)<ArtProps>( // <-- without the type argument, we'd get a compiler error!
+  class extends React.Component<ArtProps & InjectedStyles<typeof styles>> {
     render() {
       const props = this.props;
       return (


### PR DESCRIPTION
- Resolves #10995 by adding the helper function `createStyles` which is basically what was suggested in https://github.com/mui-org/material-ui/pull/11512#issuecomment-390831675. It doesn't actually "do anything", it's just the identity function, but it's useful for guiding TypeScript inference, particularly for styles which depend on the theme.
- Adds a helper type operator called `InjectedStyles` which can be used instead of `WithStyles`, and takes `typeof styles` as input, where `styles` is either a `StyleRules` or `StyleRulesCallback`.

See the updated (and much simpler) TypeScript guide for more about how to use these.