### PR TITLE
[slider] Faster transitions

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -10,7 +10,7 @@ import clamp from '../utils/clamp';
 
 export const styles = theme => {
   const commonTransitionsOptions = {
-    duration: theme.transitions.duration.short,
+    duration: theme.transitions.duration.shortest,
     easing: theme.transitions.easing.easeOut,
   };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
While testing the custom slider icon PR, I noticed the transitions seemed quite sluggish. This PR speeds them up.