### PR TITLE
[ClickAwayListener] Ignore touchend after touchmove

### DIFF
--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -65,14 +65,13 @@ class ClickAwayListener extends React.Component {
 
   render() {
     const { children, mouseEvent, touchEvent, onClickAway, ...other } = this.props;
-    const listenerProps = {
-      onTouchMove: this.handleTouchMove,
-    };
+    const listenerProps = {};
     if (mouseEvent !== false) {
       listenerProps[mouseEvent] = this.handleClickAway;
     }
     if (touchEvent !== false) {
       listenerProps[touchEvent] = this.handleClickAway;
+      listenerProps.onTouchMove = this.handleTouchMove;
     }
 
     return (

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -13,6 +13,8 @@ import ownerDocument from '../utils/ownerDocument';
 class ClickAwayListener extends React.Component {
   mounted = false;
 
+  moved = false;
+
   componentDidMount() {
     // Finds the first child when a component returns a fragment.
     // https://github.com/facebook/react/blob/036ae3c6e2f056adffc31dfb78d1b6f0c63272f0/packages/react-dom/src/__tests__/ReactDOMFiber-test.js#L105
@@ -35,6 +37,12 @@ class ClickAwayListener extends React.Component {
       return;
     }
 
+    // Do not act if user performed touchmove
+    if (this.moved) {
+      this.moved = false;
+      return;
+    }
+
     // The child might render null.
     if (!this.node) {
       return;
@@ -51,9 +59,15 @@ class ClickAwayListener extends React.Component {
     }
   };
 
+  handleTouchMove = () => {
+    this.moved = true;
+  };
+
   render() {
     const { children, mouseEvent, touchEvent, onClickAway, ...other } = this.props;
-    const listenerProps = {};
+    const listenerProps = {
+      onTouchMove: this.handleTouchMove,
+    };
     if (mouseEvent !== false) {
       listenerProps[mouseEvent] = this.handleClickAway;
     }

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -5,6 +5,16 @@ import { spy } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import ClickAwayListener from './ClickAwayListener';
 
+function fireBodyMouseEvent(name, properties = {}) {
+  const event = document.createEvent('MouseEvents');
+  event.initEvent(name, true, true);
+  Object.keys(properties).forEach(key => {
+    event[key] = properties[key];
+  });
+  document.body.dispatchEvent(event);
+  return event;
+}
+
 describe('<ClickAwayListener />', () => {
   let mount;
   let wrapper;
@@ -36,9 +46,7 @@ describe('<ClickAwayListener />', () => {
         </ClickAwayListener>,
       );
 
-      const event = document.createEvent('MouseEvents');
-      event.initEvent('mouseup', true, true);
-      window.document.body.dispatchEvent(event);
+      const event = fireBodyMouseEvent('mouseup');
 
       assert.strictEqual(handleClickAway.callCount, 1);
       assert.deepEqual(handleClickAway.args[0], [event]);
@@ -85,11 +93,7 @@ describe('<ClickAwayListener />', () => {
           <span>Hello</span>
         </ClickAwayListener>,
       );
-
-      const event = document.createEvent('MouseEvents');
-      event.initEvent('mouseup', true, true);
-      window.document.body.dispatchEvent(event);
-
+      fireBodyMouseEvent('mouseup');
       assert.strictEqual(handleClickAway.callCount, 0);
     });
 
@@ -100,17 +104,9 @@ describe('<ClickAwayListener />', () => {
           <span>Hello</span>
         </ClickAwayListener>,
       );
-
-      const mouseUpEvent = document.createEvent('MouseEvents');
-      mouseUpEvent.initEvent('mouseup', true, true);
-      window.document.body.dispatchEvent(mouseUpEvent);
-
+      fireBodyMouseEvent('mouseup');
       assert.strictEqual(handleClickAway.callCount, 0);
-
-      const mouseDownEvent = document.createEvent('MouseEvents');
-      mouseDownEvent.initEvent('mousedown', true, true);
-      window.document.body.dispatchEvent(mouseDownEvent);
-
+      const mouseDownEvent = fireBodyMouseEvent('mousedown');
       assert.strictEqual(handleClickAway.callCount, 1);
       assert.deepEqual(handleClickAway.args[0], [mouseDownEvent]);
     });
@@ -124,11 +120,7 @@ describe('<ClickAwayListener />', () => {
           <span>Hello</span>
         </ClickAwayListener>,
       );
-
-      const event = document.createEvent('Events');
-      event.initEvent('touchend', true, true);
-      window.document.body.dispatchEvent(event);
-
+      fireBodyMouseEvent('touchend');
       assert.strictEqual(handleClickAway.callCount, 0);
     });
 
@@ -139,17 +131,9 @@ describe('<ClickAwayListener />', () => {
           <span>Hello</span>
         </ClickAwayListener>,
       );
-
-      const touchEndEvent = document.createEvent('Events');
-      touchEndEvent.initEvent('touchend', true, true);
-      window.document.body.dispatchEvent(touchEndEvent);
-
+      fireBodyMouseEvent('touchend');
       assert.strictEqual(handleClickAway.callCount, 0);
-
-      const touchStartEvent = document.createEvent('Events');
-      touchStartEvent.initEvent('touchstart', true, true);
-      window.document.body.dispatchEvent(touchStartEvent);
-
+      const touchStartEvent = fireBodyMouseEvent('touchstart');
       assert.strictEqual(handleClickAway.callCount, 1);
       assert.deepEqual(handleClickAway.args[0], [touchStartEvent]);
     });
@@ -161,24 +145,12 @@ describe('<ClickAwayListener />', () => {
           <span>Hello</span>
         </ClickAwayListener>,
       );
-
-      const touchStartEvent = document.createEvent('Events');
-      touchStartEvent.initEvent('touchstart', true, true);
-      window.document.body.dispatchEvent(touchStartEvent);
-
-      const touchMoveEvent = document.createEvent('Events');
-      touchMoveEvent.initEvent('touchmove', true, true);
-      window.document.body.dispatchEvent(touchMoveEvent);
-
-      const touchEndEvent = document.createEvent('Events');
-      touchEndEvent.initEvent('touchend', true, true);
-      window.document.body.dispatchEvent(touchEndEvent);
-
+      fireBodyMouseEvent('touchstart');
+      fireBodyMouseEvent('touchmove');
+      fireBodyMouseEvent('touchend');
       assert.strictEqual(handleClickAway.callCount, 0);
 
-      touchEndEvent.initEvent('touchend', true, true);
-      window.document.body.dispatchEvent(touchEndEvent);
-
+      const touchEndEvent = fireBodyMouseEvent('touchend');
       assert.strictEqual(handleClickAway.callCount, 1);
       assert.deepEqual(handleClickAway.args[0], [touchEndEvent]);
     });
@@ -193,11 +165,7 @@ describe('<ClickAwayListener />', () => {
         </ClickAwayListener>,
       );
       wrapper.instance().mounted = false;
-
-      const event = document.createEvent('MouseEvents');
-      event.initEvent('mouseup', true, true);
-      window.document.body.dispatchEvent(event);
-
+      fireBodyMouseEvent('mouseup');
       assert.strictEqual(handleClickAway.callCount, 0);
     });
   });
@@ -210,11 +178,7 @@ describe('<ClickAwayListener />', () => {
         <Child />
       </ClickAwayListener>,
     );
-
-    const event = document.createEvent('MouseEvents');
-    event.initEvent('mouseup', true, true);
-    window.document.body.dispatchEvent(event);
-
+    fireBodyMouseEvent('mouseup');
     assert.strictEqual(handleClickAway.callCount, 0);
   });
 });

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -153,6 +153,35 @@ describe('<ClickAwayListener />', () => {
       assert.strictEqual(handleClickAway.callCount, 1);
       assert.deepEqual(handleClickAway.args[0], [touchStartEvent]);
     });
