### PR TITLE
[docs] Switch autosuggest highlighting

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
@@ -71,11 +71,11 @@ function renderSuggestion(suggestion, { query, isHighlighted }) {
       <div>
         {parts.map((part, index) => {
           return part.highlight ? (
-            <span key={String(index)} style={{ fontWeight: 300 }}>
+            <span key={String(index)} style={{ fontWeight: 500 }}>
               {part.text}
             </span>
           ) : (
-            <strong key={String(index)} style={{ fontWeight: 500 }}>
+            <strong key={String(index)} style={{ fontWeight: 300 }}>
               {part.text}
             </strong>
           );


### PR DESCRIPTION
At the moment highlight works the opposite way:

![screenshot](https://dha4w82d62smt.cloudfront.net/items/0u2V323A351P0c0F3Y1U/Screenshot%20from%202018-06-30%2016-48-24.png?X-CloudApp-Visitor-Id=bace96d0fdf2822e2923028b4445d2c1&v=d5b9d18f)