### PR TITLE
[ExpansionPanelSummary] Add IconButtonProps property

### DIFF
--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.d.ts
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.d.ts
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { ButtonBaseProps } from '../ButtonBase';
+import { IconButtonProps } from '../IconButton';
 
 export interface ExpansionPanelSummaryProps
   extends StandardProps<ButtonBaseProps, ExpansionPanelSummaryClassKey> {
   disabled?: boolean;
   expanded?: boolean;
   expandIcon?: React.ReactNode;
+  expandIconProps?: IconButtonProps;
   onChange?: React.ReactEventHandler<{}>;
 }
 

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.d.ts
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.d.ts
@@ -8,7 +8,7 @@ export interface ExpansionPanelSummaryProps
   disabled?: boolean;
   expanded?: boolean;
   expandIcon?: React.ReactNode;
-  expandIconProps?: IconButtonProps;
+  IconButtonProps?: Partial<IconButtonProps>;
   onChange?: React.ReactEventHandler<{}>;
 }
 

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -99,7 +99,7 @@ class ExpansionPanelSummary extends React.Component {
       disabled,
       expanded,
       expandIcon,
-      expandIconProps,
+      IconButtonProps,
       onChange,
       ...other
     } = this.props;
@@ -138,7 +138,7 @@ class ExpansionPanelSummary extends React.Component {
             component="div"
             tabIndex={-1}
             aria-hidden="true"
-            {...expandIconProps}
+            {...IconButtonProps}
           >
             {expandIcon}
           </IconButton>
@@ -177,10 +177,9 @@ ExpansionPanelSummary.propTypes = {
    */
   expandIcon: PropTypes.node,
   /**
-   * @ignore
-   * Properties to pass to the underlying IconButton component wrapping the Expand Icon
+   * Properties applied to the `TouchRipple` element wrapping the expand icon.
    */
-  expandIconProps: PropTypes.object,
+  IconButtonProps: PropTypes.object,
   /**
    * @ignore
    */
@@ -193,7 +192,6 @@ ExpansionPanelSummary.propTypes = {
 
 ExpansionPanelSummary.defaultProps = {
   disabled: false,
-  expandIconProps: {},
 };
 
 ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -192,7 +192,7 @@ ExpansionPanelSummary.propTypes = {
 
 ExpansionPanelSummary.defaultProps = {
   disabled: false,
-  expandIconProps: {}
+  expandIconProps: {},
 };
 
 ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -99,6 +99,7 @@ class ExpansionPanelSummary extends React.Component {
       disabled,
       expanded,
       expandIcon,
+      expandIconProps,
       onChange,
       ...other
     } = this.props;
@@ -137,6 +138,7 @@ class ExpansionPanelSummary extends React.Component {
             component="div"
             tabIndex={-1}
             aria-hidden="true"
+            {...expandIconProps}
           >
             {expandIcon}
           </IconButton>
@@ -175,6 +177,10 @@ ExpansionPanelSummary.propTypes = {
    */
   expandIcon: PropTypes.node,
   /**
+   * Properties to pass to the underlying IconButton component wrapping the Expand Icon
+   */
+  expandIconProps: PropTypes.object,
+  /**
    * @ignore
    */
   onChange: PropTypes.func,
@@ -186,6 +192,7 @@ ExpansionPanelSummary.propTypes = {
 
 ExpansionPanelSummary.defaultProps = {
   disabled: false,
+  expandIconProps: {}
 };
 
 ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -177,6 +177,7 @@ ExpansionPanelSummary.propTypes = {
    */
   expandIcon: PropTypes.node,
   /**
+   * @ignore
    * Properties to pass to the underlying IconButton component wrapping the Expand Icon
    */
   expandIconProps: PropTypes.object,

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -18,6 +18,7 @@ title: ExpansionPanelSummary API
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | The content of the expansion panel summary. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node |   | The icon to display as the expand indicator. |
+| <span class="prop-name">IconButtonProps</span> | <span class="prop-type">object |   | Properties applied to the `TouchRipple` element wrapping the expand icon. |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
 

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -18,6 +18,7 @@ title: ExpansionPanelSummary API
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | The content of the expansion panel summary. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node |   | The icon to display as the expand indicator. |
+| <span class="prop-name">expandIconProps</span> | <span class="prop-type">object |   | Optional props that will be passed to the underlying IconButton component wrapping the Expand Icon  |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
 

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -18,7 +18,6 @@ title: ExpansionPanelSummary API
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | The content of the expansion panel summary. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node |   | The icon to display as the expand indicator. |
-| <span class="prop-name">expandIconProps</span> | <span class="prop-type">object |   | Optional props that will be passed to the underlying IconButton component wrapping the Expand Icon  |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
## Purpose
Add expandIconProps property to ExpantionPanelSummary component. 
Right now there is no way to do things like disable the ripple for the expand Icon.
```jsx
        <ExpansionPanel >
          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />} expandIconProps={{ disableRipple: true }}>
                    <Typography className={classes.heading}>General settings</Typography>
                    <Typography className={classes.secondaryHeading}>I am an expansion panel</Typography>
            </ExpansionPanelSummary>
            <ExpansionPanelDetails>
                <Typography>
                  Nulla facilisi. Phasellus sollicitudin nulla et quam mattis feugiat. Aliquam eget
                  maximus est, id dignissim quam.
                </Typography>
          </ExpansionPanelDetails>
        </ExpansionPanel>
```
