### PR TITLE
[ToggleButton, ToggleButtonGroup] Use context to pass data between ToggleButtonGroup and ToggleButton

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import withStyles from '@material-ui/core/styles/withStyles';
 import { fade } from '@material-ui/core/styles/colorManipulator';
 import ButtonBase from '@material-ui/core/ButtonBase';
+import withContext from './withContext';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -187,4 +188,4 @@ ToggleButton.defaultProps = {
 
 ToggleButton.muiName = 'ToggleButton';
 
-export default withStyles(styles, { name: 'MuiToggleButton' })(ToggleButton);
+export default withStyles(styles, { name: 'MuiToggleButton' })(withContext(ToggleButton));

--- a/packages/material-ui-lab/src/ToggleButton/withContext.js
+++ b/packages/material-ui-lab/src/ToggleButton/withContext.js
@@ -3,10 +3,10 @@ import { Consumer } from '../ToggleButtonGroup/context';
 import isValueSelected from '../ToggleButtonGroup/isValueSelected';
 
 export default function withContext(ToggleButton) {
-  return ({ selectedProp, onChangeProp, ...other }) => {
+  return ({ selected: selectedProp, onChange: onChangeProp, ...other }) => {
     return (
       <Consumer>
-        {ctx => {
+        {(ctx = {}) => {
           const selected = selectedProp === undefined
             ? isValueSelected(other.value, ctx.value)
             : selectedProp;

--- a/packages/material-ui-lab/src/ToggleButton/withContext.js
+++ b/packages/material-ui-lab/src/ToggleButton/withContext.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Consumer } from '../ToggleButtonGroup/context';
+import isValueSelected from '../ToggleButtonGroup/isValueSelected';
+
+export default function withContext(ToggleButton) {
+  return ({ selectedProp, onChangeProp, ...other }) => {
+    return (
+      <Consumer>
+        {ctx => {
+          const selected = selectedProp === undefined
+            ? isValueSelected(other.value, ctx.value)
+            : selectedProp;
+
+          const onChange = onChangeProp || ctx.onChange;
+
+          return (
+            <ToggleButton
+              selected={selected}
+              onChange={onChange}
+              {...other}
+            />
+          );
+          }
+        }
+      </Consumer>
+    );
+  };
+}

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '@material-ui/core/styles/withStyles';
 import hasValue from './hasValue';
-import isValueSelected from './isValueSelected';
+import { Provider } from './context';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -64,22 +64,6 @@ class ToggleButtonGroup extends React.Component {
       ...other
     } = this.props;
 
-    const children = React.Children.map(childrenProp, child => {
-      if (!React.isValidElement(child)) {
-        return null;
-      }
-
-      const { selected: buttonSelected, value: buttonValue } = child.props;
-
-      const selected =
-        buttonSelected === undefined ? isValueSelected(buttonValue, value) : buttonSelected;
-
-      return React.cloneElement(child, {
-        selected,
-        onChange: exclusive ? this.handleExclusiveChange : this.handleChange,
-      });
-    });
-
     const groupSelected = selectedProp === 'auto' ? hasValue(value) : selectedProp;
     const className = classNames(
       classes.root,
@@ -91,7 +75,11 @@ class ToggleButtonGroup extends React.Component {
 
     return (
       <div className={className} {...other}>
-        {children}
+        <Provider value={
+          { value, onChange: exclusive ? this.handleExclusiveChange : this.handleChange }}
+        >
+          {childrenProp}
+        </Provider>
       </div>
     );
   }

--- a/packages/material-ui-lab/src/ToggleButtonGroup/context.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const { Provider, Consumer } = React.createContext();
+
+export { Provider, Consumer };


### PR DESCRIPTION
One possible implementation that allows people to use ToggleButton in ToggleButtonGroup without caring about how nested ToggleButton is.

This was discussed in #12921 

Let me know if this is something you might merge and I'll take care of testing as well

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
