### PR TITLE
[docs] Fix class name in overrides example

### DIFF
--- a/docs/src/pages/customization/overrides/ClassNames.js
+++ b/docs/src/pages/customization/overrides/ClassNames.js
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 
 // We can inject some CSS into the DOM.
 const styles = {
-  button: {
+  root: {
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
     borderRadius: 3,
     border: 0,
@@ -18,7 +18,7 @@ const styles = {
 
 function ClassNames(props) {
   return (
-    <Button className={props.classes.button}>
+    <Button className={props.classes.root}>
       {props.children ? props.children : 'class names'}
     </Button>
   );


### PR DESCRIPTION
According to its API documentation, a key `button` does not exist on the
styles object of Button. Changing to `root` instead.

Avoids
> "Warning: Material-UI: the key `button` provided to the classes property is not implemented in Button."