### PR TITLE
Enable tsc in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha packages/material-ui/test/**/*.test.js packages/material-ui/src/{,**/}*.test.js && nyc report --reporter=html",
     "test:karma": "cross-env NODE_ENV=test karma start test/karma.conf.js --single-run",
     "test:regressions": "webpack --config test/regressions/webpack.config.js && rimraf test/regressions/screenshots/chrome/* && vrtest run --config test/vrtest.config.js --record",
-    "typescript": "tslint -p tsconfig.json \"packages/*/{src,test}/**/*.{ts,tsx}\"",
+    "typescript": "tslint -p tsconfig.json \"packages/*/{src,test}/**/*.{ts,tsx}\" && tsc",
     "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN || true"
   },
   "peerDependencies": {
@@ -70,6 +70,7 @@
     "@babel/register": "7.0.0",
     "@types/enzyme": "^3.1.4",
     "@types/react": "^16.3.14",
+    "@types/react-dom": "^16.0.7",
     "argos-cli": "^0.0.9",
     "autoprefixer": "^9.0.0",
     "autosuggest-highlight": "^3.1.1",
@@ -154,7 +155,7 @@
     "sinon": "^6.0.0",
     "size-limit": "^0.19.0",
     "tslint": "^5.11.0",
-    "typescript": "^3.0.0",
+    "typescript": "3.0.1",
     "url-loader": "^1.0.1",
     "vrtest": "^0.2.0",
     "webfontloader": "^1.6.28",

--- a/yarn.lock
+++ b/yarn.lock
@@ -903,6 +903,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@^16.0.7":
+  version "16.0.7"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.0.7.tgz#54d0f867a76b90597e8432030d297982f25c20ba"
+  dependencies:
+    "@types/node" "*"
+    "@types/react" "*"
+
 "@types/react-transition-group@^2.0.8":
   version "2.0.13"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.13.tgz#7769fb61eb71d64d087a713956f086a42c3ee171"
@@ -9566,7 +9573,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^3.0.0:
+typescript@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 


### PR DESCRIPTION
Typescript wasn't being tested.....not sure if we never put it in or it fell out during a refactoring.

Enable `tsc` in build and lock at previous known good version.  Let's solve the issues with this before moving on to issues with typescript `3.0.3`.