### PR TITLE
[TextField] Fix/core/input label/declarations and refactor

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -11,6 +11,7 @@ export interface FormControlProps
   onBlur?: React.EventHandler<any>;
   onFocus?: React.EventHandler<any>;
   required?: boolean;
+  variant?: 'standard' | 'outlined' | 'filled';
 }
 
 export type FormControlClassKey = 'root' | 'marginNormal' | 'marginDense' | 'fullWidth';

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -78,9 +78,9 @@ function InputLabel(props, context) {
     className: classNameProp,
     disableAnimation,
     FormLabelClasses,
-    margin: marginProp,
+    margin,
     shrink: shrinkProp,
-    variant: variantProp,
+    variant,
     ...other
   } = props;
 


### PR DESCRIPTION
Minor cleanup of #12076
Closes #13191 

Includes some minor refactoring. While looking through InputLabel I saw that some destructured props were renamed which looks to me like it was intended to be used but it turns out this was just to prevent them from spreading down the component tree. Fixed that to avoid future confusion.
