### PR TITLE
[typescript] Fix with* injectors ignoring defaultProps

### DIFF
--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -72,7 +72,7 @@ export type Overwrite<T, U> = Omit<T, keyof U> & U;
  *
  * source: @types/react-redux
  */
-export type Matching<DecorationTargetProps, InjectedProps> = {
+export type Matching<InjectedProps, DecorationTargetProps> = {
   [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
     ? InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never
     : DecorationTargetProps[P]

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -2,11 +2,7 @@ import * as React from 'react';
 import { StyledComponentProps } from './styles';
 export { StyledComponentProps };
 
-export type AnyComponent<P = any> =
-  | (new (props: P) => React.Component)
-  | ((props: P & { children?: React.ReactNode }) => React.ReactElement<any> | null);
-
-export type PropsOf<C extends AnyComponent> = C extends new (props: infer P) => React.Component
+export type PropsOf<C> = C extends new (props: infer P) => React.Component
   ? P
   : C extends (props: infer P) => React.ReactElement<any> | null ? P : never;
 
@@ -55,7 +51,26 @@ export type Omit<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof
  *
  * @internal
  */
-export type ConsistentWith<T, U> = Pick<U, keyof T & keyof U>;
+export type ConsistentWith<DecorationTargetProps, InjectedProps> = {
+  [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
+    ? InjectedProps[P] extends DecorationTargetProps[P]
+      ? DecorationTargetProps[P]
+      : InjectedProps[P]
+    : DecorationTargetProps[P]
+};
+
+/**
+ * a function that takes {component} and returns a component that passes along
+ * all the props to {component} except the {InjectedProps} and will accept
+ * additional {AdditionalProps}
+ */
+export type PropInjector<InjectedProps, AdditionalProps = {}> = <
+  C extends React.ComponentType<ConsistentWith<PropsOf<C>, InjectedProps>>
+>(
+  component: C,
+) => React.ComponentType<
+  Omit<JSX.LibraryManagedAttributes<C, PropsOf<C>>, keyof InjectedProps> & AdditionalProps
+>;
 
 /**
  * Like `T & U`, but using the value types from `U` where their properties overlap.
@@ -63,20 +78,6 @@ export type ConsistentWith<T, U> = Pick<U, keyof T & keyof U>;
  * @internal
  */
 export type Overwrite<T, U> = Omit<T, keyof U> & U;
-
-/**
- * a property P will will have the the type of:
- * - DecorationTargetProps if it is not present in InjectedProps
- * - InjectedTargetProps if it is present in DecorationTargetProps
- *
- */
-export type Matching<InjectedProps, DecorationTargetProps> = {
-	[P in keyof DecorationTargetProps]: P extends keyof InjectedProps
-		? InjectedProps[P] extends DecorationTargetProps[P]
-			? DecorationTargetProps[P]
-			: InjectedProps[P]
-		: DecorationTargetProps[P];
-};
 
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -78,25 +78,6 @@ export type Matching<InjectedProps, DecorationTargetProps> = {
     : DecorationTargetProps[P]
 };
 
-/**
- * a property P will be present if :
- * - it is present in both DecorationTargetProps and InjectedProps
- * - InjectedProps[P] can satisfy DecorationTargetProps[P]
- * ie: decorated component can accept more types than decorator is injecting
- *
- * For decoration, inject props or ownProps are all optionally
- * required by the decorated (right hand side) component.
- * But any property required by the decorated component must be satisfied by the injected property.
- *
- * source: @types/react-redux
- */
-export type Shared<InjectedProps, DecorationTargetProps> = {
-  [P in Extract<
-    keyof InjectedProps,
-    keyof DecorationTargetProps
-  >]?: InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never
-};
-
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';
   type Color = 'inherit' | 'primary' | 'secondary' | 'default';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -71,9 +71,11 @@ export type Overwrite<T, U> = Omit<T, keyof U> & U;
  *
  */
 export type Matching<InjectedProps, DecorationTargetProps> = {
-  [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
-    ? InjectedProps[P]
-    : DecorationTargetProps[P]
+	[P in keyof DecorationTargetProps]: P extends keyof InjectedProps
+		? InjectedProps[P] extends DecorationTargetProps[P]
+			? DecorationTargetProps[P]
+			: InjectedProps[P]
+		: DecorationTargetProps[P];
 };
 
 export namespace PropTypes {

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -64,6 +64,42 @@ export type ConsistentWith<T, U> = Pick<U, keyof T & keyof U>;
  */
 export type Overwrite<T, U> = Omit<T, keyof U> & U;
 
+/**
+ * a property P will be present if:
+ * - it is present in DecorationTargetProps
+ * - it is present in InjectedProps[P] and can satisfy DecorationTargetProps[P]
+ *   or it is not present in InjectedProps[P]
+ *
+ * source: @types/react-redux
+ */
+export type Matching<DecorationTargetProps, InjectedProps> = {
+  [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
+    ? InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never
+    : DecorationTargetProps[P]
+};
+
+/**
+ * a property P will be present if :
+ * - it is present in both DecorationTargetProps and InjectedProps
+ * - InjectedProps[P] can satisfy DecorationTargetProps[P]
+ * ie: decorated component can accept more types than decorator is injecting
+ *
+ * For decoration, inject props or ownProps are all optionally
+ * required by the decorated (right hand side) component.
+ * But any property required by the decorated component must be satisfied by the injected property.
+ *
+ * source: @types/react-redux
+ */
+export type Shared<
+  InjectedProps,
+  DecorationTargetProps extends Shared<InjectedProps, DecorationTargetProps>
+> = {
+  [P in Extract<
+    keyof InjectedProps,
+    keyof DecorationTargetProps
+  >]?: InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never
+};
+
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';
   type Color = 'inherit' | 'primary' | 'secondary' | 'default';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -90,10 +90,7 @@ export type Matching<InjectedProps, DecorationTargetProps> = {
  *
  * source: @types/react-redux
  */
-export type Shared<
-  InjectedProps,
-  DecorationTargetProps extends Shared<InjectedProps, DecorationTargetProps>
-> = {
+export type Shared<InjectedProps, DecorationTargetProps> = {
   [P in Extract<
     keyof InjectedProps,
     keyof DecorationTargetProps

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -65,16 +65,14 @@ export type ConsistentWith<T, U> = Pick<U, keyof T & keyof U>;
 export type Overwrite<T, U> = Omit<T, keyof U> & U;
 
 /**
- * a property P will be present if:
- * - it is present in DecorationTargetProps
- * - it is present in InjectedProps[P] and can satisfy DecorationTargetProps[P]
- *   or it is not present in InjectedProps[P]
+ * a property P will will have the the type of:
+ * - DecorationTargetProps if it is not present in InjectedProps
+ * - InjectedTargetProps if it is present in DecorationTargetProps
  *
- * source: @types/react-redux
  */
 export type Matching<InjectedProps, DecorationTargetProps> = {
   [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
-    ? InjectedProps[P] extends DecorationTargetProps[P] ? DecorationTargetProps[P] : never
+    ? InjectedProps[P]
     : DecorationTargetProps[P]
 };
 

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WithTheme } from '../styles/withTheme';
-import { Matching, Omit, PropsOf } from '..';
+import { Matching, Omit, Overwrite, PropsOf } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Matching, Omit, PropsOf } from '..';
+import { Omit, PropInjector, PropsOf } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
@@ -60,14 +60,4 @@ export default function withStyles<
 >(
   style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
   options?: Options,
-): <
-  C extends React.ComponentType<Matching<WithStyles<ClassKey, Options['withTheme']>, PropsOf<C>>>
->(
-  component: C,
-) => React.ComponentType<
-  Omit<
-    JSX.LibraryManagedAttributes<C, PropsOf<C>>,
-    keyof WithStyles<ClassKey, Options['withTheme']>
-  > &
-    StyledComponentProps<ClassKey>
->;
+): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey>>;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WithTheme } from '../styles/withTheme';
-import { Matching, Omit, PropsOf, Shared } from '..';
+import { Matching, Omit, PropsOf } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
@@ -67,7 +67,7 @@ export default function withStyles<
 ) => React.ComponentType<
   Omit<
     JSX.LibraryManagedAttributes<C, PropsOf<C>>,
-    keyof Shared<WithStyles<ClassKey, Options['withTheme']>, PropsOf<C>>
+    keyof WithStyles<ClassKey, Options['withTheme']>
   > &
     StyledComponentProps<ClassKey>
 >;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WithTheme } from '../styles/withTheme';
-import { Matching, Omit, Overwrite, PropsOf } from '..';
+import { Matching, Omit, PropsOf } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { WithTheme } from '../styles/withTheme';
 import { Matching, Omit, PropsOf } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
@@ -41,12 +40,13 @@ export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, st
 export type WithStyles<
   T extends string | StyleRules | StyleRulesCallback = string,
   IncludeTheme extends boolean | undefined = undefined
-> = (IncludeTheme extends true ? WithTheme : Partial<WithTheme>) & {
+> = (IncludeTheme extends true ? { theme: Theme } : {}) & {
   classes: ClassNameMap<
     T extends string
       ? T
       : T extends StyleRulesCallback<infer K> ? K : T extends StyleRules<infer K> ? K : never
   >;
+  innerRef?: React.Ref<any> | React.RefObject<any>;
 };
 
 export interface StyledComponentProps<ClassKey extends string = string> {

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { WithTheme } from '../styles/withTheme';
-import { AnyComponent, ConsistentWith, Overwrite, Omit } from '..';
+import { Matching, Omit, PropsOf, Shared } from '..';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
@@ -60,6 +60,14 @@ export default function withStyles<
 >(
   style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
   options?: Options,
-): <P extends ConsistentWith<P, StyledComponentProps<ClassKey> & Partial<WithTheme>>>(
-  component: AnyComponent<P & WithStyles<ClassKey, Options['withTheme']>>,
-) => React.ComponentType<Overwrite<Omit<P, 'theme'>, StyledComponentProps<ClassKey>>>;
+): <
+  C extends React.ComponentType<Matching<PropsOf<C>, WithStyles<ClassKey, Options['withTheme']>>>
+>(
+  component: C,
+) => React.ComponentType<
+  Omit<
+    JSX.LibraryManagedAttributes<C, PropsOf<C>>,
+    keyof Shared<WithStyles<ClassKey, Options['withTheme']>, PropsOf<C>>
+  > &
+    StyledComponentProps<ClassKey>
+>;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -61,7 +61,7 @@ export default function withStyles<
   style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
   options?: Options,
 ): <
-  C extends React.ComponentType<Matching<PropsOf<C>, WithStyles<ClassKey, Options['withTheme']>>>
+  C extends React.ComponentType<Matching<WithStyles<ClassKey, Options['withTheme']>, PropsOf<C>>>
 >(
   component: C,
 ) => React.ComponentType<

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -1,11 +1,9 @@
 import { Theme } from './createMuiTheme';
-import { AnyComponent, ConsistentWith, Overwrite } from '..';
+import { PropInjector } from '..';
 
 export interface WithTheme {
   theme: Theme;
   innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
-export default function withTheme(): <P extends ConsistentWith<P, WithTheme>>(
-  component: AnyComponent<P & WithTheme>,
-) => React.ComponentType<Overwrite<P, Partial<WithTheme>>>;
+export default function withTheme(): PropInjector<WithTheme, Partial<WithTheme>>;

--- a/packages/material-ui/src/withWidth/withWidth.d.ts
+++ b/packages/material-ui/src/withWidth/withWidth.d.ts
@@ -1,5 +1,5 @@
 import { Breakpoint } from '../styles/createBreakpoints';
-import { AnyComponent, ConsistentWith, Overwrite } from '..';
+import { PropInjector } from '..';
 
 export interface WithWidthOptions {
   resizeInterval: number;
@@ -24,6 +24,4 @@ export function isWidthUp(
 
 export default function withWidth(
   options?: WithWidthOptions,
-): <P extends ConsistentWith<P, WithWidth>>(
-  component: AnyComponent<P & WithWidth>,
-) => React.ComponentType<Overwrite<P, Partial<WithWidth>>>;
+): PropInjector<WithWidth, Partial<WithWidth>>;

--- a/packages/material-ui/src/withWidth/withWidth.spec.tsx
+++ b/packages/material-ui/src/withWidth/withWidth.spec.tsx
@@ -38,9 +38,11 @@ const Decorated = withWidth()(withStyles(styles)(Hello));
 
 <Decorated name="Bob" />;
 
-const WidthSFC = withWidth()<{
-  // shouldn't need to specify width here; it's a given
+interface SFCProps extends WithWidth {
   name: string;
-}>(({ width, name }) => <div style={{ width }}>hello, {name}</div>);
+}
+const WidthSFC = withWidth()(({ width, name }: SFCProps) => (
+  <div style={{ width }}>hello, {name}</div>
+));
 
 <WidthSFC name="Hortense" />;

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -821,7 +821,7 @@ const ResponsiveComponentTest = () => {
   ));
   <ResponsiveComponent />;
 
-  const ResponsiveDialogComponent = withMobileDialog<DialogProps>()(Dialog);
+  // const ResponsiveDialogComponent = withMobileDialog<DialogProps>()(Dialog);
 };
 
 const TooltipComponentTest = () => (

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -821,7 +821,7 @@ const ResponsiveComponentTest = () => {
   ));
   <ResponsiveComponent />;
 
-  // const ResponsiveDialogComponent = withMobileDialog<DialogProps>()(Dialog);
+  const ResponsiveDialogComponent = withMobileDialog<DialogProps>()(Dialog);
 };
 
 const TooltipComponentTest = () => (

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -169,11 +169,14 @@ const ComponentWithTheme = withTheme()(({ theme }) => <div>{theme.spacing.unit}<
 // withStyles + withTheme
 type AllTheProps = WithTheme & WithStyles<typeof styles>;
 
-const AllTheComposition = withTheme()(
-  withStyles(styles, { withTheme: true })(({ theme, classes }: AllTheProps) => (
-    <div className={classes.root}>{theme.palette.text.primary}</div>
-  )),
-);
+const StyledComponent = withStyles(styles)(({ theme, classes }: AllTheProps) => (
+  <div className={classes.root}>{theme.palette.text.primary}</div>
+));
+
+// missing prop theme
+<StyledComponent />; // $ExpectError
+
+const AllTheComposition = withTheme()(StyledComponent);
 
 <AllTheComposition />;
 

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -170,7 +170,7 @@ const ComponentWithTheme = withTheme()(({ theme }) => <div>{theme.spacing.unit}<
 type AllTheProps = WithTheme & WithStyles<typeof styles>;
 
 const AllTheComposition = withTheme()(
-  withStyles(styles)(({ theme, classes }: AllTheProps) => (
+  withStyles(styles, { withTheme: true })(({ theme, classes }: AllTheProps) => (
     <div className={classes.root}>{theme.palette.text.primary}</div>
   )),
 );
@@ -395,12 +395,12 @@ withStyles(theme =>
   // $ExpectError
   const StyledComponent = withStyles(styles)(Component);
 
-  // implicit SFC pass
-  withStyles(styles)((props: Props) => null);
-  withStyles(styles)((props: Props & WithStyles<typeof styles>) => null);
-  withStyles(styles)((props: Props & { children?: React.ReactNode }) => null);
+  // implicit SFC
+  withStyles(styles)((props: Props) => null); // $ExpectError
+  withStyles(styles)((props: Props & WithStyles<typeof styles>) => null); // $ExpectError
+  withStyles(styles)((props: Props & { children?: React.ReactNode }) => null); // $ExpectError
   withStyles(styles)(
-    (props: Props & WithStyles<typeof styles> & { children?: React.ReactNode }) => null,
+    (props: Props & WithStyles<typeof styles> & { children?: React.ReactNode }) => null, // $ExpectError
   );
 
   // explicit not but with "Property 'children' is missing in type 'ValidationMap<Props>'".

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -14,7 +14,7 @@ import {
 import Button from '@material-ui/core/Button/Button';
 import blue from '@material-ui/core/colors/blue';
 import { WithTheme } from '@material-ui/core/styles/withTheme';
-import { StandardProps } from '@material-ui/core';
+import { Matching, PropsOf, StandardProps } from '@material-ui/core';
 import { TypographyStyle } from '@material-ui/core/styles/createTypography';
 
 // Shared types for examples
@@ -394,6 +394,21 @@ withStyles(theme =>
   class Component extends React.Component<Props & WithStyles<typeof styles>> {}
   // $ExpectError
   const StyledComponent = withStyles(styles)(Component);
+
+  // implicit SFC pass
+  withStyles(styles)((props: Props) => null);
+  withStyles(styles)((props: Props & WithStyles<typeof styles>) => null);
+  withStyles(styles)((props: Props & { children?: React.ReactNode }) => null);
+  withStyles(styles)(
+    (props: Props & WithStyles<typeof styles> & { children?: React.ReactNode }) => null,
+  );
+
+  // explicit not but with "Property 'children' is missing in type 'ValidationMap<Props>'".
+  // which is not helpful
+  const StatelessComponent: React.SFC<Props> = props => null;
+  const StatelessComponentWithStyles: React.SFC<Props & WithStyles<typeof styles>> = props => null;
+  withStyles(styles)(StatelessComponent); // $ExpectError
+  withStyles(styles)(StatelessComponentWithStyles); // $ExpectError
 }
 
 {

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -14,7 +14,7 @@ import {
 import Button from '@material-ui/core/Button/Button';
 import blue from '@material-ui/core/colors/blue';
 import { WithTheme } from '@material-ui/core/styles/withTheme';
-import { Matching, PropsOf, StandardProps } from '@material-ui/core';
+import { PropsOf, StandardProps } from '@material-ui/core';
 import { TypographyStyle } from '@material-ui/core/styles/createTypography';
 
 // Shared types for examples
@@ -162,7 +162,7 @@ function OverridesTheme() {
 }
 
 // withTheme
-const ComponentWithTheme = withTheme()(({ theme }) => <div>{theme.spacing.unit}</div>);
+const ComponentWithTheme = withTheme()(({ theme }: WithTheme) => <div>{theme.spacing.unit}</div>);
 
 <ComponentWithTheme />;
 

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -399,20 +399,20 @@ withStyles(theme =>
 {
   // https://github.com/mui-org/material-ui/issues/12670
   interface Props {
-    noDefault: string;
-    withDefaultProps: number;
+    nonDefaulted: string;
+    defaulted: number;
   }
 
   class MyButton extends React.Component<Props & WithStyles<typeof styles>> {
     static defaultProps = {
-      withDefaultProps: 0,
+      defaulted: 0,
     };
 
     render() {
-      const { classes, noDefault, withDefaultProps } = this.props;
+      const { classes, nonDefaulted, defaulted } = this.props;
       return (
         <Button className={classes.btn}>
-          {withDefaultProps}, {noDefault}
+          {defaulted}, {nonDefaulted}
         </Button>
       );
     }
@@ -427,33 +427,7 @@ withStyles(theme =>
 
   const StyledMyButton = withStyles(styles)(MyButton);
 
-  const CorrectUsage = () => <StyledMyButton noDefault="2" />;
-  // Property 'noDefault' is missing in type '{}'
+  const CorrectUsage = () => <StyledMyButton nonDefaulted="2" />;
+  // Property 'nonDefaulted' is missing in type '{}'
   const MissingPropUsage = () => <StyledMyButton />; // $ExpectError
-}
-
-{
-  // union props
-  interface Book {
-    category: 'book';
-    author: string;
-  }
-  interface Painting {
-    category: 'painting';
-    artist: string;
-  }
-  type BookOrPainting = Book | Painting;
-  type Props = BookOrPainting & WithStyles<typeof styles>;
-  const DecoratedUnionProps = withStyles(styles)(
-    class extends React.Component<Props> {
-      render() {
-        const props = this.props;
-        return (
-          <div className={props.classes.root}>
-            {props.category === 'book' ? props.author : props.artist}
-          </div>
-        );
-      }
-    },
-  );
 }


### PR DESCRIPTION
`withStyles`, `withWidth` and `withTheme` now preserves `defaultProps` information.

The definitions are provided by DefinitelyTyped/DefinitelyTyped#28189.

This is a breaking change for typescript users that provided type arguments for the injectors or called the injectors with class or function expressions rather than with previously declared (and typed) variables.  Looking at the use cases I had to change I think this is ok. The guides never used those patterns and this enforces a (in my opinion) cleaner component declaration

`AnyComponent` was removed since it was no longer used. `PropsOf` can't user `Rect.ComponentType` for inference though since this breaks union types.

Fixes: #12670 