### PR TITLE
[Tooltip.d.ts] Remove className attribute

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { TransitionProps } from '../transitions/transition';
 
 export interface TooltipProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title'> {
+  extends Omit<StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title'>, 'className'> {
   children: React.ReactElement<any>;
   disableFocusListener?: boolean;
   disableHoverListener?: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

According to the doc, `className` is no longer supported, so it should be removed from the typescript definition as well.