### PR TITLE
[docs] Correct the React Select example for release 3.0.0

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
@@ -122,9 +122,9 @@ function Control(props) {
       fullWidth
       InputProps={{
         inputComponent,
+        inputRef: props.innerRef,
         inputProps: {
           className: props.selectProps.classes.input,
-          inputRef: props.innerRef,
           children: props.children,
           ...props.innerProps,
         },


### PR DESCRIPTION
The following error occurs when migrate from 1.5.1 to 3.0.0 as the type of `inputProps` has changed since PR #12591.

```
Type '{ inputComponent: ({ inputRef, ...props }: any) => Element; inputProps: { onMouseDown: (event: MouseEvent<HTMLElement>) => void; className: string; inputRef: Ref<any>; children: ReactNode; }; }' is not assignable to type 'Partial<InputProps>'.
  Types of property 'inputProps' are incompatible.
    Type '{ onMouseDown: (event: MouseEvent<HTMLElement>) => void; className: string; inputRef: Ref<any>; children: ReactNode; }' is not assignable to type 'InputHTMLAttributes<HTMLInputElement>'.
      Object literal may only specify known properties, and 'inputRef' does not exist in type 'InputHTMLAttributes<HTMLInputElement>'.
```