### PR TITLE
[Table] Avoid unnecessary re-rendering

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of the @material-ui/core modules',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '94.9 KB',
+    limit: '95.1 KB',
   },
   {
     name: 'The size of the @material-ui/styles modules',

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { shallowEqual } from 'recompose';
 import withStyles from '../styles/withStyles';
 import TableContext from './TableContext';
 
@@ -20,8 +19,15 @@ class Table extends React.Component {
   memoizedContextValue = {};
 
   getMemoizedContextValue(contextValue) {
-    if (!shallowEqual(contextValue, this.memoizedContextValue)) {
-      this.memoizedContextValue = contextValue;
+    const objectKeys = Object.keys(contextValue);
+
+    for (let i = 0; i < objectKeys.length; i++) {
+      const objectKey = objectKeys[i];
+
+      if (contextValue[objectKey] !== this.memoizedContextValue[objectKey]) {
+        this.memoizedContextValue = contextValue;
+        break;
+      }
     }
     return this.memoizedContextValue;
   }

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -21,7 +21,7 @@ class Table extends React.Component {
   getMemoizedContextValue(contextValue) {
     const objectKeys = Object.keys(contextValue);
 
-    for (let i = 0; i < objectKeys.length; i++) {
+    for (let i = 0; i < objectKeys.length; i += 1) {
       const objectKey = objectKeys[i];
 
       if (contextValue[objectKey] !== this.memoizedContextValue[objectKey]) {

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { shallowEqual } from 'recompose';
 import withStyles from '../styles/withStyles';
 import TableContext from './TableContext';
 
@@ -15,14 +16,25 @@ export const styles = theme => ({
   },
 });
 
-function Table(props) {
-  const { classes, className, component: Component, padding, ...other } = props;
+class Table extends React.Component {
+  memoizedContextValue = {};
 
-  return (
-    <TableContext.Provider value={{ padding }}>
-      <Component className={classNames(classes.root, className)} {...other} />
-    </TableContext.Provider>
-  );
+  getMemoizedContextValue(contextValue) {
+    if (!shallowEqual(contextValue, this.memoizedContextValue)) {
+      this.memoizedContextValue = contextValue;
+    }
+    return this.memoizedContextValue;
+  }
+
+  render() {
+    const { classes, className, component: Component, padding, ...other } = this.props;
+
+    return (
+      <TableContext.Provider value={this.getMemoizedContextValue({ padding })}>
+        <Component className={classNames(classes.root, className)} {...other} />
+      </TableContext.Provider>
+    );
+  }
 }
 
 Table.propTypes = {

--- a/packages/material-ui/src/Table/Table.js
+++ b/packages/material-ui/src/Table/Table.js
@@ -18,7 +18,9 @@ export const styles = theme => ({
 class Table extends React.Component {
   memoizedContextValue = {};
 
-  getMemoizedContextValue(contextValue) {
+  // To replace with the corresponding Hook once Material-UI v4.0.0 is out:
+  // https://reactjs.org/docs/hooks-reference.html#usememo
+  useMemo(contextValue) {
     const objectKeys = Object.keys(contextValue);
 
     for (let i = 0; i < objectKeys.length; i += 1) {
@@ -36,7 +38,7 @@ class Table extends React.Component {
     const { classes, className, component: Component, padding, ...other } = this.props;
 
     return (
-      <TableContext.Provider value={this.getMemoizedContextValue({ padding })}>
+      <TableContext.Provider value={this.useMemo({ padding })}>
         <Component className={classNames(classes.root, className)} {...other} />
       </TableContext.Provider>
     );

--- a/packages/material-ui/src/TableBody/TableBody.js
+++ b/packages/material-ui/src/TableBody/TableBody.js
@@ -11,11 +11,13 @@ export const styles = {
   },
 };
 
+const contextValue = { variant: 'body' };
+
 function TableBody(props) {
   const { classes, className, component: Component, ...other } = props;
 
   return (
-    <Tablelvl2Context.Provider value={{ variant: 'body' }}>
+    <Tablelvl2Context.Provider value={contextValue}>
       <Component className={classNames(classes.root, className)} {...other} />
     </Tablelvl2Context.Provider>
   );

--- a/packages/material-ui/src/TableFooter/TableFooter.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.js
@@ -11,11 +11,13 @@ export const styles = {
   },
 };
 
+const contextValue = { variant: 'footer' };
+
 function TableFooter(props) {
   const { classes, className, component: Component, ...other } = props;
 
   return (
-    <Tablelvl2Context.Provider value={{ variant: 'footer' }}>
+    <Tablelvl2Context.Provider value={contextValue}>
       <Component className={classNames(classes.root, className)} {...other} />
     </Tablelvl2Context.Provider>
   );

--- a/packages/material-ui/src/TableHead/TableHead.js
+++ b/packages/material-ui/src/TableHead/TableHead.js
@@ -11,11 +11,13 @@ export const styles = {
   },
 };
 
+const contextValue = { variant: 'head' };
+
 function TableHead(props) {
   const { classes, className, component: Component, ...other } = props;
 
   return (
-    <Tablelvl2Context.Provider value={{ variant: 'head' }}>
+    <Tablelvl2Context.Provider value={contextValue}>
       <Component className={classNames(classes.root, className)} {...other} />
     </Tablelvl2Context.Provider>
   );


### PR DESCRIPTION
Please consider this or similar change to improve performance of table re-rendering.
Before this change all table cells are going to re-render no matter the content of the cell changes or not. This improvement has big impact on frequently updating tables where only few cells changes.
See also: https://reactjs.org/docs/context.html#caveats

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
