### PR TITLE
[Zoom] Correct transition delay value of the example

### DIFF
--- a/docs/src/pages/utils/transitions/SimpleZoom.js
+++ b/docs/src/pages/utils/transitions/SimpleZoom.js
@@ -50,7 +50,7 @@ class SimpleZoom extends React.Component {
               </svg>
             </Paper>
           </Zoom>
-          <Zoom in={checked} style={{ transitionDelay: checked ? 500 : 0 }}>
+          <Zoom in={checked} style={{ transitionDelay: checked ? '500ms' : '0ms' }}>
             <Paper elevation={4} className={classes.paper}>
               <svg className={classes.svg}>
                 <polygon points="0,100 50,00, 100,100" className={classes.polygon} />


### PR DESCRIPTION
In this PR:

Correct the value of `transitionDelay` style attribute on `Zoom` component example as raised in #13575. The value should be a string with number following by time unit.

Closse #13575.