### PR TITLE
[typescript] Fix ModalClasses prop type on popover

### DIFF
--- a/packages/material-ui/src/InputLabel/InputLabel.d.ts
+++ b/packages/material-ui/src/InputLabel/InputLabel.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { StandardProps } from '..';
-import { FormLabelProps, FormLabelClassKey } from '../FormLabel';
+import { FormLabelProps } from '../FormLabel';
 
 export interface InputLabelProps extends StandardProps<FormLabelProps, InputLabelClassKey> {
   disableAnimation?: boolean;

--- a/packages/material-ui/src/InputLabel/InputLabel.d.ts
+++ b/packages/material-ui/src/InputLabel/InputLabel.d.ts
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { FormLabelProps, FormLabelClassKey } from '../FormLabel';
-import { ClassNameMap } from '../styles/withStyles';
 
 export interface InputLabelProps extends StandardProps<FormLabelProps, InputLabelClassKey> {
   disableAnimation?: boolean;
   disabled?: boolean;
   error?: boolean;
-  FormLabelClasses?: Partial<ClassNameMap<FormLabelClassKey>>;
+  FormLabelClasses?: FormLabelProps['classes'];
   focused?: boolean;
   required?: boolean;
   shrink?: boolean;

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -4,14 +4,13 @@ import { MenuListProps } from '../MenuList';
 import { PaperProps } from '../Paper';
 import { StandardProps } from '..';
 import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
-import { ClassNameMap } from '../styles/withStyles';
 
 export interface MenuProps
   extends StandardProps<PopoverProps & Partial<TransitionHandlerProps>, MenuClassKey> {
   disableAutoFocusItem?: boolean;
   MenuListProps?: Partial<MenuListProps>;
   PaperProps?: Partial<PaperProps>;
-  PopoverClasses?: Partial<ClassNameMap<PopoverClassKey>>;
+  PopoverClasses?: PopoverProps['classes'];
   transitionDuration?: TransitionProps['timeout'] | 'auto';
 }
 

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PopoverProps, PopoverClassKey } from '../Popover';
+import { PopoverProps } from '../Popover';
 import { MenuListProps } from '../MenuList';
 import { PaperProps } from '../Paper';
 import { StandardProps } from '..';

--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
-import { ModalProps, ModalClassKey } from '../Modal';
+import { ModalProps } from '../Modal';
 import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
 
 export interface PopoverOrigin {

--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -3,7 +3,6 @@ import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
 import { ModalProps, ModalClassKey } from '../Modal';
 import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
-import { ClassNameMap } from '../styles/withStyles';
 
 export interface PopoverOrigin {
   horizontal: 'left' | 'center' | 'right' | number;
@@ -29,7 +28,7 @@ export interface PopoverProps
   getContentAnchorEl?: null | ((element: HTMLElement) => HTMLElement);
   marginThreshold?: number;
   modal?: boolean;
-  ModalClasses?: Partial<ClassNameMap<ModalClassKey>>;
+  ModalClasses?: ModalProps['classes'];
   PaperProps?: Partial<PaperProps>;
   role?: string;
   transformOrigin?: PopoverOrigin;

--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -3,6 +3,7 @@ import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
 import { ModalProps, ModalClassKey } from '../Modal';
 import { TransitionHandlerProps, TransitionProps } from '../transitions/transition';
+import { ClassNameMap } from '../styles/withStyles';
 
 export interface PopoverOrigin {
   horizontal: 'left' | 'center' | 'right' | number;
@@ -28,7 +29,7 @@ export interface PopoverProps
   getContentAnchorEl?: null | ((element: HTMLElement) => HTMLElement);
   marginThreshold?: number;
   modal?: boolean;
-  ModalClasses?: ModalClassKey;
+  ModalClasses?: Partial<ClassNameMap<ModalClassKey>>;
   PaperProps?: Partial<PaperProps>;
   role?: string;
   transformOrigin?: PopoverOrigin;

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -37,6 +37,7 @@ import {
   IconButton,
   Input,
   InputAdornment,
+  InputLabel,
   LinearProgress,
   List,
   ListItem,
@@ -48,6 +49,7 @@ import {
   MenuItem,
   MobileStepper,
   Paper,
+  Popover,
   Select,
   Snackbar,
   SnackbarContent,
@@ -450,7 +452,13 @@ const MenuTest = () => {
   ];
 
   return (
-    <Menu id="lock-menu" anchorEl={anchorEl} open={true} onClose={log}>
+    <Menu
+      id="lock-menu"
+      anchorEl={anchorEl}
+      open={true}
+      onClose={log}
+      PopoverClasses={{ paper: 'foo' }}
+    >
       {options.map((option, index) => (
         <MenuItem key={option} selected={false} onClick={log}>
           {option}
@@ -848,3 +856,19 @@ const TransitionTest = () => (
 );
 
 const BackdropTest = () => <Backdrop open onTouchMove={() => {}} />;
+
+const PopoverTest = () => <Popover open ModalClasses={{ root: 'foo', hidden: 'bar' }} />;
+
+const InputLabelTest = () => (
+  <InputLabel
+    FormLabelClasses={{
+      root: 'foo',
+      asterisk: 'foo',
+      disabled: 'foo',
+      error: 'foo',
+      filled: 'foo',
+      focused: 'foo',
+      required: 'foo',
+    }}
+  />
+);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Right now `Popover` `ModalClasses` prop is of type `'root' | 'hidden'` which is incorrect

This PR fixes it to be an object with correct keys