### PR TITLE
[SpeedDial] Improve hover intent between Dial and Actions

### DIFF
--- a/docs/src/pages/lab/speed-dial/SpeedDials.js
+++ b/docs/src/pages/lab/speed-dial/SpeedDials.js
@@ -1,7 +1,13 @@
+import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-import Button from '@material-ui/core/Button';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormLabel from '@material-ui/core/FormLabel';
+import Radio from '@material-ui/core/Radio';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Switch from '@material-ui/core/Switch';
+import { capitalize } from '@material-ui/core/utils/helpers';
 import SpeedDial from '@material-ui/lab/SpeedDial';
 import SpeedDialIcon from '@material-ui/lab/SpeedDialIcon';
 import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
@@ -13,13 +19,33 @@ import DeleteIcon from '@material-ui/icons/Delete';
 
 const styles = theme => ({
   root: {
+    width: '100%',
+  },
+  controls: {
+    margin: theme.spacing.unit * 3,
+  },
+  exampleWrapper: {
+    position: 'relative',
     height: 380,
+  },
+  radioGroup: {
+    margin: `${theme.spacing.unit}px 0`,
   },
   speedDial: {
     position: 'absolute',
-    bottom: theme.spacing.unit * 2,
-    right: theme.spacing.unit * 3,
+    '&$directionUp, &$directionLeft': {
+      bottom: theme.spacing.unit * 2,
+      right: theme.spacing.unit * 3,
+    },
+    '&$directionDown, &$directionRight': {
+      top: theme.spacing.unit * 2,
+      left: theme.spacing.unit * 3,
+    },
   },
+  directionUp: {},
+  directionRight: {},
+  directionDown: {},
+  directionLeft: {},
 });
 
 const actions = [
@@ -32,15 +58,9 @@ const actions = [
 
 class SpeedDials extends React.Component {
   state = {
+    direction: 'up',
     open: false,
     hidden: false,
-  };
-
-  handleVisibility = () => {
-    this.setState(state => ({
-      open: false,
-      hidden: !state.hidden,
-    }));
   };
 
   handleClick = () => {
@@ -49,49 +69,91 @@ class SpeedDials extends React.Component {
     }));
   };
 
-  handleOpen = () => {
-    if (!this.state.hidden) {
-      this.setState({
-        open: true,
-      });
-    }
+  handleDirectionChange = (event, value) => {
+    this.setState({
+      direction: value,
+    });
+  };
+
+  handleHiddenChange = (event, hidden) => {
+    this.setState(state => ({
+      hidden,
+      // hidden implies !open
+      open: hidden ? false : state.open,
+    }));
   };
 
   handleClose = () => {
-    this.setState({
-      open: false,
-    });
+    this.setState({ open: false });
+  };
+
+  handleOpen = () => {
+    this.setState({ open: true });
   };
 
   render() {
     const { classes } = this.props;
-    const { hidden, open } = this.state;
+    const { direction, hidden, open } = this.state;
+
+    const speedDialClassName = classNames(
+      classes.speedDial,
+      classes[`direction${capitalize(direction)}`],
+    );
 
     return (
       <div className={classes.root}>
-        <Button onClick={this.handleVisibility}>Toggle Speed Dial</Button>
-        <SpeedDial
-          ariaLabel="SpeedDial example"
-          className={classes.speedDial}
-          hidden={hidden}
-          icon={<SpeedDialIcon />}
-          onBlur={this.handleClose}
-          onClick={this.handleClick}
-          onClose={this.handleClose}
-          onFocus={this.handleOpen}
-          onMouseEnter={this.handleOpen}
-          onMouseLeave={this.handleClose}
-          open={open}
-        >
-          {actions.map(action => (
-            <SpeedDialAction
-              key={action.name}
-              icon={action.icon}
-              tooltipTitle={action.name}
-              onClick={this.handleClick}
-            />
-          ))}
-        </SpeedDial>
+        <div className={classes.controls}>
+          <FormControlLabel
+            control={
+              <Switch
+                checked={hidden}
+                onChange={this.handleHiddenChange}
+                value="hidden"
+                color="primary"
+              />
+            }
+            label="Hidden"
+          />
+          <FormLabel component="legend">Direction</FormLabel>
+          <RadioGroup
+            aria-label="Direction"
+            name="direction"
+            className={classes.radioGroup}
+            value={direction}
+            onChange={this.handleDirectionChange}
+            row
+          >
+            <FormControlLabel value="up" control={<Radio />} label="Up" />
+            <FormControlLabel value="right" control={<Radio />} label="Right" />
+            <FormControlLabel value="down" control={<Radio />} label="Down" />
+            <FormControlLabel value="left" control={<Radio />} label="Left" />
+          </RadioGroup>
+        </div>
+        <div className={classes.exampleWrapper}>
+          <SpeedDial
+            ariaLabel="SpeedDial example"
+            className={speedDialClassName}
+            hidden={hidden}
+            icon={<SpeedDialIcon />}
+            onBlur={this.handleClose}
+            onClick={this.handleClick}
+            onClose={this.handleClose}
+            onFocus={this.handleOpen}
+            onMouseEnter={this.handleOpen}
+            onMouseLeave={this.handleClose}
+            open={open}
+            direction={direction}
+          >
+            {actions.map(action => (
+              <SpeedDialAction
+                key={action.name}
+                icon={action.icon}
+                tooltipTitle={action.name}
+                onClick={this.handleClick}
+              />
+            ))}
+          </SpeedDial>
+        </div>
       </div>
     );
   }

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -10,6 +10,8 @@ import { duration } from '@material-ui/core/styles/transitions';
 import Button from '@material-ui/core/Button';
 import { isMuiElement } from '@material-ui/core/utils/reactHelpers';
 
+const spacingActions = 16;
+
 export const styles = {
   /* Styles applied to the root element. */
   root: {
@@ -40,8 +42,19 @@ export const styles = {
   /* Styles applied to the actions (`children` wrapper) element. */
   actions: {
     display: 'flex',
-    paddingBottom: 16,
     pointerEvents: 'auto',
+    '&$directionUp': {
+      paddingBottom: spacingActions,
+    },
+    '&$directionRight': {
+      paddingLeft: spacingActions,
+    },
+    '&$directionDown': {
+      paddingTop: spacingActions,
+    },
+    '&$directionLeft': {
+      paddingRight: spacingActions,
+    },
   },
   /* Styles applied to the actions (`children` wrapper) element if `open={false}`. */
   actionsClosed: {

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -10,6 +10,7 @@ import { duration } from '@material-ui/core/styles/transitions';
 import Button from '@material-ui/core/Button';
 import { isMuiElement } from '@material-ui/core/utils/reactHelpers';
 
+const dialRadius = 32;
 const spacingActions = 16;
 
 export const styles = {
@@ -44,16 +45,20 @@ export const styles = {
     display: 'flex',
     pointerEvents: 'auto',
     '&$directionUp': {
-      paddingBottom: spacingActions,
+      marginBottom: -dialRadius,
+      paddingBottom: spacingActions + dialRadius,
     },
     '&$directionRight': {
-      paddingLeft: spacingActions,
+      marginLeft: -dialRadius,
+      paddingLeft: spacingActions + dialRadius,
     },
     '&$directionDown': {
-      paddingTop: spacingActions,
+      marginTop: -dialRadius,
+      paddingTop: spacingActions + dialRadius,
     },
     '&$directionLeft': {
-      paddingRight: spacingActions,
+      marginRight: -dialRadius,
+      paddingRight: spacingActions + dialRadius,
     },
   },
   /* Styles applied to the actions (`children` wrapper) element if `open={false}`. */


### PR DESCRIPTION
# Includes
1. fix inconsistent spacing between Dial and Actions across directions which also cause alignment issues
2. hovering from Dial to Actions is now more forgiving
3. Add direction switches to simple [SpeedDial example](https://deploy-preview-13018--material-ui.netlify.com/lab/speed-dial/#simple-speed-dial)

## To 1. (a033718)
### Before
![speeddial-alignment-before](https://user-images.githubusercontent.com/12292047/46138293-d1068000-c24b-11e8-942f-56b1a3ba33fc.gif)
### After
![speeddial-alignment-after](https://user-images.githubusercontent.com/12292047/46138298-d5329d80-c24b-11e8-8125-1299ac592b29.gif)

## To 2. (efd6d95)
### Before
![speeddial-hover-before](https://user-images.githubusercontent.com/12292047/46138308-da8fe800-c24b-11e8-91b4-9759f98057a8.gif)
### After
![speeddial-hover-after](https://user-images.githubusercontent.com/12292047/46138316-de236f00-c24b-11e8-9e0c-6892dc7a8b35.gif)
