### PR TITLE
[typescript] Fix AnyComponent for functional components.

### DIFF
--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -4,7 +4,7 @@ export { StyledComponentProps };
 
 export type AnyComponent<P = any> =
   | (new (props: P) => React.Component)
-  | ((props: P & { children?: React.ReactNode }) => React.ReactElement<P> | null);
+  | ((props: P & { children?: React.ReactNode }) => React.ReactElement<any> | null);
 
 export type PropsOf<C extends AnyComponent> = C extends new (props: infer P) => React.Component
   ? P


### PR DESCRIPTION
A functional component does not return a ReactElement with the same props as its input, but a ReactElement with props of its child component.
The props of its child component can not be determined and are irrelevant for typing purposes.

This PR aligns the functional component type to match the one from react (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L343)

I can not reproduce this issue with codesandbox.io, but I am able to reproduce it after ejecting from create-react-app and using typescript 3.0.1 (as opposed to some 2.x version that is required by react-scripts-ts)

The reproduction is available at https://github.com/vierbergenlars/material-ui-repro-1, run `npm install && npm run start` to see the type error.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
