### PR TITLE
fix: prevent overflow on IE11

### DIFF
--- a/packages/material-ui-icons/src/MarkunreadMailbox.js
+++ b/packages/material-ui-icons/src/MarkunreadMailbox.js
@@ -2,5 +2,5 @@ import React from 'react';
 import createSvgIcon from './utils/createSvgIcon';
 
 export default createSvgIcon(
-  <React.Fragment><path fill="none" d="M-618-3000H782V600H-618zM0 0h24v24H0z" /><path d="M20 6H10v6H8V4h6V0H6v6H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z" /></React.Fragment>
+  <React.Fragment><path fill="none" d="M0 0h24v24H0z" /><path d="M20 6H10v6H8V4h6V0H6v6H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2z" /></React.Fragment>
 , 'MarkunreadMailbox');


### PR DESCRIPTION
Reduce size of transparent rectangle causing overflow on IE11.
Took the shape from markunread.js
