### PR TITLE
[StepLabel] Introduce StepIconComponent property

### DIFF
--- a/packages/material-ui/src/StepLabel/StepLabel.d.ts
+++ b/packages/material-ui/src/StepLabel/StepLabel.d.ts
@@ -16,6 +16,7 @@ export interface StepLabelProps
   last?: boolean;
   optional?: React.ReactNode;
   orientation?: Orientation;
+  StepIconComponent?: React.ReactType;
   StepIconProps?: Partial<StepIconProps>;
 }
 

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -78,10 +78,16 @@ function StepLabel(props) {
     last,
     optional,
     orientation,
-    StepIconComponent = StepIcon,
+    StepIconComponent: StepIconComponentProp,
     StepIconProps,
     ...other
   } = props;
+
+  let StepIconComponent = StepIconComponentProp;
+
+  if (icon && !StepIconComponent) {
+    StepIconComponent = StepIcon;
+  }
 
   return (
     <span
@@ -97,7 +103,7 @@ function StepLabel(props) {
       )}
       {...other}
     >
-      {(icon || StepIconComponent) && (
+      {icon || StepIconComponent ? (
         <span
           className={classNames(classes.iconContainer, {
             [classes.alternativeLabel]: alternativeLabel,
@@ -111,7 +117,7 @@ function StepLabel(props) {
             {...StepIconProps}
           />
         </span>
-      )}
+      ) : null}
       <span className={classes.labelContainer}>
         <Typography
           variant="body1"
@@ -186,7 +192,7 @@ StepLabel.propTypes = {
    */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
   /**
-   * The React Element to render in place of the [`StepIcon`](/api/step-icon) element.
+   * The component to render in place of the [`StepIcon`](/api/step-icon).
    */
   StepIconComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
   /**

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -78,6 +78,7 @@ function StepLabel(props) {
     last,
     optional,
     orientation,
+    StepIconComponent,
     StepIconProps,
     ...other
   } = props;
@@ -96,12 +97,21 @@ function StepLabel(props) {
       )}
       {...other}
     >
-      {icon && (
+      {(icon || StepIconComponent) && (
         <span
           className={classNames(classes.iconContainer, {
             [classes.alternativeLabel]: alternativeLabel,
           })}
         >
+        {StepIconComponent ? (
+          <StepIconComponent
+            completed={completed}
+            active={active}
+            error={error}
+            icon={icon}
+            {...StepIconProps}
+          />
+        ) : (
           <StepIcon
             completed={completed}
             active={active}
@@ -109,6 +119,7 @@ function StepLabel(props) {
             icon={icon}
             {...StepIconProps}
           />
+        )}
         </span>
       )}
       <span className={classes.labelContainer}>
@@ -184,6 +195,18 @@ StepLabel.propTypes = {
    * @ignore
    */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
+  /**
+   * The React Element to render in place of the [`StepIcon`](/api/step-icon) element.
+   */
+  StepIconComponent: PropTypes.oneOfType([
+    PropTypes.func,
+    // eslint-disable-next-line consistent-return
+    (props, propName) => {
+      if (!props[propName] || typeof props[propName].render !== 'function') {
+        return new Error(`${propName}.render must be a function!`);
+      }
+    },
+  ]),
   /**
    * Properties applied to the [`StepIcon`](/api/step-icon) element.
    */

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -78,7 +78,7 @@ function StepLabel(props) {
     last,
     optional,
     orientation,
-    StepIconComponent,
+    StepIconComponent = StepIcon,
     StepIconProps,
     ...other
   } = props;
@@ -103,7 +103,6 @@ function StepLabel(props) {
             [classes.alternativeLabel]: alternativeLabel,
           })}
         >
-        {StepIconComponent ? (
           <StepIconComponent
             completed={completed}
             active={active}
@@ -111,15 +110,6 @@ function StepLabel(props) {
             icon={icon}
             {...StepIconProps}
           />
-        ) : (
-          <StepIcon
-            completed={completed}
-            active={active}
-            error={error}
-            icon={icon}
-            {...StepIconProps}
-          />
-        )}
         </span>
       )}
       <span className={classes.labelContainer}>
@@ -198,15 +188,7 @@ StepLabel.propTypes = {
   /**
    * The React Element to render in place of the [`StepIcon`](/api/step-icon) element.
    */
-  StepIconComponent: PropTypes.oneOfType([
-    PropTypes.func,
-    // eslint-disable-next-line consistent-return
-    (props, propName) => {
-      if (!props[propName] || typeof props[propName].render !== 'function') {
-        return new Error(`${propName}.render must be a function!`);
-      }
-    },
-  ]),
+  StepIconComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
   /**
    * Properties applied to the [`StepIcon`](/api/step-icon) element.
    */

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -57,12 +57,12 @@ describe('<StepLabel />', () => {
       assert.strictEqual(props.prop1, 'value1', 'should have inherited custom prop1');
       assert.strictEqual(props.prop2, 'value2', 'should have inherited custom prop2');
     });
-  
-  it('renders <StepIconComponent>', () => {
+
+    it('renders <StepIconComponent>', () => {
       const stepIconProps = { prop1: 'value1', prop2: 'value2' };
       const CustomizedIcon = () => <div />;
       const wrapper = shallow(
-        <StepLabel 
+        <StepLabel
           StepIconComponent={CustomizedIcon}
           active
           completed
@@ -78,17 +78,11 @@ describe('<StepLabel />', () => {
       assert.strictEqual(props.prop1, 'value1', 'should have inherited custom prop1');
       assert.strictEqual(props.prop2, 'value2', 'should have inherited custom prop2');
     });
-  
+
     it('does not render <StepIcon> if <StepIconComponent> is provided', () => {
       const CustomizedIcon = () => <div />;
       const wrapper = shallow(
-        <StepLabel
-          icon={1}
-          StepIconComponent={CustomizedIcon}
-          active
-          completed
-          alternativeLabel
-        >
+        <StepLabel icon={1} StepIconComponent={CustomizedIcon} active completed alternativeLabel>
           Step One
         </StepLabel>,
       );
@@ -113,9 +107,9 @@ describe('<StepLabel />', () => {
       const stepIcon = wrapper.find(StepIcon);
       assert.strictEqual(stepIcon.props().active, true, 'should set active');
     });
-    
+
     it('renders <StepIconComponent> with the prop active set to true', () => {
-            const CustomizedIcon = () => <div />;
+      const CustomizedIcon = () => <div />;
       const wrapper = shallow(
         <StepLabel StepIconComponent={CustomizedIcon} active>
           Step One
@@ -148,7 +142,7 @@ describe('<StepLabel />', () => {
       const stepIcon = wrapper.find(StepIcon);
       assert.strictEqual(stepIcon.props().completed, true, 'should set completed');
     });
-    
+
     it('renders <StepIconComponent> with the prop completed set to true', () => {
       const CustomizedIcon = () => <div />;
       const wrapper = shallow(
@@ -177,9 +171,9 @@ describe('<StepLabel />', () => {
       const stepIcon = wrapper.find(StepIcon);
       assert.strictEqual(stepIcon.props().error, true, 'should set error');
     });
-    
+
     it('renders <StepIconComponent> with the prop error set to true', () => {
-            const CustomizedIcon = () => <div />;
+      const CustomizedIcon = () => <div />;
       const wrapper = shallow(
         <StepLabel StepIconComponent={CustomizedIcon} error>
           Step One

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -57,6 +57,44 @@ describe('<StepLabel />', () => {
       assert.strictEqual(props.prop1, 'value1', 'should have inherited custom prop1');
       assert.strictEqual(props.prop2, 'value2', 'should have inherited custom prop2');
     });
+  
+  it('renders <StepIconComponent>', () => {
+      const stepIconProps = { prop1: 'value1', prop2: 'value2' };
+      const CustomizedIcon = () => <div />;
+      const wrapper = shallow(
+        <StepLabel 
+          StepIconComponent={CustomizedIcon}
+          active
+          completed
+          alternativeLabel
+          StepIconProps={stepIconProps}
+        >
+          Step One
+        </StepLabel>,
+      );
+      const customizedIcon = wrapper.find(CustomizedIcon);
+      assert.strictEqual(customizedIcon.length, 1, 'should have an <CustomizedIcon />');
+      const props = customizedIcon.props();
+      assert.strictEqual(props.prop1, 'value1', 'should have inherited custom prop1');
+      assert.strictEqual(props.prop2, 'value2', 'should have inherited custom prop2');
+    });
+  
+    it('does not render <StepIcon> if <StepIconComponent> is provided', () => {
+      const CustomizedIcon = () => <div />;
+      const wrapper = shallow(
+        <StepLabel
+          icon={1}
+          StepIconComponent={CustomizedIcon}
+          active
+          completed
+          alternativeLabel
+        >
+          Step One
+        </StepLabel>,
+      );
+      const stepIcon = wrapper.find(StepIcon);
+      assert.strictEqual(stepIcon.length, 0, 'should not have an <StepIcon />');
+    });
   });
 
   describe('prop: active', () => {
@@ -73,6 +111,17 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
+      assert.strictEqual(stepIcon.props().active, true, 'should set active');
+    });
+    
+    it('renders <StepIconComponent> with the prop active set to true', () => {
+            const CustomizedIcon = () => <div />;
+      const wrapper = shallow(
+        <StepLabel StepIconComponent={CustomizedIcon} active>
+          Step One
+        </StepLabel>,
+      );
+      const stepIcon = wrapper.find(CustomizedIcon);
       assert.strictEqual(stepIcon.props().active, true, 'should set active');
     });
 
@@ -99,6 +148,17 @@ describe('<StepLabel />', () => {
       const stepIcon = wrapper.find(StepIcon);
       assert.strictEqual(stepIcon.props().completed, true, 'should set completed');
     });
+    
+    it('renders <StepIconComponent> with the prop completed set to true', () => {
+      const CustomizedIcon = () => <div />;
+      const wrapper = shallow(
+        <StepLabel StepIconComponent={CustomizedIcon} completed>
+          Step One
+        </StepLabel>,
+      );
+      const customizedIcon = wrapper.find(CustomizedIcon);
+      assert.strictEqual(customizedIcon.props().completed, true, 'should set completed');
+    });
   });
 
   describe('prop: error', () => {
@@ -115,6 +175,17 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
+      assert.strictEqual(stepIcon.props().error, true, 'should set error');
+    });
+    
+    it('renders <StepIconComponent> with the prop error set to true', () => {
+            const CustomizedIcon = () => <div />;
+      const wrapper = shallow(
+        <StepLabel StepIconComponent={CustomizedIcon} error>
+          Step One
+        </StepLabel>,
+      );
+      const stepIcon = wrapper.find(CustomizedIcon);
       assert.strictEqual(stepIcon.props().error, true, 'should set error');
     });
   });

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -57,9 +57,10 @@ describe('<StepLabel />', () => {
       assert.strictEqual(props.prop1, 'value1', 'should have inherited custom prop1');
       assert.strictEqual(props.prop2, 'value2', 'should have inherited custom prop2');
     });
+  });
 
+  describe('prop: StepIconComponent', () => {
     it('renders <StepIconComponent>', () => {
-      const stepIconProps = { prop1: 'value1', prop2: 'value2' };
       const CustomizedIcon = () => <div />;
       const wrapper = shallow(
         <StepLabel
@@ -67,19 +68,19 @@ describe('<StepLabel />', () => {
           active
           completed
           alternativeLabel
-          StepIconProps={stepIconProps}
+          StepIconProps={{ prop1: 'value1', prop2: 'value2' }}
         >
           Step One
         </StepLabel>,
       );
       const customizedIcon = wrapper.find(CustomizedIcon);
-      assert.strictEqual(customizedIcon.length, 1, 'should have an <CustomizedIcon />');
+      assert.strictEqual(customizedIcon.length, 1);
       const props = customizedIcon.props();
-      assert.strictEqual(props.prop1, 'value1', 'should have inherited custom prop1');
-      assert.strictEqual(props.prop2, 'value2', 'should have inherited custom prop2');
+      assert.strictEqual(props.prop1, 'value1');
+      assert.strictEqual(props.prop2, 'value2');
     });
 
-    it('does not render <StepIcon> if <StepIconComponent> is provided', () => {
+    it('does not render <StepIcon>', () => {
       const CustomizedIcon = () => <div />;
       const wrapper = shallow(
         <StepLabel icon={1} StepIconComponent={CustomizedIcon} active completed alternativeLabel>
@@ -87,7 +88,17 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.length, 0, 'should not have an <StepIcon />');
+      assert.strictEqual(stepIcon.length, 0);
+    });
+
+    it('does not render <StepIcon>', () => {
+      const wrapper = shallow(
+        <StepLabel active completed alternativeLabel>
+          Step One
+        </StepLabel>,
+      );
+      const stepIcon = wrapper.find(StepIcon);
+      assert.strictEqual(stepIcon.length, 0);
     });
   });
 
@@ -105,17 +116,6 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.props().active, true, 'should set active');
-    });
-
-    it('renders <StepIconComponent> with the prop active set to true', () => {
-      const CustomizedIcon = () => <div />;
-      const wrapper = shallow(
-        <StepLabel StepIconComponent={CustomizedIcon} active>
-          Step One
-        </StepLabel>,
-      );
-      const stepIcon = wrapper.find(CustomizedIcon);
       assert.strictEqual(stepIcon.props().active, true, 'should set active');
     });
 
@@ -142,17 +142,6 @@ describe('<StepLabel />', () => {
       const stepIcon = wrapper.find(StepIcon);
       assert.strictEqual(stepIcon.props().completed, true, 'should set completed');
     });
-
-    it('renders <StepIconComponent> with the prop completed set to true', () => {
-      const CustomizedIcon = () => <div />;
-      const wrapper = shallow(
-        <StepLabel StepIconComponent={CustomizedIcon} completed>
-          Step One
-        </StepLabel>,
-      );
-      const customizedIcon = wrapper.find(CustomizedIcon);
-      assert.strictEqual(customizedIcon.props().completed, true, 'should set completed');
-    });
   });
 
   describe('prop: error', () => {
@@ -169,17 +158,6 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.props().error, true, 'should set error');
-    });
-
-    it('renders <StepIconComponent> with the prop error set to true', () => {
-      const CustomizedIcon = () => <div />;
-      const wrapper = shallow(
-        <StepLabel StepIconComponent={CustomizedIcon} error>
-          Step One
-        </StepLabel>,
-      );
-      const stepIcon = wrapper.find(CustomizedIcon);
       assert.strictEqual(stepIcon.props().error, true, 'should set error');
     });
   });

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -60,40 +60,33 @@ describe('<StepLabel />', () => {
   });
 
   describe('prop: StepIconComponent', () => {
-    it('renders <StepIconComponent>', () => {
+    it('should render', () => {
       const CustomizedIcon = () => <div />;
       const wrapper = shallow(
         <StepLabel
           StepIconComponent={CustomizedIcon}
           active
           completed
-          alternativeLabel
           StepIconProps={{ prop1: 'value1', prop2: 'value2' }}
         >
           Step One
         </StepLabel>,
       );
+      const stepIcon = wrapper.find(StepIcon);
+      assert.strictEqual(stepIcon.length, 0);
+
       const customizedIcon = wrapper.find(CustomizedIcon);
       assert.strictEqual(customizedIcon.length, 1);
       const props = customizedIcon.props();
       assert.strictEqual(props.prop1, 'value1');
       assert.strictEqual(props.prop2, 'value2');
+      assert.strictEqual(props.completed, true);
+      assert.strictEqual(props.active, true);
     });
 
-    it('does not render <StepIcon>', () => {
-      const CustomizedIcon = () => <div />;
+    it('should not render', () => {
       const wrapper = shallow(
-        <StepLabel icon={1} StepIconComponent={CustomizedIcon} active completed alternativeLabel>
-          Step One
-        </StepLabel>,
-      );
-      const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.length, 0);
-    });
-
-    it('does not render <StepIcon>', () => {
-      const wrapper = shallow(
-        <StepLabel active completed alternativeLabel>
+        <StepLabel active completed>
           Step One
         </StepLabel>,
       );

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -25,7 +25,7 @@ import StepLabel from '@material-ui/core/StepLabel';
 | <span class="prop-name">error</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node |   | Override the default icon. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node |   | The optional node to display. |
-| <span class="prop-name">StepIconComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | The React Element to render in place of the [`StepIcon`](/api/step-icon) element. |
+| <span class="prop-name">StepIconComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | The component to render in place of the [`StepIcon`](/api/step-icon). |
 | <span class="prop-name">StepIconProps</span> | <span class="prop-type">object |   | Properties applied to the [`StepIcon`](/api/step-icon) element. |
 
 Any other properties supplied will be spread to the root element (native element).

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -25,11 +25,7 @@ import StepLabel from '@material-ui/core/StepLabel';
 | <span class="prop-name">error</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node |   | Override the default icon. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node |   | The optional node to display. |
-| <span class="prop-name">StepIconComponent</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;(props, propName) => {
-  if (!props[propName] || typeof props[propName].render !== 'function') {
-    return new Error(`${propName}.render must be a function!`);
-  }
-}<br> |   | The React Element to render in place of the [`StepIcon`](/api/step-icon) element. |
+| <span class="prop-name">StepIconComponent</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> |   | The React Element to render in place of the [`StepIcon`](/api/step-icon) element. |
 | <span class="prop-name">StepIconProps</span> | <span class="prop-type">object |   | Properties applied to the [`StepIcon`](/api/step-icon) element. |
 
 Any other properties supplied will be spread to the root element (native element).

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -25,6 +25,11 @@ import StepLabel from '@material-ui/core/StepLabel';
 | <span class="prop-name">error</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node |   | Override the default icon. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node |   | The optional node to display. |
+| <span class="prop-name">StepIconComponent</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;(props, propName) => {
+  if (!props[propName] || typeof props[propName].render !== 'function') {
+    return new Error(`${propName}.render must be a function!`);
+  }
+}<br> |   | The React Element to render in place of the [`StepIcon`](/api/step-icon) element. |
 | <span class="prop-name">StepIconProps</span> | <span class="prop-type">object |   | Properties applied to the [`StepIcon`](/api/step-icon) element. |
 
 Any other properties supplied will be spread to the root element (native element).


### PR DESCRIPTION
Add a StepIconComponent prop in StepLabel to overwrite StepIcon standard behaviour with the provided component.

The component will be instantiated with the completed/active/error props.
Unit tests are OK.

fix #12987 