### PR TITLE
[Modal] Fix removeEventListener

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -123,7 +123,7 @@ class Modal extends React.Component {
     this.props.manager.remove(this);
     const doc = ownerDocument(this.mountNode);
     doc.removeEventListener('keydown', this.handleDocumentKeyDown);
-    doc.removeEventListener('focus', this.enforceFocus);
+    doc.removeEventListener('focus', this.enforceFocus, true);
     this.restoreLastFocus();
   };
 


### PR DESCRIPTION
It seems like focus event listener in Modal isn't removed correctly (`useCapture` flag isn't the same as when adding the event). This PR fixes that.

^ Note: I haven't experienced any practical problems because of it - I was just checking the MUI source and found this issue. 
