### PR TITLE
[ButtonBase] Fix findDOMNode deprecation warnings

### DIFF
--- a/docs/src/modules/components/HomeSteps.js
+++ b/docs/src/modules/components/HomeSteps.js
@@ -89,6 +89,10 @@ const styles = theme => ({
   },
 });
 
+const PremiumThemesLink = React.forwardRef((props, ref) => {
+  return <Link href="/premium-themes" naked prefetch ref={ref} {...props} />;
+});
+
 function HomeSteps(props) {
   const { classes, t } = props;
 
@@ -178,11 +182,7 @@ function HomeSteps(props) {
           </Link>
         </div>
         <Divider className={classes.divider} />
-        <Button
-          component={buttonProps => <Link naked prefetch href="/premium-themes" {...buttonProps} />}
-        >
-          {t('themesButton')}
-        </Button>
+        <Button component={PremiumThemesLink}>{t('themesButton')}</Button>
       </Grid>
     </Grid>
   );

--- a/docs/src/modules/components/Link.js
+++ b/docs/src/modules/components/Link.js
@@ -9,11 +9,11 @@ import { connect } from 'react-redux';
 import compose from 'docs/src/modules/utils/compose';
 
 function NextComposed(props) {
-  const { as, href, prefetch, ...other } = props;
+  const { as, href, innerRef, prefetch, ...other } = props;
 
   return (
     <NextLink href={href} prefetch={prefetch} as={as}>
-      <a {...other} />
+      <a ref={innerRef} {...other} />
     </NextLink>
   );
 }
@@ -21,12 +21,13 @@ function NextComposed(props) {
 NextComposed.propTypes = {
   as: PropTypes.string,
   href: PropTypes.string,
+  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   prefetch: PropTypes.bool,
 };
 
 // A styled version of the Next.js Link component:
 // https://nextjs.org/docs/#with-link
-function Link(props) {
+const Link = React.forwardRef(function Link(props, ref) {
   const {
     activeClassName,
     className: classNameProps,
@@ -46,11 +47,11 @@ function Link(props) {
   }
 
   if (naked) {
-    return <NextComposed className={className} {...other} />;
+    return <NextComposed className={className} innerRef={ref} {...other} />;
   }
 
-  return <MuiLink component={NextComposed} className={className} {...other} />;
-}
+  return <MuiLink component={NextComposed} className={className} ref={ref} {...other} />;
+});
 
 Link.propTypes = {
   activeClassName: PropTypes.string,

--- a/docs/src/modules/components/Link.js
+++ b/docs/src/modules/components/Link.js
@@ -8,20 +8,19 @@ import MuiLink from '@material-ui/core/Link';
 import { connect } from 'react-redux';
 import compose from 'docs/src/modules/utils/compose';
 
-function NextComposed(props) {
-  const { as, href, innerRef, prefetch, ...other } = props;
+const NextComposed = React.forwardRef(function NextComposed(props, ref) {
+  const { as, href, prefetch, ...other } = props;
 
   return (
     <NextLink href={href} prefetch={prefetch} as={as}>
-      <a ref={innerRef} {...other} />
+      <a ref={ref} {...other} />
     </NextLink>
   );
-}
+});
 
 NextComposed.propTypes = {
   as: PropTypes.string,
   href: PropTypes.string,
-  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   prefetch: PropTypes.bool,
 };
 
@@ -47,7 +46,7 @@ const Link = React.forwardRef(function Link(props, ref) {
   }
 
   if (naked) {
-    return <NextComposed className={className} innerRef={ref} {...other} />;
+    return <NextComposed className={className} ref={ref} {...other} />;
   }
 
   return <MuiLink component={NextComposed} className={className} ref={ref} {...other} />;

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -117,12 +117,20 @@ You can take advantage of this lower level component to build custom interaction
 
 One common use case is to use the button to trigger a navigation to a new page.
 The `ButtonBase` component provides a property to handle this use case: `component`.
+However for certain focus polyfills `ButtonBase` requires the DOM node of the provided
+component. This is achieved by attaching a ref to the component and expecting that the
+component forwards this ref to the underlying DOM node.
 Given that a lot of our interactive components rely on `ButtonBase`, you should be
 able to take advantage of it everywhere:
 
 ```jsx
-import { Link } from 'react-router-dom'
+import React from 'react';
+import { Link as RouterLink } from 'react-router-dom'
 import Button from '@material-ui/core/Button';
+
+// required for react-router-dom < 5.0.0 
+// see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
+const Link = React.forwardRef((props, ref) => <RouterLink {...props} innerRef={ref} />)
 
 <Button component={Link} to="/open-collective">
   Link
@@ -135,7 +143,8 @@ or if you want to avoid properties collision:
 import { Link } from 'react-router-dom'
 import Button from '@material-ui/core/Button';
 
-const MyLink = props => <Link to="/open-collective" {...props} />
+// use `ref` instead of `innerRef` with react-router-dom@^5.0.0
+const MyLink = React.forwardRef((props, ref) => <Link to="/open-collective" {...props} innerRef={ref} />);
 
 <Button component={MyLink}>
   Link

--- a/docs/src/pages/guides/composition/ComponentProperty.js
+++ b/docs/src/pages/guides/composition/ComponentProperty.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-this-in-sfc */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
@@ -12,7 +13,7 @@ import DraftsIcon from '@material-ui/icons/Drafts';
 import Typography from '@material-ui/core/Typography';
 import MemoryRouter from 'react-router/MemoryRouter';
 import Route from 'react-router/Route';
-import { Link } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
 
 const styles = theme => ({
   root: {
@@ -26,7 +27,10 @@ const styles = theme => ({
 });
 
 class ListItemLink extends React.Component {
-  renderLink = itemProps => <Link to={this.props.to} {...itemProps} />;
+  renderLink = React.forwardRef((itemProps, ref) => (
+    // with react-router-dom@^5.0.0 use `ref` instead of `innerRef`
+    <RouterLink to={this.props.to} {...itemProps} innerRef={ref} />
+  ));
 
   render() {
     const { icon, primary } = this.props;
@@ -46,6 +50,9 @@ ListItemLink.propTypes = {
   primary: PropTypes.node.isRequired,
   to: PropTypes.string.isRequired,
 };
+
+// polyfill required for react-router-dom < 5.0.0
+const Link = React.forwardRef((props, ref) => <RouterLink {...props} innerRef={ref} />);
 
 function ListItemLinkShorthand(props) {
   const { primary, to } = props;

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -137,6 +137,7 @@ since we can safely use `ReactDOM.findDOMNode`. For function components you have
 to wrap your component however in `React.forwardRef`:
 
 ```diff
-- <Button component={props => <div {...props} />} />
-+ <Button component={React.forwardRef((props, ref) => <div {...props} ref={ref} />)} />
+- const MyButton = props => <div {...props} />
++ const MyButton = React.forwardRef((props, ref) => <div {...props} ref={ref} />)
+<Button component={MyButton} />
 ```

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -82,7 +82,10 @@ Let's change our `ListItemLink` to the following:
 import { Link } from 'react-router-dom';
 
 class ListItemLink extends React.Component {
-  renderLink = itemProps => <Link to={this.props.to} {...itemProps} />;
+  renderLink = React.forwardRef((itemProps, ref) => (
+    // with react-router-dom@^5.0.0 use `ref` instead of `innerRef`
+    <RouterLink to={this.props.to} {...itemProps} innerRef={ref} />
+  ));
 
   render() {
     const { icon, primary, secondary, to } = this.props;
@@ -123,3 +126,17 @@ Here is a demo with [React Router DOM](https://github.com/ReactTraining/react-ro
 ### With TypeScript
 
 You can find the details in the [TypeScript guide](/guides/typescript#usage-of-component-property).
+
+### Caveat with refs
+Some components such as `ButtonBase` (and therefore `Button`) require access to the 
+underlying DOM node. This was previously done with `ReactDOM.findDOMNode(this)`.
+However `findDOMNode` was deprecated (which disqualifies its usage in react's concurrent mode)
+in favour of component refs and ref forwarding. If you pass class components to
+the `component` and don't run in strict mode you won't have to change anything
+since we can safely use `ReactDOM.findDOMNode`. For function components you have
+to wrap your component however in `React.forwardRef`:
+
+```diff
+- <Button component={props => <div {...props} />} />
++ <Button component={React.forwardRef((props, ref) => <div {...props} ref={ref} />)} />
+```

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -128,6 +128,7 @@ Here is a demo with [React Router DOM](https://github.com/ReactTraining/react-ro
 You can find the details in the [TypeScript guide](/guides/typescript#usage-of-component-property).
 
 ### Caveat with refs
+
 Some components such as `ButtonBase` (and therefore `Button`) require access to the 
 underlying DOM node. This was previously done with `ReactDOM.findDOMNode(this)`.
 However `findDOMNode` was deprecated (which disqualifies its usage in react's concurrent mode)

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -336,7 +336,7 @@ ButtonBase.propTypes = {
   action: PropTypes.func,
   /**
    * Use that property to pass a ref callback to the native button component.
-   * @deprecated
+   * @deprecated Use `ref` instead
    */
   buttonRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -233,6 +233,14 @@ class ButtonBase extends React.Component {
     }
   };
 
+  handleRef = ref => {
+    const { buttonRef, innerRef } = this.props;
+
+    setRef(this.buttonRef, ref);
+    setRef(buttonRef, ref);
+    setRef(innerRef, ref);
+  };
+
   render() {
     const {
       action,
@@ -303,11 +311,7 @@ class ButtonBase extends React.Component {
         onTouchEnd={this.handleTouchEnd}
         onTouchMove={this.handleTouchMove}
         onTouchStart={this.handleTouchStart}
-        ref={ref => {
-          setRef(this.buttonRef, ref);
-          setRef(buttonRefProp, ref);
-          setRef(innerRef, ref);
-        }}
+        ref={this.handleRef}
         tabIndex={disabled ? '-1' : tabIndex}
         {...buttonProps}
         {...other}

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import clsx from 'clsx';
 import ownerWindow from '../utils/ownerWindow';
 import withForwardedRef from '../utils/withForwardedRef';
+import { setRef } from '../utils/reactHelpers';
 import withStyles from '../styles/withStyles';
 import NoSsr from '../NoSsr';
 import { listenForFocusKeys, detectFocusVisible } from './focusVisible';
@@ -56,6 +57,8 @@ export const styles = {
 class ButtonBase extends React.Component {
   state = {};
 
+  buttonRef = React.createRef();
+
   keyDown = false; // Used to help track keyboard activation keyDown
 
   focusVisibleCheckTime = 50;
@@ -93,14 +96,13 @@ class ButtonBase extends React.Component {
   });
 
   componentDidMount() {
-    this.button = ReactDOM.findDOMNode(this);
-    listenForFocusKeys(ownerWindow(this.button));
+    listenForFocusKeys(ownerWindow(this.getButtonNode()));
 
     if (this.props.action) {
       this.props.action({
         focusVisible: () => {
           this.setState({ focusVisible: true });
-          this.button.focus();
+          this.getButtonNode().focus();
         },
       });
     }
@@ -119,6 +121,10 @@ class ButtonBase extends React.Component {
 
   componentWillUnmount() {
     clearTimeout(this.focusVisibleTimeout);
+  }
+
+  getButtonNode() {
+    return ReactDOM.findDOMNode(this.buttonRef.current);
   }
 
   onRippleRef = node => {
@@ -178,13 +184,14 @@ class ButtonBase extends React.Component {
       onKeyDown(event);
     }
 
+    const button = this.getButtonNode();
     // Keyboard accessibility for non interactive elements
     if (
       event.target === event.currentTarget &&
       component &&
       component !== 'button' &&
       (event.key === ' ' || event.key === 'Enter') &&
-      !(this.button.tagName === 'A' && this.button.href)
+      !(button.tagName === 'A' && button.href)
     ) {
       event.preventDefault();
       if (onClick) {
@@ -212,12 +219,12 @@ class ButtonBase extends React.Component {
     }
 
     // Fix for https://github.com/facebook/react/issues/7769
-    if (!this.button) {
-      this.button = event.currentTarget;
+    if (!this.buttonRef.current) {
+      this.buttonRef.current = event.currentTarget;
     }
 
     event.persist();
-    detectFocusVisible(this, this.button, () => {
+    detectFocusVisible(this, this.getButtonNode(), () => {
       this.onFocusVisibleHandler(event);
     });
 
@@ -229,7 +236,7 @@ class ButtonBase extends React.Component {
   render() {
     const {
       action,
-      buttonRef,
+      buttonRef: buttonRefProp,
       centerRipple,
       children,
       classes,
@@ -296,8 +303,11 @@ class ButtonBase extends React.Component {
         onTouchEnd={this.handleTouchEnd}
         onTouchMove={this.handleTouchMove}
         onTouchStart={this.handleTouchStart}
-        onContextMenu={this.handleContextMenu}
-        ref={innerRef || buttonRef}
+        ref={ref => {
+          setRef(this.buttonRef, ref);
+          setRef(buttonRefProp, ref);
+          setRef(innerRef, ref);
+        }}
         tabIndex={disabled ? '-1' : tabIndex}
         {...buttonProps}
         {...other}

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -359,7 +359,8 @@ ButtonBase.propTypes = {
   className: PropTypes.string,
   /**
    * The component used for the root node.
-   * Either a string to use a DOM element or a component.
+   * Either a string to use a DOM element or a component. If a component is provided
+   * it must properly forward their refs via React.forwardRef.
    */
   component: PropTypes.elementType,
   /**

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -236,7 +236,7 @@ class ButtonBase extends React.Component {
   render() {
     const {
       action,
-      buttonRef: buttonRefProp,
+      buttonRef,
       centerRipple,
       children,
       classes,
@@ -305,7 +305,7 @@ class ButtonBase extends React.Component {
         onTouchStart={this.handleTouchStart}
         ref={ref => {
           setRef(this.buttonRef, ref);
-          setRef(buttonRefProp, ref);
+          setRef(buttonRef, ref);
           setRef(innerRef, ref);
         }}
         tabIndex={disabled ? '-1' : tabIndex}

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -233,14 +233,6 @@ class ButtonBase extends React.Component {
     }
   };
 
-  handleRef = ref => {
-    const { buttonRef, innerRef } = this.props;
-
-    setRef(this.buttonRef, ref);
-    setRef(buttonRef, ref);
-    setRef(innerRef, ref);
-  };
-
   render() {
     const {
       action,
@@ -311,7 +303,11 @@ class ButtonBase extends React.Component {
         onTouchEnd={this.handleTouchEnd}
         onTouchMove={this.handleTouchMove}
         onTouchStart={this.handleTouchStart}
-        ref={this.handleRef}
+        ref={ref => {
+          setRef(this.buttonRef, ref);
+          setRef(buttonRefProp, ref);
+          setRef(innerRef, ref);
+        }}
         tabIndex={disabled ? '-1' : tabIndex}
         {...buttonProps}
         {...other}

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { assert } from 'chai';
@@ -419,7 +420,7 @@ describe('<ButtonBase />', () => {
 
   describe('prop: component', () => {
     it('should allow to use a link component', () => {
-      const Link = props => <div {...props} />;
+      const Link = React.forwardRef((props, ref) => <div ref={ref} {...props} />);
       const wrapper = mount(<ButtonBase component={Link}>Hello</ButtonBase>);
       assert.strictEqual(
         wrapper
@@ -465,11 +466,13 @@ describe('<ButtonBase />', () => {
     });
 
     it('should work with a functional component', () => {
-      const MyLink = props => (
-        <a href="/foo" {...props}>
-          bar
-        </a>
-      );
+      const MyLink = React.forwardRef((props, ref) => {
+        return (
+          <a href="/foo" ref={ref} {...props}>
+            bar
+          </a>
+        );
+      });
       const wrapper = mount(
         <ButtonBase theme={{}} component={MyLink}>
           Hello
@@ -676,7 +679,7 @@ describe('<ButtonBase />', () => {
       assert.strictEqual(typeof buttonActions.focusVisible, 'function');
       buttonActions.focusVisible();
       wrapper.update();
-      assert.strictEqual(wrapper.find('ButtonBase').instance().button, document.activeElement);
+      assert.strictEqual(wrapper.find('button').getDOMNode(), document.activeElement);
       assert.strictEqual(wrapper.find('.focusVisible').exists(), true);
     });
   });

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -13,6 +13,10 @@ import getPageContext from 'docs/src/modules/styles/getPageContext';
 import GoogleAnalytics from 'docs/src/modules/components/GoogleAnalytics';
 import loadScript from 'docs/src/modules/utils/loadScript';
 
+// Add the strict mode back once the number of warnings is manageable.
+// We might miss important warnings by keeping the strict mode 🌊🌊🌊.
+const USE_STRICT_MODE = true;
+
 let dependenciesLoaded = false;
 
 function loadDependencies() {
@@ -390,22 +394,21 @@ class MyApp extends App {
     }
     const activePage = findActivePage(pages, { ...router, pathname });
 
-    // Add the strict mode back once the number of warnings is manageable.
-    // We might miss important warnings by keeping the strict mode 🌊🌊🌊.
-    // <React.StrictMode>
-    // </React.StrictMode>
+    const Mode = USE_STRICT_MODE ? React.StrictMode : React.Fragment;
 
     return (
-      <Container>
-        <Provider store={this.redux}>
-          <PageContext.Provider value={{ activePage, pages }}>
-            <AppWrapper pageContext={this.pageContext}>
-              <Component pageContext={this.pageContext} {...pageProps} />
-            </AppWrapper>
-          </PageContext.Provider>
-        </Provider>
-        <GoogleAnalytics key={router.route} />
-      </Container>
+      <Mode>
+        <Container>
+          <Provider store={this.redux}>
+            <PageContext.Provider value={{ activePage, pages }}>
+              <AppWrapper pageContext={this.pageContext}>
+                <Component pageContext={this.pageContext} {...pageProps} />
+              </AppWrapper>
+            </PageContext.Provider>
+          </Provider>
+          <GoogleAnalytics key={router.route} />
+        </Container>
+      </Mode>
     );
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -15,7 +15,7 @@ import loadScript from 'docs/src/modules/utils/loadScript';
 
 // Add the strict mode back once the number of warnings is manageable.
 // We might miss important warnings by keeping the strict mode 🌊🌊🌊.
-const USE_STRICT_MODE = true;
+const USE_STRICT_MODE = false;
 
 let dependenciesLoaded = false;
 

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -25,7 +25,7 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">centerRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component. If a component is provided it must properly forward their refs via React.forwardRef. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the base button will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">disableTouchRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the touch ripple effect will be disabled. |

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import 'docs/src/modules/components/bootstrap';
 // --- Post bootstrap -----
 import React from 'react';
@@ -96,6 +97,10 @@ const styles = theme => ({
   },
 });
 
+const GettingStartedLink = React.forwardRef((props, ref) => {
+  return <Link href="/getting-started/installation" naked prefetch ref={ref} {...props} />;
+});
+
 class HomePage extends React.Component {
   componentDidMount() {
     if (window.location.hash !== '') {
@@ -133,9 +138,7 @@ class HomePage extends React.Component {
                   {t('strapline')}
                 </Typography>
                 <Button
-                  component={buttonProps => (
-                    <Link naked prefetch href="/getting-started/installation" {...buttonProps} />
-                  )}
+                  component={GettingStartedLink}
                   className={classes.button}
                   variant="outlined"
                   color="primary"


### PR DESCRIPTION
BREAKING: components passed via `component` prop need to be able to hold refs.
