### PR TITLE
[Menu] Add prop to disable auto focus

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -27,7 +27,7 @@ module.exports = [
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '94.7 KB',
+    limit: '94.8 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -9,6 +9,7 @@ import { ClassNameMap } from '../styles/withStyles';
 export interface MenuProps
   extends StandardProps<PopoverProps & Partial<TransitionHandlerProps>, MenuClassKey> {
   anchorEl?: HTMLElement;
+  disableAutoFocusItem?: boolean;
   MenuListProps?: Partial<MenuListProps>;
   PaperProps?: Partial<PaperProps>;
   PopoverClasses?: Partial<ClassNameMap<PopoverClassKey>>;

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -33,7 +33,7 @@ class Menu extends React.Component {
   menuList = null;
 
   componentDidMount() {
-    if (this.props.open && this.props.disableAutoFocus !== true) {
+    if (this.props.open && this.props.disableAutoFocusSelectedItem !== true) {
       this.focus();
     }
   }
@@ -63,7 +63,7 @@ class Menu extends React.Component {
     const menuList = ReactDOM.findDOMNode(this.menuList);
 
     // Focus so the scroll computation of the Popover works as expected.
-    if (this.props.disableAutoFocus !== true) {
+    if (this.props.disableAutoFocusSelectedItem !== true) {
       this.focus();
     }
 
@@ -151,7 +151,7 @@ Menu.propTypes = {
   /**
    * If `true`, the first menu item will not be auto focused.
    */
-  disableAutoFocus: PropTypes.bool,
+  disableAutoFocusSelectedItem: PropTypes.bool,
   /**
    * Properties applied to the `MenuList` element.
    */

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -33,7 +33,7 @@ class Menu extends React.Component {
   menuList = null;
 
   componentDidMount() {
-    if (this.props.open) {
+    if (this.props.open && this.props.disableAutoFocus !== true) {
       this.focus();
     }
   }
@@ -63,7 +63,9 @@ class Menu extends React.Component {
     const menuList = ReactDOM.findDOMNode(this.menuList);
 
     // Focus so the scroll computation of the Popover works as expected.
-    this.focus();
+    if (this.props.disableAutoFocus !== true) {
+      this.focus();
+    }
 
     // Let's ignore that piece of logic if users are already overriding the width
     // of the menu.
@@ -147,6 +149,10 @@ Menu.propTypes = {
    */
   classes: PropTypes.object.isRequired,
   /**
+   * If `true`, the first menu item will not be auto focused.
+   */
+  disableAutoFocus: PropTypes.bool,
+  /**
    * Properties applied to the `MenuList` element.
    */
   MenuListProps: PropTypes.object,
@@ -203,7 +209,7 @@ Menu.propTypes = {
     PropTypes.number,
     PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
     PropTypes.oneOf(['auto']),
-  ]),
+  ])
 };
 
 Menu.defaultProps = {

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -33,7 +33,7 @@ class Menu extends React.Component {
   menuList = null;
 
   componentDidMount() {
-    if (this.props.open && this.props.disableAutoFocusSelectedItem !== true) {
+    if (this.props.open && this.props.disableAutoFocusItem !== true) {
       this.focus();
     }
   }
@@ -59,11 +59,11 @@ class Menu extends React.Component {
   };
 
   handleEnter = element => {
-    const { theme } = this.props;
+    const { disableAutoFocusItem, theme } = this.props;
     const menuList = ReactDOM.findDOMNode(this.menuList);
 
     // Focus so the scroll computation of the Popover works as expected.
-    if (this.props.disableAutoFocusSelectedItem !== true) {
+    if (disableAutoFocusItem !== true) {
       this.focus();
     }
 
@@ -94,6 +94,7 @@ class Menu extends React.Component {
     const {
       children,
       classes,
+      disableAutoFocusItem,
       MenuListProps,
       onEnter,
       PaperProps = {},
@@ -149,9 +150,9 @@ Menu.propTypes = {
    */
   classes: PropTypes.object.isRequired,
   /**
-   * If `true`, the first menu item will not be auto focused.
+   * If `true`, the selected / first menu item will not be auto focused.
    */
-  disableAutoFocusSelectedItem: PropTypes.bool,
+  disableAutoFocusItem: PropTypes.bool,
   /**
    * Properties applied to the `MenuList` element.
    */
@@ -209,10 +210,11 @@ Menu.propTypes = {
     PropTypes.number,
     PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
     PropTypes.oneOf(['auto']),
-  ])
+  ]),
 };
 
 Menu.defaultProps = {
+  disableAutoFocusItem: false,
   transitionDuration: 'auto',
 };
 

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -18,6 +18,7 @@ title: Menu API
 | <span class="prop-name">anchorEl</span> | <span class="prop-type">object |   | The DOM element used to set the position of the menu. |
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | Menu contents, normally `MenuItem`s. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">disableAutoFocusItem</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the selected / first menu item will not be auto focused. |
 | <span class="prop-name">MenuListProps</span> | <span class="prop-type">object |   | Properties applied to the `MenuList` element. |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func |   | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span class="prop-name">onEnter</span> | <span class="prop-type">func |   | Callback fired before the Menu enters. |


### PR DESCRIPTION
I keep a fork of material ui simply and only because material ui Menu forcefully updates the element focus. I would greatly appreciate the merging of this PR to allow disabling this "feature". Thank you!