### PR TITLE
[core] Add missing unwrap export to test-utils type definition

### DIFF
--- a/packages/material-ui/src/test-utils/index.d.ts
+++ b/packages/material-ui/src/test-utils/index.d.ts
@@ -2,3 +2,4 @@ export { default as createShallow } from './createShallow';
 export { default as createMount } from './createMount';
 export { default as createRender } from './createRender';
 export { default as getClasses } from './getClasses';
+export { default as unwrap } from './unwrap';


### PR DESCRIPTION
Adds missing export to `unwrap` in `test-utils/index.d.ts`, as requested [here](https://github.com/mui-org/material-ui/issues/11864#issuecomment-402873132).