### PR TITLE
[Divider] Add support for middle divider

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -11,7 +11,6 @@ const [main] = fs.readdirSync(dirname).reduce((result, filename) => {
   return result;
 }, []);
 
-
 module.exports = [
   {
     name: 'The initial cost paid for using one component',

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -11,6 +11,7 @@ const [main] = fs.readdirSync(dirname).reduce((result, filename) => {
   return result;
 }, []);
 
+
 module.exports = [
   {
     name: 'The initial cost paid for using one component',

--- a/docs/src/pages/demos/dividers/InsetDividers.js
+++ b/docs/src/pages/demos/dividers/InsetDividers.js
@@ -21,32 +21,30 @@ const styles = theme => ({
 function InsetDividers(props) {
   const { classes } = props;
   return (
-    <div className={classes.root}>
-      <List>
-        <ListItem>
-          <Avatar>
-            <ImageIcon />
-          </Avatar>
-          <ListItemText primary="Photos" secondary="Jan 9, 2014" />
-        </ListItem>
-        <li>
-          <Divider variant={'inset'} />
-        </li>
-        <ListItem>
-          <Avatar>
-            <WorkIcon />
-          </Avatar>
-          <ListItemText primary="Work" secondary="Jan 7, 2014" />
-        </ListItem>
-        <Divider variant={'inset'} component="li" />
-        <ListItem>
-          <Avatar>
-            <BeachAccessIcon />
-          </Avatar>
-          <ListItemText primary="Vacation" secondary="July 20, 2014" />
-        </ListItem>
-      </List>
-    </div>
+    <List className={classes.root}>
+      <ListItem>
+        <Avatar>
+          <ImageIcon />
+        </Avatar>
+        <ListItemText primary="Photos" secondary="Jan 9, 2014" />
+      </ListItem>
+      <li>
+        <Divider variant="inset" />
+      </li>
+      <ListItem>
+        <Avatar>
+          <WorkIcon />
+        </Avatar>
+        <ListItemText primary="Work" secondary="Jan 7, 2014" />
+      </ListItem>
+      <Divider variant="inset" component="li" />
+      <ListItem>
+        <Avatar>
+          <BeachAccessIcon />
+        </Avatar>
+        <ListItemText primary="Vacation" secondary="July 20, 2014" />
+      </ListItem>
+    </List>
   );
 }
 

--- a/docs/src/pages/demos/dividers/ListDividers.js
+++ b/docs/src/pages/demos/dividers/ListDividers.js
@@ -17,24 +17,22 @@ const styles = theme => ({
 function ListDividers(props) {
   const { classes } = props;
   return (
-    <div className={classes.root}>
-      <List component="nav">
-        <ListItem button>
-          <ListItemText primary="Inbox" />
-        </ListItem>
-        <Divider />
-        <ListItem button divider>
-          <ListItemText primary="Drafts" />
-        </ListItem>
-        <ListItem button>
-          <ListItemText primary="Trash" />
-        </ListItem>
-        <Divider light />
-        <ListItem button>
-          <ListItemText primary="Spam" />
-        </ListItem>
-      </List>
-    </div>
+    <List component="nav" className={classes.root}>
+      <ListItem button>
+        <ListItemText primary="Inbox" />
+      </ListItem>
+      <Divider />
+      <ListItem button divider>
+        <ListItemText primary="Drafts" />
+      </ListItem>
+      <ListItem button>
+        <ListItemText primary="Trash" />
+      </ListItem>
+      <Divider light />
+      <ListItem button>
+        <ListItemText primary="Spam" />
+      </ListItem>
+    </List>
   );
 }
 

--- a/docs/src/pages/demos/dividers/MiddleDividers.js
+++ b/docs/src/pages/demos/dividers/MiddleDividers.js
@@ -18,7 +18,7 @@ const styles = theme => ({
   },
 });
 
-function InsetDividers(props) {
+function MiddleDividers(props) {
   const { classes } = props;
   return (
     <div className={classes.root}>
@@ -29,16 +29,14 @@ function InsetDividers(props) {
           </Avatar>
           <ListItemText primary="Photos" secondary="Jan 9, 2014" />
         </ListItem>
-        <li>
-          <Divider variant={'inset'} />
-        </li>
+        <Divider component="li" variant={'middle'} />
         <ListItem>
           <Avatar>
             <WorkIcon />
           </Avatar>
           <ListItemText primary="Work" secondary="Jan 7, 2014" />
         </ListItem>
-        <Divider variant={'inset'} component="li" />
+        <Divider variant={'middle'} component="li" />
         <ListItem>
           <Avatar>
             <BeachAccessIcon />
@@ -50,8 +48,8 @@ function InsetDividers(props) {
   );
 }
 
-InsetDividers.propTypes = {
+MiddleDividers.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(InsetDividers);
+export default withStyles(styles)(MiddleDividers);

--- a/docs/src/pages/demos/dividers/MiddleDividers.js
+++ b/docs/src/pages/demos/dividers/MiddleDividers.js
@@ -1,14 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-import List from '@material-ui/core/List';
-import ListItem from '@material-ui/core/ListItem';
-import ListItemText from '@material-ui/core/ListItemText';
-import Avatar from '@material-ui/core/Avatar';
-import ImageIcon from '@material-ui/icons/Image';
-import WorkIcon from '@material-ui/icons/Work';
-import BeachAccessIcon from '@material-ui/icons/BeachAccess';
+import Chip from '@material-ui/core/Chip';
+import Button from '@material-ui/core/Button';
+import Grid from '@material-ui/core/Grid';
 import Divider from '@material-ui/core/Divider';
+import Typography from '@material-ui/core/Typography';
 
 const styles = theme => ({
   root: {
@@ -16,33 +13,60 @@ const styles = theme => ({
     maxWidth: 360,
     backgroundColor: theme.palette.background.paper,
   },
+  chip: {
+    marginRight: theme.spacing.unit,
+  },
+  section1: {
+    margin: `${theme.spacing.unit * 3}px ${theme.spacing.unit * 2}px`,
+  },
+  section2: {
+    margin: theme.spacing.unit * 2,
+  },
+  section3: {
+    margin: `${theme.spacing.unit * 6}px ${theme.spacing.unit * 2}px ${theme.spacing.unit * 2}px`,
+  },
 });
 
 function MiddleDividers(props) {
   const { classes } = props;
   return (
-    <List className={classes.root}>
-      <ListItem>
-        <Avatar>
-          <ImageIcon />
-        </Avatar>
-        <ListItemText primary="Photos" secondary="Jan 9, 2014" />
-      </ListItem>
-      <Divider component="li" variant="middle" />
-      <ListItem>
-        <Avatar>
-          <WorkIcon />
-        </Avatar>
-        <ListItemText primary="Work" secondary="Jan 7, 2014" />
-      </ListItem>
-      <Divider variant="middle" component="li" />
-      <ListItem>
-        <Avatar>
-          <BeachAccessIcon />
-        </Avatar>
-        <ListItemText primary="Vacation" secondary="July 20, 2014" />
-      </ListItem>
-    </List>
+    <div className={classes.root}>
+      <div className={classes.section1}>
+        <Grid container alignItems="center">
+          <Grid item xs>
+            <Typography gutterBottom variant="h4">
+              Toothbrush
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Typography gutterBottom variant="h6">
+              $4.50
+            </Typography>
+          </Grid>
+        </Grid>
+        <Typography color="textSecondary">
+          Pinstriped cornflower blue cotton blouse takes you on a walk to the park or just down the
+          hall.
+        </Typography>
+      </div>
+      <Divider variant="middle" />
+      <div className={classes.section2}>
+        <Typography gutterBottom variant="body1">
+          Select type
+        </Typography>
+        <div>
+          <Chip className={classes.chip} label="Extra Soft" />
+          <Chip className={classes.chip} label="Soft" />
+          <Chip className={classes.chip} label="Medium" />
+          <Chip className={classes.chip} label="Hard" />
+        </div>
+      </div>
+      <div className={classes.section3}>
+        <Button variant="contained" color="primary" fullWidth>
+          Add to cart
+        </Button>
+      </div>
+    </div>
   );
 }
 

--- a/docs/src/pages/demos/dividers/MiddleDividers.js
+++ b/docs/src/pages/demos/dividers/MiddleDividers.js
@@ -21,30 +21,28 @@ const styles = theme => ({
 function MiddleDividers(props) {
   const { classes } = props;
   return (
-    <div className={classes.root}>
-      <List>
-        <ListItem>
-          <Avatar>
-            <ImageIcon />
-          </Avatar>
-          <ListItemText primary="Photos" secondary="Jan 9, 2014" />
-        </ListItem>
-        <Divider component="li" variant={'middle'} />
-        <ListItem>
-          <Avatar>
-            <WorkIcon />
-          </Avatar>
-          <ListItemText primary="Work" secondary="Jan 7, 2014" />
-        </ListItem>
-        <Divider variant={'middle'} component="li" />
-        <ListItem>
-          <Avatar>
-            <BeachAccessIcon />
-          </Avatar>
-          <ListItemText primary="Vacation" secondary="July 20, 2014" />
-        </ListItem>
-      </List>
-    </div>
+    <List className={classes.root}>
+      <ListItem>
+        <Avatar>
+          <ImageIcon />
+        </Avatar>
+        <ListItemText primary="Photos" secondary="Jan 9, 2014" />
+      </ListItem>
+      <Divider component="li" variant="middle" />
+      <ListItem>
+        <Avatar>
+          <WorkIcon />
+        </Avatar>
+        <ListItemText primary="Work" secondary="Jan 7, 2014" />
+      </ListItem>
+      <Divider variant="middle" component="li" />
+      <ListItem>
+        <Avatar>
+          <BeachAccessIcon />
+        </Avatar>
+        <ListItemText primary="Vacation" secondary="July 20, 2014" />
+      </ListItem>
+    </List>
   );
 }
 

--- a/docs/src/pages/demos/dividers/SubheaderDividers.js
+++ b/docs/src/pages/demos/dividers/SubheaderDividers.js
@@ -5,10 +5,9 @@ import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import Avatar from '@material-ui/core/Avatar';
-import ImageIcon from '@material-ui/icons/Image';
-import WorkIcon from '@material-ui/icons/Work';
 import BeachAccessIcon from '@material-ui/icons/BeachAccess';
 import Divider from '@material-ui/core/Divider';
+import Typography from '@material-ui/core/Typography';
 
 const styles = theme => ({
   root: {
@@ -16,35 +15,43 @@ const styles = theme => ({
     maxWidth: 360,
     backgroundColor: theme.palette.background.paper,
   },
+  dividerFullWidth: {
+    margin: `5px 0 0 ${theme.spacing.unit * 2}px`,
+  },
+  dividerInset: {
+    margin: `5px 0 0 ${theme.spacing.unit * 9}px`,
+  },
 });
 
 function SubheaderDividers(props) {
   const { classes } = props;
   return (
-    <div className={classes.root}>
-      <List>
-        <ListItem>
-          <Avatar>
-            <ImageIcon />
-          </Avatar>
-          <ListItemText primary="Photos" secondary="Jan 9, 2014" />
-        </ListItem>
-        <Divider subheader="Test" component="li" />
-        <ListItem>
-          <Avatar>
-            <WorkIcon />
-          </Avatar>
-          <ListItemText primary="Work" secondary="Jan 7, 2014" />
-        </ListItem>
-        <Divider variant={'inset'} subheader="Test" component="li" />
-        <ListItem>
-          <Avatar>
-            <BeachAccessIcon />
-          </Avatar>
-          <ListItemText primary="Vacation" secondary="July 20, 2014" />
-        </ListItem>
-      </List>
-    </div>
+    <List className={classes.root}>
+      <ListItem>
+        <ListItemText primary="Photos" secondary="Jan 9, 2014" />
+      </ListItem>
+      <Divider component="li" />
+      <li>
+        <Typography className={classes.dividerFullWidth} color="textSecondary" variant="caption">
+          Divider
+        </Typography>
+      </li>
+      <ListItem>
+        <ListItemText primary="Work" secondary="Jan 7, 2014" />
+      </ListItem>
+      <Divider component="li" variant="inset" />
+      <li>
+        <Typography className={classes.dividerInset} color="textSecondary" variant="caption">
+          Leisure
+        </Typography>
+      </li>
+      <ListItem>
+        <Avatar>
+          <BeachAccessIcon />
+        </Avatar>
+        <ListItemText primary="Vacation" secondary="July 20, 2014" />
+      </ListItem>
+    </List>
   );
 }
 

--- a/docs/src/pages/demos/dividers/SubheaderDividers.js
+++ b/docs/src/pages/demos/dividers/SubheaderDividers.js
@@ -18,7 +18,7 @@ const styles = theme => ({
   },
 });
 
-function InsetDividers(props) {
+function SubheaderDividers(props) {
   const { classes } = props;
   return (
     <div className={classes.root}>
@@ -29,16 +29,14 @@ function InsetDividers(props) {
           </Avatar>
           <ListItemText primary="Photos" secondary="Jan 9, 2014" />
         </ListItem>
-        <li>
-          <Divider variant={'inset'} />
-        </li>
+        <Divider subheader="Test" component="li" />
         <ListItem>
           <Avatar>
             <WorkIcon />
           </Avatar>
           <ListItemText primary="Work" secondary="Jan 7, 2014" />
         </ListItem>
-        <Divider variant={'inset'} component="li" />
+        <Divider variant={'inset'} subheader="Test" component="li" />
         <ListItem>
           <Avatar>
             <BeachAccessIcon />
@@ -50,8 +48,8 @@ function InsetDividers(props) {
   );
 }
 
-InsetDividers.propTypes = {
+SubheaderDividers.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles)(InsetDividers);
+export default withStyles(styles)(SubheaderDividers);

--- a/docs/src/pages/demos/dividers/dividers.md
+++ b/docs/src/pages/demos/dividers/dividers.md
@@ -16,11 +16,14 @@ You can save rendering this DOM element by using the `divider` property on the `
 
 {{"demo": "pages/demos/dividers/ListDividers.js"}}
 
+## HTML5 Specification
+
+We need to make sure the `Divider` is rendered as a `li` to match the HTML5 specification.
+The examples below show two ways of achieving this.
+
 ## Inset Dividers
 
-The following example demonstrates the `inset` variant.
-We need to make sure the `Divider` is rendered as a `li` to match the HTML5 specification.
-The example shows two ways of achieving this.
+The `inset` property has now been deprecated. You should now use `variant="inset"`
 
 {{"demo": "pages/demos/dividers/InsetDividers.js"}}
 

--- a/docs/src/pages/demos/dividers/dividers.md
+++ b/docs/src/pages/demos/dividers/dividers.md
@@ -27,10 +27,10 @@ The `inset` property has now been deprecated. You should now use `variant="inset
 
 {{"demo": "pages/demos/dividers/InsetDividers.js"}}
 
-## Middle Dividers
-
-{{"demo": "pages/demos/dividers/MiddleDividers.js"}}
-
 ## Subheader Dividers
 
 {{"demo": "pages/demos/dividers/SubheaderDividers.js"}}
+
+## Middle Dividers
+
+{{"demo": "pages/demos/dividers/MiddleDividers.js"}}

--- a/docs/src/pages/demos/dividers/dividers.md
+++ b/docs/src/pages/demos/dividers/dividers.md
@@ -18,8 +18,16 @@ You can save rendering this DOM element by using the `divider` property on the `
 
 ## Inset Dividers
 
-The following example demonstrates the `inset` property.
+The following example demonstrates the `inset` variant.
 We need to make sure the `Divider` is rendered as a `li` to match the HTML5 specification.
 The example shows two ways of achieving this.
 
 {{"demo": "pages/demos/dividers/InsetDividers.js"}}
+
+## Middle Dividers
+
+{{"demo": "pages/demos/dividers/MiddleDividers.js"}}
+
+## Subheader Dividers
+
+{{"demo": "pages/demos/dividers/SubheaderDividers.js"}}

--- a/packages/material-ui/src/Divider/Divider.d.ts
+++ b/packages/material-ui/src/Divider/Divider.d.ts
@@ -7,11 +7,10 @@ export interface DividerProps
   component?: React.ReactType<DividerProps>;
   inset?: boolean;
   light?: boolean;
-  subheader?: string;
-  variant?: 'fullBleed' | 'inset' | 'middle';
+  variant?: 'fullWidth' | 'inset' | 'middle';
 }
 
-export type DividerClassKey = 'root' | 'absolute' | 'inset' | 'light' | 'middle' | 'subheader';
+export type DividerClassKey = 'root' | 'absolute' | 'inset' | 'light' | 'middle';
 
 declare const Divider: React.ComponentType<DividerProps>;
 

--- a/packages/material-ui/src/Divider/Divider.d.ts
+++ b/packages/material-ui/src/Divider/Divider.d.ts
@@ -5,6 +5,7 @@ export interface DividerProps
   extends StandardProps<React.HTMLAttributes<HTMLHRElement>, DividerClassKey> {
   absolute?: boolean;
   component?: React.ReactType<DividerProps>;
+  inset?: boolean;
   light?: boolean;
   subheader?: string;
   variant?: 'fullBleed' | 'inset' | 'middle';

--- a/packages/material-ui/src/Divider/Divider.d.ts
+++ b/packages/material-ui/src/Divider/Divider.d.ts
@@ -5,11 +5,12 @@ export interface DividerProps
   extends StandardProps<React.HTMLAttributes<HTMLHRElement>, DividerClassKey> {
   absolute?: boolean;
   component?: React.ReactType<DividerProps>;
-  inset?: boolean;
   light?: boolean;
+  subheader?: string;
+  variant?: 'fullBleed' | 'inset' | 'middle';
 }
 
-export type DividerClassKey = 'root' | 'absolute' | 'inset' | 'light';
+export type DividerClassKey = 'root' | 'absolute' | 'inset' | 'light' | 'middle' | 'subheader';
 
 declare const Divider: React.ComponentType<DividerProps>;
 

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import { fade } from '../styles/colorManipulator';
-import Typography from '../Typography/Typography';
 import chainPropTypes from '../utils/chainPropTypes';
 
 export const styles = theme => ({
@@ -22,27 +21,18 @@ export const styles = theme => ({
     left: 0,
     width: '100%',
   },
-  /* Styles applied to the root element if `variant={'inset'}`. */
+  /* Styles applied to the root element if `variant="inset"`. */
   inset: {
     marginLeft: 72,
-    '& + $subheader': {
-      marginLeft: 72,
-      marginTop: theme.spacing.unit / 2,
-    },
   },
   /* Styles applied to the root element if `light={true}`. */
   light: {
     backgroundColor: fade(theme.palette.divider, 0.08),
   },
-  /* Styles applied to the root element if `variant={'middle'}`. */
+  /* Styles applied to the root element if `variant="middle"`. */
   middle: {
     marginLeft: theme.spacing.unit * 2,
     marginRight: theme.spacing.unit * 2,
-  },
-  /* Styles applied to the Typography element */
-  subheader: {
-    marginLeft: theme.spacing.unit * 2,
-    marginTop: theme.spacing.unit / 2 + 1,
   },
 });
 
@@ -50,45 +40,35 @@ function Divider(props) {
   const {
     absolute,
     classes,
-    className: classNameProp,
+    className,
     component: Component,
     inset,
     light,
-    subheader,
     variant,
     ...other
   } = props;
 
-  const className = classNames(
-    classes.root,
-    {
-      [classes.absolute]: absolute,
-      [classes.inset]: inset || variant === 'inset',
-      [classes.light]: light,
-      [classes.middle]: variant === 'middle',
-    },
-    classNameProp,
-  );
-
-  let subheaderComponent;
-
-  if (subheader && variant !== 'middle') {
-    subheaderComponent = (
-      <Typography color="textSecondary" className={classes.subheader}>
-        {subheader}
-      </Typography>
-    );
-  }
-
   return (
-    <React.Fragment>
-      <Component className={className} {...other} />
-      {subheaderComponent}
-    </React.Fragment>
+    <Component
+      className={classNames(
+        classes.root,
+        {
+          [classes.inset]: inset || variant === 'inset',
+          [classes.middle]: variant === 'middle',
+          [classes.absolute]: absolute,
+          [classes.light]: light,
+        },
+        className,
+      )}
+      {...other}
+    />
   );
 }
 
 Divider.propTypes = {
+  /**
+   * Absolutely position the element.
+   */
   absolute: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
@@ -113,9 +93,9 @@ Divider.propTypes = {
     /* istanbul ignore if */
     if (props.inset) {
       return new Error(
-        'Material-UI: You are using the deprecated `inset` property ' +
+        'Material-UI: you are using the deprecated `inset` property ' +
           'that will be removed in the next major release. The property `variant="inset"` ' +
-          'is equivalent and should be used instead',
+          'is equivalent and should be used instead.',
       );
     }
 
@@ -126,30 +106,16 @@ Divider.propTypes = {
    */
   light: PropTypes.bool,
   /**
-   * Divider subheader text. This will not work with `variant={'middle'}`
-   */
-  subheader: chainPropTypes(PropTypes.string, props => {
-    /* istanbul ignore if */
-    if (props.subheader && props.variant === 'middle') {
-      return new Error(
-        'Material-UI: you have provided the `subheader` property ' +
-          'with the variant `middle`. This will have no effect.',
-      );
-    }
-
-    return null;
-  }),
-  /**
    *  The variant to use.
    */
-  variant: PropTypes.oneOf(['fullBleed', 'inset', 'middle']),
+  variant: PropTypes.oneOf(['fullWidth', 'inset', 'middle']),
 };
 
 Divider.defaultProps = {
   absolute: false,
   component: 'hr',
   light: false,
-  variant: 'fullBleed',
+  variant: 'fullWidth',
 };
 
 export default withStyles(styles, { name: 'MuiDivider' })(Divider);

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -106,6 +106,8 @@ Divider.propTypes = {
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
   /**
    * If `true`, the divider will be indented.
+   * __WARNING__: `inset` is deprecated.
+   * Instead use `variant="inset"`.
    */
   inset: chainPropTypes(PropTypes.bool, props => {
     /* istanbul ignore if */

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import withStyles from '../styles/withStyles';
 import { fade } from '../styles/colorManipulator';
+import Typography from '../Typography/Typography';
+import chainPropTypes from '../utils/chainPropTypes';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -20,13 +22,27 @@ export const styles = theme => ({
     left: 0,
     width: '100%',
   },
-  /* Styles applied to the root element if `inset={true}`. */
+  /* Styles applied to the root element if `variant={'inset'}`. */
   inset: {
     marginLeft: 72,
+    '& + $subheader': {
+      marginLeft: 72,
+      marginTop: theme.spacing.unit / 2,
+    },
   },
   /* Styles applied to the root element if `light={true}`. */
   light: {
     backgroundColor: fade(theme.palette.divider, 0.08),
+  },
+  /* Styles applied to the root element if `variant={'middle'}`. */
+  middle: {
+    marginLeft: theme.spacing.unit * 2,
+    marginRight: theme.spacing.unit * 2,
+  },
+  /* Styles applied to the Typography element */
+  subheader: {
+    marginLeft: theme.spacing.unit * 2,
+    marginTop: theme.spacing.unit / 2 + 1,
   },
 });
 
@@ -36,8 +52,9 @@ function Divider(props) {
     classes,
     className: classNameProp,
     component: Component,
-    inset,
     light,
+    subheader,
+    variant,
     ...other
   } = props;
 
@@ -45,13 +62,29 @@ function Divider(props) {
     classes.root,
     {
       [classes.absolute]: absolute,
-      [classes.inset]: inset,
+      [classes.inset]: variant === 'inset',
       [classes.light]: light,
+      [classes.middle]: variant === 'middle',
     },
     classNameProp,
   );
 
-  return <Component className={className} {...other} />;
+  let subheaderComponent;
+
+  if (subheader && variant !== 'middle') {
+    subheaderComponent = (
+      <Typography color="textSecondary" className={classes.subheader}>
+        {subheader}
+      </Typography>
+    );
+  }
+
+  return (
+    <React.Fragment>
+      <Component className={className} {...other} />
+      {subheaderComponent}
+    </React.Fragment>
+  );
 }
 
 Divider.propTypes = {
@@ -71,20 +104,34 @@ Divider.propTypes = {
    */
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
   /**
-   * If `true`, the divider will be indented.
-   */
-  inset: PropTypes.bool,
-  /**
    * If `true`, the divider will have a lighter color.
    */
   light: PropTypes.bool,
+  /**
+   * Divider subheader text. This will not work with `variant={'middle'}`
+   */
+  subheader: chainPropTypes(PropTypes.string, props => {
+    /* istanbul ignore if */
+    if (props.subheader && props.variant === 'middle') {
+      return new Error(
+        'Material-UI: you have provided the `subheader` property ' +
+          'with the variant `middle`. This will have no effect.',
+      );
+    }
+
+    return null;
+  }),
+  /**
+   *  The variant to use.
+   */
+  variant: PropTypes.oneOf(['fullBleed', 'inset', 'middle']),
 };
 
 Divider.defaultProps = {
   absolute: false,
   component: 'hr',
-  inset: false,
   light: false,
+  variant: 'fullBleed',
 };
 
 export default withStyles(styles, { name: 'MuiDivider' })(Divider);

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -52,6 +52,7 @@ function Divider(props) {
     classes,
     className: classNameProp,
     component: Component,
+    inset,
     light,
     subheader,
     variant,
@@ -62,7 +63,7 @@ function Divider(props) {
     classes.root,
     {
       [classes.absolute]: absolute,
-      [classes.inset]: variant === 'inset',
+      [classes.inset]: inset || variant === 'inset',
       [classes.light]: light,
       [classes.middle]: variant === 'middle',
     },
@@ -103,6 +104,21 @@ Divider.propTypes = {
    * Either a string to use a DOM element or a component.
    */
   component: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
+  /**
+   * If `true`, the divider will be indented.
+   */
+  inset: chainPropTypes(PropTypes.bool, props => {
+    /* istanbul ignore if */
+    if (props.inset) {
+      return new Error(
+        'Material-UI: You are using the deprecated `inset` property ' +
+          'that will be removed in the next major release. The property `variant="inset"` ' +
+          'is equivalent and should be used instead',
+      );
+    }
+
+    return null;
+  }),
   /**
    * If `true`, the divider will have a lighter color.
    */

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -38,6 +38,27 @@ describe('<Divider />', () => {
     assert.strictEqual(hr.hasClass(classes.light), true);
   });
 
+  describe('prop: inset', () => {
+    before(() => {
+      consoleErrorMock.spy();
+    });
+
+    after(() => {
+      consoleErrorMock.reset();
+    });
+
+    it('should set the inset class', () => {
+      const wrapper = shallow(<Divider inset />);
+      const hr = wrapper.childAt(0);
+      assert.strictEqual(hr.hasClass(classes.inset), true);
+    });
+
+    it('should log a deprecation warning if this property is used', () => {
+      shallow(<Divider inset />);
+      assert.match(consoleErrorMock.args()[0][0], /You are using the deprecated `inset` property/);
+    });
+  });
+
   describe('prop: subheader', () => {
     it('should render a Typography component', () => {
       const wrapper = shallow(<Divider subheader="test" />);
@@ -93,7 +114,7 @@ describe('<Divider />', () => {
         assert.strictEqual(hr.hasClass(classes.middle), true);
       });
 
-      it('should throw error if subheader is supplied', () => {
+      it('should log a warning if subheader is supplied with variant="middle"', () => {
         shallow(<Divider variant={'middle'} subheader="test" />);
         assert.match(
           consoleErrorMock.args()[0][0],

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '@material-ui/core/test-utils';
 import Divider from './Divider';
+import Typography from '../Typography';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 
 describe('<Divider />', () => {
   let shallow;
@@ -14,26 +16,90 @@ describe('<Divider />', () => {
 
   it('should render a hr', () => {
     const wrapper = shallow(<Divider />);
-    assert.strictEqual(wrapper.name(), 'hr');
+    const hr = wrapper.childAt(0);
+    assert.strictEqual(hr.name(), 'hr');
   });
 
   it('should render with the root and default class', () => {
     const wrapper = shallow(<Divider />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    const hr = wrapper.childAt(0);
+    assert.strictEqual(hr.hasClass(classes.root), true);
   });
 
   it('should set the absolute class', () => {
     const wrapper = shallow(<Divider absolute />);
-    assert.strictEqual(wrapper.hasClass(classes.absolute), true);
-  });
-
-  it('should set the inset class', () => {
-    const wrapper = shallow(<Divider inset />);
-    assert.strictEqual(wrapper.hasClass(classes.inset), true);
+    const hr = wrapper.childAt(0);
+    assert.strictEqual(hr.hasClass(classes.absolute), true);
   });
 
   it('should set the light class', () => {
     const wrapper = shallow(<Divider light />);
-    assert.strictEqual(wrapper.hasClass(classes.light), true);
+    const hr = wrapper.childAt(0);
+    assert.strictEqual(hr.hasClass(classes.light), true);
+  });
+
+  describe('prop: subheader', () => {
+    it('should render a Typography component', () => {
+      const wrapper = shallow(<Divider subheader="test" />);
+      const wrappedTypography = wrapper.find(Typography);
+      const typography = wrappedTypography.childAt(0);
+      assert.strictEqual(wrappedTypography.type(), Typography);
+      assert.strictEqual(wrappedTypography.hasClass(classes.subheader), true);
+      assert.strictEqual(typography.text(), 'test');
+    });
+
+    it('should not render a Typography component when null or not present', () => {
+      const wrapper = shallow(<Divider />);
+      assert.strictEqual(wrapper.childAt(1).exists(), false);
+    });
+  });
+
+  describe('prop: variant', () => {
+    it('should default to variant={"fullBleed"}', () => {
+      const wrapper = shallow(<Divider />);
+      const hr = wrapper.childAt(0);
+      assert.strictEqual(hr.hasClass(classes.inset), false);
+      assert.strictEqual(hr.hasClass(classes.middle), false);
+    });
+
+    describe('prop: variant={"fullBleed"} ', () => {
+      it('should render with the root and default class', () => {
+        const wrapper = shallow(<Divider />);
+        const hr = wrapper.childAt(0);
+        assert.strictEqual(hr.hasClass(classes.root), true);
+      });
+    });
+
+    describe('prop: variant={"inset"} ', () => {
+      it('should set the inset class', () => {
+        const wrapper = shallow(<Divider variant={'inset'} />);
+        const hr = wrapper.childAt(0);
+        assert.strictEqual(hr.hasClass(classes.inset), true);
+      });
+    });
+
+    describe('prop: variant={"middle"}', () => {
+      before(() => {
+        consoleErrorMock.spy();
+      });
+
+      after(() => {
+        consoleErrorMock.reset();
+      });
+
+      it('should set the middle class', () => {
+        const wrapper = shallow(<Divider variant={'middle'} />);
+        const hr = wrapper.childAt(0);
+        assert.strictEqual(hr.hasClass(classes.middle), true);
+      });
+
+      it('should throw error if subheader is supplied', () => {
+        shallow(<Divider variant={'middle'} subheader="test" />);
+        assert.match(
+          consoleErrorMock.args()[0][0],
+          /`subheader` property with the variant `middle`. This will have no effect./,
+        );
+      });
+    });
   });
 });

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '@material-ui/core/test-utils';
 import Divider from './Divider';
-import Typography from '../Typography';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 
 describe('<Divider />', () => {
@@ -16,26 +15,22 @@ describe('<Divider />', () => {
 
   it('should render a hr', () => {
     const wrapper = shallow(<Divider />);
-    const hr = wrapper.childAt(0);
-    assert.strictEqual(hr.name(), 'hr');
+    assert.strictEqual(wrapper.name(), 'hr');
   });
 
   it('should render with the root and default class', () => {
     const wrapper = shallow(<Divider />);
-    const hr = wrapper.childAt(0);
-    assert.strictEqual(hr.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
   it('should set the absolute class', () => {
     const wrapper = shallow(<Divider absolute />);
-    const hr = wrapper.childAt(0);
-    assert.strictEqual(hr.hasClass(classes.absolute), true);
+    assert.strictEqual(wrapper.hasClass(classes.absolute), true);
   });
 
   it('should set the light class', () => {
     const wrapper = shallow(<Divider light />);
-    const hr = wrapper.childAt(0);
-    assert.strictEqual(hr.hasClass(classes.light), true);
+    assert.strictEqual(wrapper.hasClass(classes.light), true);
   });
 
   describe('prop: inset', () => {
@@ -49,77 +44,35 @@ describe('<Divider />', () => {
 
     it('should set the inset class', () => {
       const wrapper = shallow(<Divider inset />);
-      const hr = wrapper.childAt(0);
-      assert.strictEqual(hr.hasClass(classes.inset), true);
-    });
-
-    it('should log a deprecation warning if this property is used', () => {
-      shallow(<Divider inset />);
-      assert.match(consoleErrorMock.args()[0][0], /You are using the deprecated `inset` property/);
-    });
-  });
-
-  describe('prop: subheader', () => {
-    it('should render a Typography component', () => {
-      const wrapper = shallow(<Divider subheader="test" />);
-      const wrappedTypography = wrapper.find(Typography);
-      const typography = wrappedTypography.childAt(0);
-      assert.strictEqual(wrappedTypography.type(), Typography);
-      assert.strictEqual(wrappedTypography.hasClass(classes.subheader), true);
-      assert.strictEqual(typography.text(), 'test');
-    });
-
-    it('should not render a Typography component when null or not present', () => {
-      const wrapper = shallow(<Divider />);
-      assert.strictEqual(wrapper.childAt(1).exists(), false);
+      assert.strictEqual(wrapper.hasClass(classes.inset), true);
     });
   });
 
   describe('prop: variant', () => {
-    it('should default to variant={"fullBleed"}', () => {
+    it('should default to variant="fullWidth"', () => {
       const wrapper = shallow(<Divider />);
-      const hr = wrapper.childAt(0);
-      assert.strictEqual(hr.hasClass(classes.inset), false);
-      assert.strictEqual(hr.hasClass(classes.middle), false);
+      assert.strictEqual(wrapper.hasClass(classes.inset), false);
+      assert.strictEqual(wrapper.hasClass(classes.middle), false);
     });
 
-    describe('prop: variant={"fullBleed"} ', () => {
+    describe('prop: variant="fullWidth" ', () => {
       it('should render with the root and default class', () => {
         const wrapper = shallow(<Divider />);
-        const hr = wrapper.childAt(0);
-        assert.strictEqual(hr.hasClass(classes.root), true);
+        assert.strictEqual(wrapper.hasClass(classes.root), true);
       });
     });
 
-    describe('prop: variant={"inset"} ', () => {
+    describe('prop: variant="inset" ', () => {
       it('should set the inset class', () => {
-        const wrapper = shallow(<Divider variant={'inset'} />);
-        const hr = wrapper.childAt(0);
-        assert.strictEqual(hr.hasClass(classes.inset), true);
+        const wrapper = shallow(<Divider variant="inset" />);
+        assert.strictEqual(wrapper.hasClass(classes.inset), true);
       });
     });
 
-    describe('prop: variant={"middle"}', () => {
-      before(() => {
-        consoleErrorMock.spy();
-      });
-
-      after(() => {
-        consoleErrorMock.reset();
-      });
-
+    describe('prop: variant="middle"', () => {
       it('should set the middle class', () => {
-        const wrapper = shallow(<Divider variant={'middle'} />);
-        const hr = wrapper.childAt(0);
-        assert.strictEqual(hr.hasClass(classes.middle), true);
-      });
-
-      it('should log a warning if subheader is supplied with variant="middle"', () => {
-        shallow(<Divider variant={'middle'} subheader="test" />);
-        assert.match(
-          consoleErrorMock.args()[0][0],
-          /`subheader` property with the variant `middle`. This will have no effect./,
-        );
+        const wrapper = shallow(<Divider variant="middle" />);
+        assert.strictEqual(wrapper.hasClass(classes.middle), true);
       });
     });
   });

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -22,8 +22,9 @@ import Divider from '@material-ui/core/Divider';
 | <span class="prop-name">absolute</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> |  |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> | <span class="prop-default">'hr'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">inset</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the divider will be indented. |
 | <span class="prop-name">light</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the divider will have a lighter color. |
+| <span class="prop-name">subheader</span> | <span class="prop-type">string</span> |   | Divider subheader text. This will not work with `variant={'middle'}` |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'fullBleed'&nbsp;&#124;<br>&nbsp;'inset'&nbsp;&#124;<br>&nbsp;'middle'<br></span> | <span class="prop-default">'fullBleed'</span> | The variant to use. |
 
 Any other properties supplied will be spread to the root element (native element).
 
@@ -37,8 +38,10 @@ This property accepts the following keys:
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">absolute</span> | Styles applied to the root element if `absolute={true}`.
-| <span class="prop-name">inset</span> | Styles applied to the root element if `inset={true}`.
+| <span class="prop-name">inset</span> | Styles applied to the root element if `variant={'inset'}`.
 | <span class="prop-name">light</span> | Styles applied to the root element if `light={true}`.
+| <span class="prop-name">middle</span> | Styles applied to the root element if `variant={'middle'}`.
+| <span class="prop-name">subheader</span> | Styles applied to the Typography element
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/Divider/Divider.js)

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -22,6 +22,7 @@ import Divider from '@material-ui/core/Divider';
 | <span class="prop-name">absolute</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> |  |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> | <span class="prop-default">'hr'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">inset</span> | <span class="prop-type">bool</span> |   | If `true`, the divider will be indented. __WARNING__: `inset` is deprecated. Instead use `variant="inset"`. |
 | <span class="prop-name">light</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the divider will have a lighter color. |
 | <span class="prop-name">subheader</span> | <span class="prop-type">string</span> |   | Divider subheader text. This will not work with `variant={'middle'}` |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'fullBleed'&nbsp;&#124;<br>&nbsp;'inset'&nbsp;&#124;<br>&nbsp;'middle'<br></span> | <span class="prop-default">'fullBleed'</span> | The variant to use. |

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -19,13 +19,12 @@ import Divider from '@material-ui/core/Divider';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">absolute</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> |  |
+| <span class="prop-name">absolute</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Absolutely position the element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> | <span class="prop-default">'hr'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">inset</span> | <span class="prop-type">bool</span> |   | If `true`, the divider will be indented. __WARNING__: `inset` is deprecated. Instead use `variant="inset"`. |
 | <span class="prop-name">light</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the divider will have a lighter color. |
-| <span class="prop-name">subheader</span> | <span class="prop-type">string</span> |   | Divider subheader text. This will not work with `variant={'middle'}` |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'fullBleed'&nbsp;&#124;<br>&nbsp;'inset'&nbsp;&#124;<br>&nbsp;'middle'<br></span> | <span class="prop-default">'fullBleed'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'fullWidth'&nbsp;&#124;<br>&nbsp;'inset'&nbsp;&#124;<br>&nbsp;'middle'<br></span> | <span class="prop-default">'fullWidth'</span> | The variant to use. |
 
 Any other properties supplied will be spread to the root element (native element).
 
@@ -39,10 +38,9 @@ This property accepts the following keys:
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">absolute</span> | Styles applied to the root element if `absolute={true}`.
-| <span class="prop-name">inset</span> | Styles applied to the root element if `variant={'inset'}`.
+| <span class="prop-name">inset</span> | Styles applied to the root element if `variant="inset"`.
 | <span class="prop-name">light</span> | Styles applied to the root element if `light={true}`.
-| <span class="prop-name">middle</span> | Styles applied to the root element if `variant={'middle'}`.
-| <span class="prop-name">subheader</span> | Styles applied to the Typography element
+| <span class="prop-name">middle</span> | Styles applied to the root element if `variant="middle"`.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/tree/master/packages/material-ui/src/Divider/Divider.js)

--- a/pages/demos/dividers.js
+++ b/pages/demos/dividers.js
@@ -23,6 +23,20 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/dividers/InsetDividers'), 'utf8')
 `,
         },
+        'pages/demos/dividers/MiddleDividers.js': {
+          js: require('docs/src/pages/demos/dividers/MiddleDividers').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/dividers/MiddleDividers'), 'utf8')
+`,
+        },
+        'pages/demos/dividers/SubheaderDividers.js': {
+          js: require('docs/src/pages/demos/dividers/SubheaderDividers').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/dividers/SubheaderDividers'), 'utf8')
+`,
+        },
       }}
     />
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

- [Divider] Added other dividers from spec
- [Divider] Added more tests
- [docs] Updated Divider documentation

Thought adding these would be a quick win :) Sadly changing to variant makes this a breaking change. The old props can be added in an a warning shown to change this.

### Upgrade path

We are introducing a new variant to the divider component: `middle`. Following our [API guideline](https://material-ui.com/guides/api/), we can no longer use a boolean property, it needs to be an enum, hence the introduction of the `variant` property.

```diff
import Divider from '@material-ui/core/Divider';

-<Divider inset />
+<Divider variant="inset" />
```