### PR TITLE
[core] Fix recompose version

### DIFF
--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-rc.1",
-    "recompose": "^0.28.0"
+    "recompose": "^0.28.2"
   },
   "devDependencies": {
     "fs-extra": "^7.0.0",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -59,7 +59,7 @@
     "react-event-listener": "^0.6.2",
     "react-jss": "^8.1.0",
     "react-transition-group": "^2.2.1",
-    "recompose": "^0.28.0",
+    "recompose": "^0.28.2",
     "warning": "^4.0.1"
   },
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8118,7 +8118,7 @@ recharts@^1.1.0:
     recharts-scale "0.3.2"
     reduce-css-calc "1.3.0"
 
-recompose@^0.28.0:
+recompose@^0.28.2:
   version "0.28.2"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.28.2.tgz#19e679227bdf979e0d31b73ffe7ae38c9194f4a7"
   dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

ref: https://github.com/mui-org/material-ui/issues/12407
and so on.

recompose 2.8.0 and 2.8.1 depend `^@babel/runtime@7.0.0-beta.55`,
but in 2.8.2, version has been fixed to `@babel/runtime@7.0.0-beta.56`
https://github.com/acdlite/recompose/pull/724

So, it would be better to change `"recompose": "^0.28.0"` to `recompose": "^0.28.2"`