### PR TITLE
[examples] Fix withRoot accepting any props

### DIFF
--- a/examples/create-react-app-with-typescript/src/withRoot.tsx
+++ b/examples/create-react-app-with-typescript/src/withRoot.tsx
@@ -13,7 +13,7 @@ const theme = createMuiTheme({
   },
 });
 
-function withRoot(Component: React.ComponentType<P>) {
+function withRoot<P>(Component: React.ComponentType<P>) {
   function WithRoot(props: P) {
     // MuiThemeProvider makes the theme available down the React tree
     // thanks to React context.


### PR DESCRIPTION
As a followup to #12712 this includes actual props which revealed that the previous work was incomplete. The generic argument was not defined. The sandbox just emits javascript anyway although typescript displays errors.

I also went ahead and switch from `type` to `interface` for `State` which is a recommended tslint rule.