+
+    it('should ignore `touchend` when preceeded by `touchmove` event', () => {
+      const handleClickAway = spy();
+      wrapper = mount(
+        <ClickAwayListener onClickAway={handleClickAway} touchEvent="onTouchEnd">
+          <span>Hello</span>
+        </ClickAwayListener>,
+      );
+
+      const touchStartEvent = document.createEvent('Events');
+      touchStartEvent.initEvent('touchstart', true, true);
+      window.document.body.dispatchEvent(touchStartEvent);
+
+      const touchMoveEvent = document.createEvent('Events');
+      touchMoveEvent.initEvent('touchmove', true, true);
+      window.document.body.dispatchEvent(touchMoveEvent);
+
+      const touchEndEvent = document.createEvent('Events');
+      touchEndEvent.initEvent('touchend', true, true);
+      window.document.body.dispatchEvent(touchEndEvent);
+
+      assert.strictEqual(handleClickAway.callCount, 0);
+
+      touchEndEvent.initEvent('touchend', true, true);
+      window.document.body.dispatchEvent(touchEndEvent);
+
+      assert.strictEqual(handleClickAway.callCount, 1);
+      assert.deepEqual(handleClickAway.args[0], [touchEndEvent]);
+    });
   });
 
   describe('IE 11 issue', () => {

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -9,13 +9,14 @@ import SwipeableDrawer, { reset } from './SwipeableDrawer';
 import SwipeArea from './SwipeArea';
 import createMuiTheme from '../styles/createMuiTheme';
 
-function fireBodyMouseEvent(name, properties) {
+function fireBodyMouseEvent(name, properties = {}) {
   const event = document.createEvent('MouseEvents');
   event.initEvent(name, true, true);
   Object.keys(properties).forEach(key => {
     event[key] = properties[key];
   });
   document.body.dispatchEvent(event);
+  return event;
 }
 
 describe('<SwipeableDrawer />', () => {


### PR DESCRIPTION
PR to fix #13681 

I have left `onTouchStart` to be triggered by a `touchmove`. If I wanted the click away handler triggered on  `touchstart` I would want it triggered pre-scroll on touch devices. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
