### PR TITLE
[typescript] Style typing improvements

### DIFF
--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -146,39 +146,6 @@ const DecoratedClass = withStyles(styles)(
 
 Unfortunately due to a [current limitation of TypeScript decorators](https://github.com/Microsoft/TypeScript/issues/4881), `withStyles(styles)` can't be used as a decorator in TypeScript.
 
-### Union props
-
-When your `props` are a union, Typescript needs you to explicitly tell it the type, by providing a generic `<Props>` parameter to `decorate`:
-
-```tsx
-interface Book {
-  category: "book";
-  author: string;
-}
-
-interface Painting {
-  category: "painting";
-  artist: string;
-}
-
-type BookOrPainting = Book | Painting;
-
-type Props = BookOrPainting & WithStyles<typeof styles>;
-
-const DecoratedUnionProps = withStyles(styles)<BookOrPainting>( // <-- without the type argument, we'd get a compiler error!
-  class extends React.Component<Props> {
-    render() {
-      const props = this.props;
-      return (
-        <Typography classes={props.classes}>
-          {props.category === "book" ? props.author : props.artist}
-        </Typography>
-      );
-    }
-  }
-);
-```
-
 ## Customization of `Theme`
 
 When adding custom properties to the `Theme`, you may continue to use it in a strongly typed way by exploiting

--- a/packages/material-ui/src/ButtonBase/TouchRipple.d.ts
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.d.ts
@@ -2,8 +2,7 @@ import * as React from 'react';
 import { TransitionGroup } from 'react-transition-group';
 import { StandardProps } from '..';
 
-export interface TouchRippleProps
-  extends StandardProps<TransitionGroup.TransitionGroupProps, TouchRippleClassKey> {
+export type TouchRippleProps = StandardProps<TransitionGroup.TransitionGroupProps, TouchRippleClassKey> & {
   center?: boolean;
 }
 

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -4,14 +4,12 @@ export { StyledComponentProps };
 
 export type AnyComponent<P = any> =
   | (new (props: P) => React.Component)
-  | ((props: P & { children?: React.ReactNode }) => React.ReactElement<P> | null)
-  ;
+  | ((props: P & { children?: React.ReactNode }) => React.ReactElement<P> | null);
 
 export type PropsOf<C extends AnyComponent> =
   C extends new (props: infer P) => React.Component ? P :
   C extends (props: infer P) => React.ReactElement<any> | null ? P :
   never;
-
 
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -39,7 +39,7 @@ export interface Color {
  *
  * @internal
  */
-export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+export type Omit<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
 
 /**
  * `T extends ConsistentWith<T, U>` means that where `T` has overlapping properties with
@@ -54,7 +54,7 @@ export type ConsistentWith<T, U> = Pick<U, keyof T & keyof U>;
  *
  * @internal
  */
-export type Overwrite<T, U> = (U extends ConsistentWith<U, T> ? T : Omit<T, keyof U>) & U;
+export type Overwrite<T, U> = Omit<T, keyof U> & U;
 
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -3,13 +3,13 @@ import { StyledComponentProps } from './styles';
 export { StyledComponentProps };
 
 export type AnyComponent<P = any> =
-  | (new (p: P) => React.Component)
+  | (new (props: P) => React.Component)
   | ((props: P & { children?: React.ReactNode }) => React.ReactElement<P> | null)
   ;
 
 export type PropsOf<C extends AnyComponent> =
-  C extends new (p: infer P) => React.Component ? P :
-  C extends (p: infer P) => React.ReactElement<any> | null ? P :
+  C extends new (props: infer P) => React.Component ? P :
+  C extends (props: infer P) => React.ReactElement<any> | null ? P :
   never;
 
 

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -2,6 +2,17 @@ import * as React from 'react';
 import { StyledComponentProps } from './styles';
 export { StyledComponentProps };
 
+export type AnyComponent<P = any> =
+  | (new (p: P) => React.Component)
+  | ((props: P & { children?: React.ReactNode }) => React.ReactElement<P> | null)
+  ;
+
+export type PropsOf<C extends AnyComponent> =
+  C extends new (p: infer P) => React.Component ? P :
+  C extends (p: infer P) => React.ReactElement<any> | null ? P :
+  never;
+
+
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with
  * certain `classes`, on which one can also set a top-level `className` and inline

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WithTheme } from '../styles/withTheme';
-import { AnyComponent, ConsistentWith, Overwrite } from '..';
+import { AnyComponent, ConsistentWith, Overwrite, Omit } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
@@ -38,13 +38,13 @@ export interface WithStylesOptions<ClassKey extends string = string>
 
 export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
 
-export type WithStyles<T extends string | StyleRules | StyleRulesCallback = string> = Partial<
-  WithTheme
-> & {
-  classes: ClassNameMap<
-    T extends string
-      ? T
-      : T extends StyleRulesCallback<infer K> ? K : T extends StyleRules<infer K> ? K : never
+export type WithStyles<T extends string | StyleRules | StyleRulesCallback = string, IncludeTheme extends boolean | undefined = undefined> =
+  (IncludeTheme extends true ? WithTheme : Partial<WithTheme>)
+  & {
+    classes: ClassNameMap<
+      T extends string
+        ? T
+        : T extends StyleRulesCallback<infer K> ? K : T extends StyleRules<infer K> ? K : never
   >;
 };
 
@@ -53,11 +53,11 @@ export interface StyledComponentProps<ClassKey extends string = string> {
   innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
-export default function withStyles<ClassKey extends string>(
+export default function withStyles<ClassKey extends string, Options extends WithStylesOptions<ClassKey>>(
   style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
-  options?: WithStylesOptions<ClassKey>,
+  options?: Options,
 ): {
-  <P extends ConsistentWith<P, StyledComponentProps<ClassKey>>>(
-    component: AnyComponent<P & WithStyles<ClassKey>>,
-  ): React.ComponentType<Overwrite<P, StyledComponentProps<ClassKey>>>;
+  <P extends ConsistentWith<P, StyledComponentProps<ClassKey> & Partial<WithTheme>>>(
+    component: AnyComponent<P & WithStyles<ClassKey, Options['withTheme']>>,
+  ): React.ComponentType<Overwrite<Omit<P, 'theme'>, StyledComponentProps<ClassKey>>>;
 };

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WithTheme } from '../styles/withTheme';
-import { ConsistentWith, Overwrite } from '..';
+import { AnyComponent, ConsistentWith, Overwrite } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
@@ -58,6 +58,6 @@ export default function withStyles<ClassKey extends string>(
   options?: WithStylesOptions<ClassKey>,
 ): {
   <P extends ConsistentWith<P, StyledComponentProps<ClassKey>>>(
-    component: React.ComponentType<P & WithStyles<ClassKey>>,
+    component: AnyComponent<P & WithStyles<ClassKey>>,
   ): React.ComponentType<Overwrite<P, StyledComponentProps<ClassKey>>>;
 };

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -8,6 +8,6 @@ export interface WithTheme {
 
 declare const withTheme: () => <P extends ConsistentWith<P, WithTheme>>(
   component: React.ComponentType<P & WithTheme>,
-) => React.ComponentClass<Overwrite<P, Partial<WithTheme>>>;
+) => React.ComponentType<Overwrite<P, Partial<WithTheme>>>;
 
 export default withTheme;

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -1,5 +1,5 @@
 import { Theme } from './createMuiTheme';
-import { ConsistentWith, Overwrite } from '..';
+import { AnyComponent, ConsistentWith, Overwrite } from '..';
 
 export interface WithTheme {
   theme: Theme;
@@ -7,7 +7,7 @@ export interface WithTheme {
 }
 
 declare const withTheme: () => <P extends ConsistentWith<P, WithTheme>>(
-  component: React.ComponentType<P & WithTheme>,
+  component: AnyComponent<P & WithTheme>,
 ) => React.ComponentType<Overwrite<P, Partial<WithTheme>>>;
 
 export default withTheme;

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -1,5 +1,5 @@
 import { Theme } from './createMuiTheme';
-import { ConsistentWith } from '..';
+import { ConsistentWith, Overwrite } from '..';
 
 export interface WithTheme {
   theme: Theme;
@@ -8,6 +8,6 @@ export interface WithTheme {
 
 declare const withTheme: () => <P extends ConsistentWith<P, WithTheme>>(
   component: React.ComponentType<P & WithTheme>,
-) => React.ComponentClass<P>;
+) => React.ComponentClass<Overwrite<P, Partial<WithTheme>>>;
 
 export default withTheme;

--- a/packages/material-ui/src/withMobileDialog/withMobileDialog.d.ts
+++ b/packages/material-ui/src/withMobileDialog/withMobileDialog.d.ts
@@ -1,5 +1,5 @@
 import { Breakpoint } from '../styles/createBreakpoints';
-import { WithWidthProps } from '../withWidth';
+import { WithWidth } from '../withWidth';
 
 export interface WithMobileDialogOptions {
   breakpoint: Breakpoint;
@@ -12,5 +12,5 @@ export interface InjectedProps {
 export default function withMobileDialog<P = {}>(
   options?: WithMobileDialogOptions,
 ): (
-  component: React.ComponentType<P & InjectedProps & Partial<WithWidthProps>>,
-) => React.ComponentType<P & Partial<WithWidthProps>>;
+  component: React.ComponentType<P & InjectedProps & Partial<WithWidth>>,
+) => React.ComponentType<P & Partial<WithWidth>>;

--- a/packages/material-ui/src/withWidth/withWidth.d.ts
+++ b/packages/material-ui/src/withWidth/withWidth.d.ts
@@ -26,4 +26,4 @@ export default function withWidth(
   options?: WithWidthOptions,
 ): <P extends ConsistentWith<P, WithWidthProps>>(
   component: React.ComponentType<P & WithWidthProps>,
-) => React.ComponentClass<Overwrite<P, Partial<WithWidthProps>>>;
+) => React.ComponentType<Overwrite<P, Partial<WithWidthProps>>>;

--- a/packages/material-ui/src/withWidth/withWidth.d.ts
+++ b/packages/material-ui/src/withWidth/withWidth.d.ts
@@ -5,7 +5,7 @@ export interface WithWidthOptions {
   resizeInterval: number;
 }
 
-export interface WithWidthProps {
+export interface WithWidth {
   width: Breakpoint;
   innerRef?: React.Ref<any> | React.RefObject<any>;
 }
@@ -24,6 +24,6 @@ export function isWidthUp(
 
 export default function withWidth(
   options?: WithWidthOptions,
-): <P extends ConsistentWith<P, WithWidthProps>>(
-  component: React.ComponentType<P & WithWidthProps>,
-) => React.ComponentType<Overwrite<P, Partial<WithWidthProps>>>;
+): <P extends ConsistentWith<P, WithWidth>>(
+  component: React.ComponentType<P & WithWidth>,
+) => React.ComponentType<Overwrite<P, Partial<WithWidth>>>;

--- a/packages/material-ui/src/withWidth/withWidth.d.ts
+++ b/packages/material-ui/src/withWidth/withWidth.d.ts
@@ -1,5 +1,5 @@
 import { Breakpoint } from '../styles/createBreakpoints';
-import { ConsistentWith, Overwrite } from '..';
+import { AnyComponent, ConsistentWith, Overwrite } from '..';
 
 export interface WithWidthOptions {
   resizeInterval: number;
@@ -25,5 +25,5 @@ export function isWidthUp(
 export default function withWidth(
   options?: WithWidthOptions,
 ): <P extends ConsistentWith<P, WithWidth>>(
-  component: React.ComponentType<P & WithWidth>,
+  component: AnyComponent<P & WithWidth>,
 ) => React.ComponentType<Overwrite<P, Partial<WithWidth>>>;

--- a/packages/material-ui/src/withWidth/withWidth.spec.tsx
+++ b/packages/material-ui/src/withWidth/withWidth.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Grid } from '..';
 import { Theme, createStyles } from '../styles';
 import withStyles, { WithStyles } from '../styles/withStyles';
-import withWidth, { WithWidthProps } from '../withWidth';
+import withWidth, { WithWidth } from '../withWidth';
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -13,7 +13,7 @@ const styles = (theme: Theme) =>
     },
   });
 
-interface IHelloProps extends WithWidthProps, WithStyles<typeof styles> {
+interface IHelloProps extends WithWidth, WithStyles<typeof styles> {
   name?: string;
 }
 

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -177,6 +177,16 @@ const AllTheComposition = withTheme()(
 
 <AllTheComposition />;
 
+{
+  const Foo = withTheme()(class extends React.Component<WithTheme> {
+    render() {
+      return null;
+    }
+  });
+
+  <Foo />
+}
+
 // Can't use withStyles effectively as a decorator in TypeScript
 // due to https://github.com/Microsoft/TypeScript/issues/4881
 //@withStyles(styles)

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -187,6 +187,22 @@ const AllTheComposition = withTheme()(
   <Foo />
 }
 
+declare const themed: boolean;
+{
+  // Test that withTheme: true guarantees the presence of the theme
+  const Foo = withStyles({}, { withTheme: true })(class extends React.Component<WithTheme> {
+    render() {
+      return <div style={{ margin: this.props.theme.spacing.unit }} />;
+    }
+  });
+  <Foo />;
+
+  const Bar = withStyles({}, { withTheme: true })(({ theme }) => (
+    <div style={{ margin: theme.spacing.unit }} />
+  ));
+  <Bar />;
+}
+
 // Can't use withStyles effectively as a decorator in TypeScript
 // due to https://github.com/Microsoft/TypeScript/issues/4881
 //@withStyles(styles)

--- a/packages/material-ui/test/typescript/styling-comparison.spec.tsx
+++ b/packages/material-ui/test/typescript/styling-comparison.spec.tsx
@@ -60,7 +60,7 @@ interface Painting {
 
 type ArtProps = Book | Painting;
 
-const DecoratedUnionProps = withStyles(styles)<ArtProps>( // <-- without the type argument, we'd get a compiler error!
+const DecoratedUnionProps = withStyles(styles)(
   class extends React.Component<ArtProps & WithStyles<typeof styles>> {
     render() {
       const props = this.props;


### PR DESCRIPTION
- Fixes definition of `Omit` so that it distributes across union types. This allows us to give better return types for `withStyles`, `withTheme` and `withWidth`.
- Use a custom `AnyComponent` definition instead of `React.ComponentType`, which allows us to get rid of the ugly type annotation when using union-typed props. Remove corresponding caveat from the docs.
- Better typing of `withStyles` so that if the type checker can statically determine that you passed the `withTheme: true` option to `withStyles`, then `theme` will not be `undefined` in the inner component's props.

Resolves #12070, supersedes #12106.
Closes #12106