### PR TITLE
[styles] Remove hoisting of static properties in HOCs

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -41,7 +41,7 @@ module.exports = [
     name: 'The main docs bundle',
     webpack: false,
     path: main.path,
-    limit: '176 KB',
+    limit: '176.1 KB',
   },
   {
     name: 'The docs home page',

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -40,7 +40,6 @@
     "@material-ui/utils": "^3.0.0-alpha.0",
     "classnames": "^2.2.5",
     "deepmerge": "^3.0.0",
-    "hoist-non-react-statics": "^3.2.1",
     "jss": "^9.3.3",
     "jss-camel-case": "^6.0.0",
     "jss-default-unit": "^8.0.2",

--- a/packages/material-ui-styles/src/hoistInternalStatics.js
+++ b/packages/material-ui-styles/src/hoistInternalStatics.js
@@ -1,0 +1,18 @@
+/**
+ * Copies internal immediate statics from material-ui from source to target
+ */
+export default function hoistStatics(target, source) {
+  const internals = ['muiName'];
+
+  for (let i = 0; i < internals.length; i += 1) {
+    const key = internals[i];
+    const descriptor = Object.getOwnPropertyDescriptor(source, key);
+    try {
+      Object.defineProperty(target, key, descriptor);
+    } catch (e) {
+      // Avoid failures from read-only properties and undefined descriptors
+    }
+  }
+
+  return target;
+}

--- a/packages/material-ui-styles/src/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles.js
@@ -8,6 +8,7 @@ import mergeClasses from './mergeClasses';
 import multiKeyStore from './multiKeyStore';
 import getStylesCreator from './getStylesCreator';
 import getThemeProps from './getThemeProps';
+import hoistStatics from './hoistInternalStatics';
 import { StylesContext } from './StylesProvider';
 import { ThemeContext } from './ThemeProvider';
 
@@ -331,6 +332,8 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
   if (process.env.NODE_ENV !== 'production') {
     WithStyles.displayName = `WithStyles(${getDisplayName(Component)})`;
   }
+
+  hoistStatics(WithStyles, Component);
 
   if (process.env.NODE_ENV !== 'production') {
     // Exposed for test purposes.

--- a/packages/material-ui-styles/src/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import warning from 'warning';
 import getDynamicStyles from 'jss/lib/utils/getDynamicStyles';
 import { getDisplayName } from '@material-ui/utils';
-import hoistNonReactStatics from 'hoist-non-react-statics';
 import { increment } from './indexCounter';
 import mergeClasses from './mergeClasses';
 import multiKeyStore from './multiKeyStore';
@@ -332,8 +331,6 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
   if (process.env.NODE_ENV !== 'production') {
     WithStyles.displayName = `WithStyles(${getDisplayName(Component)})`;
   }
-
-  hoistNonReactStatics(WithStyles, Component);
 
   if (process.env.NODE_ENV !== 'production') {
     // Exposed for test purposes.

--- a/packages/material-ui-styles/src/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles.test.js
@@ -1,0 +1,11 @@
+import { assert } from 'chai';
+import withStyles from './withStyles';
+
+describe('withStyles', () => {
+  it('does not hoist statics', () => {
+    const Test = () => null;
+    Test.someStatic = 'will not get hoisted';
+    const TestWithStyles = withStyles()(Test);
+    assert.strictEqual(TestWithStyles.someStatic, undefined);
+  });
+});

--- a/packages/material-ui-styles/src/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles.test.js
@@ -5,7 +5,7 @@ describe('withStyles', () => {
   it('does not hoist statics', () => {
     const Test = () => null;
     Test.someStatic = 'will not get hoisted';
-    const TestWithStyles = withStyles()(Test);
+    const TestWithStyles = withStyles({})(Test);
     assert.strictEqual(TestWithStyles.someStatic, undefined);
   });
 });

--- a/packages/material-ui-styles/src/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles.test.js
@@ -1,4 +1,7 @@
 import { assert } from 'chai';
+import React from 'react';
+import { Input } from '@material-ui/core';
+import { isMuiElement } from '@material-ui/core/utils/reactHelpers';
 import withStyles from './withStyles';
 
 describe('withStyles', () => {
@@ -7,5 +10,14 @@ describe('withStyles', () => {
     Test.someStatic = 'will not get hoisted';
     const TestWithStyles = withStyles({})(Test);
     assert.strictEqual(TestWithStyles.someStatic, undefined);
+  });
+
+  it('hoists mui internals', () => {
+    assert.strictEqual(isMuiElement(<Input />, ['Input']), true);
+
+    // the imported Input is decorated with @material-ui/core/styles
+    const StyledInput = withStyles({})(Input);
+
+    assert.strictEqual(isMuiElement(<StyledInput />, ['Input']), true);
   });
 });

--- a/packages/material-ui-styles/src/withTheme.js
+++ b/packages/material-ui-styles/src/withTheme.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { getDisplayName } from '@material-ui/utils';
+import hoistStatics from './hoistInternalStatics';
 import { ThemeContext } from './ThemeProvider';
 
 // Provide the theme object as a property to the input component.
@@ -24,6 +25,8 @@ const withTheme = () => Component => {
   if (process.env.NODE_ENV !== 'production') {
     WithTheme.displayName = `WithTheme(${getDisplayName(Component)})`;
   }
+
+  hoistStatics(WithTheme, Component);
 
   return WithTheme;
 };

--- a/packages/material-ui-styles/src/withTheme.js
+++ b/packages/material-ui-styles/src/withTheme.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import hoistNonReactStatics from 'hoist-non-react-statics';
 import { getDisplayName } from '@material-ui/utils';
 import { ThemeContext } from './ThemeProvider';
 
@@ -25,8 +24,6 @@ const withTheme = () => Component => {
   if (process.env.NODE_ENV !== 'production') {
     WithTheme.displayName = `WithTheme(${getDisplayName(Component)})`;
   }
-
-  hoistNonReactStatics(WithTheme, Component);
 
   return WithTheme;
 };

--- a/packages/material-ui-styles/src/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createMount } from '@material-ui/core/test-utils';
+import { Input } from '@material-ui/core';
+import { isMuiElement } from '@material-ui/core/utils/reactHelpers';
 import PropTypes from 'prop-types';
 import withTheme from './withTheme';
 import ThemeProvider from './ThemeProvider';
@@ -40,5 +42,13 @@ describe('withTheme', () => {
     Test.someStatic = 'will not get hoisted';
     const TestWithTheme = withTheme()(Test);
     assert.strictEqual(TestWithTheme.someStatic, undefined);
+  });
+
+  it('hoists mui internals', () => {
+    assert.strictEqual(isMuiElement(<Input />, ['Input']), true);
+
+    const ThemedInput = withTheme()(Input);
+
+    assert.strictEqual(isMuiElement(<ThemedInput />, ['Input']), true);
   });
 });

