### PR TITLE
[ci] Use yarn offline mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,26 @@ defaults: &defaults
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:9.10
+restore_repo: &restore_repo
+  # The cache logic of CircleCI has been disabled for Security reasons.
+  # We can no longer use it.
+  # restore_cache:
+  #   keys:
+  #     - v1-repo-{{ .Branch }}-{{ .Revision }}
+  run:
+    name: Install js dependencies
+    command: yarn
 version: 2
 jobs:
   checkout:
     <<: *defaults
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-yarn-sha-{{ checksum "yarn.lock" }}
+            # offline mirror
+            - v1-npm-packages-offline-cache
       - run:
           name: Check versions and env
           command: |
@@ -17,17 +31,10 @@ jobs:
             docker-compose --version
             env
             yarn cache dir
-      - restore_cache:
-          keys:
-          - v1-yarn-sha-{{ checksum "yarn.lock" }}
-          # offline mirror
-          - v1-npm-packages-offline-cache
       - run:
           name: yarn offline mirror setup
           command: yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1
-      - run:
-          name: Install js dependencies
-          command: yarn
+      - *restore_repo
       - run:
           name: Should not have any git not staged
           command: git diff --exit-code
@@ -47,6 +54,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - *restore_repo
       - run:
           name: Export changed files
           command: |
@@ -95,6 +103,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - *restore_repo
       - run:
           name: material-ui-icons
           command: |
@@ -163,6 +172,7 @@ jobs:
       - image: circleci/node:9.10
     steps:
       - checkout
+      - *restore_repo
       - run:
           name: Can we generate the material-ui build?
           command: cd packages/material-ui && yarn build
@@ -176,6 +186,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - *restore_repo
       - run:
           name: Can we generate the api of the docs?
           command: yarn docs:api
@@ -198,6 +209,7 @@ jobs:
       - image: selenium/standalone-chrome:3.11.0
     steps:
       - checkout
+      - *restore_repo
       - run:
           name: Visual regression tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,8 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-yarn-sha-{{ checksum "yarn.lock" }}
-            - v1-yarn-sha-
+            - v2-yarn-sha-{{ checksum "yarn.lock" }}
+            - v2-yarn-sha-
       - run:
           name: Check versions and env
           command: |
@@ -33,7 +33,7 @@ jobs:
           name: Should not have any git not staged
           command: git diff --exit-code
       - save_cache:
-          key: v1-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v2-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn/v1
             - ~/.cache/npm-packages-offline-cache/v1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,6 @@ defaults: &defaults
   docker:
     - image: circleci/node:9.10
 restore_repo: &restore_repo
-  restore_cache:
-    keys:
-      - v1-yarn-sha-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - v1-yarn-sha-{{ .Branch }}
-      - v1-yarn-sha-
   run:
     name: Install js dependencies
     command: yarn
@@ -17,6 +12,10 @@ jobs:
     <<: *defaults
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - v1-yarn-sha-{{ checksum "yarn.lock" }}
+            - v1-yarn-sha-
       - run:
           name: Check versions and env
           command: |
@@ -34,7 +33,7 @@ jobs:
           name: Should not have any git not staged
           command: git diff --exit-code
       - save_cache:
-          key: v1-yarn-sha-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: v1-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn/v1
             - ~/.cache/npm-packages-offline-cache/v1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
 restore_repo: &restore_repo
   run:
     name: Install js dependencies
-    command: yarn
+    command: yarn --offline
 version: 2
 jobs:
   checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,13 @@ jobs:
             env
             yarn cache dir
       - restore_cache:
-          key: v1-yarn-sha-{{ checksum "yarn.lock" }}
+          keys:
+          - v1-yarn-sha-{{ checksum "yarn.lock" }}
+          # offline mirror
+          - v1-npm-packages-offline-cache
+      - run:
+          name: yarn offline mirror setup
+          command: yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1
       - run:
           name: Install js dependencies
           command: yarn
@@ -39,6 +45,10 @@ jobs:
           key: v1-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn/v1
