### PR TITLE
[slider] Don't pass component props down to root div

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -377,13 +377,17 @@ class Slider extends React.Component {
   render() {
     const { currentState } = this.state;
     const {
-      component: Component,
-      classes,
       className: classNameProp,
+      classes,
+      component: Component,
       disabled,
       max,
       min,
+      onChange,
+      onDragEnd,
+      onDragStart,
       reverse,
+      step,
       theme,
       value,
       vertical,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
<img width="1419" alt="image" src="https://user-images.githubusercontent.com/357702/45379540-43deec80-b5f8-11e8-9fe6-1dfb2ed30b9f.png">
