### PR TITLE
feat(Tab): pass through children

### DIFF
--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -134,6 +134,7 @@ class Tab extends React.Component {
 
   render() {
     const {
+      children,
       classes,
       className: classNameProp,
       disabled,
@@ -193,6 +194,7 @@ class Tab extends React.Component {
           {icon}
           {label}
         </span>
+        {children}
         {indicator}
       </ButtonBase>
     );
@@ -200,6 +202,10 @@ class Tab extends React.Component {
 }
 
 Tab.propTypes = {
+  /**
+   * Optional additional children
+   */
+  children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css-api) below for more details.


### PR DESCRIPTION
for cases when the desired content doesn't fit neatly into the `label`/`icon` dichotomy

fix #11860 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
