### PR TITLE
[docs] Warn about using withRoot HOC more than one time per page

### DIFF
--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -22,6 +22,6 @@ npm run develop
 
 ## `withRoot` usage
 
-We are using the `withRoot` higher-order component to accommodate the styling solution of Material-UI with Gatsby.
+We are using the `withRoot` higher-order component to accommodate Material-UI's styling solution with Gatsby.
 
-⚠️ You should be using a single `withRoot` for rendering one page.
+⚠️ You should only use a single `withRoot` for rendering one page.

--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -16,6 +16,12 @@ npm install
 npm run develop
 ```
 
+## Providing the theme
+
+To propagate the theme to a component tree use the `src/withRoot.js` HOC.
+You should wrap **only** your top-level components with this HOC otherwise you risk re-rendering your React tree multiple times and styling issues during the build phase.
+
+
 ## The idea behind the example
 
 [Gatsby](https://github.com/gatsbyjs/gatsby) is a static site generator for React.

--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -16,12 +16,12 @@ npm install
 npm run develop
 ```
 
-## Providing the theme
-
-To propagate the theme to a component tree use the `src/withRoot.js` HOC.
-You should wrap **only** your top-level components with this HOC otherwise you risk re-rendering your React tree multiple times and styling issues during the build phase.
-
-
 ## The idea behind the example
 
 [Gatsby](https://github.com/gatsbyjs/gatsby) is a static site generator for React.
+
+## `withRoot` usage
+
+We are using the `withRoot` higher-order component to accommodate the styling solution of Material-UI with Gatsby.
+
+⚠️ You should be using a single `withRoot` for rendering one page.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Based on discussions here #12649 and https://github.com/gatsbyjs/gatsby/issues/2116 i think the gatsby example deserves a small warning on the usage of the withRoot HOC