### PR TITLE
[slider] Fix transitions

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -14,10 +14,13 @@ export const styles = theme => {
     easing: theme.transitions.easing.easeOut,
   };
 
-  const commonTransitionsProperty = ['width', 'height', 'box-shadow', 'left', 'top'];
-
   const commonTransitions = theme.transitions.create(
-    commonTransitionsProperty,
+    ['width', 'height', 'left', 'top', 'box-shadow'],
+    commonTransitionsOptions,
+  );
+  // no transition on the position
+  const thumbActivatedTransitions = theme.transitions.create(
+    ['width', 'height', 'box-shadow'],
     commonTransitionsOptions,
   );
 
@@ -62,7 +65,7 @@ export const styles = theme => {
       top: '50%',
       height: 2,
       backgroundColor: colors.primary,
-      '&$focused, &$activated': {
+      '&$activated': {
         transition: 'none',
       },
       '&$disabled': {
@@ -106,7 +109,7 @@ export const styles = theme => {
       '&$activated': {
         width: 17,
         height: 17,
-        transition: 'none',
+        transition: thumbActivatedTransitions,
       },
       '&$disabled': {
         cursor: 'no-drop',


### PR DESCRIPTION
Behavior when focusing the slider and changing values via arrow key:
__before (actual)__:
![mui-slider outspace-before](https://user-images.githubusercontent.com/12292047/44138032-e26ae6a6-a072-11e8-8dbb-4d9599d97718.gif)
__after__ (expect/on this branch):
![mui-slider outspace-after](https://user-images.githubusercontent.com/12292047/44138039-e7ed71e8-a072-11e8-8ca4-c158c4338d4e.gif)

This also fixes inconsistent transition behavior for the box-shadow and resizing of the thumb i.e. no transition on mousedown but a transition on mouseup. 