### PR TITLE
[SwitchBase] Fix type declarations

### DIFF
--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -23,12 +23,6 @@ export interface SwitchBaseProps
 
 export type SwitchBaseClassKey = 'root' | 'checked' | 'disabled' | 'input';
 
-export type SwitchBase = React.Component<SwitchBaseProps>;
+declare const SwitchBase: React.ComponentType<SwitchBaseProps>;
 
-export interface CreateSwitchBaseOptions {
-  defaultIcon?: React.ReactNode;
-  defaultCheckedIcon?: React.ReactNode;
-  type?: string;
-}
-
-export default function createSwitch(options: CreateSwitchBaseOptions): SwitchBase;
+export default SwitchBase;


### PR DESCRIPTION
For internal tooling only i.e. intellisense in vscode uses type declarations.
