### PR TITLE
[test] Fix codecov failing on merge commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
             fi
       - run:
           name: Coverage
-          command: bash <(curl -s https://codecov.io/bash) -Z
+          command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
   test_material-ui-x:
     <<: *defaults
     steps:


### PR DESCRIPTION
Since codecov/codecov-bash#134 has been unanswered and this happened 3 times now I guess it's time to explicitly set the commit SHA. As I see it this should be the default behavior anyway.