### PR TITLE
[docs] Ensure `inputRef` is wired up to react-number-format's input

### DIFF
--- a/docs/src/pages/demos/text-fields/FormattedInputs.js
+++ b/docs/src/pages/demos/text-fields/FormattedInputs.js
@@ -44,7 +44,7 @@ function NumberFormatCustom(props) {
   return (
     <NumberFormat
       {...other}
-      ref={inputRef}
+      getInputRef={inputRef}
       onValueChange={values => {
         onChange({
           target: {


### PR DESCRIPTION
See https://github.com/s-yadav/react-number-format#getting-reference.

This doesn't actually matter much because `Input` only seems to use the input ref [when](https://github.com/mui-org/material-ui/blob/18aa629/packages/material-ui/src/Input/Input.js#L297-L299) it's uncontrolled, but thought I'd correct the example anyway 🙂

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
