### PR TITLE
[docs] Customize LinearProgress color

### DIFF
--- a/docs/src/pages/demos/progress/LinearIndeterminate.js
+++ b/docs/src/pages/demos/progress/LinearIndeterminate.js
@@ -12,7 +12,7 @@ const styles = {
   },
   barColorPrimary: {
     backgroundColor: '#00695C',
-  }
+  },
 };
 
 function LinearIndeterminate(props) {
@@ -23,7 +23,9 @@ function LinearIndeterminate(props) {
       <br />
       <LinearProgress color="secondary" />
       <br />
-      <LinearProgress classes={{colorPrimary: classes.colorPrimary, barColorPrimary: classes.barColorPrimary}}/>
+      <LinearProgress
+        classes={{ colorPrimary: classes.colorPrimary, barColorPrimary: classes.barColorPrimary }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
This pull request is related with #12858. A new custom colored linear progress has beed added to [demo page](https://material-ui.com/demos/progress/#linear-indeterminate).

Closes #12858.