### PR TITLE
[docs] Removed focus outline on modal demo

### DIFF
--- a/docs/src/pages/utils/modal/SimpleModal.js
+++ b/docs/src/pages/utils/modal/SimpleModal.js
@@ -27,6 +27,7 @@ const styles = theme => ({
     backgroundColor: theme.palette.background.paper,
     boxShadow: theme.shadows[5],
     padding: theme.spacing.unit * 4,
+    outline: 'none',
   },
 });
 


### PR DESCRIPTION
Removes the browser default outline to the modal

![screen shot 2018-12-28 at 4 13 49 pm](https://user-images.githubusercontent.com/1605931/50525743-273dc600-0abc-11e9-84ea-e63eca6768c8.png)

Closes #11504 
cc: @oliviertassinari 