### PR TITLE
[docs] Add polyfill for IE 11 

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -28,7 +28,7 @@ module.exports = [
     name: 'The main docs bundle',
     webpack: false,
     path: main.path,
-    limit: '178 KB',
+    limit: '182 KB',
   },
   {
     name: 'The docs home page',

--- a/babel.config.js
+++ b/babel.config.js
@@ -70,6 +70,7 @@ module.exports = {
       ],
     },
     'docs-development': {
+      presets: [['@babel/preset-env', { useBuiltIns: 'usage' }]],
       plugins: [
         'babel-plugin-preval',
         [
@@ -91,6 +92,7 @@ module.exports = {
       ],
     },
     'docs-production': {
+      presets: [['@babel/preset-env', { useBuiltIns: 'usage' }]],
       plugins: [
         'babel-plugin-preval',
         [

--- a/babel.config.js
+++ b/babel.config.js
@@ -70,7 +70,6 @@ module.exports = {
       ],
     },
     'docs-development': {
-      presets: [['@babel/preset-env', { useBuiltIns: 'usage' }]],
       plugins: [
         'babel-plugin-preval',
         [
@@ -92,7 +91,6 @@ module.exports = {
       ],
     },
     'docs-production': {
-      presets: [['@babel/preset-env', { useBuiltIns: 'usage' }]],
       plugins: [
         'babel-plugin-preval',
         [

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -186,7 +186,8 @@ class Demo extends React.Component {
     addHiddenInput(form, 'project[title]', demo.title);
     addHiddenInput(form, 'project[description]', demo.description);
     addHiddenInput(form, 'project[dependencies]', JSON.stringify(demo.dependencies));
-    Object.entries(demo.files).forEach(([key, value]) => {
+    Object.keys(demo.files).forEach(key => {
+      const value = demo.files[key];
       addHiddenInput(form, `project[files][${key}]`, value);
     });
     document.body.appendChild(form);

--- a/docs/src/modules/components/withRoot.js
+++ b/docs/src/modules/components/withRoot.js
@@ -1,3 +1,7 @@
+// Use the same helper than Babel to avoid bundle bloat.
+import 'core-js/modules/es6.array.find-index';
+import 'core-js/modules/es6.set';
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import find from 'lodash/find';

--- a/docs/src/pages/demos/app-bar/BottomAppBar.js
+++ b/docs/src/pages/demos/app-bar/BottomAppBar.js
@@ -43,6 +43,7 @@ const styles = theme => ({
   },
   fabButton: {
     position: 'absolute',
+    zIndex: 1,
     top: -30,
     left: 0,
     right: 0,

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -56,8 +56,9 @@ class MyDocument extends Document {
         </Head>
         <body>
           <Main />
+          <NextScript />
           {/* Global Site Tag (gtag.js) - Google Analytics */}
-          <script async src="https://www.google-analytics.com/analytics.js" />
+          <script defer src="https://www.google-analytics.com/analytics.js" />
           <script
             // eslint-disable-next-line react/no-danger
             dangerouslySetInnerHTML={{
@@ -67,8 +68,7 @@ ga('create', '${config.google.id}', 'material-ui.com');
               `,
             }}
           />
-          <NextScript />
-          <script async src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js" />
+          <script defer src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js" />
         </body>
       </html>
     );


### PR DESCRIPTION
TL;DR:
Fixes the following issues in ie11:
* https://material-ui.com/demos/steppers/#horizontal-linear: crash when skipping a step 
* https://material-ui.com/demos/steppers/#horizontal-non-linear: clicking next does not wrap i.e. it does not select the first not completed step when clicking next on the last step
* all demos: "edit stackblitz" does nothing

Opened PR instead of issue so that reviewers have access to deploy preview and see if `yarn size` catches bundle size increase.

## Current behavior
Our docs are deployed as JS that can be **parsed** by every browser listed in our `.browserlistsrc`
## Expected
Our docs are deployed as JS that is equivalent in all browsers in our `.browserlistrc`
## Context
Thanks to `@babel/preset-env` and `.browserlistrc` the syntax in our demos is transpiled so that it can be understood by mainstream browsers. However we don't have any polyfills (other than `fetch`). That provide functionality that was added with es6 and es7.

Since we don't have any compat tests for our docs things like `Object.values` or `new Set(iterable)` can easily slip by. We can't expect from contributors to know about all of those and expect from reviewers to catch those.

## Solutions
### eslint-plugin-compat
At first glance `eslint-plugin-compat` sounds like an easy solution but will never catch every compat issue because it does not have access to type information so bultin prototype polyfills can not be identified perfectly. However it is possible to catch those overzealous which is annoying for a linter.

### useBultins with *entry*
`@babel/preset-env` with `useBuiltins: 'entry'` will polyfill every feature that was added in es6 and beyond and is not (correctly) implemented by the browsers in `.browserlistrc`. However this adds around 400KB uncompressed. 
<details><summary>This option will add the following polyfills:</summary><p>

```
 Replaced `@babel/polyfill` with the following polyfills:
  es6.array.copy-within { "ie":"11" }
  es6.array.fill { "ie":"11" }
  es6.array.find { "ie":"11" }
  es6.array.find-index { "ie":"11" }
  es6.array.from { "chrome":"49", "edge":"14", "ie":"11" }
  es7.array.includes { "ie":"11" }
  es6.array.iterator { "ie":"11" }
  es6.array.of { "ie":"11" }
  es6.array.sort { "chrome":"49", "node":"6.11", "safari":"10" }
  es6.array.species { "chrome":"49", "ie":"11" }
  es6.date.to-primitive { "edge":"14", "ie":"11" }
  es6.function.has-instance { "chrome":"49", "edge":"14", "ie":"11" }
  es6.function.name { "ie":"11" }
  es6.map { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11" }
  es6.math.acosh { "ie":"11" }
  es6.math.asinh { "ie":"11" }
  es6.math.atanh { "ie":"11" }
  es6.math.cbrt { "ie":"11" }
  es6.math.clz32 { "ie":"11" }
  es6.math.cosh { "ie":"11" }
  es6.math.expm1 { "ie":"11" }
  es6.math.fround { "ie":"11" }
  es6.math.hypot { "ie":"11" }
  es6.math.imul { "ie":"11" }
  es6.math.log1p { "ie":"11" }
  es6.math.log10 { "ie":"11" }
  es6.math.log2 { "ie":"11" }
  es6.math.sign { "ie":"11" }
  es6.math.sinh { "ie":"11" }
  es6.math.tanh { "ie":"11" }
  es6.math.trunc { "ie":"11" }
  es6.number.constructor { "ie":"11" }
  es6.number.epsilon { "ie":"11" }
  es6.number.is-finite { "ie":"11" }
  es6.number.is-integer { "ie":"11" }
  es6.number.is-nan { "ie":"11" }
  es6.number.is-safe-integer { "ie":"11" }
  es6.number.max-safe-integer { "ie":"11" }
  es6.number.min-safe-integer { "ie":"11" }
  es6.number.parse-float { "ie":"11" }
  es6.number.parse-int { "ie":"11" }
  es6.object.assign { "ie":"11" }
  es7.object.define-getter { "chrome":"49", "edge":"14", "ie":"11", "node":"6.11" }
  es7.object.define-setter { "chrome":"49", "edge":"14", "ie":"11", "node":"6.11" }
  es7.object.entries { "chrome":"49", "ie":"11", "node":"6.11", "safari":"10" }
  es6.object.freeze { "ie":"11" }
  es6.object.get-own-property-descriptor { "ie":"11" }
  es7.object.get-own-property-descriptors { "chrome":"49", "edge":"14", "ie":"11", "node":"6.11", "safari":"10" }
  es6.object.get-own-property-names { "ie":"11" }
  es6.object.get-prototype-of { "ie":"11" }
  es7.object.lookup-getter { "chrome":"49", "edge":"14", "ie":"11", "node":"6.11" }
  es7.object.lookup-setter { "chrome":"49", "edge":"14", "ie":"11", "node":"6.11" }
  es6.object.prevent-extensions { "ie":"11" }
  es6.object.is { "ie":"11" }
  es6.object.is-frozen { "ie":"11" }
  es6.object.is-sealed { "ie":"11" }
  es6.object.is-extensible { "ie":"11" }
  es6.object.keys { "ie":"11" }
  es6.object.seal { "ie":"11" }
  es7.object.values { "chrome":"49", "ie":"11", "node":"6.11", "safari":"10" }
  es6.promise { "chrome":"49", "ie":"11" }
  es7.promise.finally { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11", "node":"6.11", "safari":"10" }
  es6.reflect.apply { "ie":"11" }
  es6.reflect.construct { "ie":"11" }
  es6.reflect.define-property { "ie":"11" }
  es6.reflect.delete-property { "ie":"11" }
  es6.reflect.get { "ie":"11" }
  es6.reflect.get-own-property-descriptor { "ie":"11" }
  es6.reflect.get-prototype-of { "ie":"11" }
  es6.reflect.has { "ie":"11" }
  es6.reflect.is-extensible { "ie":"11" }
  es6.reflect.own-keys { "ie":"11" }
  es6.reflect.prevent-extensions { "ie":"11" }
  es6.reflect.set { "ie":"11" }
  es6.reflect.set-prototype-of { "ie":"11" }
  es6.regexp.constructor { "chrome":"49", "edge":"14", "ie":"11" }
  es6.regexp.flags { "edge":"14", "ie":"11" }
  es6.regexp.match { "chrome":"49", "edge":"14", "ie":"11" }
  es6.regexp.replace { "chrome":"49", "edge":"14", "ie":"11" }
  es6.regexp.split { "chrome":"49", "edge":"14", "ie":"11" }
  es6.regexp.search { "chrome":"49", "edge":"14", "ie":"11" }
  es6.regexp.to-string { "chrome":"49", "edge":"14", "ie":"11" }
  es6.set { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11" }
  es6.symbol { "chrome":"49", "edge":"14", "ie":"11" }
  es7.symbol.async-iterator { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11", "node":"6.11", "safari":"10" }
  es6.string.anchor { "ie":"11" }
  es6.string.big { "ie":"11" }
  es6.string.blink { "ie":"11" }
  es6.string.bold { "ie":"11" }
  es6.string.code-point-at { "ie":"11" }
  es6.string.ends-with { "ie":"11" }
  es6.string.fixed { "ie":"11" }
  es6.string.fontcolor { "ie":"11" }
  es6.string.fontsize { "ie":"11" }
  es6.string.from-code-point { "ie":"11" }
  es6.string.includes { "ie":"11" }
  es6.string.italics { "ie":"11" }
  es6.string.iterator { "ie":"11" }
  es6.string.link { "ie":"11" }
  es7.string.pad-start { "chrome":"49", "edge":"14", "ie":"11", "node":"6.11" }
  es7.string.pad-end { "chrome":"49", "edge":"14", "ie":"11", "node":"6.11" }
  es6.string.raw { "ie":"11" }
  es6.string.repeat { "ie":"11" }
  es6.string.small { "ie":"11" }
  es6.string.starts-with { "ie":"11" }
  es6.string.strike { "ie":"11" }
  es6.string.sub { "ie":"11" }
  es6.string.sup { "ie":"11" }
  es6.typed.array-buffer { "chrome":"49", "ie":"11" }
  es6.typed.int8-array { "chrome":"49", "ie":"11" }
  es6.typed.uint8-array { "chrome":"49", "ie":"11" }
  es6.typed.uint8-clamped-array { "chrome":"49", "ie":"11" }
  es6.typed.int16-array { "chrome":"49", "ie":"11" }
  es6.typed.uint16-array { "chrome":"49", "ie":"11" }
  es6.typed.int32-array { "chrome":"49", "ie":"11" }
  es6.typed.uint32-array { "chrome":"49", "ie":"11" }
  es6.typed.float32-array { "chrome":"49", "ie":"11" }
  es6.typed.float64-array { "chrome":"49", "ie":"11" }
  es6.weak-map { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11" }
  es6.weak-set { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11" }
  web.timers { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11", "node":"6.11", "safari":"10" }
  web.immediate { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11", "node":"6.11", "safari":"10" }
  web.dom.iterable { "chrome":"49", "edge":"14", "firefox":"52", "ie":"11", "node":"6.11", "safari":"10" }
```

</p></details>

### useBultins with *usage*
`useBuiltins: 'usage'` is currently flagged as experimental but is probably the best tradeoff. It's still overzealous (which it will always be due to missing type information). For example it polyfills `string.prototype.link` every time a `link` property is accessed. I think this will not catch usage in other packages.

<details><summary>This option will add the following polyfills:</summary><p>

```
es6.array.find-index
es6.array.iterator
es6.array.sort
es6.function.name
es6.map
es6.number.constructor
es6.object.assign
es6.object.keys
es6.regexp.constructor
es6.regexp.match
es6.regexp.replace
es6.regexp.search
es6.regexp.split
es6.regexp.to-string
es6.set
es6.string.anchor
es6.string.includes
es6.string.iterator
es6.string.link
es7.array.includes
es7.object.entries
regenerator-runtime
web.dom.iterable
```

</p></details>

### Just fix the code™
This is what web development was >10 years ago. Current offenders are `Object.values`, `new Set(iterable)`, `Array.prototype.findIndex`. `Object.keys` is most likeley safe. I think there is some difference in the implementation concerning Symbols in some browsers but that doesn't affect our usage I believe. `Array.prototype.includes` is only used in server side render so we should be fine there.