### PR TITLE
[docs] Improve the docs to have matches

### DIFF
--- a/docs/src/pages/demos/app-bar/app-bar.md
+++ b/docs/src/pages/demos/app-bar/app-bar.md
@@ -9,7 +9,7 @@ components: AppBar, Toolbar
 
 The [top App Bar](https://material.io/design/components/app-bars-top.html) provides content and actions related to the current screen. It’s used for branding, screen titles, navigation, and actions.
 
-It can transform into a contextual action bar.
+It can transform into a contextual action bar or used as a navbar.
 
 ## Simple App Bar
 

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -27,11 +27,13 @@ In cards, text buttons help maintain an emphasis on card content.
 {{"demo": "pages/demos/buttons/TextButtons.js"}}
 
 ## Outlined Buttons
+
 [Outlined buttons](https://material.io/design/components/buttons.html#outlined-button)
 are medium-emphasis buttons. They contain actions that are important,
 but aren’t the primary action in an app.
 
 ### Alternatives
+
 Outlined buttons are also a lower emphasis alternative to contained buttons,
 or a higher emphasis alternative to text buttons.
 
@@ -42,6 +44,8 @@ or a higher emphasis alternative to text buttons.
 [Contained buttons](https://material.io/design/components/buttons.html#contained-button)
 are high-emphasis, distinguished by their use of elevation and fill.
 They contain actions that are primary to your app.
+
+The last example of this demo show how to use an upload button.
 
 {{"demo": "pages/demos/buttons/ContainedButtons.js"}}
 

--- a/docs/src/pages/demos/pickers/pickers.md
+++ b/docs/src/pages/demos/pickers/pickers.md
@@ -15,19 +15,25 @@ components: TextField
 We are currently falling back to **native input controls**.
 If you are interested in implementing or have implemented a rich Material Design Picker with an awesome UX, please, let us know on [#4787](https://github.com/mui-org/material-ui/issues/4787) and [#4796](https://github.com/mui-org/material-ui/issues/4796)! We could add a link to or a demo of your project in the documentation.
 Here are some components that are **promising**:
-- [material-ui-pickers](https://github.com/dmtrKovalenko/material-ui-pickers)
-- [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker)
+- [material-ui-pickers](https://github.com/dmtrKovalenko/material-ui-pickers): date pickers and time pickers.
+- [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker): time pickers.
 
 ⚠️ Native input controls support by browsers [isn't perfect](https://caniuse.com/#feat=input-datetime).
 
 ## Date pickers
 
+A native date picker example with `type="date"`:
+
 {{"demo": "pages/demos/pickers/DatePickers.js"}}
 
 ## Time pickers
 
+A native time picker example with `type="time"`:
+
 {{"demo": "pages/demos/pickers/TimePickers.js"}}
 
 ## Date & Time pickers
+
+A native date & time picker example with `type="datetime-local"`:
 
 {{"demo": "pages/demos/pickers/DateAndTimePickers.js"}}

--- a/docs/src/pages/demos/snackbars/snackbars.md
+++ b/docs/src/pages/demos/snackbars/snackbars.md
@@ -10,7 +10,7 @@ components: Snackbar, SnackbarContent
 [Snackbars](https://material.io/design/components/snackbars.html) inform users of a process that an app has performed or will perform. They appear temporarily, towards the bottom of the screen. They shouldn’t interrupt the user experience, and they don’t require user input to disappear.
 
 Snackbars contain a single line of text directly related to the operation performed.
-They may contain a text action, but no icons.
+They may contain a text action, but no icons. You can use them to display notifications.
 
 #### Frequency
 

--- a/docs/src/pages/demos/text-fields/text-fields.md
+++ b/docs/src/pages/demos/text-fields/text-fields.md
@@ -37,6 +37,7 @@ other styles to meet the specification.
 
 `Input` allows the provision of `InputAdornment`.
 These can be used to add a prefix, a suffix or an action to an input.
+For instance, you can use an icon button to hide or reveal the password.
 
 {{"demo": "pages/demos/text-fields/InputAdornments.js"}}
 


### PR DESCRIPTION
The goal is simple. I want to help people find what they are looking for. Here are the data coming from Algolia.

![capture d ecran 2018-07-28 a 23 44 56](https://user-images.githubusercontent.com/3165635/43360862-57bf921e-92c0-11e8-81d6-ed619367e139.png)

A figure I find it hard to believe, only 14% of our users use the search bar.