### PR TITLE
[ci] Move coverage test to own job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,7 +99,7 @@ jobs:
             fi
       - run:
           name: Coverage
-          command: bash <(curl -s https://codecov.io/bash)
+          command: bash <(curl -s https://codecov.io/bash) -Z
   test_material-ui-x:
     <<: *defaults
     steps:


### PR DESCRIPTION
The coverage report could previously fail silently which could leave codecov in an infinite pending state. If the report fails now CI will also fail. ~Since this didn't test anything that test:unit didn't test already I moved this to another job so that it doesn't block other jobs because of a simple network error.~

See codecov/codecov-bash#134