### PR TITLE
[styles] Follow react docs for firstRender flag

### DIFF
--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -232,15 +232,14 @@ function makeStyles(stylesOrCreator, options = {}) {
 
     // Execute asynchronously every time the theme changes.
     React.useEffect(
-      () =>
-        function removeStyles() {
-          detach({
-            state,
-            stylesCreator,
-            stylesOptions,
-            theme,
-          });
-        },
+      () => () => {
+        detach({
+          state,
+          stylesCreator,
+          stylesOptions,
+          theme,
+        });
+      },
       [theme],
     );
 

--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -233,7 +233,7 @@ function makeStyles(stylesOrCreator, options = {}) {
     // Execute asynchronously every time the theme changes.
     React.useEffect(
       () =>
-        function componentWillUnmount() {
+        function removeStyles() {
           detach({
             state,
             stylesCreator,

--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -203,7 +203,7 @@ function makeStyles(stylesOrCreator, options = {}) {
     const firstRender = React.useRef(true);
     React.useEffect(() => {
       firstRender.current = false;
-    });
+    }, []);
 
 <<<<<<< HEAD
     // Execute synchronously every time the theme changes.

--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -200,12 +200,8 @@ function makeStyles(stylesOrCreator, options = {}) {
       ...stylesOptions2,
     };
 
-    const firstRender = React.useRef(true);
-    React.useEffect(() => {
-      firstRender.current = false;
-    }, []);
+    const { current: state } = React.useRef({});
 
-<<<<<<< HEAD
     // Execute synchronously every time the theme changes.
     React.useMemo(() => {
       attach({
@@ -217,25 +213,8 @@ function makeStyles(stylesOrCreator, options = {}) {
         theme,
       });
     }, [theme]);
-=======
-    const { current: state } = React.useRef({});
 
-    // Execute synchronously everytime the theme changes.
-    React.useMemo(
-      () => {
-        attach({
-          name,
-          props,
-          state,
-          stylesCreator,
-          stylesOptions,
-          theme,
-        });
-      },
-      [theme],
-    );
->>>>>>> [styles] Follow react docs for firstRender flag
-
+    const firstRender = React.useRef(true);
     React.useEffect(() => {
       if (!firstRender.current) {
         update({
@@ -247,11 +226,14 @@ function makeStyles(stylesOrCreator, options = {}) {
         });
       }
     });
+    React.useEffect(() => {
+      firstRender.current = false;
+    }, []);
 
     // Execute asynchronously every time the theme changes.
     React.useEffect(
       () =>
-        function cleanup() {
+        function componentWillUnmount() {
           detach({
             state,
             stylesCreator,

--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -200,16 +200,12 @@ function makeStyles(stylesOrCreator, options = {}) {
       ...stylesOptions2,
     };
 
-    let firstRender = false;
-
-    const [state] = React.useState(() => {
-      firstRender = true;
-      return {
-        // Helper to debug
-        // id: id++,
-      };
+    const firstRender = React.useRef(true);
+    React.useEffect(() => {
+      firstRender.current = false;
     });
 
+<<<<<<< HEAD
     // Execute synchronously every time the theme changes.
     React.useMemo(() => {
       attach({
@@ -221,9 +217,27 @@ function makeStyles(stylesOrCreator, options = {}) {
         theme,
       });
     }, [theme]);
+=======
+    const { current: state } = React.useRef({});
+
+    // Execute synchronously everytime the theme changes.
+    React.useMemo(
+      () => {
+        attach({
+          name,
+          props,
+          state,
+          stylesCreator,
+          stylesOptions,
+          theme,
+        });
+      },
+      [theme],
+    );
+>>>>>>> [styles] Follow react docs for firstRender flag
 
     React.useEffect(() => {
-      if (!firstRender) {
+      if (!firstRender.current) {
         update({
           props,
           state,


### PR DESCRIPTION
This was something where the intention of the code was not apparent to me and looked like it was using `useState` not for its intended purpose. Turns out the react docs already had this use case in mind: https://reactjs.org/docs/hooks-faq.html#can-i-run-an-effect-only-on-updates

