### PR TITLE
[ Snackbar ] Remove styles for IconButton in Demo

### DIFF
--- a/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
+++ b/docs/src/pages/demos/snackbars/ConsecutiveSnackbars.js
@@ -1,17 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Snackbar from '@material-ui/core/Snackbar';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
-
-const styles = theme => ({
-  close: {
-    width: theme.spacing.unit * 4,
-    height: theme.spacing.unit * 4,
-  },
-});
 
 class ConsecutiveSnackbars extends React.Component {
   queue = [];
@@ -57,7 +48,6 @@ class ConsecutiveSnackbars extends React.Component {
   };
 
   render() {
-    const { classes } = this.props;
     const { message, key } = this.state.messageInfo;
     return (
       <div>
@@ -85,7 +75,6 @@ class ConsecutiveSnackbars extends React.Component {
               key="close"
               aria-label="Close"
               color="inherit"
-              className={classes.close}
               onClick={this.handleClose}
             >
               <CloseIcon />
@@ -97,8 +86,4 @@ class ConsecutiveSnackbars extends React.Component {
   }
 }
 
-ConsecutiveSnackbars.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(ConsecutiveSnackbars);
+export default ConsecutiveSnackbars;

--- a/docs/src/pages/demos/snackbars/SimpleSnackbar.js
+++ b/docs/src/pages/demos/snackbars/SimpleSnackbar.js
@@ -1,17 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Snackbar from '@material-ui/core/Snackbar';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
-
-const styles = theme => ({
-  close: {
-    width: theme.spacing.unit * 4,
-    height: theme.spacing.unit * 4,
-  },
-});
 
 class SimpleSnackbar extends React.Component {
   state = {
@@ -31,7 +22,6 @@ class SimpleSnackbar extends React.Component {
   };
 
   render() {
-    const { classes } = this.props;
     return (
       <div>
         <Button onClick={this.handleClick}>Open simple snackbar</Button>
@@ -55,7 +45,6 @@ class SimpleSnackbar extends React.Component {
               key="close"
               aria-label="Close"
               color="inherit"
-              className={classes.close}
               onClick={this.handleClose}
             >
               <CloseIcon />
@@ -67,8 +56,4 @@ class SimpleSnackbar extends React.Component {
   }
 }
 
-SimpleSnackbar.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(SimpleSnackbar);
+export default SimpleSnackbar;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Issue ID: [#12962](https://github.com/mui-org/material-ui/issues/12962)
Removed the style applied to Snackbar Close IconButton in SimpleSnackbar and ConsecutiveSnackbars demo.


Previously close IconButton was below the message content due to fixed width and height.


<img width="394" alt="screen shot 2018-09-22 at 7 37 08 pm" src="https://user-images.githubusercontent.com/25824784/45920802-7ece0380-bec7-11e8-9bae-563ece524da4.png">



After removing the existing style containing fixed width and height.


<img width="395" alt="screen shot 2018-09-23 at 12 30 19 am" src="https://user-images.githubusercontent.com/25824784/45920830-e3895e00-bec7-11e8-97e5-e0689113e890.png">
