### PR TITLE
[Button] Deprecate flat and raised variant naming

### DIFF
--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -229,13 +229,13 @@ function Button(props) {
 
   warning(
     process.env.MUI_SUPPRESS_DEPRECATION_WARNINGS || variant !== 'flat',
-    'Deprecation Warning: Material-UI: The `flat` Button variant will be removed in ' +
+    'Material-UI: The `flat` Button variant will be removed in ' +
       'the next major release. `text` is equivalent and should be used instead.',
   );
 
   warning(
     process.env.MUI_SUPPRESS_DEPRECATION_WARNINGS || variant !== 'raised',
-    'Deprecation Warning: Material-UI: The `raised` Button variant will be removed in ' +
+    'Material-UI: The `raised` Button variant will be removed in ' +
       'the next major release. `contained` is equivalent and should be used instead.',
   );
 

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import warning from 'warning';
 import withStyles from '../styles/withStyles';
 import { fade } from '../styles/colorManipulator';
 import ButtonBase from '../ButtonBase';
@@ -225,6 +226,18 @@ function Button(props) {
     variant,
     ...other
   } = props;
+
+  warning(
+    process.env.MUI_SUPPRESS_DEPRECATION_WARNINGS || variant !== 'flat',
+    'Deprecation Warning: Material-UI: The `flat` Button variant will be removed in ' +
+      'the next major release. `text` is equivalent and should be used instead.',
+  );
+
+  warning(
+    process.env.MUI_SUPPRESS_DEPRECATION_WARNINGS || variant !== 'raised',
+    'Deprecation Warning: Material-UI: The `raised` Button variant will be removed in ' +
+      'the next major release. `contained` is equivalent and should be used instead.',
+  );
 
   const fab = variant === 'fab' || variant === 'extendedFab';
   const contained = variant === 'contained' || variant === 'raised';

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -347,7 +347,8 @@ Button.propTypes = {
    */
   type: PropTypes.string,
   /**
-   * The variant to use.
+   * The variant to use. __WARNING__: `flat` and `raised` are deprecated. Instead use
+   * `text` and `contained` respectively.
    */
   variant: PropTypes.oneOf([
     'text',

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -140,7 +140,7 @@ function getVariant(theme, props, variant) {
     typography.suppressDeprecationWarnings ||
       (props.internalDeprecatedVariant && typography.useNextVariants) ||
       !typographyMigration.deprecatedVariants.includes(variant),
-    'Deprecation Warning: Material-UI: You are using the deprecated typography variant ' +
+    'Material-UI: You are using the deprecated typography variant ' +
       `${variant} that will be removed in the next major release. ${
         typographyMigration.migrationGuideMessage
       }`,
@@ -155,7 +155,7 @@ function getVariant(theme, props, variant) {
   warning(
     typography.suppressDeprecationWarnings ||
       !typographyMigration.restyledVariants.includes(variant),
-    'Deprecation Warning: Material-UI: You are using the typography variant ' +
+    'Material-UI: You are using the typography variant ' +
       `${variant} which will be restyled in the next major release. ${
         typographyMigration.migrationGuideMessage
       }`,

--- a/packages/material-ui/src/Typography/Typography.test.js
+++ b/packages/material-ui/src/Typography/Typography.test.js
@@ -155,7 +155,7 @@ describe('<Typography />', () => {
      * tests if a warning is issued from the `warning` module when mounting {component}
      */
     const testMount = (component, expectDeprecation) => {
-      const expectedWarning = expectDeprecation ? 'Deprecation Warning: Material-UI:' : undefined;
+      const expectedWarning = expectDeprecation ? 'Material-UI:' : undefined;
       warning.resetHistory();
 
       const theme = createMuiTheme({

--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -36,14 +36,14 @@ export default function createTypography(palette, typography) {
 
   warning(
     !Object.keys(other).some(variant => typographyMigration.deprecatedVariants.includes(variant)),
-    'Deprecation Warning: Material-UI: You are passing a deprecated variant to ' +
+    'Material-UI: You are passing a deprecated variant to ' +
       `createTypography. ${typographyMigration.migrationGuideMessage}`,
   );
 
   warning(
     useNextVariants ||
       !Object.keys(other).some(variant => typographyMigration.restyledVariants.includes(variant)),
-    'Deprecation Warning: Material-UI: You are passing a variant to createTypography ' +
+    'Material-UI: You are passing a variant to createTypography ' +
       'that will be restyled in the next major release, without indicating that you ' +
       `are using typography v2 (set \`useNextVariants\` to true. ${
         typographyMigration.migrationGuideMessage

--- a/packages/material-ui/src/styles/createTypography.test.js
+++ b/packages/material-ui/src/styles/createTypography.test.js
@@ -89,7 +89,7 @@ describe('createTypography', () => {
 
       if (expectDeprecation) {
         assert.strictEqual(warning.calledOnce, true);
-        assert.include(warning.firstCall.args[0], 'Deprecation Warning: Material-UI:');
+        assert.include(warning.firstCall.args[0], 'Material-UI:');
       }
 
       return typography;

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -30,7 +30,7 @@ import Button from '@material-ui/core/Button';
 | <span class="prop-name">href</span> | <span class="prop-type">string |   | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | <span class="prop-name">mini</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, and `variant` is `'fab'`, will use mini floating action button styling. |
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text', 'flat', 'outlined', 'contained', 'raised', 'fab', 'extendedFab'<br> | <span class="prop-default">'text'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text', 'flat', 'outlined', 'contained', 'raised', 'fab', 'extendedFab'<br> | <span class="prop-default">'text'</span> | The variant to use. __WARNING__: `flat` and `raised` are deprecated. Instead use `text` and `contained` respectively. |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 


### PR DESCRIPTION
### Deprecation

This change updates the variant wording to match the one used in the material design specification.

```diff
-<Button variant="flat" />
+<Button variant="text" />
```

```diff
-<Button variant="raised" />
+<Button variant="contained" />
```

You can suppress the warnings with the environment variable `MUI_SUPPRESS_DEPRECATION_WARNINGS` set to a truthy value.