### PR TITLE
[slider] Increase color specification conformance 

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -23,8 +23,6 @@ export const styles = theme => {
 
   const colors = {
     primary: theme.palette.primary.main,
-    secondary: theme.palette.grey[400],
-    focused: theme.palette.grey[500],
     disabled: theme.palette.grey[400],
   };
 
@@ -63,12 +61,12 @@ export const styles = theme => {
       transform: 'translate(0, -50%)',
       top: '50%',
       height: 2,
+      backgroundColor: colors.primary,
       '&$focused, &$activated': {
         transition: 'none',
-        backgroundColor: colors.focused,
       },
       '&$disabled': {
-        backgroundColor: colors.secondary,
+        backgroundColor: colors.disabled,
       },
       '&$vertical': {
         transform: 'translate(-50%, 0)',
@@ -76,24 +74,17 @@ export const styles = theme => {
         top: 'initial',
         width: 2,
       },
-      '&$jumped': {
-        backgroundColor: colors.focused,
-      },
     },
     /* Styles applied to the track element before the thumb. */
     trackBefore: {
       zIndex: 1,
       left: 0,
-      backgroundColor: colors.primary,
       transition: commonTransitions,
-      '&$focused, &$activated, &$jumped': {
-        backgroundColor: colors.primary,
-      },
     },
     /* Styles applied to the track element after the thumb. */
     trackAfter: {
       right: 0,
-      backgroundColor: colors.secondary,
+      opacity: 0.24,
       transition: commonTransitions,
       '&$vertical': {
         bottom: 0,
@@ -128,12 +119,12 @@ export const styles = theme => {
         backgroundColor: 'transparent',
       },
       '&$focused$zero': {
-        border: `2px solid ${colors.focused}`,
-        backgroundColor: fade(colors.focused, 0.34),
-        boxShadow: `0px 0px 0px 9px ${fade(colors.focused, 0.34)}`,
+        border: `2px solid ${colors.primary}`,
+        backgroundColor: fade(colors.primary, 0.34),
+        boxShadow: `0px 0px 0px 9px ${fade(colors.primary, 0.34)}`,
       },
       '&$activated$zero': {
-        border: `2px solid ${colors.focused}`,
+        border: `2px solid ${colors.primary}`,
       },
       '&$jumped': {
         width: 17,


### PR DESCRIPTION
As mentioned in #12242:
The spec only displays two different colors for different states (disabled and not-disabled). Track before and after thumb only varies in opacity.

The [spec](https://material.io/design/components/sliders.html#spec) specifies an explicit color code with .24 opacity after thumb whereas the Crane theme uses secondary color from the palette with .38 opacity. I'm not sure what the best choice would be. I'm leaning towards using the same approach as the Crane theme but went with the primary color and .24 to be as close to the spec as possible while sticking to the previous color theme.
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
