### PR TITLE
update yarn cache location based on cli output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,13 +13,13 @@ install_js: &install_js
     name: Install js dependencies
     command: |
       yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1
-      yarn
+      yarn --frozen-lockfile
 restore_yarn_cache: &restore_yarn_cache
   restore_cache:
-    key: v1-yarn-sha-{{ checksum "yarn.lock" }}
+    key: v2-yarn-sha-{{ checksum "yarn.lock" }}
 restore_yarn_offline_mirror: &restore_yarn_offline_mirror
   restore_cache:
-    key: v1-npm-packages-offline-cache
+    key: v2-npm-packages-offline-cache
 version: 2
 jobs:
   checkout:
@@ -42,11 +42,11 @@ jobs:
           name: Should not have any git not staged
           command: git diff --exit-code
       - save_cache:
-          key: v1-yarn-sha-{{ checksum "yarn.lock" }}
+          key: v2-yarn-sha-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn/v1
+            - ~/.cache/yarn/v4
       - save_cache:
-          key: v1-npm-packages-offline-cache
+          key: v2-npm-packages-offline-cache
           paths:
             - ~/.cache/npm-packages-offline-cache/v1
   test_unit:
@@ -188,7 +188,7 @@ jobs:
           name: Can we generate the documentation?
           command: yarn docs:api
       - run:
-          name: "`yarn docs:api` changes commited?"
+          name: '`yarn docs:api` changes commited?'
           command: git diff --exit-code
       - run:
           name: Install dependencies for Chrome Headless


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Found the ci config to be a bit out of date on the yarn cache and problematic `yarn` command which can cause unexpected diffs:
- use --frozen-lockfile to avoid diff between repo and ci runs
- update the yarn cache to that reported by the cli in the Check versions and env step

extracted from #14048 (in case that one needs closed)