### PR TITLE
[typescript] Revert type checking for inputProps

### DIFF
--- a/packages/material-ui/src/Input/Input.d.ts
+++ b/packages/material-ui/src/Input/Input.d.ts
@@ -17,7 +17,7 @@ export interface InputProps
   fullWidth?: boolean;
   id?: string;
   inputComponent?: React.ReactType<InputComponentProps>;
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  inputProps?: InputComponentProps;
   inputRef?: React.Ref<any> | React.RefObject<any>;
   margin?: 'dense';
   multiline?: boolean;


### PR DESCRIPTION
This did not accept custom props if a custom inputComponent was provided. While it is possible to infer the correct types it would also require explicit callback types which would be a breaking change.

Reverts #12591
Closes #12691, #12697

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
