### PR TITLE
[slider] Fix hover state not being registered

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -101,7 +101,6 @@ export const styles = theme => {
     thumbWrapper: {
       position: 'relative',
       zIndex: 2,
-      pointerEvents: 'none',
       transition: thumbTransitions,
       '&$activated': {
         transition: 'none',


### PR DESCRIPTION
Missed during review of #13325, discussed in https://github.com/mui-org/material-ui/pull/13325/files#r228850709
