### PR TITLE
[FormControl] Use stable context API

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -5,6 +5,7 @@ import { isFilled, isAdornedStart } from '../InputBase/utils';
 import withStyles from '../styles/withStyles';
 import { capitalize } from '../utils/helpers';
 import { isMuiElement } from '../utils/reactHelpers';
+import FormControlContext from './FormControlContext';
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -86,28 +87,6 @@ class FormControl extends React.Component {
     }
   }
 
-  getChildContext() {
-    const { disabled, error, required, margin, variant } = this.props;
-    const { adornedStart, filled, focused } = this.state;
-
-    return {
-      muiFormControl: {
-        adornedStart,
-        disabled,
-        error,
-        filled,
-        focused,
-        margin,
-        onBlur: this.handleBlur,
-        onEmpty: this.handleClean,
-        onFilled: this.handleDirty,
-        onFocus: this.handleFocus,
-        required,
-        variant,
-      },
-    };
-  }
-
   handleFocus = () => {
     this.setState(state => (!state.focused ? { focused: true } : null));
   };
@@ -141,19 +120,37 @@ class FormControl extends React.Component {
       variant,
       ...other
     } = this.props;
+    const { adornedStart, filled, focused } = this.state;
+
+    const childContext = {
+      adornedStart,
+      disabled,
+      error,
+      filled,
+      focused,
+      margin,
+      onBlur: this.handleBlur,
+      onEmpty: this.handleClean,
+      onFilled: this.handleDirty,
+      onFocus: this.handleFocus,
+      required,
+      variant,
+    };
 
     return (
-      <Component
-        className={classNames(
-          classes.root,
-          {
-            [classes[`margin${capitalize(margin)}`]]: margin !== 'none',
-            [classes.fullWidth]: fullWidth,
-          },
-          className,
-        )}
-        {...other}
-      />
+      <FormControlContext.Provider value={childContext}>
+        <Component
+          className={classNames(
+            classes.root,
+            {
+              [classes[`margin${capitalize(margin)}`]]: margin !== 'none',
+              [classes.fullWidth]: fullWidth,
+            },
+            className,
+          )}
+          {...other}
+        />
+      </FormControlContext.Provider>
     );
   }
 }
@@ -211,10 +208,6 @@ FormControl.defaultProps = {
   margin: 'none',
   required: false,
   variant: 'standard',
-};
-
-FormControl.childContextTypes = {
-  muiFormControl: PropTypes.object,
 };
 
 export default withStyles(styles, { name: 'MuiFormControl' })(FormControl);

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -1,57 +1,61 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import Input from '../Input';
 import Select from '../Select';
 import FormControl from './FormControl';
+import FormControlContext from './FormControlContext';
 
 describe('<FormControl />', () => {
-  let shallow;
+  let mount;
   let classes;
 
+  function setState(wrapper, state) {
+    return wrapper.find('FormControl').setState(state);
+  }
+
+  function getState(wrapper) {
+    return wrapper.find('FormControl').state();
+  }
+
   before(() => {
-    shallow = createShallow({ dive: true });
+    mount = createMount();
     classes = getClasses(<FormControl />);
+  });
+
+  after(() => {
+    mount.cleanUp();
   });
 
   describe('initial state', () => {
     it('should render a div with the root and user classes', () => {
-      const wrapper = shallow(<FormControl className="woofFormControl" />);
+      const wrapper = mount(<FormControl className="woofFormControl" />);
 
-      assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass('woofFormControl'), true);
-    });
-
-    it('should have the focused class', () => {
-      const wrapper = shallow(<FormControl className="woofFormControl" />);
-
-      assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass('woofFormControl'), true);
+      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.root), true);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass('woofFormControl'), true);
     });
 
     it('should have no margin', () => {
-      const wrapper = shallow(<FormControl />);
+      const wrapper = mount(<FormControl />);
 
-      assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.marginNormal), false);
-      assert.strictEqual(wrapper.hasClass(classes.marginDense), false);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginNormal), false);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginDense), false);
     });
 
     it('should have the margin normal class', () => {
-      const wrapper = shallow(<FormControl margin="normal" />);
+      const wrapper = mount(<FormControl margin="normal" />);
 
-      assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.marginNormal), true);
+      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginNormal), true);
     });
 
     it('should have the margin dense class', () => {
-      const wrapper = shallow(<FormControl margin="dense" />);
+      const wrapper = mount(<FormControl margin="dense" />);
 
-      assert.strictEqual(wrapper.name(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
-      assert.strictEqual(wrapper.hasClass(classes.marginNormal), false);
+      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginDense), true);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginNormal), false);
     });
   });
 
@@ -59,89 +63,89 @@ describe('<FormControl />', () => {
     let wrapper;
 
     beforeEach(() => {
-      wrapper = shallow(<FormControl />);
+      wrapper = mount(<FormControl />);
     });
 
     it('should not be filled initially', () => {
-      assert.strictEqual(wrapper.state().filled, false);
+      assert.strictEqual(getState(wrapper).filled, false);
     });
 
     it('should not be focused initially', () => {
-      assert.strictEqual(wrapper.state().focused, false);
+      assert.strictEqual(getState(wrapper).focused, false);
     });
   });
 
   describe('prop: required', () => {
     it('should not apply it to the DOM', () => {
-      const wrapper = shallow(<FormControl required />);
-      assert.strictEqual(wrapper.props().required, undefined);
+      const wrapper = mount(<FormControl required />);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).props().required, undefined);
     });
   });
 
   describe('prop: disabled', () => {
     it('will be unfocused if it gets disabled', () => {
-      const wrapper = shallow(<FormControl />);
-      wrapper.setState({ focused: true });
+      const wrapper = mount(<FormControl />);
+      setState(wrapper, { focused: true });
       wrapper.setProps({ disabled: true });
-      assert.strictEqual(wrapper.state().focused, false);
+      assert.strictEqual(getState(wrapper).focused, false);
     });
   });
 
   describe('input', () => {
     it('should be filled with a value', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <FormControl>
           <Input value="bar" />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().filled, true);
+      assert.strictEqual(getState(wrapper).filled, true);
     });
 
     it('should be filled with a defaultValue', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <FormControl>
           <Input defaultValue="bar" />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().filled, true);
