### PR TITLE
Fix Input's defaultValue set after first render would not be taken into account

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -353,6 +353,8 @@ class InputBase extends React.Component {
       ...other
     } = this.props;
 
+    const valuePassed = this.props.hasOwnProperty('value');
+
     const { muiFormControl } = this.context;
     const fcs = formControlState({
       props: this.props,
@@ -452,7 +454,7 @@ class InputBase extends React.Component {
           readOnly={readOnly}
           required={fcs.required}
           rows={rows}
-          value={value}
+          {...valuePassed && { value }}
           {...inputProps}
         />
         {endAdornment}

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -102,6 +102,8 @@ class TextField extends React.Component {
       'Material-UI: `children` must be passed when using the `TextField` component with `select`.',
     );
 
+    const valuePassed = this.props.hasOwnProperty('value');
+
     const InputMore = {};
 
     if (variant === 'outlined') {
@@ -125,7 +127,6 @@ class TextField extends React.Component {
         rows={rows}
         rowsMax={rowsMax}
         type={type}
-        value={value}
         id={id}
         inputRef={inputRef}
         onBlur={onBlur}
@@ -133,6 +134,7 @@ class TextField extends React.Component {
         onFocus={onFocus}
         placeholder={placeholder}
         inputProps={inputProps}
+        {...valuePassed && { value }}
         {...InputMore}
         {...InputProps}
       />
@@ -154,7 +156,7 @@ class TextField extends React.Component {
           </InputLabel>
         )}
         {select ? (
-          <Select value={value} input={InputElement} {...SelectProps}>
+          <Select input={InputElement} {...valuePassed && { value }} {...SelectProps}>
             {children}
           </Select>
         ) : (


### PR DESCRIPTION
#### What's this PR do?
We found out that setting any `value` prop (even to `undefined`) would result in putting the native `<input>` into a sort of non-default mode. If the `defaultValue` is set after that it is not taken into account (here is a sandbox showing the different cases: https://codesandbox.io/s/y3nx2jxxxv).

The problem is that `TextField` and `Input` force set `value` even when not explicitly defined:

```js
const {value} = this.props;
<input value={value} />
```
This pattern result in `value` being set to `undefined` even if it wasn't explictly added as a prop to the parent component

#### What are the relevant tickets?
https://github.com/mui-org/material-ui/issues/12876