### PR TITLE
[Hidden] render prop implementation

### DIFF
--- a/packages/material-ui/src/Hidden/Hidden.js
+++ b/packages/material-ui/src/Hidden/Hidden.js
@@ -66,6 +66,10 @@ Hidden.propTypes = {
     PropTypes.arrayOf(PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl'])),
   ]),
   /**
+   * Render prop.  If specified Hidden will render this rather than children.
+   */
+  render: PropTypes.func,
+  /**
    * If true, screens this size and down will be hidden.
    */
   smDown: PropTypes.bool,

--- a/packages/material-ui/src/Hidden/HiddenCss.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.js
@@ -44,6 +44,7 @@ function HiddenCss(props) {
     xlUp,
     xsDown,
     xsUp,
+    render,
     ...other
   } = props;
 
@@ -79,6 +80,10 @@ function HiddenCss(props) {
     onlyBreakpoints.forEach(breakpoint => {
       classNames.push(classes[`only${capitalize(breakpoint)}`]);
     });
+  }
+
+  if (render) {
+    return render({ className: classNames.join(' ') });
   }
 
   return <div className={classNames.join(' ')}>{children}</div>;
@@ -126,6 +131,10 @@ HiddenCss.propTypes = {
     PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
     PropTypes.arrayOf(PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl'])),
   ]),
+  /**
+   * Render prop.  If specified Hidden will render this rather than children.
+   */
+  render: PropTypes.func,
   /**
    * If true, screens this size and down will be hidden.
    */

--- a/packages/material-ui/src/Hidden/HiddenJs.js
+++ b/packages/material-ui/src/Hidden/HiddenJs.js
@@ -7,7 +7,7 @@ import exactProp from '../utils/exactProp';
  * @ignore - internal component.
  */
 function HiddenJs(props) {
-  const { children, only, width } = props;
+  const { children, only, width, render } = props;
 
   let visible = true;
 
@@ -45,6 +45,10 @@ function HiddenJs(props) {
 
   if (!visible) {
     return null;
+  }
+
+  if (render) {
+    return render();
   }
 
   return children;
@@ -99,6 +103,10 @@ HiddenJs.propTypes = {
     PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl']),
     PropTypes.arrayOf(PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl'])),
   ]),
+  /**
+   * Render prop.  If specified Hidden will render this rather than children.
+   */
+  render: PropTypes.func,
   /**
    * If true, screens this size and down will be hidden.
    */


### PR DESCRIPTION
Accept 'render' prop as alternative to children (#11850).

Fixes CSS implementation where you want content to be direct child of
parent.

example:

```
<Hidden
  mdUp
  render={({ className }) => (
    <Grid className={className} item xs={12} sm={12}>
      Hi there!
    </Grid>
  )}
/>
```

If this commit is on the right track I can look at adding TS decl and
tests.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
