### PR TITLE
[core] Drop Firefox 45 support

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,5 @@
 ie 11
 edge > 14
-firefox > 45
+firefox > 52
 chrome > 49
 safari > 10

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,7 @@ if (process.env.BABEL_ENV === 'es') {
         targets: {
           ie: 11,
           edge: 14,
-          firefox: 45,
+          firefox: 52,
           chrome: 49,
           safari: 10,
           node: '6.11',

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -10,7 +10,7 @@ You don't need to provide any JavaScript polyfill as we manage unsupported brows
 
 | IE    | Edge   | Firefox | Chrome | Safari |
 |:------|:-------|:--------|:-------|:-------|
-| 11    | >= 14  | >= 45   | >= 49  | >= 10  |
+| 11    | >= 14  | >= 52   | >= 49  | >= 10  |
 
 ## Server
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -102,7 +102,7 @@ module.exports = function setKarmaConfig(config) {
           os: 'Windows',
           os_version: '10',
           browser: 'Firefox',
-          browser_version: '45.0',
+          browser_version: '52.0',
         },
         BrowserStack_Safari: {
           base: 'BrowserStack',


### PR DESCRIPTION
Firefore 52 is the last version supported by Windows XP. The market share of Firefox 45 is 0.03%.

Closes #12559