### PR TITLE
[Menu] Fix scrolling issue

### DIFF
--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -24,6 +24,8 @@ export const styles = {
     // height. This ensures a tappable area outside of the simple menu with which to dismiss
     // the menu.
     maxHeight: 'calc(100% - 96px)',
+    // Ensure it's up to the same level as other relative elements (ex. Tabs) to respect scrolling.
+    position: 'relative',
     // Add iOS momentum scrolling.
     WebkitOverflowScrolling: 'touch',
   },

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -24,10 +24,10 @@ export const styles = {
     // height. This ensures a tappable area outside of the simple menu with which to dismiss
     // the menu.
     maxHeight: 'calc(100% - 96px)',
-    // Ensure it's up to the same level as other relative elements (ex. Tabs) to respect scrolling.
-    transform: 'translate3d(0,0,0)',
     // Add iOS momentum scrolling.
     WebkitOverflowScrolling: 'touch',
+    // Fix a scrolling issue on Chrome.
+    transform: 'translateZ(0)',
   },
 };
 

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -25,7 +25,7 @@ export const styles = {
     // the menu.
     maxHeight: 'calc(100% - 96px)',
     // Ensure it's up to the same level as other relative elements (ex. Tabs) to respect scrolling.
-    position: 'relative',
+    transform: 'translate3d(0,0,0)',
     // Add iOS momentum scrolling.
     WebkitOverflowScrolling: 'touch',
   },


### PR DESCRIPTION
What's happening is other elements on the page like Tabs are higher in the z-index by merely being relative elements. So with that we enter a z-index war with elements like this paper menu which aren't raised up in the z-index. Adding translate3d to the paper styles ensures that when it's open, you can interact with the menu for scrolling, otherwise your effectively scrolling the other competing element. Fixes #10601

Updated demo of the fix [here](https://codesandbox.io/s/l4mljq9r3q)
My thanks to @lgerndt for discovering an easy fix.
