### PR TITLE
[Menu] Fix wrong condition

### DIFF
--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -38,11 +38,13 @@ class Menu extends React.Component {
   }
 
   getContentAnchorEl = () => {
-    if (!this.menuListRef || !this.menuListRef.selectedItemRef) {
+    if (this.menuListRef) {
+      if (this.menuListRef.selectedItemRef) {
+        return ReactDOM.findDOMNode(this.menuListRef.selectedItemRef);
+      }
       return ReactDOM.findDOMNode(this.menuListRef).firstChild;
     }
-
-    return ReactDOM.findDOMNode(this.menuListRef.selectedItemRef);
+    return null;
   };
 
   focus = () => {

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -38,13 +38,11 @@ class Menu extends React.Component {
   }
 
   getContentAnchorEl = () => {
-    if (this.menuListRef) {
-      if (this.menuListRef.selectedItemRef) {
-        return ReactDOM.findDOMNode(this.menuListRef.selectedItemRef);
-      }
-      return ReactDOM.findDOMNode(this.menuListRef).firstChild;
+    if (this.menuListRef.selectedItemRef) {
+      return ReactDOM.findDOMNode(this.menuListRef.selectedItemRef);
     }
-    return null;
+
+    return ReactDOM.findDOMNode(this.menuListRef).firstChild;
   };
 
   focus = () => {
@@ -57,6 +55,10 @@ class Menu extends React.Component {
     if (menuList && menuList.firstChild) {
       menuList.firstChild.focus();
     }
+  };
+
+  handleMenuListRef = ref => {
+    this.menuListRef = ref;
   };
 
   handleEntering = element => {
@@ -124,9 +126,7 @@ class Menu extends React.Component {
           data-mui-test="Menu"
           onKeyDown={this.handleListKeyDown}
           {...MenuListProps}
-          ref={ref => {
-            this.menuListRef = ref;
-          }}
+          ref={this.handleMenuListRef}
         >
           {children}
         </MenuList>

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -221,4 +221,11 @@ describe('<Menu />', () => {
       });
     });
   });
+
+  it('should not throw error on missing menuListRef ', () => {
+    const wrapper = shallow(<Menu open />);
+    const instance = wrapper.instance();
+    delete instance.menuListRef;
+    instance.getContentAnchorEl();
+  });
 });

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -221,11 +221,4 @@ describe('<Menu />', () => {
       });
     });
   });
-
-  it('should not throw error on missing menuListRef ', () => {
-    const wrapper = shallow(<Menu open />);
-    const instance = wrapper.instance();
-    delete instance.menuListRef;
-    instance.getContentAnchorEl();
-  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Displaying menu randomly throws error `Cannot read property 'firstChild' of null`