### PR TITLE
[Tabs] Remove the href form simple tab example

### DIFF
--- a/docs/src/pages/demos/tabs/SimpleTabs.js
+++ b/docs/src/pages/demos/tabs/SimpleTabs.js
@@ -44,7 +44,7 @@ class SimpleTabs extends React.Component {
           <Tabs value={value} onChange={this.handleChange}>
             <Tab label="Item One" />
             <Tab label="Item Two" />
-            <Tab label="Item Three" href="#basic-tabs" />
+            <Tab label="Item Three" />
           </Tabs>
         </AppBar>
         {value === 0 && <TabContainer>Item One</TabContainer>}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

easily-track-on: https://material-ui.com/demos/tabs/ 

in "simpletabs api" have unnecessary href i think and that makes application route conflict i guess.
i just simply remove this one and it's work perfect.any word would be appreciate.

Thank You.  