### PR TITLE
[Input] Fix Input passing inputRef to intrinsic elements

### DIFF
--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -421,14 +421,13 @@ class Input extends React.Component {
       inputPropsClassName,
     );
 
-    let InputComponent = 'input';
+    let InputComponent = inputComponent;
     let inputProps = {
       ...inputPropsProp,
       ref: this.handleRefInput,
     };
 
-    if (inputComponent) {
-      InputComponent = inputComponent;
+    if (typeof InputComponent !== 'string') {
       inputProps = {
         // Rename ref to inputRef as we don't know the
         // provided `inputComponent` structure.
@@ -633,6 +632,7 @@ Input.muiName = 'Input';
 Input.defaultProps = {
   disableUnderline: false,
   fullWidth: false,
+  inputComponent: 'input',
   multiline: false,
   type: 'text',
 };

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -182,7 +182,7 @@ describe('<Input />', () => {
 
   describe('prop: inputComponent', () => {
     it('should accept any html component', () => {
-      const wrapper = shallow(<Input inputComponent="span" />);
+      const wrapper = mount(<Input inputComponent="span" />);
       assert.strictEqual(wrapper.find('span').length, 1);
     });
 

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -26,7 +26,7 @@ title: Input API
 | <span class="prop-name">error</span> | <span class="prop-type">bool |   | If `true`, the input will indicate an error. This is normally obtained via context from FormControl. |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the input will take up the full width of its container. |
 | <span class="prop-name">id</span> | <span class="prop-type">string |   | The id of the `input` element. |
-| <span class="prop-name">inputComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | The component used for the native input. Either a string to use a DOM element or a component. |
+| <span class="prop-name">inputComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> | <span class="prop-default">'input'</span> | The component used for the native input. Either a string to use a DOM element or a component. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |   | Attributes applied to the `input` element. |
 | <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |
 | <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'&nbsp;&#124;<br>&nbsp;'none'<br> |   | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |


### PR DESCRIPTION
`Input` accepts for `inputComponent` strings that represent native DOM elements. This currently causes the implementation to pass an `inputRef` prop the the native element which triggers react warnings. 
```
Error: Uncaught [Error: Warning: React does not recognize the `inputComponent` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `inputcomponent` instead. If you accidentally passed it from a parent component, removeit from the DOM element.
```

Although completely harmless we should try to avoid those because it might encourage users to ignore other warnings that might do harm.

On the plus side, this improves documentation.


Related to #12691 or rather [this comment](https://github.com/mui-org/material-ui/pull/12691#issuecomment-416693894).