### PR TITLE
[typescript] improve autocomplete for css properties in createStyles

### DIFF
--- a/packages/material-ui/src/styles/createStyles.d.ts
+++ b/packages/material-ui/src/styles/createStyles.d.ts
@@ -8,4 +8,4 @@ import { CSSProperties, StyleRules } from './withStyles';
  * @param styles a set of style mappings
  * @returns the same styles that were passed in
  */
-export default function createStyles<S extends StyleRules>(styles: S): S;
+export default function createStyles<C extends string>(styles: StyleRules<C>): StyleRules<C>;


### PR DESCRIPTION
Improves autocomplete when typing css properties in `createStyles`.

Tested in `vscode@1.25.1`:
![material-ui-create-styles-autocomplete](https://user-images.githubusercontent.com/12292047/43905477-74da12d6-9bf1-11e8-8559-a954cf5af91c.png)

Classkey inference still possible:
![material-ui-create-styles-no-regression](https://user-images.githubusercontent.com/12292047/43905573-9eb66884-9bf1-11e8-8608-8cdf78520880.png)

Related:
- #11693