### PR TITLE
[slider] Removal of findDOMNode()

### DIFF
--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
 import EventListener from 'react-event-listener';
 import debounce from 'debounce';
 import Transition from 'react-transition-group/Transition';
@@ -97,7 +96,7 @@ class Slide extends React.Component {
   transition = null;
 
   updatePosition() {
-    const node = ReactDOM.findDOMNode(this.transition);
+    const node = this.transition;
     if (node) {
       node.style.visibility = 'inherit';
       setTranslateValue(this.props, node);
@@ -110,7 +109,7 @@ class Slide extends React.Component {
       return;
     }
 
-    const node = ReactDOM.findDOMNode(this.transition);
+    const node = this.transition;
     if (node) {
       setTranslateValue(this.props, node);
     }


### PR DESCRIPTION
There is no need of findDOMNode() and it is an anti-pattern.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
