### PR TITLE
[InputAdornment] Fix flexbox alignment bug for IE

### DIFF
--- a/packages/material-ui/src/InputAdornment/InputAdornment.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.js
@@ -8,6 +8,7 @@ export const styles = {
   /* Styles applied to the root element. */
   root: {
     display: 'flex',
+    height: '0.01em',  // IE flexbox alignment fix
     maxHeight: '2em',
     alignItems: 'center',
   },


### PR DESCRIPTION
[Using the TextField examples on the docs](https://material-ui.com/demos/text-fields/):

Before: 
![image](https://user-images.githubusercontent.com/1796078/45736635-634dba80-bba0-11e8-8d6a-5a723a359695.png)

After:
![image](https://user-images.githubusercontent.com/1796078/45736650-6b0d5f00-bba0-11e8-9b7f-02a357990455.png)

Closes #10342