### PR TITLE
[InputAdornment] Add missing "variant" prop to types

### DIFF
--- a/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
@@ -6,6 +6,7 @@ export interface InputAdornmentProps
   component?: React.ReactType<InputAdornmentProps>;
   disableTypography?: boolean;
   position: 'start' | 'end';
+  variant?: 'standard' | 'outlined' | 'filled';
 }
 
 export type InputAdornmentClassKey = 'root' | 'positionStart' | 'positionEnd' | 'filled';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I noticed that the `variant` property was missing in the type definitions =)