### PR TITLE
[core] Remove unused lint directives

### DIFF
--- a/docs/src/modules/components/HomeSteps.js
+++ b/docs/src/modules/components/HomeSteps.js
@@ -7,7 +7,7 @@ import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
 import FileDownloadIcon from '@material-ui/docs/svgIcons/FileDownload';
-import BuildIcon from '@material-ui/icons/Build'; // eslint-disable-line import/no-unresolved
+import BuildIcon from '@material-ui/icons/Build';
 import WhatshotIcon from '@material-ui/icons/Whatshot';
 import MarkdownElement from '@material-ui/docs/MarkdownElement';
 import NoSsr from '@material-ui/core/NoSsr';

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -34,7 +34,6 @@ class ThemeDefault extends React.Component {
       return;
     }
 
-    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({
       expandPaths: expandPath.split('.').reduce((acc, path) => {
         const last = acc.length > 0 ? `${acc[acc.length - 1]}.` : '';

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-multi-comp */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';

--- a/docs/src/pages/demos/dialogs/SimpleDialog.js
+++ b/docs/src/pages/demos/dialogs/SimpleDialog.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-multi-comp */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';

--- a/docs/src/pages/demos/text-fields/FormattedInputs.js
+++ b/docs/src/pages/demos/text-fields/FormattedInputs.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/prefer-stateless-function */
-
 import React from 'react';
 import MaskedInput from 'react-text-mask';
 import NumberFormat from 'react-number-format';

--- a/docs/src/pages/utils/popover/MouseOverPopover.js
+++ b/docs/src/pages/utils/popover/MouseOverPopover.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/mouse-events-have-key-events */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import Popover from '@material-ui/core/Popover';

--- a/docs/src/pages/versions/StableVersions.js
+++ b/docs/src/pages/versions/StableVersions.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-did-mount-set-state */
-
 import 'isomorphic-fetch';
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/examples/gatsby/gatsby-browser.js
+++ b/examples/gatsby/gatsby-browser.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/prop-types, import/prefer-default-export */
-
 // It's not ready yet: https://github.com/gatsbyjs/gatsby/issues/8237.
 //
 // import React from 'react';

--- a/examples/gatsby/gatsby-ssr.js
+++ b/examples/gatsby/gatsby-ssr.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/prop-types, react/no-danger */
+/* eslint-disable react/no-danger */
 
 const React = require('react');
 const { renderToString } = require('react-dom/server');

--- a/examples/gatsby/src/pages/about.js
+++ b/examples/gatsby/src/pages/about.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';

--- a/examples/gatsby/src/pages/index.js
+++ b/examples/gatsby/src/pages/index.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "docs:deploy": "git push material-ui-docs master:latest",
     "jsonlint": "yarn --silent jsonlint:files | xargs -n1 jsonlint -q -c && echo \"jsonlint: no lint errors\"",
     "jsonlint:files": "find . -name \"*.json\" | grep -v -f .eslintignore",
-    "lint": "eslint . --cache && echo \"eslint: no lint errors\"",
+    "lint": "eslint . --cache --report-unused-disable-directives && echo \"eslint: no lint errors\"",
     "lint:fix": "eslint . --cache --fix && echo \"eslint: no lint errors\"",
     "prettier": "yarn babel-node ./scripts/prettier.js",
     "prettier:all": "yarn babel-node ./scripts/prettier.js write",

--- a/packages/material-ui-styles/src/createGenerateClassName.js
+++ b/packages/material-ui-styles/src/createGenerateClassName.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 import warning from 'warning';
 
 const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;

--- a/packages/material-ui-styles/src/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';

--- a/packages/material-ui-utils/src/exactProp.js
+++ b/packages/material-ui-utils/src/exactProp.js
@@ -13,7 +13,6 @@ function exactProp(propTypes) {
 
   return {
     ...propTypes,
-    // eslint-disable-next-line prefer-arrow-callback
     [specialProperty]: props => {
       const unsupportedProps = Object.keys(props).filter(prop => !propTypes.hasOwnProperty(prop));
       if (unsupportedProps.length > 0) {

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/label-has-for */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -134,7 +134,6 @@ describe('<FormControlLabel />', () => {
   });
 
   it('should not inject extra properties', () => {
-    // eslint-disable-next-line react/prop-types
     const Control = ({ inputRef, ...props }) => <div name="name" {...props} />;
     const wrapper = mount(<FormControlLabel label="Pizza" control={<Control />} />);
     assert.strictEqual(wrapper.find('div').props().name, 'name');

--- a/packages/material-ui/src/Modal/manageAriaHidden.js
+++ b/packages/material-ui/src/Modal/manageAriaHidden.js
@@ -5,7 +5,7 @@ function isHidable(node) {
 }
 
 function siblings(container, mount, currentNode, callback) {
-  const blacklist = [mount, currentNode]; // eslint-disable-line no-param-reassign
+  const blacklist = [mount, currentNode];
 
   [].forEach.call(container.children, node => {
     if (blacklist.indexOf(node) === -1 && isHidable(node)) {

--- a/packages/material-ui/src/NoSsr/NoSsr.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.js
@@ -34,7 +34,7 @@ class NoSsr extends React.Component {
         });
       });
     } else {
-      this.setState({ mounted: true }); // eslint-disable-line react/no-did-mount-set-state
+      this.setState({ mounted: true });
     }
   }
 

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -83,7 +83,6 @@ class Tabs extends React.Component {
   };
 
   componentDidMount() {
-    // eslint-disable-next-line react/no-did-mount-set-state
     this.setState({ mounted: true });
     this.updateIndicatorState(this.props);
     this.updateScrollButtonState();

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';

--- a/packages/material-ui/src/styles/createGenerateClassName.js
+++ b/packages/material-ui/src/styles/createGenerateClassName.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-underscore-dangle */
-
 import warning from 'warning';
 
 const escapeRegex = /([[\].#*$><+~=|^:(),"'`\s])/g;

--- a/packages/material-ui/src/styles/transitions.js
+++ b/packages/material-ui/src/styles/transitions.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-param-reassign */
 /* eslint-disable no-restricted-globals */
 
 import warning from 'warning';

--- a/packages/material-ui/src/utils/reactHelpers.js
+++ b/packages/material-ui/src/utils/reactHelpers.js
@@ -1,5 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-
 import React from 'react';
 import classNames from 'classnames';
 

--- a/packages/material-ui/src/withWidth/withWidth.js
+++ b/packages/material-ui/src/withWidth/withWidth.js
@@ -1,5 +1,3 @@
-/* eslint-disable react/no-did-mount-set-state */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import EventListener from 'react-event-listener';


### PR DESCRIPTION
- removes unused lint directives
- `yarn lint` now checks for unused lint directives and errors out if it finds some via `eslint` cli option [report-unused-disable-directives](https://eslint.org/docs/user-guide/command-line-interface#options)