### PR TITLE
[TextField] Fix the recent regressions

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
@@ -56,6 +56,7 @@ function renderInput(inputProps) {
         inputRef: ref,
         classes: {
           root: classes.inputRoot,
+          input: classes.inputInput,
         },
         ...InputProps,
       }}
@@ -233,6 +234,10 @@ const styles = theme => ({
   },
   inputRoot: {
     flexWrap: 'wrap',
+  },
+  inputInput: {
+    width: 'auto',
+    flexGrow: 1,
   },
   divider: {
     height: theme.spacing.unit * 2,

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -17,6 +17,7 @@ export const styles = theme => {
       backgroundColor: light ? 'rgba(0, 0, 0, 0.09)' : 'rgba(255, 255, 255, 0.09)',
       borderTopLeftRadius: theme.shape.borderRadius,
       borderTopRightRadius: theme.shape.borderRadius,
+      boxSizing: 'border-box',
       transition: theme.transitions.create('background-color', {
         duration: theme.transitions.duration.shorter,
         easing: theme.transitions.easing.easeOut,

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -17,7 +17,6 @@ export const styles = theme => {
       backgroundColor: light ? 'rgba(0, 0, 0, 0.09)' : 'rgba(255, 255, 255, 0.09)',
       borderTopLeftRadius: theme.shape.borderRadius,
       borderTopRightRadius: theme.shape.borderRadius,
-      boxSizing: 'border-box',
       transition: theme.transitions.create('background-color', {
         duration: theme.transitions.duration.shorter,
         easing: theme.transitions.easing.easeOut,
@@ -93,6 +92,7 @@ export const styles = theme => {
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: '27px 12px 10px',
+      boxSizing: 'border-box', // Prevent padding issue with fullWidth.
     },
     /* Styles applied to the `input` element. */
     input: {

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -80,7 +80,7 @@ function NotchedOutline(props) {
   } = props;
 
   const align = theme.direction === 'rtl' ? 'right' : 'left';
-  const labelWidth = labelWidthProp * 0.75 + 8;
+  const labelWidth = labelWidthProp > 0 ? labelWidthProp * 0.75 + 8 : 0;
 
   return (
     <fieldset

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -33,10 +33,7 @@ export const styles = theme => {
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: '18.5px 14px',
-      // // These values are needed to prevent us from
-      // // overrunning the notched outline (including label)
-      // paddingTop: 27,
-      // paddingBottom: 10,
+      boxSizing: 'border-box', // Prevent padding issue with fullWidth.
     },
     /* Styles applied to the `NotchedOutline` element. */
     notchedOutline: {},


### PR DESCRIPTION
Multiline, fullwidth textfields have padding which is added on top of the `width: 100%` which means they can break out of the parent element.

Here's the example code:
```jsx
<div style={{width: 100, backgroundColor: 'gray'}}>
  <TextField
    fullWidth
    label='non-ml'
    variant='filled'
    required
  />
  <TextField
    fullWidth
    label='multiline'
    variant='filled'
    required
    multiline
  />
</div>
```

Screenshot before this patch:
<img width="127" alt="s1" src="https://user-images.githubusercontent.com/327999/46137935-dcba6c80-c274-11e8-9604-7bb27cca309a.png">

Screenshot after this patch:
<img width="138" alt="s2" src="https://user-images.githubusercontent.com/327999/46137954-e3e17a80-c274-11e8-8cb6-9b7947728b60.png">


Closes #12994.