### PR TITLE
[SnackbarContent] Fix invalid dom

### DIFF
--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -53,6 +53,7 @@ function SnackbarContent(props) {
       component={Typography}
       headlineMapping={{
         body1: 'div',
+        body2: 'div',
       }}
       role="alertdialog"
       square

--- a/packages/material-ui/src/styles/createTypography.test.js
+++ b/packages/material-ui/src/styles/createTypography.test.js
@@ -31,7 +31,7 @@ describe('createTypography', () => {
 
   it('should accept a custom font size', () => {
     const typography = createTypography(palette, { fontSize: 16 });
-    assert.strictEqual(typography.body1.fontSize, '1rem', 'should be 16px');
+    assert.strictEqual(typography.body2.fontSize, '1rem', 'should be 16px');
   });
 
   it('should create a typography with a custom baseFontSize', () => {
@@ -119,6 +119,7 @@ describe('createTypography', () => {
           body1: {
             fontSize: customFontSize,
           },
+          useNextVariants: false,
         },
         true,
       );


### PR DESCRIPTION
Closes #13144 

I went ahead and defaulted `useNextVariants` to `true` and ran the unit tests to see if there are more potential issues. Only the `createTypography` test needed adjustment because `body1` and `body2` will have different font sizes.