### PR TITLE
Added touchAction: 'none' to css to alleviate a console warning regar…

### DIFF
--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -16,6 +16,8 @@ export const styles = {
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     // Remove grey highlight
     WebkitTapHighlightColor: 'transparent',
+    // Disable scroll capabilities.
+    touchAction: 'none',
   },
   /* Styles applied to the root element if `invisible={true}`. */
   invisible: {


### PR DESCRIPTION
Added touchAction: 'none' to css to alleviate a console warning regarding canceling an event when dragging a Drawer (https://github.com/mui-org/material-ui/issues/12094)