### PR TITLE
[docs] Generate import examples in API docs

### DIFF
--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -330,6 +330,21 @@ ${pagesMarkdown.map(page => `- [${pageToTitle(page)}](${page.pathname})`).join('
 `;
 }
 
+function generateImportStatement(reactAPI) {
+  const source = reactAPI.filename
+    .replace(
+      /\/packages\/material-ui(-(.+?))?\/src/,
+      (match, dash, pkg) => `@material-ui/${pkg || 'core'}`,
+    )
+    // convert things like `Table/Table.js` to `Table`
+    .replace(/([^/]+)\/\1\.js$/, '$1')
+    // strip off trailing `.js` if any
+    .replace(/\.js$/, '');
+  return `\`\`\`js
+import ${reactAPI.name} from '${source}';
+\`\`\``;
+}
+
 export default function generateMarkdown(reactAPI) {
   return [
     generateHeader(reactAPI),
@@ -339,6 +354,8 @@ export default function generateMarkdown(reactAPI) {
     `# ${reactAPI.name}`,
     '',
     `<p class="description">The API documentation of the ${reactAPI.name} React component.</p>`,
+    '',
+    generateImportStatement(reactAPI),
     '',
     reactAPI.description,
     '',

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -332,6 +332,7 @@ ${pagesMarkdown.map(page => `- [${pageToTitle(page)}](${page.pathname})`).join('
 
 function generateImportStatement(reactAPI) {
   const source = reactAPI.filename
+    // determine the published package name
     .replace(
       /\/packages\/material-ui(-(.+?))?\/src/,
       (match, dash, pkg) => `@material-ui/${pkg || 'core'}`,

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -9,6 +9,10 @@ title: AppBar API
 
 <p class="description">The API documentation of the AppBar React component.</p>
 
+```js
+import AppBar from '@material-ui/core/AppBar';
+```
+
 
 
 ## Props

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -9,6 +9,10 @@ title: Avatar API
 
 <p class="description">The API documentation of the Avatar React component.</p>
 
+```js
+import Avatar from '@material-ui/core/Avatar';
+```
+
 
 
 ## Props

--- a/pages/api/backdrop.md
+++ b/pages/api/backdrop.md
@@ -9,6 +9,10 @@ title: Backdrop API
 
 <p class="description">The API documentation of the Backdrop React component.</p>
 
+```js
+import Backdrop from '@material-ui/core/Backdrop';
+```
+
 
 
 ## Props

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -9,6 +9,10 @@ title: Badge API
 
 <p class="description">The API documentation of the Badge React component.</p>
 
+```js
+import Badge from '@material-ui/core/Badge';
+```
+
 
 
 ## Props

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -9,6 +9,10 @@ title: BottomNavigationAction API
 
 <p class="description">The API documentation of the BottomNavigationAction React component.</p>
 
+```js
+import BottomNavigationAction from '@material-ui/core/BottomNavigationAction';
+```
+
 
 
 ## Props

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -9,6 +9,10 @@ title: BottomNavigation API
 
 <p class="description">The API documentation of the BottomNavigation React component.</p>
 
+```js
+import BottomNavigation from '@material-ui/core/BottomNavigation';
+```
+
 
 
 ## Props

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -9,6 +9,10 @@ title: ButtonBase API
 
 <p class="description">The API documentation of the ButtonBase React component.</p>
 
+```js
+import ButtonBase from '@material-ui/core/ButtonBase';
+```
+
 `ButtonBase` contains as few styles as possible.
 It aims to be a simple building block for creating a button.
 It contains a load of style reset and some focus/ripple logic.

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -9,6 +9,10 @@ title: Button API
 
 <p class="description">The API documentation of the Button React component.</p>
 
+```js
+import Button from '@material-ui/core/Button';
+```
+
 
 
 ## Props

--- a/pages/api/card-action-area.md
+++ b/pages/api/card-action-area.md
@@ -9,6 +9,10 @@ title: CardActionArea API
 
 <p class="description">The API documentation of the CardActionArea React component.</p>
 
+```js
+import CardActionArea from '@material-ui/core/CardActionArea';
+```
+
 
 
 ## Props

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -9,6 +9,10 @@ title: CardActions API
 
 <p class="description">The API documentation of the CardActions React component.</p>
 
+```js
+import CardActions from '@material-ui/core/CardActions';
+```
+
 
 
 ## Props

--- a/pages/api/card-content.md
+++ b/pages/api/card-content.md
@@ -9,6 +9,10 @@ title: CardContent API
 
 <p class="description">The API documentation of the CardContent React component.</p>
 
+```js
+import CardContent from '@material-ui/core/CardContent';
+```
+
 
 
 ## Props

--- a/pages/api/card-header.md
+++ b/pages/api/card-header.md
@@ -9,6 +9,10 @@ title: CardHeader API
 
 <p class="description">The API documentation of the CardHeader React component.</p>
 
+```js
+import CardHeader from '@material-ui/core/CardHeader';
+```
+
 
 
 ## Props

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -9,6 +9,10 @@ title: CardMedia API
 
 <p class="description">The API documentation of the CardMedia React component.</p>
 
+```js
+import CardMedia from '@material-ui/core/CardMedia';
+```
+
 
 
 ## Props

--- a/pages/api/card.md
+++ b/pages/api/card.md
@@ -9,6 +9,10 @@ title: Card API
 
 <p class="description">The API documentation of the Card React component.</p>
 
+```js
+import Card from '@material-ui/core/Card';
+```
+
 
 
 ## Props

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -9,6 +9,10 @@ title: Checkbox API
 
 <p class="description">The API documentation of the Checkbox React component.</p>
 
+```js
+import Checkbox from '@material-ui/core/Checkbox';
+```
+
 
 
 ## Props

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -9,6 +9,10 @@ title: Chip API
 
 <p class="description">The API documentation of the Chip React component.</p>
 
+```js
+import Chip from '@material-ui/core/Chip';
+```
+
 Chips represent complex entities in small blocks, such as a contact.
 
 ## Props

--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -9,6 +9,10 @@ title: CircularProgress API
 
 <p class="description">The API documentation of the CircularProgress React component.</p>
 
+```js
+import CircularProgress from '@material-ui/core/CircularProgress';
+```
+
 ## ARIA
 
 If the progress bar is describing the loading progress of a particular region of a page,

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -9,6 +9,10 @@ title: ClickAwayListener API
 
 <p class="description">The API documentation of the ClickAwayListener React component.</p>
 
+```js
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+```
+
 Listen for click events that occur somewhere in the document, outside of the element itself.
 For instance, if you need to hide a menu when people click anywhere else on your page.
 

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -9,6 +9,10 @@ title: Collapse API
 
 <p class="description">The API documentation of the Collapse React component.</p>
 
+```js
+import Collapse from '@material-ui/core/Collapse';
+```
+
 The Collapse transition is used by the
 [Vertical Stepper](/demos/steppers#vertical-stepper) StepContent component.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -9,6 +9,10 @@ title: CssBaseline API
 
 <p class="description">The API documentation of the CssBaseline React component.</p>
 
+```js
+import CssBaseline from '@material-ui/core/CssBaseline';
+```
+
 Kickstart an elegant, consistent, and simple baseline to build upon.
 
 ## Props

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -9,6 +9,10 @@ title: DialogActions API
 
 <p class="description">The API documentation of the DialogActions React component.</p>
 
+```js
+import DialogActions from '@material-ui/core/DialogActions';
+```
+
 
 
 ## Props

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -9,6 +9,10 @@ title: DialogContentText API
 
 <p class="description">The API documentation of the DialogContentText React component.</p>
 
+```js
+import DialogContentText from '@material-ui/core/DialogContentText';
+```
+
 
 
 ## Props

--- a/pages/api/dialog-content.md
+++ b/pages/api/dialog-content.md
@@ -9,6 +9,10 @@ title: DialogContent API
 
 <p class="description">The API documentation of the DialogContent React component.</p>
 
+```js
+import DialogContent from '@material-ui/core/DialogContent';
+```
+
 
 
 ## Props

--- a/pages/api/dialog-title.md
+++ b/pages/api/dialog-title.md
@@ -9,6 +9,10 @@ title: DialogTitle API
 
 <p class="description">The API documentation of the DialogTitle React component.</p>
 
+```js
+import DialogTitle from '@material-ui/core/DialogTitle';
+```
+
 
 
 ## Props

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -9,6 +9,10 @@ title: Dialog API
 
 <p class="description">The API documentation of the Dialog React component.</p>
 
+```js
+import Dialog from '@material-ui/core/Dialog';
+```
+
 Dialogs are overlaid modal paper based components with a backdrop.
 
 ## Props

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -9,6 +9,10 @@ title: Divider API
 
 <p class="description">The API documentation of the Divider React component.</p>
 
+```js
+import Divider from '@material-ui/core/Divider';
+```
+
 
 
 ## Props

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -9,6 +9,10 @@ title: Drawer API
 
 <p class="description">The API documentation of the Drawer React component.</p>
 
+```js
+import Drawer from '@material-ui/core/Drawer';
+```
+
 The properties of the [Modal](/api/modal) component are available
 when `variant="temporary"` is set.
 

--- a/pages/api/expansion-panel-actions.md
+++ b/pages/api/expansion-panel-actions.md
@@ -9,6 +9,10 @@ title: ExpansionPanelActions API
 
 <p class="description">The API documentation of the ExpansionPanelActions React component.</p>
 
+```js
+import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
+```
+
 
 
 ## Props

--- a/pages/api/expansion-panel-details.md
+++ b/pages/api/expansion-panel-details.md
@@ -9,6 +9,10 @@ title: ExpansionPanelDetails API
 
 <p class="description">The API documentation of the ExpansionPanelDetails React component.</p>
 
+```js
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+```
+
 
 
 ## Props

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -9,6 +9,10 @@ title: ExpansionPanelSummary API
 
 <p class="description">The API documentation of the ExpansionPanelSummary React component.</p>
 
+```js
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+```
+
 
 
 ## Props

--- a/pages/api/expansion-panel.md
+++ b/pages/api/expansion-panel.md
@@ -9,6 +9,10 @@ title: ExpansionPanel API
 
 <p class="description">The API documentation of the ExpansionPanel React component.</p>
 
+```js
+import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+```
+
 
 
 ## Props

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -9,6 +9,10 @@ title: Fade API
 
 <p class="description">The API documentation of the Fade React component.</p>
 
+```js
+import Fade from '@material-ui/core/Fade';
+```
+
 The Fade transition is used by the [Modal](/utils/modal) component.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -9,6 +9,10 @@ title: FormControlLabel API
 
 <p class="description">The API documentation of the FormControlLabel React component.</p>
 
+```js
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+```
+
 Drop in replacement of the `Radio`, `Switch` and `Checkbox` component.
 Use this component if you want to display an extra label.
 

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -9,6 +9,10 @@ title: FormControl API
 
 <p class="description">The API documentation of the FormControl React component.</p>
 
+```js
+import FormControl from '@material-ui/core/FormControl';
+```
+
 Provides context such as filled/focused/error/required for form inputs.
 Relying on the context provides high flexibilty and ensures that the state always stays
 consistent across the children of the `FormControl`.

--- a/pages/api/form-group.md
+++ b/pages/api/form-group.md
@@ -9,6 +9,10 @@ title: FormGroup API
 
 <p class="description">The API documentation of the FormGroup React component.</p>
 
+```js
+import FormGroup from '@material-ui/core/FormGroup';
+```
+
 `FormGroup` wraps controls such as `Checkbox` and `Switch`.
 It provides compact row layout.
 For the `Radio`, you should be using the `RadioGroup` component instead of this one.

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -9,6 +9,10 @@ title: FormHelperText API
 
 <p class="description">The API documentation of the FormHelperText React component.</p>
 
+```js
+import FormHelperText from '@material-ui/core/FormHelperText';
+```
+
 
 
 ## Props

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -9,6 +9,10 @@ title: FormLabel API
 
 <p class="description">The API documentation of the FormLabel React component.</p>
 
+```js
+import FormLabel from '@material-ui/core/FormLabel';
+```
+
 
 
 ## Props

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -9,6 +9,10 @@ title: GridListTileBar API
 
 <p class="description">The API documentation of the GridListTileBar React component.</p>
 
+```js
+import GridListTileBar from '@material-ui/core/GridListTileBar';
+```
+
 
 
 ## Props

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -9,6 +9,10 @@ title: GridListTile API
 
 <p class="description">The API documentation of the GridListTile React component.</p>
 
+```js
+import GridListTile from '@material-ui/core/GridListTile';
+```
+
 
 
 ## Props

--- a/pages/api/grid-list.md
+++ b/pages/api/grid-list.md
@@ -9,6 +9,10 @@ title: GridList API
 
 <p class="description">The API documentation of the GridList React component.</p>
 
+```js
+import GridList from '@material-ui/core/GridList';
+```
+
 
 
 ## Props

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -9,6 +9,10 @@ title: Grid API
 
 <p class="description">The API documentation of the Grid React component.</p>
 
+```js
+import Grid from '@material-ui/core/Grid';
+```
+
 
 
 ## Props

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -9,6 +9,10 @@ title: Grow API
 
 <p class="description">The API documentation of the Grow React component.</p>
 
+```js
+import Grow from '@material-ui/core/Grow';
+```
+
 The Grow transition is used by the [Tooltip](/demos/tooltips) and
 [Popover](/utils/popover) components.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.

--- a/pages/api/hidden.md
+++ b/pages/api/hidden.md
@@ -9,6 +9,10 @@ title: Hidden API
 
 <p class="description">The API documentation of the Hidden React component.</p>
 
+```js
+import Hidden from '@material-ui/core/Hidden';
+```
+
 Responsively hides children based on the selected implementation.
 
 ## Props

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -9,6 +9,10 @@ title: IconButton API
 
 <p class="description">The API documentation of the IconButton React component.</p>
 
+```js
+import IconButton from '@material-ui/core/IconButton';
+```
+
 Refer to the [Icons](/style/icons) section of the documentation
 regarding the available icon options.
 

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -9,6 +9,10 @@ title: Icon API
 
 <p class="description">The API documentation of the Icon React component.</p>
 
+```js
+import Icon from '@material-ui/core/Icon';
+```
+
 
 
 ## Props

--- a/pages/api/input-adornment.md
+++ b/pages/api/input-adornment.md
@@ -9,6 +9,10 @@ title: InputAdornment API
 
 <p class="description">The API documentation of the InputAdornment React component.</p>
 
+```js
+import InputAdornment from '@material-ui/core/InputAdornment';
+```
+
 
 
 ## Props

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -9,6 +9,10 @@ title: InputLabel API
 
 <p class="description">The API documentation of the InputLabel React component.</p>
 
+```js
+import InputLabel from '@material-ui/core/InputLabel';
+```
+
 
 
 ## Props

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -9,6 +9,10 @@ title: Input API
 
 <p class="description">The API documentation of the Input React component.</p>
 
+```js
+import Input from '@material-ui/core/Input';
+```
+
 
 
 ## Props

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -9,6 +9,10 @@ title: LinearProgress API
 
 <p class="description">The API documentation of the LinearProgress React component.</p>
 
+```js
+import LinearProgress from '@material-ui/core/LinearProgress';
+```
+
 ## ARIA
 
 If the progress bar is describing the loading progress of a particular region of a page,

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -9,6 +9,10 @@ title: ListItemAvatar API
 
 <p class="description">The API documentation of the ListItemAvatar React component.</p>
 
+```js
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+```
+
 This is a simple wrapper to apply the `dense` mode styles to `Avatar`.
 
 ## Props

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -9,6 +9,10 @@ title: ListItemIcon API
 
 <p class="description">The API documentation of the ListItemIcon React component.</p>
 
+```js
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+```
+
 A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
 
 ## Props

--- a/pages/api/list-item-secondary-action.md
+++ b/pages/api/list-item-secondary-action.md
@@ -9,6 +9,10 @@ title: ListItemSecondaryAction API
 
 <p class="description">The API documentation of the ListItemSecondaryAction React component.</p>
 
+```js
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+```
+
 
 
 ## Props

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -9,6 +9,10 @@ title: ListItemText API
 
 <p class="description">The API documentation of the ListItemText React component.</p>
 
+```js
+import ListItemText from '@material-ui/core/ListItemText';
+```
+
 
 
 ## Props

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -9,6 +9,10 @@ title: ListItem API
 
 <p class="description">The API documentation of the ListItem React component.</p>
 
+```js
+import ListItem from '@material-ui/core/ListItem';
+```
+
 
 
 ## Props

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -9,6 +9,10 @@ title: ListSubheader API
 
 <p class="description">The API documentation of the ListSubheader React component.</p>
 
+```js
+import ListSubheader from '@material-ui/core/ListSubheader';
+```
+
 
 
 ## Props

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -9,6 +9,10 @@ title: List API
 
 <p class="description">The API documentation of the List React component.</p>
 
+```js
+import List from '@material-ui/core/List';
+```
+
 
 
 ## Props

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -9,6 +9,10 @@ title: MenuItem API
 
 <p class="description">The API documentation of the MenuItem React component.</p>
 
+```js
+import MenuItem from '@material-ui/core/MenuItem';
+```
+
 
 
 ## Props

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -9,6 +9,10 @@ title: MenuList API
 
 <p class="description">The API documentation of the MenuList React component.</p>
 
+```js
+import MenuList from '@material-ui/core/MenuList';
+```
+
 
 
 ## Props

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -9,6 +9,10 @@ title: Menu API
 
 <p class="description">The API documentation of the Menu React component.</p>
 
+```js
+import Menu from '@material-ui/core/Menu';
+```
+
 
 
 ## Props

--- a/pages/api/mobile-stepper.md
+++ b/pages/api/mobile-stepper.md
@@ -9,6 +9,10 @@ title: MobileStepper API
 
 <p class="description">The API documentation of the MobileStepper React component.</p>
 
+```js
+import MobileStepper from '@material-ui/core/MobileStepper';
+```
+
 
 
 ## Props

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -9,6 +9,10 @@ title: Modal API
 
 <p class="description">The API documentation of the Modal React component.</p>
 
+```js
+import Modal from '@material-ui/core/Modal';
+```
+
 This component shares many concepts with [react-overlays](https://react-bootstrap.github.io/react-overlays/#modals).
 
 ## Props

--- a/pages/api/mui-theme-provider.md
+++ b/pages/api/mui-theme-provider.md
@@ -9,6 +9,10 @@ title: MuiThemeProvider API
 
 <p class="description">The API documentation of the MuiThemeProvider React component.</p>
 
+```js
+import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider';
+```
+
 This component takes a `theme` property.
 It makes the `theme` available down the React tree thanks to React context.
 This component should preferably be used at **the root of your component tree**.

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -9,6 +9,10 @@ title: NativeSelect API
 
 <p class="description">The API documentation of the NativeSelect React component.</p>
 
+```js
+import NativeSelect from '@material-ui/core/NativeSelect';
+```
+
 An alternative to `<Select native />` with a much smaller dependency graph.
 
 ## Props

--- a/pages/api/no-ssr.md
+++ b/pages/api/no-ssr.md
@@ -9,6 +9,10 @@ title: NoSsr API
 
 <p class="description">The API documentation of the NoSsr React component.</p>
 
+```js
+import NoSsr from '@material-ui/core/NoSsr';
+```
+
 NoSsr purposely removes components from the subject of Server Side Rendering (SSR).
 
 This component can be useful in a variety of situations:

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -9,6 +9,10 @@ title: Paper API
 
 <p class="description">The API documentation of the Paper React component.</p>
 
+```js
+import Paper from '@material-ui/core/Paper';
+```
+
 
 
 ## Props

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -9,6 +9,10 @@ title: Popover API
 
 <p class="description">The API documentation of the Popover React component.</p>
 
+```js
+import Popover from '@material-ui/core/Popover';
+```
+
 
 
 ## Props

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -9,6 +9,10 @@ title: Popper API
 
 <p class="description">The API documentation of the Popper React component.</p>
 
+```js
+import Popper from '@material-ui/core/Popper';
+```
+
 Poppers rely on the 3rd party library [Popper.js](https://github.com/FezVrasta/popper.js) for positioning.
 
 ## Props

--- a/pages/api/portal.md
+++ b/pages/api/portal.md
@@ -9,6 +9,10 @@ title: Portal API
 
 <p class="description">The API documentation of the Portal React component.</p>
 
+```js
+import Portal from '@material-ui/core/Portal';
+```
+
 Portals provide a first-class way to render children into a DOM node
 that exists outside the DOM hierarchy of the parent component.
 

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -9,6 +9,10 @@ title: RadioGroup API
 
 <p class="description">The API documentation of the RadioGroup React component.</p>
 
+```js
+import RadioGroup from '@material-ui/core/RadioGroup';
+```
+
 
 
 ## Props

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -9,6 +9,10 @@ title: Radio API
 
 <p class="description">The API documentation of the Radio React component.</p>
 
+```js
+import Radio from '@material-ui/core/Radio';
+```
+
 
 
 ## Props

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -9,6 +9,10 @@ title: RootRef API
 
 <p class="description">The API documentation of the RootRef React component.</p>
 
+```js
+import RootRef from '@material-ui/core/RootRef';
+```
+
 Helper component to allow attaching a ref to a
 wrapped element to access the underlying DOM element.
 

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -9,6 +9,10 @@ title: Select API
 
 <p class="description">The API documentation of the Select React component.</p>
 
+```js
+import Select from '@material-ui/core/Select';
+```
+
 
 
 ## Props

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -9,6 +9,10 @@ title: Slide API
 
 <p class="description">The API documentation of the Slide React component.</p>
 
+```js
+import Slide from '@material-ui/core/Slide';
+```
+
 The Slide transition is used by the [Snackbar](/demos/snackbars) component.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
 

--- a/pages/api/snackbar-content.md
+++ b/pages/api/snackbar-content.md
@@ -9,6 +9,10 @@ title: SnackbarContent API
 
 <p class="description">The API documentation of the SnackbarContent React component.</p>
 
+```js
+import SnackbarContent from '@material-ui/core/SnackbarContent';
+```
+
 
 
 ## Props

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -9,6 +9,10 @@ title: Snackbar API
 
 <p class="description">The API documentation of the Snackbar React component.</p>
 
+```js
+import Snackbar from '@material-ui/core/Snackbar';
+```
+
 
 
 ## Props

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -9,6 +9,10 @@ title: StepButton API
 
 <p class="description">The API documentation of the StepButton React component.</p>
 
+```js
+import StepButton from '@material-ui/core/StepButton';
+```
+
 
 
 ## Props

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -9,6 +9,10 @@ title: StepConnector API
 
 <p class="description">The API documentation of the StepConnector React component.</p>
 
+```js
+import StepConnector from '@material-ui/core/StepConnector';
+```
+
 
 
 ## Props

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -9,6 +9,10 @@ title: StepContent API
 
 <p class="description">The API documentation of the StepContent React component.</p>
 
+```js
+import StepContent from '@material-ui/core/StepContent';
+```
+
 
 
 ## Props

--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -9,6 +9,10 @@ title: StepIcon API
 
 <p class="description">The API documentation of the StepIcon React component.</p>
 
+```js
+import StepIcon from '@material-ui/core/StepIcon';
+```
+
 
 
 ## Props

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -9,6 +9,10 @@ title: StepLabel API
 
 <p class="description">The API documentation of the StepLabel React component.</p>
 
+```js
+import StepLabel from '@material-ui/core/StepLabel';
+```
+
 
 
 ## Props

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -9,6 +9,10 @@ title: Step API
 
 <p class="description">The API documentation of the Step React component.</p>
 
+```js
+import Step from '@material-ui/core/Step';
+```
+
 
 
 ## Props

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -9,6 +9,10 @@ title: Stepper API
 
 <p class="description">The API documentation of the Stepper React component.</p>
 
+```js
+import Stepper from '@material-ui/core/Stepper';
+```
+
 
 
 ## Props

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -9,6 +9,10 @@ title: SvgIcon API
 
 <p class="description">The API documentation of the SvgIcon React component.</p>
 
+```js
+import SvgIcon from '@material-ui/core/SvgIcon';
+```
+
 
 
 ## Props

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -9,6 +9,10 @@ title: SwipeableDrawer API
 
 <p class="description">The API documentation of the SwipeableDrawer React component.</p>
 
+```js
+import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
+```
+
 
 
 ## Props

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -9,6 +9,10 @@ title: Switch API
 
 <p class="description">The API documentation of the Switch React component.</p>
 
+```js
+import Switch from '@material-ui/core/Switch';
+```
+
 
 
 ## Props

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -9,6 +9,10 @@ title: Tab API
 
 <p class="description">The API documentation of the Tab React component.</p>
 
+```js
+import Tab from '@material-ui/core/Tab';
+```
+
 
 
 ## Props

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -9,6 +9,10 @@ title: TableBody API
 
 <p class="description">The API documentation of the TableBody React component.</p>
 
+```js
+import TableBody from '@material-ui/core/TableBody';
+```
+
 
 
 ## Props

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -9,6 +9,10 @@ title: TableCell API
 
 <p class="description">The API documentation of the TableCell React component.</p>
 
+```js
+import TableCell from '@material-ui/core/TableCell';
+```
+
 
 
 ## Props

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -9,6 +9,10 @@ title: TableFooter API
 
 <p class="description">The API documentation of the TableFooter React component.</p>
 
+```js
+import TableFooter from '@material-ui/core/TableFooter';
+```
+
 
 
 ## Props

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -9,6 +9,10 @@ title: TableHead API
 
 <p class="description">The API documentation of the TableHead React component.</p>
 
+```js
+import TableHead from '@material-ui/core/TableHead';
+```
+
 
 
 ## Props

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -9,6 +9,10 @@ title: TablePagination API
 
 <p class="description">The API documentation of the TablePagination React component.</p>
 
+```js
+import TablePagination from '@material-ui/core/TablePagination';
+```
+
 A `TableCell` based component for placing inside `TableFooter` for pagination.
 
 ## Props

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -9,6 +9,10 @@ title: TableRow API
 
 <p class="description">The API documentation of the TableRow React component.</p>
 
+```js
+import TableRow from '@material-ui/core/TableRow';
+```
+
 Will automatically set dynamic row height
 based on the material table element parent (head, body, etc).
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -9,6 +9,10 @@ title: TableSortLabel API
 
 <p class="description">The API documentation of the TableSortLabel React component.</p>
 
+```js
+import TableSortLabel from '@material-ui/core/TableSortLabel';
+```
+
 A button based label for placing inside `TableCell` for column sorting.
 
 ## Props

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -9,6 +9,10 @@ title: Table API
 
 <p class="description">The API documentation of the Table React component.</p>
 
+```js
+import Table from '@material-ui/core/Table';
+```
+
 
 
 ## Props

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -9,6 +9,10 @@ title: Tabs API
 
 <p class="description">The API documentation of the Tabs React component.</p>
 
+```js
+import Tabs from '@material-ui/core/Tabs';
+```
+
 
 
 ## Props

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -9,6 +9,10 @@ title: TextField API
 
 <p class="description">The API documentation of the TextField React component.</p>
 
+```js
+import TextField from '@material-ui/core/TextField';
+```
+
 The `TextField` is a convenience wrapper for the most common cases (80%).
 It cannot be all things to all people, otherwise the API would grow out of control.
 

--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -9,6 +9,10 @@ title: Toolbar API
 
 <p class="description">The API documentation of the Toolbar React component.</p>
 
+```js
+import Toolbar from '@material-ui/core/Toolbar';
+```
+
 
 
 ## Props

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -9,6 +9,10 @@ title: Tooltip API
 
 <p class="description">The API documentation of the Tooltip React component.</p>
 
+```js
+import Tooltip from '@material-ui/core/Tooltip';
+```
+
 
 
 ## Props

--- a/pages/api/touch-ripple.md
+++ b/pages/api/touch-ripple.md
@@ -9,6 +9,10 @@ title: TouchRipple API
 
 <p class="description">The API documentation of the TouchRipple React component.</p>
 
+```js
+import TouchRipple from '@material-ui/core/ButtonBase/TouchRipple';
+```
+
 
 
 ## Props

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -9,6 +9,10 @@ title: Typography API
 
 <p class="description">The API documentation of the Typography React component.</p>
 
+```js
+import Typography from '@material-ui/core/Typography';
+```
+
 
 
 ## Props

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -9,6 +9,10 @@ title: Zoom API
 
 <p class="description">The API documentation of the Zoom React component.</p>
 
+```js
+import Zoom from '@material-ui/core/Zoom';
+```
+
 The Zoom transition can be used for the floating variant of the
 [Button](https://material-ui.com/demos/buttons/#floating-action-buttons) component.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.

--- a/pages/lab/api/slider.md
+++ b/pages/lab/api/slider.md
@@ -9,6 +9,10 @@ title: Slider API
 
 <p class="description">The API documentation of the Slider React component.</p>
 
+```js
+import Slider from '@material-ui/lab/Slider';
+```
+
 
 
 ## Props

--- a/pages/lab/api/speed-dial-action.md
+++ b/pages/lab/api/speed-dial-action.md
@@ -9,6 +9,10 @@ title: SpeedDialAction API
 
 <p class="description">The API documentation of the SpeedDialAction React component.</p>
 
+```js
+import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
+```
+
 
 
 ## Props

--- a/pages/lab/api/speed-dial-icon.md
+++ b/pages/lab/api/speed-dial-icon.md
@@ -9,6 +9,10 @@ title: SpeedDialIcon API
 
 <p class="description">The API documentation of the SpeedDialIcon React component.</p>
 
+```js
+import SpeedDialIcon from '@material-ui/lab/SpeedDialIcon';
+```
+
 
 
 ## Props

--- a/pages/lab/api/speed-dial.md
+++ b/pages/lab/api/speed-dial.md
@@ -9,6 +9,10 @@ title: SpeedDial API
 
 <p class="description">The API documentation of the SpeedDial React component.</p>
 
+```js
+import SpeedDial from '@material-ui/lab/SpeedDial';
+```
+
 
 
 ## Props

--- a/pages/lab/api/toggle-button-group.md
+++ b/pages/lab/api/toggle-button-group.md
@@ -9,6 +9,10 @@ title: ToggleButtonGroup API
 
 <p class="description">The API documentation of the ToggleButtonGroup React component.</p>
 
+```js
+import ToggleButtonGroup from '@material-ui/lab/ToggleButton/ToggleButtonGroup';
+```
+
 
 
 ## Props

--- a/pages/lab/api/toggle-button.md
+++ b/pages/lab/api/toggle-button.md
@@ -9,6 +9,10 @@ title: ToggleButton API
 
 <p class="description">The API documentation of the ToggleButton React component.</p>
 
+```js
+import ToggleButton from '@material-ui/lab/ToggleButton';
+```
+
 
 
 ## Props


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
fix #12708 
Example generated imports:
```js
import Button from '@material-ui/core/Button'
import MuiThemeProvider from '@material-ui/core/styles/MuiThemeProvider'
import ToggleButtonGroup from '@material-ui/lab/ToggleButton/ToggleButtonGroup'
```
![image](https://user-images.githubusercontent.com/1448194/44868440-6cf29b00-ac50-11e8-8a38-48caf078dd47.png)
