### PR TITLE
[docs] Correct markdown example from svg icon

### DIFF
--- a/docs/src/pages/guides/migration-v0x/migration-v0x.md
+++ b/docs/src/pages/guides/migration-v0x/migration-v0x.md
@@ -89,7 +89,7 @@ In the future, we will look into providing a simple component to solve the simpl
 Run [the migration helper](https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod) on your project.
 
 This will apply a change such as the following:
-```
+
 ```diff
 -import AddIcon from 'material-ui/svg-icons/Add';
 +import AddIcon from '@material-ui/icons/Add';


### PR DESCRIPTION
Removed an extra code indicator (```) from the svg-icon part (under Components).
