### PR TITLE
[styles] Warn when the first argument is wrong

### DIFF
--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -248,7 +248,7 @@ For instance, it can be used to defined a `getInitialProps()` static method (nex
 
 #### Arguments
 
-1. `styles` (*Function | Object*): A function generating the styles or an object.
+1. `styles` (*Function | Object*): A function generating the styles or a styles object.
 It will be linked to the component.
 Use the function signature if you need to have access to the theme. It's provided as the first argument.
 2. `options` (*Object* [optional]):

--- a/packages/material-ui/src/styles/getStylesCreator.js
+++ b/packages/material-ui/src/styles/getStylesCreator.js
@@ -9,6 +9,14 @@ function arrayMerge(destination, source) {
 function getStylesCreator(stylesOrCreator) {
   const themingEnabled = typeof stylesOrCreator === 'function';
 
+  warning(
+    typeof stylesOrCreator === 'object' || themingEnabled,
+    [
+      'Material-UI: the first argument provided to withStyles() is invalid.',
+      'You need to provide a function generating the styles or a styles object.',
+    ].join('\n'),
+  );
+
   function create(theme, name) {
     const styles = themingEnabled ? stylesOrCreator(theme) : stylesOrCreator;
 


### PR DESCRIPTION
Today at work, I noticed that the following condition doesn't raise any warning, while incorrect.

```js
export default withStyles()(SimpleAppBar);
```

It's fixed:

![capture d ecran 2018-06-23 a 00 49 40](https://user-images.githubusercontent.com/3165635/41802214-828d2702-767f-11e8-8f95-d7cfc4e3cef1.png)
