### PR TITLE
[TextField] Fix ClassKey inference for outlined and filled variants

### DIFF
--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -2,11 +2,13 @@ import * as React from 'react';
 import { StandardProps, PropTypes } from '..';
 import { FormControlClassKey, FormControlProps } from '../FormControl';
 import { FormHelperTextProps } from '../FormHelperText';
-import { InputProps } from '../Input';
+import { InputProps as StandardInputProps } from '../Input';
+import { FilledInputProps } from '../FilledInput';
+import { OutlinedInputProps } from '../OutlinedInput';
 import { InputLabelProps } from '../InputLabel';
 import { SelectProps } from '../Select';
 
-export interface TextFieldProps
+export interface BaseTextFieldProps
   extends StandardProps<FormControlProps, TextFieldClassKey, 'onChange' | 'defaultValue'> {
   autoComplete?: string;
   autoFocus?: boolean;
@@ -19,8 +21,6 @@ export interface TextFieldProps
   helperText?: React.ReactNode;
   id?: string;
   InputLabelProps?: Partial<InputLabelProps>;
-  InputProps?: Partial<InputProps>;
-  inputProps?: InputProps['inputProps'];
   inputRef?: React.Ref<any> | React.RefObject<any>;
   label?: React.ReactNode;
   margin?: PropTypes.Margin;
@@ -35,8 +35,27 @@ export interface TextFieldProps
   SelectProps?: Partial<SelectProps>;
   type?: string;
   value?: Array<string | number | boolean> | string | number | boolean;
-  variant?: 'standard' | 'outlined' | 'filled';
 }
+
+export interface StandardTextFieldProps extends BaseTextFieldProps {
+  variant?: 'standard';
+  InputProps?: Partial<StandardInputProps>;
+  inputProps?: StandardInputProps['inputProps'];
+}
+
+export interface FilledTextFieldProps extends BaseTextFieldProps {
+  variant: 'filled';
+  InputProps?: Partial<FilledInputProps>;
+  inputProps?: FilledInputProps['inputProps'];
+}
+
+export interface OutlinedTextFieldProps extends BaseTextFieldProps {
+  variant: 'outlined';
+  InputProps?: Partial<OutlinedInputProps>;
+  inputProps?: OutlinedInputProps['inputProps'];
+}
+
+export type TextFieldProps = StandardTextFieldProps | FilledTextFieldProps | OutlinedTextFieldProps;
 
 export type TextFieldClassKey = FormControlClassKey;
 

--- a/packages/material-ui/src/TextField/TextField.spec.tsx
+++ b/packages/material-ui/src/TextField/TextField.spec.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import TextField from '@material-ui/core/TextField';
+
+{
+  // https://github.com/mui-org/material-ui/issues/12999
+  const defaulted = (
+    <TextField InputProps={{ classes: { inputTypeSearch: 'search-input', input: 'input' } }} />
+  );
+  const standard = (
+    <TextField variant="standard" InputProps={{ classes: { inputTypeSearch: 'search-input' } }} />
+  );
+  const standardOutlinedClassname = (
+    <TextField
+      variant="standard"
+      InputProps={{
+        // notchedOutline is only used with variant "outlined"
+        classes: { inputTypeSearch: 'search-input', notchedOutline: 'notched-outline' }, // $ExpectError
+      }}
+    />
+  );
+
+  const filled = (
+    <TextField
+      variant="filled"
+      InputProps={{ classes: { inputAdornedStart: 'adorned-start' } }}
+      onChange={event => {
+        // type inference for event still works?
+        const value = event.target.value; // $ExpectType string
+      }}
+    />
+  );
+
+  const outlined = (
+    <TextField variant="outlined" InputProps={{ classes: { notchedOutline: 'notched-outline' } }} />
+  );
+}


### PR DESCRIPTION
Closes #12999

Good thing this was achievable without generics. Type inference for callbacks still works with discriminated unions it seems.

As originally mentioned in #12637 I added a typescript test file for TextField only. `components.spec.tsx` is becoming to big. At some point this should be split up completely.