### PR TITLE
[styles] use provided spacing units or default #13438

### DIFF
--- a/packages/material-ui/src/styles/createMuiTheme.js
+++ b/packages/material-ui/src/styles/createMuiTheme.js
@@ -7,7 +7,7 @@ import createPalette from './createPalette';
 import createTypography from './createTypography';
 import shadows from './shadows';
 import shape from './shape';
-import spacing from './spacing';
+import spacing as defaultSpacing from './spacing';
 import transitions from './transitions';
 import zIndex from './zIndex';
 
@@ -17,6 +17,7 @@ function createMuiTheme(options = {}) {
     mixins: mixinsInput = {},
     palette: paletteInput = {},
     shadows: shadowsInput,
+    spacing: defaultSpacing,
     typography: typographyInput = {},
     ...other
   } = options;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fixes #13438 as the spacing was not being destructured from options