### PR TITLE
[FormHelperText] Error styles should override disabled styles

### DIFF
--- a/packages/material-ui/src/FormHelperText/FormHelperText.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.js
@@ -15,11 +15,11 @@ export const styles = theme => ({
     lineHeight: '1em',
     minHeight: '1em',
     margin: 0,
-    '&$error': {
-      color: theme.palette.error.main,
-    },
     '&$disabled': {
       color: theme.palette.text.disabled,
+    },
+    '&$error': {
+      color: theme.palette.error.main,
     },
   },
   /* Styles applied to the root element if `error={true}`. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Material UI is a great project so just looking to help out. 

According to the issue the _error_ styles in the `FormHelperText` take precedence over the _disabled_ styles. Please let me know if there is further changes that are required. If this is not an actual issue also feel free to close the PR. 

Before this PR here was the behavior:

Example Code:

```
<TextField
          error
          disabled
          id="standard-disabled"
          label="Disabled"
          defaultValue="Hello World"
          className={classes.textField}
          margin="normal"
          helperText="Some helper text"
 />
```

Before this PR:

![image](https://user-images.githubusercontent.com/5889417/46875225-c37ef780-ce00-11e8-9854-49248599844a.png)

After this PR:

![image](https://user-images.githubusercontent.com/5889417/46875148-89155a80-ce00-11e8-9147-29c6eba9770a.png)

Closes #13210