### PR TITLE
[CircularProgress] End of line shape: use butt

### DIFF
--- a/packages/material-ui/src/CircularProgress/CircularProgress.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.js
@@ -42,7 +42,8 @@ export const styles = theme => ({
   svg: {},
   circle: {
     stroke: 'currentColor',
-    strokeLinecap: 'butt',
+    // Use butt to follow the specification, by chance, it's already the default CSS value.
+    // strokeLinecap: 'butt',
   },
   circleStatic: {
     transition: theme.transitions.create('stroke-dashoffset'),

--- a/packages/material-ui/src/CircularProgress/CircularProgress.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.js
@@ -42,7 +42,7 @@ export const styles = theme => ({
   svg: {},
   circle: {
     stroke: 'currentColor',
-    strokeLinecap: 'round',
+    strokeLinecap: 'butt'
   },
   circleStatic: {
     transition: theme.transitions.create('stroke-dashoffset'),

--- a/packages/material-ui/src/CircularProgress/CircularProgress.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.js
@@ -42,7 +42,7 @@ export const styles = theme => ({
   svg: {},
   circle: {
     stroke: 'currentColor',
-    strokeLinecap: 'butt'
+    strokeLinecap: 'butt',
   },
   circleStatic: {
     transition: theme.transitions.create('stroke-dashoffset'),


### PR DESCRIPTION
### Issue
Closes #11887

### Solution
Changed default svg circle stroke linecap to `butt`, because material design no longer uses round variant.
https://material.io/design/components/progress-indicators.html#circular-progress-indicators