### PR TITLE
[docs] Use public api of jss instead of private vars

### DIFF
--- a/docs/src/modules/styles/getPageContext.js
+++ b/docs/src/modules/styles/getPageContext.js
@@ -37,8 +37,10 @@ const theme = getTheme({
 });
 
 // Configure JSS
-const jss = create({ plugins: [...jssPreset().plugins, rtl()] });
-jss.options.insertionPoint = 'insertion-point-jss';
+const jss = create({
+  insertionPoint: 'insertion-point-jss',
+  plugins: [...jssPreset().plugins, rtl()],
+});
 
 function createPageContext() {
   return {

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -116,9 +116,11 @@ import { create } from 'jss';
 import { createGenerateClassName, jssPreset } from '@material-ui/core/styles';
 
 const generateClassName = createGenerateClassName();
-const jss = create(jssPreset());
-// We define a custom insertion point that JSS will look for injecting the styles in the DOM.
-jss.options.insertionPoint = 'jss-insertion-point';
+const jss = create({
+  ...jssPreset(),
+  // We define a custom insertion point that JSS will look for injecting the styles in the DOM.
+  insertionPoint: 'insertion-point-jss',
+});
 
 function App() {
   return (
@@ -151,9 +153,11 @@ import { create } from 'jss';
 import { createGenerateClassName, jssPreset } from '@material-ui/core/styles';
 
 const generateClassName = createGenerateClassName();
-const jss = create(jssPreset());
-// We define a custom insertion point that JSS will look for injecting the styles in the DOM.
-jss.options.insertionPoint = document.getElementById('jss-insertion-point');
+const jss = create({
+  ...jssPreset(),
+  // We define a custom insertion point that JSS will look for injecting the styles in the DOM.
+  insertionPoint: document.getElementById('jss-insertion-point'),
+});
 
 function App() {
   return (
@@ -180,9 +184,11 @@ const styleNode = document.createComment("jss-insertion-point");
 document.head.insertBefore(styleNode, document.head.firstChild);
 
 const generateClassName = createGenerateClassName();
-const jss = create(jssPreset());
-// We define a custom insertion point that JSS will look for injecting the styles in the DOM.
-jss.options.insertionPoint = 'jss-insertion-point';
+const jss = create({
+  ...jssPreset(),
+  // We define a custom insertion point that JSS will look for injecting the styles in the DOM.
+  insertionPoint: 'jss-insertion-point',
+});
 
 function App() {
   return (


### PR DESCRIPTION
The behavior is perfectly valid at the moment. It was confirmed however (cssinjs/jss#828) that this usage is kind of dangerous at the moment.

This is mainly aimed at typescript users that just copy and paste the code and will get type errors because `options` is not listed in the definitions.
