### PR TITLE
[Tab] Fix fullWidth CSS

### DIFF
--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -66,7 +66,7 @@ export const styles = theme => ({
   fullWidth: {
     flexShrink: 1,
     flexGrow: 1,
-    maxWidth: '100%',
+    maxWidth: 'none',
   },
   /* Styles applied to the `icon` and `label`'s wrapper element. */
   wrapper: {

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -66,7 +66,7 @@ export const styles = theme => ({
   fullWidth: {
     flexShrink: 1,
     flexGrow: 1,
-    maxWidth: 'auto',
+    maxWidth: '100%',
   },
   /* Styles applied to the `icon` and `label`'s wrapper element. */
   wrapper: {


### PR DESCRIPTION
`auto` is not a valid value for `max-width` according to
https://developer.mozilla.org/en-US/docs/Web/CSS/max-width

and

https://www.w3.org/wiki/CSS/Properties/max-width

Chrome og firefox ignore the `max-width: auto`.

`max-width: 100%` yields expected behaviour on Chrome and Firefox.
