### PR TITLE
[LinearProgress] Fix TypeScript definition

### DIFF
--- a/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
@@ -24,6 +24,7 @@ export type LinearProgressClassKey =
   | 'bar1Indeterminate'
   | 'bar2Indeterminate'
   | 'bar1Determinate'
+  | 'bar2Determinate'
   | 'bar1Buffer'
   | 'bar2Buffer';
 


### PR DESCRIPTION
Added `bar2Indeterminate` to typings for LinearProgress element

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
