### PR TITLE
Update dialogs.md to use fullScreen

### DIFF
--- a/docs/src/pages/demos/dialogs/dialogs.md
+++ b/docs/src/pages/demos/dialogs/dialogs.md
@@ -70,8 +70,8 @@ here is one example of how you can customize the `DialogTitle` to support a clos
 
 ## Optional sizes
 
-You can set a dialog maximum width by using the `maxWidth` enumerable in combination with the `fullWidth` boolean.
-When the `fullWidth` property is true, the dialog will adapt based on the `maxWidth` value.
+You can set a dialog maximum width by using the `maxWidth` enumerable in combination with the `fullScreen` boolean.
+When the `fullScreen` property is true, the dialog will adapt based on the `maxWidth` value.
 
 {{"demo": "pages/demos/dialogs/MaxWidthDialog.js"}}
 


### PR DESCRIPTION
Property is not called `fullWidth`, but rather `fullScreen`.  Update dailogs.md to reflect this.

https://github.com/mui-org/material-ui/blob/7c074a73c9a185b98d0bca440a34fdd2617fd4c4/docs/src/pages/demos/dialogs/FullScreenDialog.js#L51

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
