### PR TITLE
[InputBase] Remove legacy lifecycle methods

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -48,6 +48,13 @@ export const styles = {
  * ⚠️ Only one input can be used within a FormControl.
  */
 class FormControl extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    if (props.disabled && state.focused) {
+      return { focused: false };
+    }
+    return null;
+  }
+
   constructor(props) {
     super();
 

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -78,6 +78,15 @@ describe('<FormControl />', () => {
     });
   });
 
+  describe('prop: disabled', () => {
+    it('will be unfocused if it gets disabled', () => {
+      const wrapper = shallow(<FormControl />);
+      wrapper.setState({ focused: true });
+      wrapper.setProps({ disabled: true });
+      assert.strictEqual(wrapper.state().focused, false);
+    });
+  });
+
   describe('input', () => {
     it('should be filled with a value', () => {
       const wrapper = shallow(

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -335,13 +335,15 @@ class InputBase extends React.Component {
       states: ['disabled', 'error', 'margin', 'required', 'filled'],
     });
 
+    const focused = muiFormControl ? muiFormControl.focused : this.state.focused;
+
     const className = classNames(
       classes.root,
       {
         [classes.disabled]: fcs.disabled,
         [classes.error]: fcs.error,
         [classes.fullWidth]: fullWidth,
-        [classes.focused]: this.state.focused,
+        [classes.focused]: focused,
         [classes.formControl]: muiFormControl,
         [classes.marginDense]: fcs.margin === 'dense',
         [classes.multiline]: multiline,
@@ -405,7 +407,7 @@ class InputBase extends React.Component {
           ? renderPrefix({
               ...fcs,
               startAdornment,
-              focused: this.state.focused,
+              focused,
             })
           : null}
         {startAdornment}

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -154,47 +154,21 @@ export function formControlState({ props, states, context }) {
  * It contains a load of style reset and some state logic.
  */
 class InputBase extends React.Component {
+  static getDerivedStateFromProps(props, state) {
+    // The blur won't fire when the disabled state is set on a focused input.
+    // We need to book keep the focused state manually.
+    if (props.disabled && state.focused) {
+      return { focused: false };
+    }
+    return null;
+  }
+
   constructor(props, context) {
     super(props, context);
     this.isControlled = props.value != null;
     if (this.isControlled) {
       this.checkDirty(props);
     }
-
-    const componentWillReceiveProps = (nextProps, nextContext) => {
-      // The blur won't fire when the disabled state is set on a focused input.
-      // We need to book keep the focused state manually.
-      if (
-        !formControlState({ props: this.props, context: this.context, states: ['disabled'] })
-          .disabled &&
-        formControlState({ props: nextProps, context: nextContext, states: ['disabled'] }).disabled
-      ) {
-        this.setState({
-          focused: false,
-        });
-      }
-    };
-
-    const componentWillUpdate = (nextProps, nextState, nextContext) => {
-      // Book keep the focused state.
-      if (
-        !formControlState({ props: this.props, context: this.context, states: ['disabled'] })
-          .disabled &&
-        formControlState({ props: nextProps, context: nextContext, states: ['disabled'] }).disabled
-      ) {
-        const { muiFormControl } = this.context;
-        if (muiFormControl && muiFormControl.onBlur) {
-          muiFormControl.onBlur();
-        }
-      }
-    };
-
-    /* eslint-disable no-underscore-dangle */
-    this.componentWillReceiveProps = componentWillReceiveProps;
-    this.componentWillReceiveProps.__suppressDeprecationWarning = true;
-    this.componentWillUpdate = componentWillUpdate;
-    this.componentWillUpdate.__suppressDeprecationWarning = true;
-    /* eslint-enable no-underscore-dangle */
   }
 
   state = {
@@ -215,7 +189,14 @@ class InputBase extends React.Component {
     }
   }
 
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
+    // Book keep the focused state.
+    if (!prevProps.disabled && this.props.disabled) {
+      const { muiFormControl } = this.context;
+      if (muiFormControl && muiFormControl.onBlur) {
+        muiFormControl.onBlur();
+      }
+    }
     if (this.isControlled) {
       this.checkDirty(this.props);
     } // else performed in the onChange

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -368,6 +368,18 @@ describe('<InputBase />', () => {
         assert.strictEqual(input.props().required, true);
       });
     });
+
+    describe('focused', () => {
+      it('prioritizes context focus', () => {
+        wrapper.setState({ focused: true });
+
+        setFormControlContext({ focused: false });
+        assert.strictEqual(wrapper.hasClass(classes.focused), false);
+
+        setFormControlContext({ focused: true });
+        assert.strictEqual(wrapper.hasClass(classes.focused), true);
+      });
+    });
   });
 
   describe('componentDidMount', () => {


### PR DESCRIPTION
Removes legacy lifecycle methods that would require legacy context API. `cWRP` -> `gDSFP`, `cWU` -> `cDU`.

**Preface**: Allowing users to handle inputs in a mix of context and props should not be allowed in future implementations. Either the Provider or the Component should be the source of truth.

There will be breakage if this component was handled in a mixed way between controlled via props vs controlled via context e.g.
```diff
- <FormControl disabled={true}><InputBase disabled={false} /></FormControl>
+ <FormControl disabled={true}><InputBase disabled={undefined} /></FormControl>
```
This would previously switch the `formControlState` from not disabled to disabled because it only uses context if the prop is undefined. This would would trigger `setState({ focused: false })` in `cWRP`. However we don't have access to context in `gDSFP` so now the input would **still be focused** and `onBlur` will **not** fire.

I see no other way forward and actually a fix. I hope nobody relied on this.

Other issues:
```diff
- <FormControl disabled={false}><InputBase /></FormControl>
+ <FormControl disabled={true}><InputBase /></FormControl>
```
~`context.onBlue()` won't get fired as well as~  It won't be necessary since we have `gDSFP` in the `FormControll`

 ~`state.focused` won't be reset. Seems like we really need to split this component up.~ Fixed in d9ff717