### PR TITLE
[TextField] Improve onChange type definition

### DIFF
--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -27,7 +27,7 @@ export interface TextFieldProps
   margin?: PropTypes.Margin;
   multiline?: boolean;
   name?: string;
-  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onChange?: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
   placeholder?: string;
   required?: boolean;
   rows?: string | number;


### PR DESCRIPTION
Minor update on `TextField.onChange` type definition.

As `TextField` is mainly a wrapper for `Input` and `Select` component, its `onChange` type definition should be combined from these two. 

This PR address the issue raised in #12257. 