### PR TITLE
[TableSortLabel] Remove sort icon when not active

### DIFF
--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
@@ -7,6 +7,7 @@ export interface TableSortLabelProps
   extends StandardProps<ButtonBaseProps, TableSortLabelClassKey> {
   active?: boolean;
   direction?: 'asc' | 'desc';
+  hideSortIcon?: boolean;
   IconComponent?: React.ComponentType<SvgIconProps>;
 }
 

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -58,9 +58,9 @@ export const styles = theme => ({
 function TableSortLabel(props) {
   const {
     active,
+    children,
     classes,
     className,
-    children,
     direction,
     hideSortIcon,
     IconComponent,
@@ -75,7 +75,7 @@ function TableSortLabel(props) {
       {...other}
     >
       {children}
-      {(active || !hideSortIcon) && (
+      {hideSortIcon && !active ? null : (
         <IconComponent
           className={classNames(classes.icon, classes[`iconDirection${capitalize(direction)}`])}
         />
@@ -107,7 +107,7 @@ TableSortLabel.propTypes = {
    */
   direction: PropTypes.oneOf(['asc', 'desc']),
   /**
-   * Hide sort icon if necessary, only when active = False
+   * Hide sort icon when active is false.
    */
   hideSortIcon: PropTypes.bool,
   /**
@@ -119,6 +119,7 @@ TableSortLabel.propTypes = {
 TableSortLabel.defaultProps = {
   active: false,
   direction: 'desc',
+  hideSortIcon: false,
   IconComponent: ArrowDownwardIcon,
 };
 

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -56,7 +56,16 @@ export const styles = theme => ({
  * A button based label for placing inside `TableCell` for column sorting.
  */
 function TableSortLabel(props) {
-  const { active, classes, className, children, direction, IconComponent, ...other } = props;
+  const {
+    active,
+    classes,
+    className,
+    children,
+    direction,
+    hideSortIcon,
+    IconComponent,
+    ...other
+  } = props;
 
   return (
     <ButtonBase
@@ -66,9 +75,11 @@ function TableSortLabel(props) {
       {...other}
     >
       {children}
-      <IconComponent
-        className={classNames(classes.icon, classes[`iconDirection${capitalize(direction)}`])}
-      />
+      {(active || !hideSortIcon) && (
+        <IconComponent
+          className={classNames(classes.icon, classes[`iconDirection${capitalize(direction)}`])}
+        />
+      )}
     </ButtonBase>
   );
 }
@@ -95,6 +106,10 @@ TableSortLabel.propTypes = {
    * The current sort direction.
    */
   direction: PropTypes.oneOf(['asc', 'desc']),
+  /**
+   * Hide sort icon if necessary, only when active = False
+   */
+  hideSortIcon: PropTypes.bool,
   /**
    * Sort icon to use.
    */

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -72,6 +72,31 @@ describe('<TableSortLabel />', () => {
     });
   });
 
+  describe('can hide icon', () => {
+    it('can hide icon when not active', () => {
+      const activeFlag = false;
+      const hideSortIconFlag = true;
+      const wrapper = mount(<TableSortLabel active={activeFlag} hideSortIcon={hideSortIconFlag} />);
+      const iconChildren = wrapper.find(`.${classes.icon}`).first();
+      assert.strictEqual(iconChildren.length, 0);
+    });
+
+    it('does not hide icon by default when not active', () => {
+      const activeFlag = false;
+      const wrapper = mount(<TableSortLabel active={activeFlag} />);
+      const iconChildren = wrapper.find(`.${classes.icon}`).first();
+      assert.strictEqual(iconChildren.length, 1);
+    });
+
+    it('does not hide icon when active', () => {
+      const activeFlag = true;
+      const hideSortIconFlag = true;
+      const wrapper = mount(<TableSortLabel active={activeFlag} hideSortIcon={hideSortIconFlag} />);
+      const iconChildren = wrapper.find(`.${classes.icon}`).first();
+      assert.strictEqual(iconChildren.length, 1);
+    });
+  });
+
   describe('mount', () => {
     it('should mount without error', () => {
       mount(<TableSortLabel />);

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -65,33 +65,27 @@ describe('<TableSortLabel />', () => {
     });
 
     it('should accept a custom icon for the sort icon', () => {
-      shallow = createShallow({ untilSelector: 'Sort' });
       const wrapper = mount(<TableSortLabel IconComponent={Sort} />);
       assert.strictEqual(wrapper.props().IconComponent, Sort);
       assert.strictEqual(wrapper.find(Sort).length, 1);
     });
   });
 
-  describe('can hide icon', () => {
+  describe('prop: hideSortIcon', () => {
     it('can hide icon when not active', () => {
-      const activeFlag = false;
-      const hideSortIconFlag = true;
-      const wrapper = mount(<TableSortLabel active={activeFlag} hideSortIcon={hideSortIconFlag} />);
+      const wrapper = shallow(<TableSortLabel active={false} hideSortIcon />);
       const iconChildren = wrapper.find(`.${classes.icon}`).first();
       assert.strictEqual(iconChildren.length, 0);
     });
 
     it('does not hide icon by default when not active', () => {
-      const activeFlag = false;
-      const wrapper = mount(<TableSortLabel active={activeFlag} />);
+      const wrapper = shallow(<TableSortLabel active={false} />);
       const iconChildren = wrapper.find(`.${classes.icon}`).first();
       assert.strictEqual(iconChildren.length, 1);
     });
 
     it('does not hide icon when active', () => {
-      const activeFlag = true;
-      const hideSortIconFlag = true;
-      const wrapper = mount(<TableSortLabel active={activeFlag} hideSortIcon={hideSortIconFlag} />);
+      const wrapper = shallow(<TableSortLabel active hideSortIcon />);
       const iconChildren = wrapper.find(`.${classes.icon}`).first();
       assert.strictEqual(iconChildren.length, 1);
     });

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -23,6 +23,7 @@ A button based label for placing inside `TableCell` for column sorting.
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | Label contents, the arrow will be appended automatically. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">direction</span> | <span class="prop-type">enum:&nbsp;'asc'&nbsp;&#124;<br>&nbsp;'desc'<br> | <span class="prop-default">'desc'</span> | The current sort direction. |
+| <span class="prop-name">hideSortIcon</span> | <span class="prop-type">bool |   | Hide sort icon if necessary, only when active = False |
 | <span class="prop-name">IconComponent</span> | <span class="prop-type">func | <span class="prop-default">ArrowDownwardIcon</span> | Sort icon to use. |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -23,7 +23,7 @@ A button based label for placing inside `TableCell` for column sorting.
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | Label contents, the arrow will be appended automatically. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">direction</span> | <span class="prop-type">enum:&nbsp;'asc'&nbsp;&#124;<br>&nbsp;'desc'<br> | <span class="prop-default">'desc'</span> | The current sort direction. |
-| <span class="prop-name">hideSortIcon</span> | <span class="prop-type">bool |   | Hide sort icon if necessary, only when active = False |
+| <span class="prop-name">hideSortIcon</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Hide sort icon when active is false. |
 | <span class="prop-name">IconComponent</span> | <span class="prop-type">func | <span class="prop-default">ArrowDownwardIcon</span> | Sort icon to use. |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).


### PR DESCRIPTION
1. Add `hideSortIcon` property to remove sort icon when active==false
2. Add test cases

Closes #12561
