### PR TITLE
[docs] Force common hoist-non-react-statics version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ jobs:
     # This isn't user facing code.
     # Let's take advantage of the most up to date node version.
     docker:
-      - image: circleci/node:9.10
+      - image: circleci/node:10.14
     steps:
       - checkout
       - *restore_yarn_offline_mirror
@@ -199,7 +199,7 @@ jobs:
   test_regressions:
     <<: *defaults
     docker:
-      - image: circleci/node:9.10
+      - image: circleci/node:10.14
       - image: selenium/standalone-chrome:3.11.0
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /tmp/material-ui
   docker:
-    - image: circleci/node:9.10
+    - image: circleci/node:10.14
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.

--- a/docs/src/pages/demos/tables/CustomizedTable.js
+++ b/docs/src/pages/demos/tables/CustomizedTable.js
@@ -16,7 +16,7 @@ const CustomTableCell = withStyles(theme => ({
   body: {
     fontSize: 14,
   },
-}))(props => <TableCell {...props} />);
+}))(TableCell);
 
 const styles = theme => ({
   root: {

--- a/package.json
+++ b/package.json
@@ -172,6 +172,9 @@
     "webpack-cli": "^3.1.0",
     "workbox-build": "^3.6.3"
   },
+  "resolutions": {
+    "**/hoist-non-react-statics": "^3.2.1"
+  },
   "sideEffects": false,
   "nyc": {
     "include": [

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -40,7 +40,7 @@
     "@material-ui/utils": "^3.0.0-alpha.0",
     "classnames": "^2.2.5",
     "deepmerge": "^2.0.1",
-    "hoist-non-react-statics": "^3.0.0",
+    "hoist-non-react-statics": "^3.2.1",
     "jss": "^9.3.3",
     "jss-camel-case": "^6.0.0",
     "jss-default-unit": "^8.0.2",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -45,7 +45,7 @@
     "debounce": "^1.1.0",
     "deepmerge": "^2.0.1",
     "dom-helpers": "^3.2.1",
-    "hoist-non-react-statics": "^3.0.0",
+    "hoist-non-react-statics": "^3.2.1",
     "is-plain-object": "^2.0.4",
     "jss": "^9.3.3",
     "jss-camel-case": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6893,15 +6893,10 @@ hoek@4.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
 
-hoist-non-react-statics@2.5.5, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
-
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.1.0.tgz#42414ccdfff019cd2168168be998c7b3bd5245c0"
-  integrity sha512-MYcYuROh7SBM69xHGqXEwQqDux34s9tz+sCnxJmN18kgWh6JFdTw/5YdZtqsOdZJXddE/wUpCzfEdDrJj8p0Iw==
+hoist-non-react-statics@2.5.5, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
+  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
   dependencies:
     react-is "^16.3.2"
 


### PR DESCRIPTION
TL;DR:
- use node lts docker image in CI 
  `yarn@1.5.1` removed the integrity checksums. The new image uses the latest yarn version
- use resolutions field to force consistent hnrs version
- bump hnrs version in our packages 

Force a single version of `hoist-non-react-statics` by using the [`resolutions` field and `yarn`](https://yarnpkg.com/lang/en/docs/selective-version-resolutions/). This should get rid of all issues concerning hoisting statics and `forwardRef`.

I also bumped the version of hnrs in our `package.json` so that the fixes are propagated faster. I think if somebody upgrades our version he doesn't necessarily upgrade transitive dependencies.

One caveat with `resolutions` is that it seems to be ignored if I add a package to a workspace. Running `yarn` will fix that.

Closes #13776