### PR TITLE
[SpeedDial] Add missing class keys

### DIFF
--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
@@ -22,7 +22,15 @@ export interface SpeedDialProps
   TransitionProps?: TransitionProps;
 }
 
-export type SpeedDialClassKey = 'root' | 'actions' | 'actionsClosed';
+export type SpeedDialClassKey =
+  | 'root'
+  | 'actions'
+  | 'actionsClosed'
+  | 'fab'
+  | 'directionUp'
+  | 'directionDown'
+  | 'directionLeft'
+  | 'directionRight';
 
 declare const SpeedDial: React.ComponentType<SpeedDialProps>;
 


### PR DESCRIPTION
The SpeedDial component typescript definition is missing some classes in the SpeedDialClassKey union type