### PR TITLE
[docs] Improve typescript issue assistance

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -61,6 +61,6 @@ Link:
 |--------------|---------|
 | Material-UI  | v1.?.?  |
 | React        |         |
-| Typescript   |         |
-| browser      |         |
+| Browser      |         |
+| TypeScript   |         |
 | etc.         |         |

--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -32,6 +32,8 @@ about: Create a bug report for Material-UI
     This codesandbox.io template _may_ be a good starting point:
     https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app
 
+    If you're using typescript a better starting point would be
+    https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript
 
     If YOU DO NOT take time to provide a codesandbox.io reproduction, should the COMMUNITY take time to help you?
 
@@ -50,11 +52,15 @@ Link:
 -->
 
 ## Your Environment
-<!--- Include as many relevant details about the environment with which you experienced the bug. -->
+<!---
+    Include as many relevant details about the environment with which you experienced the bug.
+    If you encounter issues with typescript please include version and tsconfig.
+-->
 
 | Tech         | Version |
 |--------------|---------|
 | Material-UI  | v1.?.?  |
 | React        |         |
+| Typescript   |         |
 | browser      |         |
 | etc.         |         |

--- a/examples/create-react-app-with-typescript/package.json
+++ b/examples/create-react-app-with-typescript/package.json
@@ -2,6 +2,7 @@
   "name": "create-react-app-with-typescript",
   "version": "0.1.0",
   "private": true,
+  "main": "src/index.tsx",
   "dependencies": {
     "@material-ui/core": "latest",
     "@types/react": "*",

--- a/examples/create-react-app-with-typescript/tsconfig.json
+++ b/examples/create-react-app-with-typescript/tsconfig.json
@@ -10,6 +10,7 @@
     "jsx": "react",
     "moduleResolution": "node",
     "rootDir": "src",
+    "types": [],
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Since the number of issues with typescript is quite significant I decided to ask for useful informations in the issue template.

Especially now with the release of typescript 3 I expect more issues that are hard to replicate without knowing typescript version and the used tsconfig.

There was already a useful codesandbox template which isn't working at the moment but is fixed with this PR.
master: https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript
PR: https://codesandbox.io/s/github/eps1lon/material-ui/tree/typescript-issues/examples/create-react-app-with-typescript

Since all of these changes are closely related to one another I decided to bundle these. Just let me know if I should file these separately or squash etc.