### PR TITLE
[core] Add setRef helper

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of all the modules of material-ui.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '92.2 KB',
+    limit: '92.22 KB',
   },
   {
     name: 'The main bundle of the docs',

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -4,6 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
+import { setRef } from '../utils/reactHelpers';
 import Textarea from './Textarea';
 import { isFilled } from './utils';
 
@@ -276,13 +277,7 @@ class InputBase extends React.Component {
       refProp = this.props.inputProps.ref;
     }
 
-    if (refProp) {
-      if (typeof refProp === 'function') {
-        refProp(ref);
-      } else {
-        refProp.current = ref;
-      }
-    }
+    setRef(refProp, ref);
   };
 
   handleClick = event => {

--- a/packages/material-ui/src/InputBase/Textarea.js
+++ b/packages/material-ui/src/InputBase/Textarea.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import debounce from 'debounce'; // < 1kb payload overhead when lodash/debounce is > 3kb.
 import EventListener from 'react-event-listener';
 import withStyles from '../styles/withStyles';
+import { setRef } from '../utils/reactHelpers';
 
 const ROWS_HEIGHT = 19;
 
@@ -86,14 +87,7 @@ class Textarea extends React.Component {
   handleRefInput = ref => {
     this.inputRef = ref;
 
-    const { textareaRef } = this.props;
-    if (textareaRef) {
-      if (typeof textareaRef === 'function') {
-        textareaRef(ref);
-      } else {
-        textareaRef.current = ref;
-      }
-    }
+    setRef(this.props.textareaRef, ref);
   };
 
   handleRefSinglelineShadow = ref => {

--- a/packages/material-ui/src/RootRef/RootRef.js
+++ b/packages/material-ui/src/RootRef/RootRef.js
@@ -2,14 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import exactProp from '../utils/exactProp';
-
-function setRef(ref, value) {
-  if (typeof ref === 'function') {
-    ref(value);
-  } else if (ref) {
-    ref.current = value;
-  }
-}
+import { setRef } from '../utils/reactHelpers';
 
 /**
  * Helper component to allow attaching a ref to a

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -5,6 +5,7 @@ import keycode from 'keycode';
 import warning from 'warning';
 import Menu from '../Menu/Menu';
 import { isFilled } from '../InputBase/utils';
+import { setRef } from '../utils/reactHelpers';
 
 /**
  * @ignore - internal component.
@@ -148,11 +149,7 @@ class SelectInput extends React.Component {
       value: this.props.value,
     };
 
-    if (typeof inputRef === 'function') {
-      inputRef(nodeProxy);
-    } else {
-      inputRef.current = nodeProxy;
-    }
+    setRef(inputRef, nodeProxy);
   };
 
   render() {

--- a/packages/material-ui/src/utils/reactHelpers.d.ts
+++ b/packages/material-ui/src/utils/reactHelpers.d.ts
@@ -13,3 +13,15 @@ export interface NamedMuiElement {
 
 export function isMuiElement(element: any, muiNames: string[]): element is NamedMuiElement;
 export function isMuiComponent(element: any, muiNames: string[]): element is NamedMuiComponent;
+/**
+ * passes {value} to {ref}
+ *
+ * useful if you want to expose the ref of an inner component to the public api
+ * while still using it inside the component
+ *
+ * @param ref a ref callback or ref object if anything falsy this is a no-op
+ */
+export function setRef<T>(
+  ref: React.RefObject<T> | ((instance: T | null) => void) | null | undefined,
+  value: T | null,
+): void;

--- a/packages/material-ui/src/utils/reactHelpers.js
+++ b/packages/material-ui/src/utils/reactHelpers.js
@@ -18,3 +18,11 @@ export function cloneChildrenWithClassName(children, className) {
 export function isMuiElement(element, muiNames) {
   return React.isValidElement(element) && muiNames.indexOf(element.type.muiName) !== -1;
 }
+
+export function setRef(ref, value) {
+  if (typeof ref === 'function') {
+    ref(value);
+  } else if (ref) {
+    ref.current = value;
+  }
+}

--- a/packages/material-ui/src/utils/reactHelpers.test.js
+++ b/packages/material-ui/src/utils/reactHelpers.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
-import { isMuiElement } from './reactHelpers';
+import { spy } from 'sinon';
+import { isMuiElement, setRef } from './reactHelpers';
 import { Input, ListItemAvatar, ListItemSecondaryAction, SvgIcon } from '..';
 
 describe('utils/reactHelpers.js', () => {
@@ -24,6 +25,39 @@ describe('utils/reactHelpers.js', () => {
       ].forEach(([Component, muiName]) => {
         assert.strictEqual(isMuiElement(<Component />, [muiName]), true);
       });
+    });
+  });
+
+  describe('setRef', () => {
+    it('can handle callback refs', () => {
+      const ref = spy();
+      const instance = 'proxy';
+
+      setRef(ref, instance);
+
+      assert.isTrue(ref.called);
+      assert.strictEqual(ref.firstCall.args[0], instance);
+    });
+
+    it('can handle ref objects', () => {
+      const ref = React.createRef();
+      const instance = 'proxy';
+
+      setRef(ref, instance);
+
+      assert.strictEqual(ref.current, instance);
+    });
+
+    it('ignores falsy refs without errors', () => {
+      const instance = 'proxy';
+
+      // all no-ops
+      setRef(undefined, instance);
+      setRef(null, instance);
+    });
+
+    it('throws on legacy string refs', () => {
+      assert.throws(() => setRef('stringRef1', 'proxy'));
     });
   });
 });


### PR DESCRIPTION
Utility method cherry-pick from unmerged #12773. Ended up moving `setRef` from `RootRef.js` to `reactHelpers.js`.