### PR TITLE
[core] clickawaylistener to ignore touchend after touchmove

### DIFF
--- a/packages/material-ui/.size-snapshot.json
+++ b/packages/material-ui/.size-snapshot.json
@@ -1,7 +1,7 @@
 {
   "build/umd/material-ui.production.min.js": {
-    "bundled": 859176,
-    "minified": 319543,
-    "gzipped": 85080
+    "bundled": 867135,
+    "minified": 322873,
+    "gzipped": 85824
   }
 }

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -61,7 +61,7 @@ class ClickAwayListener extends React.Component {
 
   handleTouchMove = () => {
     this.moved = true;
-  }
+  };
 
   render() {
     const { children, mouseEvent, touchEvent, onClickAway, ...other } = this.props;

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -13,6 +13,8 @@ import ownerDocument from '../utils/ownerDocument';
 class ClickAwayListener extends React.Component {
   mounted = false;
 
+  moved = false;
+
   componentDidMount() {
     // Finds the first child when a component returns a fragment.
     // https://github.com/facebook/react/blob/036ae3c6e2f056adffc31dfb78d1b6f0c63272f0/packages/react-dom/src/__tests__/ReactDOMFiber-test.js#L105
@@ -35,6 +37,12 @@ class ClickAwayListener extends React.Component {
       return;
     }
 
+    // Do not act if user performed touchmove
+    if (this.moved) {
+      this.moved = false;
+      return;
+    }
+
     // The child might render null.
     if (!this.node) {
       return;
@@ -51,9 +59,15 @@ class ClickAwayListener extends React.Component {
     }
   };
 
+  handleTouchMove = () => {
+    this.moved = true;
+  }
+
   render() {
     const { children, mouseEvent, touchEvent, onClickAway, ...other } = this.props;
-    const listenerProps = {};
+    const listenerProps = {
+      onTouchMove: this.handleTouchMove,
+    };
     if (mouseEvent !== false) {
       listenerProps[mouseEvent] = this.handleClickAway;
     }


### PR DESCRIPTION
PR for #13681 

Ignore `touchend` if user scrolled on a touch device. I left `touchstart` because, in my opinion, if you want the event to fire when the user touches the screen, it should occur pre-scroll.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
