### PR TITLE
[ToggleButton] Change the classes structure to match the core components convention

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -45,34 +45,9 @@ export const styles = theme => ({
   /* Styles applied to the root element if `selected={true}`. */
   selected: {
     color: theme.palette.action.active,
-    '&:after': {
-      content: '""',
-      display: 'block',
-      position: 'absolute',
-      overflow: 'hidden',
-      borderRadius: 'inherit',
-      width: '100%',
-      height: '100%',
-      left: 0,
-      top: 0,
-      pointerEvents: 'none',
-      zIndex: 0,
-      backgroundColor: 'currentColor',
-      opacity: 0.38,
-    },
-    '& + &:before': {
-      content: '""',
-      display: 'block',
-      position: 'absolute',
-      overflow: 'hidden',
-      width: 1,
-      height: '100%',
-      left: 0,
-      top: 0,
-      pointerEvents: 'none',
-      zIndex: 0,
-      backgroundColor: 'currentColor',
-      opacity: 0.12,
+    backgroundColor: fade(theme.palette.action.active, 0.2),
+    '&:hover': {
+      backgroundColor: fade(theme.palette.action.active, 0.25),
     },
   },
   /* Styles applied to the `label` wrapper element. */

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -18,6 +18,16 @@ export const styles = theme => ({
     borderRadius: 2,
     willChange: 'opacity',
     color: fade(theme.palette.action.active, 0.38),
+    '&$selected': {
+      color: theme.palette.action.active,
+      backgroundColor: fade(theme.palette.action.active, 0.2),
+      '&:hover': {
+        backgroundColor: fade(theme.palette.action.active, 0.25),
+      },
+    },
+    '&$disabled': {
+      color: fade(theme.palette.action.disabled, 0.12),
+    },
     '&:hover': {
       textDecoration: 'none',
       // Reset on mouse devices
@@ -39,17 +49,9 @@ export const styles = theme => ({
     },
   },
   /* Styles applied to the root element if `disabled={true}`. */
-  disabled: {
-    color: fade(theme.palette.action.disabled, 0.12),
-  },
+  disabled: {},
   /* Styles applied to the root element if `selected={true}`. */
-  selected: {
-    color: theme.palette.action.active,
-    backgroundColor: fade(theme.palette.action.active, 0.2),
-    '&:hover': {
-      backgroundColor: fade(theme.palette.action.active, 0.25),
-    },
-  },
+  selected: {},
   /* Styles applied to the `label` wrapper element. */
   label: {
     width: '100%',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Hi. I stumbled across this issue when I attempted to override the background color of the `selected` `ToggleButton` `classes` property. The color came back faded. I spent a lot of time trying different things to override the styling, until I decided to look through the source.

The change submitted appears to style the default components as before, while providing a simpler means for overriding those default styles, and with fewer lines of code.