### PR TITLE
[DialogContent] should be padded 24px on all sides

### DIFF
--- a/packages/material-ui/src/DialogContent/DialogContent.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.js
@@ -9,10 +9,7 @@ export const styles = {
     flex: '1 1 auto',
     overflowY: 'auto',
     WebkitOverflowScrolling: 'touch', // Add iOS momentum scrolling.
-    padding: '0 24px 24px',
-    '&:first-child': {
-      paddingTop: 24,
-    },
+    padding: 24,
   },
 };
 


### PR DESCRIPTION
`:first-child` selector does not work on class-based selectors https://stackoverflow.com/a/8539107/2363935

The following screenshot illustrates the problem, showing that the first-child does not receive the expected `24px` top padding.

![dialog-content](https://user-images.githubusercontent.com/136564/49391639-dc65a400-f6f1-11e8-9317-f83fc5f4bc5f.png)

Since this component is quite simple, and the highest (higher than 80%) use-case is going to be a single `DialogContent` inside a `Dialog`, the fix is quite simple.  For those that want custom padding/multiples, the answer is to simply customize their own `div` (or override the classes to `DialogContent`), as this component is already quite simple. 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
