### PR TITLE
[Grid] Refactor prop order for clarity

### DIFF
--- a/docs/src/pages/layout/grid/NestedGrid.js
+++ b/docs/src/pages/layout/grid/NestedGrid.js
@@ -43,13 +43,13 @@ function NestedGrid(props) {
   return (
     <div className={classes.root}>
       <Grid container spacing={8}>
-        <Grid item xs={12} container spacing={24}>
+        <Grid container item xs={12} spacing={24}>
           <FormRow classes={classes} />
         </Grid>
-        <Grid item xs={12} container spacing={24}>
+        <Grid container item xs={12} spacing={24}>
           <FormRow classes={classes} />
         </Grid>
-        <Grid item xs={12} container spacing={24}>
+        <Grid container item xs={12} spacing={24}>
           <FormRow classes={classes} />
         </Grid>
       </Grid>


### PR DESCRIPTION
To explicitly show the `container` and `item` prop next to each other. This emphasizes the nested grid demo.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
