### PR TITLE
[icons] move babel/runtime to devDep

### DIFF
--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -41,10 +41,10 @@
     "react-dom": "^16.3.0"
   },
   "dependencies": {
-    "@babel/runtime": "7.1.2",
     "recompose": "0.28.0 - 0.30.0"
   },
   "devDependencies": {
+    "@babel/runtime": "7.1.2",
     "fs-extra": "^7.0.0",
     "mkdirp": "^0.5.0",
     "mustache": "^3.0.0",


### PR DESCRIPTION
`@babel/runtime` does not look like it is needed to run package so it
should be a devDependency

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
