### PR TITLE
[LinearProgress] Change height from 5 to 4 pixels

### DIFF
--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -12,7 +12,7 @@ export const styles = theme => ({
   root: {
     position: 'relative',
     overflow: 'hidden',
-    height: 5,
+    height: 4,
   },
   /* Styles applied to the root & bar2 element if `color="primary"`; bar2 if `variant-"buffer"`. */
   colorPrimary: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Hello, first contribution. In working with the LinearProgress component, I found that it had a height discrepancy compared to the material definitions from Google: https://material.io/design/components/progress-indicators.html#specs

**The Linear progress indicators should be 4px tall instead of 5px.**

Again, first contribution, please let me know if I missed a step.
