### PR TITLE
[styles] Infer optional props argument for makeStyles in TypeScript

### DIFF
--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -111,10 +111,24 @@ declare module '@material-ui/styles/makeStyles' {
     WithStylesOptions,
   } from '@material-ui/styles/withStyles';
 
+  // https://stackoverflow.com/a/49928360/3406963 without generic branch types
+  type IsAny<T> = 0 extends (1 & T) ? true : false;
+
+  /**
+   * @internal
+   *
+   * `Props` are `any` either by explicit annotation or if there are no callbacks
+   * from which the typechecker could infer a type so it falls back to `any`.
+   * See the test cases for examples and implications of explicit `any` annotation
+   */
+  export type StylesHook<S extends Styles<any, any>> = IsAny<PropsOfStyles<S>> extends true
+    ? (props?: any) => ClassNameMap<ClassKeyOfStyles<S>>
+    : (props: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
+
   export default function makeStyles<S extends Styles<any, any>>(
     styles: S,
     options?: WithStylesOptions<ClassKeyOfStyles<S>>,
-  ): (props: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
+  ): StylesHook<S>;
 }
 
 declare module '@material-ui/styles/styled' {
@@ -200,9 +214,10 @@ declare module '@material-ui/styles/withStyles' {
    * @internal
    * This is basically the API of JSS. It defines a Map<string, CSS>,
    * where
-   *
    * - the `keys` are the class (names) that will be created
    * - the `values` are objects that represent CSS rules (`React.CSSProperties`).
+   *
+   * if only `CSSProperties` are matched `Props` are inferred to `any`
    */
   export type StyleRules<Props extends object, ClassKey extends string = string> = Record<
     ClassKey,

--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -119,7 +119,23 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
   );
   const NoPropsComponent = () => {
     const classes = useWithoutProps();
-    const alssoClasses = useWithoutProps({});
+    const alsoClasses = useWithoutProps(5);
+  };
+
+  // unsafe any props make the param optional
+  const useUnsafeProps = makeStyles(
+    createStyles({
+      root: (props: any) => ({
+        backgroundColor: props.deep.color,
+      }),
+    }),
+  );
+
+  const UnsafeProps = (props: StyleProps) => {
+    // would be nice to have at least a compile time error because we forgot the argument
+    const classes = useUnsafeProps(); // runtime: Can't read property color of undefined
+    // but this would pass anyway
+    const alsoClasses = useUnsafeProps(undefined); // runtime: Can't read property color of undefined
   };
 }
 

--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -83,6 +83,8 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
 
   const MyComponent = (props: MyComponentProps) => {
     const { color, message } = props;
+    // Expected 1 argument, but got 0
+    const emptyClasses = useMyStyles(); // $ExpectError
     const classes = useMyStyles(props);
     // $ExpectError
     const invalidClasses = useMyStyles({ colourTypo: 'red' });
@@ -106,6 +108,19 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
     // Property 'toot' does not exist on type 'Record<"root", string>'
     generateClassName: (_, sheet) => (sheet ? sheet.classes.toot : 'no-sheet'), // $ExpectError
   });
+
+  // optional props
+  const useWithoutProps = makeStyles((theme: Theme) =>
+    createStyles({
+      root: {
+        background: 'none',
+      },
+    }),
+  );
+  const NoPropsComponent = () => {
+    const classes = useWithoutProps();
+    const alssoClasses = useWithoutProps({});
+  };
 }
 
 // styled


### PR DESCRIPTION
Continues #13801.

Enables omission of the props argument in the returned hook function if no props are referenced in the styles argument for `makeStyles`.

Whenever the typechecker infers that the type of the props is `any` we make the argument optional. If people would explicitly annotate the props used in `makeStyles` then they could've already passed `undefined`. 

