### PR TITLE
[docs] Fix the scroll functionality of the mini drawer demo

### DIFF
--- a/docs/src/pages/demos/drawers/MiniDrawer.js
+++ b/docs/src/pages/demos/drawers/MiniDrawer.js
@@ -47,25 +47,30 @@ const styles = theme => ({
   hide: {
     display: 'none',
   },
-  drawerPaper: {
-    position: 'relative',
-    whiteSpace: 'nowrap',
+  drawer: {
+    width: drawerWidth,
+    flexShrink: 0,
+  },
+  drawerOpen: {
     width: drawerWidth,
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.enteringScreen,
     }),
   },
-  drawerPaperClose: {
-    overflowX: 'hidden',
+  drawerClose: {
     transition: theme.transitions.create('width', {
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.leavingScreen,
     }),
+    overflowX: 'hidden',
     width: theme.spacing.unit * 7,
     [theme.breakpoints.up('sm')]: {
       width: theme.spacing.unit * 9,
     },
+  },
+  drawerPaper: {
+    whiteSpace: 'nowrap',
   },
   toolbar: {
     display: 'flex',
@@ -123,8 +128,15 @@ class MiniDrawer extends React.Component {
         </AppBar>
         <Drawer
           variant="permanent"
+          className={classNames(classes.drawer, {
+            [classes.drawerOpen]: this.state.open,
+            [classes.drawerClose]: !this.state.open,
+          })}
           classes={{
-            paper: classNames(classes.drawerPaper, !this.state.open && classes.drawerPaperClose),
+            paper: classNames(classes.drawerPaper, {
+              [classes.drawerOpen]: this.state.open,
+              [classes.drawerClose]: !this.state.open,
+            }),
           }}
           open={this.state.open}
         >

--- a/docs/src/pages/demos/drawers/MiniDrawer.js
+++ b/docs/src/pages/demos/drawers/MiniDrawer.js
@@ -50,6 +50,7 @@ const styles = theme => ({
   drawer: {
     width: drawerWidth,
     flexShrink: 0,
+    whiteSpace: 'nowrap',
   },
   drawerOpen: {
     width: drawerWidth,
@@ -64,13 +65,10 @@ const styles = theme => ({
       duration: theme.transitions.duration.leavingScreen,
     }),
     overflowX: 'hidden',
-    width: theme.spacing.unit * 7,
+    width: theme.spacing.unit * 7 + 1,
     [theme.breakpoints.up('sm')]: {
-      width: theme.spacing.unit * 9,
+      width: theme.spacing.unit * 9 + 1,
     },
-  },
-  drawerPaper: {
-    whiteSpace: 'nowrap',
   },
   toolbar: {
     display: 'flex',
@@ -133,7 +131,7 @@ class MiniDrawer extends React.Component {
             [classes.drawerClose]: !this.state.open,
           })}
           classes={{
-            paper: classNames(classes.drawerPaper, {
+            paper: classNames({
               [classes.drawerOpen]: this.state.open,
               [classes.drawerClose]: !this.state.open,
             }),


### PR DESCRIPTION
In this commit, we are changing the CSS for the mini drawer demo so to separate the vertical scroll of the drawer to be independent of the window scroll.

Credits for @oliviertassinari that came up with these changes, I tested it locally and it works perfectly.

Fixes #13412

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
