### PR TITLE
[Tooltip] Prevent onOpen, onClose to pass through

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -258,6 +258,8 @@ class Tooltip extends React.Component {
       id,
       leaveDelay,
       leaveTouchDelay,
+      onClose,
+      onOpen,
       open: openProp,
       placement,
       PopperProps,


### PR DESCRIPTION
Minor fixes to #13138.

Another case where `mount` would've caught the error.