### PR TITLE
Use `window` or `global` depending on execution environment.

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -166,7 +166,8 @@ function roundToStep(number, step) {
 }
 
 function getOffset(node) {
-  const { pageYOffset, pageXOffset } = global;
+  const Global = typeof window !== 'undefined' ? window : global;
+  const { pageYOffset, pageXOffset } = Global;
   const { left, top } = node.getBoundingClientRect();
 
   return {

--- a/packages/material-ui/src/styles/createGenerateClassName.js
+++ b/packages/material-ui/src/styles/createGenerateClassName.js
@@ -2,9 +2,11 @@
 
 import warning from 'warning';
 
+const Global = typeof window !== 'undefined' ? window : global;
+
 // People might bundle this classname generator twice.
 // We need to use a global.
-global.__MUI_GENERATOR_COUNTER__ = 0;
+Global.__MUI_GENERATOR_COUNTER__ = 0;
 
 const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;
 
@@ -30,9 +32,9 @@ export default function createGenerateClassName(options = {}) {
   // - We expect a class name generator to be instantiated per new request on the server,
   // so the warning is only triggered client side.
   if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
-    global.__MUI_GENERATOR_COUNTER__ += 1;
+    Global.__MUI_GENERATOR_COUNTER__ += 1;
 
-    if (global.__MUI_GENERATOR_COUNTER__ > 2) {
+    if (Global.__MUI_GENERATOR_COUNTER__ > 2) {
       // eslint-disable-next-line no-console
       console.error(
         [


### PR DESCRIPTION
This eliminates all unchecked access to Node's `global` object in production code. With this change I was able to successfully compile against material-ui's ES6 sources (in `build/es`) with Rollup.

All remaining references to `global` are in documentation code ([example](https://github.com/mui-org/material-ui/blob/4eb6628e5be27a6c140c774069ea794d091c48c3/docs/src/modules/styles/getPageContext.js#L59)) and test code ([example](https://github.com/mui-org/material-ui/blob/4eb6628e5be27a6c140c774069ea794d091c48c3/packages/material-ui/src/Popover/Popover.test.js#L646)), both of which I believe run in Node only; and in the example code ([example](https://github.com/mui-org/material-ui/blob/4eb6628e5be27a6c140c774069ea794d091c48c3/examples/nextjs/src/getPageContext.js#L45)), which I wasn't sure whether it needed fixing.