### PR TITLE
[Grid] Fix rounding errors

### DIFF
--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -44,8 +44,7 @@ function generateGrid(globalStyles, theme, breakpoint) {
       return;
     }
 
-    // Only keep 6 significant numbers.
-    const width = `${Math.round((size / 12) * 10e6) / 10e4}%`;
+    const width = `${Math.round((size / 12) * 10e7) / 10e4}%`;
 
     // Close to the bootstrap implementation:
     // https://github.com/twbs/bootstrap/blob/8fccaa2439e97ec72a4b7dc42ccc1f649790adb0/scss/mixins/_grid.scss#L41

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -44,7 +44,8 @@ function generateGrid(globalStyles, theme, breakpoint) {
       return;
     }
 
-    const width = `${Math.round((size / 12) * 10e7) / 10e4}%`;
+    // Keep 7 significant numbers.
+    const width = `${Math.round((size / 12) * 10e7) / 10e5}%`;
 
     // Close to the bootstrap implementation:
     // https://github.com/twbs/bootstrap/blob/8fccaa2439e97ec72a4b7dc42ccc1f649790adb0/scss/mixins/_grid.scss#L41


### PR DESCRIPTION
Use 7 significant numbers instead of 6 for better rounding accuracy when calculating grid sizes

Closes #12353

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
