### PR TITLE
[core] Disable the jss vendor plugin server side

### DIFF
--- a/packages/material-ui-benchmark/src/benchmark.js
+++ b/packages/material-ui-benchmark/src/benchmark.js
@@ -12,11 +12,12 @@ import ButtonBase from '@material-ui/core/ButtonBase';
 const theme = createMuiTheme();
 
 const suite = new Benchmark.Suite('ssr', {
-  minSamples: 100,
   onError: event => {
     console.log(event.target.error);
   },
 });
+
+Benchmark.options.minSamples = 100;
 
 global.__MUI_USE_NEXT_TYPOGRAPHY_VARIANTS__ = true;
 

--- a/packages/material-ui/src/styles/jssPreset.js
+++ b/packages/material-ui/src/styles/jssPreset.js
@@ -5,8 +5,7 @@ import jssDefaultUnit from 'jss-default-unit';
 import jssVendorPrefixer from 'jss-vendor-prefixer';
 import jssPropsSort from 'jss-props-sort';
 
-// Subset of jss-preset-default with only the plugins the Material-UI
-// components are using.
+// Subset of jss-preset-default with only the plugins the Material-UI components are using.
 function jssPreset() {
   return {
     plugins: [
@@ -14,7 +13,10 @@ function jssPreset() {
       jssNested(),
       jssCamelCase(),
       jssDefaultUnit(),
-      jssVendorPrefixer(),
+      // Disable the vendor prefixer server-side, it does nothing.
+      // This way, we can get a performance boost.
+      // In the documentation, we are using `autoprefixer` to solve this problem.
+      typeof window === 'undefined' ? null : jssVendorPrefixer(),
       jssPropsSort(),
     ],
   };

--- a/packages/material-ui/src/styles/mergeClasses.js
+++ b/packages/material-ui/src/styles/mergeClasses.js
@@ -8,34 +8,33 @@ function mergeClasses(options = {}) {
     return baseClasses;
   }
 
-  return {
-    ...baseClasses,
-    ...Object.keys(newClasses).reduce((accumulator, key) => {
-      warning(
-        baseClasses[key] || !newClasses[key],
-        [
-          `Material-UI: the key \`${key}\` ` +
-            `provided to the classes property is not implemented in ${getDisplayName(Component)}.`,
-          `You can only override one of the following: ${Object.keys(baseClasses).join(',')}`,
-        ].join('\n'),
-      );
+  const nextClasses = { ...baseClasses };
 
-      warning(
-        !newClasses[key] || typeof newClasses[key] === 'string',
-        [
-          `Material-UI: the key \`${key}\` ` +
-            `provided to the classes property is not valid for ${getDisplayName(Component)}.`,
-          `You need to provide a non empty string instead of: ${newClasses[key]}.`,
-        ].join('\n'),
-      );
+  Object.keys(newClasses).forEach(key => {
+    warning(
+      baseClasses[key] || !newClasses[key],
+      [
+        `Material-UI: the key \`${key}\` ` +
+          `provided to the classes property is not implemented in ${getDisplayName(Component)}.`,
+        `You can only override one of the following: ${Object.keys(baseClasses).join(',')}.`,
+      ].join('\n'),
+    );
 
-      if (newClasses[key]) {
-        accumulator[key] = `${baseClasses[key]} ${newClasses[key]}`;
-      }
+    warning(
+      !newClasses[key] || typeof newClasses[key] === 'string',
+      [
+        `Material-UI: the key \`${key}\` ` +
+          `provided to the classes property is not valid for ${getDisplayName(Component)}.`,
+        `You need to provide a non empty string instead of: ${newClasses[key]}.`,
+      ].join('\n'),
+    );
 
-      return accumulator;
-    }, {}),
-  };
+    if (newClasses[key]) {
+      nextClasses[key] = `${baseClasses[key]} ${newClasses[key]}`;
+    }
+  });
+
+  return nextClasses;
 }
 
 export default mergeClasses;


### PR DESCRIPTION
A simple and small (~5%) performance boost on the server suggested by @kof. I'm assuming that removing the plugin from the list is the fastest approach. Maybe we can remove the logic when it's moved inside the plugin?