### PR TITLE
[slider] Fix failing handler test

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -459,7 +459,6 @@ class Slider extends React.Component {
             style={inlineThumbStyles}
             onBlur={this.handleBlur}
             onKeyDown={this.handleKeyDown}
-            onMouseDown={this.handleMouseDown}
             onTouchStartCapture={this.handleTouchStart}
             onTouchMove={this.handleMouseMove}
             onFocusVisible={this.handleFocus}

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -44,11 +44,13 @@ describe('<Slider />', () => {
         value={0}
       />,
     );
-    const button = wrapper.find('button');
 
     wrapper.simulate('click');
-    button.simulate('mousedown');
-    button.simulate('mouseup');
+    wrapper.simulate('mousedown');
+    // document.simulate('mouseup')
+    const mouseupEvent = document.createEvent('HTMLEvents');
+    mouseupEvent.initEvent('mouseup', false, true);
+    document.dispatchEvent(mouseupEvent);
 
     assert.strictEqual(handleChange.callCount, 1, 'should have called the handleChange cb');
     assert.strictEqual(handleDragStart.callCount, 1, 'should have called the handleDragStart cb');


### PR DESCRIPTION
Includes mostly changes that handle `enzyme#simulate` gotchas. I also removed the mousedownhandler from the button since it seemed redundant.

See https://github.com/airbnb/enzyme/blob/master/docs/api/ShallowWrapper/simulate.md#common-gotchas for why we need to simulate events on the wrapper.

Errors were introduced in #11889
Fixes one error surfaced in #12531 
