### PR TITLE
[core] Add MuiTableBody to theme overrides

### DIFF
--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -167,6 +167,7 @@ type ComponentNameToClassKey = {
   MuiSwitchBase: SwitchBaseClassKey;
   MuiTab: TabClassKey;
   MuiTable: TableClassKey;
+  MuiTableBody: TableBodyClassKey;
   MuiTableCell: TableCellClassKey;
   MuiTablePagination: TablePaginationClassKey;
   MuiTableRow: TableRowClassKey;


### PR DESCRIPTION
`MuiTableBody` is currently missing in overrides.d.ts. Adding this key allows for overriding styles in TypeScript projects. As the class key import was there already, this key missing was probably a small mistake.