### PR TITLE
[Button] Fix styles classes isolation

### DIFF
--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -228,16 +228,15 @@ function Button(props) {
 
   const fab = variant === 'fab' || variant === 'extendedFab';
   const contained = variant === 'contained' || variant === 'raised';
-  const text = variant === 'text' || variant === 'flat' || variant === 'outlined';
   const className = classNames(
     classes.root,
     {
       [classes.fab]: fab,
       [classes.mini]: fab && mini,
       [classes.extendedFab]: variant === 'extendedFab',
-      [classes.text]: text,
-      [classes.textPrimary]: text && color === 'primary',
-      [classes.textSecondary]: text && color === 'secondary',
+      [classes.text]: variant === 'text',
+      [classes.textPrimary]: variant === 'text' && color === 'primary',
+      [classes.textSecondary]: variant === 'text' && color === 'secondary',
       [classes.flat]: variant === 'text' || variant === 'flat',
       [classes.flatPrimary]: (variant === 'text' || variant === 'flat') && color === 'primary',
       [classes.flatSecondary]: (variant === 'text' || variant === 'flat') && color === 'secondary',

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -240,15 +240,16 @@ function Button(props) {
 
   const fab = variant === 'fab' || variant === 'extendedFab';
   const contained = variant === 'contained' || variant === 'raised';
+  const text = variant === 'text' || variant === 'flat';
   const className = classNames(
     classes.root,
     {
       [classes.fab]: fab,
       [classes.mini]: fab && mini,
       [classes.extendedFab]: variant === 'extendedFab',
-      [classes.text]: variant === 'text',
-      [classes.textPrimary]: variant === 'text' && color === 'primary',
-      [classes.textSecondary]: variant === 'text' && color === 'secondary',
+      [classes.text]: text,
+      [classes.textPrimary]: text && color === 'primary',
+      [classes.textSecondary]: text && color === 'secondary',
       [classes.flat]: variant === 'text' || variant === 'flat',
       [classes.flatPrimary]: (variant === 'text' || variant === 'flat') && color === 'primary',
       [classes.flatSecondary]: (variant === 'text' || variant === 'flat') && color === 'secondary',

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -82,9 +82,15 @@ export const styles = theme => ({
   },
   /* Styles applied to the root element if `variant="outlined"` and `color="primary"`. */
   outlinedPrimary: {
+    color: theme.palette.primary.main,
     border: `1px solid ${fade(theme.palette.primary.main, 0.5)}`,
     '&:hover': {
       border: `1px solid ${theme.palette.primary.main}`,
+      backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
     },
     '&$disabled': {
       border: `1px solid ${theme.palette.action.disabled}`,
@@ -92,9 +98,15 @@ export const styles = theme => ({
   },
   /* Styles applied to the root element if `variant="outlined"` and `color="secondary"`. */
   outlinedSecondary: {
+    color: theme.palette.secondary.main,
     border: `1px solid ${fade(theme.palette.secondary.main, 0.5)}`,
     '&:hover': {
       border: `1px solid ${theme.palette.secondary.main}`,
+      backgroundColor: fade(theme.palette.secondary.main, theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
     },
     '&$disabled': {
       border: `1px solid ${theme.palette.action.disabled}`,

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -149,10 +149,10 @@ describe('<Button />', () => {
         </Button>,
       );
       assert.strictEqual(wrapper.hasClass(classes.root), true);
+      assert.strictEqual(wrapper.hasClass(classes.text), true);
       assert.strictEqual(wrapper.hasClass(classes.flat), true);
+      assert.strictEqual(wrapper.hasClass(classes.textSecondary), true);
       assert.strictEqual(wrapper.hasClass(classes.flatSecondary), true);
-      assert.strictEqual(wrapper.hasClass(classes.text), false);
-      assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
     });
   });
 

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -149,23 +149,23 @@ describe('<Button />', () => {
         </Button>,
       );
       assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass(classes.text), true);
       assert.strictEqual(wrapper.hasClass(classes.flat), true);
-      assert.strictEqual(wrapper.hasClass(classes.textSecondary), true);
       assert.strictEqual(wrapper.hasClass(classes.flatSecondary), true);
+      assert.strictEqual(wrapper.hasClass(classes.text), false);
+      assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
     });
   });
 
   it('should render an outlined button', () => {
     const wrapper = shallow(<Button variant="outlined">Hello World</Button>);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.text), true);
     assert.strictEqual(wrapper.hasClass(classes.outlined), true);
     assert.strictEqual(
       wrapper.hasClass(classes.contained),
       false,
       'should not have the contained class',
     );
+    assert.strictEqual(wrapper.hasClass(classes.text), false);
     assert.strictEqual(wrapper.hasClass(classes.raised), false);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
   });
@@ -177,9 +177,10 @@ describe('<Button />', () => {
       </Button>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.text), true);
     assert.strictEqual(wrapper.hasClass(classes.outlined), true);
-    assert.strictEqual(wrapper.hasClass(classes.textPrimary), true);
+    assert.strictEqual(wrapper.hasClass(classes.outlinedPrimary), true);
+    assert.strictEqual(wrapper.hasClass(classes.text), false);
+    assert.strictEqual(wrapper.hasClass(classes.textPrimary), false);
     assert.strictEqual(wrapper.hasClass(classes.contained), false);
     assert.strictEqual(wrapper.hasClass(classes.raised), false);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);
@@ -192,9 +193,10 @@ describe('<Button />', () => {
       </Button>,
     );
     assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.text), true);
     assert.strictEqual(wrapper.hasClass(classes.outlined), true);
-    assert.strictEqual(wrapper.hasClass(classes.textSecondary), true);
+    assert.strictEqual(wrapper.hasClass(classes.outlinedSecondary), true);
+    assert.strictEqual(wrapper.hasClass(classes.text), false);
+    assert.strictEqual(wrapper.hasClass(classes.textSecondary), false);
     assert.strictEqual(wrapper.hasClass(classes.contained), false);
     assert.strictEqual(wrapper.hasClass(classes.raised), false);
     assert.strictEqual(wrapper.hasClass(classes.fab), false);


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Currently, a class like `textPrimary` will erroneously apply to an `outlined` button. I have updated the `Button` styling to match what is described in the docs as shown below. This will properly allow us to override text button styles separately from outlined button styles.

![screen shot 2018-10-22 at 5 00 41 pm](https://user-images.githubusercontent.com/4968616/47321984-0d938480-d61c-11e8-8dc6-669301680145.png)
