### PR TITLE
[core] Add React.createRef support

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -27,7 +27,7 @@ module.exports = [
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '94.6 KB',
+    limit: '94.7 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -98,7 +98,7 @@ Checkbox.propTypes = {
   /**
    * Use that property to pass a ref callback to the native input component.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * Callback fired when the state is changed.
    *

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -116,7 +116,7 @@ FormControlLabel.propTypes = {
   /**
    * Use that property to pass a ref callback to the native input component.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * The text to be used in an enclosing label element.
    */

--- a/packages/material-ui/src/Input/Input.d.ts
+++ b/packages/material-ui/src/Input/Input.d.ts
@@ -18,7 +18,7 @@ export interface InputProps
   id?: string;
   inputComponent?: React.ReactType<InputComponentProps>;
   inputProps?: { [arbitrary: string]: any };
-  inputRef?: React.Ref<any>;
+  inputRef?: React.Ref<any> | React.RefObject<any>;
   margin?: 'dense';
   multiline?: boolean;
   name?: string;

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -275,7 +275,7 @@ class Input extends React.Component {
 
   componentDidMount() {
     if (!this.isControlled) {
-      this.checkDirty(this.currentInput());
+      this.checkDirty(this.input);
     }
   }
 
@@ -311,7 +311,7 @@ class Input extends React.Component {
 
   handleChange = event => {
     if (!this.isControlled) {
-      this.checkDirty(this.currentInput());
+      this.checkDirty(this.input);
     }
 
     // Perform in the willUpdate
@@ -323,26 +323,21 @@ class Input extends React.Component {
   handleRefInput = node => {
     this.input = node;
 
-    const { inputRef, inputProps } = this.props;
-    const refCallback = inputRef || (inputProps && inputProps.ref);
+    let ref;
 
-    if (refCallback) {
-      refCallback(node);
+    if (this.props.inputRef) {
+      ref = this.props.inputRef;
+    } else if (this.props.inputProps && this.props.inputProps.ref) {
+      ref = this.props.inputProps.ref;
     }
-  };
 
-  ref = () => {
-    const { inputRef, inputProps } = this.props;
-    const ref = inputRef || (inputProps && inputProps.ref);
-
-    return ref === undefined || typeof ref === 'function' ? this.handleRefInput : ref;
-  };
-
-  currentInput = () => {
-    const { inputRef, inputProps } = this.props;
-    const ref = inputRef || (inputProps && inputProps.ref);
-
-    return ref === undefined || typeof ref === 'function' ? this.input : ref;
+    if (ref) {
+      if (typeof ref === 'function') {
+        ref(node);
+      } else {
+        ref.current = node;
+      }
+    }
   };
 
   checkDirty(obj) {
@@ -436,7 +431,7 @@ class Input extends React.Component {
     let InputComponent = 'input';
     let inputProps = {
       ...inputPropsProp,
-      ref: this.ref(),
+      ref: this.handleRefInput,
     };
 
     if (inputComponent) {
@@ -444,7 +439,7 @@ class Input extends React.Component {
       inputProps = {
         // Rename ref to inputRef as we don't know the
         // provided `inputComponent` structure.
-        inputRef: this.ref(),
+        inputRef: this.handleRefInput,
         ...inputProps,
         ref: null,
       };
@@ -454,7 +449,7 @@ class Input extends React.Component {
       } else {
         inputProps = {
           rowsMax,
-          textareaRef: this.ref(),
+          textareaRef: this.handleRefInput,
           ...inputProps,
           ref: null,
         };

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -275,7 +275,7 @@ class Input extends React.Component {
 
   componentDidMount() {
     if (!this.isControlled) {
-      this.checkDirty(this.input);
+      this.checkDirty(this.currentInput());
     }
   }
 
@@ -311,7 +311,7 @@ class Input extends React.Component {
 
   handleChange = event => {
     if (!this.isControlled) {
-      this.checkDirty(this.input);
+      this.checkDirty(this.currentInput());
     }
 
     // Perform in the willUpdate
@@ -323,11 +323,26 @@ class Input extends React.Component {
   handleRefInput = node => {
     this.input = node;
 
-    if (this.props.inputRef) {
-      this.props.inputRef(node);
-    } else if (this.props.inputProps && this.props.inputProps.ref) {
-      this.props.inputProps.ref(node);
+    const { inputRef, inputProps } = this.props;
+    const refCallback = inputRef || (inputProps && inputProps.ref);
+
+    if (refCallback) {
+      refCallback(node);
     }
+  };
+
+  ref = () => {
+    const { inputRef, inputProps } = this.props;
+    const ref = inputRef || (inputProps && inputProps.ref);
+
+    return ref === undefined || typeof ref === 'function' ? this.handleRefInput : ref;
+  };
+
+  currentInput = () => {
+    const { inputRef, inputProps } = this.props;
+    const ref = inputRef || (inputProps && inputProps.ref);
+
+    return ref === undefined || typeof ref === 'function' ? this.input : ref;
   };
 
   checkDirty(obj) {
@@ -421,7 +436,7 @@ class Input extends React.Component {
     let InputComponent = 'input';
     let inputProps = {
       ...inputPropsProp,
-      ref: this.handleRefInput,
+      ref: this.ref(),
     };
 
     if (inputComponent) {
@@ -429,7 +444,7 @@ class Input extends React.Component {
       inputProps = {
         // Rename ref to inputRef as we don't know the
         // provided `inputComponent` structure.
-        inputRef: this.handleRefInput,
+        inputRef: this.ref(),
         ...inputProps,
         ref: null,
       };
@@ -439,7 +454,7 @@ class Input extends React.Component {
       } else {
         inputProps = {
           rowsMax,
-          textareaRef: this.handleRefInput,
+          textareaRef: this.ref(),
           ...inputProps,
           ref: null,
         };
@@ -541,7 +556,7 @@ Input.propTypes = {
   /**
    * Use that property to pass a ref callback to the native input component.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * If `dense`, will adjust vertical spacing. This is normally obtained via context from
    * FormControl.

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -471,4 +471,18 @@ describe('<Input />', () => {
       assert.strictEqual(wrapper.childAt(1).type(), InputAdornment);
     });
   });
+
+  describe('prop: inputRef', () => {
+    it('should be able to return the input node via a ref object', () => {
+      const ref = React.createRef();
+      mount(<Input inputRef={ref} />);
+      assert.strictEqual(ref.current.tagName, 'INPUT');
+    });
+
+    it('should be able to return the textarea node via a ref object', () => {
+      const ref = React.createRef();
+      mount(<Input multiline inputRef={ref} />);
+      assert.strictEqual(ref.current.tagName, 'TEXTAREA');
+    });
+  });
 });

--- a/packages/material-ui/src/Input/Textarea.d.ts
+++ b/packages/material-ui/src/Input/Textarea.d.ts
@@ -11,7 +11,7 @@ export interface TextareaProps
   disabled?: boolean;
   rows?: string | number;
   rowsMax?: string | number;
-  textareaRef?: React.Ref<any>;
+  textareaRef?: React.Ref<any> | React.RefObject<any>;
   value?: string;
 }
 

--- a/packages/material-ui/src/Input/Textarea.js
+++ b/packages/material-ui/src/Input/Textarea.js
@@ -142,6 +142,14 @@ class Textarea extends React.Component {
     }
   };
 
+  ref = () => {
+    const { textareaRef } = this.props;
+
+    return textareaRef === undefined || typeof textareaRef === 'function'
+      ? this.handleRefInput
+      : textareaRef;
+  };
+
   render() {
     const {
       classes,
@@ -183,7 +191,7 @@ class Textarea extends React.Component {
           defaultValue={defaultValue}
           value={value}
           onChange={this.handleChange}
-          ref={this.handleRefInput}
+          ref={this.ref()}
           {...other}
         />
       </div>
@@ -224,7 +232,7 @@ Textarea.propTypes = {
   /**
    * Use that property to pass a ref callback to the native textarea element.
    */
-  textareaRef: PropTypes.func,
+  textareaRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * @ignore
    */

--- a/packages/material-ui/src/Input/Textarea.js
+++ b/packages/material-ui/src/Input/Textarea.js
@@ -115,8 +115,14 @@ class Textarea extends React.Component {
 
   handleRefInput = node => {
     this.input = node;
-    if (this.props.textareaRef) {
-      this.props.textareaRef(node);
+
+    const { textareaRef } = this.props;
+    if (textareaRef) {
+      if (typeof textareaRef === 'function') {
+        textareaRef(node);
+      } else {
+        textareaRef.current = node;
+      }
     }
   };
 
@@ -140,14 +146,6 @@ class Textarea extends React.Component {
     if (this.props.onChange) {
       this.props.onChange(event);
     }
-  };
-
-  ref = () => {
-    const { textareaRef } = this.props;
-
-    return textareaRef === undefined || typeof textareaRef === 'function'
-      ? this.handleRefInput
-      : textareaRef;
   };
 
   render() {
@@ -191,7 +189,7 @@ class Textarea extends React.Component {
           defaultValue={defaultValue}
           value={value}
           onChange={this.handleChange}
-          ref={this.ref()}
+          ref={this.handleRefInput}
           {...other}
         />
       </div>

--- a/packages/material-ui/src/Input/Textarea.test.js
+++ b/packages/material-ui/src/Input/Textarea.test.js
@@ -1,5 +1,3 @@
-// @flow
-
 import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
@@ -154,6 +152,14 @@ describe('<Textarea />', () => {
       assert.strictEqual(wrapper.state().height, 19);
       clock.tick(166);
       assert.strictEqual(wrapper.state().height, 43);
+    });
+  });
+
+  describe('prop: textareaRef', () => {
+    it('should be able to return the input node via a ref object', () => {
+      const ref = React.createRef();
+      mount(<Textarea textareaRef={ref} />);
+      assert.strictEqual(ref.current.tagName, 'TEXTAREA');
     });
   });
 });

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -69,7 +69,7 @@ NativeSelectInput.propTypes = {
   /**
    * Use that property to pass a ref callback to the native select element.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * Name attribute of the `select` or hidden `input` element.
    */

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -90,7 +90,7 @@ Radio.propTypes = {
   /**
    * Use that property to pass a ref callback to the native input component.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * Callback fired when the state is changed.
    *

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -142,16 +142,24 @@ class SelectInput extends React.Component {
     this.updateDisplayWidth();
   };
 
-  handleSelectRef = node => {
-    if (!this.props.inputRef) {
+  handleInputRef = node => {
+    const { inputRef } = this.props;
+
+    if (!inputRef) {
       return;
     }
 
-    this.props.inputRef({
+    const nodeProxy = {
       node,
       // By pass the native input as we expose a rich object (array).
       value: this.props.value,
-    });
+    };
+
+    if (typeof inputRef === 'function') {
+      inputRef(nodeProxy);
+    } else {
+      inputRef.current = nodeProxy;
+    }
   };
 
   render() {
@@ -276,7 +284,7 @@ class SelectInput extends React.Component {
           value={Array.isArray(value) ? value.join(',') : value}
           name={name}
           readOnly={readOnly}
-          ref={this.handleSelectRef}
+          ref={this.handleInputRef}
           type={type}
           {...other}
         />
@@ -345,7 +353,7 @@ SelectInput.propTypes = {
   /**
    * Use that property to pass a ref callback to the native select element.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * Properties applied to the `Menu` element.
    */

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -327,4 +327,12 @@ describe('<SelectInput />', () => {
       });
     });
   });
+
+  describe('prop: inputRef', () => {
+    it('should be able to return the input node via a ref object', () => {
+      const ref = React.createRef();
+      mount(<SelectInput {...defaultProps} inputRef={ref} />);
+      assert.strictEqual(ref.current.node.tagName, 'INPUT');
+    });
+  });
 });

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -156,7 +156,7 @@ Switch.propTypes = {
   /**
    * Use that property to pass a ref callback to the native input component.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * Callback fired when the state is changed.
    *

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -22,7 +22,7 @@ export interface TextFieldProps
   InputLabelProps?: Partial<InputLabelProps>;
   InputProps?: Partial<InputProps>;
   inputProps?: InputProps['inputProps'];
-  inputRef?: React.Ref<any>;
+  inputRef?: React.Ref<any> | React.RefObject<any>;
   label?: React.ReactNode;
   margin?: PropTypes.Margin;
   multiline?: boolean;

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -195,7 +195,7 @@ TextField.propTypes = {
   /**
    * Use that property to pass a ref callback to the native input component.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
    * The label content.
    */

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -181,7 +181,7 @@ SwitchBase.propTypes = {
   /**
    * Use that property to pass a ref callback to the native input component.
    */
-  inputRef: PropTypes.func,
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /*
    * @ignore
    */

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -23,7 +23,7 @@ filename: /packages/material-ui/src/Checkbox/Checkbox.js
 | <span class="prop-name">indeterminate</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the component appears indeterminate. |
 | <span class="prop-name">indeterminateIcon</span> | <span class="prop-type">node | <span class="prop-default">&lt;IndeterminateCheckBoxIcon /></span> | The icon to display when the component is indeterminate. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |   | Properties applied to the `input` element. |
-| <span class="prop-name">inputRef</span> | <span class="prop-type">func |   | Use that property to pass a ref callback to the native input component. |
+| <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |   | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string |   | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">string |   | The value of the component. |

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -17,7 +17,7 @@ Use this component if you want to display an extra label.
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">control</span> | <span class="prop-type">element |   | A control element. For instance, it can be be a `Radio`, a `Switch` or a `Checkbox`. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool |   | If `true`, the control will be disabled. |
-| <span class="prop-name">inputRef</span> | <span class="prop-type">func |   | Use that property to pass a ref callback to the native input component. |
+| <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">label</span> | <span class="prop-type">node |   | The text to be used in an enclosing label element. |
 | <span class="prop-name">name</span> | <span class="prop-type">string |   |  |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |   | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -25,7 +25,7 @@ filename: /packages/material-ui/src/Input/Input.js
 | <span class="prop-name">id</span> | <span class="prop-type">string |   | The id of the `input` element. |
 | <span class="prop-name">inputComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> |   | The component used for the native input. Either a string to use a DOM element or a component. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |   | Attributes applied to the `input` element. |
-| <span class="prop-name">inputRef</span> | <span class="prop-type">func |   | Use that property to pass a ref callback to the native input component. |
+| <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'none'<br> |   | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
 | <span class="prop-name">multiline</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, a textarea element will be rendered. |
 | <span class="prop-name">name</span> | <span class="prop-type">string |   | Name attribute of the `input` element. |

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -21,7 +21,7 @@ filename: /packages/material-ui/src/Radio/Radio.js
 | <span class="prop-name">icon</span> | <span class="prop-type">node |   | The icon to display when the component is unchecked. |
 | <span class="prop-name">id</span> | <span class="prop-type">string |   | The id of the `input` element. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |   | Attributes applied to the `input` element. |
-| <span class="prop-name">inputRef</span> | <span class="prop-type">func |   | Use that property to pass a ref callback to the native input component. |
+| <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |   | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string |   | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">string |   | The value of the component. |

--- a/pages/api/switch-base.md
+++ b/pages/api/switch-base.md
@@ -22,7 +22,7 @@ filename: /packages/material-ui/src/internal/SwitchBase.js
 | <span class="prop-name">indeterminate</span> | <span class="prop-type">bool |   | If `true`, the component appears indeterminate. |
 | <span class="prop-name">indeterminateIcon</span> | <span class="prop-type">node |   | The icon to display when the component is indeterminate. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |   | Attributes applied to the `input` element. |
-| <span class="prop-name">inputRef</span> | <span class="prop-type">func |   | Use that property to pass a ref callback to the native input component. |
+| <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">name</span> | <span class="prop-type">string |   |  |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |   | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string | <span class="prop-default">'checkbox'</span> | The input component property `type`. |

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -21,7 +21,7 @@ filename: /packages/material-ui/src/Switch/Switch.js
 | <span class="prop-name">icon</span> | <span class="prop-type">node |   | The icon to display when the component is unchecked. |
 | <span class="prop-name">id</span> | <span class="prop-type">string |   | The id of the `input` element. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |   | Attributes applied to the `input` element. |
-| <span class="prop-name">inputRef</span> | <span class="prop-type">func |   | Use that property to pass a ref callback to the native input component. |
+| <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |   | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string |   | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">string |   | The value of the component. |

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -49,7 +49,7 @@ For advanced cases, please look at the source of TextField by clicking on the
 | <span class="prop-name">InputLabelProps</span> | <span class="prop-type">object |   | Properties applied to the `InputLabel` element. |
 | <span class="prop-name">InputProps</span> | <span class="prop-type">object |   | Properties applied to the `Input` element. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |   | Attributes applied to the native `input` element. |
-| <span class="prop-name">inputRef</span> | <span class="prop-type">func |   | Use that property to pass a ref callback to the native input component. |
+| <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">label</span> | <span class="prop-type">node |   | The label content. |
 | <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'none'&nbsp;&#124;<br>&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'normal'<br> |   | If `dense` or `normal`, will adjust vertical spacing of this and contained components. |
 | <span class="prop-name">multiline</span> | <span class="prop-type">bool |   | If `true`, a textarea element will be rendered instead of an input. |


### PR DESCRIPTION
This PR resolve the issue with `<Input>`, `<TextField>` and `<TextArea>` components don't accept `React.createRef` as `inputRef` or `textareaRef`.

Issues raised in #11709 #11486.

The idea for the solution is partly from #11293 and #11486.

Closes #11709