### PR TITLE
[Core] Upgrade JSS to latest minor version

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -47,7 +47,7 @@
     "dom-helpers": "^3.2.1",
     "hoist-non-react-statics": "^3.2.1",
     "is-plain-object": "^2.0.4",
-    "jss": "^9.3.3",
+    "jss": "^9.8.7",
     "jss-camel-case": "^6.0.0",
     "jss-default-unit": "^8.0.2",
     "jss-global": "^3.0.0",


### PR DESCRIPTION
Updating JSS dependency to the latest minor version (9.8.7).  This solves an issue around namespacing when using multiple JSS instances.

Use cases solved:
- In my case, createMuiTheme is called multiple times while using [Webpacker](https://github.com/rails/webpacker).  Workaround requires repetition and additional libraries.
- More general issue and resolution in JSS repo [here](https://github.com/cssinjs/jss/issues/644).

All tests pass.  Thanks for the great library!

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
