### PR TITLE
[ListItem] Simplify the ListItem interface when href is provided

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -112,7 +112,7 @@ class ListItem extends React.Component {
         [classes.gutters]: !disableGutters,
         [classes.divider]: divider,
         [classes.disabled]: disabled,
-        [classes.button]: button,
+        [classes.button]: button || other.href,
         [classes.secondaryAction]: hasSecondaryAction,
         [classes.selected]: selected,
       },
@@ -122,8 +122,13 @@ class ListItem extends React.Component {
     const componentProps = { className, disabled, ...other };
     let Component = componentProp || 'li';
 
-    if (button) {
-      componentProps.component = componentProp || 'div';
+    if (button || other.href) {
+      if (componentProp) {
+        componentProps.component = componentProp;
+      } else {
+        componentProps.component = other.href ? 'a' : 'div';
+      }
+
       componentProps.focusVisibleClassName = classNames(
         classes.focusVisible,
         focusVisibleClassName,

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -85,6 +85,18 @@ describe('<ListItem />', () => {
     });
   });
 
+  describe('prop: href', () => {
+    it('should render an anchor', () => {
+      const wrapper = shallow(<ListItem href="#" />);
+      assert.strictEqual(wrapper.props().component, 'a');
+    });
+
+    it('should use the button class', () => {
+      const wrapper = shallow(<ListItem href="#" />);
+      assert.strictEqual(wrapper.hasClass(classes.button), true);
+    });
+  });
+
   describe('context: dense', () => {
     it('should forward the context', () => {
       const wrapper = shallow(<ListItem />);


### PR DESCRIPTION
In this commit, we are implementing the change suggested in #12941.

This is a sugar syntax when the user provides the `href` prop, so they don't need to also provide `button=true` and `component="a"`.

Before this change:
```js
<ListItem href="#" button component="a" />
```

After this change:
```js
<ListItem href="#" />
```

I'm not totally convinced this is a valuable change because it makes the behavior of the `ListItem` less predictable, but I agree that it helps simplify the production code.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
