### PR TITLE
[docs] Link a new Menu demo

### DIFF
--- a/docs/src/pages/demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.js
@@ -6,7 +6,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
-import MenuIcon from '@material-ui/core/Menu';
+import MenuIcon from '@material-ui/icons/Menu';
 
 const styles = {
   root: {

--- a/docs/src/pages/demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.js
@@ -6,7 +6,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
-import MenuIcon from '@material-ui/icons/Menu';
+import MenuIcon from '@material-ui/core/Menu';
 
 const styles = {
   root: {

--- a/docs/src/pages/demos/app-bar/app-bar.md
+++ b/docs/src/pages/demos/app-bar/app-bar.md
@@ -1,6 +1,6 @@
 ---
 title: App Bar React component
-components: AppBar, Toolbar
+components: AppBar, Toolbar, Menu
 ---
 
 # App Bar

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -58,5 +58,6 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Demos
 
+- [App Bar](/demos/app-bar)
 - [Menus](/demos/menus)
 


### PR DESCRIPTION
[ButtonAppBar.js]
the path import MenuIcon from '@material-ui/icons/Menu'; throw an error : Module not found: Can't resolve '@material-ui/icons/Menu'
by changing  the path [ import MenuIcon from '@material-ui/core/Menu'; ] it works.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
