### PR TITLE
[docs] Make the lab > core dependency more explicit

### DIFF
--- a/docs/src/pages/lab/about/about.md
+++ b/docs/src/pages/lab/about/about.md
@@ -14,8 +14,8 @@ If you are not already using Material-UI in your project, you can add it with:
 
 ```sh
 // with npm
-npm install @material-ui/core
+npm install @material-ui/lab
 
 // with yarn
-yarn add @material-ui/core
+yarn add @material-ui/lab
 ```

--- a/docs/src/pages/lab/about/about.md
+++ b/docs/src/pages/lab/about/about.md
@@ -7,15 +7,16 @@
 Install the package in your project directory with:
 
 ```sh
-npm install @material-ui/lab
-```
-
-If you are not already using Material-UI in your project, you can add it with:
-
-```sh
 // with npm
 npm install @material-ui/lab
 
 // with yarn
 yarn add @material-ui/lab
+```
+
+The lab has a peer dependency on the core components.
+If you are not already using Material-UI in your project, you can install it with:
+
+```sh
+npm install @material-ui/core
 ```


### PR DESCRIPTION
Spent a few mins wondering why after pasting `npm install @material-ui/core` it couldn't find `@material-ui/lab` 😅.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).