### PR TITLE
[Dialog] Fix unable to drag scrollbar when scroll="body"

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -68,7 +68,7 @@ via [Patreon](https://www.patreon.com/oliviertassinari)
 | Avétis KAZARIAN | Withinpixels | SIM KIM SIA | Renaud Bompuis | Yaron Malin |
 | Arvanitis Panagiotis | Jesse Weigel | Bogdan Mihai Nicolae | Dung Tran | Kyle Pennell |
 | Kai Mit Pansen | Eric Nagy | Karens Grigorjancs | Mohamed Turco | Haroun Serang |
-| Antonio Seveso | Ali Akhavan | Bruno Winck |
+| Antonio Seveso | Ali Akhavan | Bruno Winck | Alessandro Annini |
 
 via [OpenCollective](https://opencollective.com/material-ui)
 

--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -27,18 +27,21 @@ const styles = theme => ({
   },
   paper: {
     padding: theme.spacing.unit,
+    display: 'block',
   },
 });
 
 function getAdblock(classes) {
   return (
-    <Paper elevation={0} className={classes.paper}>
-      <Typography gutterBottom>Like Material-UI?</Typography>
-      <Typography gutterBottom>
+    <Paper component="span" elevation={0} className={classes.paper}>
+      <Typography component="span" gutterBottom>
+        Like Material-UI?
+      </Typography>
+      <Typography component="span" gutterBottom>
         {`If you don't mind tech-related ads, and want to support Open Source,
             please whitelist Material-UI in your ad blocker.`}
       </Typography>
-      <Typography>
+      <Typography component="span">
         Thank you!{' '}
         <span role="img" aria-label="Love">
           ❤️

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -277,7 +277,7 @@ describe('<SpeedDial />', () => {
 
     it('displays the actions on focus gain', () => {
       resetDialToOpen();
-      assert.strictEqual(wrapper.prop('open'), true);
+      assert.strictEqual(wrapper.props().open, true);
     });
 
     describe('first item selection', () => {

--- a/packages/material-ui/src/Card/Card.test.js
+++ b/packages/material-ui/src/Card/Card.test.js
@@ -32,6 +32,6 @@ describe('<Card />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<Card data-my-prop="woofCard" />);
-    assert.strictEqual(wrapper.prop('data-my-prop'), 'woofCard', 'custom prop should be woofCard');
+    assert.strictEqual(wrapper.props()['data-my-prop'], 'woofCard');
   });
 });

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -20,7 +20,7 @@ describe('<CardMedia />', () => {
 
   it('should have the backgroundImage specified', () => {
     const wrapper = shallow(<CardMedia image="/foo.jpg" />);
-    assert.strictEqual(wrapper.prop('style').backgroundImage, 'url("/foo.jpg")');
+    assert.strictEqual(wrapper.props().style.backgroundImage, 'url("/foo.jpg")');
   });
 
   it('should spread custom props on the root node', () => {
@@ -34,15 +34,15 @@ describe('<CardMedia />', () => {
 
   it('should have backgroundImage specified even though custom styles got passed', () => {
     const wrapper = shallow(<CardMedia image="/foo.jpg" style={{ height: 200 }} />);
-    assert.strictEqual(wrapper.prop('style').backgroundImage, 'url("/foo.jpg")');
-    assert.strictEqual(wrapper.prop('style').height, 200);
+    assert.strictEqual(wrapper.props().style.backgroundImage, 'url("/foo.jpg")');
+    assert.strictEqual(wrapper.props().style.height, 200);
   });
 
   it('should be possible to overwrite backgroundImage via custom styles', () => {
     const wrapper = shallow(
       <CardMedia image="/foo.jpg" style={{ backgroundImage: 'url(/bar.jpg)' }} />,
     );
-    assert.strictEqual(wrapper.prop('style').backgroundImage, 'url(/bar.jpg)');
+    assert.strictEqual(wrapper.props().style.backgroundImage, 'url(/bar.jpg)');
   });
 
   describe('prop: component', () => {
@@ -58,7 +58,7 @@ describe('<CardMedia />', () => {
 
     it('should not have default inline style when media component specified', () => {
       const wrapper = shallow(<CardMedia src="/foo.jpg" component="picture" />);
-      assert.strictEqual(wrapper.prop('style'), undefined);
+      assert.strictEqual(wrapper.props().style, undefined);
     });
 
     it('should not have `src` prop if not media component specified', () => {

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -24,6 +24,11 @@ export const styles = theme => ({
     overflowY: 'auto',
     overflowX: 'hidden',
   },
+  container: {
+    height: '100%',
+    // We disable the focus ring for mouse, touch and keyboard users.
+    outline: 'none',
+  },
   /* Styles applied to the `Paper` component. */
   paper: {
     display: 'flex',
@@ -31,8 +36,6 @@ export const styles = theme => ({
     margin: 48,
     position: 'relative',
     overflowY: 'auto', // Fix IE 11 issue, to remove at some point.
-    // We disable the focus ring for mouse, touch and keyboard users.
-    outline: 'none',
   },
   /* Styles applied to the `Paper` component if `scroll="paper"`. */
   paperScrollPaper: {
@@ -100,77 +103,101 @@ export const styles = theme => ({
 /**
  * Dialogs are overlaid modal paper based components with a backdrop.
  */
-function Dialog(props) {
-  const {
-    BackdropProps,
-    children,
-    classes,
-    className,
-    disableBackdropClick,
-    disableEscapeKeyDown,
-    fullScreen,
-    fullWidth,
-    maxWidth,
-    onBackdropClick,
-    onClose,
-    onEnter,
-    onEntered,
-    onEntering,
-    onEscapeKeyDown,
-    onExit,
-    onExited,
-    onExiting,
-    open,
-    PaperProps,
-    scroll,
-    TransitionComponent,
-    transitionDuration,
-    TransitionProps,
-    ...other
-  } = props;
+class Dialog extends React.Component {
+  handleBackdropClick = event => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
 
-  return (
-    <Modal
-      className={classNames(classes.root, classes[`scroll${capitalize(scroll)}`], className)}
-      BackdropProps={{
-        transitionDuration,
-        ...BackdropProps,
-      }}
-      disableBackdropClick={disableBackdropClick}
-      disableEscapeKeyDown={disableEscapeKeyDown}
-      onBackdropClick={onBackdropClick}
-      onEscapeKeyDown={onEscapeKeyDown}
-      onClose={onClose}
-      open={open}
-      role="dialog"
-      {...other}
-    >
-      <TransitionComponent
-        appear
-        in={open}
-        timeout={transitionDuration}
-        onEnter={onEnter}
-        onEntering={onEntering}
-        onEntered={onEntered}
-        onExit={onExit}
-        onExiting={onExiting}
-        onExited={onExited}
-        {...TransitionProps}
+    if (this.props.onBackdropClick) {
+      this.props.onBackdropClick(event);
+    }
+
+    if (!this.props.disableBackdropClick && this.props.onClose) {
+      this.props.onClose(event, 'backdropClick');
+    }
+  };
+
+  render() {
+    const {
+      BackdropProps,
+      children,
+      classes,
+      className,
+      disableBackdropClick,
+      disableEscapeKeyDown,
+      fullScreen,
+      fullWidth,
+      maxWidth,
+      onBackdropClick,
+      onClose,
+      onEnter,
+      onEntered,
+      onEntering,
+      onEscapeKeyDown,
+      onExit,
+      onExited,
+      onExiting,
+      open,
+      PaperProps,
+      scroll,
+      TransitionComponent,
+      transitionDuration,
+      TransitionProps,
+      ...other
+    } = this.props;
+
+    const Div = 'div';
+
+    return (
+      <Modal
+        className={classNames(classes.root, className)}
+        BackdropProps={{
+          transitionDuration,
+          ...BackdropProps,
+        }}
+        disableBackdropClick={disableBackdropClick}
+        disableEscapeKeyDown={disableEscapeKeyDown}
+        onBackdropClick={onBackdropClick}
+        onEscapeKeyDown={onEscapeKeyDown}
+        onClose={onClose}
+        open={open}
+        role="dialog"
+        {...other}
       >
-        <Paper
-          elevation={24}
-          className={classNames(classes.paper, classes[`paperScroll${capitalize(scroll)}`], {
-            [classes[`paperWidth${maxWidth ? capitalize(maxWidth) : ''}`]]: maxWidth,
-            [classes.paperFullScreen]: fullScreen,
-            [classes.paperFullWidth]: fullWidth,
-          })}
-          {...PaperProps}
+        <TransitionComponent
+          appear
+          in={open}
+          timeout={transitionDuration}
+          onEnter={onEnter}
+          onEntering={onEntering}
+          onEntered={onEntered}
+          onExit={onExit}
+          onExiting={onExiting}
+          onExited={onExited}
+          {...TransitionProps}
         >
-          {children}
-        </Paper>
-      </TransitionComponent>
-    </Modal>
-  );
+          <Div
+            className={classNames(classes[`scroll${capitalize(scroll)}`], classes.container)}
+            onClick={this.handleBackdropClick}
+            role="dialog"
+          >
+            <Paper
+              elevation={24}
+              className={classNames(classes.paper, classes[`paperScroll${capitalize(scroll)}`], {
+                [classes[`paperWidth${maxWidth ? capitalize(maxWidth) : ''}`]]: maxWidth,
+                [classes.paperFullScreen]: fullScreen,
+                [classes.paperFullWidth]: fullWidth,
+              })}
+              {...PaperProps}
+            >
+              {children}
+            </Paper>
+          </Div>
+        </TransitionComponent>
+      </Modal>
+    );
+  }
 }
 
 Dialog.propTypes = {

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
+/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 // @inheritedComponent Modal
 
 import React from 'react';
@@ -148,8 +150,6 @@ class Dialog extends React.Component {
       ...other
     } = this.props;
 
-    const Div = 'div';
-
     return (
       <Modal
         className={classNames(classes.root, className)}
@@ -178,10 +178,10 @@ class Dialog extends React.Component {
           onExited={onExited}
           {...TransitionProps}
         >
-          <Div
-            className={classNames(classes[`scroll${capitalize(scroll)}`], classes.container)}
+          <div
+            className={classNames(classes.container, classes[`scroll${capitalize(scroll)}`])}
             onClick={this.handleBackdropClick}
-            role="dialog"
+            role="document"
           >
             <Paper
               elevation={24}
@@ -194,7 +194,7 @@ class Dialog extends React.Component {
             >
               {children}
             </Paper>
-          </Div>
+          </div>
         </TransitionComponent>
       </Modal>
     );

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -24,6 +24,7 @@ export const styles = theme => ({
     overflowY: 'auto',
     overflowX: 'hidden',
   },
+  /* Styles applied to the container element. */
   container: {
     height: '100%',
     // We disable the focus ring for mouse, touch and keyboard users.

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
+import { spy } from 'sinon';
 import { createShallow, getClasses } from '../test-utils';
 import Paper from '../Paper';
 import Fade from '../Fade';
@@ -77,14 +78,17 @@ describe('<Dialog />', () => {
     assert.strictEqual(wrapper.hasClass('woofDialog'), true);
   });
 
-  it('should render Fade > Paper > children inside the Modal', () => {
+  it('should render Fade > div > Paper > children inside the Modal', () => {
     const children = <p>Hello</p>;
     const wrapper = shallow(<Dialog {...defaultProps}>{children}</Dialog>);
 
     const fade = wrapper.childAt(0);
     assert.strictEqual(fade.type(), Fade);
 
-    const paper = fade.childAt(0);
+    const div = fade.childAt(0);
+    assert.strictEqual(div.type(), 'div');
+
+    const paper = div.childAt(0);
     assert.strictEqual(paper.length === 1 && paper.type(), Paper);
 
     assert.strictEqual(paper.hasClass(classes.paper), true);
@@ -105,6 +109,71 @@ describe('<Dialog />', () => {
   it('should fade down and make the transition appear on first mount', () => {
     const wrapper = shallow(<Dialog {...defaultProps}>foo</Dialog>);
     assert.strictEqual(wrapper.find(Fade).props().appear, true);
+  });
+
+  describe('backdrop', () => {
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = shallow(<Dialog open>foo</Dialog>);
+    });
+
+    it('should attach a handler to the backdrop that fires onClose', () => {
+      const onClose = spy();
+      wrapper.setProps({ onClose });
+
+      const handler = wrapper.instance().handleBackdropClick;
+      const backdrop = wrapper.find('div');
+      assert.strictEqual(
+        backdrop.prop('onClick'),
+        handler,
+        'should attach the handleBackdropClick handler',
+      );
+
+      handler({});
+      assert.strictEqual(onClose.callCount, 1, 'should fire the onClose callback');
+    });
+
+    it('should let the user disable backdrop click triggering onClose', () => {
+      const onClose = spy();
+      wrapper.setProps({ onClose, disableBackdropClick: true });
+
+      const handler = wrapper.instance().handleBackdropClick;
+
+      handler({});
+      assert.strictEqual(onClose.callCount, 0, 'should not fire the onClose callback');
+    });
+
+    it('should call through to the user specified onBackdropClick callback', () => {
+      const onBackdropClick = spy();
+      wrapper.setProps({ onBackdropClick });
+
+      const handler = wrapper.instance().handleBackdropClick;
+
+      handler({});
+      assert.strictEqual(onBackdropClick.callCount, 1, 'should fire the onBackdropClick callback');
+    });
+
+    it('should ignore the backdrop click if the event did not come from the backdrop', () => {
+      const onBackdropClick = spy();
+      wrapper.setProps({ onBackdropClick });
+
+      const handler = wrapper.instance().handleBackdropClick;
+
+      handler({
+        target: {
+          /* a dom node */
+        },
+        currentTarget: {
+          /* another dom node */
+        },
+      });
+      assert.strictEqual(
+        onBackdropClick.callCount,
+        0,
+        'should not fire the onBackdropClick callback',
+      );
+    });
   });
 
   describe('prop: classes', () => {

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -125,7 +125,7 @@ describe('<Dialog />', () => {
       const handler = wrapper.instance().handleBackdropClick;
       const backdrop = wrapper.find('div');
       assert.strictEqual(
-        backdrop.prop('onClick'),
+        backdrop.props().onClick,
         handler,
         'should attach the handleBackdropClick handler',
       );

--- a/packages/material-ui/src/DialogContent/DialogContent.test.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.test.js
@@ -20,7 +20,7 @@ describe('<DialogContent />', () => {
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<DialogContent data-my-prop="woofDialogContent" />);
     assert.strictEqual(
-      wrapper.prop('data-my-prop'),
+      wrapper.props()['data-my-prop'],
       'woofDialogContent',
       'custom prop should be woofDialogContent',
     );

--- a/packages/material-ui/src/DialogTitle/DialogTitle.test.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.test.js
@@ -20,7 +20,7 @@ describe('<DialogTitle />', () => {
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<DialogTitle data-my-prop="woofDialogTitle">foo</DialogTitle>);
     assert.strictEqual(
-      wrapper.prop('data-my-prop'),
+      wrapper.props()['data-my-prop'],
       'woofDialogTitle',
       'custom prop should be woofDialogTitle',
     );

--- a/packages/material-ui/src/GridList/GridList.test.js
+++ b/packages/material-ui/src/GridList/GridList.test.js
@@ -63,7 +63,7 @@ describe('<GridList />', () => {
       wrapper
         .children()
         .at(0)
-        .prop('style').height,
+        .props().style.height,
       cellHeight + 4,
       'should have height to 254',
     );
@@ -110,7 +110,7 @@ describe('<GridList />', () => {
       wrapper
         .children()
         .at(0)
-        .prop('style').width,
+        .props().style.width,
       '25%',
       'should have 25% of width',
     );
@@ -138,7 +138,7 @@ describe('<GridList />', () => {
       wrapper
         .children()
         .at(0)
-        .prop('style').padding,
+        .props().style.padding,
       spacing / 2,
       'should have 5 of padding',
     );
@@ -162,11 +162,7 @@ describe('<GridList />', () => {
     );
 
     assert.strictEqual(wrapper.find('.grid-tile').length, 2, 'should contain the children');
-    assert.strictEqual(
-      wrapper.prop('style').backgroundColor,
-      style.backgroundColor,
-      'should have a red backgroundColor',
-    );
+    assert.strictEqual(wrapper.props().style.backgroundColor, style.backgroundColor);
   });
 
   describe('prop: cellHeight', () => {

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -82,14 +82,10 @@ describe('<Modal />', () => {
 
       const handler = wrapper.instance().handleBackdropClick;
       const backdrop = wrapper.find(Backdrop);
-      assert.strictEqual(
-        backdrop.prop('onClick'),
-        handler,
-        'should attach the handleBackdropClick handler',
-      );
+      assert.strictEqual(backdrop.props().onClick, handler);
 
       handler({});
-      assert.strictEqual(onClose.callCount, 1, 'should fire the onClose callback');
+      assert.strictEqual(onClose.callCount, 1);
     });
 
     it('should let the user disable backdrop click triggering onClose', () => {
@@ -99,7 +95,7 @@ describe('<Modal />', () => {
       const handler = wrapper.instance().handleBackdropClick;
 
       handler({});
-      assert.strictEqual(onClose.callCount, 0, 'should not fire the onClose callback');
+      assert.strictEqual(onClose.callCount, 0);
     });
 
     it('should call through to the user specified onBackdropClick callback', () => {
@@ -109,7 +105,7 @@ describe('<Modal />', () => {
       const handler = wrapper.instance().handleBackdropClick;
 
       handler({});
-      assert.strictEqual(onBackdropClick.callCount, 1, 'should fire the onBackdropClick callback');
+      assert.strictEqual(onBackdropClick.callCount, 1);
     });
 
     it('should ignore the backdrop click if the event did not come from the backdrop', () => {
@@ -126,11 +122,7 @@ describe('<Modal />', () => {
           /* another dom node */
         },
       });
-      assert.strictEqual(
-        onBackdropClick.callCount,
-        0,
-        'should not fire the onBackdropClick callback',
-      );
+      assert.strictEqual(onBackdropClick.callCount, 0);
     });
   });
 

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -232,7 +232,7 @@ describe('<Popover />', () => {
         wrapper
           .childAt(0)
           .childAt(0)
-          .prop('elevation'),
+          .props().elevation,
         8,
         'should be 8 elevation by default',
       );
@@ -241,7 +241,7 @@ describe('<Popover />', () => {
         wrapper
           .childAt(0)
           .childAt(0)
-          .prop('elevation'),
+          .props().elevation,
         16,
         'should be 16 elevation',
       );

--- a/packages/material-ui/src/TableRow/TableRow.test.js
+++ b/packages/material-ui/src/TableRow/TableRow.test.js
@@ -24,11 +24,7 @@ describe('<TableRow />', () => {
 
   it('should spread custom props on the root node', () => {
     const wrapper = shallow(<TableRow data-my-prop="woofTableRow" />);
-    assert.strictEqual(
-      wrapper.prop('data-my-prop'),
-      'woofTableRow',
-      'custom prop should be woofTableRow',
-    );
+    assert.strictEqual(wrapper.props()['data-my-prop'], 'woofTableRow');
   });
 
   it('should render with the user and root classes', () => {

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -55,6 +55,7 @@ This property accepts the following keys:
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">scrollPaper</span> | Styles applied to the root element if `scroll="paper"`.
 | <span class="prop-name">scrollBody</span> | Styles applied to the root element if `scroll="body"`.
+| <span class="prop-name">container</span> | Styles applied to the container element.
 | <span class="prop-name">paper</span> | Styles applied to the `Paper` component.
 | <span class="prop-name">paperScrollPaper</span> | Styles applied to the `Paper` component if `scroll="paper"`.
 | <span class="prop-name">paperScrollBody</span> | Styles applied to the `Paper` component if `scroll="body"`.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

---

Closes #12420

The use of `position: fixed` or `position: absolute` will overlap on top of the scrollbar, therefore this solution wrap around the `Paper` using `div` and allow scrolling on that `div`.

The `div` also listen to click actions so that the user could dismiss the dialog by clicking outside of the `Paper`. `Backdrop` is not applicable here because it doesn't accept a children.

I have tried to write a test for the comparison before and after this fix but I am unable to find a good way to do so because `click` event is not possible on scroll bar.