### PR TITLE
[SvgIcon] Expand fontSize options

### DIFF
--- a/docs/src/pages/demos/buttons/ButtonSizes.js
+++ b/docs/src/pages/demos/buttons/ButtonSizes.js
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+
 import AddIcon from '@material-ui/icons/Add';
+import DeleteIcon from '@material-ui/icons/Delete';
 
 const styles = theme => ({
   button: {
@@ -54,6 +57,17 @@ function ButtonSizes(props) {
         <Button variant="fab" color="secondary" aria-label="Add" className={classes.button}>
           <AddIcon />
         </Button>
+      </div>
+      <div>
+        <IconButton className={classes.button} aria-label="Delete">
+          <DeleteIcon fontSize="small" />
+        </IconButton>
+        <IconButton className={classes.button} aria-label="Delete">
+          <DeleteIcon />
+        </IconButton>
+        <IconButton className={classes.button} aria-label="Delete">
+          <DeleteIcon fontSize="large" />
+        </IconButton>
       </div>
     </div>
   );

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -73,12 +73,6 @@ animation to finish before the new one enters.
 
 {{"demo": "pages/demos/buttons/FloatingActionButtonZoom.js"}}
 
-## Sizes
-
-Fancy larger or smaller buttons? Use the `size` or the `mini` property.
-
-{{"demo": "pages/demos/buttons/ButtonSizes.js"}}
-
 ## Icon Buttons
 
 Icon buttons are commonly found in app bars and toolbars.
@@ -87,6 +81,12 @@ Icons are also appropriate for toggle buttons that allow a single choice to be s
 deselected, such as adding or removing a star to an item.
 
 {{"demo": "pages/demos/buttons/IconButtons.js"}}
+
+## Sizes
+
+Fancy larger or smaller buttons? Use the `size` or the `mini` property.
+
+{{"demo": "pages/demos/buttons/ButtonSizes.js"}}
 
 ### Buttons with icons and label
 

--- a/docs/src/pages/style/icons/SvgIcons.js
+++ b/docs/src/pages/style/icons/SvgIcons.js
@@ -39,11 +39,11 @@ function SvgIcons(props) {
       <HomeIcon className={classes.icon} color="secondary" />
       <HomeIcon className={classes.icon} color="action" />
       <HomeIcon className={classes.iconHover} color="error" style={{ fontSize: 30 }} />
-      <HomeIcon color="disabled" className={classes.icon} style={{ fontSize: 36 }} />
+      <HomeIcon color="disabled" className={classes.icon} fontSize="large" />
       <HomeIcon
         className={classes.icon}
         color="primary"
-        style={{ fontSize: 36 }}
+        fontSize="large"
         component={svgProps => (
           <svg {...svgProps}>
             <defs>

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -14,9 +14,7 @@ export const styles = theme => ({
     textAlign: 'center',
     flex: '0 0 auto',
     fontSize: theme.typography.pxToRem(24),
-    width: 48,
-    height: 48,
-    padding: 0,
+    padding: 12,
     borderRadius: '50%',
     overflow: 'visible', // Explicitly set the default value to solve a bug on IE11.
     color: theme.palette.action.active,

--- a/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
@@ -5,7 +5,7 @@ export interface SvgIconProps
   extends StandardProps<React.SVGProps<SVGSVGElement>, SvgIconClassKey> {
   color?: PropTypes.Color | 'action' | 'disabled' | 'error';
   component?: React.ReactType<SvgIconProps>;
-  fontSize?: 'inherit' | 'default';
+  fontSize?: 'inherit' | 'default' | 'small' | 'large';
   nativeColor?: string;
   titleAccess?: string;
   viewBox?: string;
@@ -18,7 +18,9 @@ export type SvgIconClassKey =
   | 'colorDisabled'
   | 'colorError'
   | 'colorPrimary'
-  | 'fontSizeInherit';
+  | 'fontSizeInherit'
+  | 'fontSizeSmall'
+  | 'fontSizeLarge';
 
 declare const SvgIcon: React.ComponentType<SvgIconProps>;
 

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -42,6 +42,14 @@ export const styles = theme => ({
   fontSizeInherit: {
     fontSize: 'inherit',
   },
+  /* Styles applied to the root element if `fontSize="small"`. */
+  fontSizeSmall: {
+    fontSize: 18,
+  },
+  /* Styles applied to the root element if `fontSize="large"`. */
+  fontSizeLarge: {
+    fontSize: 36,
+  },
 });
 
 function SvgIcon(props) {
@@ -61,7 +69,7 @@ function SvgIcon(props) {
   const className = classNames(
     classes.root,
     {
-      [classes.fontSizeInherit]: fontSize === 'inherit',
+      [classes[`fontSize${capitalize(fontSize)}`]]: fontSize !== 'default',
       [classes[`color${capitalize(color)}`]]: color !== 'inherit',
     },
     classNameProp,
@@ -110,7 +118,7 @@ SvgIcon.propTypes = {
   /**
    * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
    */
-  fontSize: PropTypes.oneOf(['inherit', 'default']),
+  fontSize: PropTypes.oneOf(['inherit', 'default', 'small', 'large']),
   /**
    * Applies a color attribute to the SVG element.
    */

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -23,7 +23,7 @@ import SvgIcon from '@material-ui/core/SvgIcon';
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'inherit', 'primary', 'secondary', 'action', 'error', 'disabled'<br> | <span class="prop-default">'inherit'</span> | The color of the component. It supports those theme colors that make sense for this component. You can use the `nativeColor` property to apply a color attribute to the SVG element. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> | <span class="prop-default">'svg'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">fontSize</span> | <span class="prop-type">enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'default'<br> | <span class="prop-default">'default'</span> | The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size. |
+| <span class="prop-name">fontSize</span> | <span class="prop-type">enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'default'&nbsp;&#124;<br>&nbsp;'small'&nbsp;&#124;<br>&nbsp;'large'<br> | <span class="prop-default">'default'</span> | The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size. |
 | <span class="prop-name">nativeColor</span> | <span class="prop-type">string |   | Applies a color attribute to the SVG element. |
 | <span class="prop-name">titleAccess</span> | <span class="prop-type">string |   | Provides a human-readable title for the element that contains it. https://www.w3.org/TR/SVG-access/#Equivalent |
 | <span class="prop-name">viewBox</span> | <span class="prop-type">string | <span class="prop-default">'0 0 24 24'</span> | Allows you to redefine what the coordinates without units mean inside an SVG element. For example, if the SVG element is 500 (width) by 200 (height), and you pass viewBox="0 0 50 20", this means that the coordinates inside the SVG will go from the top left corner (0,0) to bottom right (50,20) and each unit will be worth 10px. |
@@ -45,6 +45,8 @@ This property accepts the following keys:
 | <span class="prop-name">colorError</span> | Styles applied to the root element if `color="error"`.
 | <span class="prop-name">colorDisabled</span> | Styles applied to the root element if `color="disabled"`.
 | <span class="prop-name">fontSizeInherit</span> | Styles applied to the root element if `fontSize="inherit"`.
+| <span class="prop-name">fontSizeSmall</span> | Styles applied to the root element if `fontSize="small"`.
+| <span class="prop-name">fontSizeLarge</span> | Styles applied to the root element if `fontSize="large"`.
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/SvgIcon/SvgIcon.js)


### PR DESCRIPTION
Closes #12863 instead of altering IconButton height/width, allow a SvgIcon to be altered instead (per suggestion from @oliviertassinari in #12865).

I used _18px_ & _36px_ as they are the sizes reccomended [here](https://google.github.io/material-design-icons/#sizing).

I updated the docs structure to show the __sizes__ section (which now include IconButton size examples) to after the `IconButton` introduction.

