### PR TITLE
[Avatar] Remove truthiness check on childrenProp

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -54,7 +54,7 @@ function Avatar(props) {
   const className = classNames(
     classes.root,
     {
-      [classes.colorDefault]: childrenProp && !src && !srcSet,
+      [classes.colorDefault]: !src && !srcSet,
     },
     classNameProp,
   );

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -20,7 +20,6 @@ export const styles = theme => ({
     userSelect: 'none',
   },
   /* Styles applied to the root element if there are children and not `src` or `srcSet` */
-  /* Styles applied to the root element if `color="default"`. */
   colorDefault: {
     color: theme.palette.background.default,
     backgroundColor:
@@ -51,16 +50,10 @@ function Avatar(props) {
     ...other
   } = props;
 
-  const className = classNames(
-    classes.root,
-    {
-      [classes.colorDefault]: !src && !srcSet,
-    },
-    classNameProp,
-  );
   let children = null;
+  const img = src || srcSet;
 
-  if (src || srcSet) {
+  if (img) {
     children = (
       <img
         alt={alt}
@@ -80,7 +73,16 @@ function Avatar(props) {
   }
 
   return (
-    <Component className={className} {...other}>
+    <Component
+      className={classNames(
+        classes.root,
+        {
+          [classes.colorDefault]: !img,
+        },
+        classNameProp,
+      )}
+      {...other}
+    >
       {children}
     </Component>
   );

--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -134,4 +134,31 @@ describe('<Avatar />', () => {
       assert.strictEqual(wrapper.hasClass(classes.colorDefault), true);
     });
   });
+
+  describe('falsey avatar', () => {
+    let wrapper;
+
+    before(() => {
+      wrapper = shallow(
+        <Avatar className="my-avatar" data-my-prop="woofAvatar">
+          {0}
+        </Avatar>,
+      );
+    });
+
+    it('should render with defaultColor class when supplied with a child with falsey value', () => {
+      assert.strictEqual(wrapper.name(), 'div');
+      assert.strictEqual(wrapper.text(), '0');
+    });
+
+    it('should merge user classes & spread custom props to the root node', () => {
+      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      assert.strictEqual(wrapper.hasClass('my-avatar'), true);
+      assert.strictEqual(wrapper.props()['data-my-prop'], 'woofAvatar');
+    });
+
+    it('should apply the colorDefault class', () => {
+      assert.strictEqual(wrapper.hasClass(classes.colorDefault), true);
+    });
+  });
 });

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -38,7 +38,7 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">colorDefault</span> | Styles applied to the root element if `color="default"`.
+| <span class="prop-name">colorDefault</span> | Styles applied to the root element if there are children and not `src` or `srcSet`
 | <span class="prop-name">img</span> | Styles applied to the img element if either `src` or `srcSet` is defined.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section


### PR DESCRIPTION
to ensure defaultColor class application if no image is supplied

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #13751