### PR TITLE
[Stepper] Expose connector index to <StepConnector />

### DIFF
--- a/docs/src/pages/demos/steppers/SwipeableTextMobileStepper.js
+++ b/docs/src/pages/demos/steppers/SwipeableTextMobileStepper.js
@@ -87,7 +87,7 @@ class SwipeableTextMobileStepper extends React.Component {
     return (
       <div className={classes.root}>
         <Paper square elevation={0} className={classes.header}>
-          <Typography>{tutorialSteps[activeStep].label}</Typography>
+          <Typography variant="body2">{tutorialSteps[activeStep].label}</Typography>
         </Paper>
         <SwipeableViews
           axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}
@@ -96,9 +96,9 @@ class SwipeableTextMobileStepper extends React.Component {
           enableMouseEvents
         >
           {tutorialSteps.map((step, index) => (
-            <div>
+            <div key={step.label}>
               {Math.abs(activeStep - index) <= 2 ? (
-                <img key={step.label} className={classes.img} src={step.imgPath} alt={step.label} />
+                <img className={classes.img} src={step.imgPath} alt={step.label} />
               ) : null}
             </div>
           ))}

--- a/docs/src/pages/demos/steppers/TextMobileStepper.js
+++ b/docs/src/pages/demos/steppers/TextMobileStepper.js
@@ -82,7 +82,7 @@ class TextMobileStepper extends React.Component {
     return (
       <div className={classes.root}>
         <Paper square elevation={0} className={classes.header}>
-          <Typography>{tutorialSteps[activeStep].label}</Typography>
+          <Typography variant="body2">{tutorialSteps[activeStep].label}</Typography>
         </Paper>
         <img
           className={classes.img}

--- a/packages/material-ui/src/StepConnector/StepConnector.d.ts
+++ b/packages/material-ui/src/StepConnector/StepConnector.d.ts
@@ -10,6 +10,7 @@ export interface StepConnectorProps
   alternativeLabel?: boolean;
   completed?: boolean;
   disabled?: boolean;
+  index?: number;
   orientation?: Orientation;
 }
 

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -113,6 +113,10 @@ StepConnector.propTypes = {
   /**
    * @ignore
    */
+  index: PropTypes.number,
+  /**
+   * @ignore
+   */
   orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 };
 

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -54,6 +54,7 @@ function StepConnector(props) {
     className: classNameProp,
     completed,
     disabled,
+    index,
     orientation,
     ...other
   } = props;

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -83,6 +83,7 @@ function Stepper(props) {
         index > 0 &&
         React.cloneElement(connector, {
           key: index, // eslint-disable-line react/no-array-index-key
+          index,
           ...state,
         }),
       React.cloneElement(step, { ...controlProps, ...step.props, ...state }),


### PR DESCRIPTION
When defining the `connector` prop for a `<Stepper />`, it's helpful for that component to know about its index relative to the steps. For instance, if I want the connector between two completed steps to be green.

e.g.:

```jsx
class CustomConnector extends React.Component {
  render() {
    const { completedSteps, index } = this.props;
    const classes = classNames({
      completed: completedSteps.includes(index) && completedSteps.includes(index - 1)
    });
    return <StepConnector classNames={classes} />;
  }
}

class MyStepper extends React.Component {
  render() {
    return <Stepper connector={<CustomConnector completedSteps={[0, 1, 2]}/>} />;
  }
}
```

This PR passes along the appropriate index of the connector to the `<StepConnector />` to make this possible.