### PR TITLE
[docs] Fix 3xx and 4xx HTTP statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### [Versions](https://material-ui.com/versions)
+### [Versions](https://material-ui.com/versions/)
 
 ## 3.1.1
 ###### *Sep 24, 2018*

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
+import { _rewriteUrlForNextExport } from 'next/router';
 import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import Drawer from '@material-ui/core/Drawer';
@@ -105,7 +106,7 @@ function AppDrawer(props, context) {
             </Typography>
           </Link>
           {process.env.LIB_VERSION ? (
-            <Link className={classes.anchor} href="/versions">
+            <Link className={classes.anchor} href={_rewriteUrlForNextExport('/versions')}>
               <Typography variant="caption">{`v${process.env.LIB_VERSION}`}</Typography>
             </Link>
           ) : null}

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { _rewriteUrlForNextExport } from 'next/router';
 import kebabCase from 'lodash/kebabCase';
 import warning from 'warning';
 import { withStyles } from '@material-ui/core/styles';
@@ -63,9 +64,9 @@ function MarkdownDocs(props, context) {
 ${headers.components
       .map(
         component =>
-          `- [&lt;${component} /&gt;](${section === 'lab' ? '/lab/api' : '/api'}/${kebabCase(
-            component,
-          )})`,
+          `- [&lt;${component} /&gt;](${
+            section === 'lab' ? '/lab/api' : '/api'
+          }/${_rewriteUrlForNextExport(kebabCase(component))})`,
       )
       .join('\n')}
         `);

--- a/docs/src/modules/components/withRoot.js
+++ b/docs/src/modules/components/withRoot.js
@@ -286,6 +286,7 @@ function withRoot(Component) {
       if (pathname !== '/') {
         // The leading / is only added to support static hosting (resolve /index.html).
         // We remove it to normalize the pathname.
+        // See `_rewriteUrlForNextExport` on Next.js side.
         pathname = pathname.replace(/\/$/, '');
       }
 

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -2,6 +2,7 @@
 
 import { parse as parseDoctrine } from 'doctrine';
 import recast from 'recast';
+import { _rewriteUrlForNextExport } from 'next/router';
 import { pageToTitle } from './helpers';
 
 const SOURCE_CODE_ROOT_URL = 'https://github.com/mui-org/material-ui/tree/master';
@@ -226,7 +227,9 @@ function generateProps(reactAPI) {
   text = `${text}
 Any other properties supplied will be spread to the root element (${
     reactAPI.inheritance
-      ? `[${reactAPI.inheritance.component}](${reactAPI.inheritance.pathname})`
+      ? `[${reactAPI.inheritance.component}](${_rewriteUrlForNextExport(
+          reactAPI.inheritance.pathname,
+        )})`
       : 'native element'
   }).`;
 
@@ -308,7 +311,7 @@ function generateInheritance(reactAPI) {
 The properties of the [${inheritance.component}](${
     inheritance.pathname
   }) component${suffix} are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 `;
 }
@@ -328,7 +331,9 @@ function generateDemos(reactAPI) {
 
   return `## Demos
 
-${pagesMarkdown.map(page => `- [${pageToTitle(page)}](${page.pathname})`).join('\n')}
+${pagesMarkdown
+    .map(page => `- [${pageToTitle(page)}](${_rewriteUrlForNextExport(page.pathname)})`)
+    .join('\n')}
 
 `;
 }

--- a/docs/src/pages/customization/overrides/overrides.md
+++ b/docs/src/pages/customization/overrides/overrides.md
@@ -31,7 +31,7 @@ of the `<head />` to ensure the components always render correctly.
 When the `className` property isn't enough, and you need to access deeper elements, you can take advantage of the `classes` property to customize all the CSS injected by Material-UI for a given component.
 The list of  classes for each
 component is documented in the **Component API** section.
-For instance, you can have a look at the [Button CSS API](/api/button#css-api).
+For instance, you can have a look at the [Button CSS API](/api/button/#css-api).
 Alternatively, you can always look at the [implementation details](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Button/Button.js).
 
 This example also uses `withStyles()` (see above), but here, `ClassesNesting` is using `Button`'s `classes` prop to
@@ -46,7 +46,7 @@ Notice that in addition to the button styling, the button label's capitalization
 #### Shorthand
 
 The above code example can be condensed by using **the same CSS API** as the child component.
-In this example, the `withStyles()` higher-order component is injecting a `classes` property that is used by the [`Button` component](/api/button#css-api).
+In this example, the `withStyles()` higher-order component is injecting a `classes` property that is used by the [`Button` component](/api/button/#css-api).
 
 ```jsx
 const StyledButton = withStyles({

--- a/docs/src/pages/customization/themes/themes.md
+++ b/docs/src/pages/customization/themes/themes.md
@@ -324,7 +324,7 @@ const theme = createMuiTheme({
 {{"demo": "pages/customization/themes/OverridesCss.js"}}
 
 The list of these customization points for each component is documented under the **Component API** section.
-For instance, you can have a look at the [Button](/api/button#css-api).
+For instance, you can have a look at the [Button](/api/button/#css-api).
 Alternatively, you can always have a look at the [implementation](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Button/Button.js).
 
 ### Properties
@@ -374,7 +374,7 @@ The main point to understand is that we cache the injected CSS with the followin
 This component takes a `theme` property, and makes the `theme` available down the React tree thanks to React context.
 It should preferably be used at **the root of your component tree**.
 
-You can see the full properties API in [this dedicated page](/api/mui-theme-provider).
+You can see the full properties API in [this dedicated page](/api/mui-theme-provider/).
 
 #### Examples
 

--- a/docs/src/pages/demos/menus/menus.md
+++ b/docs/src/pages/demos/menus/menus.md
@@ -22,7 +22,7 @@ Choosing an option should immediately ideally commit the option and close the me
 ## Selected menus
 
 If used for item selection, when opened, simple menus attempt to vertically align the currently selected menu item with the anchor element.
-The currently selected menu item is set using the `selected` property (from [ListItem](/api/list-item)).
+The currently selected menu item is set using the `selected` property (from [ListItem](/api/list-item/)).
 
 {{"demo": "pages/demos/menus/SimpleListMenu.js"}}
 

--- a/docs/src/pages/demos/selects/selects.md
+++ b/docs/src/pages/demos/selects/selects.md
@@ -37,7 +37,7 @@ While it's discouraged by the Material Design specification, you can use a selec
 
 ## Text Fields
 
-The `TextField` wrapper component is a complete form control including a label, input and help text. You can find an example with the select mode [in this section](/demos/text-fields#textfield).
+The `TextField` wrapper component is a complete form control including a label, input and help text. You can find an example with the select mode [in this section](/demos/text-fields/#textfield).
 
 ## Controlled open Select
 

--- a/docs/src/pages/demos/text-fields/text-fields.md
+++ b/docs/src/pages/demos/text-fields/text-fields.md
@@ -30,12 +30,12 @@ The `TextField` wrapper component is a complete form control including a label, 
 ## Components
 
 `TextField` is composed of smaller components (
-[`FormControl`](/api/form-control),
-[`Input`](/api/input),
-[`InputLabel`](/api/filled-input),
-[`InputLabel`](/api/input-label),
-[`OutlinedInput`](/api/outlined-input),
-and [`FormHelperText`](/api/form-helper-text)
+[`FormControl`](/api/form-control/),
+[`Input`](/api/input/),
+[`InputLabel`](/api/filled-input/),
+[`InputLabel`](/api/input-label/),
+[`OutlinedInput`](/api/outlined-input/),
+and [`FormHelperText`](/api/form-helper-text/)
 ) that you can leverage directly to significantly customize your form inputs.
 
 You might also have noticed that some native HTML input properties are missing from the `TextField` component.

--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -62,7 +62,7 @@ As a rule of thumb, only use inline-style for dynamic style properties. The CSS 
 
 ## How do I use react-router?
 
-We have documented how to use a [third-party routing library](/demos/buttons#third-party-routing-library) with the `ButtonBase` component.
+We have documented how to use a [third-party routing library](/demos/buttons/#third-party-routing-library) with the `ButtonBase` component.
 A lot of our interactive components use it internally:
 `Button`, `MenuItem`, `<ListItem button />`, `Tab`, etc.
 You can use the same solution with them.
@@ -96,7 +96,7 @@ export default withTheme()(withStyles(styles)(Modal));
 
 ## How can I access the DOM element?
 
-Wrap the component with the [`<RootRef>`](/api/root-ref) helper.
+Wrap the component with the [`RootRef`](/api/root-ref/) helper.
 
 ## Why are the colors I am seeing different from what I see here?
 

--- a/docs/src/pages/getting-started/usage/usage.md
+++ b/docs/src/pages/getting-started/usage/usage.md
@@ -57,7 +57,7 @@ It's fixing some inconsistencies across browsers and devices while providing sli
 ## Versioned Documentation
 
 This documentation always reflects the latest stable version of Material-UI.
-You can find older versions of the documentation on a [separate page](/versions).
+You can find older versions of the documentation on a [separate page](/versions/).
 
 ## Next steps
 

--- a/docs/src/pages/guides/api/api.md
+++ b/docs/src/pages/guides/api/api.md
@@ -33,7 +33,7 @@ You can take advantage of the spread behavior:
 ```jsx
 <MenuItem disableRipple />
 ```
-The `disableRipple` property will flow this way: [`MenuItem`](/api/menu-item) > [`ListItem`](/api/list-item) > [`ButtonBase`](/api/button-base).
+The `disableRipple` property will flow this way: [`MenuItem`](/api/menu-item/) > [`ListItem`](/api/list-item/) > [`ButtonBase`](/api/button-base/).
 
 ### Native properties
 

--- a/docs/src/pages/guides/composition/ComponentProperty.js
+++ b/docs/src/pages/guides/composition/ComponentProperty.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
+import NoSsr from '@material-ui/core/NoSsr';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
 import ListItemText from '@material-ui/core/ListItemText';
@@ -64,29 +65,33 @@ ListItemLink2.propTypes = {
 
 function ComponentProperty(props) {
   const { classes } = props;
+
+  // Use NoSsr to avoid SEO issues with the documentation website.
   return (
-    <MemoryRouter initialEntries={['/drafts']} initialIndex={0}>
-      <div className={classes.root}>
-        <Route>
-          {({ location }) => (
-            <Typography gutterBottom type="title">
-              Current route: {location.pathname}
-            </Typography>
-          )}
-        </Route>
-        <div className={classes.lists}>
-          <List component="nav">
-            <ListItemLink1 to="/inbox" primary="Inbox" icon={<InboxIcon />} />
-            <ListItemLink1 to="/drafts" primary="Drafts" icon={<DraftsIcon />} />
-          </List>
-          <Divider />
-          <List component="nav">
-            <ListItemLink2 to="/trash" primary="Trash" />
-            <ListItemLink2 to="/spam" primary="Spam" />
-          </List>
+    <NoSsr>
+      <MemoryRouter initialEntries={['/drafts']} initialIndex={0}>
+        <div className={classes.root}>
+          <Route>
+            {({ location }) => (
+              <Typography gutterBottom type="title">
+                Current route: {location.pathname}
+              </Typography>
+            )}
+          </Route>
+          <div className={classes.lists}>
+            <List component="nav">
+              <ListItemLink1 to="/inbox" primary="Inbox" icon={<InboxIcon />} />
+              <ListItemLink1 to="/drafts" primary="Drafts" icon={<DraftsIcon />} />
+            </List>
+            <Divider />
+            <List component="nav">
+              <ListItemLink2 to="/trash" primary="Trash" />
+              <ListItemLink2 to="/spam" primary="Spam" />
+            </List>
+          </div>
         </div>
-      </div>
-    </MemoryRouter>
+      </MemoryRouter>
+    </NoSsr>
   );
 }
 

--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -146,7 +146,7 @@ export default StyledComponentsButton;
 ### Deeper elements
 
 In some cases, the approaches above will not work.
-For example, if you attempt to style a [Drawer](/demos/drawers) with variant `permanent`,
+For example, if you attempt to style a [Drawer](/demos/drawers/) with variant `permanent`,
 you will likely need to affect the Drawer's underlying `paper` style.
 
 However, this is not the root element of `Drawer` and therefore styled-components customization as above will not work.

--- a/docs/src/pages/guides/server-rendering/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering.md
@@ -58,7 +58,7 @@ app.listen(port);
 The first thing that we need to do on every request is create a new `sheetsRegistry` and `theme` instance.
 
 When rendering, we will wrap `App`, our root component,
-inside a `JssProvider` and [`MuiThemeProvider`](/api/mui-theme-provider) to make the `sheetsRegistry` and the `theme` available to all components in the component tree.
+inside a `JssProvider` and [`MuiThemeProvider`](/api/mui-theme-provider/) to make the `sheetsRegistry` and the `theme` available to all components in the component tree.
 
 The key step in server side rendering is to render the initial HTML of our component **before** we send it to the client side. To do this, we use [ReactDOMServer.renderToString()](https://reactjs.org/docs/react-dom-server.html).
 

--- a/docs/src/pages/utils/click-away-listener/click-away-listener.md
+++ b/docs/src/pages/utils/click-away-listener/click-away-listener.md
@@ -13,4 +13,4 @@ For instance, if you need to hide a menu when people click anywhere else on your
 
 {{"demo": "pages/utils/click-away-listener/ClickAway.js"}}
 
-You can find a more advanced demo on the [menu documentation section](/demos/menus#menulist-composition).
+You can find a more advanced demo on the [menu documentation section](/demos/menus/#menulist-composition).

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -24,7 +24,7 @@ import AppBar from '@material-ui/core/AppBar';
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br> | <span class="prop-default">'primary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">position</span> | <span class="prop-type">enum:&nbsp;'fixed', 'absolute', 'sticky', 'static', 'relative'<br> | <span class="prop-default">'fixed'</span> | The positioning type. The behavior of the different options is described [here](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning). Note: `sticky` is not universally supported and will fall back to `static` when unavailable. |
 
-Any other properties supplied will be spread to the root element ([Paper](/api/paper)).
+Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS API
 
@@ -55,9 +55,9 @@ you need to use the following style sheet name: `MuiAppBar`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [App Bar](/demos/app-bar)
+- [App Bar](/demos/app-bar/)
 

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -52,5 +52,5 @@ you need to use the following style sheet name: `MuiAvatar`.
 
 ## Demos
 
-- [Avatars](/demos/avatars)
+- [Avatars](/demos/avatars/)
 

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -51,5 +51,5 @@ you need to use the following style sheet name: `MuiBadge`.
 
 ## Demos
 
-- [Badges](/demos/badges)
+- [Badges](/demos/badges/)
 

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -26,7 +26,7 @@ import BottomNavigationAction from '@material-ui/core/BottomNavigationAction';
 | <span class="prop-name">showLabel</span> | <span class="prop-type">bool |   | If `true`, the `BottomNavigationAction` will show its label. By default, only the selected `BottomNavigationAction` inside `BottomNavigation` will show its label. |
 | <span class="prop-name">value</span> | <span class="prop-type">any |   | You can provide your own value. Otherwise, we fallback to the child position index. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -53,9 +53,9 @@ you need to use the following style sheet name: `MuiBottomNavigationAction`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Bottom Navigation](/demos/bottom-navigation)
+- [Bottom Navigation](/demos/bottom-navigation/)
 

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -47,5 +47,5 @@ you need to use the following style sheet name: `MuiBottomNavigation`.
 
 ## Demos
 
-- [Bottom Navigation](/demos/bottom-navigation)
+- [Bottom Navigation](/demos/bottom-navigation/)
 

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -60,5 +60,5 @@ you need to use the following style sheet name: `MuiButtonBase`.
 
 ## Demos
 
-- [Buttons](/demos/buttons)
+- [Buttons](/demos/buttons/)
 

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -32,7 +32,7 @@ import Button from '@material-ui/core/Button';
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text', 'flat', 'outlined', 'contained', 'raised', 'fab', 'extendedFab'<br> | <span class="prop-default">'text'</span> | The variant to use. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -80,9 +80,9 @@ you need to use the following style sheet name: `MuiButton`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Buttons](/demos/buttons)
+- [Buttons](/demos/buttons/)
 

--- a/pages/api/card-action-area.md
+++ b/pages/api/card-action-area.md
@@ -22,7 +22,7 @@ import CardActionArea from '@material-ui/core/CardActionArea';
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -47,9 +47,9 @@ you need to use the following style sheet name: `MuiCardActionArea`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Cards](/demos/cards)
+- [Cards](/demos/cards/)
 

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -46,5 +46,5 @@ you need to use the following style sheet name: `MuiCardActions`.
 
 ## Demos
 
-- [Cards](/demos/cards)
+- [Cards](/demos/cards/)
 

--- a/pages/api/card-content.md
+++ b/pages/api/card-content.md
@@ -44,5 +44,5 @@ you need to use the following style sheet name: `MuiCardContent`.
 
 ## Demos
 
-- [Cards](/demos/cards)
+- [Cards](/demos/cards/)
 

--- a/pages/api/card-header.md
+++ b/pages/api/card-header.md
@@ -56,5 +56,5 @@ you need to use the following style sheet name: `MuiCardHeader`.
 
 ## Demos
 
-- [Cards](/demos/cards)
+- [Cards](/demos/cards/)
 

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -47,5 +47,5 @@ you need to use the following style sheet name: `MuiCardMedia`.
 
 ## Demos
 
-- [Cards](/demos/cards)
+- [Cards](/demos/cards/)
 

--- a/pages/api/card.md
+++ b/pages/api/card.md
@@ -22,7 +22,7 @@ import Card from '@material-ui/core/Card';
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">raised</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the card will use raised styling. |
 
-Any other properties supplied will be spread to the root element ([Paper](/api/paper)).
+Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS API
 
@@ -45,9 +45,9 @@ you need to use the following style sheet name: `MuiCard`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Cards](/demos/cards)
+- [Cards](/demos/cards/)
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -62,5 +62,5 @@ you need to use the following style sheet name: `MuiCheckbox`.
 
 ## Demos
 
-- [Selection Controls](/demos/selection-controls)
+- [Selection Controls](/demos/selection-controls/)
 

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -77,5 +77,5 @@ you need to use the following style sheet name: `MuiChip`.
 
 ## Demos
 
-- [Chips](/demos/chips)
+- [Chips](/demos/chips/)
 

--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -60,5 +60,5 @@ you need to use the following style sheet name: `MuiCircularProgress`.
 
 ## Demos
 
-- [Progress](/demos/progress)
+- [Progress](/demos/progress/)
 

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -25,15 +25,15 @@ For instance, if you need to hide a menu when people click anywhere else on your
 | <span class="prop-name required">onClickAway *</span> | <span class="prop-type">func |   | Callback fired when a "click away" event is detected. |
 | <span class="prop-name">touchEvent</span> | <span class="prop-type">enum:&nbsp;'onTouchStart'&nbsp;&#124;<br>&nbsp;'onTouchEnd'&nbsp;&#124;<br>&nbsp;false<br> | <span class="prop-default">'onTouchEnd'</span> | The touch event to listen to. You can disable the listener by providing `false`. |
 
-Any other properties supplied will be spread to the root element ([EventListener](https://github.com/oliviertassinari/react-event-listener)).
+Any other properties supplied will be spread to the root element ([EventListener](https://github.com/oliviertassinari/react-event-listener/)).
 
 ## Inheritance
 
 The properties of the [EventListener](https://github.com/oliviertassinari/react-event-listener) component, from react-event-listener, are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Menus](/demos/menus)
-- [Click Away Listener](/utils/click-away-listener)
+- [Menus](/demos/menus/)
+- [Click Away Listener](/utils/click-away-listener/)
 

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -54,11 +54,11 @@ you need to use the following style sheet name: `MuiCollapse`.
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Cards](/demos/cards)
-- [Lists](/demos/lists)
-- [Transitions](/utils/transitions)
+- [Cards](/demos/cards/)
+- [Lists](/demos/lists/)
+- [Transitions](/utils/transitions/)
 

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -25,5 +25,5 @@ Any other properties supplied will be spread to the root element (native element
 
 ## Demos
 
-- [Css Baseline](/style/css-baseline)
+- [Css Baseline](/style/css-baseline/)
 

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -46,5 +46,5 @@ you need to use the following style sheet name: `MuiDialogActions`.
 
 ## Demos
 
-- [Dialogs](/demos/dialogs)
+- [Dialogs](/demos/dialogs/)
 

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -22,7 +22,7 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 
-Any other properties supplied will be spread to the root element ([Typography](/api/typography)).
+Any other properties supplied will be spread to the root element ([Typography](/api/typography/)).
 
 ## CSS API
 
@@ -45,9 +45,9 @@ you need to use the following style sheet name: `MuiDialogContentText`.
 ## Inheritance
 
 The properties of the [Typography](/api/typography) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Dialogs](/demos/dialogs)
+- [Dialogs](/demos/dialogs/)
 

--- a/pages/api/dialog-content.md
+++ b/pages/api/dialog-content.md
@@ -44,5 +44,5 @@ you need to use the following style sheet name: `MuiDialogContent`.
 
 ## Demos
 
-- [Dialogs](/demos/dialogs)
+- [Dialogs](/demos/dialogs/)
 

--- a/pages/api/dialog-title.md
+++ b/pages/api/dialog-title.md
@@ -45,5 +45,5 @@ you need to use the following style sheet name: `MuiDialogTitle`.
 
 ## Demos
 
-- [Dialogs](/demos/dialogs)
+- [Dialogs](/demos/dialogs/)
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -42,7 +42,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |   | Properties applied to the `Transition` element. |
 
-Any other properties supplied will be spread to the root element ([Modal](/api/modal)).
+Any other properties supplied will be spread to the root element ([Modal](/api/modal/)).
 
 ## CSS API
 
@@ -76,9 +76,9 @@ you need to use the following style sheet name: `MuiDialog`.
 ## Inheritance
 
 The properties of the [Modal](/api/modal) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Dialogs](/demos/dialogs)
+- [Dialogs](/demos/dialogs/)
 

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -50,6 +50,6 @@ you need to use the following style sheet name: `MuiDivider`.
 
 ## Demos
 
-- [Dividers](/demos/dividers)
-- [Lists](/demos/lists)
+- [Dividers](/demos/dividers/)
+- [Lists](/demos/lists/)
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -64,5 +64,5 @@ you need to use the following style sheet name: `MuiDrawer`.
 
 ## Demos
 
-- [Drawers](/demos/drawers)
+- [Drawers](/demos/drawers/)
 

--- a/pages/api/expansion-panel-actions.md
+++ b/pages/api/expansion-panel-actions.md
@@ -45,5 +45,5 @@ you need to use the following style sheet name: `MuiExpansionPanelActions`.
 
 ## Demos
 
-- [Expansion Panels](/demos/expansion-panels)
+- [Expansion Panels](/demos/expansion-panels/)
 

--- a/pages/api/expansion-panel-details.md
+++ b/pages/api/expansion-panel-details.md
@@ -44,5 +44,5 @@ you need to use the following style sheet name: `MuiExpansionPanelDetails`.
 
 ## Demos
 
-- [Expansion Panels](/demos/expansion-panels)
+- [Expansion Panels](/demos/expansion-panels/)
 

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -24,7 +24,7 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node |   | The icon to display as the expand indicator. |
 | <span class="prop-name">IconButtonProps</span> | <span class="prop-type">object |   | Properties applied to the `TouchRipple` element wrapping the expand icon. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -52,9 +52,9 @@ you need to use the following style sheet name: `MuiExpansionPanelSummary`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Expansion Panels](/demos/expansion-panels)
+- [Expansion Panels](/demos/expansion-panels/)
 

--- a/pages/api/expansion-panel.md
+++ b/pages/api/expansion-panel.md
@@ -27,7 +27,7 @@ import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 | <span class="prop-name">expanded</span> | <span class="prop-type">bool |   | If `true`, expands the panel, otherwise collapse it. Setting this prop enables control over the panel. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |   | Callback fired when the expand/collapse state is changed.<br><br>**Signature:**<br>`function(event: object, expanded: boolean) => void`<br>*event:* The event source of the callback<br>*expanded:* The `expanded` state of the panel |
 
-Any other properties supplied will be spread to the root element ([Paper](/api/paper)).
+Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS API
 
@@ -52,9 +52,9 @@ you need to use the following style sheet name: `MuiExpansionPanel`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Expansion Panels](/demos/expansion-panels)
+- [Expansion Panels](/demos/expansion-panels/)
 

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -29,9 +29,9 @@ Any other properties supplied will be spread to the root element ([Transition](h
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Transitions](/utils/transitions)
+- [Transitions](/utils/transitions/)
 

--- a/pages/api/filled-input.md
+++ b/pages/api/filled-input.md
@@ -45,7 +45,7 @@ import FilledInput from '@material-ui/core/FilledInput';
 | <span class="prop-name">type</span> | <span class="prop-type">string |   | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br> |   | The input value, required for a controlled component. |
 
-Any other properties supplied will be spread to the root element ([InputBase](/api/input-base)).
+Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 
 ## CSS API
 
@@ -80,9 +80,9 @@ you need to use the following style sheet name: `MuiFilledInput`.
 ## Inheritance
 
 The properties of the [InputBase](/api/input-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Text Fields](/demos/text-fields)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -56,5 +56,5 @@ you need to use the following style sheet name: `MuiFormControlLabel`.
 
 ## Demos
 
-- [Selection Controls](/demos/selection-controls)
+- [Selection Controls](/demos/selection-controls/)
 

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -61,6 +61,6 @@ you need to use the following style sheet name: `MuiFormControl`.
 
 ## Demos
 
-- [Selection Controls](/demos/selection-controls)
-- [Text Fields](/demos/text-fields)
+- [Selection Controls](/demos/selection-controls/)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/form-group.md
+++ b/pages/api/form-group.md
@@ -48,5 +48,5 @@ you need to use the following style sheet name: `MuiFormGroup`.
 
 ## Demos
 
-- [Selection Controls](/demos/selection-controls)
+- [Selection Controls](/demos/selection-controls/)
 

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -59,5 +59,5 @@ you need to use the following style sheet name: `MuiFormHelperText`.
 
 ## Demos
 
-- [Text Fields](/demos/text-fields)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -56,5 +56,5 @@ you need to use the following style sheet name: `MuiFormLabel`.
 
 ## Demos
 
-- [Selection Controls](/demos/selection-controls)
+- [Selection Controls](/demos/selection-controls/)
 

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -58,5 +58,5 @@ you need to use the following style sheet name: `MuiGridListTileBar`.
 
 ## Demos
 
-- [Grid List](/demos/grid-list)
+- [Grid List](/demos/grid-list/)
 

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -50,5 +50,5 @@ you need to use the following style sheet name: `MuiGridListTile`.
 
 ## Demos
 
-- [Grid List](/demos/grid-list)
+- [Grid List](/demos/grid-list/)
 

--- a/pages/api/grid-list.md
+++ b/pages/api/grid-list.md
@@ -48,5 +48,5 @@ you need to use the following style sheet name: `MuiGridList`.
 
 ## Demos
 
-- [Grid List](/demos/grid-list)
+- [Grid List](/demos/grid-list/)
 

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -99,5 +99,5 @@ you need to use the following style sheet name: `MuiGrid`.
 
 ## Demos
 
-- [Grid](/layout/grid)
+- [Grid](/layout/grid/)
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -30,10 +30,10 @@ Any other properties supplied will be spread to the root element ([Transition](h
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Popover](/utils/popover)
-- [Transitions](/utils/transitions)
+- [Popover](/utils/popover/)
+- [Transitions](/utils/transitions/)
 

--- a/pages/api/hidden.md
+++ b/pages/api/hidden.md
@@ -38,5 +38,5 @@ Any other properties supplied will be spread to the root element (native element
 
 ## Demos
 
-- [Hidden](/layout/hidden)
+- [Hidden](/layout/hidden/)
 

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -26,7 +26,7 @@ regarding the available icon options.
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool |   | If `true`, the ripple will be disabled. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -54,10 +54,10 @@ you need to use the following style sheet name: `MuiIconButton`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Buttons](/demos/buttons)
-- [Grid List](/demos/grid-list)
+- [Buttons](/demos/buttons/)
+- [Grid List](/demos/grid-list/)
 

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -55,5 +55,5 @@ you need to use the following style sheet name: `MuiIcon`.
 
 ## Demos
 
-- [Icons](/style/icons)
+- [Icons](/style/icons/)
 

--- a/pages/api/input-adornment.md
+++ b/pages/api/input-adornment.md
@@ -51,5 +51,5 @@ you need to use the following style sheet name: `MuiInputAdornment`.
 
 ## Demos
 
-- [Text Fields](/demos/text-fields)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/input-base.md
+++ b/pages/api/input-base.md
@@ -85,5 +85,5 @@ you need to use the following style sheet name: `MuiInputBase`.
 
 ## Demos
 
-- [Text Fields](/demos/text-fields)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -31,7 +31,7 @@ import InputLabel from '@material-ui/core/InputLabel';
 | <span class="prop-name">shrink</span> | <span class="prop-type">bool |   | If `true`, the label is shrunk. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br> |   | The variant to use. |
 
-Any other properties supplied will be spread to the root element ([FormLabel](/api/form-label)).
+Any other properties supplied will be spread to the root element ([FormLabel](/api/form-label/)).
 
 ## CSS API
 
@@ -60,9 +60,9 @@ you need to use the following style sheet name: `MuiInputLabel`.
 ## Inheritance
 
 The properties of the [FormLabel](/api/form-label) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Text Fields](/demos/text-fields)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -46,7 +46,7 @@ import Input from '@material-ui/core/Input';
 | <span class="prop-name">type</span> | <span class="prop-type">string |   | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br> |   | The input value, required for a controlled component. |
 
-Any other properties supplied will be spread to the root element ([InputBase](/api/input-base)).
+Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 
 ## CSS API
 
@@ -81,9 +81,9 @@ you need to use the following style sheet name: `MuiInput`.
 ## Inheritance
 
 The properties of the [InputBase](/api/input-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Text Fields](/demos/text-fields)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -67,5 +67,5 @@ you need to use the following style sheet name: `MuiLinearProgress`.
 
 ## Demos
 
-- [Progress](/demos/progress)
+- [Progress](/demos/progress/)
 

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -45,5 +45,5 @@ you need to use the following style sheet name: `MuiListItemAvatar`.
 
 ## Demos
 
-- [Lists](/demos/lists)
+- [Lists](/demos/lists/)
 

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -44,5 +44,5 @@ you need to use the following style sheet name: `MuiListItemIcon`.
 
 ## Demos
 
-- [Lists](/demos/lists)
+- [Lists](/demos/lists/)
 

--- a/pages/api/list-item-secondary-action.md
+++ b/pages/api/list-item-secondary-action.md
@@ -44,5 +44,5 @@ you need to use the following style sheet name: `MuiListItemSecondaryAction`.
 
 ## Demos
 
-- [Lists](/demos/lists)
+- [Lists](/demos/lists/)
 

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -55,5 +55,5 @@ you need to use the following style sheet name: `MuiListItemText`.
 
 ## Demos
 
-- [Lists](/demos/lists)
+- [Lists](/demos/lists/)
 

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -63,5 +63,5 @@ you need to use the following style sheet name: `MuiListItem`.
 
 ## Demos
 
-- [Lists](/demos/lists)
+- [Lists](/demos/lists/)
 

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -54,6 +54,6 @@ you need to use the following style sheet name: `MuiListSubheader`.
 
 ## Demos
 
-- [Grid List](/demos/grid-list)
-- [Lists](/demos/lists)
+- [Grid List](/demos/grid-list/)
+- [Lists](/demos/lists/)
 

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -51,5 +51,5 @@ you need to use the following style sheet name: `MuiList`.
 
 ## Demos
 
-- [Lists](/demos/lists)
+- [Lists](/demos/lists/)
 

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -23,7 +23,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br> | <span class="prop-default">'li'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
-Any other properties supplied will be spread to the root element ([ListItem](/api/list-item)).
+Any other properties supplied will be spread to the root element ([ListItem](/api/list-item/)).
 
 ## CSS API
 
@@ -47,10 +47,10 @@ you need to use the following style sheet name: `MuiMenuItem`.
 ## Inheritance
 
 The properties of the [ListItem](/api/list-item) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Autocomplete](/demos/autocomplete)
-- [Menus](/demos/menus)
+- [Autocomplete](/demos/autocomplete/)
+- [Menus](/demos/menus/)
 

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -21,14 +21,14 @@ import MenuList from '@material-ui/core/MenuList';
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node |   | MenuList contents, normally `MenuItem`s. |
 
-Any other properties supplied will be spread to the root element ([List](/api/list)).
+Any other properties supplied will be spread to the root element ([List](/api/list/)).
 
 ## Inheritance
 
 The properties of the [List](/api/list) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Menus](/demos/menus)
+- [Menus](/demos/menus/)
 

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -35,7 +35,7 @@ import Menu from '@material-ui/core/Menu';
 | <span class="prop-name">PopoverClasses</span> | <span class="prop-type">object |   | `classes` property applied to the [`Popover`](/api/popover) element. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">'auto'</span> | The length of the transition in `ms`, or 'auto' |
 
-Any other properties supplied will be spread to the root element ([Popover](/api/popover)).
+Any other properties supplied will be spread to the root element ([Popover](/api/popover/)).
 
 ## CSS API
 
@@ -58,10 +58,10 @@ you need to use the following style sheet name: `MuiMenu`.
 ## Inheritance
 
 The properties of the [Popover](/api/popover) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [App Bar](/demos/app-bar)
-- [Menus](/demos/menus)
+- [App Bar](/demos/app-bar/)
+- [Menus](/demos/menus/)
 

--- a/pages/api/mobile-stepper.md
+++ b/pages/api/mobile-stepper.md
@@ -28,7 +28,7 @@ import MobileStepper from '@material-ui/core/MobileStepper';
 | <span class="prop-name required">steps *</span> | <span class="prop-type">number |   | The total steps. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'dots'&nbsp;&#124;<br>&nbsp;'progress'<br> | <span class="prop-default">'dots'</span> | The variant to use. |
 
-Any other properties supplied will be spread to the root element ([Paper](/api/paper)).
+Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS API
 
@@ -58,9 +58,9 @@ you need to use the following style sheet name: `MuiMobileStepper`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Steppers](/demos/steppers)
+- [Steppers](/demos/steppers/)
 

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -62,5 +62,5 @@ you need to use the following style sheet name: `MuiModal`.
 
 ## Demos
 
-- [Modal](/utils/modal)
+- [Modal](/utils/modal/)
 

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -28,7 +28,7 @@ An alternative to `<Select native />` with a much smaller bundle size footprint.
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br> |   | The input value. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br> |   | The variant to use. |
 
-Any other properties supplied will be spread to the root element ([Input](/api/input)).
+Any other properties supplied will be spread to the root element ([Input](/api/input/)).
 
 ## CSS API
 
@@ -57,9 +57,9 @@ you need to use the following style sheet name: `MuiNativeSelect`.
 ## Inheritance
 
 The properties of the [Input](/api/input) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Selects](/demos/selects)
+- [Selects](/demos/selects/)
 

--- a/pages/api/no-ssr.md
+++ b/pages/api/no-ssr.md
@@ -33,5 +33,5 @@ Any other properties supplied will be spread to the root element (native element
 
 ## Demos
 
-- [No Ssr](/utils/no-ssr)
+- [No Ssr](/utils/no-ssr/)
 

--- a/pages/api/outlined-input.md
+++ b/pages/api/outlined-input.md
@@ -47,7 +47,7 @@ import OutlinedInput from '@material-ui/core/OutlinedInput';
 | <span class="prop-name">type</span> | <span class="prop-type">string |   | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br> |   | The input value, required for a controlled component. |
 
-Any other properties supplied will be spread to the root element ([InputBase](/api/input-base)).
+Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 
 ## CSS API
 
@@ -82,9 +82,9 @@ you need to use the following style sheet name: `MuiOutlinedInput`.
 ## Inheritance
 
 The properties of the [InputBase](/api/input-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Text Fields](/demos/text-fields)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -73,7 +73,7 @@ you need to use the following style sheet name: `MuiPaper`.
 
 ## Demos
 
-- [Autocomplete](/demos/autocomplete)
-- [Cards](/demos/cards)
-- [Paper](/demos/paper)
+- [Autocomplete](/demos/autocomplete/)
+- [Cards](/demos/cards/)
+- [Paper](/demos/paper/)
 

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -45,7 +45,7 @@ import Popover from '@material-ui/core/Popover';
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br> | <span class="prop-default">'auto'</span> | Set to 'auto' to automatically calculate transition time based on height. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object |   | Properties applied to the `Transition` element. |
 
-Any other properties supplied will be spread to the root element ([Modal](/api/modal)).
+Any other properties supplied will be spread to the root element ([Modal](/api/modal/)).
 
 ## CSS API
 
@@ -68,10 +68,10 @@ you need to use the following style sheet name: `MuiPopover`.
 ## Inheritance
 
 The properties of the [Modal](/api/modal) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Menus](/demos/menus)
-- [Popover](/utils/popover)
+- [Menus](/demos/menus/)
+- [Popover](/utils/popover/)
 

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -34,7 +34,7 @@ Any other properties supplied will be spread to the root element (native element
 
 ## Demos
 
-- [Autocomplete](/demos/autocomplete)
-- [Menus](/demos/menus)
-- [Popper](/utils/popper)
+- [Autocomplete](/demos/autocomplete/)
+- [Menus](/demos/menus/)
+- [Popper](/utils/popper/)
 

--- a/pages/api/portal.md
+++ b/pages/api/portal.md
@@ -29,5 +29,5 @@ Any other properties supplied will be spread to the root element (native element
 
 ## Demos
 
-- [Portal](/utils/portal)
+- [Portal](/utils/portal/)
 

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -24,14 +24,14 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 | <span class="prop-name">onChange</span> | <span class="prop-type">func |   | Callback fired when a radio button is selected.<br><br>**Signature:**<br>`function(event: object, value: string) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`.<br>*value:* The `value` of the selected radio button |
 | <span class="prop-name">value</span> | <span class="prop-type">string |   | Value of the selected radio button. |
 
-Any other properties supplied will be spread to the root element ([FormGroup](/api/form-group)).
+Any other properties supplied will be spread to the root element ([FormGroup](/api/form-group/)).
 
 ## Inheritance
 
 The properties of the [FormGroup](/api/form-group) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Selection Controls](/demos/selection-controls)
+- [Selection Controls](/demos/selection-controls/)
 

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -59,5 +59,5 @@ you need to use the following style sheet name: `MuiRadio`.
 
 ## Demos
 
-- [Selection Controls](/demos/selection-controls)
+- [Selection Controls](/demos/selection-controls/)
 

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -38,7 +38,7 @@ import Select from '@material-ui/core/Select';
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br> |   | The input value. This property is required when the `native` property is `false` (default). |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br> |   | The variant to use. |
 
-Any other properties supplied will be spread to the root element ([Input](/api/input)).
+Any other properties supplied will be spread to the root element ([Input](/api/input/)).
 
 ## CSS API
 
@@ -67,9 +67,9 @@ you need to use the following style sheet name: `MuiSelect`.
 ## Inheritance
 
 The properties of the [Input](/api/input) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Selects](/demos/selects)
+- [Selects](/demos/selects/)
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -30,10 +30,10 @@ Any other properties supplied will be spread to the root element ([Transition](h
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Dialogs](/demos/dialogs)
-- [Transitions](/utils/transitions)
+- [Dialogs](/demos/dialogs/)
+- [Transitions](/utils/transitions/)
 

--- a/pages/api/snackbar-content.md
+++ b/pages/api/snackbar-content.md
@@ -23,7 +23,7 @@ import SnackbarContent from '@material-ui/core/SnackbarContent';
 | <span class="prop-name">classes</span> | <span class="prop-type">object |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">message</span> | <span class="prop-type">node |   | The message to display. |
 
-Any other properties supplied will be spread to the root element ([Paper](/api/paper)).
+Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS API
 
@@ -48,9 +48,9 @@ you need to use the following style sheet name: `MuiSnackbarContent`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Snackbars](/demos/snackbars)
+- [Snackbars](/demos/snackbars/)
 

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -70,5 +70,5 @@ you need to use the following style sheet name: `MuiSnackbar`.
 
 ## Demos
 
-- [Snackbars](/demos/snackbars)
+- [Snackbars](/demos/snackbars/)
 

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -24,7 +24,7 @@ import StepButton from '@material-ui/core/StepButton';
 | <span class="prop-name">icon</span> | <span class="prop-type">node |   | The icon displayed by the step label. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node |   | The optional node to display. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -50,9 +50,9 @@ you need to use the following style sheet name: `MuiStepButton`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Steppers](/demos/steppers)
+- [Steppers](/demos/steppers/)
 

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -52,5 +52,5 @@ you need to use the following style sheet name: `MuiStepConnector`.
 
 ## Demos
 
-- [Steppers](/demos/steppers)
+- [Steppers](/demos/steppers/)
 

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -49,5 +49,5 @@ you need to use the following style sheet name: `MuiStepContent`.
 
 ## Demos
 
-- [Steppers](/demos/steppers)
+- [Steppers](/demos/steppers/)
 

--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -51,5 +51,5 @@ you need to use the following style sheet name: `MuiStepIcon`.
 
 ## Demos
 
-- [Steppers](/demos/steppers)
+- [Steppers](/demos/steppers/)
 

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -60,5 +60,5 @@ you need to use the following style sheet name: `MuiStepLabel`.
 
 ## Demos
 
-- [Steppers](/demos/steppers)
+- [Steppers](/demos/steppers/)
 

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -51,5 +51,5 @@ you need to use the following style sheet name: `MuiStep`.
 
 ## Demos
 
-- [Steppers](/demos/steppers)
+- [Steppers](/demos/steppers/)
 

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -27,7 +27,7 @@ import Stepper from '@material-ui/core/Stepper';
 | <span class="prop-name">nonLinear</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If set the `Stepper` will not assist in controlling steps for linear flow. |
 | <span class="prop-name">orientation</span> | <span class="prop-type">enum:&nbsp;'horizontal'&nbsp;&#124;<br>&nbsp;'vertical'<br> | <span class="prop-default">'horizontal'</span> | The stepper orientation (layout flow direction). |
 
-Any other properties supplied will be spread to the root element ([Paper](/api/paper)).
+Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS API
 
@@ -53,9 +53,9 @@ you need to use the following style sheet name: `MuiStepper`.
 ## Inheritance
 
 The properties of the [Paper](/api/paper) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Steppers](/demos/steppers)
+- [Steppers](/demos/steppers/)
 

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -58,5 +58,5 @@ you need to use the following style sheet name: `MuiSvgIcon`.
 
 ## Demos
 
-- [Icons](/style/icons)
+- [Icons](/style/icons/)
 

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -30,14 +30,14 @@ import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 | <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-Any other properties supplied will be spread to the root element ([Drawer](/api/drawer)).
+Any other properties supplied will be spread to the root element ([Drawer](/api/drawer/)).
 
 ## Inheritance
 
 The properties of the [Drawer](/api/drawer) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Drawers](/demos/drawers)
+- [Drawers](/demos/drawers/)
 

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -63,5 +63,5 @@ you need to use the following style sheet name: `MuiSwitch`.
 
 ## Demos
 
-- [Selection Controls](/demos/selection-controls)
+- [Selection Controls](/demos/selection-controls/)
 

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -26,7 +26,7 @@ import Tab from '@material-ui/core/Tab';
 | <span class="prop-name">label</span> | <span class="prop-type">node |   | The label element. |
 | <span class="prop-name">value</span> | <span class="prop-type">any |   | You can provide your own value. Otherwise, we fallback to the child position index. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -60,9 +60,9 @@ you need to use the following style sheet name: `MuiTab`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Tabs](/demos/tabs)
+- [Tabs](/demos/tabs/)
 

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -45,5 +45,5 @@ you need to use the following style sheet name: `MuiTableBody`.
 
 ## Demos
 
-- [Tables](/demos/tables)
+- [Tables](/demos/tables/)
 

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -57,5 +57,5 @@ you need to use the following style sheet name: `MuiTableCell`.
 
 ## Demos
 
-- [Tables](/demos/tables)
+- [Tables](/demos/tables/)
 

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -45,5 +45,5 @@ you need to use the following style sheet name: `MuiTableFooter`.
 
 ## Demos
 
-- [Tables](/demos/tables)
+- [Tables](/demos/tables/)
 

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -45,5 +45,5 @@ you need to use the following style sheet name: `MuiTableHead`.
 
 ## Demos
 
-- [Tables](/demos/tables)
+- [Tables](/demos/tables/)
 

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -34,7 +34,7 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 | <span class="prop-name">rowsPerPageOptions</span> | <span class="prop-type">array | <span class="prop-default">[5, 10, 25]</span> | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |
 | <span class="prop-name">SelectProps</span> | <span class="prop-type">object |   | Properties applied to the rows per page [`Select`](/api/select) element. |
 
-Any other properties supplied will be spread to the root element ([TableCell](/api/table-cell)).
+Any other properties supplied will be spread to the root element ([TableCell](/api/table-cell/)).
 
 ## CSS API
 
@@ -66,9 +66,9 @@ you need to use the following style sheet name: `MuiTablePagination`.
 ## Inheritance
 
 The properties of the [TableCell](/api/table-cell) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Tables](/demos/tables)
+- [Tables](/demos/tables/)
 

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -52,5 +52,5 @@ you need to use the following style sheet name: `MuiTableRow`.
 
 ## Demos
 
-- [Tables](/demos/tables)
+- [Tables](/demos/tables/)
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -26,7 +26,7 @@ A button based label for placing inside `TableCell` for column sorting.
 | <span class="prop-name">hideSortIcon</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | Hide sort icon when active is false. |
 | <span class="prop-name">IconComponent</span> | <span class="prop-type">func | <span class="prop-default">ArrowDownwardIcon</span> | Sort icon to use. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -53,9 +53,9 @@ you need to use the following style sheet name: `MuiTableSortLabel`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Tables](/demos/tables)
+- [Tables](/demos/tables/)
 

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -46,5 +46,5 @@ you need to use the following style sheet name: `MuiTable`.
 
 ## Demos
 
-- [Tables](/demos/tables)
+- [Tables](/demos/tables/)
 

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -64,5 +64,5 @@ you need to use the following style sheet name: `MuiTabs`.
 
 ## Demos
 
-- [Tabs](/demos/tabs)
+- [Tabs](/demos/tabs/)
 

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -72,16 +72,16 @@ For advanced cases, please look at the source of TextField by clicking on the
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br> |   | The value of the `Input` element, required for a controlled component. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br> | <span class="prop-default">'standard'</span> | The variant to use. |
 
-Any other properties supplied will be spread to the root element ([FormControl](/api/form-control)).
+Any other properties supplied will be spread to the root element ([FormControl](/api/form-control/)).
 
 ## Inheritance
 
 The properties of the [FormControl](/api/form-control) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Autocomplete](/demos/autocomplete)
-- [Pickers](/demos/pickers)
-- [Text Fields](/demos/text-fields)
+- [Autocomplete](/demos/autocomplete/)
+- [Pickers](/demos/pickers/)
+- [Text Fields](/demos/text-fields/)
 

--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -49,5 +49,5 @@ you need to use the following style sheet name: `MuiToolbar`.
 
 ## Demos
 
-- [App Bar](/demos/app-bar)
+- [App Bar](/demos/app-bar/)
 

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -66,5 +66,5 @@ you need to use the following style sheet name: `MuiTooltip`.
 
 ## Demos
 
-- [Tooltips](/demos/tooltips)
+- [Tooltips](/demos/tooltips/)
 

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -77,5 +77,5 @@ you need to use the following style sheet name: `MuiTypography`.
 
 ## Demos
 
-- [Typography](/style/typography)
+- [Typography](/style/typography/)
 

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -30,10 +30,10 @@ Any other properties supplied will be spread to the root element ([Transition](h
 ## Inheritance
 
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Buttons](/demos/buttons)
-- [Transitions](/utils/transitions)
+- [Buttons](/demos/buttons/)
+- [Transitions](/utils/transitions/)
 

--- a/pages/lab/api/slider.md
+++ b/pages/lab/api/slider.md
@@ -66,5 +66,5 @@ you need to use the following style sheet name: `MuiSlider`.
 
 ## Demos
 
-- [Slider](/lab/slider)
+- [Slider](/lab/slider/)
 

--- a/pages/lab/api/speed-dial-action.md
+++ b/pages/lab/api/speed-dial-action.md
@@ -51,5 +51,5 @@ you need to use the following style sheet name: `MuiSpeedDialAction`.
 
 ## Demos
 
-- [Speed Dial](/lab/speed-dial)
+- [Speed Dial](/lab/speed-dial/)
 

--- a/pages/lab/api/speed-dial-icon.md
+++ b/pages/lab/api/speed-dial-icon.md
@@ -50,5 +50,5 @@ you need to use the following style sheet name: `MuiSpeedDialIcon`.
 
 ## Demos
 
-- [Speed Dial](/lab/speed-dial)
+- [Speed Dial](/lab/speed-dial/)
 

--- a/pages/lab/api/speed-dial.md
+++ b/pages/lab/api/speed-dial.md
@@ -62,5 +62,5 @@ you need to use the following style sheet name: `MuiSpeedDial`.
 
 ## Demos
 
-- [Speed Dial](/lab/speed-dial)
+- [Speed Dial](/lab/speed-dial/)
 

--- a/pages/lab/api/toggle-button-group.md
+++ b/pages/lab/api/toggle-button-group.md
@@ -49,5 +49,5 @@ you need to use the following style sheet name: `MuiToggleButtonGroup`.
 
 ## Demos
 
-- [Toggle Button](/lab/toggle-button)
+- [Toggle Button](/lab/toggle-button/)
 

--- a/pages/lab/api/toggle-button.md
+++ b/pages/lab/api/toggle-button.md
@@ -27,7 +27,7 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 | <span class="prop-name">selected</span> | <span class="prop-type">bool |   | If `true`, the button will be rendered in an active state. |
 | <span class="prop-name required">value *</span> | <span class="prop-type">any |   | The value to associate with the button when selected in a ToggleButtonGroup. |
 
-Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base)).
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS API
 
@@ -53,9 +53,9 @@ you need to use the following style sheet name: `MuiToggleButton`.
 ## Inheritance
 
 The properties of the [ButtonBase](/api/button-base) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api#spread).
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 
-- [Toggle Button](/lab/toggle-button)
+- [Toggle Button](/lab/toggle-button/)
 


### PR DESCRIPTION
Solve the 3xx and 4xx. It's important to get as much SEO "juice" as possible:

![capture d ecran 2018-09-30 a 12 04 18](https://user-images.githubusercontent.com/3165635/46256293-00fe8f00-c4a9-11e8-953e-2368f7925f6c.png)

- The 3xx issues come from the [`_rewriteUrlForNextExport`](https://github.com/zeit/next.js/search?q=_rewriteUrlForNextExport&unscoped_q=_rewriteUrlForNextExport) method not being applied. 
- The 4xx issues come from a react router demo.