### PR TITLE
[ButtonBase] Fix process is not defined

### DIFF
--- a/packages/material-ui/src/ButtonBase/createRippleHandler.js
+++ b/packages/material-ui/src/ButtonBase/createRippleHandler.js
@@ -28,7 +28,7 @@ let createRippleHandler = (instance, eventName, action, cb) => event => {
 };
 
 /* istanbul ignore if */
-if (!process.browser) {
+if (typeof window === 'undefined') {
   createRippleHandler = () => () => {};
 }
 

--- a/test/regressions/webpack.config.js
+++ b/test/regressions/webpack.config.js
@@ -16,7 +16,4 @@ module.exports = Object.assign({}, webpackBaseConfig, {
       },
     ]),
   }),
-  node: {
-    process: false,
-  },
 });

--- a/test/regressions/webpack.config.js
+++ b/test/regressions/webpack.config.js
@@ -16,4 +16,7 @@ module.exports = Object.assign({}, webpackBaseConfig, {
       },
     ]),
   }),
+  node: {
+    process: false,
+  },
 });


### PR DESCRIPTION
Closes #13247

I tried to not mock `process` but we execute on dependencies that are built for node (e.g. enzyme) so not polyfilling this will cause all sorts of problems in transitive dependencies.

A better place for removing the mock might be our visual regression tests.