### PR TITLE
[FormControl] Added zIndex of 0 to root style

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -18,7 +18,7 @@ export const styles = {
     margin: 0,
     border: 0,
     verticalAlign: 'top', // Fix alignment issue on Safari.
-    zIndex: 0,
+    zIndex: 0, // Reset the stacking context for the label z-index.
   },
   /* Styles applied to the root element if `margin="normal"`. */
   marginNormal: {

--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -18,6 +18,7 @@ export const styles = {
     margin: 0,
     border: 0,
     verticalAlign: 'top', // Fix alignment issue on Safari.
+    zIndex: 0,
   },
   /* Styles applied to the root element if `margin="normal"`. */
   marginNormal: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

- Added zIndex of 0 to root style of `FormControl.js` to keep the label from rendering on top of fixed elements (such as `BottomNavigation` in certain uses).

Fixes #13246 
