### PR TITLE
[Tabs] Prevent unwanted auto-move in scrolling tabs

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -256,13 +256,13 @@ class Tabs extends React.Component {
         theme.direction === 'rtl'
           ? tabsMeta.scrollLeftNormalized + tabsMeta.clientWidth - tabsMeta.scrollWidth
           : tabsMeta.scrollLeft;
-      left = tabMeta.left - tabsMeta.left + correction;
+      left = Math.round(tabMeta.left - tabsMeta.left + correction);
     }
 
     const indicatorStyle = {
       left,
       // May be wrong until the font is loaded.
-      width: tabMeta ? tabMeta.width : 0,
+      width: tabMeta ? Math.round(tabMeta.width) : 0,
     };
 
     if (


### PR DESCRIPTION
Closes #10826
Closes #11624

@oliviertassinari it seems that both `left` _and_ `width` needed to be rounded.