### PR TITLE
[Typography] Small improvements

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -72,14 +72,12 @@ class Ad extends React.Component {
     if (adblock) {
       return (
         <Paper elevation={0} className={classes.paper}>
-          <Typography variant="body2" gutterBottom>
-            Like Material-UI?
-          </Typography>
-          <Typography variant="body2" gutterBottom>
+          <Typography gutterBottom>Like Material-UI?</Typography>
+          <Typography gutterBottom>
             {`If you don't mind tech-related ads, and want to support Open Source,
             please whitelist Material-UI in your ad blocker.`}
           </Typography>
-          <Typography variant="body2">
+          <Typography>
             Thank you!{' '}
             <span role="img" aria-label="Love">
               ❤️

--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -19,11 +19,13 @@ const styles = theme => ({
     paddingBottom: 0,
   },
   button: {
+    letterSpacing: 0,
     justifyContent: 'flex-start',
     textTransform: 'none',
     width: '100%',
   },
   buttonLeaf: {
+    letterSpacing: 0,
     justifyContent: 'flex-start',
     textTransform: 'none',
     width: '100%',

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -141,7 +141,7 @@ class AppTableOfContents extends React.Component {
         {disableAd ? null : <Ad />}
         {itemsServer.length > 0 ? (
           <React.Fragment>
-            <Typography variant="body2" gutterBottom className={classes.contents}>
+            <Typography gutterBottom className={classes.contents}>
               Contents
             </Typography>
             <EventListener target="window" onScroll={this.handleScroll} />

--- a/docs/src/modules/components/Link.js
+++ b/docs/src/modules/components/Link.js
@@ -10,8 +10,6 @@ import { withStyles } from '@material-ui/core/styles';
 
 const styles = theme => ({
   root: {
-    ...theme.typography.body2,
-    color: null,
     textDecoration: 'none',
     '&:hover': {
       textDecoration: 'underline',

--- a/docs/src/modules/components/Tidelift.js
+++ b/docs/src/modules/components/Tidelift.js
@@ -46,9 +46,7 @@ function Tidelift(props) {
       rel="noopener"
     >
       <span className={classes.logo} />
-      <Typography variant="body2" className={classes.label}>
-        Get Professionally Supported Material-UI
-      </Typography>
+      <Typography className={classes.label}>Get Professionally Supported Material-UI</Typography>
     </Link>
   );
 }

--- a/docs/src/modules/components/withRoot.js
+++ b/docs/src/modules/components/withRoot.js
@@ -305,7 +305,10 @@ function withRoot(Component) {
     }
 
     componentDidMount() {
-      this.setState({ userLanguage: acceptLanguage.get(navigator.language) || 'en' });
+      this.setState({
+        userLanguage:
+          this.props.router.query.lang || acceptLanguage.get(navigator.language) || 'en',
+      });
     }
 
     render() {

--- a/docs/src/pages/demos/cards/RecipeReviewCard.js
+++ b/docs/src/pages/demos/cards/RecipeReviewCard.js
@@ -103,9 +103,7 @@ class RecipeReviewCard extends React.Component {
         </CardActions>
         <Collapse in={this.state.expanded} timeout="auto" unmountOnExit>
           <CardContent>
-            <Typography paragraph variant="body2">
-              Method:
-            </Typography>
+            <Typography paragraph>Method:</Typography>
             <Typography paragraph>
               Heat 1/2 cup of the broth in a pot until simmering, add saffron and set aside for 10
               minutes.

--- a/docs/src/pages/demos/steppers/SwipeableTextMobileStepper.js
+++ b/docs/src/pages/demos/steppers/SwipeableTextMobileStepper.js
@@ -90,7 +90,7 @@ class SwipeableTextMobileStepper extends React.Component {
     return (
       <div className={classes.root}>
         <Paper square elevation={0} className={classes.header}>
-          <Typography variant="body2">{tutorialSteps[activeStep].label}</Typography>
+          <Typography>{tutorialSteps[activeStep].label}</Typography>
         </Paper>
         <AutoPlaySwipeableViews
           axis={theme.direction === 'rtl' ? 'x-reverse' : 'x'}

--- a/docs/src/pages/demos/steppers/TextMobileStepper.js
+++ b/docs/src/pages/demos/steppers/TextMobileStepper.js
@@ -82,7 +82,7 @@ class TextMobileStepper extends React.Component {
     return (
       <div className={classes.root}>
         <Paper square elevation={0} className={classes.header}>
-          <Typography variant="body2">{tutorialSteps[activeStep].label}</Typography>
+          <Typography>{tutorialSteps[activeStep].label}</Typography>
         </Paper>
         <img
           className={classes.img}

--- a/docs/src/pages/discover-more/team/Team.js
+++ b/docs/src/pages/discover-more/team/Team.js
@@ -129,9 +129,7 @@ function Team(props) {
                   <Typography variant="subtitle1" color="textSecondary">
                     {member.flag}
                   </Typography>
-                  <Typography variant="body2" color="textSecondary">
-                    {member.city}
-                  </Typography>
+                  <Typography color="textSecondary">{member.city}</Typography>
                   <div className={classes.controls}>
                     {member.github && (
                       <IconButton

--- a/docs/src/pages/style/typography/typography.md
+++ b/docs/src/pages/style/typography/typography.md
@@ -75,6 +75,7 @@ const theme = createMuiTheme({
 ```
 
 This will use new variants instead of old variants according to the following mapping:
+
 ```json
 display4 => h1
 display3 => h2
@@ -83,7 +84,10 @@ display1 => h4
 headline => h5
 title => h6
 subheading => subtitle1
+body2 => body1
+body1 (default) => body2 (default)
 ```
+
 Please note that this will still log deprecation warnings if you use one of the variants.
 We recommend you replace those old variants with the recommended variants to be prepared
 for the next major release.

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -133,8 +133,14 @@ function nextVariantMapping(variant) {
   return nextVariant;
 }
 
-function getVariant(theme, props, variant) {
+function getVariant(theme, props, variantProp) {
   const typography = theme.typography;
+
+  let variant = variantProp;
+
+  if (!variant) {
+    variant = typography.useNextVariants ? 'body2' : 'body1';
+  }
 
   warning(
     typography.suppressDeprecationWarnings ||
@@ -276,6 +282,7 @@ Typography.propTypes = {
    * A deprecated variant is used from an internal component. Users don't need
    * a deprecation warning here if they switched to the v2 theme. They already
    * get the mapping that will be applied in the next major release.
+   *
    * @internal
    */
   internalDeprecatedVariant: PropTypes.bool,
@@ -289,6 +296,7 @@ Typography.propTypes = {
   paragraph: PropTypes.bool,
   /**
    * Applies the theme typography styles.
+   * Use `body1` as the default value with the legacy implementation and `body2` with the new one.
    */
   variant: PropTypes.oneOf([
     'h1',
@@ -324,7 +332,6 @@ Typography.defaultProps = {
   headlineMapping: defaultHeadlineMapping,
   noWrap: false,
   paragraph: false,
-  variant: 'body1',
 };
 
 export default withStyles(styles, { name: 'MuiTypography', withTheme: true })(Typography);

--- a/packages/material-ui/src/Typography/Typography.test.js
+++ b/packages/material-ui/src/Typography/Typography.test.js
@@ -42,9 +42,9 @@ describe('<Typography />', () => {
     assert.strictEqual(wrapper.props()['data-test'], 'hello');
   });
 
-  it('should render body1 root by default', () => {
+  it('should render body2 root by default', () => {
     const wrapper = shallow(<Typography theme={v2Theme}>Hello</Typography>);
-    assert.strictEqual(wrapper.hasClass(classes.body1), true);
+    assert.strictEqual(wrapper.hasClass(classes.body2), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
@@ -54,7 +54,7 @@ describe('<Typography />', () => {
         Hello
       </Typography>,
     );
-    assert.strictEqual(wrapper.hasClass(classes.body1), true);
+    assert.strictEqual(wrapper.hasClass(classes.body2), true);
     assert.strictEqual(wrapper.hasClass('woofTypography'), true);
   });
 

--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -51,7 +51,6 @@ export default function createTypography(palette, typography) {
   );
 
   const coef = fontSize / 14;
-  const letterSpacingToEm = (tracking, spSize) => `${(tracking / spSize) * coef}em`;
   const pxToRem = size => `${(size / htmlFontSize) * coef}rem`;
   const buildVariant = (fontWeight, size, lineHeight, letterSpacing, casing) => ({
     color: palette.text.primary,
@@ -63,7 +62,7 @@ export default function createTypography(palette, typography) {
     // The letter spacing was designed for the Roboto font-family. Using the same letter-spacing
     // across font-families can cause issues with the kerning.
     ...(fontFamily === defaultFontFamiliy
-      ? { letterSpacing: letterSpacingToEm(letterSpacing, size) }
+      ? { letterSpacing: `${round(letterSpacing / size)}em` }
       : {}),
     ...casing,
     ...allVariants,
@@ -78,11 +77,11 @@ export default function createTypography(palette, typography) {
     h6: buildVariant(fontWeightMedium, 20, 1.6, 0.15),
     subtitle1: buildVariant(fontWeightRegular, 16, 1.75, 0.15),
     subtitle2: buildVariant(fontWeightMedium, 14, 1.57, 0.1),
-    body1Next: buildVariant(fontWeightRegular, 16, 1.5, 0.5),
-    body2Next: buildVariant(fontWeightRegular, 14, 1.42, 0.25),
-    buttonNext: buildVariant(fontWeightMedium, 14, 2.57, 0.75, caseAllCaps),
+    body1Next: buildVariant(fontWeightRegular, 16, 1.5, 0.15),
+    body2Next: buildVariant(fontWeightRegular, 14, 1.42, 0.15),
+    buttonNext: buildVariant(fontWeightMedium, 14, 2.57, 0.4, caseAllCaps),
     captionNext: buildVariant(fontWeightRegular, 12, 1.66, 0.4),
-    overline: buildVariant(fontWeightRegular, 12, 2.66, 1.5, caseAllCaps),
+    overline: buildVariant(fontWeightRegular, 12, 2.66, 1, caseAllCaps),
   };
 
   // To remove in v4

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -29,7 +29,7 @@ import Typography from '@material-ui/core/Typography';
 | <span class="prop-name">internalDeprecatedVariant</span> | <span class="prop-type">bool |   | A deprecated variant is used from an internal component. Users don't need a deprecation warning here if they switched to the v2 theme. They already get the mapping that will be applied in the next major release. |
 | <span class="prop-name">noWrap</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the text will not wrap, but instead will truncate with an ellipsis. |
 | <span class="prop-name">paragraph</span> | <span class="prop-type">bool | <span class="prop-default">false</span> | If `true`, the text will have a bottom margin. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2', 'caption', 'button', 'overline', 'srOnly', 'inherit', "display4", 'display3', 'display2', 'display1', 'headline', 'title', 'subheading'<br> | <span class="prop-default">'body1'</span> | Applies the theme typography styles. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2', 'caption', 'button', 'overline', 'srOnly', 'inherit', "display4", 'display3', 'display2', 'display1', 'headline', 'title', 'subheading'<br> |   | Applies the theme typography styles. Use `body1` as the default value with the legacy implementation and `body2` with the new one. |
 
 Any other properties supplied will be spread to the root element (native element).
 


### PR DESCRIPTION
- Switch the default variant between typography v1 and v2.
- Don't apply the scale twice
- Round the letter spacing value
- Makes Material-UI less opinionated regarding the letter-spacing value. I think that the specification is promoting a too strong letter-spacing value, at least for a minor release. I'm softening the change.