### PR TITLE
[docs] Correct typo in comment of snackbar, children

### DIFF
--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -292,8 +292,7 @@ Snackbar.propTypes = {
    */
   autoHideDuration: PropTypes.number,
   /**
-   * If you wish to take control over the children of the component you can use this property.
-   * When used, you replace the `SnackbarContent` component with the children.
+   * Replace the `SnackbarContent` component.
    */
   children: PropTypes.element,
   /**

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -292,7 +292,7 @@ Snackbar.propTypes = {
    */
   autoHideDuration: PropTypes.number,
   /**
-   * If you wish the take control over the children of the component you can use this property.
+   * If you wish to take control over the children of the component you can use this property.
    * When used, you replace the `SnackbarContent` component with the children.
    */
   children: PropTypes.element,

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -21,7 +21,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 | <span class="prop-name">action</span> | <span class="prop-type">node</span> |   | The action to display. |
 | <span class="prop-name">anchorOrigin</span> | <span class="prop-type">{ horizontal: enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'center'&nbsp;&#124;<br>&nbsp;'right'<br>, vertical: enum:&nbsp;'top'&nbsp;&#124;<br>&nbsp;'bottom'<br> }</span> | <span class="prop-default">{  vertical: 'bottom',  horizontal: 'center',}</span> | The anchor of the `Snackbar`. |
 | <span class="prop-name">autoHideDuration</span> | <span class="prop-type">number</span> |   | The number of milliseconds to wait before automatically calling the `onClose` function. `onClose` should then set the state of the `open` prop to hide the Snackbar. This behavior is disabled by default with the `null` value. |
-| <span class="prop-name">children</span> | <span class="prop-type">element</span> |   | If you wish the take control over the children of the component you can use this property. When used, you replace the `SnackbarContent` component with the children. |
+| <span class="prop-name">children</span> | <span class="prop-type">element</span> |   | Replace the `SnackbarContent` component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">ClickAwayListenerProps</span> | <span class="prop-type">object</span> |   | Properties applied to the `ClickAwayListener` element. |
 | <span class="prop-name">ContentProps</span> | <span class="prop-type">object</span> |   | Properties applied to the [`SnackbarContent`](/api/snackbar-content/) element. |


### PR DESCRIPTION
I corrected "the" to "to". 
I don't know enough about the project and style guidelines, but I think the phrasing is a little cumbersome. I didn't change it, but I think this can work better:

> Use this property to replace the `SnackbarContent` component with the children.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
