### PR TITLE
[ExpansionPanelSummary] Fix event forwarding

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of the @material-ui/core modules',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '94.1 KB',
+    limit: '94.2 KB',
   },
   {
     name: 'The size of the @material-ui/styles modules',

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -75,17 +75,24 @@ class ExpansionPanelSummary extends React.Component {
     focused: false,
   };
 
-  handleFocus = () => {
+  handleFocusVisible = event => {
     this.setState({
       focused: true,
     });
+
+    if (this.props.onFocusVisible) {
+      this.props.onFocusVisible(event);
+    }
   };
 
-  handleBlur = () => {
+  handleBlur = event => {
     this.setState({
       focused: false,
     });
-    if (typeof this.props.onBlur === 'function') this.props.onBlur();
+
+    if (this.props.onBlur) {
+      this.props.onBlur(event);
+    }
   };
 
   handleChange = event => {
@@ -107,7 +114,10 @@ class ExpansionPanelSummary extends React.Component {
       expanded,
       expandIcon,
       IconButtonProps,
+      onBlur,
       onChange,
+      onClick,
+      onFocusVisible,
       ...other
     } = this.props;
     const { focused } = this.state;
@@ -128,10 +138,10 @@ class ExpansionPanelSummary extends React.Component {
           },
           className,
         )}
-        {...other}
-        onFocusVisible={this.handleFocus}
+        onFocusVisible={this.handleFocusVisible}
         onBlur={this.handleBlur}
         onClick={this.handleChange}
+        {...other}
       >
         <div className={classNames(classes.content, { [classes.expanded]: expanded })}>
           {children}

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -85,6 +85,7 @@ class ExpansionPanelSummary extends React.Component {
     this.setState({
       focused: false,
     });
+    if (typeof this.props.onBlur === 'function') this.props.onBlur();
   };
 
   handleChange = event => {

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -54,10 +54,10 @@ describe('<ExpansionPanelSummary />', () => {
     assert.strictEqual(iconWrap.hasClass(classes.expandIcon), true);
   });
 
-  it('handleFocus() should set focused state', () => {
+  it('handleFocusVisible() should set focused state', () => {
     const eventMock = 'woofExpansionPanelSummary';
     const wrapper = mount(<ExpansionPanelSummaryNaked classes={{}} />);
-    wrapper.instance().handleFocus(eventMock);
+    wrapper.instance().handleFocusVisible(eventMock);
     assert.strictEqual(wrapper.state().focused, true);
   });
 
@@ -69,12 +69,22 @@ describe('<ExpansionPanelSummary />', () => {
     assert.strictEqual(wrapper.state().focused, false);
   });
 
-  describe('prop: onBlur', () => {
-    it('handleblur should call onBlur prop when focus leaves', () => {
-      const myOnBlur = spy();
-      const wrapper = mount(<ExpansionPanelSummaryNaked onBlur={myOnBlur} classes={{}} />);
-      wrapper.instance().handleBlur();
-      assert.strictEqual(myOnBlur.callCount, 1, 'should have been called once');
+  describe('event callbacks', () => {
+    it('should fire event callbacks', () => {
+      const events = ['onClick', 'onFocusVisible', 'onBlur'];
+
+      const handlers = events.reduce((result, n) => {
+        result[n] = spy();
+        return result;
+      }, {});
+
+      const wrapper = shallow(<ExpansionPanelSummary {...handlers} />);
+
+      events.forEach(n => {
+        const event = n.charAt(2).toLowerCase() + n.slice(3);
+        wrapper.simulate(event, { persist: () => {} });
+        assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
+      });
     });
   });
 

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -69,6 +69,15 @@ describe('<ExpansionPanelSummary />', () => {
     assert.strictEqual(wrapper.state().focused, false);
   });
 
+  describe('prop: onBlur', () => {
+    it('handleblur should call onBlur prop when focus leaves', () => {
+      const myOnBlur = spy();
+      const wrapper = mount(<ExpansionPanelSummaryNaked onBlur={myOnBlur} classes={{}} />);
+      wrapper.instance().handleBlur();
+      assert.strictEqual(myOnBlur.callCount, 1, 'should have been called once');
+    });
+  });
+
   describe('prop: onChange', () => {
     it('should propagate call to onChange prop', () => {
       const eventMock = 'woofExpansionPanelSummary';


### PR DESCRIPTION
Closes #13577 and adds test for it. 

I wasn't clear on what I should change proptypes to. onchange and onclick are in proptypes now, but they're ignored from the generated docs. Is that done for some reason? Should onfocus and onblur be added there but with @ignore for some reason? I can update it to whatever is desired style.

