### PR TITLE
[TypeScript] Update SnackbarContent type def to accept action prop as array

### DIFF
--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -13,12 +13,12 @@ export interface SnackbarProps
       React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>,
       SnackbarClassKey
     > {
-  action?: React.ReactElement<any> | React.ReactElement<any>[];
+  action?: React.ReactNode;
   anchorOrigin?: SnackbarOrigin;
   autoHideDuration?: number;
   ContentProps?: Partial<SnackbarContentProps>;
   disableWindowBlurListener?: boolean;
-  message?: React.ReactElement<any>;
+  message?: React.ReactNode;
   onClose?: (event: React.SyntheticEvent<any>, reason: string) => void;
   onMouseEnter?: React.MouseEventHandler<any>;
   onMouseLeave?: React.MouseEventHandler<any>;

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -13,12 +13,12 @@ export interface SnackbarProps
       React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>,
       SnackbarClassKey
     > {
-  action?: React.ReactNode;
+  action?: SnackbarContentProps['action'];
   anchorOrigin?: SnackbarOrigin;
   autoHideDuration?: number;
   ContentProps?: Partial<SnackbarContentProps>;
   disableWindowBlurListener?: boolean;
-  message?: React.ReactNode;
+  message?: SnackbarContentProps['message'];
   onClose?: (event: React.SyntheticEvent<any>, reason: string) => void;
   onMouseEnter?: React.MouseEventHandler<any>;
   onMouseLeave?: React.MouseEventHandler<any>;

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
 
 export interface SnackbarContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
-  action?: React.ReactElement<any>;
+  action?: React.ReactElement<any> | React.ReactElement<any>[];
   message: React.ReactElement<any> | string;
 }
 

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
@@ -4,7 +4,7 @@ import { PaperProps } from '../Paper';
 
 export interface SnackbarContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
   action?: React.ReactNode;
-  message: React.ReactElement<any> | string;
+  message: React.ReactNode;
 }
 
 export type SnackbarContentClassKey = 'root' | 'message' | 'action';

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
@@ -4,7 +4,7 @@ import { PaperProps } from '../Paper';
 
 export interface SnackbarContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
   action?: React.ReactNode;
-  message: React.ReactNode;
+  message?: React.ReactNode;
 }
 
 export type SnackbarContentClassKey = 'root' | 'message' | 'action';

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
 
 export interface SnackbarContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
-  action?: React.ReactElement<any> | React.ReactElement<any>[];
+  action?: React.ReactNode;
   message: React.ReactElement<any> | string;
 }
 

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
@@ -25,6 +25,15 @@ describe('<SnackbarContent />', () => {
       assert.strictEqual(wrapper.childAt(1).hasClass(classes.action), true);
       assert.strictEqual(wrapper.childAt(1).contains(action), true);
     });
+
+    it('should render an array of elements', () => {
+      const action0 = <span key={0}>action0</span>;
+      const action1 = <span key={1}>action1</span>;
+      const wrapper = shallow(<SnackbarContent message="message" action={[action0, action1]} />);
+      assert.strictEqual(wrapper.childAt(1).hasClass(classes.action), true);
+      assert.strictEqual(wrapper.childAt(1).contains(action0), true);
+      assert.strictEqual(wrapper.childAt(1).contains(action1), true);
+    });
   });
 
   describe('prop: message', () => {


### PR DESCRIPTION
Closes #12594 

This PR alters the `SnackbarContentProps` interface. I've updated the `action` prop to a type union that accepts both a single element and an array of elements. The `Snackbar` component already uses the same union type for its action prop ([source](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Snackbar/Snackbar.d.ts#L16)), and I couldn't find any documentation suggesting `SnackbarContent` should behave any differently.

I've also added a test to confirm the existing expected behavior, outside the type defs.