### PR TITLE
[withStyle] Improve the dangerouslyUseGlobalCSS option

### DIFF
--- a/packages/material-ui-docs/src/NProgressBar/NProgressBar.js
+++ b/packages/material-ui-docs/src/NProgressBar/NProgressBar.js
@@ -78,7 +78,7 @@ const styles = theme => {
   };
 };
 
-const GlobalStyles = withStyles(styles, { flip: false })(() => null);
+const GlobalStyles = withStyles(styles, { flip: false, name: 'MuiNProgressBar' })(() => null);
 
 /**
  * Elegant and ready to use wrapper on top of https://github.com/rstacruz/nprogress/.

--- a/packages/material-ui/src/Hidden/HiddenCss.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.js
@@ -152,4 +152,4 @@ HiddenCss.propTypes = {
   xsUp: PropTypes.bool,
 };
 
-export default withStyles(styles)(HiddenCss);
+export default withStyles(styles, { name: 'MuiHiddenCss' })(HiddenCss);

--- a/packages/material-ui/src/InputBase/Textarea.js
+++ b/packages/material-ui/src/InputBase/Textarea.js
@@ -234,4 +234,4 @@ Textarea.defaultProps = {
   rows: 1,
 };
 
-export default withStyles(styles)(Textarea);
+export default withStyles(styles, { name: 'MuiTextarea' })(Textarea);

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -55,4 +55,4 @@ TabIndicator.propTypes = {
   color: PropTypes.oneOf(['primary', 'secondary']),
 };
 
-export default withStyles(styles)(TabIndicator);
+export default withStyles(styles, { name: 'MuiTabIndicator' })(TabIndicator);

--- a/packages/material-ui/src/styles/createGenerateClassName.js
+++ b/packages/material-ui/src/styles/createGenerateClassName.js
@@ -31,24 +31,8 @@ export default function createGenerateClassName(options = {}) {
       ].join(''),
     );
 
-    // Code branch the whole block at the expense of more code.
-    if (dangerouslyUseGlobalCSS) {
-      if (styleSheet) {
-        if (styleSheet.options.name) {
-          return `${styleSheet.options.name}-${rule.key}`;
-        }
-
-        if (styleSheet.options.classNamePrefix && process.env.NODE_ENV !== 'production') {
-          const prefix = safePrefix(styleSheet.options.classNamePrefix);
-          return `${prefix}-${rule.key}-${seed}${ruleCounter}`;
-        }
-      }
-
-      if (process.env.NODE_ENV === 'production') {
-        return `${productionPrefix}${seed}${ruleCounter}`;
-      }
-
-      return `${rule.key}-${seed}${ruleCounter}`;
+    if (dangerouslyUseGlobalCSS && styleSheet && styleSheet.options.name) {
+      return `${styleSheet.options.name}-${rule.key}`;
     }
 
     if (process.env.NODE_ENV === 'production') {
@@ -57,7 +41,6 @@ export default function createGenerateClassName(options = {}) {
 
     if (styleSheet && styleSheet.options.classNamePrefix) {
       const prefix = safePrefix(styleSheet.options.classNamePrefix);
-
       return `${prefix}-${rule.key}-${seed}${ruleCounter}`;
     }
 

--- a/packages/material-ui/src/styles/withStyles.js
+++ b/packages/material-ui/src/styles/withStyles.js
@@ -234,6 +234,7 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
       let meta = name;
 
       if (process.env.NODE_ENV !== 'production' && !meta) {
+        // Provide a better DX outside production.
         meta = getDisplayName(Component);
         warning(
           typeof meta === 'string',
@@ -251,7 +252,7 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
         link: false,
         ...this.sheetOptions,
         ...this.stylesCreatorSaved.options,
-        name,
+        name: name || Component.displayName,
         ...styleSheetOptions,
       });
 

--- a/packages/material-ui/src/styles/withStyles.test.js
+++ b/packages/material-ui/src/styles/withStyles.test.js
@@ -277,4 +277,43 @@ describe('withStyles', () => {
       assert.notStrictEqual(classes1, classes2, 'should generate new classes');
     });
   });
+
+  describe('options', () => {
+    let jss;
+    let generateClassName;
+    let sheetsRegistry;
+
+    beforeEach(() => {
+      jss = create(jssPreset());
+      generateClassName = createGenerateClassName();
+      sheetsRegistry = new SheetsRegistry();
+    });
+
+    it('should use the displayName', () => {
+      // Uglified
+      const a = () => <div />;
+      const StyledComponent1 = withStyles({ root: { padding: 1 } })(a);
+      const fooo = () => <div />;
+      const StyledComponent2 = withStyles({ root: { padding: 1 } })(fooo);
+      const AppFrame = () => <div />;
+      AppFrame.displayName = 'AppLayout';
+      const StyledComponent3 = withStyles({ root: { padding: 1 } })(AppFrame);
+
+      mount(
+        <JssProvider registry={sheetsRegistry} jss={jss} generateClassName={generateClassName}>
+          <div>
+            <StyledComponent1 />
+            <StyledComponent2 />
+            <StyledComponent3 />
+          </div>
+        </JssProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry[0].options.classNamePrefix, 'a');
+      assert.strictEqual(sheetsRegistry.registry[0].options.name, undefined);
+      assert.strictEqual(sheetsRegistry.registry[1].options.classNamePrefix, 'fooo');
+      assert.strictEqual(sheetsRegistry.registry[1].options.name, undefined);
+      assert.strictEqual(sheetsRegistry.registry[2].options.classNamePrefix, 'AppLayout');
+      assert.strictEqual(sheetsRegistry.registry[2].options.name, 'AppLayout');
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4302,9 +4302,9 @@ dot-prop@^4.1.0:
     is-obj "^1.0.0"
 
 downshift@^3.0.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.1.1.tgz#91e14d45d6ee3e239023cdfcc06248c7f5a1b2b2"
-  integrity sha512-teJ4ACfySJPC1+nOg6XqSMtCwjQkdXLfM2FlObr5FQAIR2r9TTFFDbXUTvzRA7mSJVf3FQZ/cx9i67Ox0iEy1Q==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/downshift/-/downshift-3.1.2.tgz#3a8238b7595796ae2f63a47bf7e2b619fa972dc1"
+  integrity sha512-OdeGRCfUTNL/eR8dLPmV6c9ytS6md1uwX2z0WGcOJaaArpV4DIdIwkmmvKH/U4NrZgXNV6J6iQAOZ/rayfQnGA==
   dependencies:
     "@babel/runtime" "^7.1.2"
     compute-scroll-into-view "^1.0.9"
@@ -8880,12 +8880,7 @@ postcss-modules-values@^1.3.0:
     icss-replace-symbols "^1.1.0"
     postcss "^6.0.1"
 
-postcss-value-parser@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz#87f38f9f18f774a4ab4c8a232f5c5ce8872a9d15"
-  integrity sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU=
-
-postcss-value-parser@^3.3.1:
+postcss-value-parser@^3.3.0, postcss-value-parser@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
@@ -10869,9 +10864,9 @@ style-loader@^0.23.0:
     schema-utils "^0.4.5"
 
 styled-components@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.0.0.tgz#bd37d79408246302051cd63f52a3539f70aa3197"
-  integrity sha512-+SXoKjaXmApQHjQXNY5pxuRpnabR7vnL6J59Gtcj118ll8gsg9MM8gkjWu6Ahc0NB9kLjh3O9Ho2iun6uLunVA==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.0.2.tgz#7d4409ada019cdd34c25ba68c4577ea95dbcf0c5"
+  integrity sha512-VTNCmBLNx0OS2GRaYk0yRAnQVDBCGnnxGkR6+BCmkKVv9VgICO7bEn3UDjlnwCw8hgIyecMzVLOPl+p1zqUxog==
   dependencies:
     "@emotion/is-prop-valid" "^0.6.8"
     babel-plugin-styled-components ">= 1"


### PR DESCRIPTION
At work, we are experimenting with the `dangerouslyUseGlobalCSS` option. It might be a good answer to the usage of JSS stylesheet caching server side (+30% req/s). I also need to look into a hash based logic over the index counter.