### PR TITLE
[Step] Add completed class to the root

### DIFF
--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -50,7 +50,7 @@ function Step(props) {
     classes[orientation],
     {
       [classes.alternativeLabel]: alternativeLabel,
-      [classes.completed]: completed
+      [classes.completed]: completed,
     },
     classNameProp,
   );

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -25,6 +25,8 @@ export const styles = {
     flex: 1,
     position: 'relative',
   },
+  /* Styles applied to the root element if `completed={true}`. */
+  completed: {},
 };
 
 function Step(props) {
@@ -48,6 +50,7 @@ function Step(props) {
     classes[orientation],
     {
       [classes.alternativeLabel]: alternativeLabel,
+      [classes.completed]: completed
     },
     classNameProp,
   );

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -35,6 +35,7 @@ This property accepts the following keys:
 | <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
 | <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical"`.
 | <span class="prop-name">alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
+| <span class="prop-name">completed</span> | Styles applied to the root element if `completed={true}`.
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/Step/Step.js)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Currently the only place a completed class is being placed in the Step component is deep on the svg element, the MuiSvgIcon of the MuiStepLabel. Adding a class at the root level allows the developer to style any aspect of the Step component when the step is completed. The specific example I've been using this for is to style the step connector and provide and line animation into the next label.