### PR TITLE
[Input] Extract helpers to their own module

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { isFilled, isAdornedStart } from '../Input/utils';
 import withStyles from '../styles/withStyles';
-import { isFilled, isAdornedStart } from '../Input/Input';
 import { capitalize } from '../utils/helpers';
 import { isMuiElement } from '../utils/reactHelpers';
 

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -3,41 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import Textarea from './Textarea';
-
-// Supports determination of isControlled().
-// Controlled input accepts its current value as a prop.
-//
-// @see https://facebook.github.io/react/docs/forms.html#controlled-components
-// @param value
-// @returns {boolean} true if string (including '') or number (including zero)
-export function hasValue(value) {
-  return value != null && !(Array.isArray(value) && value.length === 0);
-}
-
-// Determine if field is empty or filled.
-// Response determines if label is presented above field or as placeholder.
-//
-// @param obj
-// @param SSR
-// @returns {boolean} False when not present or empty string.
-//                    True when any number or string with length.
-export function isFilled(obj, SSR = false) {
-  return (
-    obj &&
-    ((hasValue(obj.value) && obj.value !== '') ||
-      (SSR && hasValue(obj.defaultValue) && obj.defaultValue !== ''))
-  );
-}
-
-// Determine if an Input is adorned on start.
-// It's corresponding to the left with LTR.
-//
-// @param obj
-// @returns {boolean} False when no adornments.
-//                    True when adorned at the start.
-export function isAdornedStart(obj) {
-  return obj.startAdornment;
-}
+import { isFilled } from './utils';
 
 export const styles = theme => {
   const light = theme.palette.type === 'light';

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -5,7 +5,7 @@ import { spy } from 'sinon';
 import { createShallow, createMount, getClasses, unwrap } from '../test-utils';
 import InputAdornment from '../InputAdornment';
 import Textarea from './Textarea';
-import Input, { hasValue, isFilled } from './Input';
+import Input from './Input';
 
 describe('<Input />', () => {
   let shallow;
@@ -430,41 +430,6 @@ describe('<Input />', () => {
       const handleRef = spy();
       mount(<Input multiline inputRef={handleRef} />);
       assert.strictEqual(handleRef.callCount, 1);
-    });
-  });
-
-  describe('hasValue', () => {
-    ['', 0].forEach(value => {
-      it(`is true for ${value}`, () => {
-        assert.strictEqual(hasValue(value), true);
-      });
-    });
-
-    [null, undefined].forEach(value => {
-      it(`is false for ${value}`, () => {
-        assert.strictEqual(hasValue(value), false);
-      });
-    });
-  });
-
-  describe('isFilled', () => {
-    [' ', 0].forEach(value => {
-      it(`is true for value ${value}`, () => {
-        assert.strictEqual(isFilled({ value }), true);
-      });
-
-      it(`is true for SSR defaultValue ${value}`, () => {
-        assert.strictEqual(isFilled({ defaultValue: value }, true), true);
-      });
-    });
-    [null, undefined, ''].forEach(value => {
-      it(`is false for value ${value}`, () => {
-        assert.strictEqual(isFilled({ value }), false);
-      });
-
-      it(`is false for SSR defaultValue ${value}`, () => {
-        assert.strictEqual(isFilled({ defaultValue: value }, true), false);
-      });
     });
   });
 

--- a/packages/material-ui/src/Input/utils.js
+++ b/packages/material-ui/src/Input/utils.js
@@ -1,0 +1,34 @@
+// Supports determination of isControlled().
+// Controlled input accepts its current value as a prop.
+//
+// @see https://facebook.github.io/react/docs/forms.html#controlled-components
+// @param value
+// @returns {boolean} true if string (including '') or number (including zero)
+export function hasValue(value) {
+  return value != null && !(Array.isArray(value) && value.length === 0);
+}
+
+// Determine if field is empty or filled.
+// Response determines if label is presented above field or as placeholder.
+//
+// @param obj
+// @param SSR
+// @returns {boolean} False when not present or empty string.
+//                    True when any number or string with length.
+export function isFilled(obj, SSR = false) {
+  return (
+    obj &&
+    ((hasValue(obj.value) && obj.value !== '') ||
+      (SSR && hasValue(obj.defaultValue) && obj.defaultValue !== ''))
+  );
+}
+
+// Determine if an Input is adorned on start.
+// It's corresponding to the left with LTR.
+//
+// @param obj
+// @returns {boolean} False when no adornments.
+//                    True when adorned at the start.
+export function isAdornedStart(obj) {
+  return obj.startAdornment;
+}

--- a/packages/material-ui/src/Input/utils.test.js
+++ b/packages/material-ui/src/Input/utils.test.js
@@ -1,0 +1,39 @@
+import { assert } from 'chai';
+import { hasValue, isFilled } from './utils';
+
+describe('Input/utils.js', () => {
+  describe('hasValue', () => {
+    ['', 0].forEach(value => {
+      it(`is true for ${value}`, () => {
+        assert.strictEqual(hasValue(value), true);
+      });
+    });
+
+    [null, undefined].forEach(value => {
+      it(`is false for ${value}`, () => {
+        assert.strictEqual(hasValue(value), false);
+      });
+    });
+  });
+
+  describe('isFilled', () => {
+    [' ', 0].forEach(value => {
+      it(`is true for value ${value}`, () => {
+        assert.strictEqual(isFilled({ value }), true);
+      });
+
+      it(`is true for SSR defaultValue ${value}`, () => {
+        assert.strictEqual(isFilled({ defaultValue: value }, true), true);
+      });
+    });
+    [null, undefined, ''].forEach(value => {
+      it(`is false for value ${value}`, () => {
+        assert.strictEqual(isFilled({ value }), false);
+      });
+
+      it(`is false for SSR defaultValue ${value}`, () => {
+        assert.strictEqual(isFilled({ defaultValue: value }, true), false);
+      });
+    });
+  });
+});

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import keycode from 'keycode';
 import warning from 'warning';
 import Menu from '../Menu/Menu';
-import { isFilled } from '../Input/Input';
+import { isFilled } from '../Input/utils';
 
 /**
  * @ignore - internal component.


### PR DESCRIPTION
This allows importing FormControl without pulling in the complete Input and Textarea modules

Fixes #12656


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->