### PR TITLE
[TextField] Fix grammar for docs

### DIFF
--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -22,7 +22,7 @@ import Select from '../Select';
  * - [Input](/api/input)
  * - [FormHelperText](/api/form-helper-text)
  *
- * If you wish to alter the properties applied to the native input, you can do as follow:
+ * If you wish to alter the properties applied to the native input, you can do so as follows:
  *
  * ```jsx
  * const inputProps = {
@@ -34,8 +34,8 @@ import Select from '../Select';
  *
  * For advanced cases, please look at the source of TextField by clicking on the
  * "Edit this page" button above. Consider either:
- * - using the upper case props for passing values direct to the components.
- * - using the underlying components directly as shown in the demos.
+ * - using the upper case props for passing values direct to the components
+ * - using the underlying components directly as shown in the demos
  */
 function TextField(props) {
   const {

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -34,7 +34,7 @@ import Select from '../Select';
  *
  * For advanced cases, please look at the source of TextField by clicking on the
  * "Edit this page" button above. Consider either:
- * - using the upper case props for passing values direct to the components
+ * - using the upper case props for passing values directly to the components
  * - using the underlying components directly as shown in the demos
  */
 function TextField(props) {

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -18,7 +18,7 @@ on top of the following components:
 - [Input](/api/input)
 - [FormHelperText](/api/form-helper-text)
 
-If you wish to alter the properties applied to the native input, you can do as follow:
+If you wish to alter the properties applied to the native input, you can do so as follows:
 
 ```jsx
 const inputProps = {
@@ -30,8 +30,8 @@ return <TextField id="time" type="time" inputProps={inputProps} />;
 
 For advanced cases, please look at the source of TextField by clicking on the
 "Edit this page" button above. Consider either:
-- using the upper case props for passing values direct to the components.
-- using the underlying components directly as shown in the demos.
+- using the upper case props for passing values directly to the components
+- using the underlying components directly as shown in the demos
 
 ## Props
 


### PR DESCRIPTION
- "do as follow" => "do so as follows"
- remove periods from sentence fragments