### PR TITLE
[docs] Update link to flow-typed definitions

### DIFF
--- a/docs/src/pages/guides/flow/flow.md
+++ b/docs/src/pages/guides/flow/flow.md
@@ -6,4 +6,4 @@ Have a look at the [Create React App with Flow](https://github.com/mui-org/mater
 ## flow-typed
 
 [flow-typed](https://github.com/flowtype/flow-typed) is a repository of third-party library interface definitions for use with Flow.
-The community is maintaining [the definitions under this project](https://github.com/flowtype/flow-typed/tree/master/definitions/npm/material-ui_v1.x.x).
+The community is maintaining [the definitions under this project](https://github.com/flowtype/flow-typed/tree/master/definitions/npm/%40material-ui/core_v1.x.x).


### PR DESCRIPTION
Refer to `@matrerial-ui/core` instead of `material-ui` in link to flow-typed definitions.