### PR TITLE
[styles] Re-add default parameter of string for WithStyles

### DIFF
--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -38,7 +38,7 @@ export interface WithStylesOptions<ClassKey extends string = string>
 
 export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
 
-export type WithStyles<T extends string | StyleRules | StyleRulesCallback> = Partial<WithTheme> & {
+export type WithStyles<T extends string | StyleRules | StyleRulesCallback = string> = Partial<WithTheme> & {
   classes: ClassNameMap<
     T extends string
       ? T


### PR DESCRIPTION
As pointed out in [this comment](https://github.com/mui-org/material-ui/pull/11609#discussion_r193989711), there was an inadvertant breaking change made in #11609, which this fixes.