### PR TITLE
[docs] Improve Autocomplete filtering suggestions

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
@@ -97,8 +97,7 @@ function getSuggestions(value) {
   return inputLength === 0
     ? []
     : suggestions.filter(suggestion => {
-        const keep =
-          count < 5 && suggestion.label.toLowerCase().slice(0, inputLength) === inputValue;
+        const keep = count < 5 && match(suggestion.label, inputValue).length > 0;
 
         if (keep) {
           count += 1;

--- a/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationAutosuggest.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import deburr from 'lodash/deburr';
 import Autosuggest from 'react-autosuggest';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
@@ -90,14 +91,15 @@ function renderSuggestion(suggestion, { query, isHighlighted }) {
 }
 
 function getSuggestions(value) {
-  const inputValue = value.trim().toLowerCase();
+  const inputValue = deburr(value.trim()).toLowerCase();
   const inputLength = inputValue.length;
   let count = 0;
 
   return inputLength === 0
     ? []
     : suggestions.filter(suggestion => {
-        const keep = count < 5 && match(suggestion.label, inputValue).length > 0;
+        const keep =
+          count < 5 && suggestion.label.slice(0, inputLength).toLowerCase() === inputValue;
 
         if (keep) {
           count += 1;

--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import deburr from 'lodash/deburr';
 import keycode from 'keycode';
 import Downshift from 'downshift';
 import { withStyles } from '@material-ui/core/styles';
@@ -89,20 +90,23 @@ renderSuggestion.propTypes = {
   suggestion: PropTypes.shape({ label: PropTypes.string }).isRequired,
 };
 
-function getSuggestions(inputValue) {
+function getSuggestions(value) {
+  const inputValue = deburr(value.trim()).toLowerCase();
+  const inputLength = inputValue.length;
   let count = 0;
 
-  return suggestions.filter(suggestion => {
-    const keep =
-      (!inputValue || suggestion.label.toLowerCase().indexOf(inputValue.toLowerCase()) !== -1) &&
-      count < 5;
+  return inputLength === 0
+    ? []
+    : suggestions.filter(suggestion => {
+        const keep =
+          count < 5 && suggestion.label.slice(0, inputLength).toLowerCase() === inputValue;
 
-    if (keep) {
-      count += 1;
-    }
+        if (keep) {
+          count += 1;
+        }
 
-    return keep;
-  });
+        return keep;
+      });
 }
 
 class DownshiftMultiple extends React.Component {


### PR DESCRIPTION
Hello guys:

This PR improves autocomplete by leveraging all the power of match:

* It can now filter accents/diacritics characters
* It returns matches everywhere in the text not only from the start.  Ex. If you write "Samo" it will return "American Samoa"
