### PR TITLE
[Modal] Add modal in handleRendered

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -68,7 +68,6 @@ class Modal extends React.Component {
     } else if (!prevProps.open && this.props.open) {
       // check for focus
       this.lastFocus = ownerDocument(this.mountNode).activeElement;
-      this.handleOpen();
     }
   }
 
@@ -116,12 +115,7 @@ class Modal extends React.Component {
     }
 
     if (this.props.open) {
-      this.handleOpened();
-    } else {
-      const doc = ownerDocument(this.mountNode);
-      const container = getContainer(this.props.container, doc.body);
-      this.props.manager.add(this, container);
-      this.props.manager.remove(this);
+      this.handleOpen();
     }
   };
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Adding modal in combination with Portal componentDidUpdate causes refs (like modalRef) to be undefined in first render cycle. In handleRendered (after portal renders with refs in its children) instead refs are set correctly.
In my opinion it isn't the best approach, probably someone finds a better solution for this.

btw removing modals in handleRendered is not necessary due to be removed in componentDidUpdate already. 
Hope modals are stable now 😃 . 
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


Closes #13365
