### PR TITLE
[docs] error in example in Migration From v0.x Guide

### DIFF
--- a/docs/src/pages/guides/migration-v0x/migration-v0x.md
+++ b/docs/src/pages/guides/migration-v0x/migration-v0x.md
@@ -63,7 +63,7 @@ taking advantage of this knowledge to address long-standing issues. To name some
   function App() {
     return (
       <MuiThemeProvider theme={theme}>
-        <V0ThemeProvider muiTheme={themeV0}>
+        <V0MuiThemeProvider muiTheme={themeV0}>
           {/*Components*/}
         </V0MuiThemeProvider>
       </MuiThemeProvider>


### PR DESCRIPTION
The code provided as an example contained an error.

`s/V0ThemeProvider/V0MuiThemeProvider/g`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
