### PR TITLE
[styles] Add TypeScript declarations

### DIFF
--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -1,0 +1,287 @@
+// allow this here since we want the declarations to be equivalent to declarations
+// in their own files
+// tslint:disable:strict-export-declare-modifiers
+
+declare module '@material-ui/styles' {
+  export { default as createGenerateClassName } from '@material-ui/styles/createGenerateClassName';
+  export { default as createStyled } from '@material-ui/styles/createStyled';
+  export { default as createStyles } from '@material-ui/styles/createStyles';
+  export { default as getThemeProps } from '@material-ui/styles/getThemeProps';
+  export { default as install } from '@material-ui/styles/install';
+  export { default as jssPreset } from '@material-ui/styles/jssPreset';
+  export { default as makeStyles } from '@material-ui/styles/makeStyles';
+  export { default as styled } from '@material-ui/styles/styled';
+  export { default as StylesProvider } from '@material-ui/styles/StylesProvider';
+  export { default as ThemeProvider } from '@material-ui/styles/ThemeProvider';
+  export { default as useTheme } from '@material-ui/styles/useTheme';
+  export { default as withStyles, WithStyles } from '@material-ui/styles/withStyles';
+  export { default as withTheme, WithTheme } from '@material-ui/styles/withTheme';
+}
+
+declare module '@material-ui/styles/createGenerateClassName' {
+  import { GenerateClassName } from 'jss';
+
+  export interface GenerateClassNameOptions {
+    dangerouslyUseGlobalCSS?: boolean;
+    productionPrefix?: string;
+    seed?: string;
+  }
+
+  export default function createGenerateClassName(
+    options?: GenerateClassNameOptions,
+  ): GenerateClassName;
+}
+
+declare module '@material-ui/styles/createStyled' {
+  import {
+    ClassKeyOfStyles,
+    ClassNameMap,
+    Styles,
+    ThemeOfStyles,
+    WithStylesOptions,
+  } from '@material-ui/styles/withStyles';
+
+  export type ThemeOfRenderProps<R> = unknown;
+
+  export type RenderProps<Theme, IncludeTheme extends boolean | undefined> = {
+    classes: ClassNameMap<'root'>;
+  } & (IncludeTheme extends true ? { theme: Theme } : {});
+
+  export interface StyledProps<Theme, IncludeTheme extends boolean | undefined = false> {
+    children: (props: RenderProps<Theme, IncludeTheme>) => React.ReactNode;
+    classes?: ClassNameMap<'root'>;
+    theme?: Theme;
+  }
+
+  export default function createStyled<
+    S extends Styles<any, any, 'root'>,
+    Options extends WithStylesOptions<ClassKeyOfStyles<S>>
+  >(
+    styles: S,
+    options?: Options,
+  ): React.ComponentType<StyledProps<ThemeOfStyles<S>, Options['withTheme']>>;
+}
+
+declare module '@material-ui/styles/createStyles' {
+  import { CSSProperties, StyleRules, ClassNameMap } from '@material-ui/styles/withStyles';
+
+  /**
+   * This function doesn't really "do anything" at runtime, it's just the identity
+   * function. Its only purpose is to defeat TypeScript's type widening when providing
+   * style rules to `withStyles` which are a function of the `Theme`.
+   *
+   * @param styles a set of style mappings
+   * @returns the same styles that were passed in
+   */
+  export default function createStyles<C extends string, P extends object>(
+    styles: StyleRules<P, C>,
+  ): StyleRules<P, C>;
+}
+
+declare module '@material-ui/styles/getThemeProps' {
+  import { ComponentsPropsList } from '@material-ui/core/styles/props';
+  import { Theme } from '@material-ui/core';
+
+  interface NamedParams<K extends keyof ComponentsPropsList> {
+    name: K;
+    props: ComponentsPropsList[K];
+    theme?: Theme;
+  }
+  export default function getThemeProps<Name extends keyof ComponentsPropsList>(
+    params: NamedParams<Name>,
+  ): ComponentsPropsList[Name];
+}
+
+declare module '@material-ui/styles/install' {
+  export default function install(): void;
+}
+
+declare module '@material-ui/styles/jssPreset' {
+  import { JSSOptions } from 'jss';
+
+  export default function jssPreset(): JSSOptions;
+}
+
+declare module '@material-ui/styles/makeStyles' {
+  import {
+    ClassKeyOfStyles,
+    ClassNameMap,
+    PropsOfStyles,
+    Styles,
+  } from '@material-ui/styles/withStyles';
+
+  export default function makeStyles<S extends Styles<any, any>>(
+    styles: S,
+  ): (props: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
+}
+
+declare module '@material-ui/styles/styled' {
+  import { ConsistentWith, Omit, PropsOf } from '@material-ui/core';
+  import {
+    CSSProperties,
+    StyledComponentProps,
+    Styles,
+    WithStylesOptions,
+  } from '@material-ui/styles/withStyles';
+
+  /**
+   * @internal
+   */
+  export type ComponentCreator<C extends React.ReactType> = <Theme>(
+    styles: CSSProperties | ((theme: Theme) => CSSProperties),
+    options?: WithStylesOptions,
+  ) => React.ComponentType<
+    Omit<JSX.LibraryManagedAttributes<C, PropsOf<C>>, 'classes' | 'className'> &
+      StyledComponentProps<'root'> & { className?: string }
+  >;
+
+  export interface StyledProps {
+    className: string;
+  }
+
+  export default function styled<
+    C extends React.ReactType<ConsistentWith<PropsOf<C>, { className: string }>>
+  >(Component: C): ComponentCreator<C>;
+}
+
+declare module '@material-ui/styles/StylesProvider' {
+  import { GenerateClassName, JSS } from 'jss';
+
+  interface StylesOptions {
+    disableGeneration?: boolean;
+    generateClassName?: GenerateClassName;
+    jss?: JSS;
+    // TODO need info @oliviertassinari
+    sheetsCache?: {};
+    // TODO need info @oliviertassinari
+    sheetsManager?: {};
+    // TODO need info @oliviertassinari
+    sheetsRegistry?: {};
+  }
+
+  const StylesContext: React.Context<StylesOptions>;
+
+  export interface StylesProviderProps extends StylesOptions {
+    children: React.ReactNode;
+  }
+  const StylesProvider: React.ComponentType<StylesProviderProps>;
+  export default StylesProvider;
+}
+
+declare module '@material-ui/styles/ThemeProvider' {
+  import { Theme } from '@material-ui/core';
+
+  const ThemeContext: React.Context<Theme>;
+
+  export interface ThemeProviderProps {
+    children: React.ReactNode;
+    theme: Theme | ((outerTheme: Theme) => Theme);
+  }
+  const ThemeProvider: React.ComponentType<ThemeProviderProps>;
+  export default ThemeProvider;
+}
+
+declare module '@material-ui/styles/useTheme' {
+  export default function useTheme<T>(): T;
+}
+
+declare module '@material-ui/styles/withStyles' {
+  import * as React from 'react';
+  import { Omit, PropInjector, PropsOf } from '@material-ui/core';
+  import * as CSS from 'csstype';
+  import * as JSS from 'jss';
+
+  export interface CSSProperties extends CSS.Properties<number | string> {
+    // Allow pseudo selectors and media queries
+    [k: string]: CSS.Properties<number | string>[keyof CSS.Properties] | CSSProperties;
+  }
+
+  /**
+   * @internal
+   * This is basically the API of JSS. It defines a Map<string, CSS>,
+   * where
+   *
+   * - the `keys` are the class (names) that will be created
+   * - the `values` are objects that represent CSS rules (`React.CSSProperties`).
+   */
+  export type StyleRules<Props extends object, ClassKey extends string = string> = Record<
+    ClassKey,
+    CSSProperties | ((props: Props) => CSSProperties)
+  >;
+
+  /**
+   * @internal
+   */
+  export type StyleRulesCallback<Theme, Props extends object, ClassKey extends string = string> = (
+    theme: Theme,
+  ) => StyleRules<Props, ClassKey>;
+
+  export type Styles<Theme, Props extends {}, ClassKey extends string = string> =
+    | StyleRules<Props, ClassKey>
+    | StyleRulesCallback<Theme, Props, ClassKey>;
+
+  export interface WithStylesOptions<ClassKey extends string = string>
+    extends JSS.CreateStyleSheetOptions<ClassKey> {
+    flip?: boolean;
+    withTheme?: boolean;
+    name?: string;
+  }
+
+  export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
+
+  /**
+   * @internal
+   */
+  export type ClassKeyInferable<Theme, Props extends {}> = string | Styles<Theme, Props>;
+  export type ClassKeyOfStyles<S> = S extends string
+    ? S
+    : S extends StyleRulesCallback<any, any, infer K>
+    ? K
+    : S extends StyleRules<any, infer K>
+    ? K
+    : never;
+
+  /**
+   * infers the type of the theme used in the styles
+   */
+  export type PropsOfStyles<S> = S extends Styles<any, infer Props> ? Props : {};
+  /**
+   * infers the type of the props used in the styles
+   */
+  export type ThemeOfStyles<S> = S extends Styles<infer Theme, any> ? Theme : {};
+
+  export type WithStyles<
+    S extends ClassKeyInferable<any, any>,
+    IncludeTheme extends boolean | undefined = false
+  > = (IncludeTheme extends true ? { theme: ThemeOfStyles<S> } : {}) & {
+    classes: ClassNameMap<ClassKeyOfStyles<S>>;
+    innerRef?: React.Ref<any> | React.RefObject<any>;
+  } & PropsOfStyles<S>;
+
+  export interface StyledComponentProps<ClassKey extends string = string> {
+    classes?: Partial<ClassNameMap<ClassKey>>;
+    innerRef?: React.Ref<any> | React.RefObject<any>;
+  }
+
+  export default function withStyles<
+    S extends Styles<any, any>,
+    Options extends WithStylesOptions<ClassKeyOfStyles<S>> = {}
+  >(
+    style: S,
+    options?: Options,
+  ): PropInjector<WithStyles<S, Options['withTheme']>, StyledComponentProps<ClassKeyOfStyles<S>>>;
+}
+
+declare module '@material-ui/styles/withTheme' {
+  import { PropInjector } from '@material-ui/core';
+
+  export interface WithTheme<Theme> {
+    theme: Theme;
+    innerRef?: React.Ref<any>;
+  }
+
+  export default function withTheme<Theme>(): PropInjector<
+    WithTheme<Theme>,
+    Partial<WithTheme<Theme>>
+  >;
+}

--- a/packages/material-ui-styles/src/index.spec.tsx
+++ b/packages/material-ui-styles/src/index.spec.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { Theme } from '@material-ui/core';
+import { AppBarProps } from '@material-ui/core/AppBar';
+import { getThemeProps } from '@material-ui/styles';
+import styled, { StyledProps } from '@material-ui/styles/styled';
+
+function testGetThemeProps(theme: Theme, props: AppBarProps): void {
+  const overriddenProps: AppBarProps = getThemeProps({ name: 'MuiAppBar', props, theme });
+
+  // AvatarProps not assignable to AppBarProps
+  // $ExpectError
+  const wronglyNamedProps: AppBarProps = getThemeProps({
+    name: 'MuiAvatar',
+    props,
+    theme,
+  });
+}
+
+{
+  // styled
+  const StyledButton = styled('button')({
+    background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+    borderRadius: 3,
+    border: 0,
+    color: 'white',
+    height: 48,
+    padding: '0 30px',
+    boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
+  });
+  const renderedStyledButton = <StyledButton classes={{ root: 'additonal-root-class' }} />;
+  // $ExpectError
+  const nonExistingClassKey = <StyledButton classes={{ notRoot: 'additonal-root-class' }} />;
+
+  interface MyTheme {
+    fontFamily: string;
+  }
+
+  interface MyComponentProps extends StyledProps {
+    defaulted: string;
+  }
+  class MyComponent extends React.Component<MyComponentProps> {
+    static defaultProps = {
+      defaulted: 'Hello, World!',
+    };
+    render() {
+      const { className, defaulted } = this.props;
+      return <div className={className}>Greeted?: {defaulted.startsWith('Hello')}</div>;
+    }
+  }
+  const StyledMyComponent = styled<typeof MyComponent>(MyComponent)((theme: MyTheme) => ({
+    fontFamily: theme.fontFamily,
+  }));
+  const renderedMyComponent = (
+    <>
+      <MyComponent className="test" />
+      <StyledMyComponent />
+    </>
+  );
+}

--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { Theme } from '@material-ui/core';
+import { AppBarProps } from '@material-ui/core/AppBar';
+import { createStyled, createStyles, getThemeProps, makeStyles } from '@material-ui/styles';
+import styled, { StyledProps } from '@material-ui/styles/styled';
+
+// createStyled
+{
+  const Styled = createStyled(
+    (theme: Theme) => ({
+      root: {
+        background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+        borderRadius: 3,
+        border: 0,
+        color: 'white',
+        height: 48,
+        padding: `0 ${theme.spacing.unit * 4}px`,
+        boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
+      },
+    }),
+    { withTheme: true },
+  );
+
+  const ValidRenderProps = () => {
+    return (
+      <Styled>
+        {({ classes, theme }) => (
+          <button type="button" className={classes.root}>
+            Render props with a spacing of {theme.spacing.unit}
+          </button>
+        )}
+      </Styled>
+    );
+  };
+
+  const NoRenderProps = () => {
+    // $ExpectError
+    return <Styled>I didn't provide a function as a child :(</Styled>;
+  };
+
+  const IncompatibleTheme = () => {
+    // Object literal may only specify known types
+    // $ExpectError
+    return <Styled theme={{ foo: 'bar' }}>{({ theme }) => theme.spacing.unit}</Styled>;
+  };
+
+  const unusedClassKey = createStyled({
+    // `foo` does not exist on type Styles
+    // $ExpectError
+    foo: {},
+  });
+}
+
+function testGetThemeProps(theme: Theme, props: AppBarProps): void {
+  const overriddenProps: AppBarProps = getThemeProps({ name: 'MuiAppBar', props, theme });
+
+  // AvatarProps not assignable to AppBarProps
+  // $ExpectError
+  const wronglyNamedProps: AppBarProps = getThemeProps({
+    name: 'MuiAvatar',
+    props,
+    theme,
+  });
+}
+
+// makeStyles
+{
+  interface StyleProps {
+    color?: 'blue' | 'red';
+  }
+
+  const styles = (theme: Theme) =>
+    createStyles({
+      root: (props: StyleProps) => ({
+        backgroundColor: props.color || theme.palette.primary.main,
+      }),
+    });
+  const useMyStyles = makeStyles(styles);
+
+  interface MyComponentProps extends StyleProps {
+    message: string;
+  }
+
+  const MyComponent = (props: MyComponentProps) => {
+    const { color, message } = props;
+    const classes = useMyStyles(props);
+    // $ExpectError
+    const invalidClasses = useMyStyles({ colourTypo: 'red' });
+    // $ExpectError
+    const undefinedClassName = classes.toot;
+
+    return (
+      <div className={classes.root}>
+        {color}: {message}
+      </div>
+    );
+  };
+}
+
+// styled
+{
+  const StyledButton = styled('button')({
+    background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+    borderRadius: 3,
+    border: 0,
+    color: 'white',
+    height: 48,
+    padding: '0 30px',
+    boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
+  });
+  const renderedStyledButton = <StyledButton classes={{ root: 'additonal-root-class' }} />;
+  // $ExpectError
+  const nonExistingClassKey = <StyledButton classes={{ notRoot: 'additonal-root-class' }} />;
+
+  interface MyTheme {
+    fontFamily: string;
+  }
+  // tslint:disable-next-line: no-empty-interface
+  interface MyComponentProps extends StyledProps {
+    defaulted: string;
+  }
+  class MyComponent extends React.Component<MyComponentProps> {
+    static defaultProps = {
+      defaulted: 'Hello, World!',
+    };
+    render() {
+      const { className, defaulted } = this.props;
+      return <div className={className}>Greeted?: {defaulted.startsWith('Hello')}</div>;
+    }
+  }
+  const StyledMyComponent = styled<typeof MyComponent>(MyComponent)((theme: MyTheme) => ({
+    fontFamily: theme.fontFamily,
+  }));
+  const renderedMyComponent = (
+    <>
+      <MyComponent className="test" />
+      <StyledMyComponent />
+    </>
+  );
+}

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -1,0 +1,390 @@
+import * as React from 'react';
+import {
+  createStyles,
+  withStyles,
+  ThemeProvider,
+  withTheme,
+  WithTheme,
+  WithStyles,
+} from '@material-ui/styles';
+import Button from '@material-ui/core/Button/Button';
+import { Theme } from '@material-ui/core/styles';
+
+// Example 1
+const styles = ({ palette, spacing }: Theme) => ({
+  root: {
+    padding: spacing.unit,
+    backgroundColor: palette.background.default,
+    color: palette.primary.dark,
+  },
+});
+
+// Shared types for examples
+interface ComponentProps extends WithStyles<typeof styles> {
+  text: string;
+}
+
+const StyledExampleOne = withStyles(styles)(({ classes, text }: ComponentProps) => (
+  <div className={classes.root}>{text}</div>
+));
+<StyledExampleOne text="I am styled!" />;
+
+// Example 2
+const Component: React.SFC<ComponentProps & WithStyles<typeof styles>> = ({ classes, text }) => (
+  <div className={classes.root}>{text}</div>
+);
+
+const StyledExampleTwo = withStyles(styles)(Component);
+<StyledExampleTwo text="I am styled!" />;
+
+// Example 3
+const styleRule = createStyles({
+  root: {
+    display: 'flex',
+    alignItems: 'stretch',
+    height: '100vh',
+    width: '100%',
+  },
+});
+
+const ComponentWithChildren: React.SFC<WithStyles<typeof styles>> = ({ classes, children }) => (
+  <div className={classes.root}>{children}</div>
+);
+
+const StyledExampleThree = withStyles(styleRule)(ComponentWithChildren);
+<StyledExampleThree />;
+
+// Also works with a plain object
+const stylesAsPojo = {
+  root: {
+    backgroundColor: 'hotpink',
+  },
+};
+
+const AnotherStyledSFC = withStyles({
+  root: { backgroundColor: 'hotpink' },
+})(({ classes }: WithStyles<'root'>) => <div className={classes.root}>Stylish!</div>);
+
+// withTheme
+const ComponentWithTheme = withTheme<Theme>()(({ theme }: WithTheme<Theme>) => (
+  <div>{theme.spacing.unit}</div>
+));
+
+<ComponentWithTheme />;
+
+// withStyles + withTheme
+type AllTheProps = WithTheme<Theme> & WithStyles<typeof styles>;
+
+const StyledComponent = withStyles(styles)(({ theme, classes }: AllTheProps) => (
+  <div className={classes.root}>{theme.palette.text.primary}</div>
+));
+
+// missing prop theme
+<StyledComponent />; // $ExpectError
+
+const AllTheComposition = withTheme<Theme>()(StyledComponent);
+
+<AllTheComposition />;
+
+{
+  const Foo = withTheme<Theme>()(
+    class extends React.Component<WithTheme<Theme>> {
+      render() {
+        return null;
+      }
+    },
+  );
+
+  <Foo />;
+}
+
+declare const themed: boolean;
+{
+  // this is necessary so that TypesScript can infer the theme
+  // usually it's better to just use withTheme<Theme> if you're not actuall styling
+  const themedStyles = (theme: Theme) => ({ root: {} });
+  // Test that withTheme: true guarantees the presence of the theme
+  const Foo = withStyles(themedStyles, { withTheme: true })(
+    class extends React.Component<WithTheme<Theme>> {
+      render() {
+        return <div style={{ margin: this.props.theme.spacing.unit }} />;
+      }
+    },
+  );
+  <Foo />;
+
+  const Bar = withStyles(themedStyles, { withTheme: true })(
+    ({ theme }: WithStyles<typeof themedStyles, true>) => (
+      <div style={{ margin: theme.spacing.unit }} />
+    ),
+  );
+  <Bar />;
+}
+
+// Can't use withStyles effectively as a decorator in TypeScript
+// due to https://github.com/Microsoft/TypeScript/issues/4881
+// @withStyles(styles)
+const DecoratedComponent = withStyles(styles)(
+  class extends React.Component<ComponentProps & WithStyles<typeof styles>> {
+    render() {
+      const { classes, text } = this.props;
+      return <div className={classes.root}>{text}</div>;
+    }
+  },
+);
+
+// no 'classes' property required at element creation time (#8267)
+<DecoratedComponent text="foo" />;
+
+// Allow nested pseudo selectors
+withStyles(theme =>
+  createStyles({
+    guttered: theme.mixins.gutters({
+      '&:hover': {
+        textDecoration: 'none',
+      },
+    }),
+    listItem: {
+      '&:hover $listItemIcon': {
+        visibility: 'inherit',
+      },
+    },
+  }),
+);
+
+{
+  // allow top level media queries
+  // https://github.com/mui-org/material-ui/issues/12277
+
+  // typescript thinks `content` is the CSS property not a classname
+  const ambiguousStyles = createStyles({
+    content: {
+      minHeight: '100vh',
+    },
+    // $ExpectError
+    '@media (min-width: 960px)': {
+      content: {
+        display: 'flex',
+      },
+    },
+  });
+
+  const styles = createStyles({
+    contentClass: {
+      minHeight: '100vh',
+    },
+    '@media (min-width: 960px)': {
+      contentClass: {
+        display: 'flex',
+      },
+    },
+  });
+}
+
+{
+  const styles = (theme: Theme) =>
+    createStyles({
+      // Styled similar to ListItemText
+      root: {
+        '&:first-child': {
+          paddingLeft: 0,
+        },
+        flex: '1 1 auto',
+        padding: '0 16px',
+      },
+
+      iiiinset: {
+        '&:first-child': {
+          paddingLeft: theme.spacing.unit * 7,
+        },
+      },
+      row: {
+        alignItems: 'center',
+        display: 'flex',
+        flexDirection: 'row',
+      },
+    });
+
+  interface ListItemContentProps extends WithStyles<typeof styles> {
+    children?: React.ReactElement<any>;
+    inset?: boolean;
+    row?: boolean;
+  }
+
+  const ListItemContent = withStyles(styles, { name: 'ui-ListItemContent' })(
+    ({ children, classes, inset, row }: ListItemContentProps) => (
+      <div className={classes.root} color="textSecondary">
+        {children}
+      </div>
+    ),
+  );
+}
+
+{
+  interface FooProps extends WithStyles<'x' | 'y'> {
+    a: number;
+    b: boolean;
+  }
+
+  const ListItemContent = withStyles({ x: {}, y: {} })((props: FooProps) => <div />);
+}
+
+{
+  // https://github.com/mui-org/material-ui/issues/11109
+  // The real test here is with "strictFunctionTypes": false,
+  // but we don't have a way currently to test under varying
+  // TypeScript configurations.
+
+  interface ComponentProps extends WithStyles<typeof styles> {
+    caption: string;
+  }
+
+  const styles = (theme: Theme) =>
+    createStyles({
+      content: {
+        margin: 4,
+      },
+    });
+
+  const Component = (props: ComponentProps) => {
+    return <div className={props.classes.content}>Hello {props.caption}</div>;
+  };
+
+  const StyledComponent = withStyles(styles)(Component);
+
+  class App extends React.Component {
+    render() {
+      return (
+        <div className="App">
+          <StyledComponent caption="Developer" />
+        </div>
+      );
+    }
+  }
+
+  <App />;
+}
+
+{
+  // https://github.com/mui-org/material-ui/issues/11191
+  const styles = (theme: Theme) =>
+    createStyles({
+      main: {},
+    });
+
+  interface Props extends WithStyles<typeof styles> {
+    someProp?: string;
+  }
+
+  class SomeComponent extends React.PureComponent<Props> {
+    render() {
+      return <div />;
+    }
+  }
+
+  const DecoratedSomeComponent = withStyles(styles)(SomeComponent);
+
+  <DecoratedSomeComponent someProp="hello world" />;
+}
+
+{
+  // https://github.com/mui-org/material-ui/issues/11312
+  withStyles(styles, { name: 'MyComponent', index: 0 })(() => <div />);
+}
+
+{
+  // can't provide own `classes` type
+  interface Props {
+    classes: number;
+  }
+
+  class Component extends React.Component<Props & WithStyles<typeof styles>> {}
+  // $ExpectError
+  const StyledComponent = withStyles(styles)(Component);
+
+  // implicit SFC
+  withStyles(styles)((props: Props) => null); // $ExpectError
+  withStyles(styles)((props: Props & WithStyles<typeof styles>) => null); // $ExpectError
+  withStyles(styles)((props: Props & { children?: React.ReactNode }) => null); // $ExpectError
+  withStyles(styles)(
+    (props: Props & WithStyles<typeof styles> & { children?: React.ReactNode }) => null, // $ExpectError
+  );
+
+  // explicit not but with "Property 'children' is missing in type 'ValidationMap<Props>'".
+  // which is not helpful
+  const StatelessComponent: React.SFC<Props> = props => null;
+  const StatelessComponentWithStyles: React.SFC<Props & WithStyles<typeof styles>> = props => null;
+  withStyles(styles)(StatelessComponent); // $ExpectError
+  withStyles(styles)(StatelessComponentWithStyles); // $ExpectError
+}
+
+{
+  // https://github.com/mui-org/material-ui/issues/12670
+  interface Props {
+    nonDefaulted: string;
+    defaulted: number;
+  }
+
+  class MyButton extends React.Component<Props & WithStyles<typeof styles>> {
+    static defaultProps = {
+      defaulted: 0,
+    };
+
+    render() {
+      const { classes, nonDefaulted, defaulted } = this.props;
+      return (
+        <Button className={classes.btn}>
+          {defaulted}, {nonDefaulted}
+        </Button>
+      );
+    }
+  }
+
+  const styles = () =>
+    createStyles({
+      btn: {
+        color: 'red',
+      },
+    });
+
+  const StyledMyButton = withStyles(styles)(MyButton);
+
+  const CorrectUsage = () => <StyledMyButton nonDefaulted="2" />;
+  // Property 'nonDefaulted' is missing in type '{}'
+  const MissingPropUsage = () => <StyledMyButton />; // $ExpectError
+}
+
+{
+  // styles from props
+  interface StyleProps {
+    color?: 'blue' | 'red';
+  }
+
+  const styles = (theme: Theme) => ({
+    root: (props: StyleProps) => ({ backgroundColor: props.color || theme.palette.primary.main }),
+  });
+
+  interface MyComponentProps extends WithStyles<typeof styles> {
+    message: string;
+  }
+
+  class MyComponent extends React.Component<MyComponentProps> {
+    render() {
+      const { classes, color, message } = this.props;
+      return (
+        <div className={classes.root}>
+          {color}: {message}
+        </div>
+      );
+    }
+  }
+
+  const StyledMyComponent = withStyles(styles)(MyComponent);
+  const rendererdStyledMyComponent = <StyledMyComponent message="Hi" />;
+
+  //  number is not assignable to 'blue' | 'red'
+  // $ExpectError
+  interface InconsistentProps extends WithStyles<typeof styles> {
+    color: number;
+  }
+}

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -6,6 +6,8 @@ export type PropsOf<C> = C extends new (props: infer P) => React.Component
   ? P
   : C extends (props: infer P) => React.ReactElement<any> | null
   ? P
+  : C extends keyof JSX.IntrinsicElements
+  ? JSX.IntrinsicElements[C]
   : never;
 
 /**


### PR DESCRIPTION
- Adds TypeScript declaration for every file that is re-exported in `index.js`

This is 70% C&P from the old `@material-ui/core/styles`. Changes where necessary to support generic themes and styles depending on props.

It would be nice if we could apply some package structure. It's hard to navigate in a flat package structure.