+      assert.strictEqual(getState(wrapper).filled, true);
     });
 
     it('should be adorned with an endAdornment', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <FormControl>
           <Input endAdornment={<div />} />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().adornedStart, false);
+      assert.strictEqual(getState(wrapper).adornedStart, false);
     });
 
     it('should be adorned with a startAdornment', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <FormControl>
           <Input startAdornment={<div />} />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().adornedStart, true);
+      assert.strictEqual(getState(wrapper).adornedStart, true);
     });
   });
 
   describe('select', () => {
     it('should not be adorned without a startAdornment', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <FormControl>
           <Select value="" />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().adornedStart, false);
+      assert.strictEqual(getState(wrapper).adornedStart, false);
     });
 
     it('should be adorned with a startAdornment', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <FormControl>
           <Select value="" input={<Input startAdornment={<div />} />} />
         </FormControl>,
       );
-      assert.strictEqual(wrapper.state().adornedStart, true);
+      assert.strictEqual(getState(wrapper).adornedStart, true);
     });
   });
 
@@ -149,34 +153,34 @@ describe('<FormControl />', () => {
     let wrapper;
     let muiFormControlContext;
 
-    function loadChildContext() {
-      muiFormControlContext = wrapper.instance().getChildContext().muiFormControl;
-    }
-
     beforeEach(() => {
-      wrapper = shallow(<FormControl />);
-      loadChildContext();
+      wrapper = mount(
+        <FormControl>
+          <FormControlContext.Consumer>
+            {context => {
+              muiFormControlContext = context;
+            }}
+          </FormControlContext.Consumer>
+        </FormControl>,
+      );
     });
 
     describe('from state', () => {
       it('should have the filled state from the instance', () => {
         assert.strictEqual(muiFormControlContext.filled, false);
-        wrapper.setState({ filled: true });
-        loadChildContext();
+        setState(wrapper, { filled: true });
         assert.strictEqual(muiFormControlContext.filled, true);
       });
 
       it('should have the focused state from the instance', () => {
         assert.strictEqual(muiFormControlContext.focused, false);
-        wrapper.setState({ focused: true });
-        loadChildContext();
+        setState(wrapper, { focused: true });
         assert.strictEqual(muiFormControlContext.focused, true);
       });
 
       it('should have the adornedStart state from the instance', () => {
         assert.strictEqual(muiFormControlContext.adornedStart, false);
-        wrapper.setState({ adornedStart: true });
-        loadChildContext();
+        setState(wrapper, { adornedStart: true });
         assert.strictEqual(muiFormControlContext.adornedStart, true);
       });
     });
@@ -185,21 +189,18 @@ describe('<FormControl />', () => {
       it('should have the required prop from the instance', () => {
         assert.strictEqual(muiFormControlContext.required, false);
         wrapper.setProps({ required: true });
-        loadChildContext();
         assert.strictEqual(muiFormControlContext.required, true);
       });
 
       it('should have the error prop from the instance', () => {
         assert.strictEqual(muiFormControlContext.error, false);
         wrapper.setProps({ error: true });
-        loadChildContext();
         assert.strictEqual(muiFormControlContext.error, true);
       });
 
       it('should have the margin prop from the instance', () => {
         assert.strictEqual(muiFormControlContext.margin, 'none');
         wrapper.setProps({ margin: 'dense' });
-        loadChildContext();
         assert.strictEqual(muiFormControlContext.margin, 'dense');
       });
     });
@@ -209,7 +210,6 @@ describe('<FormControl />', () => {
         it('should set the filled state', () => {
           assert.strictEqual(muiFormControlContext.filled, false);
           muiFormControlContext.onFilled();
-          loadChildContext();
           assert.strictEqual(muiFormControlContext.filled, true);
           muiFormControlContext.onFilled();
           assert.strictEqual(muiFormControlContext.filled, true);
@@ -219,10 +219,8 @@ describe('<FormControl />', () => {
       describe('onEmpty', () => {
         it('should clean the filled state', () => {
           muiFormControlContext.onFilled();
-          loadChildContext();
           assert.strictEqual(muiFormControlContext.filled, true);
           muiFormControlContext.onEmpty();
-          loadChildContext();
           assert.strictEqual(muiFormControlContext.filled, false);
           muiFormControlContext.onEmpty();
           assert.strictEqual(muiFormControlContext.filled, false);
@@ -231,23 +229,23 @@ describe('<FormControl />', () => {
 
       describe('handleFocus', () => {
         it('should set the focused state', () => {
-          assert.strictEqual(wrapper.state().focused, false);
+          assert.strictEqual(getState(wrapper).focused, false);
           muiFormControlContext.onFocus();
-          assert.strictEqual(wrapper.state().focused, true);
+          assert.strictEqual(getState(wrapper).focused, true);
           muiFormControlContext.onFocus();
-          assert.strictEqual(wrapper.state().focused, true);
+          assert.strictEqual(getState(wrapper).focused, true);
         });
       });
 
       describe('handleBlur', () => {
         it('should clear the focused state', () => {
-          assert.strictEqual(wrapper.state().focused, false);
+          assert.strictEqual(getState(wrapper).focused, false);
           muiFormControlContext.onFocus();
-          assert.strictEqual(wrapper.state().focused, true);
+          assert.strictEqual(getState(wrapper).focused, true);
           muiFormControlContext.onBlur();
-          assert.strictEqual(wrapper.state().focused, false);
+          assert.strictEqual(getState(wrapper).focused, false);
           muiFormControlContext.onBlur();
-          assert.strictEqual(wrapper.state().focused, false);
+          assert.strictEqual(getState(wrapper).focused, false);
         });
       });
     });

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -53,7 +53,7 @@ describe('<FormControl />', () => {
     it('should have the margin dense class', () => {
       const wrapper = mount(<FormControl margin="dense" />);
 
-      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
+      assert.strictEqual(findOutermostIntrinsic(wrapper).name(), 'div');
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginDense), true);
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginNormal), false);
     });

--- a/packages/material-ui/src/FormControl/FormControlContext.d.ts
+++ b/packages/material-ui/src/FormControl/FormControlContext.d.ts
@@ -13,4 +13,6 @@ export interface FormControlContextProps extends Pick<FormControlProps, ContextF
   onFocus: () => void;
 }
 
-declare const FormControlContext: Context<FormControlContextProps | undefined>;
+declare const FormControlContext: Context<FormControlContextProps | null | undefined>;
+
+export default FormControlContext;

--- a/packages/material-ui/src/FormControl/FormControlContext.d.ts
+++ b/packages/material-ui/src/FormControl/FormControlContext.d.ts
@@ -1,0 +1,16 @@
+import { Context } from 'react';
+import { FormControlProps } from './FormControl';
+
+type ContextFromPropsKey = 'disabled' | 'error' | 'margin' | 'required' | 'variant';
+
+export interface FormControlContextProps extends Pick<FormControlProps, ContextFromPropsKey> {
+  adornedStart: boolean;
+  filled: boolean;
+  focused: boolean;
+  onBlur: () => void;
+  onEmpty: () => void;
+  onFilled: () => void;
+  onFocus: () => void;
+}
+
+declare const FormControlContext: Context<FormControlContextProps | undefined>;

--- a/packages/material-ui/src/FormControl/FormControlContext.js
+++ b/packages/material-ui/src/FormControl/FormControlContext.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const FormControlContext = React.createContext();
+
+export default FormControlContext;

--- a/packages/material-ui/src/FormControl/FormControlContext.js
+++ b/packages/material-ui/src/FormControl/FormControlContext.js
@@ -1,5 +1,8 @@
 import React from 'react';
 
+/**
+ * @ignore - internal component.
+ */
 const FormControlContext = React.createContext();
 
 export default FormControlContext;

--- a/packages/material-ui/src/FormControl/formControlState.js
+++ b/packages/material-ui/src/FormControl/formControlState.js
@@ -1,0 +1,13 @@
+export default function formControlState({ props, states, muiFormControl }) {
+  return states.reduce((acc, state) => {
+    acc[state] = props[state];
+
+    if (muiFormControl) {
+      if (typeof props[state] === 'undefined') {
+        acc[state] = muiFormControl[state];
+      }
+    }
+
+    return acc;
+  }, {});
+}

--- a/packages/material-ui/src/FormControl/withFormControlContext.js
+++ b/packages/material-ui/src/FormControl/withFormControlContext.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import FormControlContext from './FormControlContext';
-import getDisplayName from '@material-ui/utils/getDisplayName';
+import { getDisplayName } from '@material-ui/utils';
 
 export default function withFormControlContext(Component) {
   const EnhancedComponent = props => {

--- a/packages/material-ui/src/FormControl/withFormControlContext.js
+++ b/packages/material-ui/src/FormControl/withFormControlContext.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import hoistNonReactStatics from 'hoist-non-react-statics';
+import FormControlContext from './FormControlContext';
+import getDisplayName from '../utils/getDisplayName';
+
+export default function withFormControlContext(Component) {
+  const EnhancedComponent = props => {
+    return (
+      <FormControlContext.Consumer>
+        {context => {
+          return <Component muiFormControl={context} {...props} />;
+        }}
+      </FormControlContext.Consumer>
+    );
+  };
+
+  if (process.env.NODE_ENV !== 'production') {
+    EnhancedComponent.displayName = `WithFormControlContext(${getDisplayName(Component)})`;
+  }
+
+  hoistNonReactStatics(EnhancedComponent, Component);
+
+  return EnhancedComponent;
+}

--- a/packages/material-ui/src/FormControl/withFormControlContext.js
+++ b/packages/material-ui/src/FormControl/withFormControlContext.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import FormControlContext from './FormControlContext';
-import getDisplayName from '../utils/getDisplayName';
+import getDisplayName from '@material-ui/utils/getDisplayName';
 
 export default function withFormControlContext(Component) {
   const EnhancedComponent = props => {

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import withFormControlContext from '../FormControl/withFormControlContext';
 import withStyles from '../styles/withStyles';
 import Typography from '../Typography';
 import { capitalize } from '../utils/helpers';
@@ -53,7 +54,7 @@ export const styles = theme => ({
  * Drop in replacement of the `Radio`, `Switch` and `Checkbox` component.
  * Use this component if you want to display an extra label.
  */
-function FormControlLabel(props, context) {
+function FormControlLabel(props) {
   const {
     checked,
     classes,
@@ -63,12 +64,12 @@ function FormControlLabel(props, context) {
     inputRef,
     label,
     labelPlacement,
+    muiFormControl,
     name,
     onChange,
     value,
     ...other
   } = props;
-  const { muiFormControl } = context;
 
   let disabled = disabledProp;
   if (typeof disabled === 'undefined' && typeof control.props.disabled !== 'undefined') {
@@ -144,6 +145,10 @@ FormControlLabel.propTypes = {
    * The position of the label.
    */
   labelPlacement: PropTypes.oneOf(['end', 'start', 'top', 'bottom']),
+  /**
+   * @ignore
+   */
+  muiFormControl: PropTypes.object,
   /*
    * @ignore
    */
@@ -166,8 +171,6 @@ FormControlLabel.defaultProps = {
   labelPlacement: 'end',
 };
 
-FormControlLabel.contextTypes = {
-  muiFormControl: PropTypes.object,
-};
-
-export default withStyles(styles, { name: 'MuiFormControlLabel' })(FormControlLabel);
+export default withStyles(styles, { name: 'MuiFormControlLabel' })(
+  withFormControlContext(FormControlLabel),
+);

--- a/packages/material-ui/src/FormHelperText/FormHelperText.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import formControlState from '../FormControl/formControlState';
+import withFormControlContext from '../FormControl/withFormControlContext';
 import withStyles from '../styles/withStyles';
-import { formControlState } from '../InputBase/InputBase';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -42,7 +43,7 @@ export const styles = theme => ({
   required: {},
 });
 
-function FormHelperText(props, context) {
+function FormHelperText(props) {
   const {
     classes,
     className: classNameProp,
@@ -52,6 +53,7 @@ function FormHelperText(props, context) {
     filled,
     focused,
     margin,
+    muiFormControl,
     required,
     variant,
     ...other
@@ -59,7 +61,7 @@ function FormHelperText(props, context) {
 
   const fcs = formControlState({
     props,
-    context,
+    muiFormControl,
     states: ['variant', 'margin', 'disabled', 'error', 'filled', 'focused', 'required'],
   });
 
@@ -124,6 +126,10 @@ FormHelperText.propTypes = {
    */
   margin: PropTypes.oneOf(['dense']),
   /**
+   * @ignore
+   */
+  muiFormControl: PropTypes.object,
+  /**
    * If `true`, the helper text should use required classes key.
    */
   required: PropTypes.bool,
@@ -137,8 +143,6 @@ FormHelperText.defaultProps = {
   component: 'p',
 };
 
-FormHelperText.contextTypes = {
-  muiFormControl: PropTypes.object,
-};
-
-export default withStyles(styles, { name: 'MuiFormHelperText' })(FormHelperText);
+export default withStyles(styles, { name: 'MuiFormHelperText' })(
+  withFormControlContext(FormHelperText),
+);

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -1,19 +1,20 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import FormHelperText from './FormHelperText';
+import FormControlContext from '../FormControl/FormControlContext';
 
 describe('<FormHelperText />', () => {
-  let shallow;
+  let mount;
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
+    mount = createMount();
     classes = getClasses(<FormHelperText />);
   });
 
   it('should render a <p />', () => {
-    const wrapper = shallow(<FormHelperText className="woofHelperText" />);
+    const wrapper = findOutermostIntrinsic(mount(<FormHelperText className="woofHelperText" />));
     assert.strictEqual(wrapper.name(), 'p');
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass('woofHelperText'), true);
@@ -21,29 +22,37 @@ describe('<FormHelperText />', () => {
 
   describe('prop: component', () => {
     it('should render the prop component', () => {
-      const wrapper = shallow(<FormHelperText component="div" />);
+      const wrapper = findOutermostIntrinsic(mount(<FormHelperText component="div" />));
       assert.strictEqual(wrapper.name(), 'div');
     });
   });
 
   describe('prop: error', () => {
     it('should have an error class', () => {
-      const wrapper = shallow(<FormHelperText error />);
+      const wrapper = findOutermostIntrinsic(mount(<FormHelperText error />));
       assert.strictEqual(wrapper.hasClass(classes.error), true);
     });
   });
 
   describe('with muiFormControl context', () => {
     let wrapper;
-    let muiFormControl;
 
     function setFormControlContext(muiFormControlContext) {
-      muiFormControl = muiFormControlContext;
-      wrapper.setContext({ muiFormControl });
+      wrapper.setProps({ context: muiFormControlContext });
     }
 
     beforeEach(() => {
-      wrapper = shallow(<FormHelperText>Foo</FormHelperText>);
+      function Provider(props) {
+        const { context, ...other } = props;
+
+        return (
+          <FormControlContext.Provider value={context}>
+            <FormHelperText {...other}>Foo</FormHelperText>
+          </FormControlContext.Provider>
+        );
+      }
+
+      wrapper = mount(<Provider />);
     });
     ['error', 'disabled'].forEach(visualState => {
       describe(visualState, () => {
@@ -52,15 +61,15 @@ describe('<FormHelperText />', () => {
         });
 
         it(`should have the ${visualState} class`, () => {
-          assert.strictEqual(wrapper.hasClass(classes[visualState]), true);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes[visualState]), true);
         });
 
         it('should be overridden by props', () => {
-          assert.strictEqual(wrapper.hasClass(classes[visualState]), true);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes[visualState]), true);
           wrapper.setProps({ [visualState]: false });
-          assert.strictEqual(wrapper.hasClass(classes[visualState]), false);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes[visualState]), false);
           wrapper.setProps({ [visualState]: true });
-          assert.strictEqual(wrapper.hasClass(classes[visualState]), true);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes[visualState]), true);
         });
       });
     });
@@ -72,14 +81,14 @@ describe('<FormHelperText />', () => {
         });
 
         it('should have the dense class', () => {
-          assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginDense), true);
         });
       });
 
       it('should be overridden by props', () => {
-        assert.strictEqual(wrapper.hasClass(classes.marginDense), false);
+        assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginDense), false);
         wrapper.setProps({ margin: 'dense' });
-        assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
+        assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginDense), true);
       });
     });
   });

--- a/packages/material-ui/src/FormLabel/FormLabel.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import formControlState from '../FormControl/formControlState';
+import withFormControlContext from '../FormControl/withFormControlContext';
 import withStyles from '../styles/withStyles';
-import { formControlState } from '../InputBase/InputBase';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -39,7 +40,7 @@ export const styles = theme => ({
   },
 });
 
-function FormLabel(props, context) {
+function FormLabel(props) {
   const {
     children,
     classes,
@@ -49,13 +50,14 @@ function FormLabel(props, context) {
     error,
     filled,
     focused,
+    muiFormControl,
     required,
     ...other
   } = props;
 
   const fcs = formControlState({
     props,
-    context,
+    muiFormControl,
     states: ['required', 'focused', 'disabled', 'error', 'filled'],
   });
 
@@ -125,6 +127,10 @@ FormLabel.propTypes = {
    */
   focused: PropTypes.bool,
   /**
+   * @ignore
+   */
+  muiFormControl: PropTypes.object,
+  /**
    * If `true`, the label will indicate that the input is required.
    */
   required: PropTypes.bool,
@@ -134,8 +140,4 @@ FormLabel.defaultProps = {
   component: 'label',
 };
 
-FormLabel.contextTypes = {
-  muiFormControl: PropTypes.object,
-};
-
-export default withStyles(styles, { name: 'MuiFormLabel' })(FormLabel);
+export default withStyles(styles, { name: 'MuiFormLabel' })(withFormControlContext(FormLabel));

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -2,19 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
+import {
+  createMount,
+  findOutermostIntrinsic,
+  getClasses,
+  unwrap,
+} from '@material-ui/core/test-utils';
+import FormControlContext from '../FormControl/FormControlContext';
 import InputAdornment from '../InputAdornment';
 import Textarea from './Textarea';
 import InputBase from './InputBase';
 
 describe('<InputBase />', () => {
-  let shallow;
   let classes;
   let mount;
   const NakedInputBase = unwrap(InputBase);
 
+  function setState(wrapper, state) {
+    return wrapper.find('InputBase').setState(state);
+  }
+
   before(() => {
-    shallow = createShallow({ untilSelector: 'InputBase' });
     mount = createMount();
     classes = getClasses(<InputBase />);
   });
@@ -24,13 +32,13 @@ describe('<InputBase />', () => {
   });
 
   it('should render a <div />', () => {
-    const wrapper = shallow(<InputBase />);
-    assert.strictEqual(wrapper.name(), 'div');
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    const wrapper = mount(<InputBase />);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).name(), 'div');
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.root), true);
   });
 
   it('should render an <input /> inside the div', () => {
-    const wrapper = shallow(<InputBase />);
+    const wrapper = mount(<InputBase />);
     const input = wrapper.find('input');
     assert.strictEqual(input.name(), 'input');
     assert.strictEqual(input.props().type, 'text');
@@ -40,24 +48,24 @@ describe('<InputBase />', () => {
 
   describe('multiline', () => {
     it('should render an <Textarea /> when passed the multiline prop', () => {
-      const wrapper = shallow(<InputBase multiline />);
+      const wrapper = mount(<InputBase multiline />);
       assert.strictEqual(wrapper.find(Textarea).length, 1);
     });
 
     it('should render an <textarea /> when passed the multiline and rows props', () => {
-      const wrapper = shallow(<InputBase multiline rows="4" />);
+      const wrapper = mount(<InputBase multiline rows="4" />);
       assert.strictEqual(wrapper.find('textarea').length, 1);
     });
 
     it('should forward the value to the Textarea', () => {
-      const wrapper = shallow(<InputBase multiline rowsMax="4" value="" />);
+      const wrapper = mount(<InputBase multiline rowsMax="4" value="" />);
       assert.strictEqual(wrapper.find(Textarea).props().value, '');
     });
   });
 
   describe('prop: disabled', () => {
     it('should render a disabled <input />', () => {
-      const wrapper = shallow(<InputBase disabled />);
+      const wrapper = mount(<InputBase disabled />);
       const input = wrapper.find('input');
       assert.strictEqual(input.name(), 'input');
       assert.strictEqual(input.hasClass(classes.input), true);
@@ -65,41 +73,34 @@ describe('<InputBase />', () => {
     });
 
     it('should reset the focused state', () => {
-      const wrapper = shallow(<InputBase />);
       const handleBlur = spy();
-      wrapper.setContext({
-        ...wrapper.context(),
-        muiFormControl: {
-          onBlur: handleBlur,
-        },
-      });
+      const wrapper = mount(<InputBase muiFormControl={{ onBlur: handleBlur }} />);
       // We simulate a focused input that is getting disabled.
-      wrapper.setState({
+      setState(wrapper, {
         focused: true,
       });
       wrapper.setProps({
         disabled: true,
       });
-      assert.strictEqual(wrapper.state().focused, false);
+      assert.strictEqual(wrapper.find('InputBase').state().focused, false);
       assert.strictEqual(handleBlur.callCount, 1);
     });
 
     // IE 11 bug
     it('should not respond the focus event when disabled', () => {
-      const wrapper = shallow(<InputBase disabled />);
-      const instance = wrapper.instance();
+      const wrapper = mount(<InputBase disabled />);
       const event = {
         stopPropagation: spy(),
       };
-      instance.handleFocus(event);
+      wrapper.find('input').simulate('focus', event);
       assert.strictEqual(event.stopPropagation.callCount, 1);
     });
   });
 
-  it('should disabled the underline', () => {
-    const wrapper = shallow(<InputBase disableUnderline />);
+  it('should disable the underline', () => {
+    const wrapper = mount(<InputBase disableUnderline />);
     const input = wrapper.find('input');
-    assert.strictEqual(wrapper.hasClass(classes.inkbar), false);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.inkbar), false);
     assert.strictEqual(input.name(), 'input');
     assert.strictEqual(input.hasClass(classes.input), true);
     assert.strictEqual(input.hasClass(classes.underline), false);
@@ -123,8 +124,8 @@ describe('<InputBase />', () => {
 
   describe('controlled', () => {
     it('should considered [] as controlled', () => {
-      const wrapper = shallow(<InputBase value={[]} />);
-      const instance = wrapper.instance();
+      const wrapper = mount(<InputBase value={[]} />);
+      const instance = wrapper.find('InputBase').instance();
       assert.strictEqual(instance.isControlled, true);
     });
 
@@ -137,13 +138,13 @@ describe('<InputBase />', () => {
         before(() => {
           handleEmpty = spy();
           handleFilled = spy();
-          wrapper = shallow(
+          wrapper = mount(
             <InputBase value={value} onFilled={handleFilled} onEmpty={handleEmpty} />,
           );
         });
 
         it('should check that the component is controlled', () => {
-          const instance = wrapper.instance();
+          const instance = wrapper.find('InputBase').instance();
           assert.strictEqual(instance.isControlled, true);
         });
 
@@ -214,21 +215,21 @@ describe('<InputBase />', () => {
     });
 
     it('should check that the component is uncontrolled', () => {
-      const instance = wrapper.instance();
+      const instance = wrapper.find('InputBase').instance();
       assert.strictEqual(instance.isControlled, false);
     });
 
     it('should fire the onFilled callback when dirtied', () => {
       assert.strictEqual(handleFilled.callCount, 1);
-      wrapper.instance().inputRef.value = 'hello';
+      wrapper.find('InputBase').instance().inputRef.value = 'hello';
       wrapper.find('input').simulate('change');
       assert.strictEqual(handleFilled.callCount, 2);
     });
 
     it('should fire the onEmpty callback when cleaned', () => {
-      // Because of shallow() this hasn't fired since there is no mounting
+      // Because of mount() this hasn't fired since there is no mounting
       assert.strictEqual(handleEmpty.callCount, 0);
-      wrapper.instance().inputRef.value = '';
+      wrapper.find('InputBase').instance().inputRef.value = '';
       wrapper.find('input').simulate('change');
       assert.strictEqual(handleEmpty.callCount, 1);
     });
@@ -240,16 +241,30 @@ describe('<InputBase />', () => {
 
     function setFormControlContext(muiFormControlContext) {
       muiFormControl = muiFormControlContext;
-      wrapper.setContext({ ...wrapper.context(), muiFormControl });
+      wrapper.setProps({ context: muiFormControlContext });
     }
 
     beforeEach(() => {
-      wrapper = shallow(<InputBase />);
+      // we need a class for enzyme otherwise: "Can't call ::setState on functional component"
+      /* eslint-disable-next-line react/prefer-stateless-function */
+      class Provider extends React.Component {
+        render() {
+          const { context, ...other } = this.props;
+
+          return (
+            <FormControlContext.Provider value={context}>
+              <InputBase {...other} />
+            </FormControlContext.Provider>
+          );
+        }
+      }
+
+      wrapper = mount(<Provider />);
     });
 
     it('should have the formControl class', () => {
       setFormControlContext({});
-      assert.strictEqual(wrapper.hasClass(classes.formControl), true);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.formControl), true);
     });
 
     describe('callbacks', () => {
@@ -257,7 +272,7 @@ describe('<InputBase />', () => {
 
       beforeEach(() => {
         focus = spy();
-        wrapper.instance().inputRef = { value: '', focus };
+        wrapper.find('InputBase').instance().inputRef = { value: '', focus };
         setFormControlContext({
           onFilled: spy(),
           onEmpty: spy(),
@@ -272,7 +287,7 @@ describe('<InputBase />', () => {
           onFilled: handleFilled,
         });
 
-        wrapper.instance().inputRef.value = 'hello';
+        wrapper.find('InputBase').instance().inputRef.value = 'hello';
         wrapper.find('input').simulate('change');
         assert.strictEqual(handleFilled.callCount, 1);
         assert.strictEqual(muiFormControl.onFilled.callCount, 1);
@@ -284,7 +299,7 @@ describe('<InputBase />', () => {
           onEmpty: handleEmpty,
         });
 
-        wrapper.instance().inputRef.value = '';
+        wrapper.find('InputBase').instance().inputRef.value = '';
         wrapper.find('input').simulate('change');
         assert.strictEqual(handleEmpty.callCount, 1);
         assert.strictEqual(muiFormControl.onEmpty.callCount, 1);
@@ -331,15 +346,15 @@ describe('<InputBase />', () => {
       });
 
       it('should have the error class', () => {
-        assert.strictEqual(wrapper.hasClass(classes.error), true);
+        assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.error), true);
       });
 
       it('should be overridden by props', () => {
-        assert.strictEqual(wrapper.hasClass(classes.error), true);
+        assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.error), true);
         wrapper.setProps({ error: false });
-        assert.strictEqual(wrapper.hasClass(classes.error), false);
+        assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.error), false);
         wrapper.setProps({ error: true });
-        assert.strictEqual(wrapper.hasClass(classes.error), true);
+        assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.error), true);
       });
     });
 
@@ -371,13 +386,13 @@ describe('<InputBase />', () => {
 
     describe('focused', () => {
       it('prioritizes context focus', () => {
-        wrapper.setState({ focused: true });
+        setState(wrapper, { focused: true });
 
         setFormControlContext({ focused: false });
-        assert.strictEqual(wrapper.hasClass(classes.focused), false);
+        assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.focused), false);
 
         setFormControlContext({ focused: true });
-        assert.strictEqual(wrapper.hasClass(classes.focused), true);
+        assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.focused), true);
       });
     });
   });
@@ -388,7 +403,7 @@ describe('<InputBase />', () => {
 
     before(() => {
       wrapper = mount(<NakedInputBase classes={classes} />);
-      instance = wrapper.instance();
+      instance = wrapper.find('InputBase').instance();
     });
 
     beforeEach(() => {
@@ -443,11 +458,11 @@ describe('<InputBase />', () => {
 
   describe('prop: inputProps', () => {
     it('should apply the props on the input', () => {
-      const wrapper = shallow(<InputBase inputProps={{ className: 'foo', maxLength: true }} />);
+      const wrapper = mount(<InputBase inputProps={{ className: 'foo', maxLength: 5 }} />);
       const input = wrapper.find('input');
       assert.strictEqual(input.hasClass('foo'), true);
       assert.strictEqual(input.hasClass(classes.input), true);
-      assert.strictEqual(input.props().maxLength, true);
+      assert.strictEqual(input.props().maxLength, 5);
     });
 
     it('should be able to get a ref', () => {
@@ -459,19 +474,29 @@ describe('<InputBase />', () => {
 
   describe('prop: startAdornment, prop: endAdornment', () => {
     it('should render adornment before input', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <InputBase startAdornment={<InputAdornment position="start">$</InputAdornment>} />,
       );
 
-      assert.strictEqual(wrapper.childAt(0).type(), InputAdornment);
+      assert.strictEqual(
+        findOutermostIntrinsic(wrapper)
+          .childAt(0)
+          .type(),
+        InputAdornment,
+      );
     });
 
     it('should render adornment after input', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <InputBase endAdornment={<InputAdornment position="end">$</InputAdornment>} />,
       );
 
-      assert.strictEqual(wrapper.childAt(1).type(), InputAdornment);
+      assert.strictEqual(
+        findOutermostIntrinsic(wrapper)
+          .childAt(1)
+          .type(),
+        InputAdornment,
+      );
     });
   });
 

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -3,9 +3,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import formControlState from '../FormControl/formControlState';
+import withFormControlContext from '../FormControl/withFormControlContext';
 import withStyles from '../styles/withStyles';
 import FormLabel from '../FormLabel';
-import { formControlState } from '../InputBase/InputBase';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -79,7 +80,7 @@ export const styles = theme => ({
   },
 });
 
-function InputLabel(props, context) {
+function InputLabel(props) {
   const {
     children,
     classes,
@@ -87,12 +88,11 @@ function InputLabel(props, context) {
     disableAnimation,
     FormLabelClasses,
     margin,
+    muiFormControl,
     shrink: shrinkProp,
     variant,
     ...other
   } = props;
-
-  const { muiFormControl } = context;
 
   let shrink = shrinkProp;
   if (typeof shrink === 'undefined' && muiFormControl) {
@@ -101,7 +101,7 @@ function InputLabel(props, context) {
 
   const fcs = formControlState({
     props,
-    context,
+    muiFormControl,
     states: ['margin', 'variant'],
   });
 
@@ -176,6 +176,10 @@ InputLabel.propTypes = {
    */
   margin: PropTypes.oneOf(['dense']),
   /**
+   * @ignore
+   */
+  muiFormControl: PropTypes.object,
+  /**
    * if `true`, the label will indicate that the input is required.
    */
   required: PropTypes.bool,
@@ -193,8 +197,4 @@ InputLabel.defaultProps = {
   disableAnimation: false,
 };
 
-InputLabel.contextTypes = {
-  muiFormControl: PropTypes.object,
-};
-
-export default withStyles(styles, { name: 'MuiInputLabel' })(InputLabel);
+export default withStyles(styles, { name: 'MuiInputLabel' })(withFormControlContext(InputLabel));

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -1,63 +1,74 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
-import FormLabel from '../FormLabel';
+import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import FormControlContext from '../FormControl/FormControlContext';
 import InputLabel from './InputLabel';
 
 describe('<InputLabel />', () => {
-  let shallow;
+  let mount;
   let classes;
 
   before(() => {
-    shallow = createShallow({ dive: true });
+    mount = createMount();
     classes = getClasses(<InputLabel />);
   });
 
+  after(() => {
+    mount.cleanUp();
+  });
+
   it('should render a FormLabel', () => {
-    const wrapper = shallow(<InputLabel>Foo</InputLabel>);
-    assert.strictEqual(wrapper.type(), FormLabel);
-    assert.strictEqual(wrapper.childAt(0).text(), 'Foo');
+    const wrapper = mount(<InputLabel>Foo</InputLabel>);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).type(), 'label');
+    assert.strictEqual(wrapper.text(), 'Foo');
   });
 
   it('should have the root and animated classes by default', () => {
-    const wrapper = shallow(<InputLabel>Foo</InputLabel>);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.animated), true);
+    const wrapper = mount(<InputLabel>Foo</InputLabel>);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.root), true);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.animated), true);
   });
 
   it('should not have the animated class when disabled', () => {
-    const wrapper = shallow(<InputLabel disableAnimation>Foo</InputLabel>);
+    const wrapper = mount(<InputLabel disableAnimation>Foo</InputLabel>);
     assert.strictEqual(wrapper.hasClass(classes.animated), false);
   });
 
   describe('prop: FormLabelClasses', () => {
     it('should be able to change the FormLabel style', () => {
-      const wrapper = shallow(<InputLabel FormLabelClasses={{ foo: 'bar' }}>Foo</InputLabel>);
-      assert.strictEqual(wrapper.props().classes.foo, 'bar');
+      const wrapper = mount(<InputLabel FormLabelClasses={{ root: 'bar' }}>Foo</InputLabel>);
+      assert.include(wrapper.find('FormLabel').props().classes.root, 'bar');
     });
   });
 
   describe('with muiFormControl context', () => {
     let wrapper;
-    let muiFormControl;
 
     function setFormControlContext(muiFormControlContext) {
-      muiFormControl = muiFormControlContext;
-      wrapper.setContext({ muiFormControl });
+      wrapper.setProps({ context: muiFormControlContext });
     }
 
     beforeEach(() => {
-      wrapper = shallow(<InputLabel />);
+      function Provider(props) {
+        const { context, ...other } = props;
+        return (
+          <FormControlContext.Provider value={context}>
+            <InputLabel {...other} />
+          </FormControlContext.Provider>
+        );
+      }
+
+      wrapper = mount(<Provider />);
     });
 
     it('should have the formControl class', () => {
       setFormControlContext({});
-      assert.strictEqual(wrapper.hasClass(classes.formControl), true);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.formControl), true);
     });
 
     it('should have the labelDense class when margin is dense', () => {
       setFormControlContext({ margin: 'dense' });
-      assert.strictEqual(wrapper.hasClass(classes.marginDense), true);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginDense), true);
     });
 
     ['filled', 'focused'].forEach(state => {
@@ -67,15 +78,15 @@ describe('<InputLabel />', () => {
         });
 
         it('should have the shrink class', () => {
-          assert.strictEqual(wrapper.hasClass(classes.shrink), true);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.shrink), true);
         });
 
         it('should be overridden by the shrink prop', () => {
-          assert.strictEqual(wrapper.hasClass(classes.shrink), true);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.shrink), true);
           wrapper.setProps({ shrink: false });
-          assert.strictEqual(wrapper.hasClass(classes.shrink), false);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.shrink), false);
           wrapper.setProps({ shrink: true });
-          assert.strictEqual(wrapper.hasClass(classes.shrink), true);
+          assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.shrink), true);
         });
       });
     });

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -4,7 +4,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import NativeSelectInput from './NativeSelectInput';
 import withStyles from '../styles/withStyles';
-import { formControlState } from '../InputBase/InputBase';
+import formControlState from '../FormControl/formControlState';
+import withFormControlContext from '../FormControl/withFormControlContext';
 import ArrowDropDownIcon from '../internal/svg-icons/ArrowDropDown';
 import Input from '../Input';
 
@@ -76,11 +77,20 @@ export const styles = theme => ({
 /**
  * An alternative to `<Select native />` with a much smaller bundle size footprint.
  */
-function NativeSelect(props, context) {
-  const { children, classes, IconComponent, input, inputProps, variant, ...other } = props;
+function NativeSelect(props) {
+  const {
+    children,
+    classes,
+    IconComponent,
+    input,
+    inputProps,
+    muiFormControl,
+    variant,
+    ...other
+  } = props;
   const fcs = formControlState({
     props,
-    context,
+    muiFormControl,
     states: ['variant'],
   });
 
@@ -125,6 +135,10 @@ NativeSelect.propTypes = {
    */
   inputProps: PropTypes.object,
   /**
+   * @ignore
+   */
+  muiFormControl: PropTypes.object,
+  /**
    * Callback function fired when a menu item is selected.
    *
    * @param {object} event The event source of the callback.
@@ -146,10 +160,8 @@ NativeSelect.defaultProps = {
   input: <Input />,
 };
 
-NativeSelect.contextTypes = {
-  muiFormControl: PropTypes.object,
-};
-
 NativeSelect.muiName = 'Select';
 
-export default withStyles(styles, { name: 'MuiNativeSelect' })(NativeSelect);
+export default withStyles(styles, { name: 'MuiNativeSelect' })(
+  withFormControlContext(NativeSelect),
+);

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,20 +1,25 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses, createMount } from '@material-ui/core/test-utils';
 import Input from '../Input';
 import NativeSelect from './NativeSelect';
 
 describe('<NativeSelect />', () => {
-  let shallow;
   let classes;
   let mount;
   const props = {
     input: <Input />,
-    children: [<option value="1">1</option>, <option value="2">2</option>],
+    children: [
+      <option key="1" value="1">
+        1
+      </option>,
+      <option key="2" value="2">
+        2
+      </option>,
+    ],
   };
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<NativeSelect {...props} />);
     mount = createMount();
   });
@@ -24,13 +29,13 @@ describe('<NativeSelect />', () => {
   });
 
   it('should render a correct top element', () => {
-    const wrapper = shallow(<NativeSelect {...props} />);
-    assert.strictEqual(wrapper.type(), Input);
+    const wrapper = mount(<NativeSelect {...props} />);
+    assert.strictEqual(wrapper.find(Input).exists(), true);
   });
 
   it('should provide the classes to the input component', () => {
-    const wrapper = shallow(<NativeSelect {...props} />);
-    assert.deepEqual(wrapper.props().inputProps.classes, classes);
+    const wrapper = mount(<NativeSelect {...props} />);
+    assert.deepEqual(wrapper.find(Input).props().inputProps.classes, classes);
   });
 
   it('should be able to mount the component', () => {

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -3,18 +3,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SelectInput from './SelectInput';
+import formControlState from '../FormControl/formControlState';
+import withFormControlContext from '../FormControl/withFormControlContext';
 import withStyles from '../styles/withStyles';
 import mergeClasses from '../styles/mergeClasses';
 import ArrowDropDownIcon from '../internal/svg-icons/ArrowDropDown';
 // To replace with InputBase in v4.0.0
 import Input from '../Input';
-import { formControlState } from '../InputBase/InputBase';
 import { styles as nativeSelectStyles } from '../NativeSelect/NativeSelect';
 import NativeSelectInput from '../NativeSelect/NativeSelectInput';
 
 export const styles = nativeSelectStyles;
 
-function Select(props, context) {
+function Select(props) {
   const {
     autoWidth,
     children,
@@ -24,6 +25,7 @@ function Select(props, context) {
     input,
     inputProps,
     MenuProps,
+    muiFormControl,
     multiple,
     native,
     onClose,
@@ -38,7 +40,7 @@ function Select(props, context) {
   const inputComponent = native ? NativeSelectInput : SelectInput;
   const fcs = formControlState({
     props,
-    context,
+    muiFormControl,
     states: ['variant'],
   });
 
@@ -192,10 +194,8 @@ Select.defaultProps = {
   native: false,
 };
 
-Select.contextTypes = {
-  muiFormControl: PropTypes.object,
-};
-
 Select.muiName = 'Select';
 
-export default withStyles(nativeSelectStyles, { name: 'MuiSelect' })(Select);
+export default withStyles(nativeSelectStyles, { name: 'MuiSelect' })(
+  withFormControlContext(Select),
+);

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -1,22 +1,28 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses, createMount } from '@material-ui/core/test-utils';
 import MenuItem from '../MenuItem';
 import Input from '../Input';
 import Select from './Select';
 import { spy } from 'sinon';
 
 describe('<Select />', () => {
-  let shallow;
   let classes;
   let mount;
   const defaultProps = {
     input: <Input />,
-    children: [<MenuItem value="1">1</MenuItem>, <MenuItem value="2">2</MenuItem>],
+    children: [
+      <MenuItem key="1" value="1">
+        1
+      </MenuItem>,
+      <MenuItem key="2" value="2">
+        2
+      </MenuItem>,
+    ],
+    value: '1',
   };
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<Select {...defaultProps} />);
     mount = createMount();
   });
@@ -26,18 +32,18 @@ describe('<Select />', () => {
   });
 
   it('should render a correct top element', () => {
-    const wrapper = shallow(<Select {...defaultProps} />);
-    assert.strictEqual(wrapper.type(), Input);
+    const wrapper = mount(<Select {...defaultProps} />);
+    assert.strictEqual(wrapper.find(Input).exists(), true);
   });
 
   it('should provide the classes to the input component', () => {
-    const wrapper = shallow(<Select {...defaultProps} />);
-    assert.deepEqual(wrapper.props().inputProps.classes, classes);
+    const wrapper = mount(<Select {...defaultProps} />);
+    assert.deepEqual(wrapper.find(Input).props().inputProps.classes, classes);
   });
 
   describe('prop: inputProps', () => {
     it('should be able to provide a custom classes property', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <Select
           {...defaultProps}
           inputProps={{
@@ -45,7 +51,7 @@ describe('<Select />', () => {
           }}
         />,
       );
-      assert.deepEqual(wrapper.props().inputProps.classes, {
+      assert.deepEqual(wrapper.find(Input).props().inputProps.classes, {
         ...classes,
         root: `${classes.root} root`,
       });

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -3,6 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import withFormControlContext from '../FormControl/withFormControlContext';
 import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';
 
@@ -50,7 +51,7 @@ class SwitchBase extends React.Component {
       this.props.onFocus(event);
     }
 
-    const { muiFormControl } = this.context;
+    const { muiFormControl } = this.props;
     if (muiFormControl && muiFormControl.onFocus) {
       muiFormControl.onFocus(event);
     }
@@ -61,7 +62,7 @@ class SwitchBase extends React.Component {
       this.props.onBlur(event);
     }
 
-    const { muiFormControl } = this.context;
+    const { muiFormControl } = this.props;
     if (muiFormControl && muiFormControl.onBlur) {
       muiFormControl.onBlur(event);
     }
@@ -91,6 +92,7 @@ class SwitchBase extends React.Component {
       id,
       inputProps,
       inputRef,
+      muiFormControl,
       name,
       onBlur,
       onChange,
@@ -103,7 +105,6 @@ class SwitchBase extends React.Component {
       ...other
     } = this.props;
 
-    const { muiFormControl } = this.context;
     let disabled = disabledProp;
 
     if (muiFormControl) {
@@ -207,6 +208,10 @@ SwitchBase.propTypes = {
    * Use that property to pass a ref callback to the native input component.
    */
   inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  /**
+   * @ignore
+   */
+  muiFormControl: PropTypes.object,
   /*
    * @ignore
    */
@@ -250,8 +255,6 @@ SwitchBase.propTypes = {
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
 };
 
-SwitchBase.contextTypes = {
-  muiFormControl: PropTypes.object,
-};
-
-export default withStyles(styles, { name: 'MuiPrivateSwitchBase' })(SwitchBase);
+export default withStyles(styles, { name: 'MuiPrivateSwitchBase' })(
+  withFormControlContext(SwitchBase),
+);


### PR DESCRIPTION
- move from deprecated context API to stable context API
- add `withFormControlContext` HOC to be able to access context via props without major component rewrite
- tried to move to DOM only testing whenever the test broke due to changed component tree
- minor propTypes fix (`disableUnderline` was spread to native `div` in `InputBase`)

Only the styling solution remains with the deprecated context API.

Closes #13465.