### PR TITLE
[core] Introduce JSS caching

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -16,13 +16,13 @@ module.exports = [
     name: 'The initial cost paid for using one component',
     webpack: true,
     path: 'packages/material-ui/build/Paper/index.js',
-    limit: '17.6 KB',
+    limit: '17.7 KB',
   },
   {
     name: 'The size of all the material-ui modules.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '93.2 KB',
+    limit: '93.4 KB',
   },
   {
     name: 'The main docs bundle',

--- a/packages/material-ui-benchmark/README.md
+++ b/packages/material-ui-benchmark/README.md
@@ -3,12 +3,18 @@
 ```sh
 yarn benchmark
 
-ButtonBase x 78,875 ops/sec ±11.38% (80 runs sampled)
-Grid x 84,284 ops/sec ±2.36% (87 runs sampled)
-JssButton x 253,054 ops/sec ±4.50% (83 runs sampled)
-StyledComponents x 110,824 ops/sec ±0.79% (92 runs sampled)
-Emotion x 119,230 ops/sec ±1.81% (89 runs sampled)
-Button x 27,616 ops/sec ±3.85% (85 runs sampled)
-ButtonBase disableRipple x 85,133 ops/sec ±2.25% (84 runs sampled)
-button x 993,210 ops/sec ±4.82% (81 runs sampled)
+ButtonBase cache instances x 37,666 ops/sec ±10.24% (64 runs sampled)
+ButtonBase cache requests x 36,496 ops/sec ±6.27% (68 runs sampled)
+ButtonBase no cache x 6,099 ops/sec ±4.62% (76 runs sampled)
+JssButton cache requests x 79,646 ops/sec ±6.08% (70 runs sampled)
+JssButton cache instances x 85,326 ops/sec ±8.94% (63 runs sampled)
+JssButton no cache x 9,896 ops/sec ±6.01% (79 runs sampled)
+JssButton no styles x 82,949 ops/sec ±4.40% (68 runs sampled)
+HocButton x 126,784 ops/sec ±5.50% (66 runs sampled)
+NakedButton x 182,888 ops/sec ±3.25% (51 runs sampled)
+StyledButton x 17,752 ops/sec ±6.89% (81 runs sampled)
+EmotionButton x 68,917 ops/sec ±19.32% (73 runs sampled)
+ButtonBase cache x 34,618 ops/sec ±12.83% (68 runs sampled)
+ButtonBase ripple x 38,715 ops/sec ±13.70% (68 runs sampled)
+ButtonBase disableRipple x 46,165 ops/sec ±13.53% (66 runs sampled)
 ```

--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "benchmark": "^2.1.4",
     "emotion": "^9.2.12",
+    "emotion-server": "^9.2.12",
     "nodemod": "^1.5.19",
     "react-emotion": "^9.2.12",
     "styled-components": "^3.4.10"

--- a/packages/material-ui/src/styles/MuiThemeProvider.js
+++ b/packages/material-ui/src/styles/MuiThemeProvider.js
@@ -23,15 +23,19 @@ class MuiThemeProvider extends React.Component {
   }
 
   getChildContext() {
-    const { sheetsManager, disableStylesGeneration } = this.props;
+    const { disableStylesGeneration, sheetsCache, sheetsManager } = this.props;
     const muiThemeProviderOptions = this.context.muiThemeProviderOptions || {};
-
-    if (sheetsManager !== undefined) {
-      muiThemeProviderOptions.sheetsManager = sheetsManager;
-    }
 
     if (disableStylesGeneration !== undefined) {
       muiThemeProviderOptions.disableStylesGeneration = disableStylesGeneration;
+    }
+
+    if (sheetsCache !== undefined) {
+      muiThemeProviderOptions.sheetsCache = sheetsCache;
+    }
+
+    if (sheetsManager !== undefined) {
+      muiThemeProviderOptions.sheetsManager = sheetsManager;
     }
 
     return {
@@ -115,6 +119,12 @@ MuiThemeProvider.propTypes = {
    * You can significantly speed up the traversal with this property.
    */
   disableStylesGeneration: PropTypes.bool,
+  /**
+   * @ignore
+   *
+   * In beta.
+   */
+  sheetsCache: PropTypes.object,
   /**
    * The sheetsManager is used to deduplicate style sheet injection in the page.
    * It's deduplicating using the (theme, styles) couple.

--- a/packages/material-ui/src/styles/getThemeProps.js
+++ b/packages/material-ui/src/styles/getThemeProps.js
@@ -3,7 +3,7 @@
 function getThemeProps(params) {
   const { theme, name, props } = params;
 
-  if (!name || !theme.props || !theme.props[name]) {
+  if (!theme.props || !name || !theme.props[name]) {
     return props;
   }
 

--- a/packages/material-ui/src/styles/mergeClasses.js
+++ b/packages/material-ui/src/styles/mergeClasses.js
@@ -2,7 +2,7 @@ import warning from 'warning';
 import getDisplayName from '../utils/getDisplayName';
 
 function mergeClasses(options = {}) {
-  const { baseClasses, newClasses, Component, noBase = false } = options;
+  const { baseClasses, newClasses, Component } = options;
 
   if (!newClasses) {
     return baseClasses;
@@ -12,7 +12,7 @@ function mergeClasses(options = {}) {
     ...baseClasses,
     ...Object.keys(newClasses).reduce((accumulator, key) => {
       warning(
-        baseClasses[key] || noBase || !newClasses[key],
+        baseClasses[key] || !newClasses[key],
         [
           `Material-UI: the key \`${key}\` ` +
             `provided to the classes property is not implemented in ${getDisplayName(Component)}.`,

--- a/packages/material-ui/src/styles/multiKeyStore.js
+++ b/packages/material-ui/src/styles/multiKeyStore.js
@@ -1,0 +1,24 @@
+// Used https://github.com/thinkloop/multi-key-cache as inspiration
+
+const multiKeyStore = {
+  set: (cache, key1, key2, value) => {
+    let subCache = cache.get(key1);
+
+    if (!subCache) {
+      subCache = new Map();
+      cache.set(key1, subCache);
+    }
+
+    subCache.set(key2, value);
+  },
+  get: (cache, key1, key2) => {
+    const subCache = cache.get(key1);
+    return subCache ? subCache.get(key2) : undefined;
+  },
+  delete: (cache, key1, key2) => {
+    const subCache = cache.get(key1);
+    subCache.delete(key2);
+  },
+};
+
+export default multiKeyStore;

--- a/packages/material-ui/src/styles/themeListener.js
+++ b/packages/material-ui/src/styles/themeListener.js
@@ -1,11 +1,9 @@
-import PropTypes from 'prop-types';
-
 // Same value used by react-jss
 export const CHANNEL = '__THEMING__';
 
 const themeListener = {
   contextTypes: {
-    [CHANNEL]: PropTypes.object,
+    [CHANNEL]: () => {},
   },
   initial: context => {
     if (!context[CHANNEL]) {

--- a/packages/material-ui/src/styles/withStyles.test.js
+++ b/packages/material-ui/src/styles/withStyles.test.js
@@ -98,7 +98,7 @@ describe('withStyles', () => {
       });
     });
 
-    describe('cache', () => {
+    describe('classes memoization', () => {
       it('should recycle with no classes property', () => {
         const wrapper = mount(<StyledComponent1 />);
         const classes1 = wrapper.find(Empty).props().classes;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,6 +2916,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+buffer-from@~0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-0.1.2.tgz#15f4b9bcef012044df31142c14333caf6e0260d0"
+  integrity sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==
+
 buffer-indexof-polyfill@~1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.1.tgz#a9fb806ce8145d5428510ce72f278bb363a638bf"
@@ -3632,6 +3637,15 @@ create-ecdh@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
+
+create-emotion-server@^9.2.12:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/create-emotion-server/-/create-emotion-server-9.2.12.tgz#30d82507bfe440bfb3dd6c9b5c8faf24597ee954"
+  integrity sha512-ET+E6A5MkQTEBNDYAnjh6+0cB33qStFXhtflkZNPEaOmvzYlB/xcPnpUk4J7ul3MVa8PCQx2Ei5g2MGY/y1n+g==
+  dependencies:
+    html-tokenize "^2.0.0"
+    multipipe "^1.0.2"
+    through "^2.3.8"
 
 create-emotion-styled@^9.2.8:
   version "9.2.8"
@@ -4363,7 +4377,7 @@ dtslint@^0.3.0:
     tslint "^5.9.1"
     typescript next
 
-duplexer2@~0.1.4:
+duplexer2@^0.1.2, duplexer2@~0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
   integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
@@ -4440,6 +4454,13 @@ emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
   integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
+
+emotion-server@^9.2.12:
+  version "9.2.12"
+  resolved "https://registry.yarnpkg.com/emotion-server/-/emotion-server-9.2.12.tgz#aaaaa04843108943d1ce5a796e0bc40b06a3223e"
+  integrity sha512-Bhjdl7eNoIeiAVa2QPP5d+1nP/31SiO/K1P/qI9cdXCydg91NwGYmteqhhge8u7PF8fLGTEVQfcPwj21815eBw==
+  dependencies:
+    create-emotion-server "^9.2.12"
 
 emotion@^9.1.2, emotion@^9.2.12:
   version "9.2.12"
@@ -6000,6 +6021,17 @@ html-to-react@^1.3.3:
     htmlparser2 "^3.8.3"
     ramda "^0.25.0"
     underscore.string.fp "^1.0.4"
+
+html-tokenize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-tokenize/-/html-tokenize-2.0.0.tgz#8b3a9a5deb475cae6a6f9671600d2c20ab298251"
+  integrity sha1-izqaXetHXK5qb5ZxYA0sIKspglE=
+  dependencies:
+    buffer-from "~0.1.1"
+    inherits "~2.0.1"
+    minimist "~0.0.8"
+    readable-stream "~1.0.27-1"
+    through2 "~0.4.1"
 
 htmlescape@1.1.1:
   version "1.1.1"
@@ -7704,7 +7736,7 @@ minimist@1.2.0, minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minimist@~0.0.1:
+minimist@~0.0.1, minimist@~0.0.8:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
   integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
@@ -7842,6 +7874,14 @@ ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+multipipe@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/multipipe/-/multipipe-1.0.2.tgz#cc13efd833c9cda99f224f868461b8e1a3fd939d"
+  integrity sha1-zBPv2DPJzamfIk+GhGG44aP9k50=
+  dependencies:
+    duplexer2 "^0.1.2"
+    object-assign "^4.1.0"
 
 mustache@^3.0.0:
   version "3.0.0"
@@ -8280,6 +8320,11 @@ object-keys@^1.0.11, object-keys@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
   integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
+  integrity sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -9505,6 +9550,16 @@ read-pkg@^3.0.0:
     safe-buffer "~5.1.1"
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
+
+readable-stream@~1.0.17, readable-stream@~1.0.27-1:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readdirp@^2.0.0:
   version "2.2.1"
@@ -10733,6 +10788,11 @@ string_decoder@^1.0.0, string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 stringify-object@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/stringify-object/-/stringify-object-3.2.2.tgz#9853052e5a88fb605a44cd27445aa257ad7ffbcd"
@@ -11017,7 +11077,15 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@^2.3.6, through@~2.3.4:
+through2@~0.4.1:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
+  integrity sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=
+  dependencies:
+    readable-stream "~1.0.17"
+    xtend "~2.1.1"
+
+through@^2.3.6, through@^2.3.8, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -12197,6 +12265,13 @@ xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
+
+xtend@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
+  integrity sha1-bv7MKk2tjmlixJAbM3znuoe10os=
+  dependencies:
+    object-keys "~0.4.0"
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
This pull request introduces a cache that can be used between different server requests. I need to benchmark that on a realistic page. So far, I have only benchmarked it for a page with a single component:
```
JssButton no cache x 9,896 ops/sec ±6.01% (79 runs sampled)
JssButton cache requests x 79,646 ops/sec ±6.08% (70 runs sampled)
JssButton cache instances x 85,326 ops/sec ±8.94% (63 runs sampled)
```

This is a ~**x7**, it's great 🚀 !

It's also interesting to see how styled-components and emotion perform:
```
StyledButton x 17,752 ops/sec ±6.89% (81 runs sampled)
EmotionButton x 68,917 ops/sec ±19.32% (73 runs sampled)
```

### Context

- first iteration #13233
- https://www.onepixel.com/ performs at 2 req/s per web instance, it's pretty bad.

### Next step

Build a full page SSR benchmark. We can use one of the page layout examples, express and go/bombardier for that.