### PR TITLE
[SpeedDialAction] Fix className prop being ignored

### DIFF
--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -65,7 +65,7 @@ class SpeedDialAction extends React.Component {
     const {
       ButtonProps,
       classes,
-      className: classNameProp,
+      className,
       delay,
       icon,
       id,
@@ -107,7 +107,7 @@ class SpeedDialAction extends React.Component {
         <Button
           variant="fab"
           mini
-          className={classNames(classes.button, !open && classes.buttonClosed)}
+          className={classNames(className, classes.button, !open && classes.buttonClosed)}
           style={{ transitionDelay: `${delay}ms` }}
           tabIndex={-1}
           role="menuitem"
@@ -131,6 +131,10 @@ SpeedDialAction.propTypes = {
    * Useful to extend the style applied to components.
    */
   classes: PropTypes.object.isRequired,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
   /**
    * Adds a transition delay, to allow a series of SpeedDialActions to be animated.
    */

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -58,6 +58,13 @@ describe('<SpeedDialAction />', () => {
     assert.strictEqual(buttonWrapper.hasClass(classes.buttonClosed), true);
   });
 
+  it('passes the className to the Button', () => {
+    const className = 'my-speeddialaction';
+    const wrapper = shallow(<SpeedDialAction {...defaultProps} className={className} />);
+    const buttonWrapper = wrapper.childAt(0);
+    assert.strictEqual(buttonWrapper.hasClass(className), true);
+  });
+
   describe('prop: onClick', () => {
     it('should be called when a click is triggered', () => {
       const handleClick = spy();


### PR DESCRIPTION
Closes #12159 (which was actually closed in #12725)

Merge `className` of SpeedDialAction into its button component.