### PR TITLE
[test] Run unit/integration test on Chrome 41

### DIFF
--- a/docs/src/modules/components/bootstrap.js
+++ b/docs/src/modules/components/bootstrap.js
@@ -1,3 +1,6 @@
+// Use the same helper as Babel to avoid bundle bloat.
+import 'core-js/modules/es6.array.find-index';
+import 'core-js/modules/es6.set';
 import { install } from '@material-ui/styles';
 
 // Disable auto highlighting

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,6 +1,3 @@
-// Use the same helper as Babel to avoid bundle bloat.
-import 'core-js/modules/es6.array.find-index';
-import 'core-js/modules/es6.set';
 import 'docs/src/modules/components/bootstrap';
 
 import React from 'react';

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -82,12 +82,7 @@ module.exports = function setKarmaConfig(config) {
   if (browserStack.accessKey) {
     newConfig = Object.assign({}, baseConfig, {
       browserStack,
-      browsers: baseConfig.browsers.concat([
-        'BrowserStack_Chrome',
-        'BrowserStack_Firefox',
-        'BrowserStack_Safari',
-        'BrowserStack_Edge',
-      ]),
+      browsers: ['BrowserStack_IE'],
       plugins: baseConfig.plugins.concat(['karma-browserstack-launcher']),
       customLaunchers: Object.assign({}, baseConfig.customLaunchers, {
         BrowserStack_Chrome: {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -62,7 +62,7 @@ module.exports = function setKarmaConfig(config) {
           {
             test: /\.js$/,
             loader: 'babel-loader',
-            exclude: /node_modules/,
+            exclude: /node_modules(\\|\/)(?!(sinon)(\\|\/)).*/,
           },
         ],
       },
@@ -117,6 +117,13 @@ module.exports = function setKarmaConfig(config) {
           os_version: '10',
           browser: 'Edge',
           browser_version: '14.0',
+        },
+        BrowserStack_IE: {
+          base: 'BrowserStack',
+          os: 'Windows',
+          os_version: '10',
+          browser: 'IE',
+          browser_version: '11.0',
         },
       }),
     });

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -62,6 +62,7 @@ module.exports = function setKarmaConfig(config) {
           {
             test: /\.js$/,
             loader: 'babel-loader',
+            // https://github.com/sinonjs/sinon/issues/1951
             exclude: /node_modules(\\|\/)(?!(sinon)(\\|\/)).*/,
           },
         ],
@@ -82,7 +83,12 @@ module.exports = function setKarmaConfig(config) {
   if (browserStack.accessKey) {
     newConfig = Object.assign({}, baseConfig, {
       browserStack,
-      browsers: ['BrowserStack_IE'],
+      browsers: baseConfig.browsers.concat([
+        'BrowserStack_Chrome',
+        'BrowserStack_Firefox',
+        'BrowserStack_Safari',
+        'BrowserStack_Edge',
+      ]),
       plugins: baseConfig.plugins.concat(['karma-browserstack-launcher']),
       customLaunchers: Object.assign({}, baseConfig.customLaunchers, {
         BrowserStack_Chrome: {
@@ -90,7 +96,7 @@ module.exports = function setKarmaConfig(config) {
           os: 'OS X',
           os_version: 'Sierra',
           browser: 'Chrome',
-          browser_version: '45.0',
+          browser_version: '41.0',
         },
         BrowserStack_Firefox: {
           base: 'BrowserStack',
@@ -112,13 +118,6 @@ module.exports = function setKarmaConfig(config) {
           os_version: '10',
           browser: 'Edge',
           browser_version: '14.0',
-        },
-        BrowserStack_IE: {
-          base: 'BrowserStack',
-          os: 'Windows',
-          os_version: '10',
-          browser: 'IE',
-          browser_version: '11.0',
         },
       }),
     });

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,6 +1,8 @@
 import './utils/performance';
 import './utils/init';
 
+import '@babel/polyfill';
+
 // eslint-disable-next-line no-underscore-dangle
 window.__MUI_USE_NEXT_TYPOGRAPHY_VARIANTS__ = true;
 

--- a/test/karma.tests.js
+++ b/test/karma.tests.js
@@ -1,7 +1,8 @@
+// https://github.com/airbnb/enzyme/issues/1792
+import 'core-js/modules/es6.array.from';
+
 import './utils/performance';
 import './utils/init';
-
-import '@babel/polyfill';
 
 // eslint-disable-next-line no-underscore-dangle
 window.__MUI_USE_NEXT_TYPOGRAPHY_VARIANTS__ = true;


### PR DESCRIPTION
Had issues reproducing test results. Looked like it was randomly throwing `describe is not defined` so I'm parking the actual reports here:
<details><summary>yarn test:karma</summary>

```
IE 11.0.0 (Windows 10 0.0.0) <MenuList> integration keyboard controls and tabIndex manipulation should focus the second item FAILED
        item at index 0 should not be tab focusable: expected 0 to equal -1
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertEqual (webpack:///node_modules/chai/lib/chai/core/assertions.js:1026 <- test/karma.tests.js:5663:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.strictEqual (webpack:///node_modules/chai/lib/chai/interface/assert.js:193 <- test/karma.tests.js:8645:5)
           at Anonymous function (webpack:///packages/material-ui/test/integration/MenuList.test.js:16:6 <- test/karma.tests.js:173549:7)
           at Anonymous function (webpack:///node_modules/enzyme/build/ReactWrapper.js:1287 <- test/karma.tests.js:41546:11)
           at forEach (webpack:///node_modules/enzyme/build/ReactWrapper.js:1286 <- test/karma.tests.js:41545:9)
           at assertMenuItemTabIndexed (webpack:///packages/material-ui/test/integration/MenuList.test.js:12:2 <- test/karma.tests.js:173545:3)
           at Anonymous function (webpack:///packages/material-ui/test/integration/MenuList.test.js:86:6 <- test/karma.tests.js:173607:7)
.
IE 11.0.0 (Windows 10 0.0.0) <MenuList> integration keyboard controls and tabIndex manipulation should reset the tabIndex to the focused elemen
t when calling resetTabIndex FAILED
        item at index 0 should not be tab focusable: expected 0 to equal -1
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertEqual (webpack:///node_modules/chai/lib/chai/core/assertions.js:1026 <- test/karma.tests.js:5663:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.strictEqual (webpack:///node_modules/chai/lib/chai/interface/assert.js:193 <- test/karma.tests.js:8645:5)
           at Anonymous function (webpack:///packages/material-ui/test/integration/MenuList.test.js:16:6 <- test/karma.tests.js:173549:7)
           at Anonymous function (webpack:///node_modules/enzyme/build/ReactWrapper.js:1287 <- test/karma.tests.js:41546:11)
           at forEach (webpack:///node_modules/enzyme/build/ReactWrapper.js:1286 <- test/karma.tests.js:41545:9)
           at assertMenuItemTabIndexed (webpack:///packages/material-ui/test/integration/MenuList.test.js:12:2 <- test/karma.tests.js:173545:3)
           at Anonymous function (webpack:///packages/material-ui/test/integration/MenuList.test.js:113:6 <- test/karma.tests.js:173636:7)
IE 11.0.0 (Windows 10 0.0.0) <MenuList> integration keyboard controls and tabIndex manipulation should select/focus the first item FAILED
        TypeError: Circular reference in value argument not supported
           at stringify (webpack:///node_modules/core-js/modules/es6.symbol.js:223 <- test/karma.tests.js:34066:5)
           at processAssertionError (node_modules/karma-mocha/lib/adapter.js:59:7)
           at Anonymous function (node_modules/karma-mocha/lib/adapter.js:129:7)
IE 11.0.0 (Windows 10 0.0.0) <MenuList> integration keyboard controls and tabIndex manipulation should focus the second item FAILED
        TypeError: Circular reference in value argument not supported
           at stringify (webpack:///node_modules/core-js/modules/es6.symbol.js:223 <- test/karma.tests.js:34066:5)
           at processAssertionError (node_modules/karma-mocha/lib/adapter.js:59:7)
           at Anonymous function (node_modules/karma-mocha/lib/adapter.js:129:7)
IE 11.0.0 (Windows 10 0.0.0) <MenuList> integration keyboard controls and tabIndex manipulation should focus the third item FAILED
        TypeError: Circular reference in value argument not supported
           at stringify (webpack:///node_modules/core-js/modules/es6.symbol.js:223 <- test/karma.tests.js:34066:5)
           at processAssertionError (node_modules/karma-mocha/lib/adapter.js:59:7)
           at Anonymous function (node_modules/karma-mocha/lib/adapter.js:129:7)
...
IE 11.0.0 (Windows 10 0.0.0) <MenuList> integration keyboard controls and tabIndex manipulation - preselected item should focus the third item
FAILED
        item at index 1 should not be tab focusable: expected 0 to equal -1
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertEqual (webpack:///node_modules/chai/lib/chai/core/assertions.js:1026 <- test/karma.tests.js:5663:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.strictEqual (webpack:///node_modules/chai/lib/chai/interface/assert.js:193 <- test/karma.tests.js:8645:5)
           at Anonymous function (webpack:///packages/material-ui/test/integration/MenuList.test.js:16:6 <- test/karma.tests.js:173549:7)
           at Anonymous function (webpack:///node_modules/enzyme/build/ReactWrapper.js:1287 <- test/karma.tests.js:41546:11)
           at forEach (webpack:///node_modules/enzyme/build/ReactWrapper.js:1286 <- test/karma.tests.js:41545:9)
           at assertMenuItemTabIndexed (webpack:///packages/material-ui/test/integration/MenuList.test.js:12:2 <- test/karma.tests.js:173545:3)
           at Anonymous function (webpack:///packages/material-ui/test/integration/MenuList.test.js:179:6 <- test/karma.tests.js:173697:7)
................................................................................
........................................
IE 11.0.0 (Windows 10 0.0.0) <ButtonBase /> mounted tab press listener "before each" hook for "should detect the keyboard" FAILED
        TypeError: Object doesn't support this action
           at Anonymous function (webpack:///packages/material-ui/src/ButtonBase/ButtonBase.test.js:345:6 <- test/karma.tests.js:116181:7)
................................................................................
...........................................
IE 11.0.0 (Windows 10 0.0.0) <ClickAwayListener /> prop: onClickAway should not be call when clicking inside FAILED
        TypeError: Object doesn't support this action
           at Anonymous function (webpack:///packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js:55:6 <- test/karma.tests.js:1
21343:7)
IE 11.0.0 (Windows 10 0.0.0) <ClickAwayListener /> prop: onClickAway should not be call when defaultPrevented FAILED
        TypeError: Object doesn't support this action
           at Anonymous function (webpack:///packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js:74:6 <- test/karma.tests.js:1
21366:7)
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
................................................................................
.............................
IE 11.0.0 (Windows 10 0.0.0) <Modal /> focus should keep focus on the modal when it is closed FAILED
        expected undefined to equal 'BODY'
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertEqual (webpack:///node_modules/chai/lib/chai/core/assertions.js:1026 <- test/karma.tests.js:5663:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.strictEqual (webpack:///node_modules/chai/lib/chai/interface/assert.js:193 <- test/karma.tests.js:8645:5)
           at Anonymous function (webpack:///packages/material-ui/src/Modal/Modal.test.js:432:6 <- test/karma.tests.js:141431:7)
..
IE 11.0.0 (Windows 10 0.0.0) <Modal /> focus should return focus to the modal FAILED
        expected 'focus-container' to equal 'modal'
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertEqual (webpack:///node_modules/chai/lib/chai/core/assertions.js:1026 <- test/karma.tests.js:5663:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.strictEqual (webpack:///node_modules/chai/lib/chai/interface/assert.js:193 <- test/karma.tests.js:8645:5)
           at Anonymous function (webpack:///packages/material-ui/src/Modal/Modal.test.js:466:6 <- test/karma.tests.js:141463:7)
..............
IE 11.0.0 (Windows 10 0.0.0) ModalManager overflow "before each" hook for "should handle the scroll" FAILED
        TypeError: Assignment to read-only properties is not allowed in strict mode
           at Anonymous function (webpack:///packages/material-ui/src/Modal/ModalManager.test.js:102:6 <- test/karma.tests.js:141859:7)
IE 11.0.0 (Windows 10 0.0.0) ModalManager overflow "after each" hook for "should handle the scroll" FAILED
        TypeError: Assignment to read-only properties is not allowed in strict mode
           at Anonymous function (webpack:///packages/material-ui/src/Modal/ModalManager.test.js:107:6 <- test/karma.tests.js:141863:7)
............................................................
IE 11.0.0 (Windows 10 0.0.0) <Popover /> getPositioningStyle(element) "before all" hook FAILED
        TypeError: Assignment to read-only properties is not allowed in strict mode
           at Anonymous function (webpack:///packages/material-ui/src/Popover/Popover.test.js:649:8 <- test/karma.tests.js:144915:9)
IE 11.0.0 (Windows 10 0.0.0) <Popover /> getPositioningStyle(element) "after all" hook FAILED
        TypeError: Assignment to read-only properties is not allowed in strict mode
           at Anonymous function (webpack:///packages/material-ui/src/Popover/Popover.test.js:664:8 <- test/karma.tests.js:144934:9)
IE 11.0.0 (Windows 10 0.0.0) <Popover /> getPositioningStyle(element) "before all" hook FAILED
        TypeError: Assignment to read-only properties is not allowed in strict mode
           at Anonymous function (webpack:///packages/material-ui/src/Popover/Popover.test.js:649:8 <- test/karma.tests.js:144915:9)
IE 11.0.0 (Windows 10 0.0.0) <Popover /> getPositioningStyle(element) "after all" hook FAILED
        TypeError: Assignment to read-only properties is not allowed in strict mode
           at Anonymous function (webpack:///packages/material-ui/src/Popover/Popover.test.js:664:8 <- test/karma.tests.js:144934:9)
IE 11.0.0 (Windows 10 0.0.0) <Popover /> getPositioningStyle(element) "before all" hook FAILED
        TypeError: Assignment to read-only properties is not allowed in strict mode
           at Anonymous function (webpack:///packages/material-ui/src/Popover/Popover.test.js:649:8 <- test/karma.tests.js:144915:9)
IE 11.0.0 (Windows 10 0.0.0) <Popover /> getPositioningStyle(element) "after all" hook FAILED
        TypeError: Assignment to read-only properties is not allowed in strict mode
           at Anonymous function (webpack:///packages/material-ui/src/Popover/Popover.test.js:664:8 <- test/karma.tests.js:144934:9)
................................................................................
......
IE 11.0.0 (Windows 10 0.0.0) <SelectInput /> prop: inputRef should be able to hit proxy function FAILED
        expected false to equal true
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertEqual (webpack:///node_modules/chai/lib/chai/core/assertions.js:1026 <- test/karma.tests.js:5663:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.strictEqual (webpack:///node_modules/chai/lib/chai/interface/assert.js:193 <- test/karma.tests.js:8645:5)
           at Anonymous function (webpack:///packages/material-ui/src/Select/SelectInput.test.js:439:6 <- test/karma.tests.js:148657:7)
................
IE 11.0.0 (Windows 10 0.0.0) <Snackbar /> prop: onClose should be call when clicking away FAILED
        TypeError: Object doesn't support this action
           at Anonymous function (webpack:///packages/material-ui/src/Snackbar/Snackbar.test.js:39:6 <- test/karma.tests.js:149973:7)
..........
IE 11.0.0 (Windows 10 0.0.0) <Snackbar /> prop: disableWindowBlurListener should pause auto hide when not disabled and window lost focus FAILED
        TypeError: Object doesn't support this action
           at Anonymous function (webpack:///packages/material-ui/src/Snackbar/Snackbar.test.js:327:6 <- test/karma.tests.js:150303:7)
IE 11.0.0 (Windows 10 0.0.0) <Snackbar /> prop: disableWindowBlurListener should not pause auto hide when disabled and window lost focus FAILED
        TypeError: Object doesn't support this action
           at Anonymous function (webpack:///packages/material-ui/src/Snackbar/Snackbar.test.js:356:6 <- test/karma.tests.js:150341:7)
................................................................................
................................................................................
................................................................................
...................................
IE 11.0.0 (Windows 10 0.0.0) <Tooltip /> prop: delay should take the enterDelay into account FAILED
        expected false to equal true
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertEqual (webpack:///node_modules/chai/lib/chai/core/assertions.js:1026 <- test/karma.tests.js:5663:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.strictEqual (webpack:///node_modules/chai/lib/chai/interface/assert.js:193 <- test/karma.tests.js:8645:5)
           at Anonymous function (webpack:///packages/material-ui/src/Tooltip/Tooltip.test.js:163:6 <- test/karma.tests.js:161918:7)
IE 11.0.0 (Windows 10 0.0.0) <Tooltip /> prop: delay should take the leaveDelay into account FAILED
        expected false to equal true
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertEqual (webpack:///node_modules/chai/lib/chai/core/assertions.js:1026 <- test/karma.tests.js:5663:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.strictEqual (webpack:///node_modules/chai/lib/chai/interface/assert.js:193 <- test/karma.tests.js:8645:5)
           at Anonymous function (webpack:///packages/material-ui/src/Tooltip/Tooltip.test.js:175:6 <- test/karma.tests.js:161934:7)
................................................................................
................................................................................
................................................................................
..................................
IE 11.0.0 (Windows 10 0.0.0) utils/reactHelpers.js setRef throws on legacy string refs FAILED
        expected [Function] to throw an error
        Error
           at AssertionError (webpack:///node_modules/assertion-error/index.js:74 <- test/karma.tests.js:2152:7)
           at Assertion.prototype.assert (webpack:///node_modules/chai/lib/chai/assertion.js:141 <- test/karma.tests.js:4497:7)
           at assertThrows (webpack:///node_modules/chai/lib/chai/core/assertions.js:2655 <- test/karma.tests.js:7292:7)
           at methodWrapper (webpack:///node_modules/chai/lib/chai/utils/addMethod.js:57 <- test/karma.tests.js:12154:5)
           at assert.throws (webpack:///node_modules/chai/lib/chai/interface/assert.js:1987 <- test/karma.tests.js:10439:5)
           at Anonymous function (webpack:///packages/material-ui/src/utils/reactHelpers.test.js:60:6 <- test/karma.tests.js:172332:7)
```

</details>

Not sure yet if those are actually true negatives but even if then this is still dangerous since it won't catch usage of language features that is not supported by IE 11 because enzyme requires polyfills.

See also sinonjs/sinon#1951

Closes #13639