### PR TITLE
[styles] Remove react-jss dependency

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -16,7 +16,7 @@ module.exports = [
     name: 'The initial cost people pay for using one component',
     webpack: true,
     path: 'packages/material-ui/build/Paper/index.js',
-    limit: '17.5 KB',
+    limit: '17.3 KB',
   },
   {
     name: 'The size of all the modules of material-ui.',

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "react-docgen": "^3.0.0-beta10",
     "react-dom": "^16.4.0",
     "react-inspector": "^2.2.2",
+    "react-jss": "^8.1.0",
     "react-markdown": "^3.4.1",
     "react-number-format": "^3.0.2",
     "react-redux": "^5.0.6",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -57,7 +57,6 @@
     "popper.js": "^1.14.1",
     "prop-types": "^15.6.0",
     "react-event-listener": "^0.6.2",
-    "react-jss": "^8.1.0",
     "react-transition-group": "^2.2.1",
     "recompose": "0.28.0 - 0.30.0",
     "warning": "^4.0.1"

--- a/packages/material-ui/src/styles/reactJssContext.js
+++ b/packages/material-ui/src/styles/reactJssContext.js
@@ -1,0 +1,9 @@
+// Share the same values than in
+// https://github.com/cssinjs/jss/blob/master/packages/react-jss/src/ns.js
+const ns = {
+  jss: '64a55d578f856d258dc345b094a2a2b3',
+  sheetsRegistry: 'd4bd0baacbc52bbd48bbb9eb24344ecd',
+  sheetOptions: '6fc570d6bd61383819d0f9e7407c452d',
+};
+
+export default ns;

--- a/packages/material-ui/src/styles/withStyles.js
+++ b/packages/material-ui/src/styles/withStyles.js
@@ -3,9 +3,8 @@ import PropTypes from 'prop-types';
 import warning from 'warning';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import wrapDisplayName from 'recompose/wrapDisplayName';
-import contextTypes from 'react-jss/lib/contextTypes';
 import { create } from 'jss';
-import * as ns from 'react-jss/lib/ns';
+import ns from './reactJssContext';
 import jssPreset from './jssPreset';
 import mergeClasses from './mergeClasses';
 import createMuiTheme from './createMuiTheme';
@@ -301,7 +300,9 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
 
   WithStyles.contextTypes = {
     muiThemeProviderOptions: PropTypes.object,
-    ...contextTypes,
+    [ns.jss]: PropTypes.object,
+    [ns.sheetOptions]: PropTypes.object,
+    [ns.sheetsRegistry]: PropTypes.object,
     ...(listenToTheme ? themeListener.contextTypes : {}),
   };
 

--- a/packages/material-ui/src/test-utils/getClasses.js
+++ b/packages/material-ui/src/test-utils/getClasses.js
@@ -1,4 +1,4 @@
-import * as ns from 'react-jss/lib/ns';
+import ns from '../styles/reactJssContext';
 import { SheetsRegistry } from 'jss';
 import createShallow from './createShallow';
 import { sheetsManager } from '../styles/withStyles';


### PR DESCRIPTION
This change is part of the effort to make Material-UI *styles engine invariant* (JSS, styled-components, emotion, etc). I think that it will help the package size too. https://packagephobia.now.sh/result?p=react-jss but I'm unsure, we will see.

---

I'm suspecting many people are using `react-jss` without installing it, relying on us to have it. It's bad, however, to minimize the noise of us removing it, I think that we should do is in a minor instead of a patch, hence the v3.2.0 milestone.
