### PR TITLE
[Select] Simpler onChange event.target logic

### DIFF
--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -80,11 +80,6 @@ class SelectInput extends React.Component {
 
     if (onChange) {
       let value;
-      let target;
-
-      if (event.target) {
-        target = event.target;
-      }
 
       if (this.props.multiple) {
         value = Array.isArray(this.props.value) ? [...this.props.value] : [];
@@ -99,8 +94,7 @@ class SelectInput extends React.Component {
       }
 
       event.persist();
-      event.target = { ...target, value, name };
-
+      event.target = { value, name };
       onChange(event, child);
     }
   };


### PR DESCRIPTION
Closes #12205. Using `event.target.dataset` doesn't make much sense in this context. The target could be coming from any element that triggered the click event. People can use `event.currentTarget.dataset` instead.

---

```js
event.target = { ...target, value, name };
```

The current spread syntax is pointless. The spread operator is using the iteration protocols to navigate over elements and collect the results (with arrays) or to copy enumerable properties (with objects).
But: 
```jsx
{...document.createElement('div')} // === {}
```
Instead, let's make a bold move. Yes, we try to make the event match the native change event at the cost of altering the event.
```jsx
event.target = { value, name };
```