### PR TITLE
[Popover] Add timeout prop to TransitionComponent

### DIFF
--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -317,7 +317,7 @@ class Popover extends React.Component {
           ref={node => {
             this.transitionEl = node;
           }}
-          transitionDuration={transitionDuration}
+          timeout={transitionDuration}
           {...TransitionProps}
         >
           <Paper

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -317,6 +317,7 @@ class Popover extends React.Component {
           ref={node => {
             this.transitionEl = node;
           }}
+          transitionDuration={transitionDuration}
           {...TransitionProps}
         >
           <Paper


### PR DESCRIPTION
This fixes the open issue #11650 about adding the transitionDuration prop to the TransitionComponent.

Thank you!

Closes #11650