### PR TITLE
[Grid] WIP, add width to container props

### DIFF
--- a/docs/src/pages/layout/grid/InteractiveGrid.js
+++ b/docs/src/pages/layout/grid/InteractiveGrid.js
@@ -4,9 +4,12 @@ import { withStyles } from '@material-ui/core/styles';
 import MarkdownElement from '@material-ui/docs/MarkdownElement';
 import Grid from '@material-ui/core/Grid';
 import FormControl from '@material-ui/core/FormControl';
+import FormGroup from '@material-ui/core/FormGroup';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
 import RadioGroup from '@material-ui/core/RadioGroup';
+import Typography from '@material-ui/core/Typography';
 import Radio from '@material-ui/core/Radio';
 import Paper from '@material-ui/core/Paper';
 
@@ -27,45 +30,89 @@ const styles = theme => ({
   },
 });
 
+const breakpoints = ['xs', 'sm', 'md', 'lg', 'xl'];
+
+const defaultGridProps = {
+  direction: 'row',
+  justify: 'flex-start',
+  alignItems: 'stretch',
+};
+
+function sortGridsByBreakpoints(a, b) {
+  return breakpoints.indexOf(a.breakpoint) - breakpoints.indexOf(b.breakpoint);
+}
+
 class InteractiveGrid extends React.Component {
   state = {
-    direction: 'row',
-    justify: 'center',
-    alignItems: 'center',
+    grids: [
+      {
+        direction: 'row',
+        justify: 'flex-start',
+        alignItems: 'stretch',
+        breakpoint: 'xs',
+      },
+    ],
   };
 
-  handleChange = key => (event, value) => {
+  handleChange = (key, breakpoint) => (event, value) => {
+    const grids = this.state.grids.slice();
+    const index = grids.findIndex(grid => grid.breakpoint === breakpoint);
+    grids[index][key] = value;
     this.setState({
-      [key]: value,
+      grids,
     });
+  };
+
+  handleChangeBreakpoints = () => (event, isChecked) => {
+    const grids = this.state.grids.slice();
+    const breakpoint = event.target.value;
+
+    if (isChecked) {
+      const item = { ...defaultGridProps, breakpoint };
+      grids.push(item);
+      grids.sort(sortGridsByBreakpoints);
+    } else {
+      const index = grids.findIndex(grid => grid.breakpoint === breakpoint);
+      if (index > -1) {
+        grids.splice(index, 1);
+      }
+    }
+
+    this.setState({ grids });
   };
 
   render() {
     const { classes } = this.props;
-    const { alignItems, direction, justify } = this.state;
+    const { grids } = this.state;
+
+    const selectedBreakpoints = grids.map(({ breakpoint }) => breakpoint);
+
+    const gridProps = grids.reduce((acc, grid) => {
+      const { breakpoint, direction, alignItems, justify } = grid;
+      acc[`${breakpoint}Direction`] = String(direction);
+      acc[`${breakpoint}Justify`] = String(justify);
+      acc[`${breakpoint}AlignItems`] = String(alignItems);
+      return acc;
+    }, {});
 
     const code = `
-\`\`\`jsx
-<Grid
-  container
-  direction="${direction}"
-  justify="${justify}"
-  alignItems="${alignItems}"
->
-\`\`\`
-`;
+    \`\`\`jsx
+    <Grid
+      container
+      ${JSON.stringify(gridProps)
+        .replace('{"', '')
+        .replace(/,/g, ' ')
+        .replace(/ "/g, ' ')
+        .replace(/":/g, '=')
+        .replace('}', '')}
+    >
+    \`\`\`
+    `;
 
     return (
-      <Grid container className={classes.root}>
+      <Grid container className={classes.root} spacing={16}>
         <Grid item xs={12}>
-          <Grid
-            container
-            spacing={16}
-            className={classes.demo}
-            alignItems={alignItems}
-            direction={direction}
-            justify={justify}
-          >
+          <Grid container spacing={16} className={classes.demo} {...gridProps}>
             {[0, 1, 2].map(value => (
               <Grid key={value} item>
                 <Paper
@@ -83,77 +130,114 @@ class InteractiveGrid extends React.Component {
             <Grid container spacing={24}>
               <Grid item xs={12}>
                 <FormControl component="fieldset">
-                  <FormLabel>direction</FormLabel>
-                  <RadioGroup
-                    row
-                    name="direction"
-                    aria-label="Direction"
-                    value={direction}
-                    onChange={this.handleChange('direction')}
-                  >
-                    <FormControlLabel value="row" control={<Radio />} label="row" />
-                    <FormControlLabel value="row-reverse" control={<Radio />} label="row-reverse" />
-                    <FormControlLabel value="column" control={<Radio />} label="column" />
-                    <FormControlLabel
-                      value="column-reverse"
-                      control={<Radio />}
-                      label="column-reverse"
-                    />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-              <Grid item xs={12}>
-                <FormControl component="fieldset">
-                  <FormLabel>justify</FormLabel>
-                  <RadioGroup
-                    row
-                    name="justify"
-                    aria-label="Justify"
-                    value={justify}
-                    onChange={this.handleChange('justify')}
-                  >
-                    <FormControlLabel value="flex-start" control={<Radio />} label="flex-start" />
-                    <FormControlLabel value="center" control={<Radio />} label="center" />
-                    <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
-                    <FormControlLabel
-                      value="space-between"
-                      control={<Radio />}
-                      label="space-between"
-                    />
-                    <FormControlLabel
-                      value="space-around"
-                      control={<Radio />}
-                      label="space-around"
-                    />
-                    <FormControlLabel
-                      value="space-evenly"
-                      control={<Radio />}
-                      label="space-evenly"
-                    />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-              <Grid item xs={12}>
-                <FormControl component="fieldset">
-                  <FormLabel>alignItems</FormLabel>
-                  <RadioGroup
-                    row
-                    name="alignItems"
-                    aria-label="Align items"
-                    value={alignItems}
-                    onChange={this.handleChange('alignItems')}
-                  >
-                    <FormControlLabel value="flex-start" control={<Radio />} label="flex-start" />
-                    <FormControlLabel value="center" control={<Radio />} label="center" />
-                    <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
-                    <FormControlLabel value="stretch" control={<Radio />} label="stretch" />
-                    <FormControlLabel value="baseline" control={<Radio />} label="baseline" />
-                  </RadioGroup>
+                  <FormLabel>breakpoint</FormLabel>
+                  <FormGroup row>
+                    {breakpoints.map(breakpoint => (
+                      <FormControlLabel
+                        key={breakpoint}
+                        control={
+                          <Checkbox
+                            checked={selectedBreakpoints.includes(breakpoint)}
+                            onChange={this.handleChangeBreakpoints()}
+                            value={breakpoint}
+                          />
+                        }
+                        label={breakpoint}
+                      />
+                    ))}
+                  </FormGroup>
                 </FormControl>
               </Grid>
             </Grid>
           </Paper>
         </Grid>
+        {grids.map(grid => (
+          <Grid item xs={6}>
+            <Paper className={classes.control} key="breakpoint">
+              <Grid container spacing={24}>
+                <Grid item xs={12}>
+                  <Typography variant="subheading" gutterBottom>
+                    breakpoint: {grid.breakpoint}
+                  </Typography>
+                </Grid>
+                <Grid item xs={12}>
+                  <FormControl component="fieldset">
+                    <FormLabel>direction</FormLabel>
+                    <RadioGroup
+                      row
+                      name="direction"
+                      aria-label="Direction"
+                      value={grid.direction}
+                      onChange={this.handleChange('direction', grid.breakpoint)}
+                    >
+                      <FormControlLabel value="row" control={<Radio />} label="row" />
+                      <FormControlLabel
+                        value="row-reverse"
+                        control={<Radio />}
+                        label="row-reverse"
+                      />
+                      <FormControlLabel value="column" control={<Radio />} label="column" />
+                      <FormControlLabel
+                        value="column-reverse"
+                        control={<Radio />}
+                        label="column-reverse"
+                      />
+                    </RadioGroup>
+                  </FormControl>
+                </Grid>
+                <Grid item xs={12}>
+                  <FormControl component="fieldset">
+                    <FormLabel>justify</FormLabel>
+                    <RadioGroup
+                      row
+                      name="justify"
+                      aria-label="Justify"
+                      value={grid.justify}
+                      onChange={this.handleChange('justify', grid.breakpoint)}
+                    >
+                      <FormControlLabel value="flex-start" control={<Radio />} label="flex-start" />
+                      <FormControlLabel value="center" control={<Radio />} label="center" />
+                      <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
+                      <FormControlLabel
+                        value="space-between"
+                        control={<Radio />}
+                        label="space-between"
+                      />
+                      <FormControlLabel
+                        value="space-around"
+                        control={<Radio />}
+                        label="space-around"
+                      />
+                      <FormControlLabel
+                        value="space-evenly"
+                        control={<Radio />}
+                        label="space-evenly"
+                      />
+                    </RadioGroup>
+                  </FormControl>
+                </Grid>
+                <Grid item xs={12}>
+                  <FormControl component="fieldset">
+                    <FormLabel>alignItems</FormLabel>
+                    <RadioGroup
+                      row
+                      name="alignItems"
+                      aria-label="Align items"
+                      value={grid.alignItems}
+                      onChange={this.handleChange('alignItems', grid.breakpoint)}
+                    >
+                      <FormControlLabel value="flex-start" control={<Radio />} label="flex-start" />
+                      <FormControlLabel value="center" control={<Radio />} label="center" />
+                      <FormControlLabel value="flex-end" control={<Radio />} label="flex-end" />
+                      <FormControlLabel value="stretch" control={<Radio />} label="stretch" />
+                      <FormControlLabel value="baseline" control={<Radio />} label="baseline" />
+                    </RadioGroup>
+                  </FormControl>
+                </Grid>
+              </Grid>
+            </Paper>
+          </Grid>
+        ))}
         <Grid item xs={12}>
           <MarkdownElement text={code} />
         </Grid>

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -39,6 +39,11 @@ export interface GridProps
   component?: string | React.ComponentType<Omit<GridProps, StrippedProps>>;
   container?: boolean;
   direction?: GridDirection;
+  xsDirection?: GridDirection;
+  smDirection?: GridDirection;
+  mdDirection?: GridDirection;
+  lgDirection?: GridDirection;
+  xlDirection?: GridDirection;
   item?: boolean;
   justify?: GridJustification;
   spacing?: GridSpacing;
@@ -50,8 +55,20 @@ export type GridClassKey =
   | 'container'
   | 'item'
   | 'direction-xs-column'
+  | 'direction-sm-column'
+  | 'direction-md-column'
+  | 'direction-lg-column'
+  | 'direction-xl-column'
   | 'direction-xs-column-reverse'
+  | 'direction-sm-column-reverse'
+  | 'direction-md-column-reverse'
+  | 'direction-lg-column-reverse'
+  | 'direction-xl-column-reverse'
   | 'direction-xs-row-reverse'
+  | 'direction-sm-row-reverse'
+  | 'direction-md-row-reverse'
+  | 'direction-lg-row-reverse'
+  | 'direction-xl-row-reverse'
   | 'wrap-xs-nowrap'
   | 'wrap-xs-wrap-reverse'
   | 'align-items-xs-center'
@@ -99,6 +116,11 @@ type StrippedProps =
   | 'alignContent'
   | 'alignItems'
   | 'direction'
+  | 'xsDirection'
+  | 'smDirection'
+  | 'mdDirection'
+  | 'lgDirection'
+  | 'xlDirection'
   | 'spacing'
   | 'hidden'
   | 'justify'

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -64,6 +64,121 @@ function generateGrid(globalStyles, theme, breakpoint) {
   }
 }
 
+function generateContainer(globalStyles, theme, breakpoint) {
+  const containeStyles = {
+    /* Styles applied to the root element if `direction="column"`. */
+    [`direction-${breakpoint}-column`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        flexDirection: 'column',
+      },
+    },
+    /* Styles applied to the root element if `direction="column-reverse"`. */
+    [`direction-${breakpoint}-column-reverse`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        flexDirection: 'column-reverse',
+      },
+    },
+    /* Styles applied to the root element if `direction="rwo-reverse"`. */
+    [`direction-${breakpoint}-row-reverse`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        flexDirection: 'row-reverse',
+      },
+    },
+    /* Styles applied to the root element if `wrap="nowrap"`. */
+    [`wrap-${breakpoint}-nowrap`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        flexWrap: 'nowrap',
+      },
+    },
+    /* Styles applied to the root element if `wrap="reverse"`. */
+    [`wrap-${breakpoint}-wrap-reverse`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        flexWrap: 'wrap-reverse',
+      },
+    },
+    /* Styles applied to the root element if `alignItems="center"`. */
+    [`align-items-${breakpoint}-center`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignItems: 'center',
+      },
+    },
+    /* Styles applied to the root element if `alignItems="flex-start"`. */
+    [`align-items-${breakpoint}-flex-start`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignItems: 'flex-start',
+      },
+    },
+    /* Styles applied to the root element if `alignItems="flex-end"`. */
+    [`align-items-${breakpoint}-flex-end`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignItems: 'flex-end',
+      },
+    },
+    /* Styles applied to the root element if `alignItems="baseline"`. */
+    [`align-items-${breakpoint}-baseline`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignItems: 'baseline',
+      },
+    },
+    /* Styles applied to the root element if `alignContent="center"`. */
+    [`align-content-${breakpoint}-center`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignContent: 'center',
+      },
+    },
+    /* Styles applied to the root element if `alignContent="flex-start"`. */
+    [`align-content-${breakpoint}-flex-start`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignContent: 'flex-start',
+      },
+    },
+    /* Styles applied to the root element if `alignContent="flex-end"`. */
+    [`align-content-${breakpoint}-flex-end`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignContent: 'flex-end',
+      },
+    },
+    /* Styles applied to the root element if `alignContent="space-between"`. */
+    [`align-content-${breakpoint}-space-between`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignContent: 'space-between',
+      },
+    },
+    /* Styles applied to the root element if `alignContent="space-around"`. */
+    [`align-content-${breakpoint}-space-around`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        alignContent: 'space-around',
+      },
+    },
+    /* Styles applied to the root element if `justify="center"`. */
+    [`justify-${breakpoint}-center`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        justifyContent: 'center',
+      },
+    },
+    /* Styles applied to the root element if `justify="flex-end"`. */
+    [`justify-${breakpoint}-flex-end`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        justifyContent: 'flex-end',
+      },
+    },
+    /* Styles applied to the root element if `justify="space-between"`. */
+    [`justify-${breakpoint}-space-between`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        justifyContent: 'space-between',
+      },
+    },
+    /* Styles applied to the root element if `justify="space-around"`. */
+    [`justify-${breakpoint}-space-around`]: {
+      [theme.breakpoints.up(breakpoint)]: {
+        justifyContent: 'space-around',
+      },
+    },
+  };
+
+  Object.assign(globalStyles, containeStyles);
+}
+
 function generateGutter(theme, breakpoint) {
   const styles = {};
 
@@ -108,82 +223,14 @@ export const styles = theme => ({
   zeroMinWidth: {
     minWidth: 0,
   },
-  /* Styles applied to the root element if `direction="column"`. */
-  'direction-xs-column': {
-    flexDirection: 'column',
-  },
-  /* Styles applied to the root element if `direction="column-reverse"`. */
-  'direction-xs-column-reverse': {
-    flexDirection: 'column-reverse',
-  },
-  /* Styles applied to the root element if `direction="rwo-reverse"`. */
-  'direction-xs-row-reverse': {
-    flexDirection: 'row-reverse',
-  },
-  /* Styles applied to the root element if `wrap="nowrap"`. */
-  'wrap-xs-nowrap': {
-    flexWrap: 'nowrap',
-  },
-  /* Styles applied to the root element if `wrap="reverse"`. */
-  'wrap-xs-wrap-reverse': {
-    flexWrap: 'wrap-reverse',
-  },
-  /* Styles applied to the root element if `alignItems="center"`. */
-  'align-items-xs-center': {
-    alignItems: 'center',
-  },
-  /* Styles applied to the root element if `alignItems="flex-start"`. */
-  'align-items-xs-flex-start': {
-    alignItems: 'flex-start',
-  },
-  /* Styles applied to the root element if `alignItems="flex-end"`. */
-  'align-items-xs-flex-end': {
-    alignItems: 'flex-end',
-  },
-  /* Styles applied to the root element if `alignItems="baseline"`. */
-  'align-items-xs-baseline': {
-    alignItems: 'baseline',
-  },
-  /* Styles applied to the root element if `alignContent="center"`. */
-  'align-content-xs-center': {
-    alignContent: 'center',
-  },
-  /* Styles applied to the root element if `alignContent="flex-start"`. */
-  'align-content-xs-flex-start': {
-    alignContent: 'flex-start',
-  },
-  /* Styles applied to the root element if `alignContent="flex-end"`. */
-  'align-content-xs-flex-end': {
-    alignContent: 'flex-end',
-  },
-  /* Styles applied to the root element if `alignContent="space-between"`. */
-  'align-content-xs-space-between': {
-    alignContent: 'space-between',
-  },
-  /* Styles applied to the root element if `alignContent="space-around"`. */
-  'align-content-xs-space-around': {
-    alignContent: 'space-around',
-  },
-  /* Styles applied to the root element if `justify="center"`. */
-  'justify-xs-center': {
-    justifyContent: 'center',
-  },
-  /* Styles applied to the root element if `justify="flex-end"`. */
-  'justify-xs-flex-end': {
-    justifyContent: 'flex-end',
-  },
-  /* Styles applied to the root element if `justify="space-between"`. */
-  'justify-xs-space-between': {
-    justifyContent: 'space-between',
-  },
-  /* Styles applied to the root element if `justify="space-around"`. */
-  'justify-xs-space-around': {
-    justifyContent: 'space-around',
-  },
   /* Styles applied to the root element if `justify="space-evenly"`. */
   'justify-xs-space-evenly': {
     justifyContent: 'space-evenly',
   },
+  ...breakpointKeys.reduce((accumulator, key) => {
+    generateContainer(accumulator, theme, key);
+    return accumulator;
+  }, {}),
   ...generateGutter(theme, 'xs'),
   ...breakpointKeys.reduce((accumulator, key) => {
     // Use side effect over immutability for better performance.
@@ -213,14 +260,23 @@ function Grid(props) {
     zeroMinWidth,
     ...other
   } = props;
-
+  // [classes[`direction-xs-${String(direction)}`]]: direction !== Grid.defaultProps.direction,
   const className = classNames(
     {
       [classes.container]: container,
       [classes.item]: item,
       [classes.zeroMinWidth]: zeroMinWidth,
       [classes[`spacing-xs-${String(spacing)}`]]: container && spacing !== 0,
-      [classes[`direction-xs-${String(direction)}`]]: direction !== Grid.defaultProps.direction,
+      // key
+      ...breakpointKeys.reduce((accumulator, key) => {
+        // console.log(props[`${key}Direction`]);
+        const w = props[`${key}Direction`];
+        // key = 'xs';
+        accumulator[classes[`direction-${key}-${String(w)}`]] = !!w;
+        // generateClasses(accumulator, key, w);
+        // console.log(accumulator);
+        return accumulator;
+      }, {}),
       [classes[`wrap-xs-${String(wrap)}`]]: wrap !== Grid.defaultProps.wrap,
       [classes[`align-items-xs-${String(alignItems)}`]]:
         alignItems !== Grid.defaultProps.alignItems,
@@ -286,6 +342,11 @@ Grid.propTypes = {
    */
   direction: PropTypes.oneOf(['row', 'row-reverse', 'column', 'column-reverse']),
   /**
+   * Defines the `flex-direction` style property.
+   * It is applied for all screen sizes.
+   */
+  xsDirection: PropTypes.oneOf([false, 'row', 'row-reverse', 'column', 'column-reverse']),
+  /**
    * If `true`, the component will have the flex *item* behavior.
    * You should be wrapping *items* with a *container*.
    */
@@ -350,6 +411,7 @@ Grid.defaultProps = {
   component: 'div',
   container: false,
   direction: 'row',
+  xsDirection: 'row',
   item: false,
   justify: 'flex-start',
   lg: false,
@@ -371,6 +433,7 @@ if (process.env.NODE_ENV !== 'production') {
     alignContent: requireProp('container'),
     alignItems: requireProp('container'),
     direction: requireProp('container'),
+    xsDirection: requireProp('container'),
     justify: requireProp('container'),
     lg: requireProp('item'),
     md: requireProp('item'),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Add an easy way to define grid container properties based on width, something like that

(this is inspired in [angular material v1 - layout](https://material.angularjs.org/latest/layout/alignment))
```javascript
<Grid
  container
  xsDirection="column"
  mdDirection="row"
  xsAlignItems="center"
  mdAlignItems="baseline"
  {...othersProps}
>
/* code here*/
</Grid>
```

Today, I can accomplish this using withWidth, them my code became this: (no judge here, pls xD)

```javascript
<Grid
  container
  direction={width === "xs" ? "column" : "row"}
  alignItems={width === "xs" ? "center" : "baseline"}
  {...othersProps}
>
/* code here*/
</Grid>
```

to not be a breaking change, we could assume that if the breakpoint is not present, the xs will be used, like we do with Grid item, example:
direction became xsDirection
alignItems became xsAlignItems
justify became xsJustify
alignContent became xsAlignContent

not ready for merge yet, for now, only working with direction.
I want to know if it is a desired thing (: