### PR TITLE
[SpeedDial] Fix invalid prop direction supplied

### DIFF
--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -303,7 +303,7 @@ SpeedDial.propTypes = {
 
 SpeedDial.defaultProps = {
   hidden: false,
-  direction: 'top',
+  direction: 'up',
   TransitionComponent: Zoom,
   transitionDuration: {
     enter: duration.enteringScreen,


### PR DESCRIPTION
During review #12244 the names for directions changed and CI did
not run which introduced errors.

Fixes one error surfaced when opening #12531 
