### PR TITLE
[Snackbar] Fix/Remove misleading prop value 'anchorOrigin.vertical=enter' for Snackbars.

### DIFF
--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -6,7 +6,7 @@ import { ClickAwayListenerProps } from '../ClickAwayListener';
 
 export interface SnackbarOrigin {
   horizontal: 'left' | 'center' | 'right';
-  vertical: 'top' | 'center' | 'bottom';
+  vertical: 'top' | 'bottom';
 }
 
 export interface SnackbarProps

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -282,7 +282,7 @@ Snackbar.propTypes = {
    */
   anchorOrigin: PropTypes.shape({
     horizontal: PropTypes.oneOf(['left', 'center', 'right']).isRequired,
-    vertical: PropTypes.oneOf(['top', 'center', 'bottom']).isRequired,
+    vertical: PropTypes.oneOf(['top', 'bottom']).isRequired,
   }),
   /**
    * The number of milliseconds to wait before automatically calling the


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR fixes a bug where user could set vertical value of anchorOrigin to `center`, which is not supported. #13234 