### PR TITLE
[core] Better assertion

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -70,8 +70,8 @@ describe('<Slider />', () => {
       wrapper.simulate('mousedown');
       callGlobalListeners();
       // pre condition: the dispatched event actually did something when mounted
-      assert.strictEqual(handleChange.callCount, 1, 'should have called the handleChange cb');
-      assert.strictEqual(handleDragEnd.callCount, 1, 'should have called the handleDragEnd cb');
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(handleDragEnd.callCount, 1);
 
       wrapper.unmount();
 
@@ -80,8 +80,8 @@ describe('<Slider />', () => {
       // or other component logic throws.
       // post condition: the dispatched events dont cause errors/warnings
       callGlobalListeners();
-      assert.strictEqual(handleChange.callCount, 1, 'should not have called handleChange again');
-      assert.strictEqual(handleDragEnd.callCount, 1, 'should not have called handleDragEnd again');
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(handleDragEnd.callCount, 1);
     });
   });
 
@@ -137,7 +137,7 @@ describe('<Slider />', () => {
 
     it('should render thumb in initial state', () => {
       const button = wrapper.find('button');
-      assert.strictEqual(button.prop('style').left, '0%');
+      assert.strictEqual(button.props().style.left, '0%');
     });
 
     it('should render tracks in initial state', () => {
@@ -145,8 +145,8 @@ describe('<Slider />', () => {
       const trackBefore = tracks.at(0);
       const trackAfter = tracks.at(1);
 
-      assert.strictEqual(trackBefore.prop('style').width, '0%');
-      assert.strictEqual(trackAfter.prop('style').width, 'calc(100% - 5px)');
+      assert.strictEqual(trackBefore.props().style.width, '0%');
+      assert.strictEqual(trackAfter.props().style.width, 'calc(100% - 5px)');
     });
 
     it('after change value should change position of thumb', () => {
@@ -155,7 +155,7 @@ describe('<Slider />', () => {
       clock.tick(transitionComplexDuration);
 
       const button = wrapper.find('button');
-      assert.strictEqual(button.prop('style').left, '50%');
+      assert.strictEqual(button.props().style.left, '50%');
     });
 
     it('should render tracks in new state', () => {
@@ -163,8 +163,8 @@ describe('<Slider />', () => {
       const trackBefore = tracks.at(0);
       const trackAfter = tracks.at(1);
 
-      assert.strictEqual(trackBefore.prop('style').width, '50%');
-      assert.strictEqual(trackAfter.prop('style').width, 'calc(100% - 5px)');
+      assert.strictEqual(trackBefore.props().style.width, '50%');
+      assert.strictEqual(trackAfter.props().style.width, 'calc(100% - 5px)');
     });
   });
 });

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -104,8 +104,8 @@ describe('<SpeedDial />', () => {
       </SpeedDial>,
     );
     const actionsWrapper = wrapper.childAt(1);
-    assert.strictEqual(actionsWrapper.childAt(0).props().open, true, 'open should be true');
-    assert.strictEqual(actionsWrapper.childAt(1).props().open, true, 'open should be true');
+    assert.strictEqual(actionsWrapper.childAt(0).props().open, true);
+    assert.strictEqual(actionsWrapper.childAt(1).props().open, true);
   });
 
   describe('prop: onClick', () => {

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -42,26 +42,14 @@ describe('<SpeedDialAction />', () => {
   it('should render the Button with the button class', () => {
     const wrapper = shallow(<SpeedDialAction icon={icon} open />);
     const buttonWrapper = wrapper.childAt(0);
-    assert.strictEqual(
-      buttonWrapper.hasClass(classes.button),
-      true,
-      'should have the actionButton class',
-    );
+    assert.strictEqual(buttonWrapper.hasClass(classes.button), true);
   });
 
   it('should render the Button with the button and buttonClosed classes', () => {
     const wrapper = shallow(<SpeedDialAction icon={icon} />);
     const buttonWrapper = wrapper.childAt(0);
-    assert.strictEqual(
-      buttonWrapper.hasClass(classes.button),
-      true,
-      'should have the button class',
-    );
-    assert.strictEqual(
-      buttonWrapper.hasClass(classes.buttonClosed),
-      true,
-      'should have the buttonClosed class',
-    );
+    assert.strictEqual(buttonWrapper.hasClass(classes.button), true);
+    assert.strictEqual(buttonWrapper.hasClass(classes.buttonClosed), true);
   });
 
   describe('prop: onClick', () => {
@@ -70,17 +58,7 @@ describe('<SpeedDialAction />', () => {
       const wrapper = shallow(<SpeedDialAction icon={icon} open onClick={handleClick} />);
       const buttonWrapper = wrapper.childAt(0);
       buttonWrapper.simulate('click');
-      assert.strictEqual(handleClick.callCount, 1, 'it should forward the click event');
+      assert.strictEqual(handleClick.callCount, 1);
     });
   });
-
-  // it('should call handleTooltipOpen & handleTooltipClose on mouseOver & blur', () => {
-  //   const wrapper = shallow(<SpeedDialAction icon={icon} open />);
-  //   const buttonWrapper = wrapper.childAt(0);
-  //   assert.strictEqual(wrapper.state().tooltipOpen, false);
-  //   buttonWrapper.simulate('mouseOver', {});
-  //   assert.strictEqual(wrapper.state().tooltipOpen, true);
-  //   buttonWrapper.simulate('blur', {});
-  //   assert.strictEqual(wrapper.state().tooltipOpen, false);
-  // });
 });

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
@@ -27,7 +27,7 @@ describe('<ToggleButton />', () => {
         Hello World
       </ToggleButton>,
     );
-    assert.strictEqual(wrapper.is('.test-class-name'), true, 'should pass the test className');
+    assert.strictEqual(wrapper.is('.test-class-name'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
@@ -38,7 +38,7 @@ describe('<ToggleButton />', () => {
       </ToggleButton>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.selected), true, 'should have the selected class');
+    assert.strictEqual(wrapper.hasClass(classes.selected), true);
   });
 
   it('should render a disabled button', () => {
@@ -48,7 +48,7 @@ describe('<ToggleButton />', () => {
       </ToggleButton>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.disabled), true, 'should have the disabled class');
+    assert.strictEqual(wrapper.hasClass(classes.disabled), true);
   });
 
   describe('prop: onChange', () => {
@@ -80,7 +80,7 @@ describe('<ToggleButton />', () => {
     it('should not be called if the click is prevented', () => {
       const handleChange = spy();
       const wrapper = shallow(
-        <ToggleButton value="one" onChange={handleChange} onClick={e => e.preventDefault()}>
+        <ToggleButton value="one" onChange={handleChange} onClick={event => event.preventDefault()}>
           Hello
         </ToggleButton>,
       );

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -35,7 +35,7 @@ describe('<ToggleButtonGroup />', () => {
         <ToggleButton value="hello" />
       </ToggleButtonGroup>,
     );
-    assert.strictEqual(wrapper.is('.test-class-name'), true, 'should pass the test className');
+    assert.strictEqual(wrapper.is('.test-class-name'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
@@ -46,7 +46,7 @@ describe('<ToggleButtonGroup />', () => {
       </ToggleButtonGroup>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.selected), true, 'should have the selected class');
+    assert.strictEqual(wrapper.hasClass(classes.selected), true);
   });
 
   it('should render a selected div when selected is "auto" and a value is present', () => {
@@ -56,7 +56,7 @@ describe('<ToggleButtonGroup />', () => {
       </ToggleButtonGroup>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.selected), true, 'should have the selected class');
+    assert.strictEqual(wrapper.hasClass(classes.selected), true);
   });
 
   it('should not render a selected div when selected is "auto" and a value is missing', () => {
@@ -66,11 +66,7 @@ describe('<ToggleButtonGroup />', () => {
       </ToggleButtonGroup>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.selected),
-      false,
-      'should not have the selected class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.selected), false);
   });
 
   describe('exclusive', () => {
@@ -113,7 +109,6 @@ describe('<ToggleButtonGroup />', () => {
           .at(0)
           .props().selected,
         true,
-        'should be selected',
       );
       assert.strictEqual(
         wrapper
@@ -121,7 +116,6 @@ describe('<ToggleButtonGroup />', () => {
           .at(1)
           .props().selected,
         false,
-        'should not be selected',
       );
     });
   });

--- a/packages/material-ui/src/AppBar/AppBar.test.js
+++ b/packages/material-ui/src/AppBar/AppBar.test.js
@@ -14,50 +14,34 @@ describe('<AppBar />', () => {
 
   it('should render a Paper component', () => {
     const wrapper = shallow(<AppBar>Hello World</AppBar>);
-    assert.strictEqual(wrapper.props().elevation, 4, 'should render with a 4dp shadow');
+    assert.strictEqual(wrapper.props().elevation, 4);
   });
 
   it('should render with the root class and primary', () => {
     const wrapper = shallow(<AppBar>Hello World</AppBar>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.colorPrimary),
-      true,
-      'should have the primary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
     assert.strictEqual(wrapper.hasClass(classes.colorSecondary), false);
   });
 
   it('should render the custom className and the appBar class', () => {
     const wrapper = shallow(<AppBar className="test-class-name">Hello World</AppBar>);
-    assert.strictEqual(wrapper.is('.test-class-name'), true, 'should pass the test className');
+    assert.strictEqual(wrapper.is('.test-class-name'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.colorPrimary),
-      true,
-      'should have the primary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
   });
 
   it('should render a primary app bar', () => {
     const wrapper = shallow(<AppBar color="primary">Hello World</AppBar>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.colorPrimary),
-      true,
-      'should have the primary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
     assert.strictEqual(wrapper.hasClass(classes.colorSecondary), false);
   });
 
   it('should render an secondary app bar', () => {
     const wrapper = shallow(<AppBar color="secondary">Hello World</AppBar>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.colorPrimary),
-      false,
-      'should not have the primary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.colorPrimary), false);
     assert.strictEqual(wrapper.hasClass(classes.colorSecondary), true);
   });
 

--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -25,27 +25,15 @@ describe('<Avatar />', () => {
       );
 
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.childAt(0).is('img'), true, 'should be an img');
+      assert.strictEqual(wrapper.childAt(0).name(), 'img');
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-avatar'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofAvatar');
-      assert.strictEqual(
-        wrapper.hasClass(classes.colorDefault),
-        false,
-        'should not apply the colorDefault class for image avatars',
-      );
+      assert.strictEqual(wrapper.props()['data-my-prop'], 'woofAvatar');
+      assert.strictEqual(wrapper.hasClass(classes.colorDefault), false);
       const img = wrapper.childAt(0);
-      assert.strictEqual(
-        img.hasClass(classes.img),
-        true,
-        'should add the img class to the img node',
-      );
-      assert.strictEqual(img.props().alt, 'Hello World!', 'should apply img props to the img node');
-      assert.strictEqual(
-        img.props().src,
-        'something.jpg',
-        'should apply img props to the img node',
-      );
+      assert.strictEqual(img.hasClass(classes.img), true);
+      assert.strictEqual(img.props().alt, 'Hello World!');
+      assert.strictEqual(img.props().src, 'something.jpg');
     });
 
     it('should be able to add more properties to the image', () => {
@@ -69,7 +57,7 @@ describe('<Avatar />', () => {
     it('should render a div containing an font icon', () => {
       const icon = wrapper.childAt(0);
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(icon.is('span'), true, 'should be a span');
+      assert.strictEqual(icon.name(), 'span');
       assert.strictEqual(icon.hasClass('my-icon-font'), true);
       assert.strictEqual(icon.text(), 'icon');
     });
@@ -77,7 +65,7 @@ describe('<Avatar />', () => {
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-avatar'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofAvatar');
+      assert.strictEqual(wrapper.props()['data-my-prop'], 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {
@@ -102,13 +90,13 @@ describe('<Avatar />', () => {
 
     it('should render a div containing an svg icon', () => {
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.childAt(0).is('pure(Cancel)'), true, 'should be an svg icon');
+      assert.strictEqual(wrapper.childAt(0).name(), 'pure(Cancel)');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-avatar'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofAvatar');
+      assert.strictEqual(wrapper.props()['data-my-prop'], 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {
@@ -139,7 +127,7 @@ describe('<Avatar />', () => {
     it('should merge user classes & spread custom props to the root node', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-avatar'), true);
-      assert.strictEqual(wrapper.prop('data-my-prop'), 'woofAvatar');
+      assert.strictEqual(wrapper.props()['data-my-prop'], 'woofAvatar');
     });
 
     it('should apply the colorDefault class', () => {

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -17,8 +17,8 @@ describe('<Badge />', () => {
   it('renders children and badgeContent', () => {
     const wrapper = shallow(<Badge badgeContent={10}>{testChildren}</Badge>);
 
-    assert.strictEqual(wrapper.contains(testChildren), true, 'should contain the children');
-    assert.ok(wrapper.find('span').length, 'should contain the badgeContent');
+    assert.strictEqual(wrapper.contains(testChildren), true);
+    assert.strictEqual(wrapper.find('span').length, 2);
   });
 
   it('renders children and overwrite badge class', () => {
@@ -30,7 +30,7 @@ describe('<Badge />', () => {
       </Badge>,
     );
 
-    assert.strictEqual(wrapper.contains(testChildren), true, 'should contain the children');
+    assert.strictEqual(wrapper.contains(testChildren), true);
     assert.strictEqual(
       wrapper
         .find('span')
@@ -43,7 +43,7 @@ describe('<Badge />', () => {
   it('renders children by default', () => {
     const wrapper = shallow(<Badge badgeContent={10}>{testChildren}</Badge>);
 
-    assert.strictEqual(wrapper.contains(testChildren), true, 'should contain the children');
+    assert.strictEqual(wrapper.contains(testChildren), true);
   });
 
   it('renders children and className', () => {
@@ -53,8 +53,8 @@ describe('<Badge />', () => {
       </Badge>,
     );
 
-    assert.strictEqual(wrapper.contains(testChildren), true, 'should contain the children');
-    assert.strictEqual(wrapper.is('.testClassName'), true, 'should contain the className');
+    assert.strictEqual(wrapper.contains(testChildren), true);
+    assert.strictEqual(wrapper.is('.testClassName'), true);
   });
 
   it('renders children and have primary styles', () => {
@@ -64,14 +64,13 @@ describe('<Badge />', () => {
       </Badge>,
     );
 
-    assert.strictEqual(wrapper.contains(testChildren), true, 'should contain the children');
+    assert.strictEqual(wrapper.contains(testChildren), true);
     assert.strictEqual(
       wrapper
         .find('span')
         .at(1)
         .hasClass(classes.colorPrimary),
       true,
-      'should have primary class',
     );
   });
 
@@ -82,7 +81,7 @@ describe('<Badge />', () => {
       </Badge>,
     );
 
-    assert.strictEqual(wrapper.contains(testChildren), true, 'should contain the children');
+    assert.strictEqual(wrapper.contains(testChildren), true);
     assert.strictEqual(
       wrapper
         .find('span')
@@ -116,11 +115,7 @@ describe('<Badge />', () => {
       </Badge>,
     );
 
-    assert.strictEqual(wrapper.contains(testChildren), true, 'should contain the children');
-    assert.strictEqual(
-      wrapper.props().style.backgroundColor,
-      style.backgroundColor,
-      'should overwrite badge backgroundColor',
-    );
+    assert.strictEqual(wrapper.contains(testChildren), true);
+    assert.strictEqual(wrapper.props().style.backgroundColor, style.backgroundColor);
   });
 });

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -64,8 +64,8 @@ describe('<BottomNavigation />', () => {
         <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
-    assert.strictEqual(wrapper.childAt(0).props().selected, false, 'should have selected to false');
-    assert.strictEqual(wrapper.childAt(1).props().selected, true, 'should have selected');
+    assert.strictEqual(wrapper.childAt(0).props().selected, false);
+    assert.strictEqual(wrapper.childAt(1).props().selected, true);
   });
 
   it('should overwrite parent showLabel prop', () => {
@@ -75,8 +75,8 @@ describe('<BottomNavigation />', () => {
         <BottomNavigationAction icon={icon} showLabel={false} />
       </BottomNavigation>,
     );
-    assert.strictEqual(wrapper.childAt(0).props().showLabel, true, 'should have parent showLabel');
-    assert.strictEqual(wrapper.childAt(1).props().showLabel, false, 'should overwrite showLabel');
+    assert.strictEqual(wrapper.childAt(0).props().showLabel, true);
+    assert.strictEqual(wrapper.childAt(1).props().showLabel, false);
   });
 
   it('should pass selected prop to children', () => {
@@ -91,8 +91,8 @@ describe('<BottomNavigation />', () => {
       .find(BottomNavigationAction)
       .at(1)
       .simulate('click');
-    assert.strictEqual(handleChange.callCount, 1, 'should have been called once');
-    assert.strictEqual(handleChange.args[0][1], 1, 'should have been called with value 1');
+    assert.strictEqual(handleChange.callCount, 1);
+    assert.strictEqual(handleChange.args[0][1], 1);
   });
 
   it('should use custom action values', () => {

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -34,19 +34,19 @@ describe('<BottomNavigationAction />', () => {
 
   it('should render with the selected and root classes', () => {
     const wrapper = shallow(<BottomNavigationAction icon={icon} selected />);
-    assert.strictEqual(wrapper.hasClass(classes.selected), true, 'should have the selected class');
+    assert.strictEqual(wrapper.hasClass(classes.selected), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render with the selectedIconOnly and root classes', () => {
     const wrapper = shallow(<BottomNavigationAction icon={icon} showLabel={false} />);
-    assert.strictEqual(wrapper.hasClass(classes.iconOnly), true, 'should have the iconOnly class');
+    assert.strictEqual(wrapper.hasClass(classes.iconOnly), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render icon', () => {
     const wrapper = shallow(<BottomNavigationAction icon={icon} />);
-    assert.strictEqual(wrapper.contains(icon), true, 'should have the icon');
+    assert.strictEqual(wrapper.contains(icon), true);
   });
 
   it('should render label with the selected class', () => {
@@ -64,7 +64,7 @@ describe('<BottomNavigationAction />', () => {
       true,
       'should have the iconOnly class',
     );
-    assert.strictEqual(labelWrapper.hasClass(classes.label), true, 'should have the label class');
+    assert.strictEqual(labelWrapper.hasClass(classes.label), true);
   });
 
   it('should not render an Icon if icon is not provided', () => {
@@ -79,7 +79,7 @@ describe('<BottomNavigationAction />', () => {
         <BottomNavigationAction icon="book" onClick={handleClick} value="foo" />,
       );
       wrapper.simulate('click', 'bar');
-      assert.strictEqual(handleClick.callCount, 1, 'it should forward the onClick');
+      assert.strictEqual(handleClick.callCount, 1);
     });
   });
 
@@ -90,7 +90,7 @@ describe('<BottomNavigationAction />', () => {
         <BottomNavigationAction icon="book" onChange={handleChange} value="foo" />,
       );
       wrapper.simulate('click', 'bar');
-      assert.strictEqual(handleChange.callCount, 1, 'it should forward the onChange');
+      assert.strictEqual(handleChange.callCount, 1);
     });
   });
 });

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -19,11 +19,7 @@ describe('<Button />', () => {
   it('should render a <ButtonBase> element', () => {
     const wrapper = shallow(<Button>Hello World</Button>);
     assert.strictEqual(wrapper.type(), ButtonBase);
-    assert.strictEqual(
-      wrapper.props().type,
-      'button',
-      'should render with the button type attribute',
-    );
+    assert.strictEqual(wrapper.props().type, 'button');
   });
 
   it('should render with the root & flat classes but no others', () => {
@@ -31,52 +27,16 @@ describe('<Button />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.flat), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textPrimary),
-      false,
-      'should not have the textPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.textSecondary),
-      false,
-      'should not have the textSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.flatPrimary),
-      false,
-      'should not have the flatPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.flatSecondary),
-      false,
-      'should not have the flatSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      false,
-      'should not have the contained class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedPrimary),
-      false,
-      'should not have the containedPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedSecondary),
-      false,
-      'should not have the containedSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
+    assert.strictEqual(wrapper.hasClass(classes.flatPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.flatSecondary), false);
+    assert.strictEqual(wrapper.hasClass(classes.contained), false);
+    assert.strictEqual(wrapper.hasClass(classes.containedPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.containedSecondary), false);
     assert.strictEqual(wrapper.hasClass(classes.raised), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.raisedPrimary),
-      false,
-      'should not have the raisedPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.outlined),
-      false,
-      'should not have the outlined class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.raisedPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.outlined), false);
   });
 
   it('should render the custom className and the root class', () => {
@@ -91,26 +51,10 @@ describe('<Button />', () => {
     assert.strictEqual(wrapper.hasClass(classes.flat), true);
     assert.strictEqual(wrapper.hasClass(classes.contained), false);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textPrimary),
-      true,
-      'should have the textPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.textSecondary),
-      false,
-      'should not have the textSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.flatPrimary),
-      true,
-      'should have the flatPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.flatSecondary),
-      false,
-      'should not have the flatSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), true);
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
+    assert.strictEqual(wrapper.hasClass(classes.flatPrimary), true);
+    assert.strictEqual(wrapper.hasClass(classes.flatSecondary), false);
   });
 
   it('should render a secondary button', () => {
@@ -119,47 +63,19 @@ describe('<Button />', () => {
     assert.strictEqual(wrapper.hasClass(classes.flat), true);
     assert.strictEqual(wrapper.hasClass(classes.contained), false);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textPrimary),
-      false,
-      'should not have the textPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.textSecondary),
-      true,
-      'should have the textSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.flatPrimary),
-      false,
-      'should not have the flatPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.flatSecondary),
-      true,
-      'should have the flatSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), true);
+    assert.strictEqual(wrapper.hasClass(classes.flatPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.flatSecondary), true);
   });
 
   it('should render a contained button', () => {
     const wrapper = shallow(<Button variant="contained">Hello World</Button>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      true,
-      'should have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textPrimary),
-      false,
-      'should not have the textPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.textSecondary),
-      false,
-      'should not have the textSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
   });
 
   it('should render a contained primary button', () => {
@@ -169,22 +85,10 @@ describe('<Button />', () => {
       </Button>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      true,
-      'should have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedPrimary),
-      true,
-      'should have the containdPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedSecondary),
-      false,
-      'should not have the containedSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.containedPrimary), true);
+    assert.strictEqual(wrapper.hasClass(classes.containedSecondary), false);
   });
 
   it('should render a contained secondary button', () => {
@@ -196,48 +100,20 @@ describe('<Button />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedPrimary),
-      false,
-      'should not have the primary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedSecondary),
-      true,
-      'should have the secondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.containedPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.containedSecondary), true);
   });
 
   it('should render a raised button', () => {
     const wrapper = shallow(<Button variant="raised">Hello World</Button>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      true,
-      'should have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.raised), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedPrimary),
-      false,
-      'should not have the containedPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.raisedPrimary),
-      false,
-      'should not have the raisedPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedSecondary),
-      false,
-      'should not have the containedSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.raisedSecondary),
-      false,
-      'should not have the raisedSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.containedPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.raisedPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.containedSecondary), false);
+    assert.strictEqual(wrapper.hasClass(classes.raisedSecondary), false);
   });
 
   it('should render a raised primary button', () => {
@@ -247,33 +123,13 @@ describe('<Button />', () => {
       </Button>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      true,
-      'should have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.raised), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedPrimary),
-      true,
-      'should have the containedPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.raisedPrimary),
-      true,
-      'should have the raisedPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedSecondary),
-      false,
-      'should not have the containedSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.raisedSecondary),
-      false,
-      'should not have the raisedSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.containedPrimary), true);
+    assert.strictEqual(wrapper.hasClass(classes.raisedPrimary), true);
+    assert.strictEqual(wrapper.hasClass(classes.containedSecondary), false);
+    assert.strictEqual(wrapper.hasClass(classes.raisedSecondary), false);
   });
 
   it('should render a raised secondary button', () => {
@@ -283,33 +139,13 @@ describe('<Button />', () => {
       </Button>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      true,
-      'should have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.raised), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedPrimary),
-      false,
-      'should not have the containedPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.raisedPrimary),
-      false,
-      'should not have the raisedPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedSecondary),
-      true,
-      'should have the containedSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.raisedSecondary),
-      true,
-      'should have the raisedSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.containedPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.raisedPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.containedSecondary), true);
+    assert.strictEqual(wrapper.hasClass(classes.raisedSecondary), true);
   });
 
   it('should render an outlined button', () => {
@@ -335,16 +171,8 @@ describe('<Button />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.text), true);
     assert.strictEqual(wrapper.hasClass(classes.outlined), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textPrimary),
-      true,
-      'should have the textPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      false,
-      'should not have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), true);
+    assert.strictEqual(wrapper.hasClass(classes.contained), false);
     assert.strictEqual(wrapper.hasClass(classes.raised), false);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
   });
@@ -358,16 +186,8 @@ describe('<Button />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.text), true);
     assert.strictEqual(wrapper.hasClass(classes.outlined), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textSecondary),
-      true,
-      'should have the textSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      false,
-      'should not have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), true);
+    assert.strictEqual(wrapper.hasClass(classes.contained), false);
     assert.strictEqual(wrapper.hasClass(classes.raised), false);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
   });
@@ -375,55 +195,23 @@ describe('<Button />', () => {
   it('should render a floating action button', () => {
     const wrapper = shallow(<Button variant="fab">Hello World</Button>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      true,
-      'should have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.extendedFab),
-      false,
-      'should not have the extendedFab class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.extendedFab), false);
     assert.strictEqual(wrapper.hasClass(classes.flat), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textPrimary),
-      false,
-      'should not have the textPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.textSecondary),
-      false,
-      'should not have the textSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
   });
 
   it('should render an extended floating action button', () => {
     const wrapper = shallow(<Button variant="extendedFab">Hello World</Button>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.contained),
-      true,
-      'should have the contained class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.extendedFab),
-      true,
-      'should have the extendedFab class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.extendedFab), true);
     assert.strictEqual(wrapper.hasClass(classes.flat), false);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textPrimary),
-      false,
-      'should not have the textPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.textSecondary),
-      false,
-      'should not have the textSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
   });
 
   it('should render a mini floating action button', () => {
@@ -436,16 +224,8 @@ describe('<Button />', () => {
     assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), true);
     assert.strictEqual(wrapper.hasClass(classes.mini), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.textPrimary),
-      false,
-      'should not have the textPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.hasClass(classes.textSecondary),
-      false,
-      'should not have the textSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), false);
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
   });
 
   it('should render a primary floating action button', () => {
@@ -457,11 +237,7 @@ describe('<Button />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.contained), true);
     assert.strictEqual(wrapper.hasClass(classes.fab), true);
-    assert.strictEqual(
-      wrapper.hasClass(classes.containedPrimary),
-      true,
-      'should have the containedPrimary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.containedPrimary), true);
     assert.strictEqual(wrapper.hasClass(classes.containedSecondary), false);
   });
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -30,7 +30,7 @@ describe('<ButtonBase />', () => {
     it('should render a button with type="button" by default', () => {
       const wrapper = shallow(<ButtonBase>Hello</ButtonBase>);
       assert.strictEqual(wrapper.name(), 'button');
-      assert.strictEqual(wrapper.childAt(0).equals('Hello'), true, 'should say Hello');
+      assert.strictEqual(wrapper.childAt(0).equals('Hello'), true);
       assert.strictEqual(wrapper.props().type, 'button');
     });
 
@@ -49,7 +49,7 @@ describe('<ButtonBase />', () => {
 
     it('should spread props on button', () => {
       const wrapper = shallow(<ButtonBase data-test="hello">Hello</ButtonBase>);
-      assert.strictEqual(wrapper.prop('data-test'), 'hello', 'should be spread on the button');
+      assert.strictEqual(wrapper.props()['data-test'], 'hello');
     });
 
     it('should render the custom className and the root class', () => {
@@ -139,7 +139,7 @@ describe('<ButtonBase />', () => {
 
     it('should be enabled by default', () => {
       const ripple = wrapper.find(TouchRipple);
-      assert.strictEqual(ripple.length, 1, 'should have one TouchRipple');
+      assert.strictEqual(ripple.length, 1);
     });
 
     it('should not have a focus ripple by default', () => {
@@ -157,76 +157,48 @@ describe('<ButtonBase />', () => {
       wrapper.instance().ripple = { start: spy() };
       wrapper.simulate('mouseDown', {});
 
-      assert.strictEqual(
-        wrapper.instance().ripple.start.callCount,
-        1,
-        'should call start on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.start.callCount, 1);
     });
 
     it('should stop the ripple when the mouse is released', () => {
       wrapper.instance().ripple = { stop: spy() };
       wrapper.simulate('mouseUp', {});
 
-      assert.strictEqual(
-        wrapper.instance().ripple.stop.callCount,
-        1,
-        'should call stop on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.stop.callCount, 1);
     });
 
     it('should start the ripple when the mouse is pressed', () => {
       wrapper.instance().ripple = { start: spy() };
       wrapper.simulate('mouseDown', {});
 
-      assert.strictEqual(
-        wrapper.instance().ripple.start.callCount,
-        1,
-        'should call start on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.start.callCount, 1);
     });
 
     it('should stop the ripple when the button blurs', () => {
       wrapper.instance().ripple = { stop: spy() };
       wrapper.simulate('blur', {});
 
-      assert.strictEqual(
-        wrapper.instance().ripple.stop.callCount,
-        1,
-        'should call stop on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.stop.callCount, 1);
     });
 
     it('should start the ripple when the mouse is pressed', () => {
       wrapper.instance().ripple = { start: spy() };
       wrapper.simulate('mouseDown', {});
 
-      assert.strictEqual(
-        wrapper.instance().ripple.start.callCount,
-        1,
-        'should call start on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.start.callCount, 1);
     });
 
     it('should stop the ripple when the mouse leaves', () => {
       wrapper.instance().ripple = { stop: spy() };
       wrapper.simulate('mouseLeave', {});
 
-      assert.strictEqual(
-        wrapper.instance().ripple.stop.callCount,
-        1,
-        'should call stop on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.stop.callCount, 1);
     });
 
     it('should center the ripple', () => {
-      assert.strictEqual(
-        wrapper.find(TouchRipple).prop('center'),
-        false,
-        'should not be centered by default',
-      );
+      assert.strictEqual(wrapper.find(TouchRipple).props().center, false);
       wrapper.setProps({ centerRipple: true });
-      assert.strictEqual(wrapper.find(TouchRipple).prop('center'), true, 'should be centered');
+      assert.strictEqual(wrapper.find(TouchRipple).props().center, true);
     });
   });
 
@@ -243,18 +215,14 @@ describe('<ButtonBase />', () => {
 
     it('should be enabled by default', () => {
       const ripple = wrapper.find(TouchRipple);
-      assert.strictEqual(ripple.length, 1, 'should have one TouchRipple');
+      assert.strictEqual(ripple.length, 1);
     });
 
     it('should pulsate the ripple when focusVisible', () => {
       wrapper.instance().ripple = { pulsate: spy() };
       wrapper.setState({ focusVisible: true });
 
-      assert.strictEqual(
-        wrapper.instance().ripple.pulsate.callCount,
-        1,
-        'should call pulsate on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.pulsate.callCount, 1);
     });
 
     it('should not stop the ripple when the mouse leaves', () => {
@@ -266,57 +234,32 @@ describe('<ButtonBase />', () => {
         },
       });
 
-      assert.strictEqual(
-        wrapper.instance().ripple.stop.callCount,
-        0,
-        'should not call stop on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.stop.callCount, 0);
     });
 
     it('should stop pulsate and start a ripple when the space button is pressed', () => {
       wrapper.instance().ripple = { stop: spy((event, cb) => cb()), start: spy() };
       wrapper.simulate('keyDown', { which: 32, keyCode: 32, key: ' ', persist: () => {} });
 
-      assert.strictEqual(
-        wrapper.instance().ripple.stop.callCount,
-        1,
-        'should call stop on the ripple',
-      );
-
-      assert.strictEqual(
-        wrapper.instance().ripple.start.callCount,
-        1,
-        'should call start on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.stop.callCount, 1);
+      assert.strictEqual(wrapper.instance().ripple.start.callCount, 1);
     });
 
     it('should stop and re-pulsate when space bar is released', () => {
       wrapper.instance().ripple = { stop: spy((event, cb) => cb()), pulsate: spy() };
       wrapper.simulate('keyUp', { which: 32, keyCode: 32, key: ' ', persist: () => {} });
 
-      assert.strictEqual(
-        wrapper.instance().ripple.stop.callCount,
-        1,
-        'should call stop on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.stop.callCount, 1);
 
-      assert.strictEqual(
-        wrapper.instance().ripple.pulsate.callCount,
-        1,
-        'should call pulsate on the ripple',
-      );
+      assert.strictEqual(wrapper.instance().ripple.pulsate.callCount, 1);
     });
 
     it('should stop on blur and set focusVisible to false', () => {
       wrapper.instance().ripple = { stop: spy() };
       wrapper.simulate('blur', {});
 
-      assert.strictEqual(
-        wrapper.instance().ripple.stop.callCount,
-        1,
-        'should call stop on the ripple',
-      );
-      assert.strictEqual(wrapper.state().focusVisible, false, 'should not be focusVisible');
+      assert.strictEqual(wrapper.instance().ripple.stop.callCount, 1);
+      assert.strictEqual(wrapper.state().focusVisible, false);
     });
   });
 
@@ -350,48 +293,32 @@ describe('<ButtonBase />', () => {
     });
 
     it('should detect the keyboard', () => {
-      assert.strictEqual(
-        wrapper.state().focusVisible,
-        false,
-        'should not set keyboard focus before time has passed',
-      );
+      assert.strictEqual(wrapper.state().focusVisible, false);
       clock.tick(instance.focusVisibleCheckTime * instance.focusVisibleMaxCheckTimes);
-      assert.strictEqual(
-        wrapper.state().focusVisible,
-        true,
-        'should listen for tab presses and set keyboard focus',
-      );
+      assert.strictEqual(wrapper.state().focusVisible, true);
     });
 
     it('should ignore the keyboard after 1s', () => {
       clock.tick(instance.focusVisibleCheckTime * instance.focusVisibleMaxCheckTimes);
-      assert.strictEqual(wrapper.state().focusVisible, true, 'should think it is keyboard based');
+      assert.strictEqual(wrapper.state().focusVisible, true);
       button.blur();
-      assert.strictEqual(wrapper.state().focusVisible, false, 'should has lost the focus');
+      assert.strictEqual(wrapper.state().focusVisible, false);
       button.focus();
       clock.tick(instance.focusVisibleCheckTime * instance.focusVisibleMaxCheckTimes);
-      assert.strictEqual(
-        wrapper.state().focusVisible,
-        true,
-        'should still think it is keyboard based',
-      );
+      assert.strictEqual(wrapper.state().focusVisible, true);
       clock.tick(1e3);
       button.blur();
-      assert.strictEqual(wrapper.state().focusVisible, false, 'should has lost the focus');
+      assert.strictEqual(wrapper.state().focusVisible, false);
       button.focus();
       clock.tick(instance.focusVisibleCheckTime * instance.focusVisibleMaxCheckTimes);
-      assert.strictEqual(
-        wrapper.state().focusVisible,
-        false,
-        'should stop think it is keyboard based',
-      );
+      assert.strictEqual(wrapper.state().focusVisible, false);
     });
   });
 
   describe('prop: disabled', () => {
-    it('should apply the right tabIndex', () => {
+    it('should not receive the focus', () => {
       const wrapper = shallow(<ButtonBase disabled>Hello</ButtonBase>);
-      assert.strictEqual(wrapper.props().tabIndex, '-1', 'should not receive the focus');
+      assert.strictEqual(wrapper.props().tabIndex, '-1');
     });
 
     it('should also apply it when using component', () => {
@@ -513,14 +440,10 @@ describe('<ButtonBase />', () => {
         instance.keyDown = false;
         instance.ripple = { stop: spy() };
         instance.handleKeyDown(event);
-        assert.strictEqual(instance.keyDown, true, 'should mark keydown as true');
-        assert.strictEqual(event.persist.callCount, 1, 'should call event.persist exactly once');
-        assert.strictEqual(instance.ripple.stop.callCount, 1, 'should call stop exactly once');
-        assert.strictEqual(
-          instance.ripple.stop.calledWith(event),
-          true,
-          'should call stop with event',
-        );
+        assert.strictEqual(instance.keyDown, true);
+        assert.strictEqual(event.persist.callCount, 1);
+        assert.strictEqual(instance.ripple.stop.callCount, 1);
+        assert.strictEqual(instance.ripple.stop.calledWith(event), true);
       });
     });
 
@@ -540,14 +463,10 @@ describe('<ButtonBase />', () => {
         instance.keyDown = false;
         instance.handleKeyDown(event);
 
-        assert.strictEqual(instance.keyDown, false, 'should not change keydown');
-        assert.strictEqual(event.persist.callCount, 0, 'should not call event.persist');
-        assert.strictEqual(onKeyDownSpy.callCount, 1, 'should call onKeyDown');
-        assert.strictEqual(
-          onKeyDownSpy.calledWith(event),
-          true,
-          'should call onKeyDown with event',
-        );
+        assert.strictEqual(instance.keyDown, false);
+        assert.strictEqual(event.persist.callCount, 0);
+        assert.strictEqual(onKeyDownSpy.callCount, 1);
+        assert.strictEqual(onKeyDownSpy.calledWith(event), true);
       });
     });
 
@@ -571,10 +490,10 @@ describe('<ButtonBase />', () => {
         instance.keyDown = false;
         instance.handleKeyDown(event);
 
-        assert.strictEqual(instance.keyDown, false, 'should not change keydown');
-        assert.strictEqual(event.preventDefault.callCount, 1, 'should call event.preventDefault');
-        assert.strictEqual(onClickSpy.callCount, 1, 'should call onClick');
-        assert.strictEqual(onClickSpy.calledWith(event), true, 'should call onClick with event');
+        assert.strictEqual(instance.keyDown, false);
+        assert.strictEqual(event.preventDefault.callCount, 1);
+        assert.strictEqual(onClickSpy.callCount, 1);
+        assert.strictEqual(onClickSpy.calledWith(event), true);
       });
 
       it('should hanlde the link with no href', () => {
@@ -626,17 +545,9 @@ describe('<ButtonBase />', () => {
         assert.strictEqual(wrapper.find(TouchRipple).length, 1);
         wrapper.instance().ripple = { start: spy(), stop: spy() };
         wrapper.simulate('mouseDown', {});
-        assert.strictEqual(
-          wrapper.instance().ripple.start.callCount,
-          0,
-          'should not call start on the ripple',
-        );
+        assert.strictEqual(wrapper.instance().ripple.start.callCount, 0);
         wrapper.simulate('mouseUp', {});
-        assert.strictEqual(
-          wrapper.instance().ripple.stop.callCount,
-          0,
-          'should not call stop on the ripple',
-        );
+        assert.strictEqual(wrapper.instance().ripple.stop.callCount, 0);
       });
     });
 
@@ -660,14 +571,10 @@ describe('<ButtonBase />', () => {
         instance.keyDown = false;
         instance.handleKeyDown(event);
 
-        assert.strictEqual(instance.keyDown, false, 'should not change keydown');
-        assert.strictEqual(event.persist.callCount, 0, 'should not call event.persist');
-        assert.strictEqual(onKeyDownSpy.callCount, 1, 'should call onKeyDown');
-        assert.strictEqual(
-          onKeyDownSpy.calledWith(event),
-          true,
-          'should call onKeyDown with event',
-        );
+        assert.strictEqual(instance.keyDown, false);
+        assert.strictEqual(event.persist.callCount, 0);
+        assert.strictEqual(onKeyDownSpy.callCount, 1);
+        assert.strictEqual(onKeyDownSpy.calledWith(event), true);
       });
     });
   });
@@ -683,7 +590,7 @@ describe('<ButtonBase />', () => {
 
       const ref = spy();
       mount(<ButtonBaseRef rootRef={ref}>Hello</ButtonBaseRef>);
-      assert.strictEqual(ref.callCount, 1, 'should call the ref function');
+      assert.strictEqual(ref.callCount, 1);
       assert.strictEqual(ReactDOM.findDOMNode(ref.args[0][0]).type, 'button');
     });
   });
@@ -704,11 +611,7 @@ describe('<ButtonBase />', () => {
         </ButtonBaseNaked>,
       );
 
-      assert.strictEqual(
-        typeof buttonActions.focusVisible === 'function',
-        true,
-        'Should be a function.',
-      );
+      assert.strictEqual(typeof buttonActions.focusVisible, 'function');
       buttonActions.focusVisible();
       wrapper.update();
       assert.strictEqual(wrapper.instance().button, document.activeElement);

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -31,16 +31,8 @@ describe('<Ripple />', () => {
     const wrapper = shallow(
       <Ripple classes={classes} timeout={{}} rippleX={0} rippleY={0} rippleSize={11} />,
     );
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.ripple),
-      true,
-      'should have the ripple class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.fast),
-      false,
-      'should not have the fast (pulse) class',
-    );
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.ripple), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.fast), false);
   });
 
   describe('starting and stopping', () => {
@@ -60,29 +52,21 @@ describe('<Ripple />', () => {
     });
 
     it('should start the ripple', () => {
-      assert.strictEqual(wrapper.state().visible, false, 'should not be visible');
+      assert.strictEqual(wrapper.state().visible, false);
       wrapper.setProps({ in: true });
       wrapper.update();
-      assert.strictEqual(wrapper.state().visible, true, 'should be visible');
+      assert.strictEqual(wrapper.state().visible, true);
       const rippleWrapper = wrapper.find('span').first();
-      assert.strictEqual(
-        rippleWrapper.hasClass(classes.rippleVisible),
-        true,
-        'should have the visible class',
-      );
+      assert.strictEqual(rippleWrapper.hasClass(classes.rippleVisible), true);
     });
 
     it('should stop the ripple', () => {
       wrapper.setProps({ in: true });
       wrapper.setProps({ in: false });
       wrapper.update();
-      assert.strictEqual(wrapper.state().leaving, true, 'should be leaving');
+      assert.strictEqual(wrapper.state().leaving, true);
       const childWrapper = wrapper.find('span').last();
-      assert.strictEqual(
-        childWrapper.hasClass(classes.childLeaving),
-        true,
-        'should have the leaving class',
-      );
+      assert.strictEqual(childWrapper.hasClass(classes.childLeaving), true);
     });
   });
 
@@ -106,53 +90,29 @@ describe('<Ripple />', () => {
     it('should render the ripple inside a pulsating Ripple', () => {
       assert.strictEqual(wrapper.name(), 'Ripple');
       const rippleWrapper = wrapper.find('span').first();
-      assert.strictEqual(
-        rippleWrapper.hasClass(classes.ripple),
-        true,
-        'should have the ripple class',
-      );
-      assert.strictEqual(
-        rippleWrapper.hasClass(classes.ripplePulsate),
-        true,
-        'should have the fast class',
-      );
+      assert.strictEqual(rippleWrapper.hasClass(classes.ripple), true);
+      assert.strictEqual(rippleWrapper.hasClass(classes.ripplePulsate), true);
       const childWrapper = wrapper.find('span').last();
-      assert.strictEqual(
-        childWrapper.hasClass(classes.childPulsate),
-        true,
-        'should have the pulsating class',
-      );
+      assert.strictEqual(childWrapper.hasClass(classes.childPulsate), true);
     });
 
     it('should start the ripple', () => {
-      assert.strictEqual(wrapper.state().visible, false, 'should not be visible');
+      assert.strictEqual(wrapper.state().visible, false);
       wrapper.setProps({ in: true });
       wrapper.update();
-      assert.strictEqual(wrapper.state().visible, true, 'should be visible');
+      assert.strictEqual(wrapper.state().visible, true);
       const rippleWrapper = wrapper.find('span').first();
-      assert.strictEqual(
-        rippleWrapper.hasClass(classes.rippleVisible),
-        true,
-        'should have the visible class',
-      );
+      assert.strictEqual(rippleWrapper.hasClass(classes.rippleVisible), true);
       const childWrapper = wrapper.find('span').last();
-      assert.strictEqual(
-        childWrapper.hasClass(classes.childPulsate),
-        true,
-        'should have the pulsating class',
-      );
+      assert.strictEqual(childWrapper.hasClass(classes.childPulsate), true);
     });
 
     it('should stop the ripple', () => {
       wrapper.setProps({ in: false });
       wrapper.update();
-      assert.strictEqual(wrapper.state().leaving, true, 'should be leaving');
+      assert.strictEqual(wrapper.state().leaving, true);
       const childWrapper = wrapper.find('span').last();
-      assert.strictEqual(
-        childWrapper.hasClass(classes.childLeaving),
-        true,
-        'should have the leaving class',
-      );
+      assert.strictEqual(childWrapper.hasClass(classes.childLeaving), true);
     });
   });
 
@@ -185,16 +145,16 @@ describe('<Ripple />', () => {
     it('handleExit should trigger a timer', () => {
       wrapper.setProps({ in: false });
       clock.tick(549);
-      assert.strictEqual(callbackSpy.callCount, 0, 'The timer is not finished yet');
+      assert.strictEqual(callbackSpy.callCount, 0);
       clock.tick(1);
-      assert.strictEqual(callbackSpy.callCount, 1, 'handleExit callback should have been called');
+      assert.strictEqual(callbackSpy.callCount, 1);
     });
 
     it('unmount should defuse the handleExit timer', () => {
       wrapper.setProps({ in: false });
       wrapper.unmount();
       clock.tick(550);
-      assert.strictEqual(callbackSpy.callCount, 0, 'handleExit callback should not be called');
+      assert.strictEqual(callbackSpy.callCount, 0);
     });
   });
 });

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -25,13 +25,13 @@ describe('<TouchRipple />', () => {
   it('should render a <ReactTransitionGroup> component', () => {
     const wrapper = shallow(<TouchRipple />);
     assert.strictEqual(wrapper.name(), 'TransitionGroup');
-    assert.strictEqual(wrapper.props().component, 'span', 'should be pass a span as the component');
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
+    assert.strictEqual(wrapper.props().component, 'span');
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render the custom className', () => {
     const wrapper = shallow(<TouchRipple className="test-class-name" />);
-    assert.strictEqual(wrapper.is('.test-class-name'), true, 'should contain the test className');
+    assert.strictEqual(wrapper.is('.test-class-name'), true);
   });
 
   describe('prop: center', () => {
@@ -46,7 +46,7 @@ describe('<TouchRipple />', () => {
         cb,
       );
       wrapper.update();
-      assert.strictEqual(wrapper.childAt(0).props().rippleSize, 1, 'should be odd');
+      assert.strictEqual(wrapper.childAt(0).props().rippleSize, 1);
     });
   });
 
@@ -54,25 +54,25 @@ describe('<TouchRipple />', () => {
     const wrapper = mount(<TouchRippleNaked classes={{}} />);
     const instance = wrapper.instance();
 
-    assert.strictEqual(wrapper.state().ripples.length, 0, 'should start with no ripples');
+    assert.strictEqual(wrapper.state().ripples.length, 0);
 
     instance.start({ clientX: 0, clientY: 0 }, cb);
-    assert.strictEqual(wrapper.state().ripples.length, 1, 'should create a ripple');
+    assert.strictEqual(wrapper.state().ripples.length, 1);
 
     instance.start({ clientX: 0, clientY: 0 }, cb);
-    assert.strictEqual(wrapper.state().ripples.length, 2, 'should create another ripple');
+    assert.strictEqual(wrapper.state().ripples.length, 2);
 
     instance.start({ clientX: 0, clientY: 0 }, cb);
-    assert.strictEqual(wrapper.state().ripples.length, 3, 'should create another ripple');
+    assert.strictEqual(wrapper.state().ripples.length, 3);
 
     instance.stop({ type: 'mouseup' });
-    assert.strictEqual(wrapper.state().ripples.length, 2, 'should remove a ripple');
+    assert.strictEqual(wrapper.state().ripples.length, 2);
 
     instance.stop({ type: 'mouseup' });
-    assert.strictEqual(wrapper.state().ripples.length, 1, 'should remove a ripple');
+    assert.strictEqual(wrapper.state().ripples.length, 1);
 
     instance.stop({ type: 'mouseup' });
-    assert.strictEqual(wrapper.state().ripples.length, 0, 'should remove all the ripples');
+    assert.strictEqual(wrapper.state().ripples.length, 0);
   });
 
   describe('creating unique ripples', () => {

--- a/packages/material-ui/src/CardHeader/CardHeader.test.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.test.js
@@ -88,7 +88,7 @@ describe('<CardHeader />', () => {
     it('should render the avatar inside the first child', () => {
       const container = wrapper.childAt(0);
 
-      assert.strictEqual(container.is('div'), true);
+      assert.strictEqual(container.name(), 'div');
       assert.strictEqual(container.hasClass(classes.avatar), true);
       assert.strictEqual(container.childAt(0).equals(avatar), true);
     });

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -27,7 +27,7 @@ describe('<Chip />', () => {
     it('should render a div containing a span', () => {
       const wrapper = shallow(<Chip className="my-Chip" data-my-prop="woofChip" />);
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.childAt(0).is('span'), true, 'should be a span');
+      assert.strictEqual(wrapper.childAt(0).name(), 'span');
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-Chip'), true);
       assert.strictEqual(wrapper.props()['data-my-prop'], 'woofChip');
@@ -72,7 +72,7 @@ describe('<Chip />', () => {
 
     it('should render a div containing a span', () => {
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.childAt(0).is('span'), true, 'should be a span');
+      assert.strictEqual(wrapper.childAt(0).name(), 'span');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
@@ -167,9 +167,9 @@ describe('<Chip />', () => {
 
     it('should render a div containing an Avatar, span and svg', () => {
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.childAt(0).is(Avatar), true, 'should have an Avatar');
-      assert.strictEqual(wrapper.childAt(1).is('span'), true, 'should have a span');
-      assert.strictEqual(wrapper.childAt(2).is('pure(Cancel)'), true, 'should be an svg icon');
+      assert.strictEqual(wrapper.childAt(0).type(), Avatar);
+      assert.strictEqual(wrapper.childAt(1).name(), 'span');
+      assert.strictEqual(wrapper.childAt(2).name(), 'pure(Cancel)');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
@@ -193,7 +193,7 @@ describe('<Chip />', () => {
       wrapper.setProps({ onDelete: onDeleteSpy });
 
       wrapper.find('pure(Cancel)').simulate('click', { stopPropagation: () => {} });
-      assert.strictEqual(onDeleteSpy.callCount, 1, 'should have called the onDelete handler');
+      assert.strictEqual(onDeleteSpy.callCount, 1);
     });
 
     it('should stop propagation in onDeleteRequest', () => {
@@ -353,12 +353,8 @@ describe('<Chip />', () => {
         const onKeyDownSpy = spy();
         wrapper = mount(<Chip classes={{}} onKeyDown={onKeyDownSpy} />);
         wrapper.find('div').simulate('keyDown', anyKeydownEvent);
-        assert.strictEqual(onKeyDownSpy.callCount, 1, 'should have called onKeyDown');
-        assert.strictEqual(
-          onKeyDownSpy.args[0][0].keyCode,
-          anyKeydownEvent.keyCode,
-          'should have same keyCode',
-        );
+        assert.strictEqual(onKeyDownSpy.callCount, 1);
+        assert.strictEqual(onKeyDownSpy.args[0][0].keyCode, anyKeydownEvent.keyCode);
       });
     });
 

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -35,7 +35,7 @@ describe('<Collapse />', () => {
     const children = <h1>Hello</h1>;
     const wrapper = shallow(<Collapse {...props}>{children}</Collapse>);
     const child = new ReactWrapper(wrapper.props().children('entered'));
-    assert.strictEqual(child.childAt(0).is('div'), true, 'should be a div');
+    assert.strictEqual(child.childAt(0).name(), 'div');
     assert.strictEqual(
       child
         .childAt(0)
@@ -43,7 +43,6 @@ describe('<Collapse />', () => {
         .children()
         .type(),
       'h1',
-      'should wrap the children',
     );
   });
 

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -30,11 +30,7 @@ describe('<Dialog />', () => {
         foo
       </Dialog>,
     );
-    assert.strictEqual(
-      wrapper.find(Transition).length,
-      1,
-      'should include element given in TransitionComponent',
-    );
+    assert.strictEqual(wrapper.find(Transition).length, 1);
   });
 
   it('should put Modal specific props on the root Modal node', () => {
@@ -69,11 +65,7 @@ describe('<Dialog />', () => {
         foo
       </Dialog>,
     );
-    assert.strictEqual(
-      wrapper.prop('data-my-prop'),
-      'woofDialog',
-      'custom prop should be woofDialog',
-    );
+    assert.strictEqual(wrapper.props()['data-my-prop'], 'woofDialog');
   });
 
   it('should render with the user classes on the root node', () => {
@@ -95,28 +87,24 @@ describe('<Dialog />', () => {
     const paper = fade.childAt(0);
     assert.strictEqual(paper.length === 1 && paper.type(), Paper);
 
-    assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the dialog class');
+    assert.strictEqual(paper.hasClass(classes.paper), true);
   });
 
   it('should not be open by default', () => {
     const wrapper = shallow(<Dialog {...defaultProps}>foo</Dialog>);
-    assert.strictEqual(wrapper.props().open, false, 'should pass show=false to the Modal');
-    assert.strictEqual(wrapper.find(Fade).props().in, false, 'should pass in=false to the Fade');
+    assert.strictEqual(wrapper.props().open, false);
+    assert.strictEqual(wrapper.find(Fade).props().in, false);
   });
 
   it('should be open by default', () => {
     const wrapper = shallow(<Dialog open>foo</Dialog>);
-    assert.strictEqual(wrapper.props().open, true, 'should pass show=true to the Modal');
-    assert.strictEqual(wrapper.find(Fade).props().in, true, 'should pass in=true to the Fade');
+    assert.strictEqual(wrapper.props().open, true);
+    assert.strictEqual(wrapper.find(Fade).props().in, true);
   });
 
   it('should fade down and make the transition appear on first mount', () => {
     const wrapper = shallow(<Dialog {...defaultProps}>foo</Dialog>);
-    assert.strictEqual(
-      wrapper.find(Fade).props().appear,
-      true,
-      'should pass appear=true to the Fade',
-    );
+    assert.strictEqual(wrapper.find(Fade).props().appear, true);
   });
 
   describe('prop: classes', () => {

--- a/packages/material-ui/src/DialogActions/DialogActions.test.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.test.js
@@ -19,11 +19,7 @@ describe('<DialogActions />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<DialogActions data-my-prop="woofDialogActions" />);
-    assert.strictEqual(
-      wrapper.prop('data-my-prop'),
-      'woofDialogActions',
-      'custom prop should be woofDialogActions',
-    );
+    assert.strictEqual(wrapper.props()['data-my-prop'], 'woofDialogActions');
   });
 
   it('should render with the user and root classes', () => {
@@ -41,9 +37,9 @@ describe('<DialogActions />', () => {
       </DialogActions>,
     );
     const button = wrapper.childAt(0);
-    assert.strictEqual(button.is('button'), true, 'should be a button');
-    assert.strictEqual(button.hasClass('woofDialogActions'), true, 'should have the user class');
-    assert.strictEqual(button.hasClass(classes.action), true, 'should have the action wrapper');
+    assert.strictEqual(button.name(), 'button');
+    assert.strictEqual(button.hasClass('woofDialogActions'), true);
+    assert.strictEqual(button.hasClass(classes.action), true);
   });
 
   it('should render children with the conditional buttons', () => {
@@ -60,8 +56,8 @@ describe('<DialogActions />', () => {
     );
 
     const button = wrapper.childAt(0);
-    assert.strictEqual(button.hasClass('woofDialogActions'), true, 'should have the user class');
-    assert.strictEqual(button.hasClass(classes.action), true, 'should have the action wrapper');
-    assert.strictEqual(button.is('button'), true, 'should be a button');
+    assert.strictEqual(button.hasClass('woofDialogActions'), true);
+    assert.strictEqual(button.hasClass(classes.action), true);
+    assert.strictEqual(button.name(), 'button');
   });
 });

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -24,16 +24,16 @@ describe('<Divider />', () => {
 
   it('should set the absolute class', () => {
     const wrapper = shallow(<Divider absolute />);
-    assert.strictEqual(wrapper.hasClass(classes.absolute), true, 'should be absolute');
+    assert.strictEqual(wrapper.hasClass(classes.absolute), true);
   });
 
   it('should set the inset class', () => {
     const wrapper = shallow(<Divider inset />);
-    assert.strictEqual(wrapper.hasClass(classes.inset), true, 'should have inset class');
+    assert.strictEqual(wrapper.hasClass(classes.inset), true);
   });
 
   it('should set the light class', () => {
     const wrapper = shallow(<Divider light />);
-    assert.strictEqual(wrapper.hasClass(classes.light), true, 'should have light class');
+    assert.strictEqual(wrapper.hasClass(classes.light), true);
   });
 });

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -38,15 +38,11 @@ describe('<Drawer />', () => {
       );
 
       const slide = wrapper.childAt(0);
-      assert.strictEqual(
-        slide.length === 1 && slide.is(Slide),
-        true,
-        'immediate wrapper child should be Slide',
-      );
+      assert.strictEqual(slide.length === 1 && slide.is(Slide), true);
 
       const paper = slide.childAt(0);
       assert.strictEqual(paper.length === 1 && paper.type(), Paper);
-      assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the paper class');
+      assert.strictEqual(paper.hasClass(classes.paper), true);
     });
 
     describe('transitionDuration property', () => {
@@ -96,7 +92,7 @@ describe('<Drawer />', () => {
 
       const modal = wrapper.find(Modal);
 
-      assert.strictEqual(modal.hasClass('woofDrawer'), true, 'should have the woofDrawer class');
+      assert.strictEqual(modal.hasClass('woofDrawer'), true);
     });
 
     it('should set the Paper className', () => {
@@ -106,8 +102,8 @@ describe('<Drawer />', () => {
         </Drawer>,
       );
       const paper = wrapper.find(Paper);
-      assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the paper class');
-      assert.strictEqual(paper.hasClass('woofDrawer'), true, 'should have the woofDrawer class');
+      assert.strictEqual(paper.hasClass(classes.paper), true);
+      assert.strictEqual(paper.hasClass('woofDrawer'), true);
     });
 
     it('should be closed by default', () => {
@@ -120,8 +116,8 @@ describe('<Drawer />', () => {
       const modal = wrapper;
       const slide = modal.find(Slide);
 
-      assert.strictEqual(modal.props().open, false, 'should not show the modal');
-      assert.strictEqual(slide.props().in, false, 'should not transition in');
+      assert.strictEqual(modal.props().open, false);
+      assert.strictEqual(slide.props().in, false);
     });
 
     describe('opening and closing', () => {
@@ -137,20 +133,20 @@ describe('<Drawer />', () => {
       });
 
       it('should start closed', () => {
-        assert.strictEqual(wrapper.props().open, false, 'should not show the modal');
-        assert.strictEqual(wrapper.find(Slide).props().in, false, 'should not transition in');
+        assert.strictEqual(wrapper.props().open, false);
+        assert.strictEqual(wrapper.find(Slide).props().in, false);
       });
 
       it('should open', () => {
         wrapper.setProps({ open: true });
-        assert.strictEqual(wrapper.props().open, true, 'should show the modal');
-        assert.strictEqual(wrapper.find(Slide).props().in, true, 'should transition in');
+        assert.strictEqual(wrapper.props().open, true);
+        assert.strictEqual(wrapper.find(Slide).props().in, true);
       });
 
       it('should close', () => {
         wrapper.setProps({ open: false });
-        assert.strictEqual(wrapper.props().open, false, 'should not show the modal');
-        assert.strictEqual(wrapper.find(Slide).props().in, false, 'should not transition in');
+        assert.strictEqual(wrapper.props().open, false);
+        assert.strictEqual(wrapper.find(Slide).props().in, false);
       });
     });
   });
@@ -168,7 +164,7 @@ describe('<Drawer />', () => {
 
     it('should render a div instead of a Modal when persistent', () => {
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.docked), true, 'should have the docked class');
+      assert.strictEqual(wrapper.hasClass(classes.docked), true);
     });
 
     it('should render Slide > Paper inside the div', () => {
@@ -194,7 +190,7 @@ describe('<Drawer />', () => {
 
     it('should render a div instead of a Modal when permanent', () => {
       assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.docked), true, 'should have the docked class');
+      assert.strictEqual(wrapper.hasClass(classes.docked), true);
     });
 
     it('should render div > Paper inside the div', () => {

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -33,7 +33,7 @@ describe('<ExpansionPanel />', () => {
     assert.strictEqual(collapse.props()['aria-hidden'], 'true');
 
     wrapper.setProps({ expanded: true });
-    assert.strictEqual(wrapper.state().expanded, false, 'should not change the expanded state');
+    assert.strictEqual(wrapper.state().expanded, false);
   });
 
   it('should handle defaultExpanded prop', () => {
@@ -43,13 +43,13 @@ describe('<ExpansionPanel />', () => {
       false,
       'should have isControlled state false',
     );
-    assert.strictEqual(wrapper.state().expanded, true, 'should set expanded state');
-    assert.strictEqual(wrapper.hasClass(classes.expanded), true, 'should have the expanded class');
+    assert.strictEqual(wrapper.state().expanded, true);
+    assert.strictEqual(wrapper.hasClass(classes.expanded), true);
   });
 
   it('should render the custom className and the root class', () => {
     const wrapper = shallow(<ExpansionPanel className="test-class-name">foo</ExpansionPanel>);
-    assert.strictEqual(wrapper.hasClass('test-class-name'), true, 'should pass the test className');
+    assert.strictEqual(wrapper.hasClass('test-class-name'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
@@ -71,7 +71,7 @@ describe('<ExpansionPanel />', () => {
     const wrapper = shallow(<ExpansionPanel expanded>foo</ExpansionPanel>);
     assert.strictEqual(wrapper.state().expanded, undefined);
     assert.strictEqual(wrapper.hasClass(classes.expanded), true);
-    assert.strictEqual(wrapper.instance().isControlled, true, 'should set isControlled prop');
+    assert.strictEqual(wrapper.instance().isControlled, true);
 
     wrapper.setProps({ expanded: false });
     assert.strictEqual(wrapper.hasClass(classes.expanded), false);
@@ -86,7 +86,7 @@ describe('<ExpansionPanel />', () => {
     );
     assert.strictEqual(wrapper.type(), ExpansionPanel);
     wrapper.find(ExpansionPanelSummary).simulate('click');
-    assert.strictEqual(handleChange.callCount, 1, 'it should forward the onChange');
+    assert.strictEqual(handleChange.callCount, 1);
   });
 
   it('when controlled should call the onChange', () => {
@@ -97,7 +97,7 @@ describe('<ExpansionPanel />', () => {
       </ExpansionPanel>,
     );
     wrapper.find(ExpansionPanelSummary).simulate('click');
-    assert.strictEqual(handleChange.callCount, 1, 'it should forward the onChange');
+    assert.strictEqual(handleChange.callCount, 1);
     assert.strictEqual(handleChange.args[0][1], false);
   });
 
@@ -115,7 +115,7 @@ describe('<ExpansionPanel />', () => {
 
   it('when disabled should have the disabled class', () => {
     const wrapper = shallow(<ExpansionPanel disabled>foo</ExpansionPanel>);
-    assert.strictEqual(wrapper.hasClass(classes.disabled), true, 'should have the disabled class');
+    assert.strictEqual(wrapper.hasClass(classes.disabled), true);
   });
 
   describe('prop: children', () => {

--- a/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.test.js
+++ b/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.test.js
@@ -21,11 +21,7 @@ describe('<ExpansionPanelActions />', () => {
     const wrapper = shallow(
       <ExpansionPanelActions data-my-prop="woofExpansionPanelActions">foo</ExpansionPanelActions>,
     );
-    assert.strictEqual(
-      wrapper.props()['data-my-prop'],
-      'woofExpansionPanelActions',
-      'custom prop should be woofExpansionPanelActions',
-    );
+    assert.strictEqual(wrapper.props()['data-my-prop'], 'woofExpansionPanelActions');
   });
 
   it('should render with the user and root classes', () => {
@@ -45,13 +41,9 @@ describe('<ExpansionPanelActions />', () => {
       </ExpansionPanelActions>,
     );
     const button = wrapper.childAt(0);
-    assert.strictEqual(button.hasClass(classes.action), true, 'should have the action wrapper');
+    assert.strictEqual(button.hasClass(classes.action), true);
     assert.strictEqual(button.type(), 'button');
-    assert.strictEqual(
-      button.hasClass('woofExpansionPanelActions'),
-      true,
-      'should have the user class',
-    );
+    assert.strictEqual(button.hasClass('woofExpansionPanelActions'), true);
   });
 
   it('should render a valid children', () => {
@@ -63,7 +55,7 @@ describe('<ExpansionPanelActions />', () => {
     );
 
     const button = wrapper.childAt(0);
-    assert.strictEqual(button.hasClass(classes.action), true, 'should have the action wrapper');
+    assert.strictEqual(button.hasClass(classes.action), true);
     assert.strictEqual(button.type(), 'button');
   });
 });

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -23,8 +23,8 @@ describe('<FormControlLabel />', () => {
     const wrapper = shallow(<FormControlLabel label="Pizza" control={<div />} />);
     const label = wrapper.childAt(1);
     assert.strictEqual(wrapper.name(), 'label');
-    assert.strictEqual(label.childAt(0).text(), 'Pizza', 'should be the label text');
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the "root" class');
+    assert.strictEqual(label.childAt(0).text(), 'Pizza');
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   describe('prop: disabled', () => {

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -16,7 +16,7 @@ describe('<FormHelperText />', () => {
     const wrapper = shallow(<FormHelperText className="woofHelperText" />);
     assert.strictEqual(wrapper.name(), 'p');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woofHelperText'), true, 'should have the user class');
+    assert.strictEqual(wrapper.hasClass('woofHelperText'), true);
   });
 
   describe('prop: component', () => {

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -16,21 +16,21 @@ describe('<FormLabel />', () => {
     const wrapper = shallow(<FormLabel className="woofFormLabel" />);
     assert.strictEqual(wrapper.name(), 'label');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass('woofFormLabel'), true, 'should have the user class');
+    assert.strictEqual(wrapper.hasClass('woofFormLabel'), true);
   });
 
   describe('prop: required', () => {
     it('should show an asterisk if required is set', () => {
       const wrapper = shallow(<FormLabel required />);
       const text = wrapper.text();
-      assert.strictEqual(text.slice(-1), '*', 'should show an asterisk at the end');
+      assert.strictEqual(text.slice(-1), '*');
       assert.strictEqual(wrapper.find('[data-mui-test="FormLabelAsterisk"]').length, 1);
     });
 
     it('should not show an asterisk by default', () => {
       const wrapper = shallow(<FormLabel />);
       assert.strictEqual(wrapper.find('[data-mui-test="FormLabelAsterisk"]').length, 0);
-      assert.strictEqual(wrapper.text().includes('*'), false, 'should not show an asterisk');
+      assert.strictEqual(wrapper.text().includes('*'), false);
     });
   });
 
@@ -40,7 +40,7 @@ describe('<FormLabel />', () => {
       const asteriskWrapper = wrapper.find('[data-mui-test="FormLabelAsterisk"]');
       assert.strictEqual(asteriskWrapper.length, 1);
       assert.strictEqual(asteriskWrapper.hasClass(classes.error), true);
-      assert.strictEqual(wrapper.hasClass(classes.error), true, 'should have the error class');
+      assert.strictEqual(wrapper.hasClass(classes.error), true);
     });
   });
 

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -15,7 +15,7 @@ describe('<Grid />', () => {
   it('should render', () => {
     const wrapper = shallow(<Grid className="woofGrid" />);
     assert.strictEqual(wrapper.name(), 'div');
-    assert.strictEqual(wrapper.hasClass('woofGrid'), true, 'should have the user class');
+    assert.strictEqual(wrapper.hasClass('woofGrid'), true);
   });
 
   describe('prop: container', () => {

--- a/packages/material-ui/src/GridListTile/GridListTile.test.js
+++ b/packages/material-ui/src/GridListTile/GridListTile.test.js
@@ -43,11 +43,7 @@ describe('<GridListTile />', () => {
       const children = <img src={tileData.img} alt="foo" />;
       const wrapper = shallow(<GridListTile>{children}</GridListTile>);
 
-      assert.strictEqual(
-        wrapper.containsMatchingElement(children),
-        true,
-        'should contain the children',
-      );
+      assert.strictEqual(wrapper.containsMatchingElement(children), true);
     });
 
     it('should not change non image child', () => {
@@ -62,7 +58,7 @@ describe('<GridListTile />', () => {
       const children = <img src={tileData.img} alt="foo" />;
       const wrapper = shallow(<GridListTile className="foo">{children}</GridListTile>);
 
-      assert.strictEqual(wrapper.hasClass('foo'), true, 'should contain the className');
+      assert.strictEqual(wrapper.hasClass('foo'), true);
     });
   });
 

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -14,24 +14,24 @@ describe('<Icon />', () => {
 
   it('renders children by default', () => {
     const wrapper = shallow(<Icon>account_circle</Icon>);
-    assert.strictEqual(wrapper.contains('account_circle'), true, 'should contain the children');
+    assert.strictEqual(wrapper.contains('account_circle'), true);
   });
 
   it('should render an span with root class', () => {
     const wrapper = shallow(<Icon>account_circle</Icon>);
     assert.strictEqual(wrapper.name(), 'span');
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the "root" class');
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should spread props on span', () => {
     const wrapper = shallow(<Icon data-test="hello">account_circle</Icon>);
-    assert.strictEqual(wrapper.prop('data-test'), 'hello', 'should be spread on the span');
+    assert.strictEqual(wrapper.props()['data-test'], 'hello');
   });
 
   describe('optional classes', () => {
     it('should render with the user class', () => {
       const wrapper = shallow(<Icon className="meow">account_circle</Icon>);
-      assert.strictEqual(wrapper.hasClass('meow'), true, 'should have the "meow" class');
+      assert.strictEqual(wrapper.hasClass('meow'), true);
     });
 
     it('should render with the secondary color', () => {
@@ -41,40 +41,24 @@ describe('<Icon />', () => {
 
     it('should render with the action color', () => {
       const wrapper = shallow(<Icon color="action">account_circle</Icon>);
-      assert.strictEqual(
-        wrapper.hasClass(classes.colorAction),
-        true,
-        'should have the "action" color',
-      );
+      assert.strictEqual(wrapper.hasClass(classes.colorAction), true);
     });
 
     it('should render with the error color', () => {
       const wrapper = shallow(<Icon color="error">account_circle</Icon>);
-      assert.strictEqual(
-        wrapper.hasClass(classes.colorError),
-        true,
-        'should have the "error" color',
-      );
+      assert.strictEqual(wrapper.hasClass(classes.colorError), true);
     });
 
     it('should render with the primary class', () => {
       const wrapper = shallow(<Icon color="primary">account_circle</Icon>);
-      assert.strictEqual(
-        wrapper.hasClass(classes.colorPrimary),
-        true,
-        'should have the "primary" color',
-      );
+      assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
     });
   });
 
   describe('prop: fontSize', () => {
     it('should be able to change the fontSize', () => {
       const wrapper = shallow(<Icon fontSize="inherit">account_circle</Icon>);
-      assert.strictEqual(
-        wrapper.hasClass(classes.fontSizeInherit),
-        true,
-        'should have fontSize "inherit',
-      );
+      assert.strictEqual(wrapper.hasClass(classes.fontSizeInherit), true);
     });
   });
 });

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -31,8 +31,8 @@ describe('<IconButton />', () => {
   it('should render an inner label span (bloody safari)', () => {
     const wrapper = shallow(<IconButton>book</IconButton>);
     const label = wrapper.childAt(0);
-    assert.strictEqual(label.hasClass(classes.label), true, 'should have the label class');
-    assert.strictEqual(label.is('span'), true, 'should be a span');
+    assert.strictEqual(label.hasClass(classes.label), true);
+    assert.strictEqual(label.name(), 'span');
   });
 
   it('should render the child normally inside the label span', () => {
@@ -40,7 +40,7 @@ describe('<IconButton />', () => {
     const wrapper = shallow(<IconButton>{child}</IconButton>);
     const label = wrapper.childAt(0);
     const icon = label.childAt(0);
-    assert.strictEqual(icon.equals(child), true, 'should be the child');
+    assert.strictEqual(icon.equals(child), true);
   });
 
   it('should render Icon children with right classes', () => {
@@ -50,7 +50,7 @@ describe('<IconButton />', () => {
     const label = wrapper.childAt(0);
     const renderedIconChild = label.childAt(0);
     assert.strictEqual(renderedIconChild.type(), Icon);
-    assert.strictEqual(renderedIconChild.hasClass(childClassName), true, 'child should be icon');
+    assert.strictEqual(renderedIconChild.hasClass(childClassName), true);
   });
 
   it('should have a ripple by default', () => {
@@ -69,7 +69,7 @@ describe('<IconButton />', () => {
         book
       </IconButton>,
     );
-    assert.strictEqual(wrapper.prop('data-test'), 'hello', 'should be spread on the ButtonBase');
+    assert.strictEqual(wrapper.props()['data-test'], 'hello');
     assert.strictEqual(wrapper.props().disableRipple, true);
   });
 
@@ -81,14 +81,14 @@ describe('<IconButton />', () => {
 
   it('should pass centerRipple={true} to ButtonBase', () => {
     const wrapper = shallow(<IconButton>book</IconButton>);
-    assert.strictEqual(wrapper.props().centerRipple, true, 'should set centerRipple to true');
+    assert.strictEqual(wrapper.props().centerRipple, true);
   });
 
   describe('prop: disabled', () => {
     it('should disable the component', () => {
       const wrapper = shallow(<IconButton disabled>book</IconButton>);
-      assert.strictEqual(wrapper.props().disabled, true, 'should pass the property down the tree');
-      assert.strictEqual(wrapper.hasClass(classes.disabled), true, 'should add the disabled class');
+      assert.strictEqual(wrapper.props().disabled, true);
+      assert.strictEqual(wrapper.hasClass(classes.disabled), true);
     });
   });
 

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -33,8 +33,8 @@ describe('<InputBase />', () => {
     const wrapper = shallow(<InputBase />);
     const input = wrapper.find('input');
     assert.strictEqual(input.name(), 'input');
-    assert.strictEqual(input.props().type, 'text', 'should pass the text type prop');
-    assert.strictEqual(input.hasClass(classes.input), true, 'should have the input class');
+    assert.strictEqual(input.props().type, 'text');
+    assert.strictEqual(input.hasClass(classes.input), true);
     assert.strictEqual(input.props().required, undefined);
   });
 
@@ -60,8 +60,8 @@ describe('<InputBase />', () => {
       const wrapper = shallow(<InputBase disabled />);
       const input = wrapper.find('input');
       assert.strictEqual(input.name(), 'input');
-      assert.strictEqual(input.hasClass(classes.input), true, 'should have the input class');
-      assert.strictEqual(input.hasClass(classes.disabled), true, 'should have the disabled class');
+      assert.strictEqual(input.hasClass(classes.input), true);
+      assert.strictEqual(input.hasClass(classes.disabled), true);
     });
 
     it('should reset the focused state', () => {
@@ -99,14 +99,10 @@ describe('<InputBase />', () => {
   it('should disabled the underline', () => {
     const wrapper = shallow(<InputBase disableUnderline />);
     const input = wrapper.find('input');
-    assert.strictEqual(wrapper.hasClass(classes.inkbar), false, 'should not have the inkbar class');
+    assert.strictEqual(wrapper.hasClass(classes.inkbar), false);
     assert.strictEqual(input.name(), 'input');
-    assert.strictEqual(input.hasClass(classes.input), true, 'should have the input class');
-    assert.strictEqual(
-      input.hasClass(classes.underline),
-      false,
-      'should not have the underline class',
-    );
+    assert.strictEqual(input.hasClass(classes.input), true);
+    assert.strictEqual(input.hasClass(classes.underline), false);
   });
 
   it('should fire event callbacks', () => {
@@ -129,7 +125,7 @@ describe('<InputBase />', () => {
     it('should considered [] as controlled', () => {
       const wrapper = shallow(<InputBase value={[]} />);
       const instance = wrapper.instance();
-      assert.strictEqual(instance.isControlled, true, 'isControlled should return true');
+      assert.strictEqual(instance.isControlled, true);
     });
 
     ['', 0].forEach(value => {
@@ -148,29 +144,25 @@ describe('<InputBase />', () => {
 
         it('should check that the component is controlled', () => {
           const instance = wrapper.instance();
-          assert.strictEqual(instance.isControlled, true, 'isControlled should return true');
+          assert.strictEqual(instance.isControlled, true);
         });
 
         // don't test number because zero is a empty state, whereas '' is not
         if (typeof value !== 'number') {
           it('should have called the handleEmpty callback', () => {
-            assert.strictEqual(handleEmpty.callCount, 1, 'should have called the onEmpty cb');
+            assert.strictEqual(handleEmpty.callCount, 1);
           });
 
           it('should fire the onFilled callback when dirtied', () => {
             assert.strictEqual(handleFilled.callCount, 0);
             wrapper.setProps({ value: typeof value === 'number' ? 2 : 'hello' });
-            assert.strictEqual(handleFilled.callCount, 1, 'should have called the onFilled cb');
+            assert.strictEqual(handleFilled.callCount, 1);
           });
 
           it('should fire the onEmpty callback when dirtied', () => {
-            assert.strictEqual(
-              handleEmpty.callCount,
-              1,
-              'should have called the onEmpty cb once already',
-            );
+            assert.strictEqual(handleEmpty.callCount, 1);
             wrapper.setProps({ value });
-            assert.strictEqual(handleEmpty.callCount, 2, 'should have called the onEmpty cb again');
+            assert.strictEqual(handleEmpty.callCount, 2);
           });
         }
       });
@@ -223,22 +215,22 @@ describe('<InputBase />', () => {
 
     it('should check that the component is uncontrolled', () => {
       const instance = wrapper.instance();
-      assert.strictEqual(instance.isControlled, false, 'isControlled should return false');
+      assert.strictEqual(instance.isControlled, false);
     });
 
     it('should fire the onFilled callback when dirtied', () => {
-      assert.strictEqual(handleFilled.callCount, 1, 'should not have called the onFilled cb yet');
+      assert.strictEqual(handleFilled.callCount, 1);
       wrapper.instance().inputRef.value = 'hello';
       wrapper.find('input').simulate('change');
-      assert.strictEqual(handleFilled.callCount, 2, 'should have called the onFilled cb');
+      assert.strictEqual(handleFilled.callCount, 2);
     });
 
     it('should fire the onEmpty callback when cleaned', () => {
       // Because of shallow() this hasn't fired since there is no mounting
-      assert.strictEqual(handleEmpty.callCount, 0, 'should not have called the onEmpty cb yet');
+      assert.strictEqual(handleEmpty.callCount, 0);
       wrapper.instance().inputRef.value = '';
       wrapper.find('input').simulate('change');
-      assert.strictEqual(handleEmpty.callCount, 1, 'should have called the onEmpty cb');
+      assert.strictEqual(handleEmpty.callCount, 1);
     });
   });
 
@@ -282,12 +274,8 @@ describe('<InputBase />', () => {
 
         wrapper.instance().inputRef.value = 'hello';
         wrapper.find('input').simulate('change');
-        assert.strictEqual(handleFilled.callCount, 1, 'should have called the onFilled props cb');
-        assert.strictEqual(
-          muiFormControl.onFilled.callCount,
-          1,
-          'should have called the onFilled muiFormControl cb',
-        );
+        assert.strictEqual(handleFilled.callCount, 1);
+        assert.strictEqual(muiFormControl.onFilled.callCount, 1);
       });
 
       it('should fire the onEmpty muiFormControl and props callback when cleaned', () => {
@@ -298,12 +286,8 @@ describe('<InputBase />', () => {
 
         wrapper.instance().inputRef.value = '';
         wrapper.find('input').simulate('change');
-        assert.strictEqual(handleEmpty.callCount, 1, 'should have called the onEmpty props cb');
-        assert.strictEqual(
-          muiFormControl.onEmpty.callCount,
-          1,
-          'should have called the onEmpty muiFormControl cb',
-        );
+        assert.strictEqual(handleEmpty.callCount, 1);
+        assert.strictEqual(muiFormControl.onEmpty.callCount, 1);
       });
 
       it('should fire the onFocus muiFormControl', () => {

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -27,102 +27,46 @@ describe('<LinearProgress />', () => {
 
   it('should render intermediate variant by default', () => {
     const wrapper = shallow(<LinearProgress />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.bar1Indeterminate),
-      true,
-      'should have the bar1Indeterminate class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.bar2Indeterminate),
-      true,
-      'should have the bar2Indeterminate class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Indeterminate), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.bar2Indeterminate), true);
   });
 
   it('should render for the primary color', () => {
     const wrapper = shallow(<LinearProgress color="primary" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorPrimary), true);
   });
 
   it('should render for the secondary color', () => {
     const wrapper = shallow(<LinearProgress color="secondary" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.barColorSecondary),
-      true,
-      'should have the barColorSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.barColorSecondary),
-      true,
-      'should have the barColorSecondary class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorSecondary), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorSecondary), true);
   });
 
   it('should render with determinate classes for the primary color by default', () => {
     const wrapper = shallow(<LinearProgress value={1} variant="determinate" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.bar1Determinate),
-      true,
-      'should have the bar1Determinate class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Determinate), true);
   });
 
   it('should render with determinate classes for the primary color', () => {
     const wrapper = shallow(<LinearProgress color="primary" value={1} variant="determinate" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.bar1Determinate),
-      true,
-      'should have the bar1Determinate class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Determinate), true);
   });
 
   it('should render with determinate classes for the secondary color', () => {
     const wrapper = shallow(<LinearProgress color="secondary" value={1} variant="determinate" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.barColorSecondary),
-      true,
-      'should have the barColorSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.bar1Determinate),
-      true,
-      'should have the bar1Determinate class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorSecondary), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Determinate), true);
   });
 
   it('should set width of bar1 on determinate variant', () => {
@@ -170,64 +114,24 @@ describe('<LinearProgress />', () => {
     const wrapper = shallow(
       <LinearProgress value={1} valueBuffer={1} color="primary" variant="buffer" />,
     );
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.dashedColorPrimary),
-      true,
-      'should have the dashedColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.bar1Buffer),
-      true,
-      'should have the bar1Buffer class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.colorPrimary),
-      true,
-      'should have the colorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.bar2Buffer),
-      true,
-      'should have the bar2Buffer class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.dashedColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.bar1Buffer), true);
+    assert.strictEqual(wrapper.childAt(2).hasClass(classes.colorPrimary), true);
+    assert.strictEqual(wrapper.childAt(2).hasClass(classes.bar2Buffer), true);
   });
 
   it('should render with buffer classes for the secondary color', () => {
     const wrapper = shallow(
       <LinearProgress value={1} valueBuffer={1} color="secondary" variant="buffer" />,
     );
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the root class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.dashedColorSecondary),
-      true,
-      'should have the dashedColorSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.barColorSecondary),
-      true,
-      'should have the barColorSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.bar1Buffer),
-      true,
-      'should have the bar1Buffer class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.colorSecondary),
-      true,
-      'should have the colorSecondary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.bar2Buffer),
-      true,
-      'should have the bar2Buffer class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.dashedColorSecondary), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorSecondary), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.bar1Buffer), true);
+    assert.strictEqual(wrapper.childAt(2).hasClass(classes.colorSecondary), true);
+    assert.strictEqual(wrapper.childAt(2).hasClass(classes.bar2Buffer), true);
   });
 
   it('should set width of bar1 and bar2 on buffer variant', () => {
@@ -248,27 +152,11 @@ describe('<LinearProgress />', () => {
   it('should render with query classes', () => {
     const wrapper = shallow(<LinearProgress variant="query" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.query), true, 'should have the query class');
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.bar1Indeterminate),
-      true,
-      'should have the bar1Indeterminate class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.bar2Indeterminate),
-      true,
-      'should have the bar2Indeterminate class',
-    );
+    assert.strictEqual(wrapper.hasClass(classes.query), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Indeterminate), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorPrimary), true);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.bar2Indeterminate), true);
   });
 
   describe('prop: value', () => {

--- a/packages/material-ui/src/List/List.test.js
+++ b/packages/material-ui/src/List/List.test.js
@@ -27,7 +27,7 @@ describe('<List />', () => {
     const wrapper = shallow(<List className="woofList" />);
     assert.strictEqual(wrapper.hasClass('woofList'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.padding), true, 'should have the padding class');
+    assert.strictEqual(wrapper.hasClass(classes.padding), true);
   });
 
   it('should disable the padding', () => {
@@ -53,7 +53,7 @@ describe('<List />', () => {
 
     it('should render ListSubheader', () => {
       const wrapper = shallow(<List subheader={<ListSubheader>Title</ListSubheader>} />);
-      assert.strictEqual(wrapper.find(ListSubheader).length, 1, 'should render ListSubheader');
+      assert.strictEqual(wrapper.find(ListSubheader).length, 1);
     });
   });
 
@@ -67,11 +67,7 @@ describe('<List />', () => {
       );
 
       const wrapper2 = shallow(<List dense />);
-      assert.strictEqual(
-        wrapper2.instance().getChildContext().dense,
-        true,
-        'dense should be true when set',
-      );
+      assert.strictEqual(wrapper2.instance().getChildContext().dense, true);
     });
   });
 });

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -31,12 +31,12 @@ describe('<ListItem />', () => {
     const wrapper = shallow(<ListItem className="woofListItem" />);
     assert.strictEqual(wrapper.hasClass('woofListItem'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.gutters), true, 'should have the gutters class');
+    assert.strictEqual(wrapper.hasClass(classes.gutters), true);
   });
 
   it('should render with the selected class', () => {
     const wrapper = shallow(<ListItem selected />);
-    assert.strictEqual(wrapper.hasClass(classes.selected), true, 'should have the selected class');
+    assert.strictEqual(wrapper.hasClass(classes.selected), true);
   });
 
   it('should disable the gutters', () => {

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
@@ -30,8 +30,8 @@ describe('<ListItemAvatar />', () => {
         },
       },
     );
-    assert.strictEqual(wrapper.hasClass('foo'), true, 'should have the "foo" class');
-    assert.strictEqual(wrapper.hasClass('bar'), true, 'should have the "bar" class');
+    assert.strictEqual(wrapper.hasClass('foo'), true);
+    assert.strictEqual(wrapper.hasClass('bar'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -31,8 +31,8 @@ describe('<ListItemIcon />', () => {
         <span className="bar" />
       </ListItemIcon>,
     );
-    assert.strictEqual(wrapper.hasClass('foo'), true, 'should have the "foo" class');
-    assert.strictEqual(wrapper.hasClass('bar'), true, 'should have the "bar" class');
+    assert.strictEqual(wrapper.hasClass('foo'), true);
+    assert.strictEqual(wrapper.hasClass('bar'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 });

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -27,19 +27,19 @@ describe('<ListItemText />', () => {
 
   it('should render with inset class', () => {
     const wrapper = shallow(<ListItemText inset />);
-    assert.strictEqual(wrapper.hasClass(classes.inset), true, 'should have the inset class');
+    assert.strictEqual(wrapper.hasClass(classes.inset), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render with no children', () => {
     const wrapper = shallow(<ListItemText />);
-    assert.strictEqual(wrapper.children().length, 0, 'should have no children');
+    assert.strictEqual(wrapper.children().length, 0);
   });
 
   describe('prop: primary', () => {
     it('should render primary text', () => {
       const wrapper = shallow(<ListItemText primary="This is the primary text" />);
-      assert.strictEqual(wrapper.children().length, 1, 'should have 1 child');
+      assert.strictEqual(wrapper.children().length, 1);
       assert.strictEqual(wrapper.childAt(0).type(), Typography);
       assert.strictEqual(wrapper.childAt(0).props().variant, 'subheading');
       assert.strictEqual(
@@ -55,13 +55,13 @@ describe('<ListItemText />', () => {
     it('should use the primary node', () => {
       const primary = <span />;
       const wrapper = shallow(<ListItemText primary={primary} />);
-      assert.strictEqual(wrapper.contains(primary), true, 'should find the node');
+      assert.strictEqual(wrapper.contains(primary), true);
     });
 
     it('should use the children prop as primary node', () => {
       const primary = <span />;
       const wrapper = shallow(<ListItemText>{primary}</ListItemText>);
-      assert.strictEqual(wrapper.contains(primary), true, 'should find the node');
+      assert.strictEqual(wrapper.contains(primary), true);
     });
 
     it('should read 0 as primary', () => {
@@ -76,25 +76,20 @@ describe('<ListItemText />', () => {
       assert.strictEqual(wrapper.children().length, 1, 'should have 1 child');
       assert.strictEqual(wrapper.childAt(0).type(), Typography);
       assert.strictEqual(wrapper.childAt(0).props().variant, 'body1');
-      assert.strictEqual(
-        wrapper.childAt(0).props().color,
-        'textSecondary',
-        'should have the text secondary property',
-      );
+      assert.strictEqual(wrapper.childAt(0).props().color, 'textSecondary');
       assert.strictEqual(
         wrapper
           .childAt(0)
           .children()
           .equals('This is the secondary text'),
         true,
-        'should have the secondary text',
       );
     });
 
     it('should use the secondary node', () => {
       const secondary = <span />;
       const wrapper = shallow(<ListItemText secondary={secondary} />);
-      assert.strictEqual(wrapper.contains(secondary), true, 'should find the node');
+      assert.strictEqual(wrapper.contains(secondary), true);
     });
 
     it('should read 0 as secondary', () => {
@@ -109,7 +104,7 @@ describe('<ListItemText />', () => {
         <ListItemText primary="This is the primary text" secondary="This is the secondary text" />,
       );
 
-      assert.strictEqual(wrapper.children().length, 2, 'should have 2 children');
+      assert.strictEqual(wrapper.children().length, 2);
       assert.strictEqual(wrapper.childAt(0).type(), Typography);
       assert.strictEqual(wrapper.childAt(0).props().variant, 'subheading');
       assert.strictEqual(
@@ -118,7 +113,6 @@ describe('<ListItemText />', () => {
           .children()
           .equals('This is the primary text'),
         true,
-        'should have the primary text',
       );
 
       assert.strictEqual(wrapper.childAt(1).type(), Typography);
@@ -150,7 +144,7 @@ describe('<ListItemText />', () => {
       <ListItemText primary="This is the primary text" secondary="This is the secondary text" />,
     );
 
-    assert.strictEqual(wrapper.children().length, 2, 'should have 2 children');
+    assert.strictEqual(wrapper.children().length, 2);
     assert.strictEqual(wrapper.childAt(0).type(), Typography);
     assert.strictEqual(wrapper.childAt(0).props().variant, 'subheading');
     assert.strictEqual(
@@ -159,7 +153,6 @@ describe('<ListItemText />', () => {
         .children()
         .equals('This is the primary text'),
       true,
-      'should have the primary text',
     );
 
     assert.strictEqual(wrapper.childAt(1).type(), Typography);
@@ -171,7 +164,6 @@ describe('<ListItemText />', () => {
         .children()
         .equals('This is the secondary text'),
       true,
-      'should have the secondary text',
     );
   });
 
@@ -194,7 +186,6 @@ describe('<ListItemText />', () => {
         .props()
         .className.includes('GeneralText'),
       true,
-      'should have the primary text class',
     );
     assert.strictEqual(
       wrapper
@@ -202,7 +193,6 @@ describe('<ListItemText />', () => {
         .props()
         .className.includes('SecondaryText'),
       true,
-      'should have the secondary text class',
     );
   });
 

--- a/packages/material-ui/src/ListSubheader/ListSubheader.test.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.test.js
@@ -35,7 +35,7 @@ describe('<ListSubheader />', () => {
 
   it('should display inset class', () => {
     const wrapper = shallow(<ListSubheader inset />);
-    assert.strictEqual(wrapper.hasClass(classes.inset), true, 'should have the primary class');
+    assert.strictEqual(wrapper.hasClass(classes.inset), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -60,30 +60,26 @@ describe('<Menu />', () => {
 
   it('should pass the instance function `getContentAnchorEl` to Popover', () => {
     const wrapper = shallow(<Menu {...defaultProps} />);
-    assert.strictEqual(
-      wrapper.props().getContentAnchorEl,
-      wrapper.instance().getContentAnchorEl,
-      'should be the same function',
-    );
+    assert.strictEqual(wrapper.props().getContentAnchorEl, wrapper.instance().getContentAnchorEl);
   });
 
   it('should pass onClose prop to Popover', () => {
     const fn = () => {};
     const wrapper = shallow(<Menu {...defaultProps} onClose={fn} />);
-    assert.strictEqual(wrapper.props().onClose, fn, 'should be the same function');
+    assert.strictEqual(wrapper.props().onClose, fn);
   });
 
   it('should pass anchorEl prop to Popover', () => {
     const el = document.createElement('div');
     const wrapper = shallow(<Menu {...defaultProps} anchorEl={el} />);
-    assert.strictEqual(wrapper.props().anchorEl, el, 'should be the same object');
+    assert.strictEqual(wrapper.props().anchorEl, el);
   });
 
   it('should pass through the `open` prop to Popover', () => {
     const wrapper = shallow(<Menu {...defaultProps} />);
-    assert.strictEqual(wrapper.props().open, false, 'should have an open prop of false');
+    assert.strictEqual(wrapper.props().open, false);
     wrapper.setProps({ open: true });
-    assert.strictEqual(wrapper.props().open, true, 'should have an open prop of true');
+    assert.strictEqual(wrapper.props().open, true);
   });
 
   describe('list node', () => {
@@ -96,19 +92,15 @@ describe('<Menu />', () => {
     });
 
     it('should render a MenuList inside the Popover', () => {
-      assert.strictEqual(
-        list.is('MenuList'),
-        true,
-        'should have a MenuList as the immediate child',
-      );
+      assert.strictEqual(list.name(), 'MenuList');
     });
 
     it('should spread other props on the list', () => {
-      assert.strictEqual(wrapper.props()['data-test'], 'hi', 'should have the custom prop');
+      assert.strictEqual(wrapper.props()['data-test'], 'hi');
     });
 
     it('should have the user classes', () => {
-      assert.strictEqual(wrapper.hasClass('test-class'), true, 'should have the user class');
+      assert.strictEqual(wrapper.hasClass('test-class'), true);
     });
   });
 
@@ -121,11 +113,7 @@ describe('<Menu />', () => {
     const popover = wrapper.find('Popover');
     assert.strictEqual(popover.props().open, true);
     const menuEl = document.querySelector('[data-mui-test="Menu"]');
-    assert.strictEqual(
-      document.activeElement,
-      menuEl && menuEl.firstChild,
-      'should be the first menu item',
-    );
+    assert.strictEqual(document.activeElement, menuEl && menuEl.firstChild);
   });
 
   describe('mount', () => {

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -24,8 +24,8 @@ describe('<MenuItem />', () => {
   it('should render a button ListItem with with ripple', () => {
     const wrapper = shallow(<MenuItem />);
     assert.strictEqual(wrapper.type(), ListItem);
-    assert.strictEqual(wrapper.props().button, true, 'should have the button prop');
-    assert.strictEqual(wrapper.props().disableRipple, undefined, 'should have a ripple');
+    assert.strictEqual(wrapper.props().button, true);
+    assert.strictEqual(wrapper.props().disableRipple, undefined);
   });
 
   it('should render with the user and root classes', () => {
@@ -36,17 +36,17 @@ describe('<MenuItem />', () => {
 
   it('should render with the selected class', () => {
     const wrapper = shallow(<MenuItem selected />);
-    assert.strictEqual(wrapper.hasClass(classes.selected), true, 'should have the selected class');
+    assert.strictEqual(wrapper.hasClass(classes.selected), true);
   });
 
   it('should have a default role of menuitem', () => {
     const wrapper = shallow(<MenuItem />);
-    assert.strictEqual(wrapper.props().role, 'menuitem', 'should have the menuitem role');
+    assert.strictEqual(wrapper.props().role, 'menuitem');
   });
 
   it('should have a role of option', () => {
     const wrapper = shallow(<MenuItem role="option" aria-selected={false} />);
-    assert.strictEqual(wrapper.props().role, 'option', 'should have the option role');
+    assert.strictEqual(wrapper.props().role, 'option');
   });
 
   it('should have a tabIndex of -1 by default', () => {

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -35,7 +35,7 @@ describe('<MobileStepper />', () => {
   it('should render a Paper component', () => {
     const wrapper = shallow(<MobileStepper {...defaultProps} />);
     assert.strictEqual(wrapper.type(), Paper);
-    assert.strictEqual(wrapper.props().elevation, 0, 'should have no elevation');
+    assert.strictEqual(wrapper.props().elevation, 0);
   });
 
   it('should render with the root class', () => {
@@ -45,8 +45,8 @@ describe('<MobileStepper />', () => {
 
   it('should render the custom className and the root class', () => {
     const wrapper = shallow(<MobileStepper className="test-class-name" {...defaultProps} />);
-    assert.strictEqual(wrapper.is('.test-class-name'), true, 'should pass the test className');
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the mobileStepper class');
+    assert.strictEqual(wrapper.is('.test-class-name'), true);
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should render with the bottom class if position prop is set to bottom', () => {
@@ -61,29 +61,21 @@ describe('<MobileStepper />', () => {
 
   it('should render two buttons', () => {
     const wrapper = shallow(<MobileStepper {...defaultProps} />);
-    assert.lengthOf(wrapper.find(Button), 2, 'should render two buttons');
+    assert.lengthOf(wrapper.find(Button), 2);
   });
 
   it('should render the back button', () => {
     const wrapper = shallow(<MobileStepper {...defaultProps} />);
     const backButton = wrapper.childAt(0);
-    assert.strictEqual(backButton.childAt(1).text(), 'Back', 'should set the back button text');
-    assert.lengthOf(
-      backButton.find(KeyboardArrowLeft),
-      1,
-      'should render a single <KeyboardArrowLeft /> component',
-    );
+    assert.strictEqual(backButton.childAt(1).text(), 'Back');
+    assert.lengthOf(backButton.find(KeyboardArrowLeft), 1);
   });
 
   it('should render next button', () => {
     const wrapper = shallow(<MobileStepper {...defaultProps} />);
     const nextButton = wrapper.childAt(2);
-    assert.strictEqual(nextButton.childAt(0).text(), 'Next', 'should set the next button text');
-    assert.lengthOf(
-      nextButton.find(KeyboardArrowRight),
-      1,
-      'should render a single <KeyboardArrowRight /> component',
-    );
+    assert.strictEqual(nextButton.childAt(0).text(), 'Next');
+    assert.lengthOf(nextButton.find(KeyboardArrowRight), 1);
   });
 
   it('should render backButton custom text', () => {
@@ -104,7 +96,6 @@ describe('<MobileStepper />', () => {
         .childAt(1)
         .text(),
       'Past',
-      'should set the back button text',
     );
   });
 
@@ -126,7 +117,6 @@ describe('<MobileStepper />', () => {
         .childAt(0)
         .text(),
       'Future',
-      'should set the back button text',
     );
   });
 
@@ -138,7 +128,7 @@ describe('<MobileStepper />', () => {
     };
     const wrapper = shallow(<MobileStepper {...props} />);
     const backButton = wrapper.childAt(0);
-    assert.strictEqual(backButton.props().disabled, true, 'should disable the back button');
+    assert.strictEqual(backButton.props().disabled, true);
   });
 
   it('should render disabled nextButton', () => {
@@ -149,27 +139,23 @@ describe('<MobileStepper />', () => {
     };
     const wrapper = shallow(<MobileStepper {...props} />);
     const nextButton = wrapper.childAt(2);
-    assert.strictEqual(nextButton.props().disabled, true, 'should disable the next button');
+    assert.strictEqual(nextButton.props().disabled, true);
   });
 
   it('should render just two buttons when supplied with variant text', () => {
     const wrapper = shallow(<MobileStepper variant="text" {...defaultProps} />);
-    assert.lengthOf(wrapper.children(), 2, 'should render exactly two children');
+    assert.lengthOf(wrapper.children(), 2);
   });
 
   it('should render dots when supplied with variant dots', () => {
     const wrapper = shallow(<MobileStepper variant="dots" {...defaultProps} />);
-    assert.lengthOf(wrapper.children(), 3, 'should render exactly three children');
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.dots),
-      true,
-      'should have a single dots class',
-    );
+    assert.lengthOf(wrapper.children(), 3);
+    assert.strictEqual(wrapper.childAt(1).hasClass(classes.dots), true);
   });
 
   it('should render a dot for each step when using dots variant', () => {
     const wrapper = shallow(<MobileStepper variant="dots" {...defaultProps} />);
-    assert.lengthOf(wrapper.find(`.${classes.dot}`), 2, 'should render exactly two dots');
+    assert.lengthOf(wrapper.find(`.${classes.dot}`), 2);
   });
 
   it('should render the first dot as active if activeStep is not set', () => {
@@ -180,7 +166,6 @@ describe('<MobileStepper />', () => {
         .childAt(0)
         .hasClass(classes.dotActive),
       true,
-      'should render the first dot active',
     );
   });
 
@@ -192,31 +177,26 @@ describe('<MobileStepper />', () => {
         .childAt(1)
         .hasClass(classes.dotActive),
       true,
-      'should render the second dot active',
     );
   });
 
   it('should render a <LinearProgress /> when supplied with variant progress', () => {
     const wrapper = shallow(<MobileStepper variant="progress" {...defaultProps} />);
-    assert.lengthOf(wrapper.find(LinearProgress), 1, 'should render a <LinearProgress />');
+    assert.lengthOf(wrapper.find(LinearProgress), 1);
   });
 
   it('should calculate the <LinearProgress /> value correctly', () => {
     const props = { backButton: defaultProps.backButton, nextButton: defaultProps.nextButton };
     let wrapper = shallow(<MobileStepper variant="progress" steps={3} {...props} />);
     let linearProgressProps = wrapper.find(LinearProgress).props();
-    assert.strictEqual(linearProgressProps.value, 0, 'should set <LinearProgress /> value to 0');
+    assert.strictEqual(linearProgressProps.value, 0);
 
     wrapper = shallow(<MobileStepper variant="progress" steps={3} activeStep={1} {...props} />);
     linearProgressProps = wrapper.find(LinearProgress).props();
-    assert.strictEqual(linearProgressProps.value, 50, 'should set <LinearProgress /> value to 50');
+    assert.strictEqual(linearProgressProps.value, 50);
 
     wrapper = shallow(<MobileStepper variant="progress" steps={3} activeStep={2} {...props} />);
     linearProgressProps = wrapper.find(LinearProgress).props();
-    assert.strictEqual(
-      linearProgressProps.value,
-      100,
-      'should set <LinearProgress /> value to 100',
-    );
+    assert.strictEqual(linearProgressProps.value, 100);
   });
 });

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -178,9 +178,9 @@ describe('<Modal />', () => {
         'div',
         'should have the element in the DOM',
       );
-      assert.strictEqual(heading.tagName.toLowerCase(), 'h1', 'should have the element in the DOM');
-      assert.strictEqual(portalLayer.contains(container), true, 'should be in the portal');
-      assert.strictEqual(portalLayer.contains(heading), true, 'should be in the portal');
+      assert.strictEqual(heading.tagName.toLowerCase(), 'h1');
+      assert.strictEqual(portalLayer.contains(container), true);
+      assert.strictEqual(portalLayer.contains(heading), true);
 
       const container2 = document.getElementById('container');
 
@@ -193,7 +193,7 @@ describe('<Modal />', () => {
         'document',
         'should add the document role',
       );
-      assert.strictEqual(container2.getAttribute('tabindex'), '-1', 'should add a -1 tab-index');
+      assert.strictEqual(container2.getAttribute('tabindex'), '-1');
     });
   });
 
@@ -214,16 +214,9 @@ describe('<Modal />', () => {
         throw new Error('missing modal');
       }
 
-      assert.strictEqual(
-        modal.children.length,
-        2,
-        'should have 2 children, the backdrop and the test container',
-      );
-      assert.ok(
-        modal.children[0],
-        'this is the backdrop, so no assertions about implementation details',
-      );
-      assert.strictEqual(modal.children[1], container, 'should be the container');
+      assert.strictEqual(modal.children.length, 2);
+      assert.ok(modal.children[0]);
+      assert.strictEqual(modal.children[1], container);
     });
   });
 
@@ -243,8 +236,8 @@ describe('<Modal />', () => {
         throw new Error('missing modal');
       }
 
-      assert.strictEqual(modal.children.length, 1, 'should have 1 child, the test container');
-      assert.strictEqual(modal.children[0], container, 'should be the container');
+      assert.strictEqual(modal.children.length, 1);
+      assert.strictEqual(modal.children[0], container);
     });
   });
 
@@ -491,7 +484,7 @@ describe('<Modal />', () => {
           <Dialog />
         </Modal>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 1, 'should call console.error');
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.match(consoleErrorMock.args()[0][0], /the modal content node does not accept focus/);
     });
 

--- a/packages/material-ui/src/Modal/ModalManager.test.js
+++ b/packages/material-ui/src/Modal/ModalManager.test.js
@@ -38,19 +38,19 @@ describe('ModalManager', () => {
     it('should add modal1', () => {
       const idx = modalManager.add(modal1, container1);
       assert.strictEqual(idx, 0, 'should be the first modal');
-      assert.strictEqual(modalManager.isTopModal(modal1), true, 'should be the top modal');
+      assert.strictEqual(modalManager.isTopModal(modal1), true);
     });
 
     it('should add modal2', () => {
       const idx = modalManager.add(modal2, container1);
       assert.strictEqual(idx, 1, 'should be the second modal');
-      assert.strictEqual(modalManager.isTopModal(modal2), true, 'should be the top modal');
+      assert.strictEqual(modalManager.isTopModal(modal2), true);
     });
 
     it('should add modal3', () => {
       const idx = modalManager.add(modal3, container1);
       assert.strictEqual(idx, 2, 'should be the third modal');
-      assert.strictEqual(modalManager.isTopModal(modal3), true, 'should be the top modal');
+      assert.strictEqual(modalManager.isTopModal(modal3), true);
     });
 
     it('should remove modal2', () => {
@@ -61,7 +61,7 @@ describe('ModalManager', () => {
     it('should add modal2', () => {
       const idx = modalManager.add(modal2, container1);
       assert.strictEqual(idx, 2, 'should be the "third" modal');
-      assert.strictEqual(modalManager.isTopModal(modal2), true, 'modal2 should be the top modal');
+      assert.strictEqual(modalManager.isTopModal(modal2), true);
       assert.strictEqual(
         modalManager.isTopModal(modal3),
         false,
@@ -71,23 +71,23 @@ describe('ModalManager', () => {
 
     it('should remove modal3', () => {
       const idx = modalManager.remove(modal3);
-      assert.strictEqual(idx, 1, 'should be the "second" modal');
+      assert.strictEqual(idx, 1);
     });
 
     it('should remove modal2', () => {
       const idx = modalManager.remove(modal2);
-      assert.strictEqual(idx, 1, 'should be the "second" modal');
-      assert.strictEqual(modalManager.isTopModal(modal1), true, 'modal1 should be the top modal');
+      assert.strictEqual(idx, 1);
+      assert.strictEqual(modalManager.isTopModal(modal1), true);
     });
 
     it('should remove modal1', () => {
       const idx = modalManager.remove(modal1);
-      assert.strictEqual(idx, 0, 'should be the "first" modal');
+      assert.strictEqual(idx, 0);
     });
 
     it('should not do anything', () => {
       const idx = modalManager.remove({ nonExisting: true });
-      assert.strictEqual(idx, -1, 'should not find the non existing modal');
+      assert.strictEqual(idx, -1);
     });
   });
 

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -55,11 +55,11 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(wrapper.props().open, false, 'should not be open');
+      assert.strictEqual(wrapper.props().open, false);
       wrapper.setProps({ open: true });
-      assert.strictEqual(wrapper.props().open, true, 'should be open');
+      assert.strictEqual(wrapper.props().open, true);
       wrapper.setProps({ open: false });
-      assert.strictEqual(wrapper.props().open, false, 'should not be open');
+      assert.strictEqual(wrapper.props().open, false);
     });
 
     describe('getOffsetTop', () => {
@@ -161,11 +161,11 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(wrapper.childAt(0).props().in, false, 'should not be in');
+      assert.strictEqual(wrapper.childAt(0).props().in, false);
       wrapper.setProps({ open: true });
-      assert.strictEqual(wrapper.childAt(0).props().in, true, 'should be in');
+      assert.strictEqual(wrapper.childAt(0).props().in, true);
       wrapper.setProps({ open: false });
-      assert.strictEqual(wrapper.childAt(0).props().in, false, 'should not be in');
+      assert.strictEqual(wrapper.childAt(0).props().in, false);
     });
 
     it('should fire Popover transition event callbacks', () => {
@@ -217,9 +217,9 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(wrapper.hasClass('test-class'), true, 'should have the user class');
+      assert.strictEqual(wrapper.hasClass('test-class'), true);
       const paper = wrapper.childAt(0).childAt(0);
-      assert.strictEqual(paper.hasClass(classes.paper), true, 'should have the popover class');
+      assert.strictEqual(paper.hasClass(classes.paper), true);
     });
 
     it('should have a elevation prop passed down', () => {

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -75,7 +75,7 @@ describe('<Select />', () => {
         .at(1)
         .simulate('click');
       const selected = onChangeHandler.args[0][1];
-      assert.strictEqual(React.isValidElement(selected), true, 'should b be a element');
+      assert.strictEqual(React.isValidElement(selected), true);
     });
   });
 });

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -34,7 +34,7 @@ describe('<StepButton />', () => {
     const wrapper = shallow(<StepButton {...defaultProps}>Step One</StepButton>);
     assert.ok(wrapper.is(ButtonBase), 'should be an ButtonBase');
     const stepLabel = wrapper.find(StepLabel);
-    assert.strictEqual(stepLabel.length, 1, 'should have a stepLabel');
+    assert.strictEqual(stepLabel.length, 1);
     assert.strictEqual(stepLabel.props().children, 'Step One');
   });
 
@@ -45,9 +45,9 @@ describe('<StepButton />', () => {
       </StepButton>,
     );
     const stepLabel = wrapper.find(StepLabel);
-    assert.strictEqual(stepLabel.props().active, true, 'should be active');
-    assert.strictEqual(stepLabel.props().completed, true, 'should be completed');
-    assert.strictEqual(stepLabel.props().disabled, true, 'should be disabled');
+    assert.strictEqual(stepLabel.props().active, true);
+    assert.strictEqual(stepLabel.props().completed, true);
+    assert.strictEqual(stepLabel.props().disabled, true);
   });
 
   it('should pass props to a provided StepLabel', () => {
@@ -57,9 +57,9 @@ describe('<StepButton />', () => {
       </StepButton>,
     );
     const stepLabel = wrapper.find(StepLabel);
-    assert.strictEqual(stepLabel.props().active, true, 'should be active');
-    assert.strictEqual(stepLabel.props().completed, true, 'should be completed');
-    assert.strictEqual(stepLabel.props().disabled, true, 'should be disabled');
+    assert.strictEqual(stepLabel.props().active, true);
+    assert.strictEqual(stepLabel.props().completed, true);
+    assert.strictEqual(stepLabel.props().disabled, true);
   });
 
   it("should pass disabled prop to a StepLabel's Button", () => {
@@ -88,10 +88,10 @@ describe('<StepButton />', () => {
           </StepButton>,
         );
         wrapper.simulate('mouseEnter');
-        assert.strictEqual(handleMouseEnter.callCount, 1, 'should call handleMouseEnter once');
+        assert.strictEqual(handleMouseEnter.callCount, 1);
         wrapper.simulate('mouseLeave');
-        assert.strictEqual(handleMouseEnter.callCount, 1, 'should call handleMouseEnter once');
-        assert.strictEqual(handleMouseLeave.callCount, 1, 'should call handleMouseLeave once');
+        assert.strictEqual(handleMouseEnter.callCount, 1);
+        assert.strictEqual(handleMouseLeave.callCount, 1);
       });
     });
 
@@ -110,19 +110,19 @@ describe('<StepButton />', () => {
         </StepButton>,
       );
       wrapper.simulate('mouseEnter');
-      assert.strictEqual(handleMouseEnter.callCount, 1, 'should call handleMouseEnter once');
+      assert.strictEqual(handleMouseEnter.callCount, 1);
       wrapper.simulate('mouseLeave');
-      assert.strictEqual(handleMouseEnter.callCount, 1, 'should call handleMouseEnter once');
-      assert.strictEqual(handleMouseLeave.callCount, 1, 'should call handleMouseLeave once');
+      assert.strictEqual(handleMouseEnter.callCount, 1);
+      assert.strictEqual(handleMouseLeave.callCount, 1);
       wrapper.simulate('touchStart');
-      assert.strictEqual(handleMouseEnter.callCount, 1, 'should call handleMouseEnter once');
-      assert.strictEqual(handleMouseLeave.callCount, 1, 'should call handleMouseLeave once');
-      assert.strictEqual(handleTouchStart.callCount, 1, 'should call handleTouchStart once');
+      assert.strictEqual(handleMouseEnter.callCount, 1);
+      assert.strictEqual(handleMouseLeave.callCount, 1);
+      assert.strictEqual(handleTouchStart.callCount, 1);
       wrapper.simulate('mouseEnter');
       wrapper.simulate('touchStart');
-      assert.strictEqual(handleMouseEnter.callCount, 2, 'should call handleMouseEnter twice');
-      assert.strictEqual(handleMouseLeave.callCount, 1, 'should call handleMouseLeave once');
-      assert.strictEqual(handleTouchStart.callCount, 2, 'should call handleTouchStart twice');
+      assert.strictEqual(handleMouseEnter.callCount, 2);
+      assert.strictEqual(handleMouseLeave.callCount, 1);
+      assert.strictEqual(handleTouchStart.callCount, 2);
     });
   });
 });

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -109,7 +109,7 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.props().active, true, 'should set active');
+      assert.strictEqual(stepIcon.props().active, true);
     });
 
     it('renders <Typography> without the className active', () => {
@@ -133,7 +133,7 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.props().completed, true, 'should set completed');
+      assert.strictEqual(stepIcon.props().completed, true);
     });
   });
 
@@ -151,7 +151,7 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.props().error, true, 'should set error');
+      assert.strictEqual(stepIcon.props().error, true);
     });
   });
 

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -22,7 +22,7 @@ describe('<SvgIcon />', () => {
 
   it('renders children by default', () => {
     const wrapper = shallow(<SvgIcon>{path}</SvgIcon>);
-    assert.strictEqual(wrapper.contains(path), true, 'should contain the children');
+    assert.strictEqual(wrapper.contains(path), true);
     assert.strictEqual(wrapper.props()['aria-hidden'], 'true');
   });
 
@@ -37,8 +37,8 @@ describe('<SvgIcon />', () => {
         {path}
       </SvgIcon>,
     );
-    assert.strictEqual(wrapper.props()['data-test'], 'hello', 'should be spread on the svg');
-    assert.strictEqual(wrapper.props().viewBox, '0 0 32 32', 'should override the viewBox');
+    assert.strictEqual(wrapper.props()['data-test'], 'hello');
+    assert.strictEqual(wrapper.props().viewBox, '0 0 32 32');
   });
 
   describe('prop: titleAccess', () => {
@@ -56,8 +56,8 @@ describe('<SvgIcon />', () => {
   describe('prop: color', () => {
     it('should render with the user and SvgIcon classes', () => {
       const wrapper = shallow(<SvgIcon className="meow">{path}</SvgIcon>);
-      assert.strictEqual(wrapper.hasClass('meow'), true, 'should have the "meow" class');
-      assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have the SvgIcon class');
+      assert.strictEqual(wrapper.hasClass('meow'), true);
+      assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
 
     it('should render with the secondary color', () => {
@@ -67,40 +67,24 @@ describe('<SvgIcon />', () => {
 
     it('should render with the action color', () => {
       const wrapper = shallow(<SvgIcon color="action">{path}</SvgIcon>);
-      assert.strictEqual(
-        wrapper.hasClass(classes.colorAction),
-        true,
-        'should have the "action" color',
-      );
+      assert.strictEqual(wrapper.hasClass(classes.colorAction), true);
     });
 
     it('should render with the error color', () => {
       const wrapper = shallow(<SvgIcon color="error">{path}</SvgIcon>);
-      assert.strictEqual(
-        wrapper.hasClass(classes.colorError),
-        true,
-        'should have the "error" color',
-      );
+      assert.strictEqual(wrapper.hasClass(classes.colorError), true);
     });
 
     it('should render with the primary class', () => {
       const wrapper = shallow(<SvgIcon color="primary">{path}</SvgIcon>);
-      assert.strictEqual(
-        wrapper.hasClass(classes.colorPrimary),
-        true,
-        'should have the "primary" color',
-      );
+      assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
     });
   });
 
   describe('prop: fontSize', () => {
     it('should be able to change the fontSize', () => {
       const wrapper = shallow(<SvgIcon fontSize="inherit">{path}</SvgIcon>);
-      assert.strictEqual(
-        wrapper.hasClass(classes.fontSizeInherit),
-        true,
-        'should have fontSize "inherit',
-      );
+      assert.strictEqual(wrapper.hasClass(classes.fontSizeInherit), true);
     });
   });
 

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -208,34 +208,26 @@ describe('<SwipeableDrawer />', () => {
           const handleOpen = spy();
           wrapper.setProps({ onOpen: handleOpen });
           fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+          assert.strictEqual(wrapper.state().maybeSwiping, true);
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
-          assert.strictEqual(instance.isSwiping, true, 'should be swiping');
+          assert.strictEqual(instance.isSwiping, true);
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[2]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[2]] });
-          assert.strictEqual(handleOpen.callCount, 1, 'should call onOpen');
-          assert.strictEqual(
-            instance.setPosition.callCount,
-            3,
-            'should move the drawer on touchstart and touchmove',
-          );
+          assert.strictEqual(handleOpen.callCount, 1);
+          assert.strictEqual(instance.setPosition.callCount, 3);
 
           // simulate close swipe
           instance.setPosition.resetHistory();
           const handleClose = spy();
           wrapper.setProps({ open: true, onClose: handleClose });
           fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+          assert.strictEqual(wrapper.state().maybeSwiping, true);
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
-          assert.strictEqual(instance.isSwiping, true, 'should be swiping');
+          assert.strictEqual(instance.isSwiping, true);
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[2]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[2]] });
-          assert.strictEqual(handleClose.callCount, 1, 'should call onClose');
-          assert.strictEqual(
-            instance.setPosition.callCount,
-            2,
-            'should move the drawer on touchmove',
-          );
+          assert.strictEqual(handleClose.callCount, 1);
+          assert.strictEqual(instance.setPosition.callCount, 2);
         });
 
         it('should stay closed when not swiping far enough', () => {
@@ -243,11 +235,11 @@ describe('<SwipeableDrawer />', () => {
           const handleOpen = spy();
           wrapper.setProps({ onOpen: handleOpen });
           fireBodyMouseEvent('touchstart', { touches: [params.openTouches[0]] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+          assert.strictEqual(wrapper.state().maybeSwiping, true);
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
-          assert.strictEqual(instance.isSwiping, true, 'should be swiping');
+          assert.strictEqual(instance.isSwiping, true);
           fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[1]] });
-          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
+          assert.strictEqual(handleOpen.callCount, 0);
         });
 
         it('should stay opened when not swiping far enough', () => {
@@ -255,11 +247,11 @@ describe('<SwipeableDrawer />', () => {
           const handleClose = spy();
           wrapper.setProps({ open: true, onClose: handleClose });
           fireBodyMouseEvent('touchstart', { touches: [params.closeTouches[0]] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
+          assert.strictEqual(wrapper.state().maybeSwiping, true);
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
-          assert.strictEqual(instance.isSwiping, true, 'should be swiping');
+          assert.strictEqual(instance.isSwiping, true);
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[1]] });
-          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+          assert.strictEqual(handleClose.callCount, 0);
         });
 
         it('should ignore swiping in the wrong direction if discovery is disabled', () => {
@@ -296,11 +288,11 @@ describe('<SwipeableDrawer />', () => {
           const handleClose = spy();
           wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
           fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
-          assert.strictEqual(instance.setPosition.callCount, 1, 'should slide in a bit');
+          assert.strictEqual(wrapper.state().maybeSwiping, true);
+          assert.strictEqual(instance.setPosition.callCount, 1);
           fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
-          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
-          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+          assert.strictEqual(handleOpen.callCount, 0);
+          assert.strictEqual(handleClose.callCount, 0);
         });
 
         it('should makes the drawer stay hidden', () => {
@@ -315,11 +307,11 @@ describe('<SwipeableDrawer />', () => {
             onClose: handleClose,
           });
           fireBodyMouseEvent('touchstart', { touches: [params.edgeTouch] });
-          assert.strictEqual(wrapper.state().maybeSwiping, true, 'should be listening for swipe');
-          assert.strictEqual(instance.setPosition.callCount, 1, 'should slide in');
+          assert.strictEqual(wrapper.state().maybeSwiping, true);
+          assert.strictEqual(instance.setPosition.callCount, 1);
           fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
-          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
-          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+          assert.strictEqual(handleOpen.callCount, 0);
+          assert.strictEqual(handleClose.callCount, 0);
         });
 
         it('should let user scroll the page', () => {
@@ -335,11 +327,11 @@ describe('<SwipeableDrawer />', () => {
             onClose: handleClose,
           });
           fireBodyMouseEvent('touchstart', { touches: [params.ignoreTouch] });
-          assert.strictEqual(wrapper.state().maybeSwiping, false, 'should be listening for swipe');
-          assert.strictEqual(instance.setPosition.callCount, 0, 'should slide in');
+          assert.strictEqual(wrapper.state().maybeSwiping, false);
+          assert.strictEqual(instance.setPosition.callCount, 0);
           fireBodyMouseEvent('touchend', { changedTouches: [params.ignoreTouch] });
-          assert.strictEqual(handleOpen.callCount, 0, 'should not call onOpen');
-          assert.strictEqual(handleClose.callCount, 0, 'should not call onClose');
+          assert.strictEqual(handleOpen.callCount, 0);
+          assert.strictEqual(handleClose.callCount, 0);
         });
       });
     });

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -49,7 +49,7 @@ describe('<Switch />', () => {
 
     it('should render the bar as the 2nd child', () => {
       const bar = wrapper.childAt(1);
-      assert.strictEqual(bar.is('span'), true);
+      assert.strictEqual(bar.name(), 'span');
       assert.strictEqual(bar.hasClass(classes.bar), true);
     });
   });

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -69,14 +69,14 @@ describe('<TableCell />', () => {
     wrapper.setContext({ tablelvl2: { variant: 'head' } });
     assert.strictEqual(wrapper.name(), 'th');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.head), true, 'should have the head class');
-    assert.strictEqual(wrapper.props().scope, 'col', 'should have the correct scope attribute');
+    assert.strictEqual(wrapper.hasClass(classes.head), true);
+    assert.strictEqual(wrapper.props().scope, 'col');
   });
 
   it('should render specified scope attribute even when in the context of a table head', () => {
     const wrapper = shallow(<TableCell scope="row" />);
     wrapper.setContext({ tablelvl2: { variant: 'head' } });
-    assert.strictEqual(wrapper.props().scope, 'row', 'should have the specified scope attribute');
+    assert.strictEqual(wrapper.props().scope, 'row');
   });
 
   it('should render a th with the footer class when in the context of a table footer', () => {
@@ -84,7 +84,7 @@ describe('<TableCell />', () => {
     wrapper.setContext({ tablelvl2: { variant: 'footer' } });
     assert.strictEqual(wrapper.name(), 'td');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.footer), true, 'should have the footer class');
+    assert.strictEqual(wrapper.hasClass(classes.footer), true);
   });
 
   it('should render a div when custom component prop is used', () => {
@@ -97,14 +97,14 @@ describe('<TableCell />', () => {
     const wrapper = shallow(<TableCell />);
     wrapper.setContext({ tablelvl2: { variant: 'footer' } });
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.footer), true, 'should have the footer class');
+    assert.strictEqual(wrapper.hasClass(classes.footer), true);
   });
 
   it('should render with the head class when variant is head, overriding context', () => {
     const wrapper = shallow(<TableCell variant="head" />);
     wrapper.setContext({ tablelvl2: { variant: 'footer' } });
     assert.strictEqual(wrapper.hasClass(classes.head), true);
-    assert.strictEqual(wrapper.props().scope, undefined, 'should have the correct scope attribute');
+    assert.strictEqual(wrapper.props().scope, undefined);
   });
 
   it('should render without head class when variant is body, overriding context', () => {
@@ -128,7 +128,7 @@ describe('<TableCell />', () => {
   it('should render with the numeric class', () => {
     const wrapper = shallow(<TableCell numeric />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.numeric), true, 'should have the numeric class');
+    assert.strictEqual(wrapper.hasClass(classes.numeric), true);
   });
 
   it('should render aria-sort="ascending" when prop sortDirection="asc" provided', () => {

--- a/packages/material-ui/src/TableRow/TableRow.test.js
+++ b/packages/material-ui/src/TableRow/TableRow.test.js
@@ -47,13 +47,13 @@ describe('<TableRow />', () => {
     const wrapper = shallow(<TableRow />);
     wrapper.setContext({ tablelvl2: { variant: 'head' } });
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.head), true, 'should have the head class');
+    assert.strictEqual(wrapper.hasClass(classes.head), true);
   });
 
   it('should render with the footer class when in the context of a table footer', () => {
     const wrapper = shallow(<TableRow />);
     wrapper.setContext({ tablelvl2: { variant: 'footer' } });
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.footer), true, 'should have the footer class');
+    assert.strictEqual(wrapper.hasClass(classes.footer), true);
   });
 });

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -21,7 +21,7 @@ describe('<TableSortLabel />', () => {
 
   it('should render TableSortLabel', () => {
     const wrapper = shallow(<TableSortLabel />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true, 'should have root class');
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should set the active class when active', () => {

--- a/packages/material-ui/src/Tabs/TabIndicator.test.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.test.js
@@ -30,7 +30,7 @@ describe('<TabIndicator />', () => {
     it('should append the className on the root element', () => {
       const wrapper = shallow(<TabIndicator color="secondary" style={style} className="foo" />);
       assert.strictEqual(wrapper.name(), 'span');
-      assert.strictEqual(wrapper.hasClass('foo'), true, 'should have the property class');
+      assert.strictEqual(wrapper.hasClass('foo'), true);
     });
   });
 });

--- a/packages/material-ui/src/Tabs/TabScrollButton.test.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.test.js
@@ -28,7 +28,7 @@ describe('<TabScrollButton />', () => {
     it('should render as a button with the root class', () => {
       const wrapper = shallow(<TabScrollButton {...props} visible />);
 
-      assert.strictEqual(wrapper.is(ButtonBase), true, 'should be a button');
+      assert.strictEqual(wrapper.type(), ButtonBase);
       assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
   });
@@ -53,12 +53,12 @@ describe('<TabScrollButton />', () => {
   describe('prop: direction', () => {
     it('should render with the left icon', () => {
       const wrapper = mount(<TabScrollButton {...props} direction="left" visible />);
-      assert.strictEqual(wrapper.find(KeyboardArrowLeft).length, 1, 'should be the left icon');
+      assert.strictEqual(wrapper.find(KeyboardArrowLeft).length, 1);
     });
 
     it('should render with the right icon', () => {
       const wrapper = mount(<TabScrollButton {...props} direction="right" visible />);
-      assert.strictEqual(wrapper.find(KeyboardArrowRight).length, 1, 'should be the right icon');
+      assert.strictEqual(wrapper.find(KeyboardArrowRight).length, 1);
     });
   });
 });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -116,8 +116,8 @@ describe('<Tabs />', () => {
         </Tabs>,
       );
       const selector = `.${classes.flexContainer}.${classes.centered}`;
-      assert.strictEqual(wrapper.find(selector).is('div'), true, 'should be a div');
-      assert.strictEqual(wrapper.find(selector).length, 1, 'should only be one');
+      assert.strictEqual(wrapper.find(selector).name(), 'div');
+      assert.strictEqual(wrapper.find(selector).length, 1);
     });
   });
 
@@ -367,8 +367,8 @@ describe('<Tabs />', () => {
 
     it('should render with the scrollable class', () => {
       const selector = `.${classes.scroller}.${classes.scrollable}`;
-      assert.strictEqual(wrapper.find(selector).is('div'), true, 'should be a div');
-      assert.strictEqual(wrapper.find(selector).length, 1, 'should only be one');
+      assert.strictEqual(wrapper.find(selector).name(), 'div');
+      assert.strictEqual(wrapper.find(selector).length, 1);
     });
 
     it('should response to scroll events', () => {
@@ -393,7 +393,7 @@ describe('<Tabs />', () => {
           <Tab />
         </Tabs>,
       );
-      assert.strictEqual(mountWrapper.find('ScrollbarSize').length, 1, 'should be one');
+      assert.strictEqual(mountWrapper.find('ScrollbarSize').length, 1);
       mountWrapper.unmount();
     });
   });
@@ -408,8 +408,8 @@ describe('<Tabs />', () => {
       );
       const baseSelector = `.${classes.scroller}`;
       const selector = `.${classes.scroller}.${classes.scrollable}`;
-      assert.strictEqual(wrapper.find(baseSelector).length, 1, 'base selector should exist');
-      assert.strictEqual(wrapper.find(selector).length, 0, 'scrolling selector should not exist');
+      assert.strictEqual(wrapper.find(baseSelector).length, 1);
+      assert.strictEqual(wrapper.find(selector).length, 0);
     });
   });
 
@@ -473,16 +473,8 @@ describe('<Tabs />', () => {
         .at(0)
         .simulate('resize');
       clock.tick(166);
-      assert.strictEqual(
-        instance.updateScrollButtonState.called,
-        true,
-        'should have called updateScrollButtonState',
-      );
-      assert.strictEqual(
-        instance.updateIndicatorState.called,
-        true,
-        'should have called updateIndicatorState',
-      );
+      assert.strictEqual(instance.updateScrollButtonState.called, true);
+      assert.strictEqual(instance.updateIndicatorState.called, true);
     });
 
     describe('scroll button visibility states', () => {
@@ -501,29 +493,29 @@ describe('<Tabs />', () => {
       it('should set neither left nor right scroll button state', () => {
         instance.tabsRef = { scrollLeft: 0, scrollWidth: 90, clientWidth: 100, ...fakeTabs };
         instance.updateScrollButtonState();
-        assert.strictEqual(wrapper.state().showLeftScroll, false, 'left scroll should be false');
-        assert.strictEqual(wrapper.state().showRightScroll, false, 'right scroll should be false');
+        assert.strictEqual(wrapper.state().showLeftScroll, false);
+        assert.strictEqual(wrapper.state().showRightScroll, false);
       });
 
       it('should set only left scroll button state', () => {
         instance.tabsRef = { scrollLeft: 1, ...fakeTabs };
         instance.updateScrollButtonState();
-        assert.strictEqual(wrapper.state().showLeftScroll, true, 'left scroll should be true');
-        assert.strictEqual(wrapper.state().showRightScroll, false, 'right scroll should be false');
+        assert.strictEqual(wrapper.state().showLeftScroll, true);
+        assert.strictEqual(wrapper.state().showRightScroll, false);
       });
 
       it('should set only right scroll button state', () => {
         instance.tabsRef = { scrollLeft: 0, scrollWidth: 110, clientWidth: 100, ...fakeTabs };
         instance.updateScrollButtonState();
-        assert.strictEqual(wrapper.state().showLeftScroll, false, 'left scroll should be false');
-        assert.strictEqual(wrapper.state().showRightScroll, true, 'right scroll should be true');
+        assert.strictEqual(wrapper.state().showLeftScroll, false);
+        assert.strictEqual(wrapper.state().showRightScroll, true);
       });
 
       it('should set both left and right scroll button state', () => {
         instance.tabsRef = { scrollLeft: 1, scrollWidth: 110, clientWidth: 100, ...fakeTabs };
         instance.updateScrollButtonState();
-        assert.strictEqual(wrapper.state().showLeftScroll, true, 'left scroll should be true');
-        assert.strictEqual(wrapper.state().showRightScroll, true, 'right scroll should be true');
+        assert.strictEqual(wrapper.state().showLeftScroll, true);
+        assert.strictEqual(wrapper.state().showRightScroll, true);
       });
     });
   });
@@ -595,7 +587,7 @@ describe('<Tabs />', () => {
       });
 
       instance.scrollSelectedIntoView();
-      assert.strictEqual(scrollStub.args[0][0], 0, 'should scroll to 0 position');
+      assert.strictEqual(scrollStub.args[0][0], 0);
     });
 
     it('should scroll right tab into view', () => {
@@ -605,7 +597,7 @@ describe('<Tabs />', () => {
       });
 
       instance.scrollSelectedIntoView();
-      assert.strictEqual(scrollStub.args[0][0], 10, 'should scroll to 10 position');
+      assert.strictEqual(scrollStub.args[0][0], 10);
     });
 
     it('should support value=false', () => {
@@ -615,7 +607,7 @@ describe('<Tabs />', () => {
       });
 
       instance.scrollSelectedIntoView();
-      assert.strictEqual(scrollStub.callCount, 0, 'should not scroll');
+      assert.strictEqual(scrollStub.callCount, 0);
     });
   });
 

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -41,7 +41,7 @@ describe('<Zoom />', () => {
         const event = n.charAt(2).toLowerCase() + n.slice(3);
         wrapper.simulate(event, { style: {} });
         assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
-        assert.strictEqual(handlers[n].args[0].length, 1, 'should forward the element');
+        assert.strictEqual(handlers[n].args[0].length, 1);
       });
     });
   });

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -16,11 +16,11 @@ function assertIsChecked(wrapper) {
   );
 
   const input = wrapper.find('input');
-  assert.strictEqual(input.instance().checked, true, 'the DOM node should be checked');
+  assert.strictEqual(input.instance().checked, true);
 
   const label = iconButton.childAt(0);
   const icon = label.childAt(0);
-  assert.strictEqual(icon.is('h2'), true, 'should be the checked icon');
+  assert.strictEqual(icon.name(), 'h2');
 }
 
 function assertIsNotChecked(wrapper) {
@@ -33,11 +33,11 @@ function assertIsNotChecked(wrapper) {
   );
 
   const input = wrapper.find('input');
-  assert.strictEqual(input.instance().checked, false, 'the DOM node should not be checked');
+  assert.strictEqual(input.instance().checked, false);
 
   const label = iconButton.childAt(0);
   const icon = label.childAt(0);
-  assert.strictEqual(icon.is('h1'), true, 'should be the icon');
+  assert.strictEqual(icon.name(), 'h1');
 }
 
 describe('<SwitchBase />', () => {
@@ -69,12 +69,8 @@ describe('<SwitchBase />', () => {
 
   it('should render an icon and input inside the button by default', () => {
     const wrapper = shallow(<SwitchBase {...defaultProps} />);
-    assert.strictEqual(wrapper.childAt(0).is('h1'), true, 'should be the icon');
-    assert.strictEqual(
-      wrapper.childAt(1).is('input[type="checkbox"]'),
-      true,
-      'should be a checkbox input',
-    );
+    assert.strictEqual(wrapper.childAt(0).name(), 'h1');
+    assert.strictEqual(wrapper.childAt(1).is('input[type="checkbox"]'), true);
   });
 
   it('should have a ripple by default', () => {
@@ -84,7 +80,7 @@ describe('<SwitchBase />', () => {
 
   it('should pass disableRipple={true} to IconButton', () => {
     const wrapper = shallow(<SwitchBase {...defaultProps} disableRipple />);
-    assert.strictEqual(wrapper.props().disableRipple, true, 'should set disableRipple to true');
+    assert.strictEqual(wrapper.props().disableRipple, true);
   });
 
   // className is put on the root node, this is a special case!
@@ -122,8 +118,8 @@ describe('<SwitchBase />', () => {
 
   it('should disable the components, and render the IconButton with the disabled className', () => {
     const wrapper = shallow(<SwitchBase {...defaultProps} disabled />);
-    assert.strictEqual(wrapper.props().disabled, true, 'should disable the root node');
-    assert.strictEqual(wrapper.childAt(1).props().disabled, true, 'should disable the input node');
+    assert.strictEqual(wrapper.props().disabled, true);
+    assert.strictEqual(wrapper.childAt(1).props().disabled, true);
   });
 
   it('should apply the custom disabled className when disabled', () => {

--- a/packages/material-ui/src/utils/exactProp.test.js
+++ b/packages/material-ui/src/utils/exactProp.test.js
@@ -11,8 +11,8 @@ describe('exactProp()', () => {
   });
 
   it('should have the right shape', () => {
-    assert.strictEqual(typeof exactProp, 'function', 'should be a function');
-    assert.strictEqual(typeof exactPropTypes, 'object', 'should be a function');
+    assert.strictEqual(typeof exactProp, 'function');
+    assert.strictEqual(typeof exactPropTypes, 'object');
   });
 
   describe('exactPropTypes', () => {

--- a/packages/material-ui/src/utils/helpers.test.js
+++ b/packages/material-ui/src/utils/helpers.test.js
@@ -17,14 +17,10 @@ describe('utils/helpers.js', () => {
   describe('find(arr, pred)', () => {
     it('should search for an item in an array containing the predicate', () => {
       const array = ['woofHelpers', 'meow', { foo: 'bar' }, { woofHelpers: 'meow' }];
-      assert.strictEqual(find(array, 'lol'), undefined, 'should work for primitives');
-      assert.strictEqual(find(array, 'woofHelpers'), array[0], 'should work for primitives');
-      assert.strictEqual(find(array, { foo: 'bar' }), array[2], 'should work for objects');
-      assert.strictEqual(
-        find(array, n => n && n.woofHelpers === 'meow'),
-        array[3],
-        'should work for functions',
-      );
+      assert.strictEqual(find(array, 'lol'), undefined);
+      assert.strictEqual(find(array, 'woofHelpers'), array[0]);
+      assert.strictEqual(find(array, { foo: 'bar' }), array[2]);
+      assert.strictEqual(find(array, n => n && n.woofHelpers === 'meow'), array[3]);
     });
   });
 

--- a/packages/material-ui/src/utils/requirePropFactory.test.js
+++ b/packages/material-ui/src/utils/requirePropFactory.test.js
@@ -10,8 +10,8 @@ describe('requirePropFactory', () => {
   });
 
   it('should have the right shape', () => {
-    assert.strictEqual(typeof requirePropFactory, 'function', 'should be a function');
-    assert.strictEqual(typeof requireProp, 'function', 'should return a function');
+    assert.strictEqual(typeof requirePropFactory, 'function');
+    assert.strictEqual(typeof requireProp, 'function');
   });
 
   describe('requireProp()', () => {
@@ -59,25 +59,12 @@ describe('requirePropFactory', () => {
         });
 
         it('should return Error', () => {
-          assert.property(result, 'name', 'result should have name property');
-          assert.property(result, 'name', 'result should have name property');
+          assert.property(result, 'name');
           assert.strictEqual(result.name, 'Error');
-          assert.property(result, 'message', 'result should have message property');
-          assert.strictEqual(
-            result.message.indexOf(propName) > -1,
-            true,
-            'returned error message should have propName',
-          );
-          assert.strictEqual(
-            result.message.indexOf(requiredPropName) > -1,
-            true,
-            'returned error message should have requiredPropName',
-          );
-          assert.strictEqual(
-            result.message.indexOf(componentNameInError) > -1,
-            true,
-            'returned error message should have componentNameInError',
-          );
+          assert.property(result, 'message');
+          assert.strictEqual(result.message.indexOf(propName) > -1, true);
+          assert.strictEqual(result.message.indexOf(requiredPropName) > -1, true);
+          assert.strictEqual(result.message.indexOf(componentNameInError) > -1, true);
         });
 
         describe('propFullName given to validator', () => {

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -39,7 +39,7 @@ describe('<Menu> integration', () => {
       const popover = wrapper.find(Popover);
       assert.strictEqual(popover.props().open, false, 'should have passed open=false to Popover');
       const menuEl = document.getElementById('simple-menu');
-      assert.strictEqual(menuEl, null, 'should not render the menu to the DOM');
+      assert.strictEqual(menuEl, null);
     });
 
     it('should focus the first item as nothing has been selected', () => {
@@ -48,62 +48,38 @@ describe('<Menu> integration', () => {
         .find(Portal)
         .instance()
         .getMountNode();
-      assert.strictEqual(
-        document.activeElement,
-        portalLayer.querySelectorAll('li')[0],
-        'should be the first menu item',
-      );
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
     });
 
     it('should change focus to the 2nd item when down arrow is pressed', () => {
       simulateEvent(portalLayer.querySelector('ul'), 'keyDown', { which: keycode('down') });
-      assert.strictEqual(
-        document.activeElement,
-        portalLayer.querySelectorAll('li')[1],
-        'should be the 2nd menu item',
-      );
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
     });
 
     it('should change focus to the 3rd item when down arrow is pressed', () => {
       simulateEvent(portalLayer.querySelector('ul'), 'keyDown', { which: keycode('down') });
-      assert.strictEqual(
-        document.activeElement,
-        portalLayer.querySelectorAll('li')[2],
-        'should be the 3rd menu item',
-      );
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
     it('should keep focus on the 3rd item (last item) when down arrow is pressed', () => {
       simulateEvent(portalLayer.querySelector('ul'), 'keyDown', { which: keycode('down') });
-      assert.strictEqual(
-        document.activeElement,
-        portalLayer.querySelectorAll('li')[2],
-        'should be the 3rd menu item',
-      );
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
     it('should keep focus on the last item when a key with no associated action is pressed', () => {
       simulateEvent(portalLayer.querySelector('ul'), 'keyDown', { which: keycode('right') });
-      assert.strictEqual(
-        document.activeElement,
-        portalLayer.querySelectorAll('li')[2],
-        'should be the 3rd menu item',
-      );
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
     it('should change focus to the 2nd item when up arrow is pressed', () => {
       simulateEvent(portalLayer.querySelector('ul'), 'keyDown', { which: keycode('up') });
-      assert.strictEqual(
-        document.activeElement,
-        portalLayer.querySelectorAll('li')[1],
-        'should be the 2nd menu item',
-      );
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
     });
 
     it('should select the 2nd item and close the menu', () => {
       portalLayer.querySelectorAll('li')[1].click();
-      assert.strictEqual(wrapper.state().selectedIndex, 1, 'should be index 1');
-      assert.strictEqual(wrapper.state().open, false, 'should have closed');
+      assert.strictEqual(wrapper.state().selectedIndex, 1);
+      assert.strictEqual(wrapper.state().open, false);
     });
   });
 
@@ -117,9 +93,9 @@ describe('<Menu> integration', () => {
 
     it('should not be open', () => {
       const popover = wrapper.find(Popover);
-      assert.strictEqual(popover.props().open, false, 'should have passed open=false to Popover');
+      assert.strictEqual(popover.props().open, false);
       const menuEl = document.getElementById('simple-menu');
-      assert.strictEqual(menuEl, null, 'should not render the menu to the DOM');
+      assert.strictEqual(menuEl, null);
     });
 
     it('should focus the 3rd selected item', () => {
@@ -128,11 +104,7 @@ describe('<Menu> integration', () => {
         .find(Portal)
         .instance()
         .getMountNode();
-      assert.strictEqual(
-        document.activeElement,
-        portalLayer.querySelectorAll('li')[2],
-        'should be the 3rd menu item',
-      );
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
     it('should select the 2nd item and close the menu', () => {
@@ -142,8 +114,8 @@ describe('<Menu> integration', () => {
         .getMountNode();
       const item = portalLayer.querySelector('ul').children[1];
       item.click();
-      assert.strictEqual(wrapper.state().selectedIndex, 1, 'should be index 1');
-      assert.strictEqual(wrapper.state().open, false, 'should have closed');
+      assert.strictEqual(wrapper.state().selectedIndex, 1);
+      assert.strictEqual(wrapper.state().open, false);
     });
 
     it('should focus the 2nd selected item', () => {
@@ -152,11 +124,7 @@ describe('<Menu> integration', () => {
         .find(Portal)
         .instance()
         .getMountNode();
-      assert.strictEqual(
-        document.activeElement,
-        portalLayer.querySelectorAll('li')[1],
-        'should be the 2nd menu item',
-      );
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
     });
   });
 
@@ -172,7 +140,7 @@ describe('<Menu> integration', () => {
       const portalWrapper = new ReactWrapper(portal);
       list = portalWrapper.find('List');
       backdrop = portalWrapper.find('Backdrop');
-      assert.strictEqual(backdrop.length, 1, 'find a backdrop');
+      assert.strictEqual(backdrop.length, 1);
     });
 
     it('should close the menu with tab', done => {
@@ -182,9 +150,9 @@ describe('<Menu> integration', () => {
           done();
         },
       });
-      assert.strictEqual(wrapper.state().open, true, 'should start open');
+      assert.strictEqual(wrapper.state().open, true);
       list.simulate('keyDown', { which: keycode('tab') });
-      assert.strictEqual(wrapper.state().open, false, 'should be closed');
+      assert.strictEqual(wrapper.state().open, false);
     });
 
     it('should close the menu using the backdrop', done => {
@@ -194,9 +162,9 @@ describe('<Menu> integration', () => {
           done();
         },
       });
-      assert.strictEqual(wrapper.state().open, true, 'should start open');
+      assert.strictEqual(wrapper.state().open, true);
       backdrop.simulate('click');
-      assert.strictEqual(wrapper.state().open, false, 'should be closed');
+      assert.strictEqual(wrapper.state().open, false);
     });
   });
 });


### PR DESCRIPTION
Remove most of the assertion messages. **Optimize for test velocity**. If you take Facebook and Jest as an example, `expect()` won't even let you provide an assertion message. I think that it's a great tradeoff. You save time writing and reading the tests at the cost of a more obscure failing message. If you really value error explicitness, better use a different assertion method tuned for one use case than a human written message that can be wrong.