### PR TITLE
[DialogContentText] Fix typography deprecation warning with useNextVariants

### DIFF
--- a/packages/material-ui/src/DialogContentText/DialogContentText.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.js
@@ -14,7 +14,15 @@ export const styles = {
 };
 
 function DialogContentText(props) {
-  return <Typography component="p" variant="subheading" color="textSecondary" {...props} />;
+  return (
+    <Typography
+      component="p"
+      internalDeprecatedVariant
+      variant="subheading"
+      color="textSecondary"
+      {...props}
+    />
+  );
 }
 
 DialogContentText.propTypes = {


### PR DESCRIPTION
Closes #13145

Searched for `"<Typography"` in the core src and found no other deprecated variants without `internalDeprecatedVariant`