### PR TITLE
[core] Upgrade the @types/jss dependency to 9.5.6

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0",
-    "@types/jss": "^9.5.3",
+    "@types/jss": "^9.5.6",
     "@types/react-transition-group": "^2.0.8",
     "brcast": "^3.0.1",
     "classnames": "^2.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -865,9 +865,9 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
-"@types/jss@^9.5.3":
-  version "9.5.5"
-  resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.5.tgz#57ed99ae768c203677cd64e0ce0df02c74075bf8"
+"@types/jss@^9.5.6":
+  version "9.5.6"
+  resolved "https://registry.yarnpkg.com/@types/jss/-/jss-9.5.6.tgz#96e1d246ddfbccc4867494077c714773cf29acde"
   dependencies:
     csstype "^2.0.0"
     indefinite-observable "^1.0.1"


### PR DESCRIPTION
`JSSPlugin` type definition was corrected in `@types/jss` version 9.5.6.

Relevant commit: https://github.com/DefinitelyTyped/DefinitelyTyped/commit/eb8b3eff61e3606fe812b65384190e7aba925fce
Relevant PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29041

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
