### PR TITLE
[docs] Position of FAB changed to 'fixed'

### DIFF
--- a/docs/src/pages/demos/buttons/FloatingActionButtonZoom.js
+++ b/docs/src/pages/demos/buttons/FloatingActionButtonZoom.js
@@ -37,7 +37,7 @@ const styles = theme => ({
     minHeight: 200,
   },
   fab: {
-    position: 'absolute',
+    position: 'fixed',
     bottom: theme.spacing.unit * 2,
     right: theme.spacing.unit * 2,
   },


### PR DESCRIPTION
I copied FAB from this page, used in my project, and I noticed some weird behavior while scrolling page: FAB was also moving when it was supposed to stay fixed. That was due to its position property. Although this is a subtle change, and I know changing its position from `absolute` to `fixed` doesn't make any sense in given doc example, this change will prevent similar cases to happen on longer pages in the future. Additionally, I believe this is correct way of using FAB.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
