### PR TITLE
[Checkbox] Revert input indeterminate support

### DIFF
--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -90,7 +90,8 @@ Checkbox.propTypes = {
    */
   id: PropTypes.string,
   /**
-   * If `true`, the component appears indeterminate.
+   * If `true`, the component appears indeterminate. This does not set the native
+   * input element to indeterminate due inconsistent behavior across browsers.
    */
   indeterminate: PropTypes.bool,
   /**

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -1,7 +1,4 @@
-/* eslint-disable react/jsx-handler-names */
-
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import SwitchBase from '../internal/SwitchBase';
@@ -40,53 +37,22 @@ export const styles = theme => ({
   },
 });
 
-class Checkbox extends React.Component {
-  componentDidMount = () => {
-    this.updateIndeterminateStatus();
-  };
+function Checkbox(props) {
+  const { checkedIcon, classes, color, icon, indeterminate, indeterminateIcon, ...other } = props;
 
-  componentDidUpdate = prevProps => {
-    if (prevProps.indeterminate !== this.props.indeterminate) {
-      this.updateIndeterminateStatus();
-    }
-  };
-
-  updateIndeterminateStatus = () => {
-    if (this.inputRef) {
-      this.inputRef.indeterminate = this.props.indeterminate;
-    }
-  };
-
-  handleInputRef = ref => {
-    this.inputRef = ReactDOM.findDOMNode(ref);
-  };
-
-  render() {
-    const {
-      checkedIcon,
-      classes,
-      color,
-      icon,
-      indeterminate,
-      indeterminateIcon,
-      ...other
-    } = this.props;
-
-    return (
-      <SwitchBase
-        type="checkbox"
-        checkedIcon={indeterminate ? indeterminateIcon : checkedIcon}
-        classes={{
-          root: classNames(classes.root, classes[`color${capitalize(color)}`]),
-          checked: classes.checked,
-          disabled: classes.disabled,
-        }}
-        icon={indeterminate ? indeterminateIcon : icon}
-        inputRef={this.handleInputRef}
-        {...other}
-      />
-    );
-  }
+  return (
+    <SwitchBase
+      type="checkbox"
+      checkedIcon={indeterminate ? indeterminateIcon : checkedIcon}
+      classes={{
+        root: classNames(classes.root, classes[`color${capitalize(color)}`]),
+        checked: classes.checked,
+        disabled: classes.disabled,
+      }}
+      icon={indeterminate ? indeterminateIcon : icon}
+      {...other}
+    />
+  );
 }
 
 Checkbox.propTypes = {

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -40,16 +40,5 @@ describe('<Checkbox />', () => {
       const wrapper = mount(<Checkbox indeterminate />);
       assert.strictEqual(wrapper.find(IndeterminateCheckBoxIcon).length, 1);
     });
-
-    it('should set input indeterminate status', () => {
-      const wrapper = mount(<Checkbox indeterminate />);
-      assert.strictEqual(wrapper.find('input').getDOMNode().indeterminate, true);
-    });
-
-    it('should change input indeterminate status on props change', () => {
-      const wrapper = mount(<Checkbox indeterminate />);
-      wrapper.setProps({ indeterminate: false });
-      assert.strictEqual(wrapper.find('input').getDOMNode().indeterminate, false);
-    });
   });
 });

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -27,7 +27,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool |   | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node | <span class="prop-default">&lt;CheckBoxOutlineBlankIcon /></span> | The icon to display when the component is unchecked. |
 | <span class="prop-name">id</span> | <span class="prop-type">string |   | The id of the `input` element. |
-| <span class="prop-name">indeterminate</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the component appears indeterminate. |
+| <span class="prop-name">indeterminate</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the component appears indeterminate. This does not set the native input element to indeterminate due inconsistent behavior across browsers. |
 | <span class="prop-name">indeterminateIcon</span> | <span class="prop-type">node | <span class="prop-default">&lt;IndeterminateCheckBoxIcon /></span> | The icon to display when the component is indeterminate. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object |   | Properties applied to the `input` element. |
 | <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | Use that property to pass a ref callback to the native input component. |


### PR DESCRIPTION
See #12773 for reasons that native indeterminate won't be supported. A short summary is added to the official docs.

Closes #12772
