### PR TITLE
[docs] Adds EnhancedButton to migration guide

### DIFF
--- a/docs/src/pages/guides/migration-v0x/migration-v0x.md
+++ b/docs/src/pages/guides/migration-v0x/migration-v0x.md
@@ -119,6 +119,16 @@ This will apply a change such as the following:
 +<Button variant="contained" />
 ```
 
+### Enhanced Button
+
+```diff
+-import EnhancedButton from 'material-ui/internal/EnhancedButton';
++import Button from '@material-ui/core/Button';
+
+-<EnhancedButton />
++<Button />
+```
+
 ### Subheader
 
 ```diff


### PR DESCRIPTION
This PR adds and item to the migration documentation for EnhancedButton from v0.x.

I am not sure how many items are to be included in this section of the docs, but in a project I am migrating, EnhancedButton was migrated as such. I considered adding the `variant` prop, but decided not to as I don't see one for `enhanced`.

### Before

<img width="1679" alt="screen shot 2018-10-05 at 12 00 56 pm" src="https://user-images.githubusercontent.com/8016859/46549108-95486780-c896-11e8-81fb-2df9415b8c5e.png">

### After

<img width="1677" alt="screen shot 2018-10-05 at 12 00 43 pm" src="https://user-images.githubusercontent.com/8016859/46549115-9aa5b200-c896-11e8-98e4-ac900bc05127.png">
