### PR TITLE
[styles] Fix typescript throwing in makeStyles with no props required

### DIFF
--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -82,6 +82,22 @@ declare module '@material-ui/styles/makeStyles' {
 
   // https://stackoverflow.com/a/49928360/3406963 without generic branch types
   type IsAny<T> = 0 extends (1 & T) ? true : false;
+
+  type Or<A, B, C = false> = A extends true
+    ? true
+    : B extends true
+    ? true
+    : C extends true
+    ? true
+    : false;
+  type And<A, B, C = true> = A extends true
+    ? B extends true
+      ? C extends true
+        ? true
+        : false
+      : false
+    : false;
+
   /**
    * @internal
    *
@@ -90,14 +106,13 @@ declare module '@material-ui/styles/makeStyles' {
    * 1. false if the given type has any members
    * 2. false if the type is `object` which is the only other type with no members
    *  {} is a top type so e.g. `string extends {}` but not `string extends object`
+   * 3. false if the given type is `unknown`
    */
-  export type IsEmptyInterface<T> = keyof T extends never
-    ? string extends T
-      ? true
-      : false
-    : false;
-
-  type Or<A, B> = A extends true ? true : B extends true ? true : false;
+  export type IsEmptyInterface<T> = And<
+    keyof T extends never ? true : false,
+    string extends T ? true : false,
+    unknown extends T ? false : true
+  >;
 
   /**
    * @internal

--- a/packages/material-ui-styles/test/IsEmptyInterface.spec.ts
+++ b/packages/material-ui-styles/test/IsEmptyInterface.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * unit testing for IsEmptyInterface utility type
+ */
+import { IsEmptyInterface } from '@material-ui/styles/makeStyles';
+
+// $ExpectType true
+type EmptyInterfaceIsValid = IsEmptyInterface<{}>;
+
+// $ExpectType false
+type ObjectIsValid = IsEmptyInterface<object>;
+
+// $ExpectType false
+type SymbolIsValid = IsEmptyInterface<symbol>;
+
+const noop = () => {};
+// $ExpectType false
+type FunctionIsValid = IsEmptyInterface<typeof noop>;
+
+// $ExpectType false
+type RecordIsValid = IsEmptyInterface<Record<'foo' | 'bar', number>>;
+
+const someObject = { foo: 5 };
+// $ExpectType false
+type ObjectWithPropertiesIsValid = IsEmptyInterface<typeof someObject>;

--- a/packages/material-ui-styles/test/IsEmptyInterface.spec.ts
+++ b/packages/material-ui-styles/test/IsEmptyInterface.spec.ts
@@ -10,7 +10,22 @@ type EmptyInterfaceIsValid = IsEmptyInterface<{}>;
 type ObjectIsValid = IsEmptyInterface<object>;
 
 // $ExpectType false
+type NullishIsValid = IsEmptyInterface<null | undefined>;
+
+// $ExpectType false
+type StringIsValid = IsEmptyInterface<string>;
+
+// $ExpectType false
+type NumberIsValid = IsEmptyInterface<number>;
+
+// $ExpectType false
 type SymbolIsValid = IsEmptyInterface<symbol>;
+
+// $ExpectType false
+type NeverIsValid = IsEmptyInterface<never>;
+
+// $ExpectType false
+type UnknownIsValid = IsEmptyInterface<unknown>;
 
 const noop = () => {};
 // $ExpectType false

--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -70,8 +70,17 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
       },
     }),
   );
+  const chartStyles = {
+    chart: {
+      width: '100%',
+      height: 70,
+      backgroundColor: '#f9f9f9',
+    },
+  };
+  const useChartClasses = makeStyles(chartStyles);
   const NoPropsComponent = () => {
     const classes = useWithoutProps();
+    const chartClasses = useChartClasses();
     const alsoClasses = useWithoutProps(5);
   };
 


### PR DESCRIPTION
Right now typescript infers `Props` to `any` in `StyleRulesCallback` but to `{}` in `StyleRules` if props are not used. I'm not sure if this is actually a typescript bug but it's fixable in our codebase.

Closes #14018 