### PR TITLE
[lab] Build and export fixes

### DIFF
--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -28,8 +28,9 @@
     "prebuild": "../../node_modules/.bin/rimraf build",
     "build:es2015": "../../node_modules/.bin/cross-env NODE_ENV=production ../../node_modules/.bin/babel ./src --out-dir ./build --ignore *.test.js",
     "build:es2015modules": "../../node_modules/.bin/cross-env NODE_ENV=production BABEL_ENV=modules ../../node_modules/.bin/babel ./src/index.js --out-file ./build/index.es.js",
+    "build:es": "../../node_modules/.bin/cross-env NODE_ENV=production BABEL_ENV=es ../../node_modules/.bin/babel ./src --out-dir ./build/es --ignore *.test.js",
     "build:copy-files": "../../node_modules/.bin/babel-node ./scripts/copy-files.js",
-    "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:copy-files",
+    "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:es && yarn build:copy-files",
     "release": "yarn build && npm publish build"
   },
   "peerDependencies": {

--- a/packages/material-ui-lab/src/index.d.ts
+++ b/packages/material-ui-lab/src/index.d.ts
@@ -1,3 +1,6 @@
+export { default as Slider } from './Slider';
 export { default as SpeedDial } from './SpeedDial';
 export { default as SpeedDialAction } from './SpeedDialAction';
 export { default as SpeedDialIcon } from './SpeedDialIcon';
+export { default as ToggleButton } from './ToggleButton/ToggleButton';
+export { default as ToggleButtonGroup } from './ToggleButton/ToggleButtonGroup';

--- a/packages/material-ui-lab/src/index.js
+++ b/packages/material-ui-lab/src/index.js
@@ -1,6 +1,6 @@
+export { default as Slider } from './Slider';
 export { default as SpeedDial } from './SpeedDial';
 export { default as SpeedDialAction } from './SpeedDialAction';
 export { default as SpeedDialIcon } from './SpeedDialIcon';
-
 export { default as ToggleButton } from './ToggleButton/ToggleButton';
 export { default as ToggleButtonGroup } from './ToggleButton/ToggleButtonGroup';


### PR DESCRIPTION
- Export Slider and ToggleButton from entry points.
  So you can do

  ```js
  import { Slider } from '@material-ui/lab'
  ```

- Build `@material-ui/lab/es/` files.

I stuck them both in a single PR because they're so tiny. Happy to break it up if that has your
preference.