### PR TITLE
enable overriding components via theme [tests do pass, CI has transient network errors]

### DIFF
--- a/packages/material-ui/src/styles/getThemeComponent.js
+++ b/packages/material-ui/src/styles/getThemeComponent.js
@@ -1,0 +1,11 @@
+function getThemeComponent(params) {
+  const { theme, name } = params;
+
+  if (!name || !theme.components || !theme.components[name]) {
+    return null;
+  }
+
+  return theme.components[name];
+}
+
+export default getThemeComponent;

--- a/packages/material-ui/src/styles/getThemeComponent.test.js
+++ b/packages/material-ui/src/styles/getThemeComponent.test.js
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { assert } from 'chai';
+import getThemeComponent from './getThemeComponent';
+
+describe('getThemeComponent', () => {
+  it('should ignore empty theme', () => {
+    const component = getThemeComponent({
+      theme: {},
+      name: 'MuiFoo',
+    });
+    assert.deepEqual(component, null);
+  });
+
+  it('should ignore different component', () => {
+    const component = getThemeComponent({
+      theme: {
+        components: {
+          MuiBar: () => <div />,
+        },
+      },
+      name: 'MuiFoo',
+    });
+    assert.deepEqual(component, null);
+  });
+
+  it('should return the component', () => {
+    const MuiFoo = () => <div />;
+    const component = getThemeComponent({
+      theme: {
+        components: {
+          MuiFoo,
+        },
+      },
+      name: 'MuiFoo',
+    });
+    assert.deepEqual(component, MuiFoo);
+  });
+});

--- a/packages/material-ui/src/styles/withStyles.test.js
+++ b/packages/material-ui/src/styles/withStyles.test.js
@@ -215,7 +215,7 @@ describe('withStyles', () => {
       assert.deepEqual(sheetsRegistry.registry[0].rules.raw, { root: { padding: 9 } });
     });
 
-    it('should support override comonents', () => {
+    it('should support override components', () => {
       const styles = { root: { padding: 8 } };
       const FormLabel = withStyles(styles, { name: 'MuiFormLabel' })(Empty);
       const OverrideFormLabel = ({ warning, classes, ...props }) => (

--- a/packages/material-ui/src/styles/withStyles.test.js
+++ b/packages/material-ui/src/styles/withStyles.test.js
@@ -215,6 +215,46 @@ describe('withStyles', () => {
       assert.deepEqual(sheetsRegistry.registry[0].rules.raw, { root: { padding: 9 } });
     });
 
+    it('should support override comonents', () => {
+      const styles = { root: { padding: 8 } };
+      const FormLabel = withStyles(styles, { name: 'MuiFormLabel' })(Empty);
+      const OverrideFormLabel = ({ warning, classes, ...props }) => (
+        <FormLabel
+          classes={{
+            ...classes,
+            root: warning ? `${classes.root || ''} test-warning` : classes.root,
+          }}
+          {...props}
+        />
+      );
+
+      const root = mount(
+        <MuiThemeProvider
+          theme={createMuiTheme({
+            components: {
+              MuiFormLabel: OverrideFormLabel,
+            },
+          })}
+        >
+          <JssProvider registry={sheetsRegistry} jss={jss} generateClassName={generateClassName}>
+            <FormLabel warning />
+          </JssProvider>
+        </MuiThemeProvider>,
+      );
+
+      assert.strictEqual(sheetsRegistry.registry.length, 1, 'should only attach once');
+      assert.exists(root.find(OverrideFormLabel), 'should render OverrideFormLabel');
+      assert.exists(
+        root.find(OverrideFormLabel).find(FormLabel),
+        'should render FormLabel inside OverrideFormLabel',
+      );
+      assert.strictEqual(
+        root.find(OverrideFormLabel).find(FormLabel).prop('classes').root,
+        'MuiFormLabel-root-1 test-warning',
+        'FormLabel should have root class name injected by OverrideFormLabel',
+      );
+    });
+
     describe('options: disableStylesGeneration', () => {
       it('should not generate the styles', () => {
         const styles = { root: { display: 'flex' } };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Docs are not written yet.
Here's what it looks like, from the test case I added:
```js
    it('should support override components', () => {
      const styles = { root: { padding: 8 } };
      const FormLabel = withStyles(styles, { name: 'MuiFormLabel' })(Empty);
      const OverrideFormLabel = ({ warning, classes, ...props }) => (
        <FormLabel
          classes={{
            ...classes,
            root: warning ? `${classes.root || ''} test-warning` : classes.root,
          }}
          {...props}
        />
      );

      const root = mount(
        <MuiThemeProvider
          theme={createMuiTheme({
            components: {
              MuiFormLabel: OverrideFormLabel,
            },
          })}
        >
          <JssProvider registry={sheetsRegistry} jss={jss} generateClassName={generateClassName}>
            <FormLabel warning />
          </JssProvider>
        </MuiThemeProvider>,
      );

      assert.strictEqual(sheetsRegistry.registry.length, 1, 'should only attach once');
      assert.exists(root.find(OverrideFormLabel), 'should render OverrideFormLabel');
      assert.exists(
        root.find(OverrideFormLabel).find(FormLabel),
        'should render FormLabel inside OverrideFormLabel',
      );
      assert.strictEqual(
        root.find(OverrideFormLabel).find(FormLabel).prop('classes').root,
        'MuiFormLabel-root-1 test-warning',
        'FormLabel should have root class name injected by OverrideFormLabel',
      );
    });
```

### Implementation notes
I needed a way for a `FormLabel` override component to be able wrap the default `FormLabel`, without that `FormLabel` it renders being overridden ad infinitum.  I solved this problem with the
`muiWithStylesOverriddenComponents` context property.

When `withStyles` is rendering an `MuiFormLabel`, it first checks if `muiWithStylesOverriddenCompnents.MuiFormLabel` is `true`.  If so, it renders the default component.  Otherwise, it looks for an override in `theme.components.MuiFormLabel`, and if found, renders that instead and sets `muiWithStylesOverriddenCompnents.MuiFormLabel` to `true` in its child context.