### PR TITLE
[styles] Loosen props consistency check in styled

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@babel/preset-react": "7.0.0",
     "@babel/register": "7.0.0",
     "@types/enzyme": "^3.1.4",
-    "@types/react": "^16.3.14",
+    "@types/react": "^16.7.10",
     "@weco/next-plugin-transpile-modules": "0.0.2",
     "accept-language": "^3.0.18",
     "argos-cli": "^0.0.9",

--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -118,7 +118,7 @@ declare module '@material-ui/styles/makeStyles' {
 }
 
 declare module '@material-ui/styles/styled' {
-  import { ConsistentWith, Omit, PropsOf } from '@material-ui/core';
+  import { Omit, PropsOf } from '@material-ui/core';
   import {
     CSSProperties,
     StyledComponentProps,
@@ -141,9 +141,7 @@ declare module '@material-ui/styles/styled' {
     className: string;
   }
 
-  export default function styled<
-    C extends React.ReactType<ConsistentWith<PropsOf<C>, { className: string }>>
-  >(Component: C): ComponentCreator<C>;
+  export default function styled<C extends React.ReactType>(Component: C): ComponentCreator<C>;
 }
 
 declare module '@material-ui/styles/StylesProvider' {

--- a/packages/material-ui-styles/src/index.spec.tsx
+++ b/packages/material-ui-styles/src/index.spec.tsx
@@ -47,7 +47,7 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
       return <div className={className}>Greeted?: {defaulted.startsWith('Hello')}</div>;
     }
   }
-  const StyledMyComponent = styled<typeof MyComponent>(MyComponent)((theme: MyTheme) => ({
+  const StyledMyComponent = styled(MyComponent)((theme: MyTheme) => ({
     fontFamily: theme.fontFamily,
   }));
   const renderedMyComponent = (
@@ -56,4 +56,10 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
       <StyledMyComponent />
     </>
   );
+
+  // will not catch type mismatch
+  interface ClassNumberProps {
+    className: number;
+  }
+  styled(({ className }: ClassNumberProps) => <div>{className.toFixed(2)}</div>)({});
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,10 +1575,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.3.14":
-  version "16.7.6"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.6.tgz#80e4bab0d0731ad3ae51f320c4b08bdca5f03040"
-  integrity sha512-QBUfzftr/8eg/q3ZRgf/GaDP6rTYc7ZNem+g4oZM38C9vXyV8AWRWaTQuW5yCoZTsfHrN7b3DeEiUnqH9SrnpA==
+"@types/react@*", "@types/react@^16.7.10":
+  version "16.7.10"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.7.10.tgz#a0ebd3af6632d6997506f6d1aac67fed8d0851b0"
+  integrity sha512-8EFSjCFLUA7JJQ6lJ9+9/99urIrdHACwH8GqPlYAPyIjxOkz2snkttOzItwUwXgqc2xg+r/IYW8M1J8WXax7xg==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
The circular constraint was always brittle since it's not actually supported. With the improved typechecking for `ReactType` from DefinitelyTyped/DefinitelyTyped#30764 typescript is no longer able to determine the valid intrinsic elements.