### PR TITLE
[Tooltip] Fix the property forwarding priority

### DIFF
--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -1,3 +1,5 @@
+// @inheritedComponent Tooltip
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -7,8 +9,6 @@ import Fab from '@material-ui/core/Fab';
 import Tooltip from '@material-ui/core/Tooltip';
 
 export const styles = theme => ({
-  /* Styles applied to the root element. */
-  root: {},
   /* Styles applied to the `Button` component. */
   button: {
     margin: 8,
@@ -103,7 +103,6 @@ class SpeedDialAction extends React.Component {
         placement={tooltipPlacement}
         onClose={this.handleTooltipClose}
         onOpen={this.handleTooltipOpen}
-        className={classes.root}
         open={open && this.state.tooltipOpen}
         {...other}
       >

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -72,8 +72,9 @@ function Avatar(props) {
       />
     );
   } else if (childrenClassNameProp && React.isValidElement(childrenProp)) {
-    const childrenClassName = classNames(childrenClassNameProp, childrenProp.props.className);
-    children = React.cloneElement(childrenProp, { className: childrenClassName });
+    children = React.cloneElement(childrenProp, {
+      className: classNames(childrenClassNameProp, childrenProp.props.className),
+    });
   } else {
     children = childrenProp;
   }

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -282,6 +282,7 @@ class Tooltip extends React.Component {
       'aria-describedby': open ? id || this.defaultId : null,
       title: !open && typeof title === 'string' ? title : null,
       ...other,
+      ...children.props,
     };
 
     if (!disableTouchListener) {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -283,6 +283,7 @@ class Tooltip extends React.Component {
       title: !open && typeof title === 'string' ? title : null,
       ...other,
       ...children.props,
+      className: classNames(other.className, children.props.className),
     };
 
     if (!disableTouchListener) {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -255,12 +255,23 @@ describe('<Tooltip />', () => {
     });
   });
 
-  it('should forward properties to the child element', () => {
-    const wrapper = shallow(
-      <Tooltip className="foo" {...defaultProps}>
-        <h1>H1</h1>
-      </Tooltip>,
-    );
-    assert.strictEqual(wrapper.find('h1').props().className, 'foo');
+  describe('forward', () => {
+    it('should forward properties to the child element', () => {
+      const wrapper = shallow(
+        <Tooltip className="foo" {...defaultProps}>
+          <h1>H1</h1>
+        </Tooltip>,
+      );
+      assert.strictEqual(wrapper.find('h1').props().className, 'foo');
+    });
+
+    it('should respect the properties priority', () => {
+      const wrapper = shallow(
+        <Tooltip className="foo" {...defaultProps}>
+          <h1 className="bar">H1</h1>
+        </Tooltip>,
+      );
+      assert.strictEqual(wrapper.find('h1').props().className, 'bar');
+    });
   });
 });

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -259,19 +259,19 @@ describe('<Tooltip />', () => {
     it('should forward properties to the child element', () => {
       const wrapper = shallow(
         <Tooltip className="foo" {...defaultProps}>
-          <h1>H1</h1>
+          <h1 className="bar">H1</h1>
         </Tooltip>,
       );
-      assert.strictEqual(wrapper.find('h1').props().className, 'foo');
+      assert.strictEqual(wrapper.find('h1').props().className, 'foo bar');
     });
 
     it('should respect the properties priority', () => {
       const wrapper = shallow(
-        <Tooltip className="foo" {...defaultProps}>
-          <h1 className="bar">H1</h1>
+        <Tooltip hidden {...defaultProps}>
+          <h1 hidden={false}>H1</h1>
         </Tooltip>,
       );
-      assert.strictEqual(wrapper.find('h1').props().className, 'bar');
+      assert.strictEqual(wrapper.find('h1').props().hidden, false);
     });
   });
 });

--- a/pages/lab/api/speed-dial-action.md
+++ b/pages/lab/api/speed-dial-action.md
@@ -26,7 +26,7 @@ import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
 | <span class="prop-name">tooltipPlacement</span> | <span class="prop-type">enum:&nbsp;'bottom-end', 'bottom-start', 'bottom', 'left-end', 'left-start', 'left', 'right-end', 'right-start', 'right', 'top-end', 'top-start', 'top'<br></span> | <span class="prop-default">'left'</span> | Placement of the tooltip. |
 | <span class="prop-name required">tooltipTitle *</span> | <span class="prop-type">node</span> |   | Label to display in the tooltip. |
 
-Any other properties supplied will be spread to the root element (native element).
+Any other properties supplied will be spread to the root element ([Tooltip](/api/tooltip/)).
 
 ## CSS
 
@@ -36,7 +36,6 @@ This property accepts the following keys:
 
 | Name | Description |
 |:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">button</span> | Styles applied to the `Button` component.
 | <span class="prop-name">buttonClosed</span> | Styles applied to the `Button` component if `open={false}`.
 
@@ -47,6 +46,11 @@ for more detail.
 If using the `overrides` key of the theme as documented
 [here](/customization/themes/#customizing-all-instances-of-a-component-type),
 you need to use the following style sheet name: `MuiSpeedDialAction`.
+
+## Inheritance
+
+The properties of the [Tooltip](/api/tooltip/) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 


### PR DESCRIPTION
The change is summarised by this test case:
```jsx
    it('should respect the properties priority', () => {
      const wrapper = shallow(
        <Tooltip className="foo" {...defaultProps}>
          <h1 className="bar">H1</h1>
        </Tooltip>,
      );
      const className = wrapper.find('h1').props().className;

      // Before : className === 'foo'
      // After : className === 'bar'
    });
```