### PR TITLE
[Checkbox] Fix checkbox indeterminate edge

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '90.1 KB',
+    limit: '90.2 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '90.2 KB',
+    limit: '90.28 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -41,25 +41,25 @@ export const styles = theme => ({
 });
 
 class Checkbox extends React.Component {
-  componentDidMount = () => {
+  componentDidMount() {
     this.updateIndeterminateStatus();
-  };
+  }
 
-  componentDidUpdate = prevProps => {
+  componentDidUpdate(prevProps) {
     if (prevProps.indeterminate !== this.props.indeterminate) {
       this.updateIndeterminateStatus();
     }
-  };
-
-  updateIndeterminateStatus = () => {
-    if (this.inputRef) {
-      this.inputRef.indeterminate = this.props.indeterminate;
-    }
-  };
+  }
 
   handleInputRef = ref => {
     this.inputRef = ReactDOM.findDOMNode(ref);
   };
+
+  updateIndeterminateStatus() {
+    if (this.inputRef) {
+      this.inputRef.indeterminate = this.props.indeterminate;
+    }
+  }
 
   render() {
     const {

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -50,6 +50,31 @@ class Checkbox extends React.Component {
     }
   }
 
+  handleClick = (event, ...clickArgs) => {
+    const { indeterminate: wasIndeterminate, onChange, onClick } = this.props;
+
+    if (this.inputRef && onChange) {
+      const { checked: isChecked, indeterminate: isIndeterminate } = this.inputRef;
+      const gotDetermined = wasIndeterminate && !isIndeterminate;
+
+      // some browser (e.g. Edge) do not change checked after setting indeterminate to false
+      if (gotDetermined && !isChecked) {
+        this.inputRef.checked = true;
+
+        // re-dispatch as change event
+        const changeEvent = new Event('change', event);
+        this.inputRef.dispatchEvent(changeEvent);
+        // dispatching the event does not trigger react onChange
+        // but calling onChange with the plain event will not include target unless we dispatch it
+        onChange(changeEvent, true);
+      }
+    }
+
+    if (onClick) {
+      onClick(event, ...clickArgs);
+    }
+  };
+
   handleInputRef = ref => {
     this.inputRef = ref;
   };
@@ -83,6 +108,7 @@ class Checkbox extends React.Component {
         icon={indeterminate ? indeterminateIcon : icon}
         inputRef={this.handleInputRef}
         {...other}
+        onClick={this.handleClick}
       />
     );
   }

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/jsx-handler-names */
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import SwitchBase from '../internal/SwitchBase';
@@ -52,7 +51,7 @@ class Checkbox extends React.Component {
   }
 
   handleInputRef = ref => {
-    this.inputRef = ReactDOM.findDOMNode(ref);
+    this.inputRef = ref;
   };
 
   updateIndeterminateStatus() {

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
+import { spy } from 'sinon';
 import IndeterminateCheckBoxIcon from '../internal/svg-icons/IndeterminateCheckBox';
 import { createShallow, getClasses, createMount } from '../test-utils';
 import SwitchBase from '../internal/SwitchBase';
@@ -50,6 +51,26 @@ describe('<Checkbox />', () => {
       const wrapper = mount(<Checkbox indeterminate />);
       wrapper.setProps({ indeterminate: false });
       assert.strictEqual(wrapper.find('input').getDOMNode().indeterminate, false);
+    });
+
+    it('should invert checked if it got determined', () => {
+      const testCombination = (checked, indeterminate) => {
+        const onChange = spy();
+        const wrapper = mount(
+          <Checkbox checked={checked} indeterminate={indeterminate} onChange={onChange} />,
+        );
+
+        // W3C recommended behavior
+        // https://www.w3.org/TR/2014/WD-html51-20140617/forms.html#checkbox-state-(type=checkbox)
+        // wrapper.simulate('click', { target: { checked: !checked, indeterminate: false } });
+
+        // Edge behavior
+        wrapper.simulate('click', { target: { checked, indeterminate: false } });
+        assert.strictEqual(onChange.args[0][1], !checked);
+      };
+
+      testCombination(false, true);
+      testCombination(true, true);
     });
   });
 });

--- a/packages/material-ui/src/utils/reactHelpers.js
+++ b/packages/material-ui/src/utils/reactHelpers.js
@@ -22,3 +22,19 @@ export function isMuiElement(element, muiNames) {
 export function isMuiComponent(element, muiNames) {
   return muiNames.indexOf(element.muiName) !== -1;
 }
+
+/**
+ * passes {instanceRef} to {toRef}
+ *
+ * useful if you want to expose the ref of an inner component to the public api
+ * while still using this inside the component
+ * @param {ReactInstance} instanceRef
+ * @param {RefObject | RefCallback | any} toRef
+ */
+export function forwardRef(instanceRef, toRef) {
+  if (typeof toRef === 'function') {
+    toRef(instanceRef);
+  } else if (toRef && 'current' in toRef) {
+    toRef.current = instanceRef;
+  }
+}


### PR DESCRIPTION
Fixes #12772

I'm still indeterminate ;) about whether we should support `indeterminate` on the DOM API. While this is consistent across browser this appears inconsistent for users that are used to Edge behavior. React currently does not even support `indeterminate` (facebook/react#1798) so I don't really see the benefit in polyfilling this behavior. 

The original PR #12671 mentioned automated testing as the primary drive behind the change and I wonder why this has to happen on the dom and not the props.

I did some refactoring while working on this to make the component consistent with other implementation patterns.