### PR TITLE
[ListItemIcon] Add wrapper <div> element to children

### DIFF
--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
@@ -1,6 +1,7 @@
 import { StandardProps } from '..';
 
-export interface ListItemIconProps extends StandardProps<{}, ListItemIconClassKey> {
+export interface ListItemIconProps
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ListItemIconClassKey> {
   children: React.ReactElement<any>;
 }
 

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -9,6 +9,7 @@ export const styles = theme => ({
     marginRight: 16,
     color: theme.palette.action.active,
     flexShrink: 0,
+    display: 'flex',
   },
 });
 

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -18,10 +18,11 @@ export const styles = theme => ({
 function ListItemIcon(props) {
   const { children, classes, className: classNameProp, ...other } = props;
 
-  return React.cloneElement(children, {
-    className: classNames(classes.root, classNameProp, children.props.className),
-    ...other,
-  });
+  return (
+    <div className={classNames(classes.root, classNameProp)} {...other}>
+      {children}
+    </div>
+  );
 }
 
 ListItemIcon.propTypes = {

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -9,7 +9,7 @@ export const styles = theme => ({
     marginRight: 16,
     color: theme.palette.action.active,
     flexShrink: 0,
-    display: 'flex',
+    display: 'inline-flex',
   },
 });
 

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -16,23 +16,25 @@ describe('<ListItemIcon />', () => {
     );
   });
 
-  it('should render a span', () => {
+  it('should render a span inside a div', () => {
     const wrapper = shallow(
       <ListItemIcon>
         <span />
       </ListItemIcon>,
     );
-    assert.strictEqual(wrapper.name(), 'span');
+    assert.strictEqual(wrapper.name(), 'div');
+    assert.strictEqual(wrapper.children().name(), 'span');
   });
 
-  it('should render with the user and root classes', () => {
+  it('should render a div with the user and root classes, but not the children classes', () => {
     const wrapper = shallow(
       <ListItemIcon className="foo">
         <span className="bar" />
       </ListItemIcon>,
     );
     assert.strictEqual(wrapper.hasClass('foo'), true);
-    assert.strictEqual(wrapper.hasClass('bar'), true);
+    assert.strictEqual(wrapper.hasClass('bar'), false);
+    assert.strictEqual(wrapper.children().hasClass('bar'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 });


### PR DESCRIPTION
Closes #13063

This PR changes the implementation of  the `ListItemIcon` component from using `React.cloneElement` to simply wrapping children in a `<div>` that contains the root classes of the component and user added classes.

### Warning

The newly introduce div element might change the UI is rare edge cases. Make sure to check that out when upgrading.