### PR TITLE
[Tabs] Add support for a `component` property

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.d.ts
+++ b/packages/material-ui/src/Tabs/Tabs.d.ts
@@ -8,6 +8,7 @@ export interface TabsProps
   action?: (actions: TabsActions) => void;
   centered?: boolean;
   children?: React.ReactNode;
+  component?: React.ReactType<TabsProps>,
   fullWidth?: boolean;
   indicatorColor?: 'secondary' | 'primary' | string;
   onChange?: (event: React.ChangeEvent<{}>, value: any) => void;

--- a/packages/material-ui/src/Tabs/Tabs.d.ts
+++ b/packages/material-ui/src/Tabs/Tabs.d.ts
@@ -4,7 +4,7 @@ import { ButtonBaseProps } from '../ButtonBase/ButtonBase';
 import { TabIndicatorProps } from './TabIndicator';
 
 export interface TabsProps
-  extends StandardProps<ButtonBaseProps, TabsClassKey, 'onChange' | 'action'> {
+  extends StandardProps<ButtonBaseProps, TabsClassKey, 'onChange' | 'action' | 'component'> {
   action?: (actions: TabsActions) => void;
   centered?: boolean;
   children?: React.ReactNode;

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -275,7 +275,7 @@ class Tabs extends React.Component {
       children: childrenProp,
       classes,
       className: classNameProp,
-      component: Component
+      component: Component,
       fullWidth,
       indicatorColor,
       onChange,

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -275,6 +275,7 @@ class Tabs extends React.Component {
       children: childrenProp,
       classes,
       className: classNameProp,
+      component: Component
       fullWidth,
       indicatorColor,
       onChange,
@@ -340,7 +341,7 @@ class Tabs extends React.Component {
     const conditionalElements = this.getConditionalElements();
 
     return (
-      <div className={className} {...other}>
+      <Component className={className} {...other}>
         <EventListener target="window" onResize={this.handleResize} />
         {conditionalElements.scrollbarSizeListener}
         <div className={classes.flexContainer}>
@@ -359,7 +360,7 @@ class Tabs extends React.Component {
           </div>
           {conditionalElements.scrollButtonRight}
         </div>
-      </div>
+      </Component>
     );
   }
 }
@@ -392,6 +393,11 @@ Tabs.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   /**
    * If `true`, the tabs will grow to use all the available space.
    * This property is intended for small views, like on mobile.
@@ -445,6 +451,7 @@ Tabs.propTypes = {
 
 Tabs.defaultProps = {
   centered: false,
+  component: 'div',
   fullWidth: false,
   indicatorColor: 'secondary',
   scrollable: false,

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -16,6 +16,7 @@ filename: /packages/material-ui/src/Tabs/Tabs.js
 | <span class="prop-name">centered</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the tabs will be centered. This property is intended for large views. |
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func<br> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the tabs will grow to use all the available space. This property is intended for small views, like on mobile. |
 | <span class="prop-name">indicatorColor</span> | <span class="prop-type">enum:&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'primary'<br> | <span class="prop-default">'secondary'</span> | Determines the color of the indicator. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |   | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: number) => void`<br>*event:* The event source of the callback<br>*value:* We default to the index of the child |


### PR DESCRIPTION
Added a 'component' prop to the Tabs component.  This allows for specifying the root node using either a DOM node (string) or a custom component.  Fixes #11807.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
