### PR TITLE
[Menu] Fix a regression on Edge

### DIFF
--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -106,7 +106,12 @@ class MenuList extends React.Component {
   resetTabIndex() {
     const list = ReactDOM.findDOMNode(this.list);
     const currentFocus = activeElement(ownerDocument(list));
-    const items = [...list.children];
+
+    const items = [];
+    for (let i = 0; i < list.children.length; i += 1) {
+      items.push(list.children[i]);
+    }
+
     const currentFocusIndex = items.indexOf(currentFocus);
 
     if (currentFocusIndex !== -1) {


### PR DESCRIPTION
I can't explain what's wrong with the Babel runtime `toConsumableArray` method nor why it doesn't fail in the CI. Something is really wrong. This is a workaround.
- 1.0.0: https://unpkg.com/@material-ui/core@1.0.0/MenuList/MenuList.js
- 1.1.0: https://unpkg.com/@material-ui/core@1.1.0/MenuList/MenuList.js

Closes #11607