--- a/packages/material-ui-styles/src/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme.test.js
@@ -34,4 +34,11 @@ describe('withTheme', () => {
     );
     assert.strictEqual(wrapper.text(), 'foo');
   });
+
+  it('does not hoist statics', () => {
+    const Test = () => null;
+    Test.someStatic = 'will not get hoisted';
+    const TestWithTheme = withTheme()(Test);
+    assert.strictEqual(TestWithTheme.someStatic, undefined);
+  });
 });

--- a/test/utils/init.js
+++ b/test/utils/init.js
@@ -1,4 +1,3 @@
-import { install as installNextStyles } from '@material-ui/styles';
 import enzyme from 'enzyme/build/index';
 import Adapter from 'enzyme-adapter-react-16';
 import consoleError from './consoleError';
@@ -6,5 +5,3 @@ import consoleError from './consoleError';
 consoleError();
 
 enzyme.configure({ adapter: new Adapter() });
-
-installNextStyles();

--- a/test/utils/init.js
+++ b/test/utils/init.js
@@ -1,3 +1,4 @@
+import { install as installNextStyles } from '@material-ui/styles';
 import enzyme from 'enzyme/build/index';
 import Adapter from 'enzyme-adapter-react-16';
 import consoleError from './consoleError';
@@ -5,3 +6,5 @@ import consoleError from './consoleError';
 consoleError();
 
 enzyme.configure({ adapter: new Adapter() });
+
+installNextStyles();


### PR DESCRIPTION
BREAKING: Removes call of `hoist-non-react-statics` in `withStyles` and `withTheme`. This does only affect the `@material-ui/styles` package which is still in alpha.

Migration for hoisting requirement:
```diff
import { withStyles } from '@material-ui/styles';
- export default withStyles(styles)(Component);
+ import hoistNonReactStatics from 'hoist-non-react-statics';
+ export default hoistNonReactStatics(withStyles(styles)(Component), Component);
```

This might be for some people a controversial change so I'm trying to explain the reasons to the best of my ability:

1. `hoist-non-react-statics` is not maintained by the react team
This is/was a major pain point when migrating to refs + `React.forwardRef` from `findDOMNode`. The react team added all these new features without considering the impact it had on a very popular pattern in the ecosystem. It caused false positives #13465 and hard to debug errors in our docs (hard to tell where the actual issue was but hoisting forwardRef.render into a class component was somehow bad).

   I'm fully aware that the react docs explicitly say that [you should copy statics over](https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over) but unless a better solution is found this part of the code needs extra maintenance for every react feature when a dependency should reduce the maintenance burden as much as possible. However the text only gives `relay` as an example which leads me to believe that copying statics is more of an issue in facebooks code. Exporting those statics is a much better solution in my opinion.

2. It is still doable in userland with e.g. `compose(hoistNonReactStatics(UnstyledComponent), withStyles(styles))(UnstyledComponent)` from the recompose package. Since I suspect that the requirement for static hoisting is not a very common use case I rather give the responsibility to the consumer than to the library. *Warning:* `recompose` still uses an outdated version of `hoist-non-react-statics`. Use your own implementation with the latest version of `hoist-non-react-statics`.

3. goes against "a function should do one thing"
For me a good example where not following this is a code smell. `withStyles` did two things and one of them bad.

4. Currently type information for non-react statics is lost anyway. So everybody who used flow or TypeScript didn't have proper statics support to begin with.

5. It's targeted at an alpha release
    We can *safely* gauge the impact of this change and get better feedback. I'm also fully expecting that this is caused by ignorance on my part since I don't think I ever relied (consciously) on hoisting statics.
6. Reduced bundle size for everyone that does not need this feature (1KB i think)

**Why not inline the dependency?**
While this might improve the response time it doesn't solve the actual issue. This would also increase our workload even more beyond "just bumping a dependency version".
