### PR TITLE
[docs] Tweak dashboard example nav list heading

### DIFF
--- a/docs/src/pages/page-layout-examples/dashboard/listItems.js
+++ b/docs/src/pages/page-layout-examples/dashboard/listItems.js
@@ -47,7 +47,7 @@ export const mainListItems = (
 
 export const secondaryListItems = (
   <div>
-    <ListSubheader>Saved reports</ListSubheader>
+    <ListSubheader inset>Saved reports</ListSubheader>
     <ListItem button>
       <ListItemIcon>
         <AssignmentIcon />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Added `inset` prop to `ListSubHeader`
- Updated the new dashboard example; When the drawer was condensed the `ListSubHeader` component was being cut off as shown below.

#### Before
![before](https://user-images.githubusercontent.com/638172/44052605-ee03bc52-9f34-11e8-869e-4f60c8058642.png)

#### After
![after](https://user-images.githubusercontent.com/638172/44052677-2254ac78-9f35-11e8-8d93-bea3dcf01979.png)

