### PR TITLE
[docs] Use typography v1 in examples

### DIFF
--- a/docs/src/pages/page-layout-examples/PageLayoutExamples.js
+++ b/docs/src/pages/page-layout-examples/PageLayoutExamples.js
@@ -104,7 +104,7 @@ function PageLayoutExamples(props) {
               target="_blank"
             />
             <CardContent className={classes.cardContent}>
-              <Typography gutterBottom variant="h5" align="left" component="h2">
+              <Typography gutterBottom variant="headline" align="left" component="h2">
                 {theme.name}
               </Typography>
               <Typography component="p">{theme.description}</Typography>

--- a/docs/src/pages/page-layout-examples/album/Album.js
+++ b/docs/src/pages/page-layout-examples/album/Album.js
@@ -73,7 +73,7 @@ function Album(props) {
       <AppBar position="static" className={classes.appBar}>
         <Toolbar>
           <CameraIcon className={classes.icon} />
-          <Typography variant="h6" color="inherit" noWrap>
+          <Typography variant="title" color="inherit" noWrap>
             Album layout
           </Typography>
         </Toolbar>
@@ -82,10 +82,10 @@ function Album(props) {
         {/* Hero unit */}
         <div className={classes.heroUnit}>
           <div className={classes.heroContent}>
-            <Typography variant="h2" align="center" color="textPrimary" gutterBottom>
+            <Typography variant="display3" align="center" color="textPrimary" gutterBottom>
               Album layout
             </Typography>
-            <Typography variant="h6" align="center" color="textSecondary" paragraph>
+            <Typography variant="title" align="center" color="textSecondary" paragraph>
               Something short and leading about the collection below—its contents, the creator, etc.
               Make it short and sweet, but not too short so folks don&apos;t simply skip over it
               entirely.
@@ -118,7 +118,7 @@ function Album(props) {
                     title="Image title"
                   />
                   <CardContent className={classes.cardContent}>
-                    <Typography gutterBottom variant="h5" component="h2">
+                    <Typography gutterBottom variant="headline" component="h2">
                       Heading
                     </Typography>
                     <Typography>
@@ -141,10 +141,10 @@ function Album(props) {
       </main>
       {/* Footer */}
       <footer className={classes.footer}>
-        <Typography variant="h6" align="center" gutterBottom>
+        <Typography variant="title" align="center" gutterBottom>
           Footer
         </Typography>
-        <Typography variant="subtitle1" align="center" color="textSecondary" component="p">
+        <Typography variant="subheading" align="center" color="textSecondary" component="p">
           Something here to give the footer a purpose!
         </Typography>
       </footer>

--- a/docs/src/pages/page-layout-examples/blog/Blog.js
+++ b/docs/src/pages/page-layout-examples/blog/Blog.js
@@ -137,7 +137,7 @@ function Blog(props) {
           <Button size="small">Subscribe</Button>
           <Typography
             component="h2"
-            variant="h5"
+            variant="headline"
             color="inherit"
             align="center"
             noWrap
@@ -165,10 +165,10 @@ function Blog(props) {
             <Grid container>
               <Grid item md={6}>
                 <div className={classes.mainFeaturedPostContent}>
-                  <Typography variant="h3" color="inherit" gutterBottom>
+                  <Typography variant="display2" color="inherit" gutterBottom>
                     Title of a longer featured blog post
                   </Typography>
-                  <Typography variant="h5" color="inherit" paragraph>
+                  <Typography variant="headline" color="inherit" paragraph>
                     Multiple lines of text that form the lede, informing new readers quickly and
                     efficiently about what&apos;s most interesting in this post&apos;s contents…
                   </Typography>
@@ -184,16 +184,16 @@ function Blog(props) {
                 <Card className={classes.card}>
                   <div className={classes.cardDetails}>
                     <CardContent>
-                      <Typography component="h2" variant="h5">
+                      <Typography component="h2" variant="headline">
                         {post.title}
                       </Typography>
-                      <Typography variant="subtitle1" color="textSecondary">
+                      <Typography variant="subheading" color="textSecondary">
                         {post.date}
                       </Typography>
-                      <Typography variant="subtitle1" paragraph>
+                      <Typography variant="subheading" paragraph>
                         {post.description}
                       </Typography>
-                      <Typography variant="subtitle1" color="primary">
+                      <Typography variant="subheading" color="primary">
                         Continue reading...
                       </Typography>
                     </CardContent>
@@ -213,7 +213,7 @@ function Blog(props) {
           <Grid container spacing={40} className={classes.mainGrid}>
             {/* Main content */}
             <Grid item xs={12} md={8}>
-              <Typography variant="h6" gutterBottom>
+              <Typography variant="title" gutterBottom>
                 From the Firehose
               </Typography>
               <Divider />
@@ -227,7 +227,7 @@ function Blog(props) {
             {/* Sidebar */}
             <Grid item xs={12} md={4}>
               <Paper elevation={0} className={classes.sidebarAboutBox}>
-                <Typography variant="h6" gutterBottom>
+                <Typography variant="title" gutterBottom>
                   About
                 </Typography>
                 <Typography>
@@ -235,13 +235,13 @@ function Blog(props) {
                   amet fermentum. Aenean lacinia bibendum nulla sed consectetur.
                 </Typography>
               </Paper>
-              <Typography variant="h6" gutterBottom className={classes.sidebarSection}>
+              <Typography variant="title" gutterBottom className={classes.sidebarSection}>
                 Archives
               </Typography>
               {archives.map(archive => (
                 <Typography key={archive}>{archive}</Typography>
               ))}
-              <Typography variant="h6" gutterBottom className={classes.sidebarSection}>
+              <Typography variant="title" gutterBottom className={classes.sidebarSection}>
                 Social
               </Typography>
               {social.map(network => (
@@ -254,10 +254,10 @@ function Blog(props) {
       </div>
       {/* Footer */}
       <footer className={classes.footer}>
-        <Typography variant="h6" align="center" gutterBottom>
+        <Typography variant="title" align="center" gutterBottom>
           Footer
         </Typography>
-        <Typography variant="subtitle1" align="center" color="textSecondary" component="p">
+        <Typography variant="subheading" align="center" color="textSecondary" component="p">
           Something here to give the footer a purpose!
         </Typography>
       </footer>

--- a/docs/src/pages/page-layout-examples/blog/Markdown.js
+++ b/docs/src/pages/page-layout-examples/blog/Markdown.js
@@ -17,20 +17,20 @@ const renderers = {
 
     switch (level) {
       case 1:
-        variant = 'h4';
+        variant = 'display1';
         break;
       case 2:
-        variant = 'h6';
+        variant = 'title';
         break;
       case 3:
-        variant = 'subtitle1';
+        variant = 'subheading';
         break;
       case 4:
         variant = 'caption';
         paragraph = true;
         break;
       default:
-        variant = 'body1';
+        variant = 'body';
         break;
     }
 

--- a/docs/src/pages/page-layout-examples/checkout/AddressForm.js
+++ b/docs/src/pages/page-layout-examples/checkout/AddressForm.js
@@ -8,7 +8,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 function AddressForm() {
   return (
     <React.Fragment>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="title" gutterBottom>
         Shipping address
       </Typography>
       <Grid container spacing={24}>

--- a/docs/src/pages/page-layout-examples/checkout/Checkout.js
+++ b/docs/src/pages/page-layout-examples/checkout/Checkout.js
@@ -98,14 +98,14 @@ class Checkout extends React.Component {
         <CssBaseline />
         <AppBar position="absolute" color="default" className={classes.appBar}>
           <Toolbar>
-            <Typography variant="h6" color="inherit" noWrap>
+            <Typography variant="title" color="inherit" noWrap>
               Company name
             </Typography>
           </Toolbar>
         </AppBar>
         <main className={classes.layout}>
           <Paper className={classes.paper}>
-            <Typography variant="h4" align="center">
+            <Typography variant="display1" align="center">
               Checkout
             </Typography>
             <Stepper activeStep={activeStep} className={classes.stepper}>
@@ -118,10 +118,10 @@ class Checkout extends React.Component {
             <React.Fragment>
               {activeStep === steps.length ? (
                 <React.Fragment>
-                  <Typography variant="h5" gutterBottom>
+                  <Typography variant="headline" gutterBottom>
                     Thank you for your order.
                   </Typography>
-                  <Typography variant="subtitle1">
+                  <Typography variant="subheading">
                     Your order number is #2001539. We have emailed your order confirmation, and will
                     send you an update when your order has shipped.
                   </Typography>

--- a/docs/src/pages/page-layout-examples/checkout/PaymentForm.js
+++ b/docs/src/pages/page-layout-examples/checkout/PaymentForm.js
@@ -8,7 +8,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 function PaymentForm() {
   return (
     <React.Fragment>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="title" gutterBottom>
         Payment method
       </Typography>
       <Grid container spacing={24}>

--- a/docs/src/pages/page-layout-examples/checkout/Review.js
+++ b/docs/src/pages/page-layout-examples/checkout/Review.js
@@ -38,7 +38,7 @@ function Review(props) {
   const { classes } = props;
   return (
     <React.Fragment>
-      <Typography variant="h6" gutterBottom>
+      <Typography variant="title" gutterBottom>
         Order summary
       </Typography>
       <List disablePadding>
@@ -50,21 +50,21 @@ function Review(props) {
         ))}
         <ListItem className={classes.listItem}>
           <ListItemText primary="Total" />
-          <Typography variant="subtitle1" className={classes.total}>
+          <Typography variant="subheading" className={classes.total}>
             $34.06
           </Typography>
         </ListItem>
       </List>
       <Grid container spacing={16}>
         <Grid item xs={12} sm={6}>
-          <Typography variant="h6" gutterBottom className={classes.title}>
+          <Typography variant="title" gutterBottom className={classes.title}>
             Shipping
           </Typography>
           <Typography gutterBottom>John Smith</Typography>
           <Typography gutterBottom>{addresses.join(', ')}</Typography>
         </Grid>
         <Grid item container direction="column" xs={12} sm={6}>
-          <Typography variant="h6" gutterBottom className={classes.title}>
+          <Typography variant="title" gutterBottom className={classes.title}>
             Payment details
           </Typography>
           <Grid container>

--- a/docs/src/pages/page-layout-examples/dashboard/Dashboard.js
+++ b/docs/src/pages/page-layout-examples/dashboard/Dashboard.js
@@ -92,9 +92,6 @@ const styles = theme => ({
   tableContainer: {
     height: 320,
   },
-  h5: {
-    marginBottom: theme.spacing.unit * 2,
-  },
 });
 
 class Dashboard extends React.Component {
@@ -135,7 +132,7 @@ class Dashboard extends React.Component {
               </IconButton>
               <Typography
                 component="h1"
-                variant="h6"
+                variant="title"
                 color="inherit"
                 noWrap
                 className={classes.title}
@@ -168,13 +165,13 @@ class Dashboard extends React.Component {
           </Drawer>
           <main className={classes.content}>
             <div className={classes.appBarSpacer} />
-            <Typography variant="h4" gutterBottom component="h2">
+            <Typography variant="display1" gutterBottom component="h2">
               Orders
             </Typography>
             <Typography component="div" className={classes.chartContainer}>
               <SimpleLineChart />
             </Typography>
-            <Typography variant="h4" gutterBottom component="h2">
+            <Typography variant="display1" gutterBottom component="h2">
               Products
             </Typography>
             <div className={classes.tableContainer}>

--- a/docs/src/pages/page-layout-examples/pricing/Pricing.js
+++ b/docs/src/pages/page-layout-examples/pricing/Pricing.js
@@ -123,7 +123,7 @@ function Pricing(props) {
       <CssBaseline />
       <AppBar position="static" color="default" className={classes.appBar}>
         <Toolbar>
-          <Typography variant="h6" color="inherit" noWrap className={classes.toolbarTitle}>
+          <Typography variant="title" color="inherit" noWrap className={classes.toolbarTitle}>
             Company name
           </Typography>
           <Button>Features</Button>
@@ -137,10 +137,10 @@ function Pricing(props) {
       <main className={classes.layout}>
         {/* Hero unit */}
         <div className={classes.heroContent}>
-          <Typography variant="h2" align="center" color="textPrimary" gutterBottom>
+          <Typography variant="display3" align="center" color="textPrimary" gutterBottom>
             Pricing
           </Typography>
-          <Typography variant="h6" align="center" color="textSecondary" component="p">
+          <Typography variant="title" align="center" color="textSecondary" component="p">
             Quickly build an effective pricing table for your potential customers with this layout.
             It&apos;s built with default Material-UI components with little customization.
           </Typography>
@@ -161,15 +161,15 @@ function Pricing(props) {
                 />
                 <CardContent>
                   <div className={classes.cardPricing}>
-                    <Typography component="h2" variant="h3" color="textPrimary">
+                    <Typography component="h2" variant="display2" color="textPrimary">
                       ${tier.price}
                     </Typography>
-                    <Typography variant="h6" color="textSecondary">
+                    <Typography variant="title" color="textSecondary">
                       /mo
                     </Typography>
                   </div>
                   {tier.description.map(line => (
-                    <Typography variant="subtitle1" align="center" key={line}>
+                    <Typography variant="subheading" align="center" key={line}>
                       {line}
                     </Typography>
                   ))}
@@ -189,11 +189,11 @@ function Pricing(props) {
         <Grid container spacing={32} justify="space-evenly">
           {footers.map(footer => (
             <Grid item xs key={footer.title}>
-              <Typography variant="h6" color="textPrimary" gutterBottom>
+              <Typography variant="title" color="textPrimary" gutterBottom>
                 {footer.title}
               </Typography>
               {footer.description.map(item => (
-                <Typography key={item} variant="subtitle1" color="textSecondary">
+                <Typography key={item} variant="subheading" color="textSecondary">
                   {item}
                 </Typography>
               ))}

--- a/docs/src/pages/page-layout-examples/sign-in/SignIn.js
+++ b/docs/src/pages/page-layout-examples/sign-in/SignIn.js
@@ -56,7 +56,7 @@ function SignIn(props) {
           <Avatar className={classes.avatar}>
             <LockIcon />
           </Avatar>
-          <Typography variant="h5">Sign in</Typography>
+          <Typography variant="headline">Sign in</Typography>
           <form className={classes.form}>
             <FormControl margin="normal" required fullWidth>
               <InputLabel htmlFor="email">Email Address</InputLabel>

--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -91,10 +91,10 @@ class Index extends React.Component {
               </Button>
             </DialogActions>
           </Dialog>
-          <Typography variant="h4" gutterBottom>
+          <Typography variant="display1" gutterBottom>
             Material-UI
           </Typography>
-          <Typography variant="subtitle1" gutterBottom>
+          <Typography variant="subheading" gutterBottom>
             example project
           </Typography>
           <Button variant="raised" color="secondary" onClick={this.handleClick}>

--- a/examples/create-react-app-with-flow/src/pages/index.js
+++ b/examples/create-react-app-with-flow/src/pages/index.js
@@ -61,10 +61,10 @@ class Index extends React.Component<ProvidedProps & Props, State> {
             </Button>
           </DialogActions>
         </Dialog>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="display1" gutterBottom>
           Material-UI
         </Typography>
-        <Typography variant="subtitle1" gutterBottom>
+        <Typography variant="subheading" gutterBottom>
           example project
         </Typography>
         <Button variant="contained" color="secondary" onClick={this.handleClick}>

--- a/examples/create-react-app-with-jss/src/pages/index.js
+++ b/examples/create-react-app-with-jss/src/pages/index.js
@@ -51,10 +51,10 @@ class Index extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="display1" gutterBottom>
           Material-UI
         </Typography>
-        <Typography variant="subtitle1" gutterBottom>
+        <Typography variant="subheading" gutterBottom>
           example project
         </Typography>
         <Button variant="contained" color="secondary" onClick={this.handleClick}>

--- a/examples/create-react-app-with-typescript/src/pages/index.tsx
+++ b/examples/create-react-app-with-typescript/src/pages/index.tsx
@@ -54,10 +54,10 @@ class Index extends React.Component<WithStyles<typeof styles>, State> {
             </Button>
           </DialogActions>
         </Dialog>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="display1" gutterBottom>
           Material-UI
         </Typography>
-        <Typography variant="subtitle1" gutterBottom>
+        <Typography variant="subheading" gutterBottom>
           example project
         </Typography>
         <Button variant="raised" color="secondary" onClick={this.handleClick}>

--- a/examples/create-react-app/src/pages/index.js
+++ b/examples/create-react-app/src/pages/index.js
@@ -51,10 +51,10 @@ class Index extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="display1" gutterBottom>
           Material-UI
         </Typography>
-        <Typography variant="subtitle1" gutterBottom>
+        <Typography variant="subheading" gutterBottom>
           example project
         </Typography>
         <Button variant="contained" color="secondary" onClick={this.handleClick}>

--- a/examples/gatsby/src/pages/index.js
+++ b/examples/gatsby/src/pages/index.js
@@ -54,10 +54,10 @@ class Index extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="display1" gutterBottom>
           Material-UI
         </Typography>
-        <Typography variant="subtitle1" gutterBottom>
+        <Typography variant="subheading" gutterBottom>
           example project
         </Typography>
         <Typography gutterBottom>

--- a/examples/nextjs/pages/about.js
+++ b/examples/nextjs/pages/about.js
@@ -19,10 +19,10 @@ function About(props) {
 
   return (
     <div className={classes.root}>
-      <Typography variant="h4" gutterBottom>
+      <Typography variant="display1" gutterBottom>
         Material-UI
       </Typography>
-      <Typography variant="subtitle1" gutterBottom>
+      <Typography variant="subheading" gutterBottom>
         about page
       </Typography>
       <Typography gutterBottom>

--- a/examples/nextjs/pages/index.js
+++ b/examples/nextjs/pages/index.js
@@ -53,10 +53,10 @@ class Index extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="display1" gutterBottom>
           Material-UI
         </Typography>
-        <Typography variant="subtitle1" gutterBottom>
+        <Typography variant="subheading" gutterBottom>
           example project
         </Typography>
         <Typography gutterBottom>

--- a/examples/parcel/src/pages/index.js
+++ b/examples/parcel/src/pages/index.js
@@ -51,10 +51,10 @@ class Index extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="display1" gutterBottom>
           Material-UI
         </Typography>
-        <Typography variant="subtitle1" gutterBottom>
+        <Typography variant="subheading" gutterBottom>
           example project
         </Typography>
         <Button variant="contained" color="secondary" onClick={this.handleClick}>

--- a/examples/ssr/App.js
+++ b/examples/ssr/App.js
@@ -50,10 +50,10 @@ class App extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-        <Typography variant="h4" gutterBottom>
+        <Typography variant="display1" gutterBottom>
           Material-UI
         </Typography>
-        <Typography variant="subtitle1" gutterBottom>
+        <Typography variant="subheading" gutterBottom>
           example project
         </Typography>
         <Button variant="contained" color="secondary" onClick={this.handleClick}>


### PR DESCRIPTION
Wrong parameter cause this error:

Warning: Failed prop type: Invalid prop `variant` of value `h5` supplied to `Typography`, expected one of ["display4","display3","display2","display1","headline","title","subheading","body2","body1","caption","button","srOnly","inherit"].