### PR TITLE
[Dialog] Fix positioning issue

### DIFF
--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -180,11 +180,11 @@ class DialogInline extends Component {
   };
 
   componentDidMount() {
-    this.positionDialog();
+    setTimeout(() => this.positionDialog(), 0);
   }
 
   componentDidUpdate() {
-    this.positionDialog();
+    setTimeout(() => this.positionDialog(), 0);
   }
 
   positionDialog() {


### PR DESCRIPTION
I encountered an issue with tall dialogs on first render. 

It looks like the position is incorrect because it's calculated based on an outdated dialog height. Calling  `this.positionDialog()` on the next iteration fixed the issue. 

Not sure if that works for all browsers but at worst it won't have any effect.

**Without `setTimeout` (incorrect)**

<img width="1680" alt="screen shot 2018-08-06 at 13 42 58" src="https://user-images.githubusercontent.com/893649/43730205-ffb2512a-9980-11e8-9904-c9feec54d728.png">

**With `setTimeout` (correct)**

<img width="1680" alt="screen shot 2018-08-06 at 13 48 43" src="https://user-images.githubusercontent.com/893649/43730210-073b0450-9981-11e8-98a5-7b2acca0da1a.png">
