### PR TITLE
[RootRef] Allow using React.createRef api with RootRef component

### DIFF
--- a/packages/material-ui/.size-snapshot.json
+++ b/packages/material-ui/.size-snapshot.json
@@ -1,25 +1,25 @@
 {
   "build/umd/material-ui.development.js": {
-    "bundled": 988164,
-    "minified": 361488,
-    "gzipped": 94315
+    "bundled": 986735,
+    "minified": 361055,
+    "gzipped": 94085
   },
   "build/umd/material-ui.production.min.js": {
-    "bundled": 815223,
-    "minified": 319257,
-    "gzipped": 84734
+    "bundled": 815902,
+    "minified": 319781,
+    "gzipped": 84808
   },
   "build/dist/material-ui.esm.js": {
-    "bundled": 582053,
-    "minified": 283504,
-    "gzipped": 63208,
+    "bundled": 583544,
+    "minified": 284185,
+    "gzipped": 63320,
     "treeshaked": {
       "rollup": {
-        "code": 195843,
+        "code": 196284,
         "import_statements": 1939
       },
       "webpack": {
-        "code": 202925
+        "code": 203380
       }
     }
   }

--- a/packages/material-ui/src/RootRef/RootRef.js
+++ b/packages/material-ui/src/RootRef/RootRef.js
@@ -1,11 +1,37 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
+import exactProp from '../utils/exactProp';
 
 /**
  * Helper component to allow attaching a ref to a
- * child element that may not accept refs (functional component).
- * It's higly inspired by https://github.com/facebook/react/issues/11401#issuecomment-340543801
+ * wrapped element to access the underlying DOM element.
+ *
+ * It's higly inspired by https://github.com/facebook/react/issues/11401#issuecomment-340543801.
+ * For example:
+ * ```jsx
+ * import React from 'react';
+ * import RootRef from '@material-ui/core/RootRef';
+ *
+ * class MyComponent extends React.Component {
+ *   constructor(props) {
+ *     super(props);
+ *     this.domRef = React.createRef();
+ *   }
+ *
+ *   componentDidMount() {
+ *     console.log(this.domRef.current); // DOM node
+ *   }
+ *
+ *   render() {
+ *     return (
+ *       <RootRef rootRef={this.domRef}>
+ *         <SomeChildComponent />
+ *       </RootRef>
+ *     );
+ *   }
+ * }
+ * ```
  */
 class RootRef extends React.Component {
   componentDidMount() {
@@ -13,7 +39,7 @@ class RootRef extends React.Component {
     const node = ReactDOM.findDOMNode(this);
     if (typeof rootRef === 'function') {
       rootRef(node);
-    } else {
+    } else if (rootRef) {
       rootRef.current = node;
     }
   }
@@ -22,7 +48,7 @@ class RootRef extends React.Component {
     const rootRef = this.props.rootRef;
     if (typeof rootRef === 'function') {
       rootRef(null);
-    } else {
+    } else if (rootRef) {
       rootRef.current = null;
     }
   }
@@ -33,8 +59,17 @@ class RootRef extends React.Component {
 }
 
 RootRef.propTypes = {
+  /**
+   * The wrapped element.
+   */
   children: PropTypes.element.isRequired,
-  rootRef: PropTypes.oneOfType([PropTypes.func.isRequired, PropTypes.object.isRequired]),
+  /**
+   * Provide a way to access the DOM node of the wrapped element.
+   * You can provide a callback ref or a `React.createRef()` ref.
+   */
+  rootRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
 };
+
+RootRef.propTypes = exactProp(RootRef.propTypes, 'RootRef');
 
 export default RootRef;

--- a/packages/material-ui/src/RootRef/RootRef.js
+++ b/packages/material-ui/src/RootRef/RootRef.js
@@ -9,11 +9,22 @@ import PropTypes from 'prop-types';
  */
 class RootRef extends React.Component {
   componentDidMount() {
-    this.props.rootRef(ReactDOM.findDOMNode(this));
+    const rootRef = this.props.rootRef;
+    const node = ReactDOM.findDOMNode(this);
+    if (typeof rootRef === 'function') {
+      rootRef(node);
+    } else {
+      rootRef.current = node;
+    }
   }
 
   componentWillUnmount() {
-    this.props.rootRef(null);
+    const rootRef = this.props.rootRef;
+    if (typeof rootRef === 'function') {
+      rootRef(null);
+    } else {
+      rootRef.current = null;
+    }
   }
 
   render() {
@@ -23,7 +34,7 @@ class RootRef extends React.Component {
 
 RootRef.propTypes = {
   children: PropTypes.element.isRequired,
-  rootRef: PropTypes.func.isRequired,
+  rootRef: PropTypes.oneOfType([PropTypes.func.isRequired, PropTypes.object.isRequired]),
 };
 
 export default RootRef;

--- a/packages/material-ui/src/RootRef/RootRef.test.js
+++ b/packages/material-ui/src/RootRef/RootRef.test.js
@@ -4,35 +4,41 @@ import { createMount } from '../test-utils';
 import RootRef from './RootRef';
 
 describe('<RootRef />', () => {
+  let mount;
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
   it('call rootRef function on mount and unmount', () => {
-    const mount = createMount();
     const Fn = () => <div />;
     const results = [];
-    mount(
+    const wrapper = mount(
       <RootRef rootRef={node => results.push(node)}>
         <Fn />
       </RootRef>,
     );
     assert.strictEqual(results.length, 1);
-    assert.ok(results[0] instanceof window.HTMLDivElement);
-
-    mount.cleanUp();
+    assert.strictEqual(results[0] instanceof window.HTMLDivElement, true);
+    wrapper.unmount();
     assert.strictEqual(results.length, 2);
     assert.strictEqual(results[1], null);
   });
 
   it('set rootRef current field on mount and unmount', () => {
-    const mount = createMount();
     const Fn = () => <div />;
-    const ref = { current: null };
-    mount(
+    const ref = React.createRef();
+    const wrapper = mount(
       <RootRef rootRef={ref}>
         <Fn />
       </RootRef>,
     );
-    assert.ok(ref.current instanceof window.HTMLDivElement);
-
-    mount.cleanUp();
+    assert.strictEqual(ref.current instanceof window.HTMLDivElement, true);
+    wrapper.unmount();
     assert.strictEqual(ref.current, null);
   });
 });

--- a/packages/material-ui/src/RootRef/RootRef.test.js
+++ b/packages/material-ui/src/RootRef/RootRef.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { assert } from 'chai';
+import { createMount } from '../test-utils';
+import RootRef from './RootRef';
+
+describe('<RootRef />', () => {
+  it('call rootRef function on mount and unmount', () => {
+    const mount = createMount();
+    const Fn = () => <div />;
+    const results = [];
+    mount(
+      <RootRef rootRef={node => results.push(node)}>
+        <Fn />
+      </RootRef>,
+    );
+    assert.strictEqual(results.length, 1);
+    assert.ok(results[0] instanceof window.HTMLDivElement);
+
+    mount.cleanUp();
+    assert.strictEqual(results.length, 2);
+    assert.strictEqual(results[1], null);
+  });
+
+  it('set rootRef current field on mount and unmount', () => {
+    const mount = createMount();
+    const Fn = () => <div />;
+    const ref = { current: null };
+    mount(
+      <RootRef rootRef={ref}>
+        <Fn />
+      </RootRef>,
+    );
+    assert.ok(ref.current instanceof window.HTMLDivElement);
+
+    mount.cleanUp();
+    assert.strictEqual(ref.current, null);
+  });
+});

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -15,7 +15,7 @@ It's higly inspired by https://github.com/facebook/react/issues/11401#issuecomme
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children *</span> | <span class="prop-type">element |   |  |
-| <span class="prop-name required">rootRef *</span> | <span class="prop-type">func |   |  |
+| <span class="prop-name">rootRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   |  |
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -7,15 +7,40 @@ filename: /packages/material-ui/src/RootRef/RootRef.js
 # RootRef
 
 Helper component to allow attaching a ref to a
-child element that may not accept refs (functional component).
-It's higly inspired by https://github.com/facebook/react/issues/11401#issuecomment-340543801
+wrapped element to access the underlying DOM element.
+
+It's higly inspired by https://github.com/facebook/react/issues/11401#issuecomment-340543801.
+For example:
+```jsx
+import React from 'react';
+import RootRef from '@material-ui/core/RootRef';
+
+class MyComponent extends React.Component {
+  constructor(props) {
+    super(props);
+    this.domRef = React.createRef();
+  }
+
+  componentDidMount() {
+    console.log(this.domRef.current); // DOM node
+  }
+
+  render() {
+    return (
+      <RootRef rootRef={this.domRef}>
+        <SomeChildComponent />
+      </RootRef>
+    );
+  }
+}
+```
 
 ## Props
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name required">children *</span> | <span class="prop-type">element |   |  |
-| <span class="prop-name">rootRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   |  |
+| <span class="prop-name required">children *</span> | <span class="prop-type">element |   | The wrapped element. |
+| <span class="prop-name required">rootRef *</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Provide a way to access the DOM node of the wrapped element. You can provide a callback ref or a `React.createRef()` ref. |
 
 Any other properties supplied will be spread to the root element (native element).
 


### PR DESCRIPTION
`React.createRef` api is a bit simpler than callback and may cover a lot
of cases. The idea is simple, just mutate `current` field of object.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
