### PR TITLE
[slider] Fix visual hover state on disabled slider

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -506,6 +506,7 @@ class Slider extends React.Component {
       <Component
         role="slider"
         className={className}
+        aria-disabled={disabled}
         aria-valuenow={value}
         aria-valuemin={min}
         aria-valuemax={max}
@@ -524,6 +525,7 @@ class Slider extends React.Component {
           <div className={thumbWrapperClasses} style={inlineThumbStyles}>
             <ButtonBase
               className={thumbClasses}
+              disabled={disabled}
               disableRipple
               onBlur={this.handleBlur}
               onKeyDown={this.handleKeyDown}

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -166,5 +166,13 @@ describe('<Slider />', () => {
 
       assert.strictEqual(handleChange.callCount, 0);
     });
+
+    it('should disable its thumb', () => {
+      assert.ok(wrapper.find('button').props().disabled);
+    });
+
+    it('should signal that it is disabled', () => {
+      assert.ok(wrapper.find('[role="slider"]').props()['aria-disabled']);
+    });
   });
 });


### PR DESCRIPTION
Hovering a disabled slider does add the outline which doesn't match the spec: https://material-ui.com/lab/slider/#disabled-slider

This PR disables the underlying button that is used for the thumb as well as indicating that the hole slider is disabled via `aria-disabled`.