### PR TITLE
[Button] Fix IE11 support of CSS 'width:initial'

### DIFF
--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -135,7 +135,7 @@ export const styles = theme => ({
   extendedFab: {
     borderRadius: 48 / 2,
     padding: '0 16px',
-    width: 'initial',
+    width: 'auto',
     minWidth: 48,
     height: 48,
   },

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -14,7 +14,6 @@ export const styles = theme => {
 
   return {
     root: {
-      pointerEvents: 'auto',
       color: theme.palette.getContrastText(backgroundColor),
       backgroundColor,
       display: 'flex',

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -14,7 +14,7 @@ export const styles = theme => {
 
   return {
     root: {
-      pointerEvents: 'initial',
+      pointerEvents: 'auto',
       color: theme.palette.getContrastText(backgroundColor),
       backgroundColor,
       display: 'flex',


### PR DESCRIPTION
Use of the CSS initial value is causing issues in IE11.  Patch to fix in 2 locations.

Closes #12114.