### PR TITLE
[TextField] replace underline content text with nbsp

### DIFF
--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -104,8 +104,7 @@ export const styles = theme => {
         left: 0,
         bottom: 0,
         // Doing the other way around crash on IE11 "''" https://github.com/cssinjs/jss/issues/242
-        content: '"need text here to prevent subpixel zoom issue"',
-        color: 'transparent',
+        content: '"\\00a0"',
         position: 'absolute',
         right: 0,
         transition: theme.transitions.create('border-bottom-color', {


### PR DESCRIPTION
Due to a few comments that were made about the pseudo element text being visible from this pull request https://github.com/mui-org/material-ui/pull/11181, I am going to change the text to a non-breaking space.  This will prevent color styles from showing the text, reduce the content size, and enable the removal of having to set the color to transparent.