### PR TITLE
[docs] Remove function call from onChange handler

### DIFF
--- a/docs/src/pages/guides/migration-v0x/migration-v0x.md
+++ b/docs/src/pages/guides/migration-v0x/migration-v0x.md
@@ -141,7 +141,7 @@ This will apply a change such as the following:
 -/>
 +<Switch
 +  checked={this.state.checkedA}
-+  onChange={this.handleSwitch()}
++  onChange={this.handleSwitch}
 +/>
 ```
 


### PR DESCRIPTION
Tiny change to pass the function rather than calling it in the migration docs.