### PR TITLE
[docs] Use the de-structured "children" variable

### DIFF
--- a/docs/src/pages/customization/css-in-js/RenderProps.js
+++ b/docs/src/pages/customization/css-in-js/RenderProps.js
@@ -8,7 +8,7 @@ import Button from '@material-ui/core/Button';
 function createStyled(styles, options) {
   function Styled(props) {
     const { children, ...other } = props;
-    return props.children(other);
+    return children(other);
   }
   Styled.propTypes = {
     children: PropTypes.func.isRequired,


### PR DESCRIPTION
The previous line de-structured "children" from props. No need to call props.children to access it.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
