### PR TITLE
[typescript] Fix onChange event types to React.ChangeEvent<HTMLInputElement>

### DIFF
--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
@@ -13,7 +13,7 @@ export interface FormControlLabelProps
   inputRef?: React.Ref<any>;
   label: React.ReactNode;
   name?: string;
-  onChange?: (event: React.ChangeEvent<{}>, checked: boolean) => void;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
   labelPlacement?: 'end' | 'start';
   value?: string;
 }

--- a/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
@@ -5,7 +5,7 @@ import { FormGroupProps, FormGroupClassKey } from '../FormGroup';
 export interface RadioGroupProps
   extends StandardProps<FormGroupProps, RadioGroupClassKey, 'onChange'> {
   name?: string;
-  onChange?: (event: React.ChangeEvent<{}>, value: string) => void;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>, value: string) => void;
   value?: string;
 }
 


### PR DESCRIPTION
Fix the `onChange` prop of `RadioGroup` and `FormControlLabel`. The correct type for the `event` parameter is `React.ChangeEvent<HTMLInputElement>` (it's the type used in `Radio`, `Checkbox`, etc). This way, we can access `event.target.value`. 

Resolves #13004 
