### PR TITLE
[SvgIcon] Add Icon suffix to SVG icons

### DIFF
--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -9,7 +9,7 @@ function createSvgIcon(path, displayName) {
     </SvgIcon>
   );
 
-  Icon.displayName = displayName;
+  Icon.displayName = `${displayName}Icon`;
   Icon = pure(Icon);
   Icon.muiName = 'SvgIcon';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Adding this suffix helps the DevTools Tree view to identify the icon.

The issue I had was that I had two `Fullscreen` components and when I used the search there was no way to know which one was which one.

But adding this suffix helps to debug and have a cleaner Tree structure in the DevTools.
