### PR TITLE
[SpeedDial] - remove unecessary 'onKeyDown' prop sent to SpeedDialAction

### DIFF
--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -143,7 +143,6 @@ class SpeedDial extends React.Component {
       return React.cloneElement(child, {
         delay,
         open,
-        onKeyDown: this.handleKeyDown,
         id: `${id}-item-${validChildCount}`,
       });
     });

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
-import { spy } from 'sinon';
+import { spy, stub } from 'sinon';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import Icon from '@material-ui/core/Icon';
 import Button from '@material-ui/core/Button';
@@ -16,6 +16,16 @@ describe('<SpeedDial />', () => {
     open: true,
     ariaLabel: 'mySpeedDial',
   };
+
+  let consoleErrorStub;
+
+  beforeEach(() => {
+    consoleErrorStub = stub(console, 'error');
+  });
+
+  afterEach(() => {
+    consoleErrorStub.restore();
+  });
 
   before(() => {
     shallow = createShallow({ dive: true });
@@ -78,6 +88,15 @@ describe('<SpeedDial />', () => {
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass('mySpeedDialClass'), true);
+  });
+
+  it('should render the actions with no warnings', () => {
+    shallow(
+      <SpeedDial {...defaultProps} className="mySpeedDial" icon={icon}>
+        <SpeedDialAction icon={icon} tooltipTitle="SpeedDialAction" />
+      </SpeedDial>,
+    );
+    assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
   });
 
   it('should render the actions with the actions class', () => {


### PR DESCRIPTION
I added a 'zero warnings' unit test to catch out the error and then removed the setting of the (seemingly) no-longer-needed prop on the child `SpeedDialAction` children. I also manually tested on my own app.

closes #12159 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
