### PR TITLE
[docs] Fix typo in Dialog

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -19,7 +19,7 @@ export const styles = theme => ({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  /* Styles applied to the root element if `scroll="bodyr"`. */
+  /* Styles applied to the root element if `scroll="body"`. */
   scrollBody: {
     overflowY: 'auto',
     overflowX: 'hidden',

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -54,7 +54,7 @@ This property accepts the following keys:
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">scrollPaper</span> | Styles applied to the root element if `scroll="paper"`.
-| <span class="prop-name">scrollBody</span> | Styles applied to the root element if `scroll="bodyr"`.
+| <span class="prop-name">scrollBody</span> | Styles applied to the root element if `scroll="body"`.
 | <span class="prop-name">paper</span> | Styles applied to the `Paper` component.
 | <span class="prop-name">paperScrollPaper</span> | Styles applied to the `Paper` component if `scroll="paper"`.
 | <span class="prop-name">paperScrollBody</span> | Styles applied to the `Paper` component if `scroll="body"`.


### PR DESCRIPTION
Fixes a small typo I found in the [Dialog CSS API](https://material-ui.com/api/dialog/#css-api), under scrollBody:  
bodyr → body   