### PR TITLE
[Table] Remove padding from getting spread to native element

### DIFF
--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -25,7 +25,7 @@ class Table extends React.Component {
   }
 
   render() {
-    const { classes, className, component: Component, ...other } = this.props;
+    const { classes, className, component: Component, padding, ...other } = this.props;
 
     return <Component className={classNames(classes.root, className)} {...other} />;
   }


### PR DESCRIPTION
Closes #12504.

Apologies, I'm not sure the cleanest way to remove a property that isn't used/not needed to be included in the `...other` spread.