### PR TITLE
[test] Fix prettier ci task with multiple changed files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,19 +49,29 @@ jobs:
       - checkout
       - *restore_repo
       - run:
+          name: Export changed files
+          command: |
+            # changed files on this branch
+            # `git diff --name-only master` but since the checkout used reset --hard
+            # we need to parse the revs for the actual master
+            echo 'export CHANGED_FILES=$(git diff --name-only $(git rev-parse origin/master))' >> $BASH_ENV
+      - run:
           name: Check if yarn prettier was run
           command: |
-            # Files changed on this branch
-            CHANGED_FILES=$(git diff --name-only master...)
-            # Files that should have been formatted while working on this branch
-            FORMATTED_FILES=$(yarn --silent prettier:files | grep "$CHANGED_FILES")
-            # if we run prettier unconditionally prettier will exit with non-zero
-            # because no file path was given
-            if [ $FORMATTED_FILES ]; then
-              echo "changes, let's check if they are formatted"
-              yarn prettier:ci "$FORMATTED_FILES"
-            else
+            # if we use an empty string as a pattern grep will match everything
+            if [ -z "$CHANGED_FILES" ]; then
               echo "no changes"
+            else
+              # Files that should have been formatted while working on this branch
+              # CircleCI does not support interpolation when setting environment variables
+              echo 'export FORMATTED_FILES=$(yarn --silent prettier:files | grep "$CHANGED_FILES")' >> $BASH_ENV
+              source $BASH_ENV
+
+              if [ -z "$FORMATTED_FILES" ]; then
+                echo "no files for prettier were changed"
+              else
+                yarn prettier:ci $FORMATTED_FILES
+              fi
             fi
       - run:
           name: Lint


### PR DESCRIPTION
Fixes various issues in #12564:
- no changes caused grep to match everything (this is a non-issue because why would this trigger a CI build?)
- more than one changed file broke the if statement (I'm concerned that an error in a bash command does not cause the CI task to fail)
- passing more than one file arg to the cli was considered on file

Sorry about the inconvenience. I should've been more careful with languages that I'm not that familiar with. 

The build should be considered broken. Once this is confirmed I will retrigger with only one file changed and the remove the broken format completely. Only if all those builds return as expected should this be merged.