### PR TITLE
[docs] Add Google Analytics events

### DIFF
--- a/docs/src/config.js
+++ b/docs/src/config.js
@@ -1,7 +1,0 @@
-const config = {
-  google: {
-    id: 'UA-106598593-2',
-  },
-};
-
-export default config;

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -199,6 +199,7 @@ class Demo extends React.Component {
   render() {
     const { classes, demoOptions, githubLocation, index, js: DemoComponent, raw } = this.props;
     const { anchorEl, codeOpen } = this.state;
+    const category = demoOptions.demo;
 
     return (
       <div className={classes.root}>
@@ -206,19 +207,32 @@ class Demo extends React.Component {
           <div>
             <div className={classes.header}>
               <Tooltip title="See the source on GitHub" placement="top">
-                <IconButton href={githubLocation} target="_blank" aria-label="GitHub">
+                <IconButton
+                  ga-event-category={category}
+                  ga-event-action="github"
+                  href={githubLocation}
+                  target="_blank"
+                  aria-label="GitHub"
+                >
                   <Github />
                 </IconButton>
               </Tooltip>
               {demoOptions.hideEditButton ? null : (
                 <Tooltip title="Edit in CodeSandbox" placement="top">
-                  <IconButton onClick={this.handleClickCodeSandbox} aria-label="CodeSandbox">
+                  <IconButton
+                    ga-event-category={category}
+                    ga-event-action="codesandbox"
+                    onClick={this.handleClickCodeSandbox}
+                    aria-label="CodeSandbox"
+                  >
                     <EditIcon />
                   </IconButton>
                 </Tooltip>
               )}
               <Tooltip title={codeOpen ? 'Hide the source' : 'Show the source'} placement="top">
                 <IconButton
+                  ga-event-category={category}
+                  ga-event-action="expand"
                   onClick={this.handleClickCodeOpen}
                   aria-label={`Source of demo n°${index}`}
                 >
@@ -248,9 +262,21 @@ class Demo extends React.Component {
                   horizontal: 'right',
                 }}
               >
-                <MenuItem onClick={this.handleClickCopy}>Copy the source</MenuItem>
+                <MenuItem
+                  ga-event-category={category}
+                  ga-event-action="copy"
+                  onClick={this.handleClickCopy}
+                >
+                  Copy the source
+                </MenuItem>
                 {demoOptions.hideEditButton ? null : (
-                  <MenuItem onClick={this.handleClickStackBlitz}>Edit in StackBlitz</MenuItem>
+                  <MenuItem
+                    ga-event-category={category}
+                    ga-event-action="stackblitz"
+                    onClick={this.handleClickStackBlitz}
+                  >
+                    Edit in StackBlitz
+                  </MenuItem>
                 )}
               </Menu>
             </div>

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -1,22 +1,57 @@
 import React from 'react';
 
-class GoogleAnalytics extends React.Component {
-  componentDidMount() {
-    if (process.env.NODE_ENV !== 'production') {
-      return;
+function handleClick(event) {
+  const rootNode = document;
+  let element = event.target;
+
+  while (element && element !== rootNode) {
+    const category = element.getAttribute('ga-event-category');
+
+    // We reach a tracking element, no need to look higher in the dom tree.
+    if (category) {
+      window.ga('send', {
+        hitType: 'event',
+        eventCategory: category,
+        eventAction: element.getAttribute('ga-event-action'),
+      });
+      break;
     }
 
-    // Wait for the title to be updated.
-    this.timer = setTimeout(() => {
-      window.ga('set', {
-        page: window.location.pathname,
-      });
-      window.ga('send', { hitType: 'pageview' });
-    });
+    element = element.parentNode;
+  }
+}
+
+let binded = false;
+
+// So we can write code like:
+//
+// <Button
+//   ga-event-category="demo"
+//   ga-event-action="expand"
+// >
+//   Foo
+// </Button>
+function bindEvents() {
+  if (binded) {
+    return;
   }
 
-  componentWillUnmount() {
-    clearTimeout(this.timer);
+  binded = true;
+  document.addEventListener('click', handleClick);
+}
+
+class GoogleAnalytics extends React.Component {
+  googleTimer = null;
+
+  componentDidMount() {
+    bindEvents();
+    // Wait for the title to be updated.
+    setTimeout(() => {
+      window.ga('send', {
+        hitType: 'pageview',
+        page: window.location.pathname,
+      });
+    });
   }
 
   render() {

--- a/docs/src/pages/demos/menus/LongMenu.js
+++ b/docs/src/pages/demos/menus/LongMenu.js
@@ -53,7 +53,6 @@ class LongMenu extends React.Component {
         <Menu
           id="long-menu"
           anchorEl={anchorEl}
-          anchorReference={anchorEl}
           open={open}
           onClose={this.handleClose}
           PaperProps={{

--- a/docs/src/pages/demos/menus/LongMenu.js
+++ b/docs/src/pages/demos/menus/LongMenu.js
@@ -53,6 +53,7 @@ class LongMenu extends React.Component {
         <Menu
           id="long-menu"
           anchorEl={anchorEl}
+          anchorReference={anchorEl}
           open={open}
           onClose={this.handleClose}
           PaperProps={{

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
 import getPageContext from 'docs/src/modules/styles/getPageContext';
-import config from 'docs/src/config';
 
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark
@@ -20,6 +19,8 @@ if (process.env.NODE_ENV === 'production') {
   prefixer = postcss([autoprefixer]);
   cleanCSS = new CleanCSS();
 }
+
+const GOOGLE_ID = process.env.NODE_ENV === 'production' ? 'UA-106598593-2' : 'UA-106598593-3';
 
 class MyDocument extends Document {
   render() {
@@ -64,7 +65,7 @@ class MyDocument extends Document {
             dangerouslySetInnerHTML={{
               __html: `
 window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', '${config.google.id}', 'material-ui.com');
+window.ga('create', '${GOOGLE_ID}', 'auto');
               `,
             }}
           />


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

As pointed out by #13449, the Menu location was incorrect.

Menu in question: https://material-ui.com/demos/menus/#max-height-menus (you may need to scroll for it to exhibit more obvious incorrect positioning)

Currently:
![image](https://user-images.githubusercontent.com/824481/47728396-a5a0f780-dc34-11e8-9475-cbce47032f1d.png)

Fixed:
![image](https://user-images.githubusercontent.com/824481/47728386-9fab1680-dc34-11e8-9195-9613145aa153.png)