### PR TITLE
[icons] Save 22 MegaBytes from the package

### DIFF
--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -30,10 +30,9 @@
     "prebuild": "rimraf material-design-icons && rimraf build",
     "build:es2015": "cross-env NODE_ENV=production babel --config-file ../../babel.config.js ./src --out-dir ./build",
     "build:es2015modules": "cross-env NODE_ENV=production BABEL_ENV=modules babel --config-file ../../babel.config.js ./src/index.js --out-file ./build/index.es.js",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es",
     "build:copy-files": "babel-node --config-file ../../babel.config.js ./scripts/copy-files.js",
     "build:typings": "babel-node --config-file ../../babel.config.js ./scripts/create-typings.js",
-    "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:es && yarn build:typings && yarn build:copy-files",
+    "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:typings && yarn build:copy-files",
     "release": "yarn build && npm publish build"
   },
   "peerDependencies": {


### PR DESCRIPTION
Cut the package size by half. You make the npm installation twice as fast.

Closes #12432