### PR TITLE
[CircularProgress] Update missing type definitions

### DIFF
--- a/packages/material-ui/src/CircularProgress/CircularProgress.d.ts
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.d.ts
@@ -12,11 +12,13 @@ export interface CircularProgressProps
 
 export type CircularProgressClassKey =
   | 'root'
+  | 'static'
+  | 'indeterminate'
   | 'colorPrimary'
   | 'colorSecondary'
   | 'svg'
-  | 'svgIndeterminate'
   | 'circle'
+  | 'circleStatic'
   | 'circleIndeterminate';
 
 declare const CircularProgress: React.ComponentType<CircularProgressProps>;


### PR DESCRIPTION
# Bug
Overriding `circleStatic` in TypeScript results in build failures.

# Solution
Update TypeScript definition file

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
