### PR TITLE
[chip] Add `clickable` property

### DIFF
--- a/docs/src/pages/demos/chips/Chips.js
+++ b/docs/src/pages/demos/chips/Chips.js
@@ -30,7 +30,13 @@ function Chips(props) {
   return (
     <div className={classes.root}>
       <Chip label="Basic Chip" className={classes.chip} />
-      <Chip label="Clickable without onClick Chip" clickable className={classes.chip} />
+      <Chip
+        href="#chip"
+        component="a"
+        label="Clickable Link Chip"
+        className={classes.chip}
+        clickable
+      />
       <Chip
         avatar={<Avatar>MB</Avatar>}
         label="Clickable Chip"

--- a/docs/src/pages/demos/chips/Chips.js
+++ b/docs/src/pages/demos/chips/Chips.js
@@ -31,13 +31,6 @@ function Chips(props) {
     <div className={classes.root}>
       <Chip label="Basic Chip" className={classes.chip} />
       <Chip
-        label="Clickable Link Chip"
-        className={classes.chip}
-        component="a"
-        href="#chip"
-        clickable
-      />
-      <Chip
         avatar={<Avatar>MB</Avatar>}
         label="Clickable Chip"
         onClick={handleClick}
@@ -66,6 +59,13 @@ function Chips(props) {
         onDelete={handleDelete}
         className={classes.chip}
         deleteIcon={<DoneIcon />}
+      />
+      <Chip
+        label="Clickable Link Chip"
+        className={classes.chip}
+        component="a"
+        href="#chip"
+        clickable
       />
     </div>
   );

--- a/docs/src/pages/demos/chips/Chips.js
+++ b/docs/src/pages/demos/chips/Chips.js
@@ -30,6 +30,7 @@ function Chips(props) {
   return (
     <div className={classes.root}>
       <Chip label="Basic Chip" className={classes.chip} />
+      <Chip label="Clickable without onClick Chip" clickable className={classes.chip} />
       <Chip
         avatar={<Avatar>MB</Avatar>}
         label="Clickable Chip"

--- a/docs/src/pages/demos/chips/Chips.js
+++ b/docs/src/pages/demos/chips/Chips.js
@@ -31,10 +31,10 @@ function Chips(props) {
     <div className={classes.root}>
       <Chip label="Basic Chip" className={classes.chip} />
       <Chip
-        href="#chip"
-        component="a"
         label="Clickable Link Chip"
         className={classes.chip}
+        component="a"
+        href="#chip"
         clickable
       />
       <Chip

--- a/packages/material-ui/src/Chip/Chip.d.ts
+++ b/packages/material-ui/src/Chip/Chip.d.ts
@@ -4,6 +4,7 @@ import { StandardProps } from '..';
 export interface ChipProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ChipClassKey> {
   avatar?: React.ReactElement<any>;
+  clickable?: boolean;
   component?: React.ReactType<ChipProps>;
   deleteIcon?: React.ReactElement<any>;
   label?: React.ReactNode;

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -131,6 +131,7 @@ class Chip extends React.Component {
       avatar: avatarProp,
       classes,
       className: classNameProp,
+      clickable,
       component: Component,
       deleteIcon: deleteIconProp,
       label,
@@ -138,7 +139,6 @@ class Chip extends React.Component {
       onDelete,
       onKeyDown,
       tabIndex: tabIndexProp,
-      clickable,
       ...other
     } = this.props;
 

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -211,8 +211,9 @@ Chip.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * If `true`, the chip will be clickable.
-   * By default, the chip will not be clickable.
+   * If true, the chip will appear clickable, and will raise when pressed,
+   * even if the onClick property is not defined. This can be used, for example,
+   * along with the component property to indicate an anchor Chip is clickable.
    */
   clickable: PropTypes.bool,
   /**

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -144,7 +144,7 @@ class Chip extends React.Component {
 
     const className = classNames(
       classes.root,
-      { [classes.clickable]: onClick || clickable},
+      { [classes.clickable]: onClick || clickable },
       { [classes.deletable]: onDelete },
       classNameProp,
     );
@@ -211,6 +211,11 @@ Chip.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, the chip will be clickable.
+   * By default, the chip will not be clickable.
+   */
+  clickable: PropTypes.bool,
+  /**
    * The component used for the root node.
    * Either a string to use a DOM element or a component.
    */
@@ -240,15 +245,11 @@ Chip.propTypes = {
    * @ignore
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  /**
-   * Boolean to determine if the chip should be clickable.
-   */
-  clickable: PropTypes.bool,
 };
 
 Chip.defaultProps = {
+  clickable: false,
   component: 'div',
-  clickable: false
 };
 
 export default withStyles(styles, { name: 'MuiChip' })(Chip);

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -174,7 +174,7 @@ class Chip extends React.Component {
     let tabIndex = tabIndexProp;
 
     if (!tabIndex) {
-      tabIndex = onClick || onDelete ? 0 : -1;
+      tabIndex = onClick || onDelete || clickable ? 0 : -1;
     }
 
     return (

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -138,12 +138,13 @@ class Chip extends React.Component {
       onDelete,
       onKeyDown,
       tabIndex: tabIndexProp,
+      clickable,
       ...other
     } = this.props;
 
     const className = classNames(
       classes.root,
-      { [classes.clickable]: onClick },
+      { [classes.clickable]: onClick || clickable},
       { [classes.deletable]: onDelete },
       classNameProp,
     );
@@ -239,10 +240,15 @@ Chip.propTypes = {
    * @ignore
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * Boolean to determine if the chip should be clickable.
+   */
+  clickable: PropTypes.bool,
 };
 
 Chip.defaultProps = {
   component: 'div',
+  clickable: false
 };
 
 export default withStyles(styles, { name: 'MuiChip' })(Chip);

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -30,6 +30,7 @@ export const styles = theme => {
       cursor: 'default',
       // We disable the focus ring for mouse, touch and keyboard users.
       outline: 'none',
+      textDecoration: 'none',
       border: 'none', // Remove `button` border
       padding: 0, // Remove `button` padding
     },

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -14,7 +14,7 @@ Chips represent complex entities in small blocks, such as a contact.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">avatar</span> | <span class="prop-type">element |  | Avatar element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
-| <span class="prop-name">clickable</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the chip will be clickable. By default, the chip will not be clickable. |
+| <span class="prop-name">clickable</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If true, the chip will appear clickable, and will raise when pressed, even if the onClick property is not defined. This can be used, for example, along with the component property to indicate an anchor Chip is clickable. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">deleteIcon</span> | <span class="prop-type">element |  | Override the default delete icon element. Shown only if `onDelete` is set. |
 | <span class="prop-name">label</span> | <span class="prop-type">node |  | The content of the label. |

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -14,6 +14,7 @@ Chips represent complex entities in small blocks, such as a contact.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">avatar</span> | <span class="prop-type">element |  | Avatar element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |  | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">clickable</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the chip will be clickable. By default, the chip will not be clickable. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">deleteIcon</span> | <span class="prop-type">element |  | Override the default delete icon element. Shown only if `onDelete` is set. |
 | <span class="prop-name">label</span> | <span class="prop-type">node |  | The content of the label. |


### PR DESCRIPTION
Have added a new prop for the Chip - 'clickable' which takes a boolean as input and makes the Chip clickable irrespective of the component type

Closes #11502