### PR TITLE
[slider] Add missing thumb TypeScript definition

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.d.ts
+++ b/packages/material-ui-lab/src/Slider/Slider.d.ts
@@ -12,6 +12,7 @@ export interface SliderProps
   min?: number;
   step?: number;
   value?: number;
+  thumb?: React.ReactElement<any>;
   onChange?: (event: React.ChangeEvent<{}>, value: number) => void;
   onDragEnd?: (event: React.ChangeEvent<{}>) => void;
   onDragStart?: (event: React.ChangeEvent<{}>) => void;


### PR DESCRIPTION
@oliviertassinari 

I have added thumb?: React.ReactElement<any>; to the interface of Sliderprops 

File : packages/material-ui-lab/src/Slider/Slider.d.ts

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #13636