### PR TITLE
[Snackbar] Change the flex-wrap to "nowrap"

### DIFF
--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -19,7 +19,7 @@ export const styles = theme => {
       backgroundColor,
       display: 'flex',
       alignItems: 'center',
-      flexWrap: 'wrap',
+      flexWrap: 'nowrap',
       padding: '6px 24px',
       [theme.breakpoints.up('md')]: {
         minWidth: 288,


### PR DESCRIPTION
### Edit
I see this actually deviates from the Material Design spec, thus closing. Overwriting the `flexWrap` manually seems a much better idea.

#### The problem
If the snackbar had a large message the action icon (close icon) would move to the next row (wrap).

#### Before
![longsnackbar](https://user-images.githubusercontent.com/638172/46246010-62622780-c3ef-11e8-879a-fa55213d700f.PNG)

#### After
![longsnackbarnowrap](https://user-images.githubusercontent.com/638172/46246020-79087e80-c3ef-11e8-87d6-b3edb1892b05.PNG)
