### PR TITLE
[core] Remove recompose/wrapDisplayName usage

### DIFF
--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -57,7 +57,7 @@ function Badge(props) {
     badgeContent,
     children,
     classes,
-    className: classNameProp,
+    className,
     color,
     component: ComponentProp,
     ...other
@@ -68,7 +68,7 @@ function Badge(props) {
   });
 
   return (
-    <ComponentProp className={classNames(classes.root, classNameProp)} {...other}>
+    <ComponentProp className={classNames(classes.root, className)} {...other}>
       {children}
       <span className={badgeClassName}>{badgeContent}</span>
     </ComponentProp>

--- a/packages/material-ui/src/styles/withStyles.js
+++ b/packages/material-ui/src/styles/withStyles.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import wrapDisplayName from 'recompose/wrapDisplayName';
 import { create } from 'jss';
 import ns from './reactJssContext';
 import jssPreset from './jssPreset';
@@ -313,7 +312,7 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
   };
 
   if (process.env.NODE_ENV !== 'production') {
-    WithStyles.displayName = wrapDisplayName(Component, 'WithStyles');
+    WithStyles.displayName = `WithStyles(${getDisplayName(Component)})`;
   }
 
   hoistNonReactStatics(WithStyles, Component);

--- a/packages/material-ui/src/styles/withTheme.js
+++ b/packages/material-ui/src/styles/withTheme.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import hoistNonReactStatics from 'hoist-non-react-statics';
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import getDisplayName from '../utils/getDisplayName';
 import createMuiTheme from './createMuiTheme';
 import themeListener from './themeListener';
 
@@ -55,7 +55,7 @@ const withTheme = () => Component => {
   WithTheme.contextTypes = themeListener.contextTypes;
 
   if (process.env.NODE_ENV !== 'production') {
-    WithTheme.displayName = wrapDisplayName(Component, 'WithTheme');
+    WithTheme.displayName = `WithTheme(${getDisplayName(Component)})`;
   }
 
   hoistNonReactStatics(WithTheme, Component);

--- a/packages/material-ui/src/withWidth/withWidth.js
+++ b/packages/material-ui/src/withWidth/withWidth.js
@@ -4,7 +4,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';
 import debounce from 'debounce'; // < 1kb payload overhead when lodash/debounce is > 3kb.
-import wrapDisplayName from 'recompose/wrapDisplayName';
+import getDisplayName from '../utils/getDisplayName';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import withTheme from '../styles/withTheme';
 import { keys as breakpointKeys } from '../styles/createBreakpoints';
@@ -152,7 +152,7 @@ const withWidth = (options = {}) => Component => {
   };
 
   if (process.env.NODE_ENV !== 'production') {
-    WithWidth.displayName = wrapDisplayName(Component, 'WithWidth');
+    WithWidth.displayName = `WithWidth(${getDisplayName(Component)})`;
   }
 
   hoistNonReactStatics(WithWidth, Component);


### PR DESCRIPTION
This pull request is part of the effort to remove the recompose dependency. React has recently introduced a `React.memo()` higher order component. We can leverage it directly. This change should reduce the bundle size.