### PR TITLE
[docs] Document breakpoint argument for withMobileDialog

### DIFF
--- a/docs/src/pages/demos/dialogs/dialogs.md
+++ b/docs/src/pages/demos/dialogs/dialogs.md
@@ -67,7 +67,7 @@ For example, if your site prompts for potential subscribers to fill in their ema
 
 ## Responsive full-screen
 
-You may make a `Dialog` responsively full screen the dialog using `withMobileDialog`. By default, `withMobileDialog()(Dialog)` responsively full screens *at or below* the `sm` [screen size](/layout/basics).
+You may make a `Dialog` responsively full screen the dialog using `withMobileDialog`. By default, `withMobileDialog()(Dialog)` responsively full screens *at or below* the `sm` [screen size](/layout/basics). You can choose your own breakpoint for example `xs` by passing the `breakpoint` argument: `withMobileDialog({breakpoint: 'xs'})(Dialog)`.
 
 {{"demo": "pages/demos/dialogs/ResponsiveDialog.js"}}
 


### PR DESCRIPTION
Add a sentence describing how one might choose their own breakpoint for their dialog to become full screen.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
