### PR TITLE
[core] Add a real life benchmark

### DIFF
--- a/packages/material-ui-benchmark/README.md
+++ b/packages/material-ui-benchmark/README.md
@@ -1,5 +1,7 @@
 # Material-UI Benchmarking
 
+## Synthetic benchmark
+
 ```sh
 yarn benchmark
 
@@ -17,4 +19,31 @@ EmotionButton x 68,917 ops/sec ±19.32% (73 runs sampled)
 ButtonBase cache x 34,618 ops/sec ±12.83% (68 runs sampled)
 ButtonBase ripple x 38,715 ops/sec ±13.70% (68 runs sampled)
 ButtonBase disableRipple x 46,165 ops/sec ±13.53% (66 runs sampled)
+```
+
+## Real life benchmark
+
+```sh
+yarn server
+
+bombardier \
+  -c 100 \
+  -l \
+  -d 60s \
+  -m GET \
+  '0.0.0.0:3001/'
+
+Statistics        Avg      Stdev        Max
+  Reqs/sec       442.47      55.44     547.63
+  Latency      225.64ms    17.11ms   471.31ms
+  Latency Distribution
+     50%   221.98ms
+     75%   230.69ms
+     90%   241.19ms
+     95%   247.87ms
+     99%   273.88ms
+  HTTP codes:
+    1xx - 0, 2xx - 26642, 3xx - 0, 4xx - 0, 5xx - 0
+    others - 0
+  Throughput:    11.61MB/s
 ```

--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -12,7 +12,8 @@
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-benchmark",
   "scripts": {
-    "benchmark": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/benchmark.js"
+    "benchmark": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/benchmark.js",
+    "server": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/server.js"
   },
   "devDependencies": {},
   "engines": {

--- a/packages/material-ui-benchmark/src/server.js
+++ b/packages/material-ui-benchmark/src/server.js
@@ -1,0 +1,65 @@
+/* eslint-disable no-console */
+
+import express from 'express';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { SheetsRegistry } from 'react-jss/lib/jss';
+import JssProvider from 'react-jss/lib/JssProvider';
+import {
+  MuiThemeProvider,
+  createMuiTheme,
+  createGenerateClassName,
+} from '@material-ui/core/styles';
+import green from '@material-ui/core/colors/green';
+import red from '@material-ui/core/colors/red';
+import Pricing from 'docs/src/pages/page-layout-examples/pricing/Pricing';
+
+function renderFullPage(html, css) {
+  return `
+    <!doctype html>
+    <html>
+      <head>
+        <title>Material-UI</title>
+      </head>
+      <body>
+        <div id="root">${html}</div>
+        <style id="jss-server-side">${css}</style>
+      </body>
+    </html>
+  `;
+}
+
+const sheetsCache = new Map();
+
+const theme = createMuiTheme({
+  palette: {
+    primary: green,
+    accent: red,
+    type: 'light',
+  },
+  typography: {
+    useNextVariants: true,
+  },
+});
+
+function handleRender(req, res) {
+  const sheetsRegistry = new SheetsRegistry();
+  const generateClassName = createGenerateClassName();
+  const html = ReactDOMServer.renderToString(
+    <JssProvider registry={sheetsRegistry} generateClassName={generateClassName}>
+      <MuiThemeProvider theme={theme} sheetsManager={new Map()} sheetsCache={sheetsCache}>
+        <Pricing />
+      </MuiThemeProvider>
+    </JssProvider>,
+  );
+  const css = sheetsRegistry.toString();
+  res.send(renderFullPage(html, css));
+}
+
+const app = express();
+app.use(handleRender);
+
+const port = 3001;
+app.listen(port, () => {
+  console.log(`listening on port ${port}`);
+});


### PR DESCRIPTION
The page: https://material-ui.com/page-layout-examples/pricing/

**Without cache**:
```
Statistics        Avg      Stdev        Max
  Reqs/sec       160.27      37.58     249.11
  Latency      621.82ms    63.78ms      1.24s
  Latency Distribution
     50%   614.04ms
     75%   635.72ms
     90%   677.14ms
     95%   749.80ms
     99%   827.46ms
  HTTP codes:
    1xx - 0, 2xx - 9697, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     4.20MB/s
```

**With cache**:
```sh
Statistics        Avg      Stdev        Max
  Reqs/sec       442.47      55.44     547.63
  Latency      225.64ms    17.11ms   471.31ms
  Latency Distribution
     50%   221.98ms
     75%   230.69ms
     90%   241.19ms
     95%   247.87ms
     99%   273.88ms
  HTTP codes:
    1xx - 0, 2xx - 26642, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    11.61MB/s
```

JSS caching provides a nice x2.7 boost 🚀.