### PR TITLE
[docs] Fix a typo, the word "the" was repeated in Layout Grid

### DIFF
--- a/docs/src/pages/layout/grid/grid.md
+++ b/docs/src/pages/layout/grid/grid.md
@@ -89,7 +89,7 @@ There is one limitation with the negative margin we use to implement the spacing
 A horizontal scroll will appear if a negative margin goes beyond the `<body>`.
 There are 3 available workarounds:
 1. Not using the spacing feature and implementing it in user space `spacing={0}` (default).
-2. Applying padding to the parent with at least half the the spacing value applied to the child:
+2. Applying padding to the parent with at least half the spacing value applied to the child:
 ```jsx
   <body>
     <div style={{ padding: 20 }}>


### PR DESCRIPTION
…e" was repeated.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Proposed Change:
- (https://material-ui.com/layout/grid/#negative-margin)
  - Fix a repeated word typo, *the*. This small PR corrects that typo.
> 2. Applying padding to the parent with at least half the **the** spacing value applied to the child: