### PR TITLE
[docs] Fix select outlined example

### DIFF
--- a/docs/src/pages/demos/selects/NativeSelects.js
+++ b/docs/src/pages/demos/selects/NativeSelects.js
@@ -29,7 +29,14 @@ class NativeSelects extends React.Component {
   state = {
     age: '',
     name: 'hai',
+    labelWidth: 0,
   };
+
+  componentDidMount() {
+    this.setState({
+      labelWidth: ReactDOM.findDOMNode(this.InputLabelRef).offsetWidth,
+    });
+  }
 
   handleChange = name => event => {
     this.setState({ [name]: event.target.value });
@@ -185,7 +192,7 @@ class NativeSelects extends React.Component {
         <FormControl variant="outlined" className={classes.formControl}>
           <InputLabel
             ref={ref => {
-              this.labelRef = ReactDOM.findDOMNode(ref);
+              this.InputLabelRef = ref;
             }}
             htmlFor="outlined-age-native-simple"
           >
@@ -198,7 +205,7 @@ class NativeSelects extends React.Component {
             input={
               <OutlinedInput
                 name="age"
-                labelWidth={this.labelRef ? this.labelRef.offsetWidth : 0}
+                labelWidth={this.state.labelWidth}
                 id="outlined-age-native-simple"
               />
             }

--- a/docs/src/pages/demos/selects/SimpleSelect.js
+++ b/docs/src/pages/demos/selects/SimpleSelect.js
@@ -29,11 +29,12 @@ class SimpleSelect extends React.Component {
   state = {
     age: '',
     name: 'hai',
+    labelWidth: 0,
   };
 
   componentDidMount() {
     this.setState({
-      labelRef: ReactDOM.findDOMNode(this.InputLabelRef),
+      labelWidth: ReactDOM.findDOMNode(this.InputLabelRef).offsetWidth,
     });
   }
 
@@ -236,7 +237,7 @@ class SimpleSelect extends React.Component {
             onChange={this.handleChange}
             input={
               <OutlinedInput
-                labelWidth={this.state.labelRef ? this.state.labelRef.offsetWidth : 0}
+                labelWidth={this.state.labelWidth}
                 name="age"
                 id="outlined-age-simple"
               />

--- a/docs/src/pages/demos/selects/SimpleSelect.js
+++ b/docs/src/pages/demos/selects/SimpleSelect.js
@@ -31,6 +31,12 @@ class SimpleSelect extends React.Component {
     name: 'hai',
   };
 
+  componentDidMount() {
+    this.setState({
+      labelRef: ReactDOM.findDOMNode(this.unresolvedRef),
+    })
+  }
+
   handleChange = event => {
     this.setState({ [event.target.name]: event.target.value });
   };
@@ -218,9 +224,7 @@ class SimpleSelect extends React.Component {
         </FormControl>
         <FormControl variant="outlined" className={classes.formControl}>
           <InputLabel
-            ref={ref => {
-              this.labelRef = ReactDOM.findDOMNode(ref);
-            }}
+            ref={ref => (this.unresolvedRef = ref)}
             htmlFor="outlined-age-simple"
           >
             Age
@@ -230,7 +234,7 @@ class SimpleSelect extends React.Component {
             onChange={this.handleChange}
             input={
               <OutlinedInput
-                labelWidth={this.labelRef ? this.labelRef.offsetWidth : 0}
+                labelWidth={this.state.labelRef ? this.state.labelRef.offsetWidth : 0}
                 name="age"
                 id="outlined-age-simple"
               />

--- a/docs/src/pages/demos/selects/SimpleSelect.js
+++ b/docs/src/pages/demos/selects/SimpleSelect.js
@@ -33,8 +33,8 @@ class SimpleSelect extends React.Component {
 
   componentDidMount() {
     this.setState({
-      labelRef: ReactDOM.findDOMNode(this.unresolvedRef),
-    })
+      labelRef: ReactDOM.findDOMNode(this.InputLabelRef),
+    });
   }
 
   handleChange = event => {
@@ -224,7 +224,9 @@ class SimpleSelect extends React.Component {
         </FormControl>
         <FormControl variant="outlined" className={classes.formControl}>
           <InputLabel
-            ref={ref => (this.unresolvedRef = ref)}
+            ref={ref => {
+              this.InputLabelRef = ref;
+            }}
             htmlFor="outlined-age-simple"
           >
             Age


### PR DESCRIPTION
https://reactjs.org/docs/react-dom.html#finddomnode should not be used in render. Does't work for first value either. (somehow in the demo it works but when stripping out other fields it doesn't.

Tried: 
https://material-ui.com/api/root-ref/ but still needed a re-render so decided to do just this.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
