### PR TITLE
[ci] Exit with non-zero if argos cli failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "test:karma": "cross-env NODE_ENV=test karma start test/karma.conf.js --single-run",
     "test:regressions": "webpack --config test/regressions/webpack.config.js && rimraf test/regressions/screenshots/chrome/* && vrtest run --config test/vrtest.config.js --record",
     "typescript": "tslint -p tsconfig.json \"packages/*/{src,test}/**/*.{ts,tsx}\"",
-    "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN || true"
+    "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
Always exiting with true can cause the argos check to hang indefinitely if the screenshots were not uploaded in `test_regression`. This happend in #13950.
