### PR TITLE
Fixed typings for makeStyles return function

### DIFF
--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -114,7 +114,7 @@ declare module '@material-ui/styles/makeStyles' {
   export default function makeStyles<S extends Styles<any, any>>(
     styles: S,
     options?: WithStylesOptions<ClassKeyOfStyles<S>>,
-  ): (props: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
+  ): (props?: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
 }
 
 declare module '@material-ui/styles/styled' {


### PR DESCRIPTION
Return function accepts optional `props` argument. Fixed TS typings. See https://github.com/mui-org/material-ui/blob/master/packages/material-ui-styles/src/makeStyles.js#L30

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
