### PR TITLE
[Textarea] Add back defensive branch logic

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -27,7 +27,7 @@ module.exports = [
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '95.7 KB',
+    limit: '95.8 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/packages/material-ui/src/Input/Textarea.js
+++ b/packages/material-ui/src/Input/Textarea.js
@@ -120,9 +120,11 @@ class Textarea extends React.Component {
 
   syncHeightWithShadow() {
     const props = this.props;
-    // Guarding for shallow rendering, where refs are always `null`.
-    // See https://github.com/mui-org/material-ui/issues/12247
-    if (!this.shadowRef || !this.singlelineShadowRef) {
+
+    // Guarding for **broken** shallow rendering method that call componentDidMount
+    // but doesn't handle refs correctly.
+    // To remove once the shallow rendering has been fixed.
+    if (!this.shadowRef) {
       return;
     }
 

--- a/packages/material-ui/src/Input/Textarea.js
+++ b/packages/material-ui/src/Input/Textarea.js
@@ -120,6 +120,11 @@ class Textarea extends React.Component {
 
   syncHeightWithShadow() {
     const props = this.props;
+    // Guarding for shallow rendering, where refs are always `null`.
+    // See https://github.com/mui-org/material-ui/issues/12247
+    if (!this.shadowRef || !this.singlelineShadowRef) {
+      return;
+    }
 
     if (this.isControlled) {
       // The component is controlled, we need to update the shallow value.

--- a/packages/material-ui/src/Input/Textarea.test.js
+++ b/packages/material-ui/src/Input/Textarea.test.js
@@ -28,7 +28,7 @@ describe('<Textarea />', () => {
   let mount;
 
   before(() => {
-    shallow = createShallow({ disableLifecycleMethods: true });
+    shallow = createShallow();
     mount = createMount();
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes shallow rendering test failures by adding back the defensive branch logic that was removed in https://github.com/mui-org/material-ui/pull/12238, along with a comment this time.

Closes #12247 