### PR TITLE
[ToggleButtonGroup] make value type generic

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButtonGroup.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButtonGroup.d.ts
@@ -2,15 +2,26 @@ import * as React from 'react';
 
 import { StandardProps } from '@material-ui/core';
 
-export interface ToggleButtonGroupProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ToggleButtonGroupClassKey> {
-  selected?: boolean;
+interface ToggleButtonGroupProps<T>
+  extends StandardProps<
+      React.HTMLAttributes<HTMLDivElement>,
+      ToggleButtonGroupClassKey,
+      'onChange'
+    > {
   exclusive?: boolean;
-  value?: any;
+  /**
+   * Triggered when a child triggers an onChange event.
+   * The value argument contains all value(s) that are still selected or is null
+   * if no values are selected.
+   */
+  onChange?: (value: T | null) => void;
+  selected?: boolean;
+  /**
+   * the selected values
+   */
+  value?: T;
 }
 
 export type ToggleButtonGroupClassKey = 'root' | 'selected';
 
-declare const ToggleButtonGroup: React.ComponentType<ToggleButtonGroupProps>;
-
-export default ToggleButtonGroup;
+export default class ToggleButtonGroup<T> extends React.Component<ToggleButtonGroupProps<T>> {}


### PR DESCRIPTION
Adds support for generic value props (which allows consistent types in `onChange`).

This changes the default export type from `ComponentType` to `Component`. I did not find a way to declare generic `const`. It might be a good idea to normalize the default export declaration across `core` and `lab`.

I'm not sure what typescript version is recommended for package consumption (devDependency lists 2.8 while 2.9.2 is locked) and depending on the used version (pre 2.9 or 2.9 and above) generic Components could add significant trouble because one would have to rely on inference i.e. generic JSX elements were added in 2.9.

I originally experimented with using a union type for Props depending on `exclusive` because `onChange` is passed an array if `exclusive=false` and the documentation specifically mentions an array of values. However I think this should be combined with a `propTypes` change and I'm not familiar with that package and would have to read up on discriminate union propTypes.

Closes #12326 