### PR TITLE
[Grid] Add `auto` to TypeScript definitions

### DIFF
--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -25,7 +25,7 @@ export type GridJustification =
 
 export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
-export type GridSize = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export interface GridProps
   extends StandardProps<
@@ -70,7 +70,8 @@ export type GridClassKey =
   | 'spacing-xs-16'
   | 'spacing-xs-24'
   | 'spacing-xs-40'
-  | 'grid-xs'
+  | 'grid-xs-auto'
+  | 'grid-xs-true'
   | 'grid-xs-1'
   | 'grid-xs-2'
   | 'grid-xs-3'


### PR DESCRIPTION
Thanks @oliviertassinari for adding `auto` as a grid size #11804 
Here are the updated type definitions


