### PR TITLE
[chip] Remove reference to checked prop in the docs 

### DIFF
--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -55,7 +55,7 @@ export const styles = theme => {
         backgroundColor: emphasize(backgroundColor, 0.08),
       },
     },
-    /* Styles applied to the `avatar` element.*/
+    /* Styles applied to the `avatar` element. */
     avatar: {
       marginRight: -4,
       width: height,

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -55,7 +55,7 @@ export const styles = theme => {
         backgroundColor: emphasize(backgroundColor, 0.08),
       },
     },
-    /* Styles applied to the `avatar` element if `checked={true}`. */
+    /* Styles applied to the `avatar` element.*/
     avatar: {
       marginRight: -4,
       width: height,
@@ -63,7 +63,7 @@ export const styles = theme => {
       color: theme.palette.type === 'light' ? theme.palette.grey[700] : theme.palette.grey[300],
       fontSize: theme.typography.pxToRem(16),
     },
-    /* Styles applied to the `avartar` elements children. */
+    /* Styles applied to the `avatar` elements children. */
     avatarChildren: {
       width: 19,
       height: 19,

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -37,8 +37,8 @@ This property accepts the following keys:
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">clickable</span> | Styles applied to the root element if `onClick` is defined or `clickable={true}`.
 | <span class="prop-name">deletable</span> | Styles applied to the root element if `onDelete` is defined.
-| <span class="prop-name">avatar</span> | Styles applied to the `avatar` element if `checked={true}`.
-| <span class="prop-name">avatarChildren</span> | Styles applied to the `avartar` elements children.
+| <span class="prop-name">avatar</span> | Styles applied to the `avatar` element.
+| <span class="prop-name">avatarChildren</span> | Styles applied to the `avatar` elements children.
 | <span class="prop-name">label</span> | Styles applied to the label `span` element`.
 | <span class="prop-name">deleteIcon</span> | Styles applied to the `deleteIcon` element.
 


### PR DESCRIPTION
## Problem
1. Checked property does not exist on Chip
2. Avatar was spelt wrong

## Solution
1. Removed reference to checked property
2. Corrected spelling of avatar