### PR TITLE
[docs] Correct `by and enum` typo in api.md

### DIFF
--- a/docs/src/pages/guides/api/api.md
+++ b/docs/src/pages/guides/api/api.md
@@ -49,7 +49,7 @@ to make the classes structure as simple as possible, while sufficient to impleme
 - The classes applied to non-root elements are prefixed with the name of the element, e.g. `paperWidthXs` in the Dialog component.
 - The variants applied by a boolean property **aren't** prefixed, e.g. the `rounded` class
 applied by the `rounded` property.
-- The variants applied by and enum property **are** prefixed, e.g. the `colorPrimary` class
+- The variants applied by an enum property **are** prefixed, e.g. the `colorPrimary` class
 applied by the `color="primary"` property.
 - A variant has **one level of specificity**.
 The `color` and `variant` properties are considered a variant.


### PR DESCRIPTION
`by and enum` should be `by an enum`

(The rest of the file looks good 😉)