### PR TITLE
[Menu] Add reason value and update documentation for on close reason

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -260,6 +260,7 @@ Dialog.propTypes = {
    * Callback fired when the component requests to be closed.
    *
    * @param {object} event The event source of the callback
+   * @param {string} reason Can be:`"escapeKeyDown"`, `"backdropClick"`
    */
   onClose: PropTypes.func,
   /**

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -88,7 +88,7 @@ class Menu extends React.Component {
       event.preventDefault();
 
       if (this.props.onClose) {
-        this.props.onClose(event);
+        this.props.onClose(event, 'tabKeydown');
       }
     }
   };
@@ -161,6 +161,7 @@ Menu.propTypes = {
    * Callback fired when the component requests to be closed.
    *
    * @param {object} event The event source of the callback
+   * @param {string} reason Can be:`"escapeKeyDown"`, `"backdropClick"`, `"tabKeydown"`
    */
   onClose: PropTypes.func,
   /**

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -444,6 +444,7 @@ Popover.propTypes = {
    * Callback fired when the component requests to be closed.
    *
    * @param {object} event The event source of the callback.
+   * @param {string} reason Can be:`"escapeKeyDown"`, `"backdropClick"`
    */
   onClose: PropTypes.func,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Add `reason` value to `Menu` component `onClose` function
* Add documentation about the `reason` value for `Menu`, `Dialog` and `Popover`

Closes https://github.com/mui-org/material-ui/issues/13833