### PR TITLE
[Input] Improve type checking for inputProps

### DIFF
--- a/packages/material-ui/src/Input/Input.d.ts
+++ b/packages/material-ui/src/Input/Input.d.ts
@@ -17,7 +17,7 @@ export interface InputProps
   fullWidth?: boolean;
   id?: string;
   inputComponent?: React.ReactType<InputComponentProps>;
-  inputProps?: { [arbitrary: string]: any };
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   inputRef?: React.Ref<any> | React.RefObject<any>;
   margin?: 'dense';
   multiline?: boolean;

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -803,7 +803,18 @@ const TextFieldTest = () => (
       onChange={event => log({ name: event.currentTarget.value })}
     />
     <TextField id="name" label="Name" value={'Alice'} InputProps={{ classes: { root: 'foo' } }} />
-    <TextField type="number" InputProps={{ inputProps: { min: '0', max: '10', step: '1' } }} />
+    <TextField
+      type="number"
+      inputProps={{
+        min: '0',
+        max: '10',
+        step: '1',
+        style: {
+          // just a long css property to test autocompletion
+          WebkitAnimationIterationCount: 0,
+        },
+      }}
+    />
   </div>
 );
 


### PR DESCRIPTION
Enables type checking for `inputProps` as well as autocompletion for props of `input` elements.

Same approach is used in https://github.com/mui-org/material-ui/blob/905a96119e474731b8e7add6320d3484377bf242/packages/material-ui/src/internal/SwitchBase.d.ts#L16