### PR TITLE
[StepButton] Fix IE 11 flexbox

### DIFF
--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -16,7 +16,7 @@ export const styles = theme => ({
     boxSizing: 'content-box',
   },
   vertical: {
-    justifyContent: 'left',
+    justifyContent: 'flex-start',
   },
   touchRipple: {
     color: 'rgba(0, 0, 0, 0.3)',


### PR DESCRIPTION
IE 11 does not recognize or ignore the value `left` for the css property: `justify-content`. This causes the content of the StepButton to be centered when using a vertical stepper.