### PR TITLE
[styles] Hash the classnames

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -28,7 +28,7 @@ module.exports = [
     name: 'The size of the @material-ui/styles modules',
     webpack: true,
     path: 'packages/material-ui-styles/build/index.js',
-    limit: '15.9 KB',
+    limit: '16.5 KB',
   },
   {
     name: 'The size of the @material-ui/system modules',

--- a/docs/src/pages/style/color/Color.js
+++ b/docs/src/pages/style/color/Color.js
@@ -55,10 +55,7 @@ export const styles = theme => ({
     color: 'inherit',
     fontWeight: 'inherit',
   },
-  themeInherit: {
-    ...theme.typography,
-    fontWeight: 500,
-  },
+  body2: theme.typography.body2,
 });
 
 function getColorBlock(classes, theme, colorName, colorValue, colorTitle) {
@@ -85,7 +82,7 @@ function getColorBlock(classes, theme, colorName, colorValue, colorTitle) {
   }
 
   return (
-    <li style={rowStyle} key={colorValue} className={classes.themeInherit}>
+    <li style={rowStyle} key={colorValue} className={classes.body2}>
       {blockTitle}
       <div className={classes.colorContainer}>
         <span>{colorValue}</span>

--- a/packages/material-ui-benchmark/README.md
+++ b/packages/material-ui-benchmark/README.md
@@ -7,13 +7,12 @@
 ```sh
 yarn core
 
-ButtonBase no cache x 5,226 ops/sec ±7.01% (181 runs sampled)
-ButtonBase cache requests x 40,400 ops/sec ±1.15% (187 runs sampled)
-HocButton x 147,810 ops/sec ±1.21% (186 runs sampled)
-NakedButton x 209,086 ops/sec ±1.26% (190 runs sampled)
-ButtonBase enable ripple x 55,893 ops/sec ±0.89% (188 runs sampled)
-ButtonBase disable ripple x 57,364 ops/sec ±2.35% (187 runs sampled)
-Markdown x 924 ops/sec ±3.05% (184 runs sampled)
+ButtonBase x 40,724 ops/sec ±1.58% (189 runs sampled)
+HocButton x 166,229 ops/sec ±1.04% (191 runs sampled)
+NakedButton x 228,473 ops/sec ±0.99% (187 runs sampled)
+ButtonBase enable ripple x 56,019 ops/sec ±0.87% (189 runs sampled)
+ButtonBase disable ripple x 61,748 ops/sec ±0.35% (190 runs sampled)
+Markdown x 954 ops/sec ±1.35% (187 runs sampled)
 ```
 
 ## `@material-ui/styles`
@@ -23,15 +22,14 @@ Markdown x 924 ops/sec ±3.05% (184 runs sampled)
 ```sh
 yarn styles
 
-JSSButton x 13,573 ops/sec ±5.01% (78 runs sampled)
-Box x 3,043 ops/sec ±4.14% (179 runs sampled)
-JSS naked x 21,021 ops/sec ±7.27% (72 runs sampled)
-WithStylesButton x 8,442 ops/sec ±3.31% (176 runs sampled)
-HookButton x 11,265 ops/sec ±3.43% (178 runs sampled)
-StyledComponentsButton x 6,745 ops/sec ±2.91% (181 runs sampled)
-EmotionButton x 6,856 ops/sec ±5.06% (165 runs sampled)
-Naked x 32,683 ops/sec ±3.54% (172 runs sampled)
-hashing x 221,423 ops/sec ±1.22% (190 runs sampled)
+Box x 3,854 ops/sec ±1.73% (189 runs sampled)
+JSS naked x 35,830 ops/sec ±1.30% (186 runs sampled)
+WithStylesButton x 15,551 ops/sec ±1.86% (189 runs sampled)
+HookButton x 21,649 ops/sec ±0.63% (190 runs sampled)
+StyledComponentsButton x 7,728 ops/sec ±1.46% (189 runs sampled)
+EmotionButton x 8,821 ops/sec ±7.96% (149 runs sampled)
+Naked x 31,835 ops/sec ±7.60% (167 runs sampled)
+hashing x 171,955 ops/sec ±5.22% (164 runs sampled)
 ```
 
 ## `@material-ui/system`

--- a/packages/material-ui-benchmark/src/core.js
+++ b/packages/material-ui-benchmark/src/core.js
@@ -37,19 +37,10 @@ class HocButton extends React.Component {
   }
 }
 
-const sheetsCache = new Map();
-
 suite
-  .add('ButtonBase no cache', () => {
+  .add('ButtonBase', () => {
     ReactDOMServer.renderToString(
       <StylesProvider sheetsManager={new Map()}>
-        <ButtonBase>Material-UI</ButtonBase>
-      </StylesProvider>,
-    );
-  })
-  .add('ButtonBase cache requests', () => {
-    ReactDOMServer.renderToString(
-      <StylesProvider sheetsManager={new Map()} sheetsCache={sheetsCache}>
         <ButtonBase>Material-UI</ButtonBase>
       </StylesProvider>,
     );

--- a/packages/material-ui-benchmark/src/server.js
+++ b/packages/material-ui-benchmark/src/server.js
@@ -43,8 +43,6 @@ function renderFullPage(html, css) {
   `;
 }
 
-const sheetsCache = new Map();
-
 const theme = createMuiTheme({
   palette: {
     primary: green,
@@ -63,7 +61,6 @@ function renderPricing(req, res) {
       sheetsRegistry={sheetsRegistry}
       generateClassName={createGenerateClassName()}
       sheetsManager={new Map()}
-      sheetsCache={sheetsCache}
     >
       <ThemeProvider theme={theme}>
         <Pricing />

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.2.0",
+    "@emotion/hash": "^0.7.1",
     "@material-ui/utils": "^3.0.0-alpha.1",
     "classnames": "^2.2.5",
     "deepmerge": "^3.0.0",

--- a/packages/material-ui-styles/src/StylesProvider.js
+++ b/packages/material-ui-styles/src/StylesProvider.js
@@ -22,7 +22,7 @@ const defaultOptions = {
   disableGeneration: false,
   generateClassName,
   jss,
-  sheetsCache: null,
+  sheetsCache: typeof window === 'undefined' ? new Map() : null,
   sheetsManager,
   sheetsRegistry: null,
 };

--- a/packages/material-ui-styles/src/createGenerateClassName.test.js
+++ b/packages/material-ui-styles/src/createGenerateClassName.test.js
@@ -7,14 +7,24 @@ describe('createGenerateClassName', () => {
   it('should generate a class name', () => {
     assert.strictEqual(
       generateClassName(
-        { key: 'key' },
         {
+          key: 'key',
+        },
+        {
+          rules: {
+            raw: {
+              key: {
+                flex: 1,
+              },
+            },
+          },
           options: {
+            theme: {},
             classNamePrefix: 'classNamePrefix',
           },
         },
       ),
-      'classNamePrefix-key-1',
+      'classNamePrefix-key-1mx1qso',
     );
   });
 });

--- a/packages/material-ui-styles/src/styled.test.js
+++ b/packages/material-ui-styles/src/styled.test.js
@@ -38,6 +38,6 @@ describe('styled', () => {
     );
 
     assert.strictEqual(sheetsRegistry.registry.length, 1);
-    assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Styled-button--root-1' });
+    assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Styled-button--root-1ds4xjv' });
   });
 });

--- a/packages/material-ui-styles/src/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles.js
@@ -74,6 +74,7 @@ export function attach({ state, props, theme, stylesOptions, stylesCreator, name
   const options = {
     ...stylesCreator.options,
     ...stylesOptions,
+    theme,
     flip: typeof stylesOptions.flip === 'boolean' ? stylesOptions.flip : theme.direction === 'rtl',
   };
   options.generateId = options.generateClassName;

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,7 +928,7 @@
     "@emotion/utils" "0.11.1"
     babel-plugin-emotion "^10.0.5"
 
-"@emotion/hash@0.7.1":
+"@emotion/hash@0.7.1", "@emotion/hash@^0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
   integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==


### PR DESCRIPTION
- +**80**% performance boost with the static styles generation server side.
*It's making @material-ui/styles x2.5 faster than emotion and styled-components (for static styles generation and under our specific synthetic benchmark).*
- Help with Jest snapshot testing: #9492.
- Help with class name mismatch between the server and the client.

```diff
JSSButton x 13,573 ops/sec ±5.01% (78 runs sampled)
EmotionButton x 7,409 ops/sec ±5.19% (73 runs sampled)
-WithStylesButton x 7,384 ops/sec ±4.94% (74 runs sampled)
+WithStylesButton x 12,243 ops/sec ±2.88% (178 runs sampled)
-HookButton x 10,386 ops/sec ±4.03% (84 runs sampled)
+HookButton x 18,632 ops/sec ±2.88% (179 runs sampled)
Naked x 39,612 ops/sec ±2.70% (175 runs sampled)
StyledComponentsButton x 7,025 ops/sec ±2.66% (179 runs sampled)
```