### PR TITLE
[CardActionArea] Add CardActionArea component

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '88.8 KB',
+    limit: '89.0 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/docs/src/pages/demos/cards/ImgMediaCard.js
+++ b/docs/src/pages/demos/cards/ImgMediaCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
@@ -22,22 +23,24 @@ function ImgMediaCard(props) {
   const { classes } = props;
   return (
     <Card className={classes.card}>
-      <CardMedia
-        component="img"
-        className={classes.media}
-        height="140"
-        image="/static/images/cards/contemplative-reptile.jpg"
-        title="Contemplative Reptile"
-      />
-      <CardContent>
-        <Typography gutterBottom variant="headline" component="h2">
-          Lizard
-        </Typography>
-        <Typography component="p">
-          Lizards are a widespread group of squamate reptiles, with over 6,000 species, ranging
-          across all continents except Antarctica
-        </Typography>
-      </CardContent>
+      <CardActionArea>
+        <CardMedia
+          component="img"
+          className={classes.media}
+          height="140"
+          image="/static/images/cards/contemplative-reptile.jpg"
+          title="Contemplative Reptile"
+        />
+        <CardContent>
+          <Typography gutterBottom variant="headline" component="h2">
+            Lizard
+          </Typography>
+          <Typography component="p">
+            Lizards are a widespread group of squamate reptiles, with over 6,000 species, ranging
+            across all continents except Antarctica
+          </Typography>
+        </CardContent>
+      </CardActionArea>
       <CardActions>
         <Button size="small" color="primary">
           Share

--- a/docs/src/pages/demos/cards/MediaCard.js
+++ b/docs/src/pages/demos/cards/MediaCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
@@ -21,20 +22,22 @@ function MediaCard(props) {
   const { classes } = props;
   return (
     <Card className={classes.card}>
-      <CardMedia
-        className={classes.media}
-        image="/static/images/cards/contemplative-reptile.jpg"
-        title="Contemplative Reptile"
-      />
-      <CardContent>
-        <Typography gutterBottom variant="headline" component="h2">
-          Lizard
-        </Typography>
-        <Typography component="p">
-          Lizards are a widespread group of squamate reptiles, with over 6,000 species, ranging
-          across all continents except Antarctica
-        </Typography>
-      </CardContent>
+      <CardActionArea>
+        <CardMedia
+          className={classes.media}
+          image="/static/images/cards/contemplative-reptile.jpg"
+          title="Contemplative Reptile"
+        />
+        <CardContent>
+          <Typography gutterBottom variant="headline" component="h2">
+            Lizard
+          </Typography>
+          <Typography component="p">
+            Lizards are a widespread group of squamate reptiles, with over 6,000 species, ranging
+            across all continents except Antarctica
+          </Typography>
+        </CardContent>
+      </CardActionArea>
       <CardActions>
         <Button size="small" color="primary">
           Share

--- a/docs/src/pages/demos/cards/cards.md
+++ b/docs/src/pages/demos/cards/cards.md
@@ -1,6 +1,6 @@
 ---
 title: Card React component
-components: Card, CardActions, CardContent, CardHeader, CardMedia, Collapse, Paper
+components: Card, CardActionArea, CardActions, CardContent, CardHeader, CardMedia, Collapse, Paper
 ---
 
 # Cards
@@ -40,4 +40,3 @@ Here's an example of a media control card.
 On desktop, card content can expand.
 
 {{"demo": "pages/demos/cards/RecipeReviewCard.js"}}
-

--- a/packages/material-ui/src/CardActionArea/CardActionArea.d.ts
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.d.ts
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { StandardProps } from '..';
+import { ButtonBaseProps } from '../ButtonBase';
+
+export interface CardActionAreaProps
+  extends StandardProps<ButtonBaseProps, CardActionAreaClassKey> {
+  focusVisibleClassName?: string;
+}
+
+export type CardActionAreaClassKey = 'root' | 'focusVisible' | 'focusHighlight';
+
+declare const CardActionArea: React.ComponentType<CardActionAreaProps>;
+
+export default CardActionArea;

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -1,0 +1,72 @@
+// @inheritedComponent ButtonBase
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import withStyles from '../styles/withStyles';
+import ButtonBase from '../ButtonBase';
+
+export const styles = theme => ({
+  /* Styles applied to the root element. */
+  root: {
+    display: 'block',
+    textAlign: 'inherit',
+  },
+  /* Styles applied to the ButtonBase root element if the action area is keyboard focused. */
+  focusVisible: {
+    '& $focusHighlight': {
+      opacity: 0.12,
+    },
+  },
+  /* Styles applied to the focus highlight that covers the action area when it is keyboard focused. */
+  focusHighlight: {
+    pointerEvents: 'none',
+    position: 'absolute',
+    backgroundColor: 'currentcolor',
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    opacity: 0,
+    transition: theme.transitions.create('opacity', {
+      duration: theme.transitions.duration.short,
+    }),
+  },
+});
+
+function CardActionArea(props) {
+  const { children, classes, className, focusVisibleClassName, ...other } = props;
+
+  return (
+    <ButtonBase
+      className={classNames(classes.root, className)}
+      focusVisibleClassName={classNames(focusVisibleClassName, classes.focusVisible)}
+      {...other}
+    >
+      {children}
+      <span aria-hidden="true" className={classes.focusHighlight} />
+    </ButtonBase>
+  );
+}
+
+CardActionArea.propTypes = {
+  /**
+   * The content of the component.
+   */
+  children: PropTypes.node,
+  /**
+   * Override or extend the styles applied to the component.
+   * See [CSS API](#css-api) below for more details.
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * @ignore
+   */
+  focusVisibleClassName: PropTypes.string,
+};
+
+export default withStyles(styles, { name: 'MuiCardActionArea' })(CardActionArea);

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -18,7 +18,7 @@ export const styles = theme => ({
       opacity: 0.12,
     },
   },
-  /* Styles applied to the focus highlight that covers the action area when it is keyboard focused. */
+  /* Styles applied to the overlay that covers the action area when it is keyboard focused. */
   focusHighlight: {
     pointerEvents: 'none',
     position: 'absolute',

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -11,10 +11,13 @@ export const styles = theme => ({
   root: {
     display: 'block',
     textAlign: 'inherit',
+    '&:hover $focusHighlight': {
+      opacity: theme.palette.action.hoverOpacity,
+    },
   },
   /* Styles applied to the ButtonBase root element if the action area is keyboard focused. */
   focusVisible: {
-    '& $focusHighlight': {
+    '& $focusHighlight, &:hover $focusHighlight': {
       opacity: 0.12,
     },
   },

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -14,13 +14,12 @@ export const styles = theme => ({
     '&:hover $focusHighlight': {
       opacity: theme.palette.action.hoverOpacity,
     },
-  },
-  /* Styles applied to the ButtonBase root element if the action area is keyboard focused. */
-  focusVisible: {
-    '& $focusHighlight, &:hover $focusHighlight': {
+    '&$focusVisible $focusHighlight': {
       opacity: 0.12,
     },
   },
+  /* Styles applied to the ButtonBase root element if the action area is keyboard focused. */
+  focusVisible: {},
   /* Styles applied to the overlay that covers the action area when it is keyboard focused. */
   focusHighlight: {
     pointerEvents: 'none',
@@ -47,7 +46,7 @@ function CardActionArea(props) {
       {...other}
     >
       {children}
-      <span aria-hidden="true" className={classes.focusHighlight} />
+      <span className={classes.focusHighlight} />
     </ButtonBase>
   );
 }

--- a/packages/material-ui/src/CardActionArea/CardActionArea.test.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.test.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow, getClasses } from '../test-utils';
+import ButtonBase from '../ButtonBase';
+import CardActionArea from './CardActionArea';
+
+describe('<CardActionArea />', () => {
+  let shallow;
+  let classes;
+
+  before(() => {
+    shallow = createShallow({ dive: true });
+    classes = getClasses(<CardActionArea />);
+  });
+
+  it('should render a ButtonBase with custom class', () => {
+    const wrapper = shallow(<CardActionArea className="cardActionArea" />);
+    assert.strictEqual(wrapper.type(), ButtonBase);
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass('cardActionArea'), true);
+  });
+});

--- a/packages/material-ui/src/CardActionArea/index.d.ts
+++ b/packages/material-ui/src/CardActionArea/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './CardActionArea';
+export * from './CardActionArea';

--- a/packages/material-ui/src/CardActionArea/index.js
+++ b/packages/material-ui/src/CardActionArea/index.js
@@ -1,0 +1,1 @@
+export { default } from './CardActionArea';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -97,6 +97,7 @@ export { default as BottomNavigationAction } from './BottomNavigationAction';
 export { default as Button } from './Button';
 export { default as ButtonBase } from './ButtonBase';
 export { default as Card } from './Card';
+export { default as CardActionArea } from './CardActionArea';
 export { default as CardActions } from './CardActions';
 export { default as CardContent } from './CardContent';
 export { default as CardHeader } from './CardHeader';

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -20,6 +20,7 @@ export { default as BottomNavigationAction } from './BottomNavigationAction';
 export { default as Button } from './Button';
 export { default as ButtonBase } from './ButtonBase';
 export { default as Card } from './Card';
+export { default as CardActionArea } from './CardActionArea';
 export { default as CardActions } from './CardActions';
 export { default as CardContent } from './CardContent';
 export { default as CardHeader } from './CardHeader';

--- a/pages/api/card-action-area.js
+++ b/pages/api/card-action-area.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './card-action-area.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default withRoot(Page);

--- a/pages/api/card-action-area.md
+++ b/pages/api/card-action-area.md
@@ -30,7 +30,7 @@ This property accepts the following keys:
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">focusVisible</span> | Styles applied to the ButtonBase root element if the action area is keyboard focused.
-| <span class="prop-name">focusHighlight</span> | Styles applied to the focus highlight that covers the action area when it is keyboard focused.
+| <span class="prop-name">focusHighlight</span> | Styles applied to the overlay that covers the action area when it is keyboard focused.
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/CardActionArea/CardActionArea.js)

--- a/pages/api/card-action-area.md
+++ b/pages/api/card-action-area.md
@@ -1,0 +1,51 @@
+---
+filename: /packages/material-ui/src/CardActionArea/CardActionArea.js
+title: CardActionArea API
+---
+
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# CardActionArea
+
+<p class="description">The API documentation of the CardActionArea React component.</p>
+
+
+
+## Props
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">children</span> | <span class="prop-type">node |   | The content of the component. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+
+## CSS API
+
+You can override all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+
+
+| Name | Description |
+|:-----|:------------|
+| <span class="prop-name">root</span> | Styles applied to the root element.
+| <span class="prop-name">focusVisible</span> | Styles applied to the ButtonBase root element if the action area is keyboard focused.
+| <span class="prop-name">focusHighlight</span> | Styles applied to the focus highlight that covers the action area when it is keyboard focused.
+
+Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/CardActionArea/CardActionArea.js)
+for more detail.
+
+If using the `overrides` key of the theme as documented
+[here](/customization/themes#customizing-all-instances-of-a-component-type),
+you need to use the following style sheet name: `MuiCardActionArea`.
+
+## Inheritance
+
+The properties of the [ButtonBase](/api/button-base) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api#spread).
+
+## Demos
+
+- [Cards](/demos/cards)
+


### PR DESCRIPTION
Sorry if it took so much :)

This PR implements the _CardActionArea_ component, which let the user add an interactive area around Card content (usually _CardContent_ and _CardMedia_).

Fixes #10944