### PR TITLE
Spread props in type definition of ListItem

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -17,6 +17,7 @@ export interface ListItemProps
   disableGutters?: boolean;
   divider?: boolean;
   focusVisibleClassName?: string;
+  [key: string]: any;
 }
 
 export type ListItemClassKey =


### PR DESCRIPTION
It's what the docs says will happen: https://material-ui.com/api/list-item/

"Any other properties supplied will be spread to the root element (native element)."

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
