### PR TITLE
[DialogContentText] Inherit TypographyProps in type definition

### DIFF
--- a/packages/material-ui/.size-snapshot.json
+++ b/packages/material-ui/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "build/umd/material-ui.production.min.js": {
-    "bundled": 841326,
-    "minified": 315302,
-    "gzipped": 85284
+    "bundled": 840544,
+    "minified": 314919,
+    "gzipped": 85087
   }
 }

--- a/packages/material-ui/src/DialogContentText/DialogContentText.d.ts
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.d.ts
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { StandardProps } from '..';
+import { TypographyProps } from '../Typography';
 
 export interface DialogContentTextProps
-  extends StandardProps<React.HTMLAttributes<HTMLParagraphElement>, DialogContentTextClassKey> {}
+extends StandardProps<TypographyProps, DialogContentTextClassKey> {}
 
 export type DialogContentTextClassKey = 'root';
 

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -19,6 +19,8 @@ import {
   Collapse,
   Dialog,
   DialogTitle,
+  DialogContent,
+  DialogContentText,
   Divider,
   Drawer,
   ExpansionPanel,
@@ -280,6 +282,11 @@ const DialogTest = () => {
           </ListItem>
         </List>
       </div>
+      <DialogContent>
+        <DialogContentText variant='body2' color='primary'>
+          Some text
+        </DialogContentText>
+      </DialogContent>
     </Dialog>
   );
 };


### PR DESCRIPTION
The docs specify that for the DialogContentText component:

> Any other properties supplied will be spread to the root element (Typography).

This is true in practice, but the typings for the component does not support that statement. This PR allows for the `DialogContentTextProps` type to inherit properties from the `TypographyProps` type.