### PR TITLE
[ButtonBase] Add stop ripple on context menu event

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -88,6 +88,8 @@ class ButtonBase extends React.Component {
 
   handleTouchMove = createRippleHandler(this, 'TouchMove', 'stop');
 
+  handleContextMenu = createRippleHandler(this, 'ContextMenu', 'stop');
+
   handleBlur = createRippleHandler(this, 'Blur', 'stop', () => {
     clearTimeout(this.focusVisibleTimeout);
     if (this.state.focusVisible) {
@@ -297,6 +299,7 @@ class ButtonBase extends React.Component {
         onTouchEnd={this.handleTouchEnd}
         onTouchMove={this.handleTouchMove}
         onTouchStart={this.handleTouchStart}
+        onContextMenu={this.handleContextMenu}
         ref={buttonRef}
         tabIndex={disabled ? '-1' : tabIndex}
         {...buttonProps}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

There's a weird interaction with spamming left and right click and the context menu at least in Chrome. Hopefully, this works towards fixing #7537 once and for all :)

@kgregory @gtsafas @stavlocker @oliviertassinari 

Wondering if you can reproduce the issue?