### PR TITLE
[typescript] Set default for withStyles' Options generic

### DIFF
--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -56,7 +56,7 @@ export interface StyledComponentProps<ClassKey extends string = string> {
 
 export default function withStyles<
   ClassKey extends string,
-  Options extends WithStylesOptions<ClassKey>
+  Options extends WithStylesOptions<ClassKey> = {}
 >(
   style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
   options?: Options,


### PR DESCRIPTION
Right now, the TypeScript defintions for `withStyles` use 2 required generics. The 2nd generic corresponds to the type of the `options` parameter. Based on the source for `withStyles`, the `options` parameter defaults to `{}`:
https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/styles/withStyles.js#L55

As a result, I think we should make the 2nd generic argument optional by assigning it a default type.
