### PR TITLE
[Tooltip] Revert update react-popper

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -27,7 +27,7 @@ module.exports = [
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '96.3 KB',
+    limit: '95.0 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/docs/src/pages/demos/menus/MenuListComposition.js
+++ b/docs/src/pages/demos/menus/MenuListComposition.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { Manager, Reference, Popper } from 'react-popper';
+import { Manager, Target, Popper } from 'react-popper';
 import Button from '@material-ui/core/Button';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import Collapse from '@material-ui/core/Collapse';
@@ -55,90 +55,72 @@ class MenuListComposition extends React.Component {
           </MenuList>
         </Paper>
         <Manager>
-          <Reference>
-            {({ ref }) => (
-              <div
-                ref={node => {
-                  this.target1 = node;
-                }}
+          <Target>
+            <div
+              ref={node => {
+                this.target1 = node;
+              }}
+            >
+              <Button
+                aria-owns={open ? 'menu-list-grow' : null}
+                aria-haspopup="true"
+                onClick={this.handleToggle}
               >
-                <Button
-                  buttonRef={ref}
-                  aria-owns={open ? 'menu-list-grow' : null}
-                  aria-haspopup="true"
-                  onClick={this.handleToggle}
-                >
-                  Toggle Menu Grow
-                </Button>
-              </div>
-            )}
-          </Reference>
+                Toggle Menu Grow
+              </Button>
+            </div>
+          </Target>
           <Popper
             placement="bottom-start"
             eventsEnabled={open}
             className={classNames({ [classes.popperClose]: !open })}
           >
-            {({ ref, style }) => (
-              <div ref={ref} style={style}>
-                <ClickAwayListener onClickAway={this.handleClose}>
-                  <Grow in={open} id="menu-list-grow" style={{ transformOrigin: '0 0 0' }}>
-                    <Paper>
-                      <MenuList role="menu">
-                        <MenuItem onClick={this.handleClose}>Profile</MenuItem>
-                        <MenuItem onClick={this.handleClose}>My account</MenuItem>
-                        <MenuItem onClick={this.handleClose}>Logout</MenuItem>
-                      </MenuList>
-                    </Paper>
-                  </Grow>
-                </ClickAwayListener>
-              </div>
-            )}
+            <ClickAwayListener onClickAway={this.handleClose}>
+              <Grow in={open} id="menu-list-grow" style={{ transformOrigin: '0 0 0' }}>
+                <Paper>
+                  <MenuList role="menu">
+                    <MenuItem onClick={this.handleClose}>Profile</MenuItem>
+                    <MenuItem onClick={this.handleClose}>My account</MenuItem>
+                    <MenuItem onClick={this.handleClose}>Logout</MenuItem>
+                  </MenuList>
+                </Paper>
+              </Grow>
+            </ClickAwayListener>
           </Popper>
         </Manager>
         <Manager>
-          <Reference>
-            {({ ref }) => (
-              <div
-                ref={node => {
-                  this.target2 = node;
-                }}
+          <Target>
+            <div
+              ref={node => {
+                this.target2 = node;
+              }}
+            >
+              <Button
+                aria-owns={open ? 'menu-list-collapse' : null}
+                aria-haspopup="true"
+                onClick={this.handleToggle}
               >
-                <Button
-                  buttonRef={ref}
-                  aria-owns={open ? 'menu-list-collapse' : null}
-                  aria-haspopup="true"
-                  onClick={this.handleToggle}
-                >
-                  Toggle Menu Collapse
-                </Button>
-              </div>
-            )}
-          </Reference>
+                Toggle Menu Collapse
+              </Button>
+            </div>
+          </Target>
           <Portal>
             <Popper
               placement="bottom"
               eventsEnabled={open}
               className={classNames({ [classes.popperClose]: !open })}
             >
-              {({ ref, style }) => (
-                <div ref={ref} style={style}>
-                  <ClickAwayListener onClickAway={this.handleClose}>
-                    <Collapse
-                      in={open}
-                      id="menu-list-collapse"
-                      style={{ transformOrigin: '0 0 0' }}
-                    >
-                      <Paper style={{ margin: 3 }}>
-                        <MenuList role="menu">
-                          <MenuItem onClick={this.handleClose}>Profile</MenuItem>
-                          <MenuItem onClick={this.handleClose}>My account</MenuItem>
-                          <MenuItem onClick={this.handleClose}>Logout</MenuItem>
-                        </MenuList>
-                      </Paper>
-                    </Collapse>
-                  </ClickAwayListener>
-                </div>
-              )}
+              <ClickAwayListener onClickAway={this.handleClose}>
+                <Collapse in={open} id="menu-list-collapse" style={{ transformOrigin: '0 0 0' }}>
+                  <Paper style={{ margin: 3 }}>
+                    <MenuList role="menu">
+                      <MenuItem onClick={this.handleClose}>Profile</MenuItem>
+                      <MenuItem onClick={this.handleClose}>My account</MenuItem>
+                      <MenuItem onClick={this.handleClose}>Logout</MenuItem>
+                    </MenuList>
+                  </Paper>
+                </Collapse>
+              </ClickAwayListener>
             </Popper>
           </Portal>
         </Manager>

--- a/docs/src/pages/utils/popovers/MouseOverPopover.js
+++ b/docs/src/pages/utils/popovers/MouseOverPopover.js
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import Grow from '@material-ui/core/Grow';
 import Paper from '@material-ui/core/Paper';
-import { Manager, Reference, Popper } from 'react-popper';
+import { Manager, Target, Popper } from 'react-popper';
 
 const styles = theme => ({
   paper: {
@@ -74,39 +74,31 @@ class MouseOverPopover extends React.Component {
           <Typography>I use Popover.</Typography>
         </Popover>
         <Manager>
-          <Reference>
-            {({ ref }) => (
-              <div ref={ref}>
-                <Typography
-                  aria-describedby="react-popper-tooltip"
-                  onMouseOver={this.handlePopperOpen}
-                  onMouseOut={this.handlePopperClose}
-                >
-                  Hover with react-popper.
-                </Typography>
-              </div>
-            )}
-          </Reference>
+          <Target>
+            <Typography
+              aria-describedby="react-popper-tooltip"
+              onMouseOver={this.handlePopperOpen}
+              onMouseOut={this.handlePopperClose}
+            >
+              Hover with react-popper.
+            </Typography>
+          </Target>
           <Popper
             placement="bottom-start"
             eventsEnabled={popperOpen}
             className={!popperOpen ? classes.popperClose : ''}
           >
-            {({ ref, style }) => (
-              <div ref={ref} style={style}>
-                <Grow in={popperOpen} style={{ transformOrigin: '0 0 0' }}>
-                  <Paper
-                    id="react-popper-tooltip"
-                    className={classes.paper}
-                    role="tooltip"
-                    aria-hidden={!popperOpen}
-                    elevation={8}
-                  >
-                    <Typography>I use react-popper.</Typography>
-                  </Paper>
-                </Grow>
-              </div>
-            )}
+            <Grow in={popperOpen} style={{ transformOrigin: '0 0 0' }}>
+              <Paper
+                id="react-popper-tooltip"
+                className={classes.paper}
+                role="tooltip"
+                aria-hidden={!popperOpen}
+                elevation={8}
+              >
+                <Typography>I use react-popper.</Typography>
+              </Paper>
+            </Grow>
           </Popper>
         </Manager>
       </div>

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "doctrine": "^2.0.0",
     "downshift": "^1.22.1",
     "enzyme": "^3.2.0",
-    "enzyme-adapter-react-16": "npm:enzyme-react-adapter-future",
+    "enzyme-adapter-react-16": "^1.1.0",
     "eslint": "^4.11.0",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-import-resolver-webpack": "^0.10.0",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -56,9 +56,9 @@
     "prop-types": "^15.6.0",
     "react-event-listener": "^0.6.0",
     "react-jss": "^8.1.0",
-    "react-popper": "^1.0.0",
+    "react-popper": "^0.10.0",
     "react-transition-group": "^2.2.1",
-    "recompose": "^0.27.0",
+    "recompose": "^0.26.0 || ^0.27.0",
     "scroll": "^2.0.3",
     "warning": "^4.0.1"
   },

--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PopperProps } from 'react-popper';
+import { IPopperProps } from 'react-popper';
 import { StandardProps } from '..';
 
 export interface TooltipProps
@@ -42,6 +42,10 @@ export type TooltipClassKey =
   | 'tooltipPlacementRight'
   | 'tooltipPlacementTop'
   | 'tooltipPlacementBottom';
+
+interface PopperProps extends IPopperProps {
+  PopperClassName: string;
+}
 
 declare const Tooltip: React.ComponentType<TooltipProps>;
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { Popper, Reference } from 'react-popper';
+import { Popper, Target } from 'react-popper';
 import { ShallowWrapper } from 'enzyme';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
@@ -16,22 +16,22 @@ function persist() {}
 // eslint-disable-next-line react/prop-types
 const Hack = ({ style, innerRef, ...other }) => <div ref={innerRef} {...other} />;
 
-function getReferenceChildren(wrapper) {
+function getTargetChildren(wrapper) {
   return new ShallowWrapper(
     wrapper
-      .find(Reference)
+      .find(Target)
       .props()
       .children({}).props.children,
     wrapper,
   );
 }
 
-function getPopperChildren(wrapper, props) {
+function getPopperChildren(wrapper) {
   return new ShallowWrapper(
     wrapper
       .find(Popper)
       .props()
-      .children(props),
+      .children({ popperProps: { style: {} }, restProps: {} }),
     null,
   );
 }
@@ -72,7 +72,7 @@ describe('<Tooltip />', () => {
         <span>Hello World</span>
       </Tooltip>,
     );
-    const popperChildren = getPopperChildren(wrapper, { style: {} });
+    const popperChildren = getPopperChildren(wrapper);
     assert.strictEqual(popperChildren.childAt(0).hasClass(classes.tooltip), true);
   });
 
@@ -94,7 +94,7 @@ describe('<Tooltip />', () => {
           <span>Hello World</span>
         </Tooltip>,
       );
-      const popperChildren = getPopperChildren(wrapper, { style: {}, placement: 'top' });
+      const popperChildren = getPopperChildren(wrapper);
       assert.strictEqual(popperChildren.childAt(0).hasClass(classes.tooltip), true);
       wrapper.childAt(0).simulate('click');
       assert.strictEqual(popperChildren.childAt(0).hasClass(classes.tooltipPlacementTop), true);
@@ -143,7 +143,7 @@ describe('<Tooltip />', () => {
         <button>Hello World</button>
       </Tooltip>,
     );
-    const children = getReferenceChildren(wrapper);
+    const children = getTargetChildren(wrapper);
     assert.strictEqual(wrapper.state().open, false);
     children.simulate('mouseOver', {});
     assert.strictEqual(wrapper.state().open, true);
@@ -166,7 +166,7 @@ describe('<Tooltip />', () => {
         <button>Hello World</button>
       </Tooltip>,
     );
-    const children = getReferenceChildren(wrapper);
+    const children = getTargetChildren(wrapper);
     assert.strictEqual(handleRequestOpen.callCount, 0);
     assert.strictEqual(handleClose.callCount, 0);
     children.simulate('mouseOver', { type: 'mouseover' });
@@ -194,7 +194,7 @@ describe('<Tooltip />', () => {
           <button>Hello World</button>
         </Tooltip>,
       );
-      const children = getReferenceChildren(wrapper);
+      const children = getTargetChildren(wrapper);
       children.simulate('touchStart', { type: 'touchstart', persist });
       children.simulate('touchEnd', { type: 'touchend', persist });
       children.simulate('focus', { type: 'focus' });
@@ -208,7 +208,7 @@ describe('<Tooltip />', () => {
           <button>Hello World</button>
         </Tooltip>,
       );
-      const children = getReferenceChildren(wrapper);
+      const children = getTargetChildren(wrapper);
       children.simulate('touchStart', { type: 'touchstart', persist });
       children.simulate('focus', { type: 'focus' });
       children.simulate('mouseover', { type: 'mouseover' });
@@ -247,7 +247,7 @@ describe('<Tooltip />', () => {
           <button>Hello World</button>
         </Tooltip>,
       );
-      const children = getReferenceChildren(wrapper);
+      const children = getTargetChildren(wrapper);
       children.simulate('focus', { type: 'focus', persist });
       assert.strictEqual(wrapper.state().open, false);
       clock.tick(111);
@@ -260,7 +260,7 @@ describe('<Tooltip />', () => {
           <button>Hello World</button>
         </Tooltip>,
       );
-      const children = getReferenceChildren(wrapper);
+      const children = getTargetChildren(wrapper);
       children.simulate('focus', { type: 'focus' });
       assert.strictEqual(wrapper.state().open, true);
       children.simulate('blur', { type: 'blur', persist });
@@ -280,7 +280,7 @@ describe('<Tooltip />', () => {
               <button {...{ [name]: handler }}>Hello World</button>
             </Tooltip>,
           );
-          const children = getReferenceChildren(wrapper);
+          const children = getTargetChildren(wrapper);
           const type = name.slice(2).toLowerCase();
           children.simulate(type, { type, persist });
           assert.strictEqual(handler.callCount, 1);
@@ -311,7 +311,7 @@ describe('<Tooltip />', () => {
       instance.handleResize();
       assert.strictEqual(handleUpdate.callCount, 0);
       clock.tick(1);
-      instance.scheduleUpdate = handleUpdate;
+      instance.popper._popper.scheduleUpdate = handleUpdate;
       clock.tick(165);
       assert.strictEqual(handleUpdate.callCount, 1);
     });

--- a/test/regressions/tests/Tooltip/PositionedTooltips.js
+++ b/test/regressions/tests/Tooltip/PositionedTooltips.js
@@ -7,7 +7,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 const styles = {
   root: {
-    width: 500,
+    width: 400,
     height: 400,
     padding: 60,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1070,8 +1070,8 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
 
 "@types/node@*":
-  version "10.3.3"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.3.tgz#8798d9e39af2fa604f715ee6a6b19796528e46c3"
+  version "10.3.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.4.tgz#c74e8aec19e555df44609b8057311052a2c84d9e"
 
 "@types/react-transition-group@^2.0.8":
   version "2.0.11"
@@ -1080,8 +1080,8 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@^16.3.14":
-  version "16.3.18"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.3.18.tgz#bf195aed4d77dc86f06e4c9bb760214a3b822b8d"
+  version "16.4.0"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.4.0.tgz#f7f639837bf1f8635f57616b12a1b0d193b6343a"
   dependencies:
     csstype "^2.2.0"
 
@@ -1627,11 +1627,11 @@ autoprefixer@^6.3.1:
     postcss-value-parser "^3.2.3"
 
 autoprefixer@^8.0.0:
-  version "8.6.2"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.6.2.tgz#51d42ff13243820a582a53ecca20dedaeb7f2efd"
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.6.3.tgz#1d38a129e6a4582a565b6570d16f2d7d3de9cbf9"
   dependencies:
     browserslist "^3.2.8"
-    caniuse-lite "^1.0.30000851"
+    caniuse-lite "^1.0.30000856"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
     postcss "^6.0.22"
@@ -2298,7 +2298,7 @@ babel-register@^6.26.0, babel-register@^6.9.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@6.x.x, babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
+babel-runtime@^6.0.0, babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.26.0, babel-runtime@^6.9.2:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -2799,7 +2799,7 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   version "1.0.30000856"
   resolved "https://registry.yarnpkg.com/caniuse-db/-/caniuse-db-1.0.30000856.tgz#fbebb99abe15a5654fc7747ebb5315bdfde3358f"
 
-caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000851:
+caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30000856:
   version "1.0.30000856"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz#ecc16978135a6f219b138991eb62009d25ee8daa"
 
@@ -2916,8 +2916,8 @@ chokidar@^1.6.1:
     fsevents "^1.0.0"
 
 chokidar@^2.0.2, chokidar@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.3.tgz#dcbd4f6cbb2a55b4799ba8a840ac527e5f4b1176"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.4.tgz#356ff4e2b0e8e43e322d18a372460bbcf3accd26"
   dependencies:
     anymatch "^2.0.0"
     async-each "^1.0.0"
@@ -2926,12 +2926,13 @@ chokidar@^2.0.2, chokidar@^2.0.3:
     inherits "^2.0.1"
     is-binary-path "^1.0.0"
     is-glob "^4.0.0"
+    lodash.debounce "^4.0.8"
     normalize-path "^2.1.1"
     path-is-absolute "^1.0.0"
     readdirp "^2.0.0"
-    upath "^1.0.0"
+    upath "^1.0.5"
   optionalDependencies:
-    fsevents "^1.1.2"
+    fsevents "^1.2.2"
 
 chownr@^1.0.1:
   version "1.0.1"
@@ -3336,13 +3337,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-create-react-context@^0.2.1:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.2.tgz#9836542f9aaa22868cd7d4a6f82667df38019dca"
-  dependencies:
-    fbjs "^0.8.0"
-    gud "^1.0.0"
-
 cross-env@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
@@ -3521,8 +3515,8 @@ cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
     cssom "0.3.x"
 
 csstype@^2.0.0, csstype@^2.2.0, csstype@^2.5.2:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.3.tgz#2504152e6e1cc59b32098b7f5d6a63f16294c1f7"
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.5.5.tgz#4125484a3d42189a863943f23b9e4b80fedfa106"
 
 currently-unhandled@^0.4.1:
   version "0.4.1"
@@ -4021,13 +4015,13 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-"enzyme-adapter-react-16@npm:enzyme-react-adapter-future":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/enzyme-react-adapter-future/-/enzyme-react-adapter-future-1.1.3.tgz#f0c102f098086a0ad0270bbdaf9da5113297dc05"
+enzyme-adapter-react-16@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
   dependencies:
     enzyme-adapter-utils "^1.3.0"
     lodash "^4.17.4"
-    object.assign "^4.1.0"
+    object.assign "^4.0.4"
     object.values "^1.0.4"
     prop-types "^15.6.0"
     react-reconciler "^0.7.0"
@@ -4073,8 +4067,8 @@ errno@^0.1.2, errno@^0.1.3, errno@~0.1.7:
     prr "~1.0.1"
 
 error-ex@^1.2.0, error-ex@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
   dependencies:
     is-arrayish "^0.2.1"
 
@@ -4627,7 +4621,7 @@ fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4:
+fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4:
   version "0.8.17"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
   dependencies:
@@ -4962,7 +4956,7 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
-fsevents@^1.0.0, fsevents@^1.1.2:
+fsevents@^1.0.0, fsevents@^1.2.2:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.4.tgz#f41dcb1af2582af3692da36fc55cbd8e1041c426"
   dependencies:
@@ -5127,8 +5121,8 @@ global@^4.3.0, global@~4.3.0:
     process "~0.5.1"
 
 globals@^11.0.1, globals@^11.1.0, globals@^11.3.0:
-  version "11.5.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.5.0.tgz#6bc840de6771173b191f13d3a9c94d441ee92642"
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.6.0.tgz#7e4d12ffd6b8d174851ff5a246bfb2b8b002a6c7"
 
 globals@^9.18.0:
   version "9.18.0"
@@ -5242,10 +5236,6 @@ graceful-fs@~3.0.2:
 growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
-
-gud@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
 
 gzip-size@^4.1.0:
   version "4.1.0"
@@ -5439,8 +5429,8 @@ hoist-non-react-statics@2.5.0:
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
 hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.4.tgz#fc3b1ac05d2ae3abedec84eba846511b0d4fcc4f"
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -6409,8 +6399,8 @@ jss-vendor-prefixer@^7.0.0:
     css-vendor "^0.3.8"
 
 jss@^9.3.3, jss@^9.7.0:
-  version "9.8.3"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.3.tgz#399da571c4b2c8f4cf418ca7e8627e44fc287fc8"
+  version "9.8.6"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-9.8.6.tgz#002af37da04c45ed28e2f38bbc02d2eced3803b5"
   dependencies:
     is-in-browser "^1.1.3"
     symbol-observable "^1.1.0"
@@ -6659,6 +6649,10 @@ lodash.camelcase@^4.3.0:
 lodash.clonedeep@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
 
 lodash.flattendeep@^4.4.0:
   version "4.4.0"
@@ -7505,8 +7499,8 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
 nwsapi@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.3.tgz#3f4010d6c943f34018d3dfb5f2fbc0de90476959"
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.4.tgz#dc79040a5f77b97716dc79565fc7fc3ef7d50570"
 
 nyc@^12.0.1:
   version "12.0.2"
@@ -7573,8 +7567,8 @@ object-is@^1.0.1:
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
 
 object-keys@^1.0.11, object-keys@^1.0.8:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -8372,10 +8366,9 @@ prop-types@15.6.0:
     object-assign "^4.1.1"
 
 prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  version "15.6.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
-    fbjs "^0.8.16"
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
@@ -8683,16 +8676,12 @@ react-number-format@^3.0.2:
     babel-runtime "^6.26.0"
     prop-types "^15.6.0"
 
-react-popper@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.0.0.tgz#b99452144e8fe4acc77fa3d959a8c79e07a65084"
+react-popper@^0.10.0:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-0.10.4.tgz#af2a415ea22291edd504678d7afda8a6ee3295aa"
   dependencies:
-    babel-runtime "6.x.x"
-    create-react-context "^0.2.1"
     popper.js "^1.14.1"
     prop-types "^15.6.1"
-    typed-styles "^0.0.5"
-    warning "^3.0.0"
 
 react-reconciler@^0.7.0:
   version "0.7.0"
@@ -8938,7 +8927,7 @@ recast@^0.15.0:
     private "~0.1.5"
     source-map "~0.6.1"
 
-"recompose@^0.26.0 || ^0.27.0", recompose@^0.27.0:
+"recompose@^0.26.0 || ^0.27.0":
   version "0.27.1"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.27.1.tgz#1a49e931f183634516633bbb4f4edbfd3f38a7ba"
   dependencies:
@@ -9274,8 +9263,8 @@ resolve@1.5.0:
     path-parse "^1.0.5"
 
 resolve@^1.1.6, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.6.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.0.tgz#a7f2ac27b78480ecc09c83782741d9f26e4f0c3e"
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   dependencies:
     path-parse "^1.0.5"
 
@@ -10391,10 +10380,6 @@ type-is@~1.6.15, type-is@~1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typed-styles@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/typed-styles/-/typed-styles-0.0.5.tgz#a60df245d482a9b1adf9c06c078d0f06085ed1cf"
-
 typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
@@ -10424,8 +10409,8 @@ uglify-js@^2.6, uglify-js@^2.8.29:
     uglify-to-browserify "~1.0.0"
 
 uglify-js@^3.3.25:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.0.tgz#796762282b5b5f0eafe7d5c8c708d1d7bd5ba11d"
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.1.tgz#006da540dc25e9319d106a99a5ef1d24ae04ce60"
   dependencies:
     commander "~2.15.0"
     source-map "~0.6.1"
@@ -10586,7 +10571,7 @@ unzipper@^0.8.11:
     readable-stream "~2.1.5"
     setimmediate "~1.0.4"
 
-upath@^1.0.0:
+upath@^1.0.5:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.1.0.tgz#35256597e46a581db4793d0ce47fa9aebfc9fabd"
 
@@ -11016,21 +11001,21 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-workbox-background-sync@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-3.2.0.tgz#08d4f79fb82fb61f72fbd0359c4b616cc75612d4"
+workbox-background-sync@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-background-sync/-/workbox-background-sync-3.3.0.tgz#87e212715391d2002274f526e77851cfab86ed8a"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
-workbox-broadcast-cache-update@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.2.0.tgz#65b4d9b3d4594751ab7ce1fee905c08214118fdc"
+workbox-broadcast-cache-update@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-broadcast-cache-update/-/workbox-broadcast-cache-update-3.3.0.tgz#ce4fa56656de5024f567c06f6614e36961c30c0f"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
 workbox-build@^3.0.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-3.2.0.tgz#01f4a4f6fb5a94dadd3f86d04480c84578fa1125"
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-build/-/workbox-build-3.3.0.tgz#7f3fa9de9714dab318122933b9615a38d94d643d"
   dependencies:
     babel-runtime "^6.26.0"
     common-tags "^1.4.0"
@@ -11039,77 +11024,77 @@ workbox-build@^3.0.1:
     joi "^11.1.1"
     lodash.template "^4.4.0"
     pretty-bytes "^4.0.2"
-    workbox-background-sync "^3.2.0"
-    workbox-broadcast-cache-update "^3.2.0"
-    workbox-cache-expiration "^3.2.0"
-    workbox-cacheable-response "^3.2.0"
-    workbox-core "^3.2.0"
-    workbox-google-analytics "^3.2.0"
-    workbox-precaching "^3.2.0"
-    workbox-range-requests "^3.2.0"
-    workbox-routing "^3.2.0"
-    workbox-strategies "^3.2.0"
-    workbox-streams "^3.2.0"
-    workbox-sw "^3.2.0"
+    workbox-background-sync "^3.3.0"
+    workbox-broadcast-cache-update "^3.3.0"
+    workbox-cache-expiration "^3.3.0"
+    workbox-cacheable-response "^3.3.0"
+    workbox-core "^3.3.0"
+    workbox-google-analytics "^3.3.0"
+    workbox-precaching "^3.3.0"
+    workbox-range-requests "^3.3.0"
+    workbox-routing "^3.3.0"
+    workbox-strategies "^3.3.0"
+    workbox-streams "^3.3.0"
+    workbox-sw "^3.3.0"
 
-workbox-cache-expiration@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-cache-expiration/-/workbox-cache-expiration-3.2.0.tgz#a585761fd5438e439668afc6f862ac5a0ebca1a8"
+workbox-cache-expiration@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-cache-expiration/-/workbox-cache-expiration-3.3.0.tgz#fe9cfde8e8168fa25ff778c6e2eda54181f58506"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
-workbox-cacheable-response@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-3.2.0.tgz#1d8e3d437d60fb80d971d79545bb27acf1fe7653"
+workbox-cacheable-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-cacheable-response/-/workbox-cacheable-response-3.3.0.tgz#b7d3904fa30baf7da271d73dd2f0da7518378acf"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
-workbox-core@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-3.2.0.tgz#d1bd4209447f5350d8dd6b964c86f054c96ffa0a"
+workbox-core@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-core/-/workbox-core-3.3.0.tgz#3606223514a85a0935550ed15d973c12b12ff680"
 
-workbox-google-analytics@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-3.2.0.tgz#1005bc71ae03a8948b687896235dafecb1696c46"
+workbox-google-analytics@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-google-analytics/-/workbox-google-analytics-3.3.0.tgz#380ecefc24040db9e191b2789bced19ad61c8ccb"
   dependencies:
-    workbox-background-sync "^3.2.0"
-    workbox-core "^3.2.0"
-    workbox-routing "^3.2.0"
-    workbox-strategies "^3.2.0"
+    workbox-background-sync "^3.3.0"
+    workbox-core "^3.3.0"
+    workbox-routing "^3.3.0"
+    workbox-strategies "^3.3.0"
 
-workbox-precaching@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-3.2.0.tgz#36568687a5615d8bd4191b38cf0f489a992d7bbc"
+workbox-precaching@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-precaching/-/workbox-precaching-3.3.0.tgz#471bbc26bd3e92b24fd9d636842cf3f358302bd2"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
-workbox-range-requests@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-3.2.0.tgz#5d6cc3621cef0951fc9c0549053f8e117736d321"
+workbox-range-requests@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-range-requests/-/workbox-range-requests-3.3.0.tgz#9703cb91e9ea9104ed09c545a87e25f41002ddce"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
-workbox-routing@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-3.2.0.tgz#6aef7622ede2412dd116231f4f9408a6485a4832"
+workbox-routing@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-routing/-/workbox-routing-3.3.0.tgz#8184d0159c8c4e4c9dd7a0da08e28e579e372319"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
-workbox-strategies@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-3.2.0.tgz#6cd5f00739764872b77b4c3766a606e43eb7d246"
+workbox-strategies@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-strategies/-/workbox-strategies-3.3.0.tgz#0681df07ebf4628454aa91317aa87de2d1ded6c6"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
-workbox-streams@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-3.2.0.tgz#cac0e4f5693b5e13029cbd7e5fec4eb7fcb30d97"
+workbox-streams@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-streams/-/workbox-streams-3.3.0.tgz#7591e37a08bf65b32d1db076b86900a8a4b7d02c"
   dependencies:
-    workbox-core "^3.2.0"
+    workbox-core "^3.3.0"
 
-workbox-sw@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-3.2.0.tgz#ccda9adff557ba2233bf1837229144b4a86276cb"
+workbox-sw@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/workbox-sw/-/workbox-sw-3.3.0.tgz#1a9fd728951c76b86225b472f9e37088913c9bc4"
 
 worker-farm@^1.5.2:
   version "1.6.0"


### PR DESCRIPTION
This reverts commit 984094fea06cd2aa120856f0b1c36eaa2d9c4842.
I'm wondering if we couldn't use popper.js directly. We might not need the react-popper abstraction. I have seen a lot of re-renders investigating the issue, plus the increased bundle size.
- popper.js: 7 kB
- popper.js + react-popper: 9.4 kB

Closes #11913
