### PR TITLE
[docs] Fixes typos & formatting in GridListTile and GridListTileBar documentation

### DIFF
--- a/packages/material-ui/src/GridListTile/GridListTile.js
+++ b/packages/material-ui/src/GridListTile/GridListTile.js
@@ -18,14 +18,14 @@ export const styles = {
     height: '100%',
     overflow: 'hidden',
   },
-  /* Styles applied to an `ing` element child, if if needed to ensure it covers the tile. */
+  /* Styles applied to an `img` element child, if needed to ensure it covers the tile. */
   imgFullHeight: {
     height: '100%',
     transform: 'translateX(-50%)',
     position: 'relative',
     left: '50%',
   },
-  /* Styles applied to an `ing` element child, if if needed to ensure it covers the tile. */
+  /* Styles applied to an `img` element child, if needed to ensure it covers the tile. */
   imgFullWidth: {
     width: '100%',
     position: 'relative',

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.js
@@ -61,7 +61,7 @@ export const styles = theme => ({
   },
   /* Styles applied to the actionIcon if supplied. */
   actionIcon: {},
-  /* Styles applied to the actionIcon if `actionPosition="left". */
+  /* Styles applied to the actionIcon if `actionPosition="left"`. */
   actionIconActionPosLeft: {
     order: -1,
   },

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -46,7 +46,7 @@ This property accepts the following keys:
 | <span class="prop-name">title</span> | Styles applied to the title container element.
 | <span class="prop-name">subtitle</span> | Styles applied to the subtitle container element.
 | <span class="prop-name">actionIcon</span> | Styles applied to the actionIcon if supplied.
-| <span class="prop-name">actionIconActionPosLeft</span> | Styles applied to the actionIcon if `actionPosition="left".
+| <span class="prop-name">actionIconActionPosLeft</span> | Styles applied to the actionIcon if `actionPosition="left"`.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/GridListTileBar/GridListTileBar.js)

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -37,8 +37,8 @@ This property accepts the following keys:
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">tile</span> | Styles applied to the `div` element that wraps the children.
-| <span class="prop-name">imgFullHeight</span> | Styles applied to an `ing` element child, if if needed to ensure it covers the tile.
-| <span class="prop-name">imgFullWidth</span> | Styles applied to an `ing` element child, if if needed to ensure it covers the tile.
+| <span class="prop-name">imgFullHeight</span> | Styles applied to an `img` element child, if needed to ensure it covers the tile.
+| <span class="prop-name">imgFullWidth</span> | Styles applied to an `img` element child, if needed to ensure it covers the tile.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/GridListTile/GridListTile.js)


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fixes a couple of typos in GridListTile. Also, adds the missing accent-mark to close the code block in GridListTileBar.