### PR TITLE
[TableCell] Fix property name

### DIFF
--- a/packages/material-ui/src/TableCell/TableCell.d.ts
+++ b/packages/material-ui/src/TableCell/TableCell.d.ts
@@ -14,7 +14,7 @@ export interface TableCellProps extends StandardProps<TableCellBaseProps, TableC
   numeric?: boolean;
   padding?: Padding;
   sortDirection?: SortDirection;
-  type?: Type;
+  variant?: 'head' | 'body' | 'footer';
 }
 
 export type TableCellBaseProps = React.ThHTMLAttributes<HTMLTableHeaderCellElement> &
@@ -23,8 +23,6 @@ export type TableCellBaseProps = React.ThHTMLAttributes<HTMLTableHeaderCellEleme
 export type Padding = 'default' | 'checkbox' | 'dense' | 'none';
 
 export type SortDirection = 'asc' | 'desc' | false;
-
-export type Type = 'head' | 'body' | 'footer';
 
 export type TableCellClassKey =
   | 'root'


### PR DESCRIPTION
Fixed type declaration.
`type` was renamed to `variant` on #10088
