### PR TITLE
[core] Change UMD output name to 'MaterialUI'

### DIFF
--- a/examples/cdn/index.html
+++ b/examples/cdn/index.html
@@ -28,7 +28,7 @@ const {
   MuiThemeProvider,
   Typography,
   withStyles,
-} = window['material-ui'];
+} = MaterialUI;
 
 const theme = createMuiTheme({
   palette: {

--- a/packages/material-ui/scripts/rollup.config.js
+++ b/packages/material-ui/scripts/rollup.config.js
@@ -7,7 +7,6 @@ import { uglify } from 'rollup-plugin-uglify';
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 
 const input = './src/index.js';
-const name = 'material-ui';
 const globals = {
   react: 'React',
   'react-dom': 'ReactDOM',
@@ -26,7 +25,12 @@ const commonjsOptions = {
 export default [
   {
     input,
-    output: { file: `build/umd/${name}.development.js`, format: 'umd', name, globals },
+    output: {
+      file: 'build/umd/material-ui.development.js',
+      format: 'umd',
+      name: 'MaterialUI',
+      globals,
+    },
     external: Object.keys(globals),
     plugins: [
       nodeResolve(),
@@ -38,7 +42,12 @@ export default [
   },
   {
     input,
-    output: { file: `build/umd/${name}.production.min.js`, format: 'umd', name, globals },
+    output: {
+      file: 'build/umd/material-ui.production.min.js',
+      format: 'umd',
+      name: 'MaterialUI',
+      globals,
+    },
     external: Object.keys(globals),
     plugins: [
       nodeResolve(),


### PR DESCRIPTION
Change UMD output name from 'material-ui' to 'MaterialUI'.
This is a breaking change.

Closes #12387

See also Stack Overflow question: [How do I add Material-UI to a JSFiddle project](https://stackoverflow.com/q/50705423)

### Breaking change

This change is easy the usage of Material-UI with a CDN:
```diff
const {
  Button,
  TextField,
-} = window['material-ui'];
+} = MaterialUI;
```

It's consistent with the other projects:
- material-ui => MaterialUI
- react-dom => ReactDOM
- prop-types => PropTypes

*You need to update the CDN example once this change is released.*