### PR TITLE
[docs] Remove/annotate deprecated button variants

### DIFF
--- a/docs/src/pages/customization/overrides/overrides.md
+++ b/docs/src/pages/customization/overrides/overrides.md
@@ -178,7 +178,7 @@ The best approach is to follow option 1 and then take advantage of the compositi
 
 ## 4. Material Design variations
 
-The Material Design specification documents different variations of certain components, such as how buttons come in different shapes: [text](https://material.io/design/components/buttons.html#text-button) (AKA "flat"), [contained](https://material.io/design/components/buttons.html#contained-button) (AKA "raised"), [FAB](https://material.io/design/components/buttons-floating-action-button.html) and more.
+The Material Design specification documents different variations of certain components, such as how buttons come in different shapes: [text](https://material.io/design/components/buttons.html#text-button) (formerly "flat"), [contained](https://material.io/design/components/buttons.html#contained-button) (formerly "raised"), [FAB](https://material.io/design/components/buttons-floating-action-button.html) and more.
 
 Material-UI attempts to implement all of these variations. Please refer to the [Supported Components](/getting-started/supported-components/) documentation to find out the current status of all supported Material Design components.
 

--- a/docs/src/pages/getting-started/supported-components/supported-components.md
+++ b/docs/src/pages/getting-started/supported-components/supported-components.md
@@ -17,7 +17,7 @@ to discuss the approach before submitting a pull request.
   - [Bottom](https://material.io/design/components/app-bars-bottom.html)
 - **[Bottom navigation](https://material.io/design/components/bottom-navigation.html) ✓**
 - **[Buttons](https://material.io/design/components/buttons.html) ✓**
-  - **[Flat & raised buttons](https://material.io/design/components/buttons.html) ✓**
+  - **[Text & contained buttons (formerly flat & raised)](https://material.io/design/components/buttons.html) ✓**
   - [Toggle buttons](https://material.io/design/components/buttons.html#buttons-toggle-buttons)
   - **[Icon toggle buttons](https://material.io/design/components/buttons.html#toggle-button) ✓** (Custom Checkbox)
 - **[Buttons: Floating Action Button](https://material.io/design/components/buttons-floating-action-button.html) ✓**

--- a/docs/src/pages/guides/api/api.md
+++ b/docs/src/pages/guides/api/api.md
@@ -108,19 +108,19 @@ For example, let's take a button that has different types. Each option has its p
 
   ```tsx
   type Props = {
-    raised: boolean;
+    contained: boolean;
     fab: boolean;
   };
   ```
 
    This API enabled the shorthand notation:
-   `<Button>`, `<Button raised />`, `<Button fab />`.
+   `<Button>`, `<Button contained />`, `<Button fab />`.
 
 - Option 2 *enum*:
 
   ```tsx
   type Props = {
-    variant: 'flat' | 'raised' | 'fab';
+    variant: 'text' | 'contained' | 'fab';
   }
   ```
 


### PR DESCRIPTION
I think when v4 is released we can remove them completely. They will still be mentioned in the migration guides so their names won't be lost.