### PR TITLE
[docs] Update notification link for release 3.0.0

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -1,6 +1,6 @@
 [
   {
     "id": 17,
-    "text": "Material-UI v3.0.0 is out 🎉. Please see <a style=\"color: white;\" target=\"_blank\" href=\"https://github.com/mui-org/material-ui/releases/tag/v1.4.2\">the release notes</a> for breaking changes."
+    "text": "Material-UI v3.0.0 is out 🎉. Please see <a style=\"color: white;\" target=\"_blank\" href=\"https://github.com/mui-org/material-ui/releases/tag/v3.0.0\">the release notes</a> for breaking changes."
   }
 ]


### PR DESCRIPTION
Notification version and id are correct but release tag version in the notification link is incorrect.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
