### PR TITLE
Change `filled-input` link text to `FilledInput`

### DIFF
--- a/docs/src/pages/demos/text-fields/text-fields.md
+++ b/docs/src/pages/demos/text-fields/text-fields.md
@@ -32,7 +32,7 @@ The `TextField` wrapper component is a complete form control including a label, 
 `TextField` is composed of smaller components (
 [`FormControl`](/api/form-control/),
 [`Input`](/api/input/),
-[`InputLabel`](/api/filled-input/),
+[`FilledInput`](/api/filled-input/),
 [`InputLabel`](/api/input-label/),
 [`OutlinedInput`](/api/outlined-input/),
 and [`FormHelperText`](/api/form-helper-text/)


### PR DESCRIPTION
Link text was previously `InputLabel`, when it should be `FilledInput`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
