### PR TITLE
[styles] Use the same class name generator

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -40,12 +40,12 @@ function getDemo(props) {
       'demo.js': props.raw,
       'index.js': `
 import React from 'react';
-import { render } from 'react-dom';
+import ReactDOM from 'react-dom';
 import Demo from './demo';
 
 const rootElement = document.querySelector('#root');
 if (rootElement) {
-  render(<Demo />, rootElement);
+  ReactDOM.render(<Demo />, rootElement);
 }
       `,
       'index.html': `

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -325,7 +325,7 @@ A function which returns [a class name generator function](http://cssinjs.org/js
 1. `options` (*Object* [optional]):
   - `options.dangerouslyUseGlobalCSS` (*Boolean* [optional]): Defaults to `false`. Makes the Material-UI class names deterministic.
   - `options.productionPrefix` (*String* [optional]): Defaults to `'jss'`. The string used to prefix the class names in production.
-  - `options.seed` (*String* [optional]): Defaults to `''`. The string used to uniquely identify the generator. It can be used to avoid class name collisions when using multiple generators.
+  - `options.seed` (*String* [optional]): Defaults to `'PACKAGE_ID-'`. The string used to uniquely identify the generator. It can be used to avoid class name collisions when using multiple generators.
 
 #### Returns
 

--- a/docs/src/pages/guides/server-rendering/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering.md
@@ -65,7 +65,7 @@ The key step in server side rendering is to render the initial HTML of our compo
 We then get the CSS from our `sheetsRegistry` using `sheetsRegistry.toString()`. We will see how this is passed along in our `renderFullPage` function.
 
 ```jsx
-import { renderToString } from 'react-dom/server'
+import ReactDOMServer from 'react-dom/server'
 import { SheetsRegistry } from 'react-jss/lib/jss';
 import JssProvider from 'react-jss/lib/JssProvider';
 import {
@@ -96,7 +96,7 @@ function handleRender(req, res) {
   const generateClassName = createGenerateClassName();
 
   // Render the component to a string.
-  const html = renderToString(
+  const html = ReactDOMServer.renderToString(
     <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>
       <MuiThemeProvider theme={theme} sheetsManager={sheetsManager}>
         <App />
@@ -142,8 +142,13 @@ Let's take a look at our client file:
 
 ```jsx
 import React from 'react';
-import { hydrate } from 'react-dom';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import ReactDOM from 'react-dom';
+import JssProvider from 'react-jss/lib/JssProvider';
+import {
+  MuiThemeProvider,
+  createMuiTheme,
+  createGenerateClassName,
+} from '@material-ui/core/styles';
 import green from '@material-ui/core/colors/green';
 import red from '@material-ui/core/colors/red';
 import App from './App';
@@ -171,10 +176,15 @@ const theme = createMuiTheme({
   },
 });
 
-hydrate(
-  <MuiThemeProvider theme={theme}>
-    <Main />
-  </MuiThemeProvider>,
+// Create a new class name generator.
+const generateClassName = createGenerateClassName();
+
+ReactDOM.hydrate(
+  <JssProvider generateClassName={generateClassName}>
+    <MuiThemeProvider theme={theme}>
+      <Main />
+    </MuiThemeProvider>
+  </JssProvider>,
   document.querySelector('#root'),
 );
 ```
@@ -216,13 +226,13 @@ function handleRender(req, res) {
   //…
 
   // Render the component to a string.
-  const html = renderToString(
+  const html = ReactDOMServer.renderToString(
 ```
 
 ### React class name hydration mismatch
 
 There is a class name mismatch between the client and the server. It might work for the first request.
-Another symptom is that the styling changes between initial page load and the downloading of the client scripts. 
+Another symptom is that the styling changes between initial page load and the downloading of the client scripts.
 
 #### Action to Take
 
@@ -244,7 +254,7 @@ function handleRender(req, res) {
   //…
 
   // Render the component to a string.
-  const html = renderToString(
+  const html = ReactDOMServer.renderToString(
 ```
 
 - You need to verify that your client and server are running the **exactly the same version** of Material-UI.

--- a/examples/gatsby/gatsby-ssr.js
+++ b/examples/gatsby/gatsby-ssr.js
@@ -11,11 +11,7 @@ function replaceRenderer({ bodyComponent, replaceBodyHTMLString, setHeadComponen
   const muiPageContext = getPageContext.default ? getPageContext.default() : getPageContext();
 
   const bodyHTML = renderToString(
-    <JssProvider registry={muiPageContext.sheetsRegistry}>
-      {React.cloneElement(bodyComponent, {
-        muiPageContext,
-      })}
-    </JssProvider>,
+    <JssProvider registry={muiPageContext.sheetsRegistry}>{bodyComponent}</JssProvider>,
   );
 
   replaceBodyHTMLString(bodyHTML);

--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/examples/ssr/client.js
+++ b/examples/ssr/client.js
@@ -1,6 +1,11 @@
 import React from 'react';
-import { hydrate } from 'react-dom';
-import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
+import ReactDOM from 'react-dom';
+import JssProvider from 'react-jss/lib/JssProvider';
+import {
+  MuiThemeProvider,
+  createMuiTheme,
+  createGenerateClassName,
+} from '@material-ui/core/styles';
 import green from '@material-ui/core/colors/green';
 import red from '@material-ui/core/colors/red';
 import App from './App';
@@ -28,9 +33,14 @@ const theme = createMuiTheme({
   },
 });
 
-hydrate(
-  <MuiThemeProvider theme={theme}>
-    <Main />
-  </MuiThemeProvider>,
+// Create a new class name generator.
+const generateClassName = createGenerateClassName();
+
+ReactDOM.hydrate(
+  <JssProvider generateClassName={generateClassName}>
+    <MuiThemeProvider theme={theme}>
+      <Main />
+    </MuiThemeProvider>
+  </JssProvider>,
   document.querySelector('#root'),
 );

--- a/examples/ssr/server.js
+++ b/examples/ssr/server.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import React from 'react';
-import { renderToString } from 'react-dom/server';
+import ReactDOMServer from 'react-dom/server';
 import { SheetsRegistry } from 'react-jss/lib/jss';
 import JssProvider from 'react-jss/lib/JssProvider';
 import {
@@ -48,7 +48,7 @@ function handleRender(req, res) {
   const generateClassName = createGenerateClassName();
 
   // Render the component to a string.
-  const html = renderToString(
+  const html = ReactDOMServer.renderToString(
     <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>
       <MuiThemeProvider theme={theme} sheetsManager={sheetsManager}>
         <App />

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { findDOMNode } from 'react-dom';
+import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import keycode from 'keycode';
 import classNames from 'classnames';
@@ -442,7 +442,7 @@ class Slider extends React.Component {
         onTouchStartCapture={this.handleTouchStart}
         onTouchMove={this.handleMouseMove}
         ref={ref => {
-          this.containerRef = findDOMNode(ref);
+          this.containerRef = ReactDOM.findDOMNode(ref);
         }}
         {...other}
       >

--- a/packages/material-ui/src/NoSsr/NoSsr.test.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.test.js
@@ -63,7 +63,7 @@ describe('<NoSsr />', () => {
         assert.strictEqual(wrapper.find('span').length, 1);
         assert.strictEqual(wrapper.text(), 'Hello');
         done();
-      }, 200);
+      }, 300);
     });
   });
 });

--- a/packages/material-ui/src/styles/MuiThemeProvider.test.js
+++ b/packages/material-ui/src/styles/MuiThemeProvider.test.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { SheetsRegistry } from 'jss';
 import JssProvider from 'react-jss/lib/JssProvider';
-import { renderToString } from 'react-dom/server';
+import ReactDOMServer from 'react-dom/server';
 import { createMount } from '../test-utils';
 import createMuiTheme from './createMuiTheme';
 import Button from '../Button';
@@ -71,9 +71,9 @@ describe('<MuiThemeProvider />', () => {
     it('should be able to extract the styles', () => {
       const theme = createMuiTheme();
       const sheetsRegistry = new SheetsRegistry();
-      const generateClassName = createGenerateClassName();
+      const generateClassName = createGenerateClassName({ seed: '' });
 
-      const markup = renderToString(
+      const markup = ReactDOMServer.renderToString(
         <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>
           <MuiThemeProvider theme={theme} sheetsManager={new Map()}>
             <Button>Hello World</Button>

--- a/packages/material-ui/src/styles/createGenerateClassName.js
+++ b/packages/material-ui/src/styles/createGenerateClassName.js
@@ -1,6 +1,13 @@
 /* eslint-disable no-underscore-dangle */
 
 import warning from 'warning';
+// The counter-based approach doesn't tolerate any mistake.
+// It's much safer to use the same counter everywhere.
+// However, because we allow people to get started without any configuration,
+// we need to handle the generator duplication case. It can happen when more than one
+// generator is used.
+// We are avoiding class name collisions with a seed, one per package installation.
+import packageId from './packageId';
 
 const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;
 
@@ -18,7 +25,11 @@ function safePrefix(classNamePrefix) {
 // It's inspired by
 // https://github.com/cssinjs/jss/blob/4e6a05dd3f7b6572fdd3ab216861d9e446c20331/src/utils/createGenerateClassName.js
 export default function createGenerateClassName(options = {}) {
-  const { dangerouslyUseGlobalCSS = false, productionPrefix = 'jss', seed = '' } = options;
+  const {
+    dangerouslyUseGlobalCSS = false,
+    productionPrefix = 'jss',
+    seed = `${packageId}-`,
+  } = options;
   let ruleCounter = 0;
 
   return (rule, styleSheet) => {

--- a/packages/material-ui/src/styles/createGenerateClassName.test.js
+++ b/packages/material-ui/src/styles/createGenerateClassName.test.js
@@ -6,16 +6,16 @@ describe('createGenerateClassName', () => {
   describe('counter', () => {
     it('should increment a scoped counter', () => {
       const rule = { key: 'root' };
-      const generateClassName1 = createGenerateClassName();
+      const generateClassName1 = createGenerateClassName({ seed: '' });
       assert.strictEqual(generateClassName1(rule), 'root-1');
       assert.strictEqual(generateClassName1(rule), 'root-2');
-      const generateClassName2 = createGenerateClassName();
+      const generateClassName2 = createGenerateClassName({ seed: '' });
       assert.strictEqual(generateClassName2(rule), 'root-1');
     });
   });
 
   it('should escape parenthesis', () => {
-    const generateClassName = createGenerateClassName();
+    const generateClassName = createGenerateClassName({ seed: '' });
     assert.strictEqual(
       generateClassName(
         { key: 'root' },
@@ -31,7 +31,7 @@ describe('createGenerateClassName', () => {
   });
 
   it('should escape spaces', () => {
-    const generateClassName = createGenerateClassName();
+    const generateClassName = createGenerateClassName({ seed: '' });
     assert.strictEqual(
       generateClassName(
         { key: 'root' },
@@ -49,6 +49,7 @@ describe('createGenerateClassName', () => {
   describe('options: dangerouslyUseGlobalCSS', () => {
     it('should use a global class name', () => {
       const generateClassName = createGenerateClassName({
+        seed: '',
         dangerouslyUseGlobalCSS: true,
       });
       assert.strictEqual(
@@ -84,6 +85,7 @@ describe('createGenerateClassName', () => {
 
     it('should default to a non deterministic name', () => {
       const generateClassName = createGenerateClassName({
+        seed: '',
         dangerouslyUseGlobalCSS: true,
       });
       assert.strictEqual(
@@ -99,13 +101,13 @@ describe('createGenerateClassName', () => {
     it('should take the sheet meta in development if available', () => {
       const rule = { key: 'root' };
       const styleSheet = { options: { classNamePrefix: 'Button' } };
-      const generateClassName = createGenerateClassName();
+      const generateClassName = createGenerateClassName({ seed: '' });
       assert.strictEqual(generateClassName(rule, styleSheet), 'Button-root-1');
     });
 
     it('should use a base 10 representation', () => {
       const rule = { key: 'root' };
-      const generateClassName = createGenerateClassName();
+      const generateClassName = createGenerateClassName({ seed: '' });
       assert.strictEqual(generateClassName(rule), 'root-1');
       assert.strictEqual(generateClassName(rule), 'root-2');
       assert.strictEqual(generateClassName(rule), 'root-3');
@@ -140,13 +142,14 @@ describe('createGenerateClassName', () => {
 
       it('should output a short representation', () => {
         const rule = { key: 'root' };
-        const generateClassName = createGenerateClassName();
+        const generateClassName = createGenerateClassName({ seed: '' });
         assert.strictEqual(generateClassName(rule), 'jss1');
       });
 
       it('should work with global CSS', () => {
         const rule = { key: 'root' };
         const generateClassName = createGenerateClassName({
+          seed: '',
           dangerouslyUseGlobalCSS: true,
         });
         assert.strictEqual(generateClassName(rule), 'jss1');

--- a/packages/material-ui/src/styles/withStyles.js
+++ b/packages/material-ui/src/styles/withStyles.js
@@ -14,18 +14,12 @@ import themeListener from './themeListener';
 import createGenerateClassName from './createGenerateClassName';
 import getStylesCreator from './getStylesCreator';
 import getThemeProps from './getThemeProps';
-import packageId from './packageId';
 
 // Default JSS instance.
 const jss = create(jssPreset());
 
 // Use a singleton or the provided one by the context.
-//
-// ⚠️ People might use the default generator more than once.
-// It can be an issue, aside from the bundle size overhead, it can break the styles.
-// The generated classNames can collide.
-// We are avoiding the collision with a seed, one per package installation.
-const generateClassName = createGenerateClassName({ seed: `${packageId}-` });
+const generateClassName = createGenerateClassName();
 
 // Global index counter to preserve source order.
 // We create the style sheet during at the creation of the component,

--- a/packages/material-ui/src/styles/withStyles.test.js
+++ b/packages/material-ui/src/styles/withStyles.test.js
@@ -143,7 +143,7 @@ describe('withStyles', () => {
 
     beforeEach(() => {
       jss = create(jssPreset());
-      generateClassName = createGenerateClassName();
+      generateClassName = createGenerateClassName({ seed: '' });
       sheetsRegistry = new SheetsRegistry();
     });
 

--- a/packages/material-ui/src/test-utils/createMount.js
+++ b/packages/material-ui/src/test-utils/createMount.js
@@ -1,4 +1,4 @@
-import { unmountComponentAtNode } from 'react-dom';
+import ReactDOM from 'react-dom';
 import { mount as enzymeMount } from 'enzyme';
 
 // Generate an enhanced mount function.
@@ -20,7 +20,7 @@ export default function createMount(options1 = {}) {
 
   mountWithContext.attachTo = attachTo;
   mountWithContext.cleanUp = () => {
-    unmountComponentAtNode(attachTo);
+    ReactDOM.unmountComponentAtNode(attachTo);
     attachTo.parentNode.removeChild(attachTo);
   };
 


### PR DESCRIPTION
Keep fixing the consequences of #12814.
- Fix the ssr example to use the same generator
- Make the counter implementation more tolerant, as we had in 3.0.2 and lower.