### PR TITLE
[docs] Simplify demos loading & error fallback

### DIFF
--- a/docs/src/modules/utils/MissingTranslation.md
+++ b/docs/src/modules/utils/MissingTranslation.md
@@ -1,0 +1,3 @@
+# Missing Page
+
+<p class="description">The translation is probably missing.</p>

--- a/docs/src/modules/utils/requireMarkdown.js
+++ b/docs/src/modules/utils/requireMarkdown.js
@@ -1,0 +1,14 @@
+/**
+ * requires the given path with a MissingTranslation fallback
+ *
+ * @param {Require.Context} req webpack require.context
+ * @param {string} path
+ */
+export default function requireMarkdown(req, path) {
+  try {
+    return req(path);
+  } catch (error) {
+    /* eslint-disable-next-line global-require */
+    return require('./MissingTranslation.md');
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -299,7 +299,15 @@ function findActivePage(currentPages, router) {
   return activePage;
 }
 
+function ErrorFallback() {
+  return <h1>Whoops</h1>;
+}
+
 class MyApp extends App {
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
   constructor(props) {
     super();
     this.redux = initRedux(props.reduxServerState || {});
@@ -307,6 +315,7 @@ class MyApp extends App {
   }
 
   state = {
+    hasError: false,
     userLanguage: 'en',
   };
 
@@ -338,7 +347,11 @@ class MyApp extends App {
 
   render() {
     const { Component, pageProps, router } = this.props;
-    const { userLanguage } = this.state;
+    const { hasError, userLanguage } = this.state;
+
+    if (hasError) {
+      return <ErrorFallback />;
+    }
 
     let pathname = router.pathname;
     if (pathname !== '/') {

--- a/pages/css-in-js/api.js
+++ b/pages/css-in-js/api.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import withRoot from 'docs/src/modules/components/withRoot';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import requireMarkdown from 'docs/src/modules/utils/requireMarkdown';
 
 const req = require.context('markdown', true, /.md$/);
 
 function Page(props) {
-  return <MarkdownDocs markdown={req(`./api${props.lang}.md`)} />;
+  return <MarkdownDocs markdown={requireMarkdown(req, `./api${props.lang}.md`)} />;
 }
 
 export default withRoot(Page);


### PR DESCRIPTION
Just something quickly thrown together. Currently whenever the markdown is missing for a page the hole page crashes i.e. unmounts. This PR includes a fallback.

This is mainly aimed at missing translations e.g. https://material-ui.com/css-in-js/api/?lang=zh which will fallback like this: https://deploy-preview-13765--material-ui.netlify.com/css-in-js/api/?lang=zh

Error boundary: https://deploy-preview-13765--material-ui.netlify.com/css-in-js/basics/?lang=zh