### PR TITLE
[example] Fix missing brackets typescript

### DIFF
--- a/examples/create-react-app-with-typescript/src/pages/index.tsx
+++ b/examples/create-react-app-with-typescript/src/pages/index.tsx
@@ -65,4 +65,4 @@ class Index extends React.Component<WithStyles<'root'>, State> {
   }
 }
 
-export default withRoot(withStyles(styles) < {} > Index);
+export default withRoot(withStyles(styles) < {} > (Index));


### PR DESCRIPTION
add missing brackets in the create-react-app-typescript example causing it not to compile and run.