### PR TITLE
[Modal] Fix arial and focus logic

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of all the material-ui modules.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '93.0 KB',
+    limit: '93.1 KB',
   },
   {
     name: 'The main docs bundle',

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -57,7 +57,7 @@ class Menu extends React.Component {
     }
   };
 
-  handleEnter = element => {
+  handleEntering = element => {
     const { disableAutoFocusItem, theme } = this.props;
     const menuList = ReactDOM.findDOMNode(this.menuListRef);
 
@@ -74,8 +74,8 @@ class Menu extends React.Component {
       menuList.style.width = `calc(100% + ${size})`;
     }
 
-    if (this.props.onEnter) {
-      this.props.onEnter(element);
+    if (this.props.onEntering) {
+      this.props.onEntering(element);
     }
   };
 
@@ -95,7 +95,7 @@ class Menu extends React.Component {
       classes,
       disableAutoFocusItem,
       MenuListProps,
-      onEnter,
+      onEntering,
       PaperProps = {},
       PopoverClasses,
       theme,
@@ -106,7 +106,7 @@ class Menu extends React.Component {
       <Popover
         getContentAnchorEl={this.getContentAnchorEl}
         classes={PopoverClasses}
-        onEnter={this.handleEnter}
+        onEntering={this.handleEntering}
         anchorOrigin={theme.direction === 'rtl' ? RTL_ORIGIN : LTR_ORIGIN}
         transformOrigin={theme.direction === 'rtl' ? RTL_ORIGIN : LTR_ORIGIN}
         PaperProps={{

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -163,16 +163,16 @@ describe('<Menu />', () => {
     });
 
     it('should call props.onEnter with element if exists', () => {
-      const onEnterSpy = spy();
-      wrapper.setProps({ onEnter: onEnterSpy });
-      instance.handleEnter(elementForHandleEnter);
-      assert.strictEqual(onEnterSpy.callCount, 1);
-      assert.strictEqual(onEnterSpy.calledWith(elementForHandleEnter), true);
+      const onEnteringSpy = spy();
+      wrapper.setProps({ onEntering: onEnteringSpy });
+      instance.handleEntering(elementForHandleEnter);
+      assert.strictEqual(onEnteringSpy.callCount, 1);
+      assert.strictEqual(onEnteringSpy.calledWith(elementForHandleEnter), true);
     });
 
     it('should call menuList focus when no menuList', () => {
       delete instance.menuListRef;
-      instance.handleEnter(elementForHandleEnter);
+      instance.handleEntering(elementForHandleEnter);
       assert.strictEqual(selectedItemFocusSpy.callCount, 0);
       assert.strictEqual(menuListFocusSpy.callCount, 1);
     });
@@ -180,7 +180,7 @@ describe('<Menu />', () => {
     it('should call menuList focus when menuList but no menuList.selectedItemRef ', () => {
       instance.menuListRef = {};
       delete instance.menuListRef.selectedItemRef;
-      instance.handleEnter(elementForHandleEnter);
+      instance.handleEntering(elementForHandleEnter);
       assert.strictEqual(selectedItemFocusSpy.callCount, 0);
       assert.strictEqual(menuListFocusSpy.callCount, 1);
     });
@@ -192,21 +192,21 @@ describe('<Menu />', () => {
       });
 
       it('should call selectedItem focus when there is a menuList.selectedItemRef', () => {
-        instance.handleEnter(elementForHandleEnter);
+        instance.handleEntering(elementForHandleEnter);
         assert.strictEqual(selectedItemFocusSpy.callCount, 1);
         assert.strictEqual(menuListFocusSpy.callCount, 0);
       });
 
       it('should not set style on list when element.clientHeight > list.clientHeight', () => {
         elementForHandleEnter.clientHeight = MENU_LIST_HEIGHT + 1;
-        instance.handleEnter(elementForHandleEnter);
+        instance.handleEntering(elementForHandleEnter);
         assert.strictEqual(menuListSpy.style.paddingRight, undefined);
         assert.strictEqual(menuListSpy.style.width, undefined);
       });
 
       it('should not set style on list when element.clientHeight == list.clientHeight', () => {
         elementForHandleEnter.clientHeight = MENU_LIST_HEIGHT;
-        instance.handleEnter(elementForHandleEnter);
+        instance.handleEntering(elementForHandleEnter);
         assert.strictEqual(menuListSpy.style.paddingRight, undefined);
         assert.strictEqual(menuListSpy.style.width, undefined);
       });
@@ -215,7 +215,7 @@ describe('<Menu />', () => {
         assert.strictEqual(menuListSpy.style.paddingRight, undefined);
         assert.strictEqual(menuListSpy.style.width, undefined);
         elementForHandleEnter.clientHeight = MENU_LIST_HEIGHT - 1;
-        instance.handleEnter(elementForHandleEnter);
+        instance.handleEntering(elementForHandleEnter);
         assert.notStrictEqual(menuListSpy.style.paddingRight, undefined);
         assert.notStrictEqual(menuListSpy.style.width, undefined);
       });

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -67,7 +67,6 @@ class Modal extends React.Component {
     if (prevProps.open && !this.props.open) {
       this.handleClose();
     } else if (!prevProps.open && this.props.open) {
-      // check for focus
       this.lastFocus = ownerDocument(this.mountNode).activeElement;
       this.handleOpen();
     }

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -11,6 +11,7 @@ import { createChainedFunction } from '../utils/helpers';
 import withStyles from '../styles/withStyles';
 import ModalManager from './ModalManager';
 import Backdrop from '../Backdrop';
+import { ariaHidden } from './manageAriaHidden';
 
 function getContainer(container, defaultContainer) {
   container = typeof container === 'function' ? container() : container;
@@ -118,10 +119,7 @@ class Modal extends React.Component {
     if (this.props.open) {
       this.handleOpened();
     } else {
-      const doc = ownerDocument(this.mountNode);
-      const container = getContainer(this.props.container, doc.body);
-      this.props.manager.add(this, container);
-      this.props.manager.remove(this);
+      ariaHidden(this.modalRef, true);
     }
   };
 

--- a/packages/material-ui/src/Modal/ModalManager.js
+++ b/packages/material-ui/src/Modal/ModalManager.js
@@ -154,7 +154,7 @@ class ModalManager {
     } else if (this.hideSiblingNodes) {
       // Otherwise make sure the next top modal is visible to a screan reader.
       const nextTop = data.modals[data.modals.length - 1];
-      // as soon as a modal is adding its modalRef is undefined. it can't set 
+      // as soon as a modal is adding its modalRef is undefined. it can't set
       // aria-hidden because the dom element doesn't exist either
       if (nextTop.modalRef !== undefined) {
         ariaHidden(nextTop.modalRef, false);

--- a/packages/material-ui/src/Modal/ModalManager.js
+++ b/packages/material-ui/src/Modal/ModalManager.js
@@ -153,7 +153,12 @@ class ModalManager {
       this.data.splice(containerIdx, 1);
     } else if (this.hideSiblingNodes) {
       // Otherwise make sure the next top modal is visible to a screan reader.
-      ariaHidden(data.modals[data.modals.length - 1].modalRef, false);
+      const nextTop = data.modals[data.modals.length - 1];
+      // as soon as a modal is adding its modalRef is undefined. it can't set 
+      // aria-hidden because the dom element doesn't exist either
+      if (nextTop.modalRef !== undefined) {
+        ariaHidden(nextTop.modalRef, false);
+      }
     }
 
     return modalIdx;

--- a/packages/material-ui/src/Modal/ModalManager.js
+++ b/packages/material-ui/src/Modal/ModalManager.js
@@ -156,7 +156,8 @@ class ModalManager {
       const nextTop = data.modals[data.modals.length - 1];
       // as soon as a modal is adding its modalRef is undefined. it can't set
       // aria-hidden because the dom element doesn't exist either
-      if (nextTop.modalRef !== undefined) {
+      // when modal was unmounted before modalRef gets null
+      if (nextTop.modalRef) {
         ariaHidden(nextTop.modalRef, false);
       }
     }

--- a/packages/material-ui/src/Modal/manageAriaHidden.d.ts
+++ b/packages/material-ui/src/Modal/manageAriaHidden.d.ts
@@ -1,3 +1,7 @@
-export function ariaHidden(show: boolean, node: Node): never;
-export function hideSiblings(container: Element, mountNode: Node): never;
-export function showSiblings(container: Element, mountNode: Node): never;
+export function ariaHidden(node: Node, show: boolean): never;
+export function ariaHiddenSiblings(
+  container: Element,
+  mountNode: Node,
+  currentNode: Node,
+  show: boolean,
+): never;

--- a/packages/material-ui/test/integration/NestedMenu.test.js
+++ b/packages/material-ui/test/integration/NestedMenu.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { assert } from 'chai';
+import { createMount } from 'packages/material-ui/src/test-utils';
+import Portal from 'packages/material-ui/src/Portal';
+import NestedMenu from './fixtures/menus/NestedMenu';
+
+describe('<NestedMenu> integration', () => {
+  let mount;
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  describe('mounted open', () => {
+    let wrapper;
+    let portalLayer;
+
+    before(() => {
+      wrapper = mount(<NestedMenu />);
+    });
+
+    it('should not be open', () => {
+      const firstMenu = document.getElementById('first-menu');
+      const secondMenu = document.getElementById('second-menu');
+      assert.strictEqual(firstMenu, null);
+      assert.strictEqual(secondMenu, null);
+    });
+
+    it('should focus the first item as nothing has been selected', () => {
+      wrapper.setState({ firstMenuOpen: true });
+
+      portalLayer = wrapper
+        .find(Portal)
+        .instance()
+        .getMountNode();
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
+    });
+
+    it('should focus the first item of second menu', () => {
+      wrapper.setState({ firstMenuOpen: false, secondMenuOpen: true });
+      const secondMenu = document.getElementById('second-menu');
+      assert.strictEqual(document.activeElement, secondMenu.querySelectorAll('li')[0]);
+    });
+  });
+});

--- a/packages/material-ui/test/integration/NestedMenu.test.js
+++ b/packages/material-ui/test/integration/NestedMenu.test.js
@@ -45,5 +45,17 @@ describe('<NestedMenu> integration', () => {
       const secondMenu = document.getElementById('second-menu');
       assert.strictEqual(document.activeElement, secondMenu.querySelectorAll('li')[0]);
     });
+
+    it('should open the first menu again', () => {
+      wrapper.setState({ firstMenuOpen: true, secondMenuOpen: false });
+      const firstMenu = document.getElementById('first-menu');
+      assert.strictEqual(document.activeElement, firstMenu.querySelectorAll('li')[0]);
+    });
+
+    it('should be able to open second menu again', () => {
+      wrapper.setState({ firstMenuOpen: false, secondMenuOpen: true });
+      const secondMenu = document.getElementById('second-menu');
+      assert.strictEqual(document.activeElement, secondMenu.querySelectorAll('li')[0]);
+    });
   });
 });

--- a/packages/material-ui/test/integration/fixtures/menus/NestedMenu.js
+++ b/packages/material-ui/test/integration/fixtures/menus/NestedMenu.js
@@ -25,10 +25,20 @@ class NestedMenu extends React.Component {
 
     return (
       <div>
-        <Menu id="second-menu" open={secondMenuOpen} onClose={this.handleClose}>
+        <Menu
+          id="second-menu"
+          open={secondMenuOpen}
+          onClose={this.handleClose}
+          transitionDuration={0}
+        >
           <MenuItem onClick={this.handleMenuItemClick2}>Second Menu</MenuItem>
         </Menu>
-        <Menu id="first-menu" open={firstMenuOpen} onClose={this.handleClose}>
+        <Menu
+          id="first-menu"
+          open={firstMenuOpen}
+          onClose={this.handleClose}
+          transitionDuration={0}
+        >
           <MenuItem onClick={this.handleMenuItemClick}>Profile 1</MenuItem>
           <MenuItem onClick={this.handleClose}>My account</MenuItem>
           <MenuItem onClick={this.handleClose}>Logout</MenuItem>

--- a/packages/material-ui/test/integration/fixtures/menus/NestedMenu.js
+++ b/packages/material-ui/test/integration/fixtures/menus/NestedMenu.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+
+class NestedMenu extends React.Component {
+  state = {
+    firstMenuOpen: false,
+    secondMenuOpen: false,
+  };
+
+  handleMenuItemClick = () => {
+    this.setState({ firstMenuOpen: false, secondMenuOpen: true });
+  };
+
+  handleMenuItemClick2 = () => {
+    this.setState({ secondMenuOpen: false });
+  };
+
+  handleClose = () => {
+    this.setState({ firstMenuOpen: false, secondMenuOpen: false });
+  };
+
+  render() {
+    const { firstMenuOpen, secondMenuOpen } = this.state;
+
+    return (
+      <div>
+        <Menu id="second-menu" open={secondMenuOpen} onClose={this.handleClose}>
+          <MenuItem onClick={this.handleMenuItemClick2}>Second Menu</MenuItem>
+        </Menu>
+        <Menu id="first-menu" open={firstMenuOpen} onClose={this.handleClose}>
+          <MenuItem onClick={this.handleMenuItemClick}>Profile 1</MenuItem>
+          <MenuItem onClick={this.handleClose}>My account</MenuItem>
+          <MenuItem onClick={this.handleClose}>Logout</MenuItem>
+        </Menu>
+      </div>
+    );
+  }
+}
+
+export default NestedMenu;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

I think there is no other way to fix that problem nicely. Checking the `modalRef` is a good step to determine if the modal exists in the dom. Adding a modal to the `ModalManager` without a correct `modalRef ` is bad but not changeable.

Closes #13365