### PR TITLE
[test] Add visual regression test for SpeedDIal

### DIFF
--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -28,9 +28,12 @@ export const styles = theme => ({
 });
 
 class SpeedDialAction extends React.Component {
-  state = {
-    tooltipOpen: false,
-  };
+  constructor(props) {
+    super();
+    this.state = {
+      tooltipOpen: props.tooltipOpen,
+    };
+  }
 
   static getDerivedStateFromProps = (props, state) => {
     if (!props.open && state.tooltipOpen) {

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -29,6 +29,11 @@ describe('<SpeedDialAction />', () => {
     wrapper.unmount();
   });
 
+  it('initializes its state from props', () => {
+    const wrapper = shallow(<SpeedDialAction {...defaultProps} open tooltipOpen />);
+    assert.strictEqual(wrapper.state().tooltipOpen, true);
+  });
+
   it('should render a Tooltip', () => {
     const wrapper = shallow(<SpeedDialAction {...defaultProps} />);
     assert.strictEqual(wrapper.type(), Tooltip);

--- a/test/regressions/tests/SpeedDial/Directions.js
+++ b/test/regressions/tests/SpeedDial/Directions.js
@@ -39,13 +39,7 @@ const styles = {
   directionLeft: {},
 };
 
-const actions = [
-  { icon: <Avatar>A</Avatar>, name: 'Tooltip' },
-  { icon: <Avatar>B</Avatar>, name: 'Tooltip' },
-  { icon: <Avatar>C</Avatar>, name: 'Tooltip' },
-];
-
-function SampleSpeedDial({ classes, ...props }) {
+function SimpleSpeedDial(props) {
   const tooltipPlacement = {
     up: 'left',
     right: 'top',
@@ -56,14 +50,14 @@ function SampleSpeedDial({ classes, ...props }) {
 
   return (
     <SpeedDial icon={<SpeedDialIcon />} open {...props}>
-      {actions.map((action, i) => {
+      {['A', 'B', 'C'].map((name, i) => {
         return (
           <SpeedDialAction
-            key={action.name}
-            icon={action.icon}
+            key={name}
+            icon={<Avatar>{name}</Avatar>}
             tooltipOpen
             tooltipPlacement={`${tooltipPlacement[props.direction]}${secondaryPlacement[i]}`}
-            tooltipTitle={action.name}
+            tooltipTitle={'Tooltip'}
           />
         );
       })}
@@ -71,7 +65,7 @@ function SampleSpeedDial({ classes, ...props }) {
   );
 }
 
-function SpeedDials({ classes }) {
+function Directions({ classes }) {
   const speedDialClassName = direction =>
     classNames(classes.speedDial, classes[`direction${capitalize(direction)}`]);
 
@@ -79,7 +73,7 @@ function SpeedDials({ classes }) {
     <div className={classes.root}>
       {['up', 'right', 'down', 'left'].map(direction => {
         return (
-          <SampleSpeedDial
+          <SimpleSpeedDial
             key={direction}
             ariaLabel={direction}
             className={speedDialClassName(direction)}
@@ -91,8 +85,8 @@ function SpeedDials({ classes }) {
   );
 }
 
-SpeedDials.propTypes = {
+Directions.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(SpeedDials);
+export default withStyles(styles)(Directions);

--- a/test/regressions/tests/SpeedDial/Directions.js
+++ b/test/regressions/tests/SpeedDial/Directions.js
@@ -1,0 +1,98 @@
+import classNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import Avatar from '@material-ui/core/Avatar';
+import { withStyles } from '@material-ui/core/styles';
+import { capitalize } from '@material-ui/core/utils/helpers';
+import SpeedDial from '@material-ui/lab/SpeedDial';
+import SpeedDialIcon from '@material-ui/lab/SpeedDialIcon';
+import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
+
+const styles = {
+  root: {
+    position: 'relative',
+    height: 360,
+    width: 400,
+  },
+  speedDial: {
+    position: 'absolute',
+    '&$directionUp': {
+      bottom: 0,
+      right: 0,
+    },
+    '&$directionRight': {
+      bottom: 0,
+      left: 0,
+    },
+    '&$directionDown': {
+      top: 0,
+      left: 0,
+    },
+    '&$directionLeft': {
+      top: 0,
+      right: 0,
+    },
+  },
+  directionUp: {},
+  directionRight: {},
+  directionDown: {},
+  directionLeft: {},
+};
+
+const actions = [
+  { icon: <Avatar>A</Avatar>, name: 'Tooltip' },
+  { icon: <Avatar>B</Avatar>, name: 'Tooltip' },
+  { icon: <Avatar>C</Avatar>, name: 'Tooltip' },
+];
+
+function SampleSpeedDial({ classes, ...props }) {
+  const tooltipPlacement = {
+    up: 'left',
+    right: 'top',
+    down: 'right',
+    left: 'bottom',
+  };
+  const secondaryPlacement = ['-start', '', '-end'];
+
+  return (
+    <SpeedDial icon={<SpeedDialIcon />} open {...props}>
+      {actions.map((action, i) => {
+        return (
+          <SpeedDialAction
+            key={action.name}
+            icon={action.icon}
+            tooltipOpen
+            tooltipPlacement={`${tooltipPlacement[props.direction]}${secondaryPlacement[i]}`}
+            tooltipTitle={action.name}
+          />
+        );
+      })}
+    </SpeedDial>
+  );
+}
+
+function SpeedDials({ classes }) {
+  const speedDialClassName = direction =>
+    classNames(classes.speedDial, classes[`direction${capitalize(direction)}`]);
+
+  return (
+    <div className={classes.root}>
+      {['up', 'right', 'down', 'left'].map(direction => {
+        return (
+          <SampleSpeedDial
+            key={direction}
+            ariaLabel={direction}
+            className={speedDialClassName(direction)}
+            direction={direction}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+SpeedDials.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(SpeedDials);


### PR DESCRIPTION
## Test
- adds a visual regression test for the SpeedDial

## Fixes
- tooltips of SpeedDialActions not being displayed if it was mounted with `open tooltipOpen`