### PR TITLE
[TextField] Fix textfield label position when empty

### DIFF
--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -54,9 +54,9 @@ export const styles = theme => ({
     // zIndex: 1 will raise the label above opaque background-colors of input.
     zIndex: 1,
     pointerEvents: 'none',
-    transform: 'translate(12px, 29px) scale(1)',
+    transform: 'translate(12px, 20px) scale(1)',
     '&$marginDense': {
-      transform: 'translate(12px, 25px) scale(1)',
+      transform: 'translate(12px, 17px) scale(1)',
     },
     '&$shrink': {
       transform: 'translate(12px, 10px) scale(0.75)',

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -54,9 +54,9 @@ export const styles = theme => ({
     // zIndex: 1 will raise the label above opaque background-colors of input.
     zIndex: 1,
     pointerEvents: 'none',
-    transform: 'translate(12px, 22px) scale(1)',
+    transform: 'translate(12px, 29px) scale(1)',
     '&$marginDense': {
-      transform: 'translate(12px, 19px) scale(1)',
+      transform: 'translate(12px, 25px) scale(1)',
     },
     '&$shrink': {
       transform: 'translate(12px, 10px) scale(0.75)',
@@ -70,9 +70,9 @@ export const styles = theme => ({
     // see comment above on filled.zIndex
     zIndex: 1,
     pointerEvents: 'none',
-    transform: 'translate(14px, 22px) scale(1)',
+    transform: 'translate(14px, 20px) scale(1)',
     '&$marginDense': {
-      transform: 'translate(14px, 17.5px) scale(1)',
+      transform: 'translate(14px, 17px) scale(1)',
     },
     '&$shrink': {
       transform: 'translate(14px, -6px) scale(0.75)',

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -31,7 +31,7 @@ export const styles = theme => {
     legend: {
       textAlign: 'left',
       padding: 0,
-      lineHeight: '10px',
+      lineHeight: '11px',
       transition: theme.transitions.create('width', {
         duration: theme.transitions.duration.shorter,
         easing: theme.transitions.easing.easeOut,


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fixes #13735 for both the outlined and filled variants of the TextField.