### PR TITLE
[BottomNavigation] Add component prop

### DIFF
--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.d.ts
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.d.ts
@@ -8,6 +8,7 @@ export interface BottomNavigationProps
     'onChange'
   > {
   children: React.ReactNode;
+  component?: React.ReactType<BottomNavigationProps>;
   onChange?: (event: React.ChangeEvent<{}>, value: any) => void;
   showLabels?: boolean;
   value?: any;

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.js
@@ -96,8 +96,8 @@ BottomNavigation.propTypes = {
 };
 
 BottomNavigation.defaultProps = {
-  showLabels: false,
   component: 'div',
+  showLabels: false,
 };
 
 export default withStyles(styles, { name: 'MuiBottomNavigation' })(BottomNavigation);

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import { componentPropType } from '@material-ui/utils';
 import warning from 'warning';
 import withStyles from '../styles/withStyles';
 
@@ -19,6 +20,7 @@ function BottomNavigation(props) {
     children: childrenProp,
     classes,
     className: classNameProp,
+    component: Component,
     onChange,
     showLabels,
     value,
@@ -50,9 +52,9 @@ function BottomNavigation(props) {
   });
 
   return (
-    <div className={className} {...other}>
+    <Component className={className} {...other}>
       {children}
-    </div>
+    </Component>
   );
 }
 
@@ -70,6 +72,11 @@ BottomNavigation.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: componentPropType,
   /**
    * Callback fired when the value changes.
    *
@@ -90,6 +97,7 @@ BottomNavigation.propTypes = {
 
 BottomNavigation.defaultProps = {
   showLabels: false,
+  component: 'div',
 };
 
 export default withStyles(styles, { name: 'MuiBottomNavigation' })(BottomNavigation);

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -20,6 +20,7 @@ import BottomNavigation from '@material-ui/core/BottomNavigation';
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children *</span> | <span class="prop-type">node</span> |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">component</span> | <span class="prop-type">componentPropType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |   | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: any) => void`<br>*event:* The event source of the callback<br>*value:* We default to the index of the child |
 | <span class="prop-name">showLabels</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, all `BottomNavigationAction`s will show their labels. By default, only the selected `BottomNavigationAction` will show its label. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |   | The value of the currently selected `BottomNavigationAction`. |


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

closes #13953 

This allows `BottomNavigation` to use anything as its root node. In the use case described in #13953, we can now use the `Paper` component to add elevation.

```jsx
// Render a BottomNavigation with some elevation by replacing the root div with Paper
class ElevatedBottomNavigation extends React.Component {
  paperComponent = props => <Paper elevation={this.props.elevation} {...props} />
  render() {
    return <BottomNavigation component={this.paperComponent} elevation={5} />
  }
}
```