### PR TITLE
[docs] Styled API Example (5 lines)

### DIFF
--- a/docs/src/pages/customization/css-in-js/StyledComponents.js
+++ b/docs/src/pages/customization/css-in-js/StyledComponents.js
@@ -1,26 +1,36 @@
 import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
 // A function you can extract and put into its own module.
-// Yes, 5 lines of code, it's all you need.
-const styled = Component => (style, options) => {
-  const StyledComponent = props => <Component {...props} />;
-  const styles = typeof style === 'function' ? theme => ({ ...style(theme) }) : { ...style };
-  return withStyles(styles, options)(StyledComponent);
-};
+// Yes, 15 lines of code, it's all you need.
+function styled(Component) {
+  return (style, options) => {
+    function StyledComponent(props) {
+      const { classes, className, ...other } = props;
+      return <Component className={classNames(classes.root, className)} {...other} />;
+    }
+    StyledComponent.propTypes = {
+      classes: PropTypes.object.isRequired,
+      className: PropTypes.string,
+    };
+    const styles =
+      typeof style === 'function' ? theme => ({ root: style(theme) }) : { root: style };
+    return withStyles(styles, options)(StyledComponent);
+  };
+}
 
 // You can even write CSS with https://github.com/cssinjs/jss-template.
 const MyButton = styled(Button)({
-  root: {
-    background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
-    borderRadius: 3,
-    border: 0,
-    color: 'white',
-    height: 48,
-    padding: '0 30px',
-    boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
-  },
+  background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+  borderRadius: 3,
+  border: 0,
+  color: 'white',
+  height: 48,
+  padding: '0 30px',
+  boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
 });
 
 function StyledComponents() {

--- a/docs/src/pages/customization/css-in-js/StyledComponents.js
+++ b/docs/src/pages/customization/css-in-js/StyledComponents.js
@@ -5,32 +5,27 @@ import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
 // A function you can extract and put into its own module.
-// Yes, 15 lines of code, it's all you need.
-function styled(Component) {
-  return (style, options) => {
-    function StyledComponent(props) {
-      const { classes, className, ...other } = props;
-      return <Component className={classNames(classes.root, className)} {...other} />;
-    }
-    StyledComponent.propTypes = {
-      classes: PropTypes.object.isRequired,
-      className: PropTypes.string,
-    };
-    const styles =
-      typeof style === 'function' ? theme => ({ root: style(theme) }) : { root: style };
-    return withStyles(styles, options)(StyledComponent);
-  };
+// Yes, 8 lines of code, it's all you need.
+const styled = Component => (style, options) => {
+  const StyledComponent = props => <Component {...props} />;
+  const styles =
+    typeof style === 'function'
+      ? theme => ({ ...style(theme) });
+      : { ...style };
+  return withStyles(styles, options)(StyledComponent);
 }
 
 // You can even write CSS with https://github.com/cssinjs/jss-template.
 const MyButton = styled(Button)({
-  background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
-  borderRadius: 3,
-  border: 0,
-  color: 'white',
-  height: 48,
-  padding: '0 30px',
-  boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
+  root: {
+    background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+    borderRadius: 3,
+    border: 0,
+    color: 'white',
+    height: 48,
+    padding: '0 30px',
+    boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
+  },
 });
 
 function StyledComponents() {

--- a/docs/src/pages/customization/css-in-js/StyledComponents.js
+++ b/docs/src/pages/customization/css-in-js/StyledComponents.js
@@ -1,19 +1,14 @@
 import React from 'react';
-import classNames from 'classnames';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
 // A function you can extract and put into its own module.
-// Yes, 8 lines of code, it's all you need.
+// Yes, 5 lines of code, it's all you need.
 const styled = Component => (style, options) => {
   const StyledComponent = props => <Component {...props} />;
-  const styles =
-    typeof style === 'function'
-      ? theme => ({ ...style(theme) });
-      : { ...style };
+  const styles = typeof style === 'function' ? theme => ({ ...style(theme) }) : { ...style };
   return withStyles(styles, options)(StyledComponent);
-}
+};
 
 // You can even write CSS with https://github.com/cssinjs/jss-template.
 const MyButton = styled(Button)({

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -383,7 +383,7 @@ const Styled = createStyled(theme => ({
 }));
 ```
 
-### styled-components API (8 lines)
+### styled-components API (5 lines)
 
 styled-components's API removes the mapping between components and styles. Using components as a low-level styling construct can be simpler.
 

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -375,7 +375,7 @@ function RenderProps() {
 {{"demo": "pages/customization/css-in-js/RenderProps.js"}}
 
 You can access the theme the same way you would do it with `withStyles`:
-```
+```js
 const Styled = createStyled(theme => ({
   root: {
     backgroundColor: theme.palette.background.paper,
@@ -383,7 +383,7 @@ const Styled = createStyled(theme => ({
 }));
 ```
 
-### styled-components API (+15 lines)
+### styled-components API (8 lines)
 
 styled-components's API removes the mapping between components and styles. Using components as a low-level styling construct can be simpler.
 
@@ -391,13 +391,15 @@ styled-components's API removes the mapping between components and styles. Using
 // You will find the `styled` implementation in the source of the demo.
 // You can even write CSS with https://github.com/cssinjs/jss-template.
 const MyButton = styled(Button)({
-  background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
-  borderRadius: 3,
-  border: 0,
-  color: 'white',
-  height: 48,
-  padding: '0 30px',
-  boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
+  root: {
+    background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+    borderRadius: 3,
+    border: 0,
+    color: 'white',
+    height: 48,
+    padding: '0 30px',
+    boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
+  },
 });
 
 function StyledComponents() {
@@ -408,8 +410,10 @@ function StyledComponents() {
 {{"demo": "pages/customization/css-in-js/StyledComponents.js"}}
 
 You can access the theme the same way you would do it with `withStyles`:
-```
+```js
 const MyButton = styled(Button)(theme => ({
-  backgroundColor: theme.palette.background.paper,
+  root: {
+    backgroundColor: theme.palette.background.paper,
+  },
 }));
 ```

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -383,7 +383,7 @@ const Styled = createStyled(theme => ({
 }));
 ```
 
-### styled-components API (5 lines)
+### styled-components API (+15 lines)
 
 styled-components's API removes the mapping between components and styles. Using components as a low-level styling construct can be simpler.
 
@@ -391,15 +391,13 @@ styled-components's API removes the mapping between components and styles. Using
 // You will find the `styled` implementation in the source of the demo.
 // You can even write CSS with https://github.com/cssinjs/jss-template.
 const MyButton = styled(Button)({
-  root: {
-    background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
-    borderRadius: 3,
-    border: 0,
-    color: 'white',
-    height: 48,
-    padding: '0 30px',
-    boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
-  },
+  background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+  borderRadius: 3,
+  border: 0,
+  color: 'white',
+  height: 48,
+  padding: '0 30px',
+  boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .30)',
 });
 
 function StyledComponents() {
@@ -412,8 +410,6 @@ function StyledComponents() {
 You can access the theme the same way you would do it with `withStyles`:
 ```js
 const MyButton = styled(Button)(theme => ({
-  root: {
-    backgroundColor: theme.palette.background.paper,
-  },
+  backgroundColor: theme.palette.background.paper,
 }));
 ```


### PR DESCRIPTION
Was implementing the [styled-components API example](https://material-ui.com/customization/css-in-js/#styled-components-api-15-lines-), but I needed to be able to set classes to the various sub classes in many of `material-ui`'s components (such as `paper` in the `Drawer` component.) I then realized the API example could be written much more simply while giving it that extra bit of functionality. Decided to do a PR, since it worked so well for me.

- Reduces `styled-components` API example down to 5 lines
- Adds `classes` functionality to the `styled-components` API example
- Updates the documentation to reflect these changes


```js
// Yes, 5 lines of code, it's all you need.
const styled = Component => (style, options) => {
  const StyledComponent = props => <Component {...props} />;
  const styles = typeof style === 'function' ? theme => ({ ...style(theme) }) : { ...style };
  return withStyles(styles, options)(StyledComponent);
};
```