### PR TITLE
[NotchedOutline] ClassKeys added to styles/overrides.d.ts

### DIFF
--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -57,6 +57,7 @@ import { MenuListClassKey } from '../MenuList';
 import { MobileStepperClassKey } from '../MobileStepper';
 import { ModalClassKey } from '../Modal';
 import { NativeSelectClassKey } from '../NativeSelect';
+import { NotchedOutlineClassKey } from '../OutlinedInput/NotchedOutline';
 import { OutlinedInputClassKey } from '../OutlinedInput';
 import { PaperClassKey } from '../Paper';
 import { PopoverClassKey } from '../Popover';
@@ -154,6 +155,7 @@ export interface ComponentNameToClassKey {
   MuiMobileStepper: MobileStepperClassKey;
   MuiModal: ModalClassKey;
   MuiNativeSelect: NativeSelectClassKey;
+  MuiNotchedOutline: NotchedOutlineClassKey;
   MuiOutlinedInput: OutlinedInputClassKey;
   MuiPaper: PaperClassKey;
   MuiPopover: PopoverClassKey;


### PR DESCRIPTION
The classkeys were missing in the overrides typing