### PR TITLE
[docs] Add notistack demo to the snackbar page

### DIFF
--- a/docs/src/pages/demos/snackbars/IntegrationNotistack.js
+++ b/docs/src/pages/demos/snackbars/IntegrationNotistack.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from '@material-ui/core/Button';
+import { SnackbarProvider, withSnackbar } from 'notistack';
+
+class App extends React.Component {
+  handleClick = () => {
+    this.props.enqueueSnackbar('I love snacks.');
+  }
+
+  handleClickVariant = variant => () => {
+    // variant could be success, error, warning or info
+    this.props.enqueueSnackbar('I love snacks.', { variant });
+  }
+
+  render() {
+    return (
+      <div>
+        <Button onClick={this.handleClick}>Display multiple snackbars</Button>
+        <Button onClick={this.handleClickVariant('warning')}>Display warning snackbar</Button>
+      </div>
+    );
+  }
+}
+
+App.propTypes = {
+  enqueueSnackbar: PropTypes.func.isRequired,
+};
+
+const MyApp = withSnackbar(App);
+
+
+export default () => (
+  <SnackbarProvider maxSnack={3}>
+    <MyApp />
+  </SnackbarProvider>
+);

--- a/docs/src/pages/demos/snackbars/IntegrationNotistack.js
+++ b/docs/src/pages/demos/snackbars/IntegrationNotistack.js
@@ -6,19 +6,19 @@ import { SnackbarProvider, withSnackbar } from 'notistack';
 class App extends React.Component {
   handleClick = () => {
     this.props.enqueueSnackbar('I love snacks.');
-  }
+  };
 
   handleClickVariant = variant => () => {
     // variant could be success, error, warning or info
     this.props.enqueueSnackbar('This is a warning message!', { variant });
-  }
+  };
 
   render() {
     return (
-      <div>
+      <React.Fragment>
         <Button onClick={this.handleClick}>Show snackbar</Button>
         <Button onClick={this.handleClickVariant('warning')}>Show warning snackbar</Button>
-      </div>
+      </React.Fragment>
     );
   }
 }
