### PR TITLE
[v0] Update react-event-listener to 0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lodash.merge": "^4.6.0",
     "lodash.throttle": "^4.1.1",
     "prop-types": "^15.5.7",
-    "react-event-listener": "^0.5.1",
+    "react-event-listener": "^0.6.2",
     "react-transition-group": "^1.2.1",
     "recompose": "^0.26.0",
     "simple-assign": "^0.1.0",


### PR DESCRIPTION
Updating react-event-listener to prevent bringing in newest babel-runtime (https://github.com/oliviertassinari/react-event-listener/issues/86)