### PR TITLE
[Drawer] Change height from 100vh to 100%

### DIFF
--- a/docs/src/pages/demos/drawers/ClippedDrawer.js
+++ b/docs/src/pages/demos/drawers/ClippedDrawer.js
@@ -14,7 +14,7 @@ const drawerWidth = 240;
 const styles = theme => ({
   root: {
     flexGrow: 1,
-    height: 430,
+    height: 440,
     zIndex: 1,
     overflow: 'hidden',
     position: 'relative',

--- a/docs/src/pages/demos/drawers/MiniDrawer.js
+++ b/docs/src/pages/demos/drawers/MiniDrawer.js
@@ -19,7 +19,7 @@ const drawerWidth = 240;
 const styles = theme => ({
   root: {
     flexGrow: 1,
-    height: 430,
+    height: 440,
     zIndex: 1,
     overflow: 'hidden',
     position: 'relative',

--- a/docs/src/pages/demos/drawers/PermanentDrawer.js
+++ b/docs/src/pages/demos/drawers/PermanentDrawer.js
@@ -19,7 +19,7 @@ const styles = theme => ({
     flexGrow: 1,
   },
   appFrame: {
-    height: 430,
+    height: 440,
     zIndex: 1,
     overflow: 'hidden',
     position: 'relative',

--- a/docs/src/pages/demos/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/demos/drawers/ResponsiveDrawer.js
@@ -17,7 +17,7 @@ const drawerWidth = 240;
 const styles = theme => ({
   root: {
     flexGrow: 1,
-    height: 430,
+    height: 440,
     zIndex: 1,
     overflow: 'hidden',
     position: 'relative',

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -35,7 +35,7 @@ export const styles = theme => ({
     overflowY: 'auto',
     display: 'flex',
     flexDirection: 'column',
-    height: '100vh',
+    height: '100%',
     flex: '1 0 auto',
     zIndex: theme.zIndex.drawer,
     WebkitOverflowScrolling: 'touch', // Add iOS momentum scrolling.
@@ -64,7 +64,7 @@ export const styles = theme => ({
     bottom: 'auto',
     right: 0,
     height: 'auto',
-    maxHeight: '100vh',
+    maxHeight: '100%',
   },
   /* Styles applied to the `Paper` component if `anchor="bottom"`. */
   paperAnchorBottom: {
@@ -73,7 +73,7 @@ export const styles = theme => ({
     bottom: 0,
     right: 0,
     height: 'auto',
-    maxHeight: '100vh',
+    maxHeight: '100%',
   },
   /* Styles applied to the `Paper` component if `anchor="left"` & `variant` is not "temporary". */
   paperAnchorDockedLeft: {


### PR DESCRIPTION
As described in issue #12285, mobile Safari has a unique interpretation of `100vh`, which includes the space behind the button bar. This can cause elements to be hidden behind the button bar, especially ones that are anchored to the bottom of the Drawer, as is common with buttons and links.

A value of `100%` behaves as expected, occupying the full height of the visible area - not only in mobile Safari, but all other browsers to my knowledge.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #12285