### PR TITLE
[core] Remove parser specification to fix JSON issue

### DIFF
--- a/examples/create-react-app-with-typescript/src/pages/index.tsx
+++ b/examples/create-react-app-with-typescript/src/pages/index.tsx
@@ -17,7 +17,7 @@ const styles: StyleRulesCallback<'root'> = theme => ({
 });
 
 type State = {
-  open: boolean,
+  open: boolean;
 };
 
 class Index extends React.Component<WithStyles<'root'>, State> {
@@ -65,4 +65,4 @@ class Index extends React.Component<WithStyles<'root'>, State> {
   }
 }
 
-export default withRoot(withStyles(styles) < {} > (Index));
+export default withRoot(withStyles(styles)<{}>(Index));

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
@@ -1,26 +1,27 @@
-import * as React from "react";
-import { StandardProps } from "@material-ui/core";
-import { ButtonProps } from "@material-ui/core/Button";
-import { TransitionProps } from "react-transition-group/Transition";
-import { TransitionHandlerProps } from "@material-ui/core/transitions/transition";
+import * as React from 'react';
+import { StandardProps } from '@material-ui/core';
+import { ButtonProps } from '@material-ui/core/Button';
+import { TransitionProps } from 'react-transition-group/Transition';
+import { TransitionHandlerProps } from '@material-ui/core/transitions/transition';
 
