### PR TITLE
[Input] Make CSS override a bit simpler

### DIFF
--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -63,10 +63,10 @@ export const styles = theme => {
         pointerEvents: 'none', // Transparent to the hover style.
       },
       '&:hover:not($disabled):not($focused):not($error):before': {
-        borderBottomWidth: '2px',
+        borderBottom: `2px solid ${theme.palette.text.primary}`,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
-          borderBottom: '1px',
+          borderBottom: `1px solid ${bottomLineColor}`,
         },
       },
       '&$disabled:before': {

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -63,14 +63,14 @@ export const styles = theme => {
         pointerEvents: 'none', // Transparent to the hover style.
       },
       '&:hover:not($disabled):not($focused):not($error):before': {
-        borderBottom: `2px solid ${theme.palette.text.primary}`,
+        borderBottomWidth: '2px',
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
-          borderBottom: `1px solid ${bottomLineColor}`,
+          borderBottom: '1px',
         },
       },
       '&$disabled:before': {
-        borderBottom: `1px dotted ${bottomLineColor}`,
+        borderBottomStyle: 'dotted',
       },
     },
     /* Styles applied to the root element if `error={true}`. */


### PR DESCRIPTION
It's hard to change the color of Input underline because it's a complex selector to override.

If this selector only change `borderBottomWidth` and `borderBottomStyle` separately, we will just need to change the `&:before`

### From
<img width="539" alt="screen shot 2018-12-05 at 7 12 36 pm" src="https://user-images.githubusercontent.com/557598/49544719-b7745b00-f8c2-11e8-9a31-59151ad9a8a2.png">

### To
<img width="464" alt="screen shot 2018-12-05 at 7 20 02 pm" src="https://user-images.githubusercontent.com/557598/49544748-ca872b00-f8c2-11e8-876e-6e662e4c60e6.png">


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
