### PR TITLE
[Portal] container should allow being 'null' type

### DIFF
--- a/packages/material-ui/src/Portal/Portal.d.ts
+++ b/packages/material-ui/src/Portal/Portal.d.ts
@@ -3,7 +3,7 @@ import { PortalProps } from '../Portal';
 
 export interface PortalProps {
   children: React.ReactElement<any>;
-  container?: React.ReactInstance | (() => React.ReactInstance);
+  container?: React.ReactInstance | (() => React.ReactInstance) | null;
   disablePortal?: boolean;
   onRendered?: () => void;
 }


### PR DESCRIPTION
By default, document.querySelector may return 'null' type value, we could pass it to 'container' directly.

```jsx
<Protal container=(document.querySelector('#mark')) />
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
