### PR TITLE
[typescript] Use interfaces for typography types

### DIFF
--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -16,23 +16,24 @@ export type TextStyle =
 
 export type Style = TextStyle | 'button';
 
-export interface FontStyle extends Required<{
-  fontFamily: CSSProperties['fontFamily'];
-  fontSize: number;
-  fontWeightLight: CSSProperties['fontWeight'];
-  fontWeightRegular: CSSProperties['fontWeight'];
-  fontWeightMedium: CSSProperties['fontWeight'];
-}> {}
+export interface FontStyle
+  extends Required<{
+      fontFamily: CSSProperties['fontFamily'];
+      fontSize: number;
+      fontWeightLight: CSSProperties['fontWeight'];
+      fontWeightRegular: CSSProperties['fontWeight'];
+      fontWeightMedium: CSSProperties['fontWeight'];
+    }> {}
 
 export interface FontStyleOptions extends Partial<FontStyle> {
   htmlFontSize?: number;
   allVariants?: CSSProperties;
 }
 
-export type TypographyStyle =
-  & Required<Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>>
-  & Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>
-  ;
+export type TypographyStyle = Required<
+  Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>
+> &
+  Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>;
 
 export interface TypographyStyleOptions extends Partial<TypographyStyle> {}
 
@@ -42,7 +43,8 @@ export interface TypographyUtils {
 
 export interface Typography extends Record<Style, TypographyStyle>, FontStyle, TypographyUtils {}
 
-export interface TypographyOptions extends Partial<Record<Style, TypographyStyleOptions> & FontStyleOptions> {}
+export interface TypographyOptions
+  extends Partial<Record<Style, TypographyStyleOptions> & FontStyleOptions> {}
 
 export default function createTypography(
   palette: Palette,

--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -16,24 +16,23 @@ export type TextStyle =
 
 export type Style = TextStyle | 'button';
 
-export interface FontStyle
-  extends Required<{
-      fontFamily: CSSProperties['fontFamily'];
-      fontSize: number;
-      fontWeightLight: CSSProperties['fontWeight'];
-      fontWeightRegular: CSSProperties['fontWeight'];
-      fontWeightMedium: CSSProperties['fontWeight'];
-    }> {}
+export interface FontStyle extends Required<{
+  fontFamily: CSSProperties['fontFamily'];
+  fontSize: number;
+  fontWeightLight: CSSProperties['fontWeight'];
+  fontWeightRegular: CSSProperties['fontWeight'];
+  fontWeightMedium: CSSProperties['fontWeight'];
+}> {}
 
 export interface FontStyleOptions extends Partial<FontStyle> {
   htmlFontSize?: number;
   allVariants?: CSSProperties;
 }
 
-export type TypographyStyle = Required<
-  Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>
-> &
-  Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>;
+export type TypographyStyle =
+  & Required<Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>>
+  & Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>
+  ;
 
 export interface TypographyStyleOptions extends Partial<TypographyStyle> {}
 
@@ -41,9 +40,9 @@ export interface TypographyUtils {
   pxToRem: (px: number) => string;
 }
 
-export type Typography = Record<Style, TypographyStyle> & FontStyle & TypographyUtils;
+export interface Typography extends Record<Style, TypographyStyle>, FontStyle, TypographyUtils {}
 
-export type TypographyOptions = Partial<Record<Style, TypographyStyleOptions> & FontStyleOptions>;
+export interface TypographyOptions extends Partial<Record<Style, TypographyStyleOptions> & FontStyleOptions> {}
 
 export default function createTypography(
   palette: Palette,


### PR DESCRIPTION
This allows customizing them via module augmentation, [just as with the `Theme`](https://material-ui.com/guides/typescript/#customization-of-theme).

Resolves #12523.
