### PR TITLE
[Grid] Better support for theme.props

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start": "yarn docs:dev",
     "docs:dev": "rimraf node_modules/.cache/babel-loader && cross-env BABEL_ENV=docs-development next dev",
     "docs:api": "yarn docs:api:core && yarn docs:api:lab",
-    "docs:api:core": "rimraf ./pages/api && cross-env BABEL_ENV=docs-development && babel-node ./docs/scripts/buildApi.js ./packages/material-ui/src ./pages/api",
+    "docs:api:core": "rimraf ./pages/api && cross-env BABEL_ENV=docs-development babel-node ./docs/scripts/buildApi.js ./packages/material-ui/src ./pages/api",
     "docs:api:lab": "rimraf ./pages/lab/api && cross-env BABEL_ENV=docs-development babel-node ./docs/scripts/buildApi.js ./packages/material-ui-lab/src ./pages/lab/api",
     "docs:icons": "rimraf static/icons/* && babel-node ./docs/scripts/buildIcons.js",
     "docs:build": "cross-env NODE_ENV=production BABEL_ENV=docs-production next build",

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -331,10 +331,11 @@ Grid.defaultProps = {
 // environment.
 /* eslint-disable react/no-multi-comp */
 // eslint-disable-next-line import/no-mutable-exports
-let GridWrapper = Grid;
+let GridWrapper = withStyles(styles, { name: 'MuiGrid' })(Grid);
 
 if (process.env.NODE_ENV !== 'production') {
-  GridWrapper = props => <Grid {...props} />;
+  const GridStyled = GridWrapper;
+  GridWrapper = props => <GridStyled {...props} />;
 
   const requireProp = requirePropFactory('Grid');
   GridWrapper.propTypes = {
@@ -350,6 +351,8 @@ if (process.env.NODE_ENV !== 'production') {
     xs: requireProp('item'),
     zeroMinWidth: requireProp('zeroMinWidth'),
   };
+  GridWrapper.Naked = GridStyled;
+  GridWrapper.options = GridStyled.options;
 }
 
-export default withStyles(styles, { name: 'MuiGrid' })(GridWrapper);
+export default GridWrapper;

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -15,7 +15,7 @@ describe('<Grid />', () => {
         .find('Grid')
         .shallow({ context: shallowInner.context });
     };
-    classes = getClasses(<Grid />);
+    classes = getClasses(<Grid.Naked />);
   });
 
   it('should render', () => {


### PR DESCRIPTION
Closes #11665
Allow the usage of custom default values **without** a prop-type warning:
```jsx
const theme = createMuiTheme({
  props: {
    // Name of the component ⚛️
    MuiGrid: {
      // The properties to apply
      spacing: 8,
    },
  },
});
```