@@ -29,9 +29,12 @@ App.propTypes = {
 
 const MyApp = withSnackbar(App);
 
+function IntegrationNotistack() {
+  return (
+    <SnackbarProvider maxSnack={3}>
+      <MyApp />
+    </SnackbarProvider>
+  );
+}
 
-export default () => (
-  <SnackbarProvider maxSnack={3}>
-    <MyApp />
-  </SnackbarProvider>
-);
+export default IntegrationNotistack;

--- a/docs/src/pages/demos/snackbars/IntegrationNotistack.js
+++ b/docs/src/pages/demos/snackbars/IntegrationNotistack.js
@@ -10,14 +10,14 @@ class App extends React.Component {
 
   handleClickVariant = variant => () => {
     // variant could be success, error, warning or info
-    this.props.enqueueSnackbar('I love snacks.', { variant });
+    this.props.enqueueSnackbar('This is a warning message!', { variant });
   }
 
   render() {
     return (
       <div>
-        <Button onClick={this.handleClick}>Display multiple snackbars</Button>
-        <Button onClick={this.handleClickVariant('warning')}>Display warning snackbar</Button>
+        <Button onClick={this.handleClick}>Show snackbar</Button>
+        <Button onClick={this.handleClickVariant('warning')}>Show warning snackbar</Button>
       </div>
     );
   }

--- a/docs/src/pages/demos/snackbars/snackbars.md
+++ b/docs/src/pages/demos/snackbars/snackbars.md
@@ -70,6 +70,12 @@ Use a different transition all together.
 
 ## Complementary projects
 
-For more advanced use cases you might be able to take advantage of:
+Material-UI doesn't provide a high-level API for displaying snackbars. You can take advantage of third party libraries for this.
 
-- [notistack](https://github.com/iamhosseindhv/notistack) Highly customisable notification snackbars that can be stacked on top of each other.
+### notistack
+![stars](https://img.shields.io/github/stars/iamhosseindhv/notistack.svg?style=social&label=Stars)
+![npm downloads](https://img.shields.io/npm/dm/notistack.svg)
+
+In the following example, we demonstrate how to use [notistack](https://github.com/iamhosseindhv/notistack). notistack makes it easy to display snackbars (so you don't have to deal with open/close state of them). It also enables you to stack them on top of one another.
+
+{{"demo": "pages/demos/snackbars/IntegrationNotistack.js"}}

--- a/docs/src/pages/demos/snackbars/snackbars.md
+++ b/docs/src/pages/demos/snackbars/snackbars.md
@@ -70,9 +70,10 @@ Use a different transition all together.
 
 ## Complementary projects
 
-Material-UI doesn't provide a high-level API for displaying snackbars. You can take advantage of third party libraries for this.
+For more advanced use cases you might be able to take advantage of:
 
 ### notistack
+
 ![stars](https://img.shields.io/github/stars/iamhosseindhv/notistack.svg?style=social&label=Stars)
 ![npm downloads](https://img.shields.io/npm/dm/notistack.svg)
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,17 @@
 const webpack = require('webpack');
 const pkg = require('./package.json');
+const withTM = require('@weco/next-plugin-transpile-modules');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { findPages } = require('./docs/src/modules/utils/find');
 
 process.env.LIB_VERSION = pkg.version;
 
 module.exports = {
-  webpack: config => {
+  webpack: (config, options) => {
+    config = withTM({
+      transpileModules: ['notistack'],
+    }).webpack(config, options);
+
     const plugins = config.plugins.concat([
       new webpack.DefinePlugin({
         'process.env': {

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ process.env.LIB_VERSION = pkg.version;
 
 module.exports = {
   webpack: (config, options) => {
+    // Alias @material-ui/core peer dependency imports form the following modules to our sources.
     config = withTM({
       transpileModules: ['notistack'],
     }).webpack(config, options);

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@babel/register": "7.0.0",
     "@types/enzyme": "^3.1.4",
     "@types/react": "^16.3.14",
+    "@weco/next-plugin-transpile-modules": "0.0.2",
     "accept-language": "^3.0.18",
     "argos-cli": "^0.0.9",
     "autoprefixer": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "material-ui-popup-state": "^1.0.1",
     "mocha": "^5.0.0",
     "next": "^7.0.0",
+    "notistack": "^0.3.9",
     "nyc": "^13.0.0",
     "postcss": "^7.0.0",
     "prettier": "^1.8.2",

--- a/pages/demos/snackbars.js
+++ b/pages/demos/snackbars.js
@@ -65,6 +65,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/snackbars/CustomizedSnackbars'), 'utf8')
 `,
         },
+        'pages/demos/snackbars/IntegrationNotistack.js': {
+          js: require('docs/src/pages/demos/snackbars/IntegrationNotistack').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/snackbars/IntegrationNotistack'), 'utf8')
+`,
+        },
       }}
     />
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -5637,7 +5637,7 @@ eslint-plugin-jsx-a11y@^6.0.3:
     jsx-ast-utils "^2.0.1"
 
 "eslint-plugin-material-ui@file:packages/eslint-plugin-material-ui":
-  version "1.0.0-beta.35"
+  version "3.0.0"
 
 eslint-plugin-mocha@^5.0.0:
   version "5.2.0"
@@ -9317,6 +9317,11 @@ normalize-scroll-left@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz#6b79691ba79eb5fb107fa5edfbdc06b55caee2aa"
   integrity sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg==
+
+notistack@^0.3.9:
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.3.9.tgz#622d89c0038b7cdebba2897b3018f89ada03551d"
+  integrity sha512-Xt55Jn2kq+1o34wS6y8ydj/84UpZrJhpWFfFqY5YqxZPdSiu5RgxhUcoTeq6XLQ8Mwg/TdhH+kRgn21Pxb6IlA==
 
 npm-bundled@^1.0.1:
   version "1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,6 +1869,11 @@
     "@webassemblyjs/wast-parser" "1.7.8"
     "@xtuc/long" "4.2.1"
 
+"@weco/next-plugin-transpile-modules@0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@weco/next-plugin-transpile-modules/-/next-plugin-transpile-modules-0.0.2.tgz#f8f8af6adc6a3c565ed6212ae82a383f18efc40e"
+  integrity sha1-+PivatxqPFZe1iEq6Co4PxjvxA4=
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Following up this [issue](https://github.com/mui-org/material-ui/issues/13682), I have added a simple example of notistack to Snackbar documentation page. 

**However**, this PR is not fully functional since `notistack` needs `@material-ui/core` as a peer dependency. So I wanted to make sure if I can add `@material-ui/core` as a devDependency to package.json ?

Thanks.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
