### PR TITLE
[core] Use proper aria roles for input elements

### DIFF
--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -276,6 +276,7 @@ function Button(props) {
       disabled={disabled}
       focusRipple={!disableFocusRipple}
       focusVisibleClassName={classNames(classes.focusVisible, focusVisibleClassName)}
+      role="button"
       {...other}
     >
       <span className={classes.label}>{children}</span>

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -1,20 +1,32 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, createRender, getClasses } from '../test-utils';
+import {
+  createShallow,
+  createMount,
+  createRender,
+  findOutermostIntrinsic,
+  getClasses,
+} from '../test-utils';
 import Button from './Button';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import ButtonBase from '../ButtonBase';
 import Icon from '../Icon';
 
 describe('<Button />', () => {
+  let mount;
   let shallow;
   let render;
   let classes;
 
   before(() => {
+    mount = createMount();
     shallow = createShallow({ dive: true });
     render = createRender();
     classes = getClasses(<Button>Hello World</Button>);
+  });
+
+  after(() => {
+    mount.cleanUp();
   });
 
   it('should render a <ButtonBase> element', () => {
@@ -292,6 +304,11 @@ describe('<Button />', () => {
     const renderedIconChild = label.childAt(0);
     assert.strictEqual(renderedIconChild.type(), Icon);
     assert.strictEqual(renderedIconChild.hasClass(childClassName), true);
+  });
+
+  it('should have a button role', () => {
+    const wrapper = mount(<Button>clickme</Button>);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).props().role, 'button');
   });
 
   describe('server side', () => {

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -72,6 +72,7 @@ function Checkbox(props) {
         ...inputProps,
       }}
       icon={indeterminate ? indeterminateIcon : icon}
+      role="checkbox"
       {...other}
     />
   );

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -35,6 +35,19 @@ describe('<Checkbox />', () => {
     mount(<Checkbox checked />);
   });
 
+  it('should have the checkbox role', () => {
+    const wrapper = mount(<Checkbox />);
+    assert.strictEqual(wrapper.find('span[role="checkbox"]').exists(), true);
+  });
+
+  it('should have the correct aria-checked attribute', () => {
+    const wrapper = mount(<Checkbox checked={false} />);
+    assert.equal(wrapper.find('span[role="checkbox"]').props()['aria-checked'], false);
+
+    wrapper.setProps({ checked: true });
+    assert.equal(wrapper.find('span[role="checkbox"]').props()['aria-checked'], true);
+  });
+
   describe('prop: indeterminate', () => {
     it('should render an indeterminate icon', () => {
       const wrapper = mount(<Checkbox indeterminate />);

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -92,6 +92,7 @@ function IconButton(props) {
       centerRipple
       focusRipple
       disabled={disabled}
+      role="button"
       {...other}
     >
       <span className={classes.label}>{children}</span>

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { spy } from 'sinon';
 import { assert } from 'chai';
 import PropTypes from 'prop-types';
-import { createShallow, createMount, getClasses } from '../test-utils';
+import { createShallow, createMount, findOutermostIntrinsic, getClasses } from '../test-utils';
 import Icon from '../Icon';
 import ButtonBase from '../ButtonBase';
 import IconButton from './IconButton';
@@ -82,6 +82,11 @@ describe('<IconButton />', () => {
   it('should pass centerRipple={true} to ButtonBase', () => {
     const wrapper = shallow(<IconButton>book</IconButton>);
     assert.strictEqual(wrapper.props().centerRipple, true);
+  });
+
+  it('should have a button role', () => {
+    const wrapper = mount(<IconButton>clickme</IconButton>);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).props().role, 'button');
   });
 
   describe('prop: disabled', () => {

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -49,6 +49,7 @@ function Radio(props) {
         checked: classes.checked,
         disabled: classes.disabled,
       }}
+      role="radio"
       {...other}
     />
   );

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
 import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
-import { getClasses, createShallow, createMount } from '../test-utils';
+import { getClasses, createShallow, createMount, findOutermostIntrinsic } from '../test-utils';
 import SwitchBase from '../internal/SwitchBase';
 import Radio from './Radio';
 
@@ -34,6 +34,11 @@ describe('<Radio />', () => {
     assert.strictEqual(wrapper.type(), SwitchBase);
   });
 
+  it('should have the radio role', () => {
+    const wrapper = mount(<Radio />);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).props().role, 'radio');
+  });
+
   describe('prop: unchecked', () => {
     it('should render an unchecked icon', () => {
       const wrapper = mount(<Radio />);
@@ -45,6 +50,14 @@ describe('<Radio />', () => {
     it('should render a checked icon', () => {
       const wrapper = mount(<Radio checked />);
       assert.strictEqual(wrapper.find(RadioButtonCheckedIcon).length, 1);
+    });
+
+    it('should have the correct aria-checked attribute', () => {
+      const wrapper = mount(<Radio checked={false} />);
+      assert.equal(wrapper.find('span[role="radio"]').props()['aria-checked'], false);
+
+      wrapper.setProps({ checked: true });
+      assert.equal(wrapper.find('span[role="radio"]').props()['aria-checked'], true);
     });
   });
 });

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -64,6 +64,7 @@ function StepButton(props) {
       disabled={disabled}
       TouchRippleProps={{ className: classes.touchRipple }}
       className={classNames(classes.root, classes[orientation], classNameProp)}
+      role="button"
       {...other}
     >
       {child}

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount } from '../test-utils';
+import { createShallow, createMount, findOutermostIntrinsic } from '../test-utils';
 import StepButton from './StepButton';
 import StepLabel from '../StepLabel';
 import ButtonBase from '../ButtonBase';
@@ -70,6 +70,11 @@ describe('<StepButton />', () => {
     );
     const stepLabel = wrapper.find(ButtonBase);
     assert.strictEqual(stepLabel.props().disabled, true);
+  });
+
+  it('should have a button role', () => {
+    const wrapper = mount(<StepButton>clickme</StepButton>);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).props().role, 'button');
   });
 
   describe('event handlers', () => {

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -1,15 +1,17 @@
 import React from 'react';
 import { assert } from 'chai';
 import classNames from 'classnames';
-import { createShallow, getClasses } from '../test-utils';
+import { createShallow, createMount, getClasses } from '../test-utils';
 import SwitchBase from '../internal/SwitchBase';
 import Switch from './Switch';
 
 describe('<Switch />', () => {
+  let mount;
   let shallow;
   let classes;
 
   before(() => {
+    mount = createMount();
     shallow = createShallow({ untilSelector: 'span' });
     classes = getClasses(<Switch />);
   });
@@ -52,5 +54,18 @@ describe('<Switch />', () => {
       assert.strictEqual(bar.name(), 'span');
       assert.strictEqual(bar.hasClass(classes.bar), true);
     });
+  });
+
+  it('should have the switch role', () => {
+    const wrapper = mount(<Switch />);
+    assert.strictEqual(wrapper.find('span[role="switch"]').exists(), true);
+  });
+
+  it('should have the correct aria-checked attribute', () => {
+    const wrapper = mount(<Switch checked={false} />);
+    assert.equal(wrapper.find('span[role="switch"]').props()['aria-checked'], false);
+
+    wrapper.setProps({ checked: true });
+    assert.equal(wrapper.find('span[role="switch"]').props()['aria-checked'], true);
   });
 });

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -117,6 +117,7 @@ class SwitchBase extends React.Component {
 
     return (
       <IconButton
+        aria-checked={checked}
         component="span"
         className={classNames(
           classes.root,
@@ -128,7 +129,7 @@ class SwitchBase extends React.Component {
         )}
         disabled={disabled}
         tabIndex={null}
-        role={undefined}
+        role="switch"
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
         {...other}


### PR DESCRIPTION
Apply `button`, `checkbox`, `radio` and `switch` roles where appropriate.

`ButtonBase` does not get a role because we have a test case against that already.
