### PR TITLE
[Menu] Fix position regression

### DIFF
--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -110,16 +110,14 @@ class Popover extends React.Component {
   };
 
   setPositioningStyles = element => {
-    if (element && element.style) {
-      const positioning = this.getPositioningStyle(element);
-      if (positioning.top !== null) {
-        element.style.top = positioning.top;
-      }
-      if (positioning.left !== null) {
-        element.style.left = positioning.left;
-      }
-      element.style.transformOrigin = positioning.transformOrigin;
+    const positioning = this.getPositioningStyle(element);
+    if (positioning.top !== null) {
+      element.style.top = positioning.top;
     }
+    if (positioning.left !== null) {
+      element.style.left = positioning.left;
+    }
+    element.style.transformOrigin = positioning.transformOrigin;
   };
 
   getPositioningStyle = element => {
@@ -262,9 +260,9 @@ class Popover extends React.Component {
     };
   }
 
-  handleEnter = element => {
-    if (this.props.onEnter) {
-      this.props.onEnter(element);
+  handleEntering = element => {
+    if (this.props.onEntering) {
+      this.props.onEntering(element);
     }
 
     this.setPositioningStyles(element);
@@ -323,9 +321,9 @@ class Popover extends React.Component {
         <TransitionComponent
           appear
           in={open}
-          onEnter={this.handleEnter}
+          onEnter={onEnter}
           onEntered={onEntered}
-          onEntering={onEntering}
+          onEntering={this.handleEntering}
           onExit={onExit}
           onExited={onExited}
           onExiting={onExiting}

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -260,18 +260,18 @@ describe('<Popover />', () => {
       },
     };
 
-    describe('handleEnter(element)', () => {
+    describe('handleEntering(element)', () => {
       let wrapper;
-      let handleEnter;
+      let handleEntering;
 
       before(() => {
-        handleEnter = spy();
+        handleEntering = spy();
         wrapper = shallow(
-          <Popover {...defaultProps} onEnter={handleEnter}>
+          <Popover {...defaultProps} onEntering={handleEntering}>
             <div />
           </Popover>,
         );
-        wrapper.instance().handleEnter(element);
+        wrapper.instance().handleEntering(element);
       });
 
       it('should set the inline styles for the enter phase', () => {


### PR DESCRIPTION
There is one key difference between `onEnter` and `onEntering`. The first one is called before the did mount / did updated hooks while the second one is called after. It's important to wait for the did mount / did updated hooks so the Modal can performant the focus management logic correctly. It's only after that we can start messing with the focus like we do in the Menu component.

Closes #13416