### PR TITLE
[Popper] Update TypeScript definitions

### DIFF
--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -21,7 +21,7 @@ export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   anchorEl?: null | HTMLElement | ((element: HTMLElement) => HTMLElement);
   children: (
     props: {
-      placement: PlacementType;
+      placement: PopperPlacementType;
       TransitionProps?: TransitionProps;
     },
   ) => React.ReactElement<any>;
@@ -30,7 +30,7 @@ export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   keepMounted?: boolean;
   modifiers?: Object;
   open: boolean;
-  placement?: PlacementType;
+  placement?: PopperPlacementType;
   popperOptions?: Object;
 }
 

--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -1,27 +1,36 @@
 import * as React from 'react';
 import { PortalProps } from '../Portal';
+import { TransitionProps } from '../transitions/transition';
+
+export type PopperPlacementType =
+  | 'bottom-end'
+  | 'bottom-start'
+  | 'bottom'
+  | 'left-end'
+  | 'left-start'
+  | 'left'
+  | 'right-end'
+  | 'right-start'
+  | 'right'
+  | 'top-end'
+  | 'top-start'
+  | 'top';
 
 export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
-  anchorEl?: HTMLElement | ((element: HTMLElement) => HTMLElement);
-  children: () => React.ReactElement<any> | React.ReactElement<any>;
+  transition?: boolean;
+  anchorEl?: null | HTMLElement | ((element: HTMLElement) => HTMLElement);
+  children: (
+    props: {
+      placement: PlacementType;
+      TransitionProps?: TransitionProps;
+    },
+  ) => React.ReactElement<any>;
   container?: PortalProps['container'];
   disablePortal?: PortalProps['disablePortal'];
   keepMounted?: boolean;
   modifiers?: Object;
   open: boolean;
-  placement?:
-    | 'bottom-end'
-    | 'bottom-start'
-    | 'bottom'
-    | 'left-end'
-    | 'left-start'
-    | 'left'
-    | 'right-end'
-    | 'right-start'
-    | 'right'
-    | 'top-end'
-    | 'top-start'
-    | 'top';
+  placement?: PlacementType;
   popperOptions?: Object;
 }
 


### PR DESCRIPTION
- Add missing `transition` prop
- Add `null` as option to `anchorEl` (`strictNullChecks` will complain that `null` is not valid)
- Add `childProps` def for `children`