### PR TITLE
[InputLabel] Add `variant` property to InputLabel type definition

### DIFF
--- a/packages/material-ui/src/InputLabel/InputLabel.d.ts
+++ b/packages/material-ui/src/InputLabel/InputLabel.d.ts
@@ -10,6 +10,7 @@ export interface InputLabelProps extends StandardProps<FormLabelProps, InputLabe
   focused?: boolean;
   required?: boolean;
   shrink?: boolean;
+  variant?: 'standard' | 'outlined' | 'filled';
 }
 
 export type InputLabelClassKey =


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
The `InputLabel` component definition includes a `variant` prop that the `InputLabel` type definition is missing. This PR adds the property to the type definition.