### PR TITLE
[docs] Increase clarity around the usage of font icons

### DIFF
--- a/docs/src/pages/demos/buttons/IconLabelButtons.js
+++ b/docs/src/pages/demos/buttons/IconLabelButtons.js
@@ -6,7 +6,7 @@ import { withStyles } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import KeyboardVoiceICon from '@material-ui/icons/KeyboardVoice';
-import Icon from '@material-ui/core/Icon';
+import SendIcon from '@material-ui/core/Send';
 import SaveIcon from '@material-ui/icons/Save';
 
 const styles = theme => ({
@@ -34,7 +34,7 @@ function IconLabelButtons(props) {
       </Button>
       <Button variant="contained" color="primary" className={classes.button}>
         Send
-        <Icon className={classes.rightIcon}>send</Icon>
+        <SendIcon className={classes.rightIcon}>send</SendIcon>
       </Button>
       <Button variant="contained" color="default" className={classes.button}>
         Upload

--- a/docs/src/pages/demos/buttons/IconLabelButtons.js
+++ b/docs/src/pages/demos/buttons/IconLabelButtons.js
@@ -6,7 +6,7 @@ import { withStyles } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import KeyboardVoiceICon from '@material-ui/icons/KeyboardVoice';
-import SendIcon from '@material-ui/core/Send';
+import Icon from '@material-ui/core/Icon';
 import SaveIcon from '@material-ui/icons/Save';
 
 const styles = theme => ({
@@ -34,7 +34,8 @@ function IconLabelButtons(props) {
       </Button>
       <Button variant="contained" color="primary" className={classes.button}>
         Send
-        <SendIcon className={classes.rightIcon}>send</SendIcon>
+        {/* This Button uses a Font Icon, see the installation instructions in the docs. */}
+        <Icon className={classes.rightIcon}>send</Icon>
       </Button>
       <Button variant="contained" color="default" className={classes.button}>
         Upload


### PR DESCRIPTION
With this current sample code, I was not able to get `SendIcon` to work.

I was able to import `SendIcon` from`'@material-ui/core/Send'` and use it to display the `SendIcon` within the button.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
