### PR TITLE
[SelectInput] make typescript value typing required

### DIFF
--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -23,7 +23,7 @@ export interface SelectInputProps {
   renderValue?: (value: SelectInputProps['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
   tabIndex?: number;
-  value?: string | number | boolean | Array<string | number | boolean>;
+  value: string | number | boolean | Array<string | number | boolean>;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Correct the typing of  `SelectInput` component, `value` prop.

The typing should not be optional as it's a required one listed in the component `propTypes`.

Issue raised #13809 .

