### PR TITLE
[TextField] Fix of Uncaught TypeError: r.inputRef.focus is not a function

### DIFF
--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -147,6 +147,9 @@ class SelectInput extends React.Component {
       node: ref,
       // By pass the native input as we expose a rich object (array).
       value: this.props.value,
+      focus: () => {
+        this.displayRef.focus();
+      },
     };
 
     setRef(inputRef, nodeProxy);

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -354,5 +354,11 @@ describe('<SelectInput />', () => {
       mount(<SelectInput {...defaultProps} inputRef={ref} />);
       assert.strictEqual(ref.current.node.tagName, 'INPUT');
     });
+
+    it('should be able to return the input focus proxy function', () => {
+      const ref = React.createRef();
+      mount(<SelectInput {...defaultProps} inputRef={ref} />);
+      assert.strictEqual(typeof ref.current.focus, 'function');
+    });
   });
 });

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -360,5 +360,13 @@ describe('<SelectInput />', () => {
       mount(<SelectInput {...defaultProps} inputRef={ref} />);
       assert.strictEqual(typeof ref.current.focus, 'function');
     });
+
+    it('should be able to hit proxy function', () => {
+      const ref = React.createRef();
+      const onFocus = spy();
+      mount(<SelectInput {...defaultProps} inputRef={ref} onFocus={onFocus} />);
+      ref.current.focus();
+      assert.isOk(onFocus.called);
+    });
   });
 });

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -366,7 +366,7 @@ describe('<SelectInput />', () => {
       const onFocus = spy();
       mount(<SelectInput {...defaultProps} inputRef={ref} onFocus={onFocus} />);
       ref.current.focus();
-      assert.isOk(onFocus.called);
+      assert.strictEqual(onFocus.called, true);
     });
   });
 });


### PR DESCRIPTION
Fix of Uncaught TypeError: r.inputRef.focus is not a function when clicking on InputAdornment
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes #13070. 