### PR TITLE
[Tabs] Fix misaligned tab

### DIFF
--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -13,8 +13,9 @@ export const styles = theme => ({
   root: {
     ...theme.typography.button,
     maxWidth: 264,
-    position: 'relative',
     minWidth: 72,
+    position: 'relative',
+    boxSizing: 'border-box',
     padding: 0,
     minHeight: 48,
     flexShrink: 0,
@@ -29,11 +30,13 @@ export const styles = theme => ({
   /* Styles applied to the root element if both `icon` and `label` are provided. */
   labelIcon: {
     minHeight: 72,
-    paddingTop: 12,
-    paddingBottom: 3,
+    // paddingTop supposed to be 12px
+    // - 3px from the paddingBottom
+    paddingTop: 9,
     // paddingBottom supposed to be 12px
     // -3px for line-height of the label
     // -6px for label padding
+    // = 3px
   },
   /* Styles applied to the root element if `textColor="inherit"`. */
   textColorInherit: {
@@ -151,7 +154,7 @@ class Tab extends React.Component {
   render() {
     const {
       classes,
-      className: classNameProp,
+      className,
       disabled,
       fullWidth,
       icon,
@@ -183,22 +186,20 @@ class Tab extends React.Component {
       );
     }
 
-    const className = classNames(
-      classes.root,
-      classes[`textColor${capitalize(textColor)}`],
-      {
-        [classes.disabled]: disabled,
-        [classes.selected]: selected,
-        [classes.labelIcon]: icon && label,
-        [classes.fullWidth]: fullWidth,
-      },
-      classNameProp,
-    );
-
     return (
       <ButtonBase
         focusRipple
-        className={className}
+        className={classNames(
+          classes.root,
+          classes[`textColor${capitalize(textColor)}`],
+          {
+            [classes.disabled]: disabled,
+            [classes.selected]: selected,
+            [classes.labelIcon]: icon && label,
+            [classes.fullWidth]: fullWidth,
+          },
+          className,
+        )}
         role="tab"
         aria-selected={selected}
         disabled={disabled}

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -29,6 +29,11 @@ export const styles = theme => ({
   /* Styles applied to the root element if both `icon` and `label` are provided. */
   labelIcon: {
     minHeight: 72,
+    paddingTop: 12,
+    paddingBottom: 3,
+    // paddingBottom supposed to be 12px
+    // -3px for line-height of the label
+    // -6px for label padding
   },
   /* Styles applied to the root element if `textColor="inherit"`. */
   textColorInherit: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This should fix #13397, the tab with icon and label is now vertically aligned to the center.