### PR TITLE
[Dialog] Simplify the DialogContentText implementation

### DIFF
--- a/packages/material-ui/src/DialogContentText/DialogContentText.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.js
@@ -2,30 +2,16 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Typography from '../Typography';
 
-export const styles = theme => ({
+export const styles = {
   /* Styles applied to the root element. */
-  root: {
-    color: theme.palette.text.secondary,
-  },
-});
+  root: {},
+};
 
 function DialogContentText(props) {
-  const { children, classes, className, ...other } = props;
-
-  return (
-    <Typography
-      component="p"
-      variant="subheading"
-      className={classNames(classes.root, className)}
-      {...other}
-    >
-      {children}
-    </Typography>
-  );
+  return <Typography component="p" variant="subheading" color="textSecondary" {...props} />;
 }
 
 DialogContentText.propTypes = {
@@ -38,10 +24,6 @@ DialogContentText.propTypes = {
    * See [CSS API](#css-api) below for more details.
    */
   classes: PropTypes.object.isRequired,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
 };
 
 export default withStyles(styles, { name: 'MuiDialogContentText' })(DialogContentText);

--- a/packages/material-ui/src/DialogContentText/DialogContentText.test.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.test.js
@@ -17,8 +17,8 @@ describe('<DialogContentText />', () => {
   describe('prop: className', () => {
     it('should render with the user and root classes', () => {
       const wrapper = shallow(<DialogContentText className="woofDialogContentText" />);
-      assert.strictEqual(wrapper.hasClass('woofDialogContentText'), true);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      assert.strictEqual(wrapper.props().className, 'woofDialogContentText');
+      assert.strictEqual(wrapper.props().classes.root, classes.root);
     });
   });
 


### PR DESCRIPTION
Prepare #12565. The implementation is strictly equivalent, the difference? We save 18 LOCs.