### PR TITLE
[test] Improve tests related to lists

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -84,7 +84,7 @@ describe('<ListItem />', () => {
 
     it('should change the component', () => {
       const wrapper = mount(<ListItem button component="li" />);
-      assert.strictEqual(wrapper.find(ButtonBase).props().component, 'li');
+      assert.strictEqual(wrapper.getDOMNode().nodeName, 'LI');
     });
   });
 

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
-import { getClasses, createMount } from '../test-utils';
+import { getClasses, createMount, findOutermostIntrinsic } from '../test-utils';
 import ListItemText from '../ListItemText';
 import ListItemSecondaryAction from '../ListItemSecondaryAction';
 import ListItem from './ListItem';
@@ -8,7 +8,6 @@ import ListItemAvatar from '../ListItemAvatar';
 import Avatar from '../Avatar';
 import ButtonBase from '../ButtonBase';
 import ListContext from '../List/ListContext';
-import MergeListContext from './MergeListContext';
 
 describe('<ListItem />', () => {
   let mount;
@@ -25,19 +24,19 @@ describe('<ListItem />', () => {
 
   it('should render a div', () => {
     const wrapper = mount(<ListItem component="div" />);
-    const listItem = wrapper.find(MergeListContext).childAt(0);
-    assert.strictEqual(listItem.name(), 'div');
+    const listItem = wrapper.getDOMNode();
+    assert.strictEqual(listItem.nodeName, 'DIV');
   });
 
   it('should render a li', () => {
     const wrapper = mount(<ListItem />);
-    const listItem = wrapper.find(MergeListContext).childAt(0);
-    assert.strictEqual(listItem.name(), 'li');
+    const listItem = wrapper.getDOMNode();
+    assert.strictEqual(listItem.nodeName, 'LI');
   });
 
   it('should render with the user, root and gutters classes', () => {
     const wrapper = mount(<ListItem className="woofListItem" />);
-    const listItem = wrapper.find(MergeListContext).childAt(0);
+    const listItem = findOutermostIntrinsic(wrapper);
     assert.strictEqual(listItem.hasClass('woofListItem'), true);
     assert.strictEqual(listItem.hasClass(classes.root), true);
     assert.strictEqual(listItem.hasClass(classes.gutters), true);
@@ -45,13 +44,13 @@ describe('<ListItem />', () => {
 
   it('should render with the selected class', () => {
     const wrapper = mount(<ListItem selected />);
-    const listItem = wrapper.find(MergeListContext).childAt(0);
+    const listItem = findOutermostIntrinsic(wrapper);
     assert.strictEqual(listItem.hasClass(classes.selected), true);
   });
 
   it('should disable the gutters', () => {
     const wrapper = mount(<ListItem disableGutters />);
-    const listItem = wrapper.find(MergeListContext).childAt(0);
+    const listItem = findOutermostIntrinsic(wrapper);
     assert.strictEqual(listItem.hasClass(classes.root), true);
     assert.strictEqual(listItem.hasClass(classes.gutters), false);
   });
@@ -66,29 +65,26 @@ describe('<ListItem />', () => {
         </ListItem>
       </ListContext.Provider>,
     );
-    const listItem = wrapper.find(MergeListContext).childAt(0);
+    const listItem = findOutermostIntrinsic(wrapper);
     assert.strictEqual(listItem.hasClass(classes.dense), true);
   });
 
   describe('prop: button', () => {
     it('should render a div', () => {
       const wrapper = mount(<ListItem button />);
-      const listItem = wrapper.find(MergeListContext).childAt(0);
-      assert.strictEqual(listItem.props().component, 'div');
+      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
     });
   });
 
   describe('prop: component', () => {
     it('should change the component', () => {
       const wrapper = mount(<ListItem button component="a" />);
-      const listItem = wrapper.find(MergeListContext).childAt(0);
-      assert.strictEqual(listItem.props().component, 'a');
+      assert.strictEqual(wrapper.getDOMNode().nodeName, 'A');
     });
 
     it('should change the component', () => {
       const wrapper = mount(<ListItem button component="li" />);
-      const listItem = wrapper.find(MergeListContext).childAt(0);
-      assert.strictEqual(listItem.props().component, 'li');
+      assert.strictEqual(wrapper.find(ButtonBase).props().component, 'li');
     });
   });
 
@@ -118,10 +114,9 @@ describe('<ListItem />', () => {
           <ListItemSecondaryAction />
         </ListItem>,
       );
-      const listItem = wrapper.find(MergeListContext).childAt(0);
+      const listItem = findOutermostIntrinsic(wrapper);
       assert.strictEqual(listItem.hasClass(classes.container), true);
-      assert.strictEqual(listItem.type(), 'li');
-      assert.strictEqual(listItem.childAt(0).type(), 'div');
+      assert.strictEqual(wrapper.find('li > div').exists(), true);
     });
 
     it('should accept a component property', () => {
@@ -131,22 +126,20 @@ describe('<ListItem />', () => {
           <ListItemSecondaryAction />
         </ListItem>,
       );
-      const listItem = wrapper.find(MergeListContext).childAt(0);
+      const listItem = findOutermostIntrinsic(wrapper);
       assert.strictEqual(listItem.hasClass(classes.container), true);
-      assert.strictEqual(listItem.type(), 'li');
-      assert.strictEqual(listItem.childAt(0).type(), 'span');
+      assert.strictEqual(wrapper.find('li > span').exists(), true);
     });
 
-    it('should accet a button property', () => {
+    it('should accept a button property', () => {
       const wrapper = mount(
         <ListItem button>
           <ListItemText primary="primary" />
           <ListItemSecondaryAction />
         </ListItem>,
       );
-      const listItem = wrapper.find(MergeListContext).childAt(0);
+      const listItem = findOutermostIntrinsic(wrapper);
       assert.strictEqual(listItem.hasClass(classes.container), true);
-      assert.strictEqual(listItem.type(), 'li');
       assert.strictEqual(listItem.childAt(0).type(), ButtonBase);
     });
 
@@ -157,10 +150,9 @@ describe('<ListItem />', () => {
           <ListItemSecondaryAction />
         </ListItem>,
       );
-      const listItem = wrapper.find(MergeListContext).childAt(0);
+      const listItem = wrapper.find('div').first();
       assert.strictEqual(listItem.hasClass(classes.container), true);
-      assert.strictEqual(listItem.type(), 'div');
-      assert.strictEqual(listItem.childAt(0).type(), 'div');
+      assert.strictEqual(wrapper.find('div > div').exists(), true);
     });
 
     it('should allow customization of the wrapper', () => {
@@ -170,7 +162,7 @@ describe('<ListItem />', () => {
           <ListItemSecondaryAction />
         </ListItem>,
       );
-      const listItem = wrapper.find(MergeListContext).childAt(0);
+      const listItem = findOutermostIntrinsic(wrapper);
       assert.strictEqual(listItem.hasClass(classes.container), true);
       assert.strictEqual(listItem.hasClass('bubu'), true);
     });
@@ -179,7 +171,7 @@ describe('<ListItem />', () => {
   describe('prop: focusVisibleClassName', () => {
     it('should merge the class names', () => {
       const wrapper = mount(<ListItem button focusVisibleClassName="focusVisibleClassName" />);
-      const listItem = wrapper.find(MergeListContext).childAt(0);
+      const listItem = wrapper.find(ButtonBase);
       assert.strictEqual(listItem.props().component, 'div');
       assert.strictEqual(
         listItem.props().focusVisibleClassName,

--- a/packages/material-ui/src/test-utils/findOutermostIntrinsic.d.ts
+++ b/packages/material-ui/src/test-utils/findOutermostIntrinsic.d.ts
@@ -3,7 +3,6 @@ import { ReactWrapper } from 'enzyme';
 /**
  * like ReactWrapper#getDOMNode() but returns a ReactWrapper
  *
- * @param reactWrapper
  * @returns the wrapper for the outermost DOM node
  */
 export default function findOutermostIntrinsic(reactWrapper: ReactWrapper): ReactWrapper;

--- a/packages/material-ui/src/test-utils/findOutermostIntrinsic.d.ts
+++ b/packages/material-ui/src/test-utils/findOutermostIntrinsic.d.ts
@@ -1,0 +1,9 @@
+import { ReactWrapper } from 'enzyme';
+
+/**
+ * like ReactWrapper#getDOMNode() but returns a ReactWrapper
+ *
+ * @param reactWrapper
+ * @returns the wrapper for the outermost DOM node
+ */
+export default function findOutermostIntrinsic(reactWrapper: ReactWrapper): ReactWrapper;

--- a/packages/material-ui/src/test-utils/findOutermostIntrinsic.js
+++ b/packages/material-ui/src/test-utils/findOutermostIntrinsic.js
@@ -1,0 +1,13 @@
+/**
+ * like ReactWrapper#getDOMNode() but returns a ReactWrapper
+ *
+ * @param {import('enzyme').ReactWrapper} reactWrapper
+ * @returns {import('enzyme').ReactWrapper} the wrapper for the outermost DOM node
+ */
+export default function findOutermostIntrinsic(reactWrapper) {
+  return reactWrapper
+    .findWhere(n => {
+      return n.exists() && typeof n.type() === 'string';
+    })
+    .first();
+}

--- a/packages/material-ui/src/test-utils/findOutermostIntrinsic.test.js
+++ b/packages/material-ui/src/test-utils/findOutermostIntrinsic.test.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import { assert } from 'chai';
+import createMount from './createMount';
+import findOutermostIntrinsic from './findOutermostIntrinsic';
+
+describe('findOutermostIntrinsic', () => {
+  let mount;
+  const assertIntrinsic = (node, expect) => {
+    const wrapper = mount(node);
+    const outermostIntrinsic = findOutermostIntrinsic(wrapper);
+
+    if (expect === null) {
+      assert.strictEqual(outermostIntrinsic.exists(), false);
+    } else {
+      assert.strictEqual(outermostIntrinsic.type(), expect);
+      assert.strictEqual(
+        outermostIntrinsic.type(),
+        outermostIntrinsic.getDOMNode().nodeName.toLowerCase(),
+      );
+    }
+  };
+  const Headless = ({ children }) => children;
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  it('returns immediate DOM nodes', () => {
+    assertIntrinsic(<div>Hello, World!</div>, 'div');
+  });
+
+  it('only returns the outermost', () => {
+    assertIntrinsic(
+      <span>
+        <div>Hello, World!</div>
+      </span>,
+      'span',
+    );
+  });
+
+  it('ignores components', () => {
+    assertIntrinsic(
+      <Headless>
+        <div>Hello, World!</div>
+      </Headless>,
+      'div',
+    );
+    assertIntrinsic(
+      <Headless>
+        <Headless>
+          <div>Hello, World!</div>
+        </Headless>
+      </Headless>,
+      'div',
+    );
+    assertIntrinsic(
+      <Headless>
+        <Headless>
+          <div>
+            <Headless>
+              <span>Hello, World!</span>
+            </Headless>
+          </div>
+        </Headless>
+      </Headless>,
+      'div',
+    );
+  });
+
+  it('can handle that no DOM node is rendered', () => {
+    assertIntrinsic(<Headless>{false && <Headless />}</Headless>, null);
+  });
+});

--- a/packages/material-ui/src/test-utils/index.d.ts
+++ b/packages/material-ui/src/test-utils/index.d.ts
@@ -1,5 +1,6 @@
 export { default as createShallow } from './createShallow';
 export { default as createMount } from './createMount';
 export { default as createRender } from './createRender';
+export { default as findOutermostIntrinsic } from './findOutermostIntrinsic';
 export { default as getClasses } from './getClasses';
 export { default as unwrap } from './unwrap';

--- a/packages/material-ui/src/test-utils/index.js
+++ b/packages/material-ui/src/test-utils/index.js
@@ -1,5 +1,6 @@
 export { default as createShallow } from './createShallow';
 export { default as createMount } from './createMount';
 export { default as createRender } from './createRender';
+export { default as findOutermostIntrinsic } from './findOutermostIntrinsic';
 export { default as getClasses } from './getClasses';
 export { default as unwrap } from './unwrap';


### PR DESCRIPTION
Followup on #13498

The general idea is to move away from explicit child traversal to a more component tree agnostic approach. We can always argue what the actual implementation detail is (component tree or DOM tree) but I read the test as `"ok if I pass component="li" I want the li DOM element"` so that's what we're testing. As far as I'm concerned nobody cares how the component tree looks and every time we add/remove a wrapper component that just handles logic we break our unit tests.

For this purpose I introduced a `findOutermostIntrinsic` helper. It works similar to `ReactWrapper#getDOMNode` but returns an actual `ReactWrapper`. I thought about using `find('*').first()` since `#find` is top-down but the universal selector is not implemented (airbnb/enzyme#1158) and might select any component if implemented and not just "DOM components".

`Intrinsic` is something I picked up from the way TypeScript handles react: https://www.typescriptlang.org/docs/handbook/jsx.html