### PR TITLE
[docs] Adds DropDownMenu to migration guide

### DIFF
--- a/docs/src/pages/guides/migration-v0x/migration-v0x.md
+++ b/docs/src/pages/guides/migration-v0x/migration-v0x.md
@@ -165,6 +165,17 @@ This will apply a change such as the following:
 +<Icon>home</Icon>
 ```
 
+### Drop Down Menu
+
+```diff
+-import DropDownMenu from 'material-ui/DropDownMenu';
++import Select from '@material-ui/core/Select';
+
+-<DropDownMenu></DropDownMenu>
++<Select value={this.state.value}></Select>
+```
+
+
 ### To be continued…
 
 Have you successfully migrated your app, and wish to help the community?


### PR DESCRIPTION
This small PR adds an item to the Migration From v0.x page. 

Specifically, I have added documentation regarding the DropDownMenu component from v0.x and how it is replaced with `<Select/>` in the new version.

### Before

<img width="1674" alt="screen shot 2018-10-05 at 11 21 52 am" src="https://user-images.githubusercontent.com/8016859/46547830-d5a5e680-c892-11e8-9e19-f991af527aeb.png">


### After

<img width="1671" alt="screen shot 2018-10-05 at 11 21 29 am" src="https://user-images.githubusercontent.com/8016859/46547537-cecaa400-c891-11e8-834e-54d961a5507f.png">
