### PR TITLE
[createMixins] Use theme spacing unit in gutters

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -16,13 +16,13 @@ module.exports = [
     name: 'The initial cost paid for using one component',
     webpack: true,
     path: 'packages/material-ui/build/Paper/index.js',
-    limit: '17.8 KB',
+    limit: '17.9 KB',
   },
   {
     name: 'The size of all the material-ui modules.',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '93.3 KB',
+    limit: '93.4 KB',
   },
   {
     name: 'The main docs bundle',

--- a/packages/material-ui/src/styles/createMuiTheme.js
+++ b/packages/material-ui/src/styles/createMuiTheme.js
@@ -7,7 +7,7 @@ import createPalette from './createPalette';
 import createTypography from './createTypography';
 import shadows from './shadows';
 import shape from './shape';
-import spacing from './spacing';
+import defaultSpacing from './spacing';
 import transitions from './transitions';
 import zIndex from './zIndex';
 
@@ -17,12 +17,14 @@ function createMuiTheme(options = {}) {
     mixins: mixinsInput = {},
     palette: paletteInput = {},
     shadows: shadowsInput,
+    spacing: spacingInput = {},
     typography: typographyInput = {},
     ...other
   } = options;
 
   const palette = createPalette(paletteInput);
   const breakpoints = createBreakpoints(breakpointsInput);
+  const spacing = { ...defaultSpacing, ...spacingInput };
 
   const muiTheme = {
     breakpoints,

--- a/packages/material-ui/src/styles/createMuiTheme.test.js
+++ b/packages/material-ui/src/styles/createMuiTheme.test.js
@@ -22,6 +22,12 @@ describe('createMuiTheme', () => {
     assert.notStrictEqual(muiTheme.transitions.duration.shorter, undefined);
   });
 
+  it('should use the defined spacing unit for the gutters mixin', () => {
+    const unit = 100;
+    const muiTheme = createMuiTheme({ spacing: { unit } });
+    assert.strictEqual(muiTheme.mixins.gutters().paddingLeft, unit * 2);
+  });
+
   describe('shadows', () => {
     it('should provide the default array', () => {
       const muiTheme = createMuiTheme();


### PR DESCRIPTION
When creating a theme using `createMuiTheme`, the `gutters` mixin was
using the default spacing unit instead of the custom defined one for the
new theme. Now, it uses the expected spacing unit.

Closes #13438

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
