### PR TITLE
[Dialog] Allow use of custom className under PaperProps

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -153,15 +153,13 @@ class Dialog extends React.Component {
       onExiting,
       open,
       PaperComponent,
-      PaperProps,
+      PaperProps = {},
       scroll,
       TransitionComponent,
       transitionDuration,
       TransitionProps,
       ...other
     } = this.props;
-
-    const { className: customPaperClassName, ...otherPaperProps } = PaperProps;
 
     return (
       <Modal
@@ -198,6 +196,7 @@ class Dialog extends React.Component {
           >
             <PaperComponent
               elevation={24}
+              {...PaperProps}
               className={classNames(
                 classes.paper,
                 classes[`paperScroll${capitalize(scroll)}`],
@@ -206,9 +205,8 @@ class Dialog extends React.Component {
                   [classes.paperFullScreen]: fullScreen,
                   [classes.paperFullWidth]: fullWidth,
                 },
-                customPaperClassName,
+                PaperProps.className,
               )}
-              {...otherPaperProps}
             >
               {children}
             </PaperComponent>

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -11,7 +11,6 @@ import { capitalize } from '../utils/helpers';
 import Modal from '../Modal';
 import Fade from '../Fade';
 import { duration } from '../styles/transitions';
-import chainPropTypes from '../utils/chainPropTypes';
 import Paper from '../Paper';
 
 export const styles = theme => ({
@@ -162,6 +161,8 @@ class Dialog extends React.Component {
       ...other
     } = this.props;
 
+    const { className: customPaperClassName, ...otherPaperProps } = PaperProps;
+
     return (
       <Modal
         className={classNames(classes.root, className)}
@@ -197,12 +198,17 @@ class Dialog extends React.Component {
           >
             <PaperComponent
               elevation={24}
-              className={classNames(classes.paper, classes[`paperScroll${capitalize(scroll)}`], {
-                [classes[`paperWidth${maxWidth ? capitalize(maxWidth) : ''}`]]: maxWidth,
-                [classes.paperFullScreen]: fullScreen,
-                [classes.paperFullWidth]: fullWidth,
-              })}
-              {...PaperProps}
+              className={classNames(
+                classes.paper,
+                classes[`paperScroll${capitalize(scroll)}`],
+                {
+                  [classes[`paperWidth${maxWidth ? capitalize(maxWidth) : ''}`]]: maxWidth,
+                  [classes.paperFullScreen]: fullScreen,
+                  [classes.paperFullWidth]: fullWidth,
+                },
+                customPaperClassName,
+              )}
+              {...otherPaperProps}
             >
               {children}
             </PaperComponent>
@@ -304,22 +310,8 @@ Dialog.propTypes = {
   PaperComponent: componentPropType,
   /**
    * Properties applied to the [`Paper`](/api/paper/) element.
-   * If you want to add a class to the `Paper` component use
-   * `classes.paper` in the `Dialog` props instead.
    */
-  PaperProps: chainPropTypes(PropTypes.object, props => {
-    const { PaperProps = {} } = props;
-    if ('className' in PaperProps) {
-      return new Error(
-        'Material-UI: `className` overrides all `Dialog` specific styles in `Paper`. ' +
-          'If you wanted to add ' +
-          'styles to the `Paper` component use `classes.paper` in the `Dialog` props ' +
-          `instead.${process.env.NODE_ENV === 'test' ? Date.now() : ''}`,
-      );
-    }
-
-    return null;
-  }),
+  PaperProps: PropTypes.object,
   /**
    * Determine the container for scrolling the dialog.
    */

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import Paper from '../Paper';
 import Fade from '../Fade';
@@ -243,30 +242,15 @@ describe('<Dialog />', () => {
   });
 
   describe('prop: PaperProps.className', () => {
-    before(() => {
-      consoleErrorMock.spy();
-    });
-
-    after(() => {
-      consoleErrorMock.reset();
-    });
-
-    it('warns on className usage', () => {
+    it('should merge the className', () => {
       const wrapper = mount(
         <Dialog open PaperProps={{ className: 'custom-paper-class' }}>
           foo
         </Dialog>,
       );
-      const paperWrapper = wrapper.find('div.custom-paper-class');
 
-      assert.strictEqual(paperWrapper.exists(), true);
-      assert.strictEqual(paperWrapper.hasClass(classes.paper), false);
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.args()[0][0],
-        '`className` overrides all `Dialog` specific styles in `Paper`. If you wanted to add ' +
-          'styles to the `Paper` component use `classes.paper` in the `Dialog` props instead.',
-      );
+      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paper), true);
+      assert.strictEqual(wrapper.find(Paper).hasClass('custom-paper-class'), true);
     });
   });
 });

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -36,7 +36,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | <span class="prop-name">onExiting</span> | <span class="prop-type">func</span> |   | Callback fired when the dialog is exiting. |
 | <span class="prop-name required">open *</span> | <span class="prop-type">bool</span> |   | If `true`, the Dialog is open. |
 | <span class="prop-name">PaperComponent</span> | <span class="prop-type">componentPropType</span> | <span class="prop-default">Paper</span> | The component used to render the body of the dialog. |
-| <span class="prop-name">PaperProps</span> | <span class="prop-type">object</span> |   | Properties applied to the [`Paper`](/api/paper/) element. If you want to add a class to the `Paper` component use `classes.paper` in the `Dialog` props instead. |
+| <span class="prop-name">PaperProps</span> | <span class="prop-type">object</span> |   | Properties applied to the [`Paper`](/api/paper/) element. |
 | <span class="prop-name">scroll</span> | <span class="prop-type">enum:&nbsp;'body'&nbsp;&#124;<br>&nbsp;'paper'<br></span> | <span class="prop-default">'paper'</span> | Determine the container for scrolling the dialog. |
 | <span class="prop-name">TransitionComponent</span> | <span class="prop-type">componentPropType</span> | <span class="prop-default">Fade</span> | The component used for the transition. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |


### PR DESCRIPTION
This is a different approach than PR https://github.com/mui-org/material-ui/pull/13797.
This allows for actually setting the className, without overriding the default classNames on the Paper component.
Allowing to add className is a legit basic behavior for overriding css classes.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
