### PR TITLE
[Snackbar] Add check for autoHideDuration if equals 0

### DIFF
--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -145,7 +145,7 @@ class Snackbar extends React.Component {
       }
 
       this.props.onClose(null, 'timeout');
-    }, autoHideDuration || this.props.autoHideDuration || 0);
+    }, autoHideDuration !== null ? autoHideDuration : this.props.autoHideDuration);
   }
 
   handleMouseEnter = event => {

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -133,19 +133,24 @@ class Snackbar extends React.Component {
   }
 
   // Timer that controls delay before snackbar auto hides
-  setAutoHideTimer(autoHideDuration = null) {
-    if (!this.props.onClose || this.props.autoHideDuration == null) {
+  setAutoHideTimer(autoHideDuration) {
+    const autoHideDurationBefore =
+      autoHideDuration != null ? autoHideDuration : this.props.autoHideDuration;
+
+    if (!this.props.onClose || autoHideDurationBefore == null) {
       return;
     }
 
     clearTimeout(this.timerAutoHide);
     this.timerAutoHide = setTimeout(() => {
-      if (!this.props.onClose || this.props.autoHideDuration == null) {
+      const autoHideDurationAfter =
+        autoHideDuration != null ? autoHideDuration : this.props.autoHideDuration;
+      if (!this.props.onClose || autoHideDurationAfter == null) {
         return;
       }
 
       this.props.onClose(null, 'timeout');
-    }, autoHideDuration !== null ? autoHideDuration : this.props.autoHideDuration);
+    }, autoHideDurationBefore);
   }
 
   handleMouseEnter = event => {
@@ -178,11 +183,11 @@ class Snackbar extends React.Component {
   // or when the window is shown back.
   handleResume = () => {
     if (this.props.autoHideDuration != null) {
-      if (this.props.resumeHideDuration !== undefined) {
+      if (this.props.resumeHideDuration != null) {
         this.setAutoHideTimer(this.props.resumeHideDuration);
         return;
       }
-      this.setAutoHideTimer((this.props.autoHideDuration || 0) * 0.5);
+      this.setAutoHideTimer(this.props.autoHideDuration * 0.5);
     }
   };
 

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -275,6 +275,31 @@ describe('<Snackbar />', () => {
       assert.strictEqual(handleClose.callCount, 1);
       assert.deepEqual(handleClose.args[0], [null, 'timeout']);
     });
+
+    it('should call onClose immediately after user interaction when 0', () => {
+      const handleClose = spy();
+      const autoHideDuration = 6000;
+      const resumeHideDuration = 0;
+      const wrapper = mount(
+        <Snackbar
+          open
+          onClose={handleClose}
+          message="message"
+          autoHideDuration={autoHideDuration}
+          resumeHideDuration={resumeHideDuration}
+        />,
+      );
+      wrapper.setProps({ open: true });
+      assert.strictEqual(handleClose.callCount, 0);
+      wrapper.simulate('mouseEnter');
+      clock.tick(100);
+      wrapper.simulate('mouseLeave');
+      clock.tick(100);
+      assert.strictEqual(handleClose.callCount, 1);
+      clock.tick(autoHideDuration);
+      assert.strictEqual(handleClose.callCount, 1);
+      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
+    });
   });
 
   describe('prop: disableWindowBlurListener', () => {

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -278,7 +278,7 @@ describe('<Snackbar />', () => {
 
     it('should call onClose immediately after user interaction when 0', () => {
       const handleClose = spy();
-      const autoHideDuration = 6000;
+      const autoHideDuration = 6e3;
       const resumeHideDuration = 0;
       const wrapper = mount(
         <Snackbar
@@ -294,9 +294,7 @@ describe('<Snackbar />', () => {
       wrapper.simulate('mouseEnter');
       clock.tick(100);
       wrapper.simulate('mouseLeave');
-      clock.tick(100);
-      assert.strictEqual(handleClose.callCount, 1);
-      clock.tick(autoHideDuration);
+      clock.tick(resumeHideDuration);
       assert.strictEqual(handleClose.callCount, 1);
       assert.deepEqual(handleClose.args[0], [null, 'timeout']);
     });


### PR DESCRIPTION
Hey,
I've added a check to prevent the Snackbar component from using the autoHideDuration property if a '0' is passed in.  This fixes #11946.

Thanks!
