### PR TITLE
[Dialog] Add xl maxWidth and demo component

### DIFF
--- a/docs/src/pages/demos/dialogs/MaxWidthDialog.js
+++ b/docs/src/pages/demos/dialogs/MaxWidthDialog.js
@@ -12,7 +12,6 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import Select from '@material-ui/core/Select';
-import Slide from '@material-ui/core/Slide';
 import Switch from '@material-ui/core/Switch';
 
 const styles = theme => ({
@@ -23,17 +22,13 @@ const styles = theme => ({
     width: 'fit-content',
   },
   formControl: {
-    marginTop: theme.spacing.unit,
+    marginTop: theme.spacing.unit * 2,
     minWidth: 120,
   },
   formControlLabel: {
     marginTop: theme.spacing.unit,
   },
 });
-
-function Transition(props) {
-  return <Slide direction="up" {...props} />;
-}
 
 class FullScreenDialog extends React.Component {
   state = {
@@ -60,24 +55,25 @@ class FullScreenDialog extends React.Component {
 
   render() {
     const { classes } = this.props;
+
     return (
-      <div>
+      <React.Fragment>
         <Button onClick={this.handleClickOpen}>Open max-width dialog</Button>
         <Dialog
           fullWidth={this.state.fullWidth}
           maxWidth={this.state.maxWidth}
           open={this.state.open}
           onClose={this.handleClose}
-          TransitionComponent={Transition}
+          aria-labelledby="max-width-dialog-title"
         >
-          <DialogTitle id="form-dialog-title">Play with me</DialogTitle>
+          <DialogTitle id="max-width-dialog-title">Optional sizes</DialogTitle>
           <DialogContent>
             <DialogContentText>
               You can set my maximum width and whether to adapt or not.
             </DialogContentText>
             <form className={classes.form} noValidate>
               <FormControl className={classes.formControl}>
-                <InputLabel htmlFor="max-width">Max width</InputLabel>
+                <InputLabel htmlFor="max-width">maxWidth</InputLabel>
                 <Select
                   value={this.state.maxWidth}
                   onChange={this.handleMaxWidthChange}
@@ -113,7 +109,7 @@ class FullScreenDialog extends React.Component {
             </Button>
           </DialogActions>
         </Dialog>
-      </div>
+      </React.Fragment>
     );
   }
 }

--- a/docs/src/pages/demos/dialogs/MaxWidthDialog.js
+++ b/docs/src/pages/demos/dialogs/MaxWidthDialog.js
@@ -1,0 +1,125 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import FormControl from '@material-ui/core/FormControl';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
+import Slide from '@material-ui/core/Slide';
+import Switch from '@material-ui/core/Switch';
+
+const styles = theme => ({
+  form: {
+    display: 'flex',
+    flexDirection: 'column',
+    margin: 'auto',
+    width: 'fit-content',
+  },
+  formControl: {
+    marginTop: theme.spacing.unit,
+    minWidth: 120,
+  },
+  formControlLabel: {
+    marginTop: theme.spacing.unit,
+  },
+});
+
+function Transition(props) {
+  return <Slide direction="up" {...props} />;
+}
+
+class FullScreenDialog extends React.Component {
+  state = {
+    open: false,
+    fullWidth: true,
+    maxWidth: 'sm',
+  };
+
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
+  handleMaxWidthChange = event => {
+    this.setState({ maxWidth: event.target.value });
+  };
+
+  handleFullWidthChange = event => {
+    this.setState({ fullWidth: event.target.checked });
+  };
+
+  render() {
+    const { classes } = this.props;
+    return (
+      <div>
+        <Button onClick={this.handleClickOpen}>Open max-width dialog</Button>
+        <Dialog
+          fullWidth={this.state.fullWidth}
+          maxWidth={this.state.maxWidth}
+          open={this.state.open}
+          onClose={this.handleClose}
+          TransitionComponent={Transition}
+        >
+          <DialogTitle id="form-dialog-title">Play with me</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              You can set my maximum width and whether to adapt or not.
+            </DialogContentText>
+            <form className={classes.form} noValidate>
+              <FormControl className={classes.formControl}>
+                <InputLabel htmlFor="max-width">Max width</InputLabel>
+                <Select
+                  value={this.state.maxWidth}
+                  onChange={this.handleMaxWidthChange}
+                  inputProps={{
+                    name: 'max-width',
+                    id: 'max-width',
+                  }}
+                >
+                  <MenuItem value={false}>false</MenuItem>
+                  <MenuItem value="xs">xs</MenuItem>
+                  <MenuItem value="sm">sm</MenuItem>
+                  <MenuItem value="md">md</MenuItem>
+                  <MenuItem value="lg">lg</MenuItem>
+                  <MenuItem value="xl">xl</MenuItem>
+                </Select>
+              </FormControl>
+              <FormControlLabel
+                className={classes.formControlLabel}
+                control={
+                  <Switch
+                    checked={this.state.fullWidth}
+                    onChange={this.handleFullWidthChange}
+                    value="fullWidth"
+                  />
+                }
+                label="Full width"
+              />
+            </form>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleClose} color="primary">
+              Close
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+}
+
+FullScreenDialog.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(FullScreenDialog);

--- a/docs/src/pages/demos/dialogs/dialogs.md
+++ b/docs/src/pages/demos/dialogs/dialogs.md
@@ -58,9 +58,15 @@ For example, if your site prompts for potential subscribers to fill in their ema
 
 {{"demo": "pages/demos/dialogs/FullScreenDialog.js"}}
 
+## Sizable dialogs
+
+You can set a `Dialog` maximum with by using the `maxWidth` enumerable in combination with the `fullWidth` boolean. When `fullWidth` is true, the dialog will adapt based on the `maxWidth` value.
+
+{{"demo": "pages/demos/dialogs/MaxWidthDialog.js"}}
+
 ## Responsive full-screen
 
-You may make a `Dialog` responsively full screen the dialog using `withMobileDialog`. By default, `withMobileDialog()(Dialog)` responsively full screens *at or below* the `sm` [screen size](/layout/basics/). You can choose your own breakpoint for example `xs` by passing the `breakpoint` argument: `withMobileDialog({breakpoint: 'xs'})(Dialog)`.
+You may make a `Dialog` responsively full screen the dialog using `withMobileDialog`. By default, `withMobileDialog()(Dialog)` responsively full screens _at or below_ the `sm` [screen size](/layout/basics/). You can choose your own breakpoint for example `xs` by passing the `breakpoint` argument: `withMobileDialog({breakpoint: 'xs'})(Dialog)`.
 
 {{"demo": "pages/demos/dialogs/ResponsiveDialog.js"}}
 

--- a/docs/src/pages/demos/dialogs/dialogs.md
+++ b/docs/src/pages/demos/dialogs/dialogs.md
@@ -58,15 +58,16 @@ For example, if your site prompts for potential subscribers to fill in their ema
 
 {{"demo": "pages/demos/dialogs/FullScreenDialog.js"}}
 
-## Sizable dialogs
+## Optional sizes
 
-You can set a `Dialog` maximum with by using the `maxWidth` enumerable in combination with the `fullWidth` boolean. When `fullWidth` is true, the dialog will adapt based on the `maxWidth` value.
+You can set a dialog maximum width by using the `maxWidth` enumerable in combination with the `fullWidth` boolean.
+When the `fullWidth` property is true, the dialog will adapt based on the `maxWidth` value.
 
 {{"demo": "pages/demos/dialogs/MaxWidthDialog.js"}}
 
 ## Responsive full-screen
 
-You may make a `Dialog` responsively full screen the dialog using `withMobileDialog`. By default, `withMobileDialog()(Dialog)` responsively full screens _at or below_ the `sm` [screen size](/layout/basics/). You can choose your own breakpoint for example `xs` by passing the `breakpoint` argument: `withMobileDialog({breakpoint: 'xs'})(Dialog)`.
+You may make a dialog responsively full screen the dialog using `withMobileDialog`. By default, `withMobileDialog()(Dialog)` responsively full screens *at or below* the `sm` [screen size](/layout/basics/). You can choose your own breakpoint for example `xs` by passing the `breakpoint` argument: `withMobileDialog({breakpoint: 'xs'})(Dialog)`.
 
 {{"demo": "pages/demos/dialogs/ResponsiveDialog.js"}}
 

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -9,7 +9,7 @@ export interface DialogProps
   children?: React.ReactNode;
   fullScreen?: boolean;
   fullWidth?: boolean;
-  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false;
+  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false;
   PaperProps?: Partial<PaperProps>;
   scroll?: 'body' | 'paper';
   TransitionComponent?: React.ReactType;

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -9,7 +9,7 @@ export interface DialogProps
   children?: React.ReactNode;
   fullScreen?: boolean;
   fullWidth?: boolean;
-  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | false;
+  maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false;
   PaperProps?: Partial<PaperProps>;
   scroll?: 'body' | 'paper';
   TransitionComponent?: React.ReactType;

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -85,6 +85,15 @@ export const styles = theme => ({
       },
     },
   },
+  /* Styles applied to the `Paper` component if `maxWidth="xl"`. */
+  paperWidthXl: {
+    maxWidth: theme.breakpoints.values.xl,
+    '&$paperScrollBody': {
+      [theme.breakpoints.down(theme.breakpoints.values.xl + 48 * 2)]: {
+        margin: 48,
+      },
+    },
+  },
   /* Styles applied to the `Paper` component if `fullWidth={true}`. */
   paperFullWidth: {
     width: '100%',
@@ -241,7 +250,7 @@ Dialog.propTypes = {
    * on the desktop where you might need some coherent different width size across your
    * application. Set to `false` to disable `maxWidth`.
    */
-  maxWidth: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', false]),
+  maxWidth: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', false]),
   /**
    * Callback fired when the backdrop is clicked.
    */

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -24,7 +24,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | <span class="prop-name">disableEscapeKeyDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, hitting escape will not fire the `onClose` callback. |
 | <span class="prop-name">fullScreen</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the dialog will be full-screen |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the dialog stretches to `maxWidth`. |
-| <span class="prop-name">maxWidth</span> | <span class="prop-type">enum:&nbsp;'xs', 'sm', 'md', 'lg', false<br></span> | <span class="prop-default">'sm'</span> | Determine the max width of the dialog. The dialog width grows with the size of the screen, this property is useful on the desktop where you might need some coherent different width size across your application. Set to `false` to disable `maxWidth`. |
+| <span class="prop-name">maxWidth</span> | <span class="prop-type">enum:&nbsp;'xs', 'sm', 'md', 'lg', 'xl', false<br></span> | <span class="prop-default">'sm'</span> | Determine the max width of the dialog. The dialog width grows with the size of the screen, this property is useful on the desktop where you might need some coherent different width size across your application. Set to `false` to disable `maxWidth`. |
 | <span class="prop-name">onBackdropClick</span> | <span class="prop-type">func</span> |   | Callback fired when the backdrop is clicked. |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func</span> |   | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
 | <span class="prop-name">onEnter</span> | <span class="prop-type">func</span> |   | Callback fired before the dialog enters. |
@@ -62,6 +62,7 @@ This property accepts the following keys:
 | <span class="prop-name">paperWidthSm</span> | Styles applied to the `Paper` component if `maxWidth="sm"`.
 | <span class="prop-name">paperWidthMd</span> | Styles applied to the `Paper` component if `maxWidth="md"`.
 | <span class="prop-name">paperWidthLg</span> | Styles applied to the `Paper` component if `maxWidth="lg"`.
+| <span class="prop-name">paperWidthXl</span> | Styles applied to the `Paper` component if `maxWidth="xl"`.
 | <span class="prop-name">paperFullWidth</span> | Styles applied to the `Paper` component if `fullWidth={true}`.
 | <span class="prop-name">paperFullScreen</span> | Styles applied to the `Paper` component if `fullScreen={true}`.
 

--- a/pages/demos/dialogs.js
+++ b/pages/demos/dialogs.js
@@ -44,6 +44,13 @@ module.exports = require('fs')
   .readFileSync(require.resolve('docs/src/pages/demos/dialogs/FullScreenDialog'), 'utf8')
 `,
         },
+        'pages/demos/dialogs/MaxWidthDialog.js': {
+          js: require('docs/src/pages/demos/dialogs/MaxWidthDialog').default,
+          raw: preval`
+module.exports = require('fs')
+  .readFileSync(require.resolve('docs/src/pages/demos/dialogs/MaxWidthDialog'), 'utf8')
+`,
+        },
         'pages/demos/dialogs/FormDialog.js': {
           js: require('docs/src/pages/demos/dialogs/FormDialog').default,
           raw: preval`


### PR DESCRIPTION
This PR:
* Adds support for the XL theme breakpoint to the `Dialog` component.
* Adds a demo component in the `Dialog` demo. The user has the ability to play with the value of both `fullWidth` and `maxWidth` to help him understand how they interact.