### PR TITLE
[Collapse] Add all class keys to the types

### DIFF
--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -11,7 +11,7 @@ export interface CollapseProps extends StandardProps<TransitionProps, CollapseCl
   timeout?: TransitionProps['timeout'] | 'auto';
 }
 
-export type CollapseClassKey = 'container' | 'entered';
+export type CollapseClassKey = 'container' | 'entered' | 'wrapper' | 'wrapperInner';
 
 declare const Collapse: React.ComponentType<CollapseProps>;
 


### PR DESCRIPTION
The `wrapper` and `wrapperInner` class keys are listed as available for override in the documentation, but they're not included in the types for the class overrides.