### PR TITLE
[Typography] Add missing classkey for overline variant

### DIFF
--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -30,6 +30,7 @@ export type TypographyClassKey =
   | 'body2'
   | 'caption'
   | 'button'
+  | 'overline'
   | 'srOnly'
   | 'alignLeft'
   | 'alignCenter'


### PR DESCRIPTION
Addresses https://github.com/mui-org/material-ui/issues/12741#issuecomment-428610926

Thanks @Abbo44 
