### PR TITLE
[Grow] Fix scroll on entered

### DIFF
--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -17,6 +17,7 @@ const styles = {
   },
   entered: {
     opacity: 1,
+    // Use translateZ to scrolling issue on Chrome.
     transform: `${getScale(1)} translateZ(0)`,
   },
 };

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -17,7 +17,7 @@ const styles = {
   },
   entered: {
     opacity: 1,
-    transform: getScale(1),
+    transform: `${getScale(1)} translateZ(0)`,
   },
 };
 

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -27,8 +27,6 @@ export const styles = {
     maxHeight: 'calc(100% - 96px)',
     // Add iOS momentum scrolling.
     WebkitOverflowScrolling: 'touch',
-    // Fix a scrolling issue on Chrome.
-    transform: 'translateZ(0)',
   },
 };
 


### PR DESCRIPTION
Continuation of https://github.com/mui-org/material-ui/pull/12003

I discovered that when upgrading my project that uses large menus with scrolling, that the original fix did not solve the issue in the project. The transform on the Grow component was overriding the Menu's translateZ declaration.
