### PR TITLE
[IconButton] Fix border radius cutting of badges on IE11

### DIFF
--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -18,7 +18,7 @@ export const styles = theme => ({
     height: 48,
     padding: 0,
     borderRadius: '50%',
-    overflow: 'visible',
+    overflow: 'visible', // Explicitly set the default value to solve a bug on IE11.
     color: theme.palette.action.active,
     transition: theme.transitions.create('background-color', {
       duration: theme.transitions.duration.shortest,

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -18,6 +18,7 @@ export const styles = theme => ({
     height: 48,
     padding: 0,
     borderRadius: '50%',
+    overflow: 'visible',
     color: theme.palette.action.active,
     transition: theme.transitions.create('background-color', {
       duration: theme.transitions.duration.shortest,


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1596280/44949171-4ec89e80-adfa-11e8-8308-ff1adb2a850c.png)

After:
![image](https://user-images.githubusercontent.com/1596280/44949173-538d5280-adfa-11e8-856b-60e4096df85a.png)
