### PR TITLE
[typescript] Remove unused isMuiComponent definition

### DIFF
--- a/packages/material-ui/src/utils/reactHelpers.d.ts
+++ b/packages/material-ui/src/utils/reactHelpers.d.ts
@@ -12,4 +12,3 @@ export interface NamedMuiElement {
 }
 
 export function isMuiElement(element: any, muiNames: string[]): element is NamedMuiElement;
-export function isMuiComponent(element: any, muiNames: string[]): element is NamedMuiComponent;


### PR DESCRIPTION
That method was removed in [#12076](https://github.com/mui-org/material-ui/pull/12076/files#diff-79c607d8d1e1954cac13b33bd71969a6).