-export interface SpeedDialProps extends StandardProps<React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>, SpeedDialClassKey> {
-    ariaLabel: string;
-    ButtonProps?: Partial<ButtonProps>;
-    hidden?: boolean;
-    icon: React.ReactNode;
-    onClose?: React.ReactEventHandler<{}>;
-    open: boolean;
-    openIcon?: React.ReactNode;
-    TransitionComponent?: React.ReactType;
-    transitionDuration?: TransitionProps["timeout"];
-    TransitionProps?: TransitionProps;
+export interface SpeedDialProps
+  extends StandardProps<
+      React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>,
+      SpeedDialClassKey
+    > {
+  ariaLabel: string;
+  ButtonProps?: Partial<ButtonProps>;
+  hidden?: boolean;
+  icon: React.ReactNode;
+  onClose?: React.ReactEventHandler<{}>;
+  open: boolean;
+  openIcon?: React.ReactNode;
+  TransitionComponent?: React.ReactType;
+  transitionDuration?: TransitionProps['timeout'];
+  TransitionProps?: TransitionProps;
 }
 
-export type SpeedDialClassKey =
-    | "root"
-    | "actions"
-    | "actionsClosed";
+export type SpeedDialClassKey = 'root' | 'actions' | 'actionsClosed';
 
 declare const SpeedDial: React.ComponentType<SpeedDialProps>;
 

--- a/packages/material-ui-lab/src/SpeedDial/index.d.ts
+++ b/packages/material-ui-lab/src/SpeedDial/index.d.ts
@@ -1,2 +1,2 @@
-export { default } from "./SpeedDial";
-export * from "./SpeedDial";
+export { default } from './SpeedDial';
+export * from './SpeedDial';

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -1,19 +1,17 @@
-import * as React from "react";
-import { StandardProps } from "@material-ui/core";
-import { ButtonProps } from "@material-ui/core/Button";
-import { TooltipProps } from "@material-ui/core/Tooltip";
+import * as React from 'react';
+import { StandardProps } from '@material-ui/core';
+import { ButtonProps } from '@material-ui/core/Button';
+import { TooltipProps } from '@material-ui/core/Tooltip';
 
-export interface SpeedDialActionProps extends StandardProps<ButtonProps & Partial<TooltipProps>, SpeedDialActionClassKey> {
-    ButtonProps?: Partial<ButtonProps>;
-    delay?: number;
-    icon: React.ReactNode;
-    tooltipTitle?: React.ReactNode;
+export interface SpeedDialActionProps
+  extends StandardProps<ButtonProps & Partial<TooltipProps>, SpeedDialActionClassKey> {
+  ButtonProps?: Partial<ButtonProps>;
+  delay?: number;
+  icon: React.ReactNode;
+  tooltipTitle?: React.ReactNode;
 }
 
-export type SpeedDialActionClassKey =
-    | "root"
-    | "button"
-    | "buttonClosed";
+export type SpeedDialActionClassKey = 'root' | 'button' | 'buttonClosed';
 
 declare const SpeedDialAction: React.ComponentType<SpeedDialActionProps>;
 

--- a/packages/material-ui-lab/src/SpeedDialAction/index.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/index.d.ts
@@ -1,2 +1,2 @@
-export { default } from "./SpeedDialAction";
-export * from "./SpeedDialAction";
+export { default } from './SpeedDialAction';
+export * from './SpeedDialAction';

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
@@ -1,18 +1,19 @@
-import * as React from "react";
-import { StandardProps } from "@material-ui/core";
+import * as React from 'react';
+import { StandardProps } from '@material-ui/core';
 
-export interface SpeedDialIconProps extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, SpeedDialIconClassKey> {
-    icon?: React.ReactNode;
-    openIcon?: React.ReactNode;
+export interface SpeedDialIconProps
+  extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, SpeedDialIconClassKey> {
+  icon?: React.ReactNode;
+  openIcon?: React.ReactNode;
 }
 
 export type SpeedDialIconClassKey =
-    | "root"
-    | "icon"
-    | "iconOpen"
-    | "iconWithOpenIconOpen"
-    | "openIcon"
-    | "openIconOpen";
+  | 'root'
+  | 'icon'
+  | 'iconOpen'
+  | 'iconWithOpenIconOpen'
+  | 'openIcon'
+  | 'openIconOpen';
 
 declare const SpeedDialIcon: React.ComponentType<SpeedDialIconProps>;
 

--- a/packages/material-ui-lab/src/SpeedDialIcon/index.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialIcon/index.d.ts
@@ -1,2 +1,2 @@
-export { default } from "./SpeedDialIcon";
-export * from "./SpeedDialIcon";
+export { default } from './SpeedDialIcon';
+export * from './SpeedDialIcon';

--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -16,22 +16,23 @@ export type TextStyle =
 
 export type Style = TextStyle | 'button';
 
-export interface FontStyle extends Required<{
-  fontFamily: CSSProperties['fontFamily'];
-  fontSize: number;
-  fontWeightLight: CSSProperties['fontWeight'];
-  fontWeightRegular: CSSProperties['fontWeight'];
-  fontWeightMedium: CSSProperties['fontWeight'];
-}> {}
+export interface FontStyle
+  extends Required<{
+      fontFamily: CSSProperties['fontFamily'];
+      fontSize: number;
+      fontWeightLight: CSSProperties['fontWeight'];
+      fontWeightRegular: CSSProperties['fontWeight'];
+      fontWeightMedium: CSSProperties['fontWeight'];
+    }> {}
 
 export interface FontStyleOptions extends Partial<FontStyle> {
   htmlFontSize?: number;
 }
 
-export type TypographyStyle =
-  & Required<Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>>
-  & Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>
-  ;
+export type TypographyStyle = Required<
+  Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>
+> &
+  Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>;
 
 export interface TypographyStyleOptions extends Partial<TypographyStyle> {}
 

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -3,7 +3,7 @@ import { WithTheme } from '../styles/withTheme';
 import { ConsistentWith, Overwrite } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
-import * as JSS from 'jss'
+import * as JSS from 'jss';
 
 export interface CSSProperties extends CSS.Properties<number | string> {
   // Allow pseudo selectors and media queries
@@ -29,7 +29,8 @@ export interface StylesCreator {
   themingEnabled: boolean;
 }
 
-export interface WithStylesOptions<ClassKey extends string = string> extends JSS.CreateStyleSheetOptions<ClassKey> {
+export interface WithStylesOptions<ClassKey extends string = string>
+  extends JSS.CreateStyleSheetOptions<ClassKey> {
   flip?: boolean;
   withTheme?: boolean;
   name?: string;
@@ -39,10 +40,9 @@ export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, st
 
 export type WithStyles<T extends string | StyleRules | StyleRulesCallback> = Partial<WithTheme> & {
   classes: ClassNameMap<
-    T extends string ? T :
-    T extends StyleRulesCallback<infer K> ? K :
-    T extends StyleRules<infer K> ? K :
-    never
+    T extends string
+      ? T
+      : T extends StyleRulesCallback<infer K> ? K : T extends StyleRules<infer K> ? K : never
   >;
 };
 

--- a/packages/material-ui/src/transitions/transition.d.ts
+++ b/packages/material-ui/src/transitions/transition.d.ts
@@ -21,6 +21,7 @@ export type TransitionKeys =
   | 'addEndListener'
   | TransitionHandlerKeys;
 export interface TransitionProps
-  extends TransitionActions, Partial<Pick<_TransitionProps, TransitionKeys>> {
+  extends TransitionActions,
+    Partial<Pick<_TransitionProps, TransitionKeys>> {
   style?: CSSProperties;
 }

--- a/packages/material-ui/src/withWidth/withWidth.spec.tsx
+++ b/packages/material-ui/src/withWidth/withWidth.spec.tsx
@@ -4,13 +4,14 @@ import { Theme, createStyles } from '../styles';
 import withStyles, { WithStyles } from '../styles/withStyles';
 import withWidth, { WithWidthProps } from '../withWidth';
 
-const styles = (theme: Theme) => createStyles({
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    backgroundColor: theme.palette.common.black,
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      backgroundColor: theme.palette.common.black,
+    },
+  });
 
 interface IHelloProps extends WithWidthProps, WithStyles<typeof styles> {
   name?: string;

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -719,11 +719,12 @@ const TableTest = () => {
           <TableFooter>
             <TableRow>
               <TablePagination
-               count={5}
-               rowsPerPage={2}
-               page={1}
-               onChangePage={() => {}}
-               onChangeRowsPerPage={event => log({ rowsPerPage: event.target.value })}/>
+                count={5}
+                rowsPerPage={2}
+                page={1}
+                onChangePage={() => {}}
+                onChangeRowsPerPage={event => log({ rowsPerPage: event.target.value })}
+              />
             </TableRow>
           </TableFooter>
         </Table>

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -37,10 +37,9 @@ const StyledExampleOne = withStyles(styles)<ComponentProps>(({ classes, text }) 
 <StyledExampleOne text="I am styled!" />;
 
 // Example 2
-const Component: React.SFC<ComponentProps & WithStyles<typeof styles>> = ({
-  classes,
-  text,
-}) => <div className={classes.root}>{text}</div>;
+const Component: React.SFC<ComponentProps & WithStyles<typeof styles>> = ({ classes, text }) => (
+  <div className={classes.root}>{text}</div>
+);
 
 const StyledExampleTwo = withStyles(styles)(Component);
 <StyledExampleTwo text="I am styled!" />;
@@ -55,10 +54,9 @@ const styleRule = createStyles({
   },
 });
 
-const ComponentWithChildren: React.SFC<WithStyles<typeof styles>> = ({
-  classes,
-  children,
-}) => <div className={classes.root}>{children}</div>;
+const ComponentWithChildren: React.SFC<WithStyles<typeof styles>> = ({ classes, children }) => (
+  <div className={classes.root}>{children}</div>
+);
 
 const StyledExampleThree = withStyles(styleRule)(ComponentWithChildren);
 <StyledExampleThree />;
@@ -193,41 +191,44 @@ const DecoratedComponent = withStyles(styles)(
 <DecoratedComponent text="foo" />;
 
 // Allow nested pseudo selectors
-withStyles(theme => createStyles({
-  guttered: theme.mixins.gutters({
-    '&:hover': {
-      textDecoration: 'none',
+withStyles(theme =>
+  createStyles({
+    guttered: theme.mixins.gutters({
+      '&:hover': {
+        textDecoration: 'none',
+      },
+    }),
+    listItem: {
+      '&:hover $listItemIcon': {
+        visibility: 'inherit',
+      },
     },
   }),
-  listItem: {
-    '&:hover $listItemIcon': {
-      visibility: 'inherit',
-    },
-  },
-}));
+);
 
 {
-  const styles = (theme: Theme) => createStyles({
-    // Styled similar to ListItemText
-    root: {
-      '&:first-child': {
-        paddingLeft: 0,
+  const styles = (theme: Theme) =>
+    createStyles({
+      // Styled similar to ListItemText
+      root: {
+        '&:first-child': {
+          paddingLeft: 0,
+        },
+        flex: '1 1 auto',
+        padding: '0 16px',
       },
-      flex: '1 1 auto',
-      padding: '0 16px',
-    },
 
-    iiiinset: {
-      '&:first-child': {
-        paddingLeft: theme.spacing.unit * 7,
+      iiiinset: {
+        '&:first-child': {
+          paddingLeft: theme.spacing.unit * 7,
+        },
       },
-    },
-    row: {
-      alignItems: 'center',
-      display: 'flex',
-      flexDirection: 'row',
-    },
-  });
+      row: {
+        alignItems: 'center',
+        display: 'flex',
+        flexDirection: 'row',
+      },
+    });
 
   interface ListItemContentProps extends WithStyles<typeof styles> {
     inset?: boolean;
@@ -239,7 +240,7 @@ withStyles(theme => createStyles({
       <div className={classes.root} color="textSecondary">
         {children}
       </div>
-    )
+    ),
   );
 }
 
@@ -262,11 +263,12 @@ withStyles(theme => createStyles({
     caption: string;
   }
 
-  const styles = (theme: Theme) => createStyles({
-    content: {
-      margin: 4,
-    },
-  });
+  const styles = (theme: Theme) =>
+    createStyles({
+      content: {
+        margin: 4,
+      },
+    });
 
   const Component = (props: ComponentProps) => {
     return <div className={props.classes.content}>Hello {props.caption}</div>;
@@ -289,9 +291,10 @@ withStyles(theme => createStyles({
 
 {
   // https://github.com/mui-org/material-ui/issues/11191
-  const styles = (theme: Theme) => createStyles({
-    main: {},
-  });
+  const styles = (theme: Theme) =>
+    createStyles({
+      main: {},
+    });
 
   interface Props extends WithStyles<typeof styles> {
     someProp?: string;
@@ -308,12 +311,14 @@ withStyles(theme => createStyles({
   <DecoratedSomeComponent someProp="hello world" />;
 }
 
-{ // https://github.com/mui-org/material-ui/issues/11312
-  withStyles(styles, { name: "MyComponent", index: 0 })(() => <div/>);
+{
+  // https://github.com/mui-org/material-ui/issues/11312
+  withStyles(styles, { name: 'MyComponent', index: 0 })(() => <div />);
 }
 
-{ // https://github.com/mui-org/material-ui/issues/11164
+{
+  // https://github.com/mui-org/material-ui/issues/11164
   const style: StyleRulesCallback = theme => ({
-    text: theme.typography.body2
+    text: theme.typography.body2,
   });
 }

--- a/packages/material-ui/test/typescript/styling-comparison.spec.tsx
+++ b/packages/material-ui/test/typescript/styling-comparison.spec.tsx
@@ -2,13 +2,14 @@ import * as React from 'react';
 import Typography, { TypographyProps } from '../../src/Typography/Typography';
 import { withStyles, WithStyles, createStyles, Theme } from '../../src/styles';
 
-const styles = ({ palette, spacing }: Theme) => createStyles({
-  root: {
-    padding: spacing.unit,
-    backgroundColor: palette.background.default,
-    color: palette.primary.dark,
-  },
-})
+const styles = ({ palette, spacing }: Theme) =>
+  createStyles({
+    root: {
+      padding: spacing.unit,
+      backgroundColor: palette.background.default,
+      color: palette.primary.dark,
+    },
+  });
 
 interface Props extends WithStyles<typeof styles> {
   color: TypographyProps['color'];

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   bracketSpacing: true,
   jsxBracketSameLine: false,
-  parser: 'babylon',
   printWidth: 100,
   semi: true,
   singleQuote: true,


### PR DESCRIPTION
Related to:
https://github.com/prettier/prettier/issues/4642

When specifying the `babylon` parser for Prettier in versions greater than `1.13.x`, it fails on certain types of files, like `.json`. Removing it fixes this issue.