### PR TITLE
[ListItemText] - Add tertiary line support

### DIFF
--- a/packages/material-ui/src/ListItemText/ListItemText.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.js
@@ -37,6 +37,12 @@ export const styles = theme => ({
       fontSize: 'inherit',
     },
   },
+  /* Styles applied to the tertiary `Typography` component. */
+  tertiary: {
+    '&$textDense': {
+      fontSize: 'inherit',
+    },
+  },
   /* Styles applied to the `Typography` components if `context.dense` is `true`. */
   textDense: {},
 });
@@ -52,6 +58,8 @@ function ListItemText(props) {
     primaryTypographyProps,
     secondary: secondaryProp,
     secondaryTypographyProps,
+    tertiary: tertiaryProp,
+    tertiaryTypographyProps,
     ...other
   } = props;
 
@@ -88,6 +96,21 @@ function ListItemText(props) {
           );
         }
 
+        let tertiary = tertiaryProp;
+        if (tertiary != null && tertiary.type !== Typography && !disableTypography) {
+          tertiary = (
+            <Typography
+              className={classNames(classes.tertiary, {
+                [classes.textDense]: dense,
+              })}
+              color="textSecondary"
+              {...tertiaryTypographyProps}
+            >
+              {tertiary}
+            </Typography>
+          );
+        }
+
         return (
           <div
             className={classNames(
@@ -102,6 +125,7 @@ function ListItemText(props) {
           >
             {primary}
             {secondary}
+            {tertiary}
           </div>
         );
       }}
@@ -153,6 +177,15 @@ ListItemText.propTypes = {
    * (as long as disableTypography is not `true`).
    */
   secondaryTypographyProps: PropTypes.object,
+  /**
+   * The tertiary content element.
+   */
+  tertiary: PropTypes.node,
+  /**
+   * These props will be forwarded to the tertiary typography component
+   * (as long as disableTypography is not `true`).
+   */
+  tertiaryTypographyProps: PropTypes.object,
 };
 
 ListItemText.defaultProps = {

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -389,13 +389,11 @@ class SwipeableDrawer extends React.Component {
           anchor={anchor}
           {...other}
         />
-        {!disableDiscovery &&
-          !disableSwipeToOpen &&
-          variant === 'temporary' && (
-            <NoSsr>
-              <SwipeArea anchor={anchor} width={swipeAreaWidth} />
-            </NoSsr>
-          )}
+        {!disableDiscovery && !disableSwipeToOpen && variant === 'temporary' && (
+          <NoSsr>
+            <SwipeArea anchor={anchor} width={swipeAreaWidth} />
+          </NoSsr>
+        )}
       </React.Fragment>
     );
   }

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -4,7 +4,9 @@ export { StyledComponentProps };
 
 export type PropsOf<C> = C extends new (props: infer P) => React.Component
   ? P
-  : C extends (props: infer P) => React.ReactElement<any> | null ? P : never;
+  : C extends (props: infer P) => React.ReactElement<any> | null
+  ? P
+  : never;
 
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -44,7 +44,11 @@ export type WithStyles<
   classes: ClassNameMap<
     T extends string
       ? T
-      : T extends StyleRulesCallback<infer K> ? K : T extends StyleRules<infer K> ? K : never
+      : T extends StyleRulesCallback<infer K>
+      ? K
+      : T extends StyleRules<infer K>
+      ? K
+      : never
   >;
   innerRef?: React.Ref<any> | React.RefObject<any>;
 };

--- a/packages/material-ui/src/utils/ponyfillGlobal.js
+++ b/packages/material-ui/src/utils/ponyfillGlobal.js
@@ -3,5 +3,5 @@
 export default (typeof window != 'undefined' && window.Math == Math
   ? window
   : typeof self != 'undefined' && self.Math == Math
-    ? self
-    : Function('return this')());
+  ? self
+  : Function('return this')());

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -27,6 +27,8 @@ import ListItemText from '@material-ui/core/ListItemText';
 | <span class="prop-name">primaryTypographyProps</span> | <span class="prop-type">object</span> |   | These props will be forwarded to the primary typography component (as long as disableTypography is not `true`). |
 | <span class="prop-name">secondary</span> | <span class="prop-type">node</span> |   | The secondary content element. |
 | <span class="prop-name">secondaryTypographyProps</span> | <span class="prop-type">object</span> |   | These props will be forwarded to the secondary typography component (as long as disableTypography is not `true`). |
+| <span class="prop-name">tertiary</span> | <span class="prop-type">node</span> |   | The tertiary content element. |
+| <span class="prop-name">tertiaryTypographyProps</span> | <span class="prop-type">object</span> |   | These props will be forwarded to the tertiary typography component (as long as disableTypography is not `true`). |
 
 Any other properties supplied will be spread to the root element (native element).
 
@@ -43,6 +45,7 @@ This property accepts the following keys:
 | <span class="prop-name">dense</span> | Styles applied to the root element if `context.dense` is `true`.
 | <span class="prop-name">primary</span> | Styles applied to the primary `Typography` component.
 | <span class="prop-name">secondary</span> | Styles applied to the secondary `Typography` component.
+| <span class="prop-name">tertiary</span> | Styles applied to the tertiary `Typography` component.
 | <span class="prop-name">textDense</span> | Styles applied to the `Typography` components if `context.dense` is `true`.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This pull request adds tertiary line support on ListItemText component as described in Material Design documentation : https://material.io/design/components/lists.html#usage

It was asked by some people : https://github.com/mui-org/material-ui/issues/9205
- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
