### PR TITLE
[typescript] Improve definitions with strictNullChecks disabled

### DIFF
--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -2,7 +2,10 @@
 
 <p class="description">You can add static typing to JavaScript to improve developer productivity and code quality thanks to TypeScript.</p>
 
-Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript) example. A minimum version of TypeScript 2.8 is required.
+Have a look at the [Create React App with TypeScript](https://github.com/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript) example. A minimum version of TypeScript 2.8 is required. 
+
+Our definitions are tested with the following [tsconfig.json](https://github.com/mui-org/material-ui/tree/master/tsconfig.json). 
+Using a less strict `tsconfig.json` or omitting some of the libraries might cause errors.
 
 ## Usage of `withStyles`
 

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -39,7 +39,7 @@ export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, st
 
 export type WithStyles<
   T extends string | StyleRules | StyleRulesCallback = string,
-  IncludeTheme extends boolean | undefined = undefined
+  IncludeTheme extends boolean | undefined = false
 > = (IncludeTheme extends true ? { theme: Theme } : {}) & {
   classes: ClassNameMap<
     T extends string


### PR DESCRIPTION
While disabling strictNullChecks is still potentially dangerous this removes one false positive that marked the theme as required. Disabling strictNullChecks will still allow the access of theme which will throw at runtime.

The workaround was discovered by @geirsagberg in #12891. I combined this with some necessary documentation so that we can refer to the documentation in future issues because we should not support `strictNullChecks` in the future (DefinitelyTyped isn't either).

Pinging @pelotom in case he has some objections to our tsconfig requirements.
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
