### PR TITLE
[docs] Autocomplete react-select dropdown overlay

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
@@ -89,10 +89,11 @@ const styles = theme => ({
     fontSize: 16,
   },
   paper: {
-    marginTop: theme.spacing.unit,
     position: 'absolute',
     zIndex: 1,
-    width: '100%',
+    marginTop: theme.spacing.unit,
+    left: 0,
+    right: 0,
   },
   divider: {
     height: theme.spacing.unit * 2,

--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
@@ -90,9 +90,9 @@ const styles = theme => ({
   },
   paper: {
     marginTop: theme.spacing.unit,
-    position:'absolute',
+    position: 'absolute',
     zIndex: 1,
-    width: '100%'
+    width: '100%',
   },
   divider: {
     height: theme.spacing.unit * 2,

--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
@@ -90,6 +90,9 @@ const styles = theme => ({
   },
   paper: {
     marginTop: theme.spacing.unit,
+    position:'absolute',
+    zIndex: 1,
+    width: '100%'
   },
   divider: {
     height: theme.spacing.unit * 2,


### PR DESCRIPTION
In autocomplete demo, when the dropdown appears, it pushes the content below it further down.
In this PR, css was changed to make the dropdown overlay the content below.

<a href="https://material-ui.com/demos/autocomplete/#react-select" target="_blank">https://material-ui.com/demos/autocomplete/#react-select</a>
<img width="519" alt="screen shot 2018-08-26 at 09 35 05" src="https://user-images.githubusercontent.com/11447903/44625479-95f2f300-a913-11e8-87e6-f9111add5675.png">
