### PR TITLE
[docs] Set react-jss version in nextjs example

### DIFF
--- a/examples/create-react-app-with-jss/package.json
+++ b/examples/create-react-app-with-jss/package.json
@@ -8,7 +8,7 @@
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-jss": "latest",
+    "react-jss": "^8.1.0",
     "react-scripts": "latest"
   },
   "scripts": {

--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -9,7 +9,7 @@
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-jss": "latest"
+    "react-jss": "^8.1.0"
   },
   "scripts": {
     "develop": "gatsby develop",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,7 +9,7 @@
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-jss": "^8.6.1"
+    "react-jss": "^8.1.0"
   },
   "scripts": {
     "dev": "next",

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,7 +9,7 @@
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-jss": "latest"
+    "react-jss": "^8.6.1"
   },
   "scripts": {
     "dev": "next",

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -15,7 +15,7 @@
     "prop-types": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-jss": "latest",
+    "react-jss": "^8.1.0",
     "webpack": "latest",
     "webpack-cli": "latest"
   },


### PR DESCRIPTION
Latest version of react-jss (as of now, 10.0.0-alpha.3) has breaking changes that cause the example not to work.

in pages/_app.tsx the import path for the JssProvider is no longer valid, and proxied through the package root.  That's not a big issue and I would have just fixed that with this PR, however there is also a breaking change with the props for the provider.  Per the change log, https://github.com/cssinjs/jss/blob/master/changelog.md#breaking-changes `generateClassName` has changed to `generateId`.  Unfortunately using the same createGenerateClassName function from materialUi/core doesn't seem to work.  As the version is still marked as alpha (and updating it to be tagged as latest may have been a mistake) I think it's best to pin the version to the previous latest until version 10 is released.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
