### PR TITLE
[Tooltip] Persistently set ignoreNonTouch when device is a touch device

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -99,6 +99,10 @@ class Tooltip extends React.Component {
   }
 
   componentDidMount() {
+    if (typeof document !== 'undefined' && 'ontouchstart' in document.documentElement) {
+      this.ignoreNonTouchEvents = true;
+    }
+
     warning(
       !this.childrenRef.disabled || !this.childrenRef.tagName.toLowerCase() === 'button',
       [
@@ -222,13 +226,9 @@ class Tooltip extends React.Component {
     }
 
     clearTimeout(this.closeTimer);
-    this.closeTimer = setTimeout(() => {
-      this.ignoreNonTouchEvents = false;
-    }, this.props.theme.transitions.duration.shortest);
   };
 
   handleTouchStart = event => {
-    this.ignoreNonTouchEvents = true;
     const { children, enterTouchDelay } = this.props;
 
     if (children.props.onTouchStart) {


### PR DESCRIPTION
While working with the speed dial, I found that tooltips were still appearing small in on mobile devices if they were automatically set to open because the logic for making them large was for some reason encapsulated in the onTouchStart and onTouchEnd methods. Not exactly sure why that is, but this proposes that if there is any case where a device responds to touch, show the larger tooltips, without seemingly unnecessarily toggling the values.