### PR TITLE
[core] Use .browserlistrc as single point of thruth for target env

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,6 @@
 ie 11
-edge > 14
-firefox > 52
-chrome > 49
-safari > 10
+edge >= 14
+firefox >= 52
+chrome >= 49
+safari >= 10
+node 6.11

--- a/babel.config.js
+++ b/babel.config.js
@@ -10,14 +10,6 @@ if (process.env.BABEL_ENV === 'es') {
     [
       '@babel/preset-env',
       {
-        targets: {
-          ie: 11,
-          edge: 14,
-          firefox: 52,
-          chrome: 49,
-          safari: 10,
-          node: '6.11',
-        },
         modules: ['modules', 'production-umd'].includes(process.env.BABEL_ENV) ? false : 'commonjs',
       },
     ],


### PR DESCRIPTION
There was also a mismatch between preset-env and .browserlistrc because preset-env uses the value as "minium inluding" not "minimum excluding" as stated in .browserlistrc.
