### PR TITLE
[Tooltip] Add some docs for disabled elements

### DIFF
--- a/docs/src/pages/demos/tooltips/DisabledTooltips.js
+++ b/docs/src/pages/demos/tooltips/DisabledTooltips.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+
+function DisabledTooltips() {
+  return (
+    <Tooltip title="You don't have permission to do this">
+      <span>
+        <Button disabled>A Disabled Button</Button>
+      </span>
+    </Tooltip>
+  );
+}
+
+export default DisabledTooltips;

--- a/docs/src/pages/demos/tooltips/tooltips.md
+++ b/docs/src/pages/demos/tooltips/tooltips.md
@@ -46,6 +46,12 @@ On mobile, the tooltip is displayed when the user longpresses the element and hi
 
 {{"demo": "pages/demos/tooltips/DelayTooltips.js"}}
 
+## Disabled Elements
+
+By default disabled elements like `Button` do not trigger user interactions so a `Tooltip` will not activate on normal events like hover. To accomodate disabled elements, add a simple wrapper element like a `span`.
+
+{{"demo": "pages/demos/tooltips/DisabledTooltips.js"}}
+
 ## Customized Tooltips
 
 {{"demo": "pages/demos/tooltips/CustomizedTooltips.js"}}

--- a/pages/demos/tooltips.js
+++ b/pages/demos/tooltips.js
@@ -63,7 +63,7 @@ module.exports = require('fs')
 module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/tooltips/DisabledTooltips'), 'utf8')
 `,
-        }
+        },
       }}
     />
   );

--- a/pages/demos/tooltips.js
+++ b/pages/demos/tooltips.js
@@ -57,6 +57,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/tooltips/CustomizedTooltips'), 'utf8')
 `,
         },
+        'pages/demos/tooltips/DisabledTooltips.js': {
+          js: require('docs/src/pages/demos/tooltips/DisabledTooltips').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/tooltips/DisabledTooltips'), 'utf8')
+`,
+        }
       }}
     />
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #11601 

Some docs around the issue of disabled elements to bring it to people's attention if reviewing the Tooltip demos and save them some headaches.

The bootstrap docs mention `pointer-events` but I haven't seen a need for that yet, not sure: https://getbootstrap.com/docs/4.1/components/popovers/#disabled-elements