### PR TITLE
[docs] Clarify on how to use the local distribution in the CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ Then, you can add Material-UI to any project you want to try your changes:
 
 ```shell
 # From the root folder of any project
-yarn add file:/path/to/material-ui/folder
+yarn add file:<path-to-material-ui-project>/packages/material-ui/build
 ```
 
 Now, every time you import `material-ui` in your project, it is going to use your local distribution.


### PR DESCRIPTION
In this commit, we are clarifying how to install the local distribution of Material-UI to test changes in a real case scenario.

It turns out that, if you don't point the installation to the `/build` folder when importing a Material-UI component, the path `@material-ui/core/<ComponentName>` does not work.

It took me a while to realize how to install the local distribution, that's why I decided to update the documentation.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
