### PR TITLE
[styles] Support multiple withStyles instances

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -16,7 +16,7 @@ module.exports = [
     name: 'The initial cost people pay for using one component',
     webpack: true,
     path: 'packages/material-ui/build/Paper/index.js',
-    limit: '17.6 KB',
+    limit: '17.5 KB',
   },
   {
     name: 'The size of all the modules of material-ui.',

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -325,6 +325,7 @@ A function which returns [a class name generator function](http://cssinjs.org/js
 1. `options` (*Object* [optional]):
   - `options.dangerouslyUseGlobalCSS` (*Boolean* [optional]): Defaults to `false`. Makes the Material-UI class names deterministic.
   - `options.productionPrefix` (*String* [optional]): Defaults to `'jss'`. The string used to prefix the class names in production.
+  - `options.seed` (*String* [optional]): Defaults to `''`. The string used to uniquely identify the generator. It can be used to avoid class name collisions when using multiple generators.
 
 #### Returns
 

--- a/packages/material-ui/src/NoSsr/NoSsr.test.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.test.js
@@ -63,7 +63,7 @@ describe('<NoSsr />', () => {
         assert.strictEqual(wrapper.find('span').length, 1);
         assert.strictEqual(wrapper.text(), 'Hello');
         done();
-      }, 100);
+      }, 200);
     });
   });
 });

--- a/packages/material-ui/src/styles/createGenerateClassName.js
+++ b/packages/material-ui/src/styles/createGenerateClassName.js
@@ -2,10 +2,6 @@
 
 import warning from 'warning';
 
-// People might bundle this classname generator twice.
-// We need to use a global.
-global.__MUI_GENERATOR_COUNTER__ = 0;
-
 const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;
 
 function safePrefix(classNamePrefix) {
@@ -22,27 +18,8 @@ function safePrefix(classNamePrefix) {
 // It's inspired by
 // https://github.com/cssinjs/jss/blob/4e6a05dd3f7b6572fdd3ab216861d9e446c20331/src/utils/createGenerateClassName.js
 export default function createGenerateClassName(options = {}) {
-  const { dangerouslyUseGlobalCSS = false, productionPrefix = 'jss' } = options;
+  const { dangerouslyUseGlobalCSS = false, productionPrefix = 'jss', seed = '' } = options;
   let ruleCounter = 0;
-
-  // - HMR can lead to many class name generators being instantiated,
-  // so the warning is only triggered in production.
-  // - We expect a class name generator to be instantiated per new request on the server,
-  // so the warning is only triggered client side.
-  if (process.env.NODE_ENV === 'production' && typeof window !== 'undefined') {
-    global.__MUI_GENERATOR_COUNTER__ += 1;
-
-    if (global.__MUI_GENERATOR_COUNTER__ > 2) {
-      // eslint-disable-next-line no-console
-      console.error(
-        [
-          'Material-UI: we have detected more than needed creation of the class name generator.',
-          'You should only use one class name generator on the client side.',
-          'If you do otherwise, you take the risk to have conflicting class names in production.',
-        ].join('\n'),
-      );
-    }
-  }
 
   return (rule, styleSheet) => {
     ruleCounter += 1;
@@ -63,27 +40,27 @@ export default function createGenerateClassName(options = {}) {
 
         if (styleSheet.options.classNamePrefix && process.env.NODE_ENV !== 'production') {
           const prefix = safePrefix(styleSheet.options.classNamePrefix);
-          return `${prefix}-${rule.key}-${ruleCounter}`;
+          return `${prefix}-${rule.key}-${seed}${ruleCounter}`;
         }
       }
 
       if (process.env.NODE_ENV === 'production') {
-        return `${productionPrefix}${ruleCounter}`;
+        return `${productionPrefix}${seed}${ruleCounter}`;
       }
 
-      return `${rule.key}-${ruleCounter}`;
+      return `${rule.key}-${seed}${ruleCounter}`;
     }
 
     if (process.env.NODE_ENV === 'production') {
-      return `${productionPrefix}${ruleCounter}`;
+      return `${productionPrefix}${seed}${ruleCounter}`;
     }
 
     if (styleSheet && styleSheet.options.classNamePrefix) {
       const prefix = safePrefix(styleSheet.options.classNamePrefix);
 
-      return `${prefix}-${rule.key}-${ruleCounter}`;
+      return `${prefix}-${rule.key}-${seed}${ruleCounter}`;
     }
 
-    return `${rule.key}-${ruleCounter}`;
+    return `${rule.key}-${seed}${ruleCounter}`;
   };
 }

--- a/packages/material-ui/src/styles/createGenerateClassName.test.js
+++ b/packages/material-ui/src/styles/createGenerateClassName.test.js
@@ -151,16 +151,6 @@ describe('createGenerateClassName', () => {
         });
         assert.strictEqual(generateClassName(rule), 'jss1');
       });
-
-      it('should warn', () => {
-        createGenerateClassName();
-        createGenerateClassName();
-        assert.strictEqual(consoleErrorMock.callCount() > 0, true);
-        assert.match(
-          consoleErrorMock.args()[0][0],
-          /Material-UI: we have detected more than needed creation of the/,
-        );
-      });
     });
   });
 });

--- a/packages/material-ui/src/styles/packageId.js
+++ b/packages/material-ui/src/styles/packageId.js
@@ -1,0 +1,8 @@
+/* eslint-disable no-underscore-dangle, no-plusplus */
+
+if (!global.__MUI_PACKAGE_ID__) {
+  global.__MUI_PACKAGE_ID__ = 0;
+}
+
+// One unique value per @material-ui/core package installation.
+export default global.__MUI_PACKAGE_ID__++;

--- a/packages/material-ui/src/styles/withStyles.js
+++ b/packages/material-ui/src/styles/withStyles.js
@@ -14,12 +14,18 @@ import themeListener from './themeListener';
 import createGenerateClassName from './createGenerateClassName';
 import getStylesCreator from './getStylesCreator';
 import getThemeProps from './getThemeProps';
+import packageId from './packageId';
 
 // Default JSS instance.
 const jss = create(jssPreset());
 
 // Use a singleton or the provided one by the context.
-const generateClassName = createGenerateClassName();
+//
+// ⚠️ People might use the default generator more than once.
+// It can be an issue, aside from the bundle size overhead, it can break the styles.
+// The generated classNames can collide.
+// We are avoiding the collision with a seed, one per package installation.
+const generateClassName = createGenerateClassName({ seed: packageId });
 
 // Global index counter to preserve source order.
 // We create the style sheet during at the creation of the component,


### PR DESCRIPTION
I thought for a year that we could avoid doing that. But I was wrong. People are really struggling with the class name counter based approach. It's never too late to recover from our mistakes.
With this change, the styles won't break when people bundle more than one version of Material-UI.
Hopefully, people can still notice the bundle bloat when analyzing it. It's gonna help with the growing ecosystem of third-party libraries using Material-UI. I would still encourage them to set Material-UI as a peer dependency.

Closes #12781