+      - save_cache:
+          key: v1-npm-packages-offline-cache
+          paths:
+            - ~/.cache/npm-packages-offline-cache/v1
       - save_cache:
           key: v1-repo-{{ .Branch }}-{{ .Revision }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ defaults: &defaults
   docker:
     - image: circleci/node:9.10
 restore_repo: &restore_repo
-  # The cache logic of CircleCI has been disabled for Security reasons.
-  # We can no longer use it.
-  # restore_cache:
-  #   keys:
-  #     - v1-repo-{{ .Branch }}-{{ .Revision }}
+  restore_cache:
+    keys:
+      - v1-yarn-sha-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - v1-yarn-sha-{{ .Branch }}
+      - v1-yarn-sha-
   run:
     name: Install js dependencies
     command: yarn
@@ -17,11 +17,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - v1-yarn-sha-{{ checksum "yarn.lock" }}
-            # offline mirror
-            - v1-npm-packages-offline-cache
       - run:
           name: Check versions and env
           command: |
@@ -39,17 +34,10 @@ jobs:
           name: Should not have any git not staged
           command: git diff --exit-code
       - save_cache:
-          key: v1-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v1-yarn-sha-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn/v1
-      - save_cache:
-          key: v1-npm-packages-offline-cache
-          paths:
             - ~/.cache/npm-packages-offline-cache/v1
-      - save_cache:
-          key: v1-repo-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /tmp/material-ui
   test_unit:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          keys:
-            - v2-yarn-sha-{{ checksum "yarn.lock" }}
-            - v2-yarn-sha-
+          key: v1-npm-packages-offline-cache
+      - restore_cache:
+          key: v1-yarn-sha-{{ checksum "yarn.lock" }}
       - run:
           name: Check versions and env
           command: |
@@ -33,9 +33,12 @@ jobs:
           name: Should not have any git not staged
           command: git diff --exit-code
       - save_cache:
-          key: v2-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v1-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn/v1
+      - save_cache:
+          key: v1-npm-packages-offline-cache
+          paths:
             - ~/.cache/npm-packages-offline-cache/v1
   test_unit:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,9 @@ jobs:
       - restore_cache:
           key: v1-npm-packages-offline-cache
       - restore_cache:
-          key: v1-yarn-sha-{{ checksum "yarn.lock" }}
+          keys: 
+            - v1-yarn-sha-{{ checksum "yarn.lock" }}
+            - v1-yarn-sha-
       - run:
           name: Check versions and env
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,23 +2,24 @@ defaults: &defaults
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:9.10
+# CircleCI has disabled the cache across forks for security reasons.
+# Following their official statement, it was a quick solution, they
+# are working on providing this feature back with appropriate security measures.
+# restore_repo: &restore_repo
+#   restore_cache:
+#     key: v1-repo-{{ .Branch }}-{{ .Revision }}
 install_js: &install_js
   run:
     name: Install js dependencies
-    command: |-
+    command: |
       yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1
       yarn
-
 restore_yarn_cache: &restore_yarn_cache
   restore_cache:
-    keys: 
-      - v1-yarn-sha-{{ checksum "yarn.lock" }}
-      - v1-yarn-sha-
-
+    key: v1-yarn-sha-{{ checksum "yarn.lock" }}
 restore_yarn_offline_mirror: &restore_yarn_offline_mirror
   restore_cache:
     key: v1-npm-packages-offline-cache
-
 version: 2
 jobs:
   checkout:
@@ -194,7 +195,7 @@ jobs:
       - *restore_yarn_cache
       - *install_js
       - run:
-          name: Can we generate the api of the docs?
+          name: "`yarn docs:api` changes commited?"
           command: yarn docs:api
       - run:
           name: Should not have any git not staged

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ install_js: &install_js
     name: Install js dependencies
     command: |-
       yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1
-      yarn --offline
+      yarn
 
 restore_yarn_cache: &restore_yarn_cache
   restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ defaults: &defaults
 restore_repo: &restore_repo
   run:
     name: Install js dependencies
-    command: yarn --offline
+    command: yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1 && yarn --offline
 version: 2
 jobs:
   checkout:
@@ -27,9 +27,6 @@ jobs:
             docker-compose --version
             env
             yarn cache dir
-      - run:
-          name: yarn offline mirror setup
-          command: yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1
       - *restore_repo
       - run:
           name: Should not have any git not staged

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,22 +2,12 @@ defaults: &defaults
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:9.10
-restore_repo: &restore_repo
-  # The cache logic of CircleCI has been disabled for Security reasons.
-  # We can no longer use it.
-  # restore_cache:
-  #   keys:
-  #     - v1-repo-{{ .Branch }}-{{ .Revision }}
-  run:
-    name: Install js dependencies
-    command: yarn
 version: 2
 jobs:
   checkout:
     <<: *defaults
     steps:
       - checkout
-      - *restore_repo
       - run:
           name: Check versions and env
           command: |
@@ -57,7 +47,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *restore_repo
       - run:
           name: Export changed files
           command: |
@@ -106,7 +95,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *restore_repo
       - run:
           name: material-ui-icons
           command: |
@@ -175,7 +163,6 @@ jobs:
       - image: circleci/node:9.10
     steps:
       - checkout
-      - *restore_repo
       - run:
           name: Can we generate the material-ui build?
           command: cd packages/material-ui && yarn build
@@ -189,7 +176,6 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *restore_repo
       - run:
           name: Can we generate the api of the docs?
           command: yarn docs:api
@@ -212,7 +198,6 @@ jobs:
       - image: selenium/standalone-chrome:3.11.0
     steps:
       - checkout
-      - *restore_repo
       - run:
           name: Visual regression tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,22 +2,31 @@ defaults: &defaults
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:9.10
-restore_repo: &restore_repo
+install_js: &install_js
   run:
     name: Install js dependencies
-    command: yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1 && yarn --offline
+    command: |-
+      yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1
+      yarn --offline
+
+restore_yarn_cache: &restore_yarn_cache
+  restore_cache:
+    keys: 
+      - v1-yarn-sha-{{ checksum "yarn.lock" }}
+      - v1-yarn-sha-
+
+restore_yarn_offline_mirror: &restore_yarn_offline_mirror
+  restore_cache:
+    key: v1-npm-packages-offline-cache
+
 version: 2
 jobs:
   checkout:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          key: v1-npm-packages-offline-cache
-      - restore_cache:
-          keys: 
-            - v1-yarn-sha-{{ checksum "yarn.lock" }}
-            - v1-yarn-sha-
+      - *restore_yarn_offline_mirror
+      - *restore_yarn_cache
       - run:
           name: Check versions and env
           command: |
@@ -27,7 +36,7 @@ jobs:
             docker-compose --version
             env
             yarn cache dir
-      - *restore_repo
+      - *install_js
       - run:
           name: Should not have any git not staged
           command: git diff --exit-code
@@ -43,7 +52,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *restore_repo
+      - *restore_yarn_offline_mirror
+      - *restore_yarn_cache
+      - *install_js
       - run:
           name: Export changed files
           command: |
@@ -92,7 +103,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *restore_repo
+      - *restore_yarn_offline_mirror
+      - *restore_yarn_cache
+      - *install_js
       - run:
           name: material-ui-icons
           command: |
@@ -161,7 +174,9 @@ jobs:
       - image: circleci/node:9.10
     steps:
       - checkout
-      - *restore_repo
+      - *restore_yarn_offline_mirror
+      - *restore_yarn_cache
+      - *install_js
       - run:
           name: Can we generate the material-ui build?
           command: cd packages/material-ui && yarn build
@@ -175,7 +190,9 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - *restore_repo
+      - *restore_yarn_offline_mirror
+      - *restore_yarn_cache
+      - *install_js
       - run:
           name: Can we generate the api of the docs?
           command: yarn docs:api
@@ -198,7 +215,9 @@ jobs:
       - image: selenium/standalone-chrome:3.11.0
     steps:
       - checkout
-      - *restore_repo
+      - *restore_yarn_offline_mirror
+      - *restore_yarn_cache
+      - *install_js
       - run:
           name: Visual regression tests
           command: |


### PR DESCRIPTION
Adds an offline mirror for yarn registry in CI. CircleCI has frequent network issues with npm/yarn registries. The offline mirror should be used as a fallback.

Side effect: The yarn cache is now used for every job. It was previously only restored for the checkout job.

~Since write access to cache is disabled in PRs this change has to run on the master branch first to have impact on PRs.~ Somehow [this works now](https://circleci.com/gh/mui-org/material-ui/42932).

~Offline mirror will not work if `yarn.lock` changes. I did not find documentation for multiple cache paths under different keys i.e. offline mirror would come from a generic `v1-npm-offline-mirror` while yarn cache would come from `v1-yarn-sha-{{.checksum}}`~