### PR TITLE
[Dialog] Add missing TypeScript style rule

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -21,6 +21,7 @@ export type DialogClassKey =
   | 'root'
   | 'scrollPaper'
   | 'scrollBody'
+  | 'container'
   | 'paper'
   | 'paperScrollPaper'
   | 'paperScrollBody'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Tried to use my own CSS class for the Dialog container and noticed the type definition was missing "container". The [docs](https://material-ui.com/api/dialog/#css-api) confirm it should be there.
