### PR TITLE
[slider] Refactor into Slider, Thumb and Track

### DIFF
--- a/docs/src/pages/lab/slider/CustomIconSlider.js
+++ b/docs/src/pages/lab/slider/CustomIconSlider.js
@@ -41,13 +41,15 @@ class CustomIconSlider extends React.Component {
           value={value}
           aria-labelledby="slider-image"
           onChange={this.handleChange}
-          thumb={
-            <img
-              alt="slider thumb icon"
-              src="/static/images/misc/circle.png"
-              className={classes.thumbIcon}
-            />
-          }
+          thumbProps={{
+            icon: (
+              <img
+                alt="slider thumb icon"
+                src="/static/images/misc/circle.png"
+                className={classes.thumbIcon}
+              />
+            ),
+          }}
         />
         <Typography id="slider-icon">Icon thumb</Typography>
         <Slider
@@ -56,9 +58,11 @@ class CustomIconSlider extends React.Component {
           onChange={this.handleChange}
           classes={{
             container: classes.slider,
-            thumbIconWrapper: classes.thumbIconWrapper,
           }}
-          thumb={<LensIcon style={{ color: '#2196f3' }} />}
+          thumbProps={{
+            className: classes.thumbIconWrapper,
+            icon: <LensIcon style={{ color: '#2196f3' }} />,
+          }}
         />
       </div>
     );

--- a/packages/material-ui-lab/src/Slider/Slider.d.ts
+++ b/packages/material-ui-lab/src/Slider/Slider.d.ts
@@ -1,34 +1,24 @@
 import * as React from 'react';
 import { StandardProps } from '@material-ui/core';
-import { ButtonProps } from '@material-ui/core/Button';
-import { TransitionProps } from 'react-transition-group/Transition';
-import { TransitionHandlerProps } from '@material-ui/core/transitions/transition';
+import { SharedClassKey, SharedProps } from './shared';
 
 export interface SliderProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, SliderClassKey, 'onChange'> {
+  component?: React.ReactType<React.HTMLAttributes<{}>>;
   disabled?: boolean;
-  vertical?: boolean;
   max?: number;
   min?: number;
-  step?: number;
-  value?: number;
   onChange?: (event: React.ChangeEvent<{}>, value: number) => void;
   onDragEnd?: (event: React.ChangeEvent<{}>) => void;
   onDragStart?: (event: React.ChangeEvent<{}>) => void;
+  step?: number;
+  thumb?: React.Component<SharedClassKey>;
+  track?: React.Component<SharedClassKey>;
+  value: number;
+  vertical?: boolean;
 }
 
-export type SliderClassKey =
-  | 'root'
-  | 'container'
-  | 'track'
-  | 'trackBefore'
-  | 'trackAfter'
-  | 'thumb'
-  | 'focused'
-  | 'activated'
-  | 'disabled'
-  | 'vertical'
-  | 'jumped';
+export type SliderClassKey = 'root' | 'container' | SharedClassKey;
 
 declare const Slider: React.ComponentType<SliderProps>;
 

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -148,19 +148,6 @@ describe('<Slider />', () => {
       wrapper = mount(<Slider onChange={handleChange} disabled value={0} />);
     });
 
-    it('should render thumb with the disabled classes', () => {
-      const button = wrapper.find('button');
-
-      assert.strictEqual(button.hasClass(classes.thumb), true);
-      assert.strictEqual(button.hasClass(classes.disabled), true);
-    });
-
-    it('should render tracks with the disabled classes', () => {
-      const tracks = wrapper.find('div').filterWhere(n => n.hasClass(classes.track));
-
-      assert.strictEqual(tracks.everyWhere(n => n.hasClass(classes.disabled)), true);
-    });
-
     it("should not call 'onChange' handler", () => {
       wrapper.simulate('click');
 

--- a/packages/material-ui-lab/src/Slider/dom.js
+++ b/packages/material-ui-lab/src/Slider/dom.js
@@ -1,0 +1,40 @@
+import clamp from '../utils/clamp';
+
+function getMousePosition(event) {
+  if (event.changedTouches && event.changedTouches[0]) {
+    return {
+      x: event.changedTouches[0].pageX,
+      y: event.changedTouches[0].pageY,
+    };
+  }
+
+  return {
+    x: event.pageX,
+    y: event.pageY,
+  };
+}
+
+function getOffset(node) {
+  const { pageYOffset, pageXOffset } = global;
+  const { left, bottom } = node.getBoundingClientRect();
+
+  return {
+    bottom: bottom + pageYOffset,
+    left: left + pageXOffset,
+  };
+}
+
+export function calculatePercent(node, event, isVertical, isRtl) {
+  const { width, height } = node.getBoundingClientRect();
+  const { bottom, left } = getOffset(node);
+  const { x, y } = getMousePosition(event);
+
+  const value = isVertical ? bottom - y : x - left;
+  const onePercent = (isVertical ? height : width) / 100;
+
+  return isRtl && !isVertical ? 100 - clamp(value / onePercent) : clamp(value / onePercent);
+}
+
+export function preventPageScrolling(event) {
+  event.preventDefault();
+}

--- a/packages/material-ui-lab/src/Slider/shared.d.ts
+++ b/packages/material-ui-lab/src/Slider/shared.d.ts
@@ -1,0 +1,11 @@
+export interface SharedProps {
+  min: number;
+  max: number;
+  state: string;
+  value: number;
+  vertical: boolean;
+}
+
+export type SharedClassKey = 'activated' | 'disabled' | 'focused' | 'jumped' | 'vertical';
+
+export type State = 'activated' | 'disabled' | 'focused' | 'jumped';

--- a/packages/material-ui-lab/src/Slider/shared.js
+++ b/packages/material-ui-lab/src/Slider/shared.js
@@ -1,0 +1,42 @@
+import clamp from '../utils/clamp';
+
+export function getTransitionOptions(theme) {
+  return {
+    duration: theme.transitions.duration.shortest,
+    easing: theme.transitions.easing.easeOut,
+  };
+}
+
+export function getValueInPercent(props) {
+  const { min, max, value } = props;
+  return clamp(((value - min) * 100) / (max - min));
+}
+
+/**
+ *
+ * @param {Object} context
+ * @param {Object} context.classes - jss classes
+ * @param {boolean} context.disabled
+ * @param {string} context.state - state of the slider
+ * @param {boolean} context.vertical
+ * @returns arg for classnames
+ */
+export function getVisualStateClasses(context) {
+  const { classes, disabled, state, vertical } = context;
+  return {
+    [classes.disabled]: disabled,
+    [classes.jumped]: !disabled && state === 'jumped',
+    [classes.focused]: !disabled && state === 'focused',
+    [classes.activated]: !disabled && state === 'activated',
+    [classes.vertical]: vertical,
+  };
+}
+
+export function percentToValue(percent, props) {
+  const { min, max } = props;
+  return ((max - min) * percent) / 100 + min;
+}
+
+export function roundToStep(number, step) {
+  return Math.round(number / step) * step;
+}

--- a/packages/material-ui-lab/src/SliderThumb/SliderThumb.d.ts
+++ b/packages/material-ui-lab/src/SliderThumb/SliderThumb.d.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { StandardProps } from '@material-ui/core';
+import { ButtonBaseProps } from '@material-ui/core/ButtonBase';
+import { SharedClassKey, SharedProps, State } from '../Slider/shared';
+
+export interface SliderThumbProps
+  extends StandardProps<ButtonBaseProps, SliderThumbClassKey, 'onChange' | 'value'>,
+    SharedProps {
+  component?: React.ReactType<React.HTMLAttributes<{}>>;
+  icon?: React.ReactElement<{}>;
+  max: number;
+  min: number;
+  value: number;
+  vertical: boolean;
+  state: State;
+}
+
+export type SliderThumbClassKey = 'button' | 'icon' | 'iconWrapper' | 'wrapper' | SharedClassKey;
+
+declare const SliderThumb: React.ComponentType<SliderThumbProps>;
+
+export default SliderThumb;

--- a/packages/material-ui-lab/src/SliderThumb/SliderThumb.js
+++ b/packages/material-ui-lab/src/SliderThumb/SliderThumb.js
@@ -1,0 +1,174 @@
+// @inheritedComponent ButtonBase
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import ButtonBase from '@material-ui/core/ButtonBase';
+import { withStyles } from '@material-ui/core/styles';
+import { fade } from '@material-ui/core/styles/colorManipulator';
+import { getTransitionOptions, getValueInPercent, getVisualStateClasses } from '../Slider/shared';
+
+export const styles = theme => {
+  const outlineColor = fade(theme.palette.primary.main, 0.16);
+  /**
+   * radius of the box-shadow when pressed
+   * hover should have a diameter equal to the pressed radius
+   */
+  const pressedOutlineRadius = 9;
+
+  const rootTransition = theme.transitions.create(['transform'], getTransitionOptions(theme));
+  const buttonTransition = theme.transitions.create(['box-shadow'], getTransitionOptions(theme));
+
+  return {
+    wrapper: {
+      position: 'relative',
+      zIndex: 2,
+      transition: rootTransition,
+      '&$activated': {
+        transition: 'none',
+        willChange: 'transform',
+      },
+      '&$vertical': {
+        bottom: 0,
+        height: '100%',
+      },
+    },
+    root: {
+      // Opt out of rtl flip as positioning here only is for centering
+      flip: false,
+      position: 'absolute',
+      left: 0,
+      transform: 'translate(-50%, -50%)',
+      width: 12,
+      height: 12,
+      borderRadius: '50%',
+      backgroundColor: theme.palette.primary.main,
+      transition: buttonTransition,
+      '$focused &, &:hover': {
+        boxShadow: `0px 0px 0px ${pressedOutlineRadius}px ${outlineColor}`,
+      },
+      '$activated &': {
+        boxShadow: `0px 0px 0px ${pressedOutlineRadius * 2}px ${outlineColor}`,
+      },
+      '$disabled &': {
+        cursor: 'no-drop',
+        width: 9,
+        height: 9,
+        backgroundColor: theme.palette.grey[400],
+      },
+      '$jumped &': {
+        boxShadow: `0px 0px 0px ${pressedOutlineRadius * 2}px ${outlineColor}`,
+      },
+    },
+    /* Class applied to the thumb element if custom thumb icon provided. */
+    iconWrapper: {
+      backgroundColor: 'transparent',
+    },
+    icon: {
+      height: 'inherit',
+      width: 'inherit',
+    },
+    /* Class applied to the track and thumb elements to trigger JSS nested styles if `disabled`. */
+    disabled: {},
+    /* Class applied to the track and thumb elements to trigger JSS nested styles if `jumped`. */
+    jumped: {},
+    /* Class applied to the track and thumb elements to trigger JSS nested styles if `focused`. */
+    focused: {},
+    /* Class applied to the track and thumb elements to trigger JSS nested styles if `activated`. */
+    activated: {},
+    /* Class applied to the root, track and container to trigger JSS nested styles if `vertical`. */
+    vertical: {},
+  };
+};
+
+function SliderThumb(props) {
+  const {
+    classes,
+    className: classNameProp,
+    component: Component,
+    icon,
+    min,
+    max,
+    state,
+    theme,
+    vertical,
+    ...other
+  } = props;
+
+  const percent = getValueInPercent(props);
+
+  const transformFunction = vertical ? 'translateY' : 'translateX';
+  const directionInverted = vertical || theme.direction === 'rtl';
+  const inlineStyles = {
+    transform: `${transformFunction}(${directionInverted ? 100 - percent : percent}%)`,
+  };
+
+  const wrapperClassName = classNames(classes.wrapper, getVisualStateClasses(props));
+  const className = classNames(
+    classes.root,
+    {
+      [classes.iconWrapper]: icon,
+    },
+    classNameProp,
+  );
+
+  const ThumbIcon = icon
+    ? React.cloneElement(icon, {
+        className: classNames(icon.props.className, classes.icon),
+      })
+    : null;
+
+  return (
+    <Component className={wrapperClassName} style={inlineStyles}>
+      <ButtonBase className={className} disableRipple {...other}>
+        {ThumbIcon}
+      </ButtonBase>
+    </Component>
+  );
+}
+
+SliderThumb.propTypes = {
+  /**
+   * @ignore
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
+  icon: PropTypes.object,
+  /**
+   * max value of the corresponding slider
+   */
+  max: PropTypes.number.isRequired,
+  /**
+   * min value of the corresponding slider
+   */
+  min: PropTypes.number.isRequired,
+  /**
+   * state of the corresponding slider
+   */
+  state: PropTypes.oneOf(['activated', 'disabled', 'focused', 'jumped', 'normal']).isRequired,
+  /**
+   * @ignore
+   */
+  theme: PropTypes.object.isRequired,
+  /**
+   * value of the corresponding slider
+   */
+  value: PropTypes.number.isRequired,
+  /**
+   * If `true`, the slider track will be vertical.
+   */
+  vertical: PropTypes.bool.isRequired,
+};
+
+SliderThumb.defaultProps = {
+  component: 'div',
+};
+
+export default withStyles(styles, { name: 'MuiSliderThumb', withTheme: true })(SliderThumb);

--- a/packages/material-ui-lab/src/SliderThumb/SliderThumb.test.js
+++ b/packages/material-ui-lab/src/SliderThumb/SliderThumb.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import SliderThumb from './SliderThumb';
+
+describe('<SliderThumb />', () => {
+  let shallow;
+  let classes;
+  const defaultProps = {
+    disabled: false,
+    max: 0,
+    min: 100,
+    state: 'normal',
+    value: 30,
+    vertical: false,
+  };
+
+  before(() => {
+    shallow = createShallow({ dive: true });
+    classes = getClasses(<SliderThumb {...defaultProps} />);
+  });
+
+  describe('prop: disabled', () => {
+    it('renders the thumb with a disabled class', () => {
+      before(() => {
+        const wrapper = shallow(<SliderThumb {...defaultProps} disabled />);
+
+        assert.strictEqual(wrapper.hasClass(classes.root), true);
+        assert.strictEqual(wrapper.hasClass(classes.disabled), true);
+      });
+    });
+  });
+});

--- a/packages/material-ui-lab/src/SliderThumb/index.d.ts
+++ b/packages/material-ui-lab/src/SliderThumb/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './SliderThumb';
+export * from './SliderThumb';

--- a/packages/material-ui-lab/src/SliderThumb/index.js
+++ b/packages/material-ui-lab/src/SliderThumb/index.js
@@ -1,0 +1,1 @@
+export { default } from './SliderThumb';

--- a/packages/material-ui-lab/src/SliderTrack/SliderTrack.d.ts
+++ b/packages/material-ui-lab/src/SliderTrack/SliderTrack.d.ts
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { StandardProps } from '@material-ui/core';
+import { ButtonBaseProps } from '@material-ui/core/ButtonBase';
+import { SharedClassKey, SharedProps, State } from '../Slider/shared';
+
+export interface SliderTrackProps
+  extends StandardProps<ButtonBaseProps, SliderTrackClassKey, 'onChange' | 'value'>,
+    SharedProps {
+  component?: React.ReactType<React.HTMLAttributes<{}>>;
+  icon?: React.ReactElement<{}>;
+  max: number;
+  min: number;
+  value: number;
+  vertical: boolean;
+  state: State;
+}
+
+export type SliderTrackClassKey = 'root' | 'selected' | 'unselected' | SharedClassKey;
+
+declare const SliderTrack: React.ComponentType<SliderTrackProps>;
+
+export default SliderTrack;

--- a/packages/material-ui-lab/src/SliderTrack/SliderTrack.js
+++ b/packages/material-ui-lab/src/SliderTrack/SliderTrack.js
@@ -1,0 +1,169 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import { getTransitionOptions, getValueInPercent, getVisualStateClasses } from '../Slider/shared';
+
+export const styles = theme => {
+  const transition = theme.transitions.create(
+    ['width', 'height', 'transform'],
+    getTransitionOptions(theme),
+  );
+
+  return {
+    /* Styles applied to the track elements. */
+    root: {
+      position: 'absolute',
+      transform: 'translate(0, -50%)',
+      top: '50%',
+      width: '100%',
+      height: 2,
+      backgroundColor: theme.palette.primary.main,
+      transition,
+      '&$activated': {
+        transition: 'none',
+      },
+      '&$disabled': {
+        backgroundColor: theme.palette.grey[400],
+        boxShadow: 'none',
+      },
+      '&$vertical': {
+        transform: 'translate(-50%, 0)',
+        left: '50%',
+        top: 'initial',
+        bottom: 0,
+        width: 2,
+        height: '100%',
+      },
+    },
+    /* Styles applied to the track element that is selected . */
+    selected: {
+      zIndex: 1,
+      left: 0,
+      transformOrigin: 'left bottom',
+    },
+    /* Styles applied to the track element that is unselected. */
+    unselected: {
+      right: 0,
+      opacity: 0.24,
+      transformOrigin: 'right top',
+      '&$vertical': {
+        top: 0,
+      },
+    },
+    /* Class applied to the track and thumb elements to trigger JSS nested styles if `disabled`. */
+    disabled: {},
+    /* Class applied to the track and thumb elements to trigger JSS nested styles if `jumped`. */
+    jumped: {},
+    /* Class applied to the track and thumb elements to trigger JSS nested styles if `focused`. */
+    focused: {},
+    /* Class applied to the track and thumb elements to trigger JSS nested styles if `activated`. */
+    activated: {},
+    /* Class applied to the root, track and container to trigger JSS nested styles if `vertical`. */
+    vertical: {},
+  };
+};
+
+function SliderTrack(props) {
+  const {
+    classes,
+    className: classNameProp,
+    component: Component,
+    max,
+    min,
+    state,
+    theme,
+    value,
+    vertical,
+    ...other
+  } = props;
+
+  function calculateTrackPartStyles(percent) {
+    switch (state) {
+      case 'disabled':
+        return {
+          [vertical ? 'height' : 'width']: `calc(${percent}% - 6px)`,
+        };
+      default:
+        return {
+          transform: `${
+            vertical
+              ? `translateX(${theme.direction === 'rtl' ? '' : '-'}50%) scaleY`
+              : 'translateY(-50%) scaleX'
+          }(${percent / 100})`,
+        };
+    }
+  }
+
+  const percent = getValueInPercent(props);
+
+  const commonClasses = getVisualStateClasses(props);
+  const selectedClassName = classNames(
+    classes.root,
+    classes.selected,
+    commonClasses,
+    classNameProp,
+  );
+  const unselectedClassName = classNames(
+    classes.root,
+    classes.unselected,
+    commonClasses,
+    classNameProp,
+  );
+
+  const inlineTrackSelectedStyles = calculateTrackPartStyles(percent);
+  const inlineTrackUnselectedStyles = calculateTrackPartStyles(100 - percent);
+
+  return (
+    <React.Fragment>
+      <Component className={selectedClassName} style={inlineTrackSelectedStyles} {...other} />
+      <Component className={unselectedClassName} style={inlineTrackUnselectedStyles} {...other} />
+    </React.Fragment>
+  );
+}
+
+SliderTrack.propTypes = {
+  /**
+   * @ignore
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for each part of the track.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
+  /**
+   * max value of the corresponding slider
+   */
+  max: PropTypes.number.isRequired,
+  /**
+   * min value of the corresponding slider
+   */
+  min: PropTypes.number.isRequired,
+  /**
+   * state of the corresponding slider
+   */
+  state: PropTypes.oneOf(['activated', 'disabled', 'focused', 'jumped', 'normal']).isRequired,
+  /**
+   * @ignore
+   */
+  theme: PropTypes.object.isRequired,
+  /**
+   * value of the corresponding slider
+   */
+  value: PropTypes.number.isRequired,
+  /**
+   * If `true`, the slider track will be vertical.
+   */
+  vertical: PropTypes.bool.isRequired,
+};
+
+SliderTrack.defaultProps = {
+  component: 'div',
+};
+
+export default withStyles(styles, { name: 'MuiSliderTrack', withTheme: true })(SliderTrack);

--- a/packages/material-ui-lab/src/SliderTrack/SliderTrack.test.js
+++ b/packages/material-ui-lab/src/SliderTrack/SliderTrack.test.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { assert } from 'chai';
+import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import SliderTrack from './SliderTrack';
+
+describe('<SliderTrack />', () => {
+  let shallow;
+  let classes;
+  const defaultProps = {
+    disabled: false,
+    max: 0,
+    min: 100,
+    state: 'normal',
+    value: 30,
+    vertical: false,
+  };
+
+  before(() => {
+    shallow = createShallow({ dive: true });
+    classes = getClasses(<SliderTrack {...defaultProps} />);
+  });
+
+  describe('prop: disabled', () => {
+    it('renders the thumb with a disabled class', () => {
+      before(() => {
+        const wrapper = shallow(<SliderTrack {...defaultProps} disabled />);
+
+        assert.strictEqual(wrapper.hasClass(classes.root), true);
+        assert.strictEqual(wrapper.hasClass(classes.disabled), true);
+      });
+    });
+  });
+});

--- a/packages/material-ui-lab/src/SliderTrack/index.js
+++ b/packages/material-ui-lab/src/SliderTrack/index.js
@@ -1,0 +1,1 @@
+export { default } from './SliderTrack';

--- a/pages/lab/api/slider-thumb.js
+++ b/pages/lab/api/slider-thumb.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './slider-thumb.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default withRoot(Page);

--- a/pages/lab/api/slider-thumb.md
+++ b/pages/lab/api/slider-thumb.md
@@ -1,0 +1,62 @@
+---
+filename: /packages/material-ui-lab/src/SliderThumb/SliderThumb.js
+title: SliderThumb API
+---
+
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# SliderThumb
+
+<p class="description">The API documentation of the SliderThumb React component. Learn more about the properties and the CSS customization points.</p>
+
+```js
+import SliderThumb from '@material-ui/lab/SliderThumb';
+```
+
+
+
+## Props
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">icon</span> | <span class="prop-type">object</span> |   |  |
+| <span class="prop-name required">max *</span> | <span class="prop-type">number</span> |   | max value of the corresponding slider |
+| <span class="prop-name required">min *</span> | <span class="prop-type">number</span> |   | min value of the corresponding slider |
+| <span class="prop-name required">state *</span> | <span class="prop-type">enum:&nbsp;'activated', 'disabled', 'focused', 'jumped', 'normal'<br></span> |   | state of the corresponding slider |
+| <span class="prop-name required">value *</span> | <span class="prop-type">number</span> |   | value of the corresponding slider |
+| <span class="prop-name required">vertical *</span> | <span class="prop-type">bool</span> |   | If `true`, the slider track will be vertical. |
+
+Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
+
+## CSS API
+
+You can override all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+
+
+| Name | Description |
+|:-----|:------------|
+| <span class="prop-name">wrapper</span> | 
+| <span class="prop-name">root</span> | 
+| <span class="prop-name">iconWrapper</span> | Class applied to the thumb element if custom thumb icon provided.
+| <span class="prop-name">icon</span> | 
+| <span class="prop-name">disabled</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `disabled`.
+| <span class="prop-name">jumped</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `jumped`.
+| <span class="prop-name">focused</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `focused`.
+| <span class="prop-name">activated</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `activated`.
+| <span class="prop-name">vertical</span> | Class applied to the root, track and container to trigger JSS nested styles if `vertical`.
+
+Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui-lab/src/SliderThumb/SliderThumb.js)
+for more detail.
+
+If using the `overrides` key of the theme as documented
+[here](/customization/themes/#customizing-all-instances-of-a-component-type),
+you need to use the following style sheet name: `MuiSliderThumb`.
+
+## Inheritance
+
+The properties of the [ButtonBase](/api/button-base/) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
+

--- a/pages/lab/api/slider-track.js
+++ b/pages/lab/api/slider-track.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import withRoot from 'docs/src/modules/components/withRoot';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './slider-track.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default withRoot(Page);

--- a/pages/lab/api/slider-track.md
+++ b/pages/lab/api/slider-track.md
@@ -1,0 +1,55 @@
+---
+filename: /packages/material-ui-lab/src/SliderTrack/SliderTrack.js
+title: SliderTrack API
+---
+
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# SliderTrack
+
+<p class="description">The API documentation of the SliderTrack React component. Learn more about the properties and the CSS customization points.</p>
+
+```js
+import SliderTrack from '@material-ui/lab/SliderTrack';
+```
+
+
+
+## Props
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> | <span class="prop-default">'div'</span> | The component used for each part of the track. Either a string to use a DOM element or a component. |
+| <span class="prop-name required">max *</span> | <span class="prop-type">number</span> |   | max value of the corresponding slider |
+| <span class="prop-name required">min *</span> | <span class="prop-type">number</span> |   | min value of the corresponding slider |
+| <span class="prop-name required">state *</span> | <span class="prop-type">enum:&nbsp;'activated', 'disabled', 'focused', 'jumped', 'normal'<br></span> |   | state of the corresponding slider |
+| <span class="prop-name required">value *</span> | <span class="prop-type">number</span> |   | value of the corresponding slider |
+| <span class="prop-name required">vertical *</span> | <span class="prop-type">bool</span> |   | If `true`, the slider track will be vertical. |
+
+Any other properties supplied will be spread to the root element (native element).
+
+## CSS API
+
+You can override all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+
+
+| Name | Description |
+|:-----|:------------|
+| <span class="prop-name">root</span> | Styles applied to the track elements.
+| <span class="prop-name">selected</span> | Styles applied to the track element that is selected .
+| <span class="prop-name">unselected</span> | Styles applied to the track element that is unselected.
+| <span class="prop-name">disabled</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `disabled`.
+| <span class="prop-name">jumped</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `jumped`.
+| <span class="prop-name">focused</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `focused`.
+| <span class="prop-name">activated</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `activated`.
+| <span class="prop-name">vertical</span> | Class applied to the root, track and container to trigger JSS nested styles if `vertical`.
+
+Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
+and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui-lab/src/SliderTrack/SliderTrack.js)
+for more detail.
+
+If using the `overrides` key of the theme as documented
+[here](/customization/themes/#customizing-all-instances-of-a-component-type),
+you need to use the following style sheet name: `MuiSliderTrack`.
+

--- a/pages/lab/api/slider.md
+++ b/pages/lab/api/slider.md
@@ -27,9 +27,12 @@ import Slider from '@material-ui/lab/Slider';
 | <span class="prop-name">onDragEnd</span> | <span class="prop-type">func</span> |   | Callback function that is fired when the slide has stopped moving. |
 | <span class="prop-name">onDragStart</span> | <span class="prop-type">func</span> |   | Callback function that is fired when the slider has begun to move. |
 | <span class="prop-name">step</span> | <span class="prop-type">number</span> |   | The granularity the slider can step through values. |
-| <span class="prop-name">thumb</span> | <span class="prop-type">element</span> |   | The component used for the slider icon. This is optional, if provided should be a react element. |
+| <span class="prop-name">thumb</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br></span> | <span class="prop-default">SliderThumb</span> | The component used for the slider thumb |
+| <span class="prop-name">thumbProps</span> | <span class="prop-type">object</span> |   | props spread into the thumb component |
+| <span class="prop-name">track</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br></span> | <span class="prop-default">SliderTrack</span> | The component used for the slider track |
+| <span class="prop-name">trackProps</span> | <span class="prop-type">object</span> |   | props spread into the track component |
 | <span class="prop-name required">value *</span> | <span class="prop-type">number</span> |   | The value of the slider. |
-| <span class="prop-name">vertical</span> | <span class="prop-type">bool</span> |   | If `true`, the slider will be vertical. |
+| <span class="prop-name">vertical</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the slider will be vertical. |
 
 Any other properties supplied will be spread to the root element (native element).
 
@@ -43,17 +46,10 @@ This property accepts the following keys:
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">container</span> | Styles applied to the container element.
-| <span class="prop-name">track</span> | Styles applied to the track elements.
-| <span class="prop-name">trackBefore</span> | Styles applied to the track element before the thumb.
-| <span class="prop-name">trackAfter</span> | Styles applied to the track element after the thumb.
-| <span class="prop-name">thumbWrapper</span> | Styles applied to the thumb wrapper element.
-| <span class="prop-name">thumb</span> | Styles applied to the thumb element.
-| <span class="prop-name">thumbIconWrapper</span> | Class applied to the thumb element if custom thumb icon provided.
-| <span class="prop-name">thumbIcon</span> | 
-| <span class="prop-name">disabled</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `disabled`.
-| <span class="prop-name">jumped</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `jumped`.
-| <span class="prop-name">focused</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `focused`.
 | <span class="prop-name">activated</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `activated`.
+| <span class="prop-name">disabled</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `disabled`.
+| <span class="prop-name">focused</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `focused`.
+| <span class="prop-name">jumped</span> | Class applied to the track and thumb elements to trigger JSS nested styles if `jumped`.
 | <span class="prop-name">vertical</span> | Class applied to the root, track and container to trigger JSS nested styles if `vertical`.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section


### PR DESCRIPTION
BREAKING: 
```diff
- <Slider thumb={<some-element />} />
+ <Slider thumbProps={{ icon: {<some-element />} }} />


- <Slider classes={{ track: 'track', trackBefore: 'trackBefore', after: 'trackAfter' }} />
+ <Slider trackProps={{ classes: { root: 'track', selected': 'trackBefore', unselected: 'trackAfter' } }} />

- <Slider classes={{ thumb: 'thumb', thumbWrapper: 'thumbWrapper', thumbIconWrapper: 'thumbIconWrapper', thumbIcon: 'thumbIcon' }} />
+ <Slider thumbProps={{ classes: { root: 'thumb', iconWrapper: 'thumbIconWrapper', icon: 'thumbIcon', wrapper: 'thumbWrapper' } }} />
```

Extracts thumb and track of the slider into its own components. The slider implementation was already pretty big and is still missing logic for a selected range of values, tick marks and the value label next to the thumb (all of which are in the spec).

Refactoring those will hopefully improve readability of the important parts of the slider and their testability. It also improves customization of the track and thumb.

I didn't move props like values, min, max etc into a separate slider context because the implementation works just fine without context and the component tree for the slider is shallow. The context API is also very verbose in 16.3.
