### PR TITLE
[docs] Correct misspelling (dasboard => dashboard)

### DIFF
--- a/docs/src/pages/page-layout-examples/PageLayoutExamples.js
+++ b/docs/src/pages/page-layout-examples/PageLayoutExamples.js
@@ -32,7 +32,7 @@ const themes = [
   {
     name: 'Dashboard',
     description:
-      'A minimal dasboard with taskbar and mini variant draw. ' +
+      'A minimal dashboard with taskbar and mini variant draw. ' +
       'The chart is courtesy of Recharts, but it is simple to substitute an alternative.',
     src: '/static/images/layouts/dashboard.png',
     href: '/page-layout-examples/dashboard',


### PR DESCRIPTION
There's a minor misspelling ('dasboard') that should be changed to 'dashboard'. 