### PR TITLE
[#12165] [typescript] Add extending overrides ability for createMuiTheme

### DIFF
--- a/packages/material-ui/src/styles/createMuiTheme.d.ts
+++ b/packages/material-ui/src/styles/createMuiTheme.d.ts
@@ -7,17 +7,17 @@ import { Shape, ShapeOptions } from './shape';
 import { Spacing, SpacingOptions } from './spacing';
 import { Transitions, TransitionsOptions } from './transitions';
 import { ZIndex, ZIndexOptions } from './zIndex';
-import { Overrides } from './overrides';
+import { Overrides, BaseOverrides } from './overrides';
 import { ComponentsProps } from './props';
 
 export type Direction = 'ltr' | 'rtl';
 
-export interface ThemeOptions {
+export interface ThemeOptions<T extends BaseOverrides = {}> {
   shape?: ShapeOptions;
   breakpoints?: BreakpointsOptions;
   direction?: Direction;
   mixins?: MixinsOptions;
-  overrides?: Overrides;
+  overrides?: Overrides & T;
   palette?: PaletteOptions;
   props?: ComponentsProps;
   shadows?: Shadows;
@@ -27,12 +27,12 @@ export interface ThemeOptions {
   zIndex?: ZIndexOptions;
 }
 
-export interface Theme {
+export interface Theme<T extends BaseOverrides = {}> {
   shape: Shape;
   breakpoints: Breakpoints;
   direction: Direction;
   mixins: Mixins;
-  overrides?: Overrides;
+  overrides?: Overrides & T;
   palette: Palette;
   props?: ComponentsProps;
   shadows: Shadows;
@@ -42,4 +42,4 @@ export interface Theme {
   zIndex: ZIndex;
 }
 
-export default function createMuiTheme(options?: ThemeOptions): Theme;
+export default function createMuiTheme<T extends BaseOverrides = {}>(options?: ThemeOptions<T>): Theme<T>;

--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -88,9 +88,11 @@ import { TooltipClassKey } from '../Tooltip';
 import { TouchRippleClassKey } from '../ButtonBase/TouchRipple';
 import { TypographyClassKey } from '../Typography';
 
-export type Overrides = {
-  [Name in keyof ComponentNameToClassKey]?: Partial<StyleRules<ComponentNameToClassKey[Name]>>
-};
+export type BaseOverrides<T extends { [key: string]: string } = {}> = {
+  [Name in keyof T]?: Partial<StyleRules<T[Name]>>
+}
+
+export type Overrides = BaseOverrides<ComponentNameToClassKey>
 
 type ComponentNameToClassKey = {
   MuiAppBar: AppBarClassKey;

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -16,6 +16,8 @@ import blue from '../../src/colors/blue';
 import { WithTheme } from '../../src/styles/withTheme';
 import { StandardProps } from '../../src';
 import { TypographyStyle } from '../../src/styles/createTypography';
+import { BaseOverrides } from '../../src/styles/overrides';
+import { ThemeOptions } from '../../src/styles/createMuiTheme';
 
 // Shared types for examples
 interface ComponentProps {
@@ -323,4 +325,36 @@ withStyles(theme =>
   const style: StyleRulesCallback = theme => ({
     text: theme.typography.body2,
   });
+}
+
+{
+  // https://github.com/mui-org/material-ui/issues/12164
+  // Add ability to extend overrides set from the createMuiTheme
+  type ExternalComponentsOverrides = BaseOverrides<{
+    SomeComponent: 'toolbar' | 'panel',
+    SomeAnotherComponent: 'switch' | 'checkbox'
+  }>
+
+  const theme = createMuiTheme<ExternalComponentsOverrides>({
+    overrides: {
+      MuiAppBar: {
+        root: {
+          margin: 10
+        }
+      },
+      SomeComponent: {
+        toolbar: {
+          margin: 5
+        },
+        panel: {
+          backgroundColor: 'red'
+        }
+      },
+      SomeAnotherComponent: {
+        switch: {
+          color: 'red'
+        }
+      }
+    } 
+  }) 
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes #12164 
This PR adds an ability to extend overrides on fly with a help of generic param. Will be very useful for override styles of 3-rd party libs, like material-ui-pickers.

```ts
type ExternalComponentsOverrides = BaseOverrides<{ SomeComponent: 'toolbar' | 'panel' }>

const theme = createMuiTheme<ExternalComponentsOverrides>({
  overrides: {
    SomeComponent: {
      toolbar: {
        margin: 5
      },
      panel: {
        backgroundColor: 'red'
      }
    }
  }
}
```