### PR TITLE
[SwitchBase] Add a transition between checked and unchecked icons

### DIFF
--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -38,7 +38,7 @@ describe('<Checkbox />', () => {
   describe('prop: indeterminate', () => {
     it('should render an indeterminate icon', () => {
       const wrapper = mount(<Checkbox indeterminate />);
-      assert.strictEqual(wrapper.find(IndeterminateCheckBoxIcon).length, 1);
+      assert.strictEqual(wrapper.find(IndeterminateCheckBoxIcon).length, 2);
     });
   });
 });

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -114,6 +114,7 @@ function Switch(props) {
           disabled: classes.disabled,
         }}
         checkedIcon={<span className={classNames(classes.icon, classes.iconChecked)} />}
+        disableFade
         {...other}
       />
       <span className={classes.bar} />

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Fade from '../Fade';
 import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';
 
@@ -18,6 +19,13 @@ export const styles = {
   },
   checked: {},
   disabled: {},
+  icon: {
+    gridColumn: 1,
+    gridRow: 1,
+  },
+  icons: {
+    display: 'grid',
+  },
   input: {
     cursor: 'inherit',
     position: 'absolute',
@@ -87,6 +95,7 @@ class SwitchBase extends React.Component {
       classes,
       className: classNameProp,
       disabled: disabledProp,
+      disableFade,
       icon,
       id,
       inputProps,
@@ -133,7 +142,21 @@ class SwitchBase extends React.Component {
         onBlur={this.handleBlur}
         {...other}
       >
-        {checked ? checkedIcon : icon}
+        {!disableFade && (
+          <span className={classes.icons}>
+            <Fade in={!checked} timeout={200}>
+              {React.cloneElement(icon, {
+                className: classes.icon,
+              })}
+            </Fade>
+            <Fade in={checked} timeout={200}>
+              {React.cloneElement(checkedIcon, {
+                className: classes.icon,
+              })}
+            </Fade>
+          </span>
+        )}
+        {disableFade && (checked ? checkedIcon : icon)}
         <input
           autoFocus={autoFocus}
           checked={checked}
@@ -187,6 +210,10 @@ SwitchBase.propTypes = {
    * If `true`, the switch will be disabled.
    */
   disabled: PropTypes.bool,
+  /**
+   * If `true`, the icon fade transition will be disabled.
+   */
+  disableFade: PropTypes.bool,
   /**
    * If `true`, the ripple effect will be disabled.
    */

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -18,8 +18,7 @@ function assertIsChecked(wrapper) {
   const input = wrapper.find('input');
   assert.strictEqual(input.instance().checked, true);
 
-  const label = iconButton.childAt(0);
-  const icon = label.childAt(0);
+  const icon = wrapper.find('Transition[in=true]').childAt(0);
   assert.strictEqual(icon.name(), 'h2');
 }
 
@@ -35,8 +34,7 @@ function assertIsNotChecked(wrapper) {
   const input = wrapper.find('input');
   assert.strictEqual(input.instance().checked, false);
 
-  const label = iconButton.childAt(0);
-  const icon = label.childAt(0);
+  const icon = wrapper.find('Transition[in=true]').childAt(0);
   assert.strictEqual(icon.name(), 'h1');
 }
 
@@ -69,7 +67,14 @@ describe('<SwitchBase />', () => {
 
   it('should render an icon and input inside the button by default', () => {
     const wrapper = shallow(<SwitchBase {...defaultProps} />);
-    assert.strictEqual(wrapper.childAt(0).name(), 'h1');
+    assert.strictEqual(
+      wrapper
+        .childAt(0)
+        .childAt(0)
+        .childAt(0)
+        .name(),
+      'h1',
+    );
     assert.strictEqual(wrapper.childAt(1).is('input[type="checkbox"]'), true);
   });
 
@@ -114,6 +119,12 @@ describe('<SwitchBase />', () => {
     Object.keys(props).forEach(n => {
       assert.strictEqual(input.props()[n], props[n]);
     });
+  });
+
+  it('should disable the fade animation when disableFade={true}', () => {
+    const wrapper = shallow(<SwitchBase {...defaultProps} disableFade />);
+    assert.strictEqual(wrapper.find('Transition').length, 0);
+    assert.strictEqual(wrapper.childAt(0).name(), 'h1');
   });
 
   it('should disable the components, and render the IconButton with the disabled className', () => {
@@ -239,7 +250,14 @@ describe('<SwitchBase />', () => {
   describe('prop: icon', () => {
     it('should render an Icon', () => {
       const wrapper = shallow(<SwitchBase {...defaultProps} icon={<Icon>heart</Icon>} />);
-      assert.strictEqual(wrapper.childAt(0).is(Icon), true);
+      assert.strictEqual(
+        wrapper
+          .childAt(0)
+          .childAt(0)
+          .childAt(0)
+          .is(Icon),
+        true,
+      );
     });
   });
 


### PR DESCRIPTION
Uses the Fade component in SwitchBase to transition between checked and unchecked icons. This animation is disabled by default for Switch, as it really only applies to Radio and Checkbox.

![switches](https://user-images.githubusercontent.com/8854811/46816326-97487580-cd31-11e8-95e1-96f3f1b811ff.gif)

Resolves #12639.
