### PR TITLE
[SwitchBase] Fix error not being thrown when controlled state is changed

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of the @material-ui/core modules',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '94.9 KB',
+    limit: '95 KB',
   },
   {
     name: 'The size of the @material-ui/styles modules',

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -87,6 +87,7 @@ class SwitchBase extends React.Component {
       checkedIcon,
       classes,
       className: classNameProp,
+      defaultChecked,
       disabled: disabledProp,
       icon,
       id,
@@ -137,7 +138,8 @@ class SwitchBase extends React.Component {
         {checked ? checkedIcon : icon}
         <input
           autoFocus={autoFocus}
-          checked={checked}
+          checked={checkedProp}
+          defaultChecked={defaultChecked}
           className={classes.input}
           disabled={disabled}
           id={hasLabelFor && id}

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -46,6 +46,23 @@ function assertIsNotChecked(wrapper) {
   assert.strictEqual(icon.name(), 'h1');
 }
 
+const shouldSuccessOnce = name => func => () => {
+  global.successOnce = global.successOnce || {};
+
+  if (!global.successOnce[name]) {
+    global.successOnce[name] = false;
+  }
+
+  try {
+    func();
+    global.successOnce[name] = true;
+  } catch (err) {
+    if (!global.successOnce[name]) {
+      throw err;
+    }
+  }
+};
+
 describe('<SwitchBase />', () => {
   let mount;
   let classes;
@@ -440,26 +457,32 @@ describe('<SwitchBase />', () => {
       consoleErrorMock.reset();
     });
 
-    it('should error when uncontrolled and changed to controlled', () => {
-      const wrapper = mount(<SwitchBase {...defaultProps} type="checkbox" />);
-      wrapper.setProps({ checked: true });
+    it(
+      'should error when uncontrolled and changed to controlled',
+      shouldSuccessOnce('didWarnUncontrolledToControlled')(() => {
+        const wrapper = mount(<SwitchBase {...defaultProps} type="checkbox" />);
+        wrapper.setProps({ checked: true });
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.args()[0][0],
-        'A component is changing an uncontrolled input of type %s to be controlled.',
-      );
-    });
+        assert.strictEqual(consoleErrorMock.callCount(), 1);
+        assert.include(
+          consoleErrorMock.args()[0][0],
+          'A component is changing an uncontrolled input of type %s to be controlled.',
+        );
+      }),
+    );
 
-    it('should error when controlled and changed to uncontrolled', () => {
-      const wrapper = mount(<SwitchBase {...defaultProps} type="checkbox" checked={false} />);
-      wrapper.setProps({ checked: undefined });
+    it(
+      'should error when controlled and changed to uncontrolled',
+      shouldSuccessOnce('didWarnControlledToUncontrolled')(() => {
+        const wrapper = mount(<SwitchBase {...defaultProps} type="checkbox" checked={false} />);
+        wrapper.setProps({ checked: undefined });
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.args()[0][0],
-        'A component is changing a controlled input of type %s to be uncontrolled.',
-      );
-    });
+        assert.strictEqual(consoleErrorMock.callCount(), 1);
+        assert.include(
+          consoleErrorMock.args()[0][0],
+          'A component is changing a controlled input of type %s to be uncontrolled.',
+        );
+      }),
+    );
   });
 });

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -7,6 +7,7 @@ import {
   getClasses,
   unwrap,
 } from '@material-ui/core/test-utils';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 import SwitchBase from './SwitchBase';
 import FormControlContext from '../FormControl/FormControlContext';
 import Icon from '../Icon';
@@ -145,7 +146,6 @@ describe('<SwitchBase />', () => {
     );
 
     wrapperA.setProps({ disabled: false });
-    wrapperA.setProps({ checked: true });
 
     assert.strictEqual(
       wrapperA.hasClass(disabledClassName),
@@ -428,6 +428,38 @@ describe('<SwitchBase />', () => {
       wrapper.find('input').simulate('blur');
       assert.strictEqual(handleFocusProps.callCount, 1);
       assert.strictEqual(handleFocusContext.callCount, 1);
+    });
+  });
+
+  describe('check transitioning between controlled states throws errors', () => {
+    beforeEach(() => {
+      consoleErrorMock.spy();
+    });
+
+    afterEach(() => {
+      consoleErrorMock.reset();
+    });
+
+    it('should error when uncontrolled and changed to controlled', () => {
+      const wrapper = mount(<SwitchBase {...defaultProps} type="checkbox" />);
+      wrapper.setProps({ checked: true });
+
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'A component is changing an uncontrolled input of type %s to be controlled.',
+      );
+    });
+
+    it('should error when controlled and changed to uncontrolled', () => {
+      const wrapper = mount(<SwitchBase {...defaultProps} type="checkbox" checked={false} />);
+      wrapper.setProps({ checked: undefined });
+
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'A component is changing a controlled input of type %s to be uncontrolled.',
+      );
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fixes #13710 
- [SwitchBase] Fix error not being thrown when controlled state is changed

- [test] Added regression tests to check errors are thrown when controlled
state is changed