### PR TITLE
[docs] Reword flexbox limitation

### DIFF
--- a/docs/src/pages/demos/menus/menus.md
+++ b/docs/src/pages/demos/menus/menus.md
@@ -66,8 +66,8 @@ keeps track of the local state for a single menu.
 
 ## Limitations
 
-There is [a flexbox bug](https://bugs.chromium.org/p/chromium/issues/detail?id=327437) that prevents `text-overflow: ellipse` to work in combination with a flexbox layout.
-You can use the `Typography` component to workaround the issue:
+There is [a flexbox bug](https://bugs.chromium.org/p/chromium/issues/detail?id=327437) that prevents `text-overflow: ellipse` from working in a flexbox layout.
+You can use the `Typography` component to workaround this issue:
 
 {{"demo": "pages/demos/menus/TypographyMenu.js"}}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Continuation of #13500

Changed: 

There is a flexbox bug that prevents text-overflow: ellipse to work in combination with a flexbox layout. You can use the Typography component to workaround the issue:

to:

There is a flexbox bug that prevents text-overflow: ellipse from working in a flexbox layout. You can use the Typography component to workaround this issue:
