### PR TITLE
[StepConnector] Customize connector based on active, completed, and disabled states

### DIFF
--- a/docs/src/pages/demos/steppers/HorizontalLinearStepper.js
+++ b/docs/src/pages/demos/steppers/HorizontalLinearStepper.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
+import StepConnector from '@material-ui/core/StepConnector';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
@@ -17,6 +18,12 @@ const styles = theme => ({
   instructions: {
     marginTop: theme.spacing.unit,
     marginBottom: theme.spacing.unit,
+  },
+  lineActive: {
+    borderColor: theme.palette.secondary.main,
+  },
+  lineCompleted: {
+    borderColor: theme.palette.primary.main,
   },
 });
 
@@ -102,7 +109,14 @@ class HorizontalLinearStepper extends React.Component {
 
     return (
       <div className={classes.root}>
-        <Stepper activeStep={activeStep}>
+        <Stepper
+          activeStep={activeStep}
+          connector={
+            <StepConnector
+              classes={{ lineActive: classes.lineActive, lineCompleted: classes.lineCompleted }}
+            />
+          }
+        >
           {steps.map((label, index) => {
             const props = {};
             const labelProps = {};

--- a/docs/src/pages/demos/steppers/steppers.md
+++ b/docs/src/pages/demos/steppers/steppers.md
@@ -30,6 +30,8 @@ The `Stepper` can be controlled by passing the current step index (zero-based) a
 
 This example also shows the use of an optional step by placing the `optional` property on the second `Step` component. Note that it's up to you to manage when an optional step is skipped. Once you've determined this for a particular step you must set `completed={false}` to signify that even though the active step index has gone beyond the optional step, it's not actually complete.
 
+The example also uses a customized `StepConnector` element that changes border color based on the `active` and `completed` state.
+
 {{"demo": "pages/demos/steppers/HorizontalLinearStepper.js"}}
 
 ## Horizontal Non-linear

--- a/packages/material-ui/src/StepConnector/StepConnector.d.ts
+++ b/packages/material-ui/src/StepConnector/StepConnector.d.ts
@@ -8,6 +8,9 @@ export interface StepConnectorProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, StepConnectorClasskey> {
   alternativeLabel?: boolean;
   orientation?: Orientation;
+  active?: boolean;
+  completed?: boolean;
+  disabled?: boolean;
 }
 
 export type StepConnectorClasskey =
@@ -17,7 +20,10 @@ export type StepConnectorClasskey =
   | 'alternativeLabel'
   | 'line'
   | 'lineHorizontal'
-  | 'lineVertical';
+  | 'lineVertical'
+  | 'lineActive'
+  | 'lineCompleted'
+  | 'lineDisabled';
 
 declare const StepConnector: React.ComponentType<StepConnectorProps>;
 

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -38,10 +38,25 @@ export const styles = theme => ({
     borderLeftWidth: 1,
     minHeight: 24,
   },
+  /* Styles applied to the line element if `active={true}`. */
+  lineActive: {},
+  /* Styles applied to the line element if `completed={true}`. */
+  lineCompleted: {},
+  /* Styles applied to the line element if `disabled={true}`. */
+  lineDisabled: {},
 });
 
 function StepConnector(props) {
-  const { alternativeLabel, className: classNameProp, classes, orientation, ...other } = props;
+  const {
+    alternativeLabel,
+    className: classNameProp,
+    classes,
+    orientation,
+    active,
+    completed,
+    disabled,
+    ...other
+  } = props;
 
   const className = classNames(
     classes.root,
@@ -54,6 +69,9 @@ function StepConnector(props) {
   const lineClassName = classNames(classes.line, {
     [classes.lineHorizontal]: orientation === 'horizontal',
     [classes.lineVertical]: orientation === 'vertical',
+    [classes.lineActive]: active,
+    [classes.lineCompleted]: completed,
+    [classes.lineDisabled]: disabled,
   });
 
   return (
@@ -64,6 +82,10 @@ function StepConnector(props) {
 }
 
 StepConnector.propTypes = {
+  /**
+   * @ignore
+   */
+  active: PropTypes.bool,
   /**
    * @ignore
    * Set internally by Step when it's supplied with the alternativeLabel property.
@@ -81,12 +103,23 @@ StepConnector.propTypes = {
   /**
    * @ignore
    */
+  completed: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  disabled: PropTypes.bool,
+  /**
+   * @ignore
+   */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 };
 
 StepConnector.defaultProps = {
   alternativeLabel: false,
   orientation: 'horizontal',
+  active: false,
+  completed: false,
+  disabled: false,
 };
 
 export default withStyles(styles, { name: 'MuiStepConnector' })(StepConnector);

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -35,5 +35,23 @@ describe('<StepConnector />', () => {
       const line = wrapper.find('span');
       assert.include(line.props().className, 'StepConnector-lineVertical');
     });
+
+    it('has the class lineActive when active', () => {
+      const wrapper = shallow(<StepConnector active />);
+      const line = wrapper.find('span');
+      assert.include(line.props().className, 'StepConnector-lineActive');
+    });
+
+    it('has the class lineCompleted when completed', () => {
+      const wrapper = shallow(<StepConnector completed />);
+      const line = wrapper.find('span');
+      assert.include(line.props().className, 'StepConnector-lineCompleted');
+    });
+
+    it('has the class lineDisabled when disabled', () => {
+      const wrapper = shallow(<StepConnector disabled />);
+      const line = wrapper.find('span');
+      assert.include(line.props().className, 'StepConnector-lineDisabled');
+    });
   });
 });

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -66,12 +66,21 @@ function Stepper(props) {
       connector: connectorProp,
     };
 
+    const connectorProps = {
+      active: false,
+      completed: false,
+      disabled: false,
+    };
+
     if (activeStep === index) {
       controlProps.active = true;
+      connectorProps.active = true;
     } else if (!nonLinear && activeStep > index) {
       controlProps.completed = true;
+      connectorProps.completed = true;
     } else if (!nonLinear && activeStep < index) {
       controlProps.disabled = true;
+      connectorProps.disabled = true;
     }
 
     return [
@@ -80,6 +89,7 @@ function Stepper(props) {
         index > 0 &&
         React.cloneElement(connector, {
           key: index, // eslint-disable-line react/no-array-index-key
+          ...connectorProps,
         }),
       React.cloneElement(step, { ...controlProps, ...step.props }),
     ];

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -166,6 +166,28 @@ describe('<Stepper />', () => {
         'should not contain a <StepConnector /> child',
       );
     });
+
+    it('should pass active prop to connector when second step is active', () => {
+      const wrapper = shallow(
+        <Stepper activeStep={1}>
+          <Step />
+          <Step />
+        </Stepper>,
+      );
+      const connectors = wrapper.find(StepConnector);
+      assert.strictEqual(connectors.first().props().active, true);
+    });
+
+    it('should pass completed prop to connector when second step is completed', () => {
+      const wrapper = shallow(
+        <Stepper activeStep={2}>
+          <Step />
+          <Step />
+        </Stepper>,
+      );
+      const connectors = wrapper.find(StepConnector);
+      assert.strictEqual(connectors.first().props().completed, true);
+    });
   });
 
   it('renders with a null child', () => {

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -38,6 +38,9 @@ This property accepts the following keys:
 | <span class="prop-name">line</span> | Styles applied to the line element.
 | <span class="prop-name">lineHorizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
 | <span class="prop-name">lineVertical</span> | Styles applied to the root element if `orientation="vertical"`.
+| <span class="prop-name">lineActive</span> | Styles applied to the line element if `active="true"`.
+| <span class="prop-name">lineCompleted</span> | Styles applied to the line element if `completed="true"`.
+| <span class="prop-name">lineDisabled</span> | Styles applied to the line element if `disabled="true"`.
 
 Have a look at [overriding with classes](/customization/overrides#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/StepConnector/StepConnector.js)


### PR DESCRIPTION
Closes #13010 

This can be accomplished with the following example:

```jsx
<Stepper
  connector={
    <StepConnector
      classes={{ lineActive: classes.lineActive, lineCompleted: classes.lineCompleted }}
    />
  }
>
{/* ... */}
</Stepper>
```

### Before

<img width="643" alt="screen shot 2018-09-27 at 21 36 21" src="https://user-images.githubusercontent.com/1057324/46170190-68e08a00-c29d-11e8-991b-48a1913e1fc5.png">

### After

<img width="646" alt="screen shot 2018-09-27 at 21 35 13" src="https://user-images.githubusercontent.com/1057324/46170157-55cdba00-c29d-11e8-874c-3f4db976756f.png">
