### PR TITLE
[docs] Add note on archived components

### DIFF
--- a/docs/src/pages/demos/expansion-panels/expansion-panels.md
+++ b/docs/src/pages/demos/expansion-panels/expansion-panels.md
@@ -3,13 +3,13 @@ title: Expansion Panel React component
 components: ExpansionPanel, ExpansionPanelActions, ExpansionPanelDetails, ExpansionPanelSummary
 ---
 
-# Expansion Panel
+# Expansion Panels
 
 <p class="description">Expansion panels contain creation flows and allow lightweight editing of an element.</p>
 
 [An expansion panel](https://material.io/archive/guidelines/components/expansion-panels.html) is a lightweight container that may either stand alone or be connected to a larger surface, such as a card.
 
-**Note:** Expansion panels are no longer documented in the current version of Material. Try using Cards instead for newer code.
+> **Note:** Expansion panels are no longer documented in the Material Design documentation.
 
 ## Simple Expansion Panel
 

--- a/docs/src/pages/demos/expansion-panels/expansion-panels.md
+++ b/docs/src/pages/demos/expansion-panels/expansion-panels.md
@@ -9,6 +9,8 @@ components: ExpansionPanel, ExpansionPanelActions, ExpansionPanelDetails, Expans
 
 [An expansion panel](https://material.io/archive/guidelines/components/expansion-panels.html) is a lightweight container that may either stand alone or be connected to a larger surface, such as a card.
 
+**Note:** Expansion panels are no longer documented in the current version of Material. Try using Cards instead for newer code.
+
 ## Simple Expansion Panel
 
 {{"demo": "pages/demos/expansion-panels/SimpleExpansionPanel.js"}}

--- a/docs/src/pages/demos/steppers/steppers.md
+++ b/docs/src/pages/demos/steppers/steppers.md
@@ -24,6 +24,8 @@ Steppers may display a transient feedback message after a step is saved.
 - Linear
 - Non-linear
 
+> **Note:** Steppers are no longer documented in the Material Design documentation.
+
 ## Horizontal Linear
 
 The `Stepper` can be controlled by passing the current step index (zero-based) as the `activeStep` property. `Stepper` orientation is set using the `orientation` property.

--- a/docs/src/pages/demos/text-fields/text-fields.md
+++ b/docs/src/pages/demos/text-fields/text-fields.md
@@ -15,6 +15,8 @@ The `TextField` wrapper component is a complete form control including a label, 
 
 {{"demo": "pages/demos/text-fields/TextFields.js"}}
 
+> **Note:** This version of the text field is no longer documented in the Material Design documentation.
+
 ## Outlined
 
 `TextField` supports outlined styling.


### PR DESCRIPTION
Expansion Panels are no longer mentioned in the latest version of Material documentation, and it looks like Cards should be preferred. Expansion Panels are definitely useful though so we should keep them around, but note that "official" Material guidelines do not mention them.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
