### PR TITLE
Remark that ThemeProvider from /styles is needed

### DIFF
--- a/docs/src/pages/css-in-js/basics/basics.md
+++ b/docs/src/pages/css-in-js/basics/basics.md
@@ -48,6 +48,7 @@ install();
 
 It is **recommended** to place the above code in a separate file (e.g. `bootstrap.js`) and to import it in your application's entry point (e.g. `index.js`).
 This ensures that the installation is executed before anything else, because ECMAScript imports are hoisted to the top of the module. If the installation step is not performed correctly the resulting build could have conflicting class names.
+Also remember wrapping your Component Tree with the `ThemeProvider` that is provided by `@material-ui/styles` as it is not the same as the one from `@material-ui/core`.
 
 We will make `@material-ui/styles` the default style implementation for the core components in Material-UI v4. This installation step is **temporary**.
 Behind the scenes, the `install()` function switches the styling engine the core components use.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
I stumbled upon this when I implemented `@material-ui/styles`.
Just to clarify its usage, a short heads-up about the additional ThemeProvider would be useful.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
