### PR TITLE
[docs] Reverse show password logic

### DIFF
--- a/docs/src/pages/demos/text-fields/InputAdornments.js
+++ b/docs/src/pages/demos/text-fields/InputAdornments.js
@@ -127,7 +127,7 @@ class InputAdornments extends React.Component {
                   aria-label="Toggle password visibility"
                   onClick={this.handleClickShowPassword}
                 >
-                  {this.state.showPassword ? <VisibilityOff /> : <Visibility />}
+                  {this.state.showPassword ? <Visibility /> : <VisibilityOff />}
                 </IconButton>
               </InputAdornment>
             }


### PR DESCRIPTION
For google.com create account.
The <VisibilityOff /> : <Visibility /> icon is the other way around compare to what this example shows.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
