### PR TITLE
[docs] Fix typo

### DIFF
--- a/docs/src/pages/demos/steppers/HorizontalLinearAlternativeLabelStepper.js
+++ b/docs/src/pages/demos/steppers/HorizontalLinearAlternativeLabelStepper.js
@@ -81,9 +81,7 @@ class HorizontalLabelPositionBelowStepper extends React.Component {
         <div>
           {this.state.activeStep === steps.length ? (
             <div>
-              <Typography className={classes.instructions}>
-                All steps completed
-              </Typography>
+              <Typography className={classes.instructions}>All steps completed</Typography>
               <Button onClick={this.handleReset}>Reset</Button>
             </div>
           ) : (

--- a/docs/src/pages/demos/steppers/HorizontalLinearAlternativeLabelStepper.js
+++ b/docs/src/pages/demos/steppers/HorizontalLinearAlternativeLabelStepper.js
@@ -82,7 +82,7 @@ class HorizontalLabelPositionBelowStepper extends React.Component {
           {this.state.activeStep === steps.length ? (
             <div>
               <Typography className={classes.instructions}>
-                All steps completed - you&quot;re finished
+                All steps completed
               </Typography>
               <Button onClick={this.handleReset}>Reset</Button>
             </div>


### PR DESCRIPTION
That phrase added nothing to the overall docs, plus it had a double quote rather than a single quote.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
