### PR TITLE
[Tabs] Add standard variant

### DIFF
--- a/docs/src/pages/demos/tabs/FullWidthTabs.hooks.js
+++ b/docs/src/pages/demos/tabs/FullWidthTabs.hooks.js
@@ -48,7 +48,7 @@ function FullWidthTabs() {
           onChange={handleChange}
           indicatorColor="primary"
           textColor="primary"
-          fullWidth
+          variant={null}
         >
           <Tab label="Item One" />
           <Tab label="Item Two" />

--- a/docs/src/pages/demos/tabs/IconLabelTabs.hooks.js
+++ b/docs/src/pages/demos/tabs/IconLabelTabs.hooks.js
@@ -27,7 +27,7 @@ function IconLabelTabs() {
       <Tabs
         value={value}
         onChange={handleChange}
-        fullWidth
+        variant="fullWidth"
         indicatorColor="secondary"
         textColor="secondary"
       >

--- a/docs/src/pages/demos/tabs/IconTabs.hooks.js
+++ b/docs/src/pages/demos/tabs/IconTabs.hooks.js
@@ -27,7 +27,7 @@ function IconTabs() {
       <Tabs
         value={value}
         onChange={handleChange}
-        fullWidth
+        variant="fullWidth"
         indicatorColor="primary"
         textColor="primary"
       >

--- a/docs/src/pages/demos/tabs/ScrollableTabsButtonAuto.hooks.js
+++ b/docs/src/pages/demos/tabs/ScrollableTabsButtonAuto.hooks.js
@@ -42,7 +42,7 @@ function ScrollableTabsButtonAuto() {
           onChange={handleChange}
           indicatorColor="primary"
           textColor="primary"
-          scrollable
+          variant="scrollable"
           scrollButtons="auto"
         >
           <Tab label="Item One" />

--- a/docs/src/pages/demos/tabs/ScrollableTabsButtonForce.hooks.js
+++ b/docs/src/pages/demos/tabs/ScrollableTabsButtonForce.hooks.js
@@ -47,7 +47,7 @@ function ScrollableTabsButtonForce() {
         <Tabs
           value={value}
           onChange={handleChange}
-          scrollable
+          variant="scrollable"
           scrollButtons="on"
           indicatorColor="primary"
           textColor="primary"

--- a/docs/src/pages/demos/tabs/ScrollableTabsButtonPrevent.hooks.js
+++ b/docs/src/pages/demos/tabs/ScrollableTabsButtonPrevent.hooks.js
@@ -44,7 +44,7 @@ function ScrollableTabsButtonPrevent() {
   return (
     <div className={classes.root}>
       <AppBar position="static">
-        <Tabs value={value} onChange={handleChange} scrollable scrollButtons="off">
+        <Tabs value={value} onChange={handleChange} variant="scrollable" scrollButtons="off">
           <Tab icon={<PhoneIcon />} />
           <Tab icon={<FavoriteIcon />} />
           <Tab icon={<PersonPinIcon />} />

--- a/packages/material-ui/src/Tabs/Tabs.d.ts
+++ b/packages/material-ui/src/Tabs/Tabs.d.ts
@@ -18,7 +18,7 @@ export interface TabsProps
   TabIndicatorProps?: Partial<TabIndicatorProps>;
   textColor?: 'secondary' | 'primary' | 'inherit' | string;
   value: any;
-  variant?: 'scrollable' | 'fullWidth';
+  variant?: 'standard' | 'scrollable' | 'fullWidth';
   width?: string;
 }
 

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -494,8 +494,9 @@ Tabs.propTypes = {
    *  scrolling (or swiping) of the tab bar.
    *  -`fullWidth` will make the tabs grow to use all the available space,
    *  which should be used for small views, like on mobile.
+   *  - `standard` will render the default state.
    */
-  variant: PropTypes.oneOf(['scrollable', 'fullWidth']),
+  variant: PropTypes.oneOf(['standard', 'scrollable', 'fullWidth']),
 };
 
 Tabs.defaultProps = {
@@ -505,6 +506,7 @@ Tabs.defaultProps = {
   ScrollButtonComponent: TabScrollButton,
   scrollButtons: 'auto',
   textColor: 'inherit',
+  variant: 'standard',
 };
 
 export default withStyles(styles, { name: 'MuiTabs', withTheme: true })(Tabs);

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -32,7 +32,7 @@ import Tabs from '@material-ui/core/Tabs';
 | <span class="prop-name">TabIndicatorProps</span> | <span class="prop-type">object</span> |   | Properties applied to the `TabIndicator` element. |
 | <span class="prop-name">textColor</span> | <span class="prop-type">enum:&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'inherit'<br></span> | <span class="prop-default">'inherit'</span> | Determines the color of the `Tab`. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |   | The value of the currently selected `Tab`. If you don't want any selected `Tab`, you can set this property to `false`. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'scrollable'&nbsp;&#124;<br>&nbsp;'fullWidth'<br></span> |   | Determines additional display behavior of the tabs:  - `scrollable` will invoke scrolling properties and allow for horizontally  scrolling (or swiping) of the tab bar.  -`fullWidth` will make the tabs grow to use all the available space,  which should be used for small views, like on mobile. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'scrollable'&nbsp;&#124;<br>&nbsp;'fullWidth'<br></span> | <span class="prop-default">'standard'</span> | Determines additional display behavior of the tabs:  - `scrollable` will invoke scrolling properties and allow for horizontally  scrolling (or swiping) of the tab bar.  -`fullWidth` will make the tabs grow to use all the available space,  which should be used for small views, like on mobile.  - `standard` will render the default state. |
 
 Any other properties supplied will be spread to the root element (native element).
 


### PR DESCRIPTION
Improve the answer for @eddy03 https://github.com/mui-org/material-ui/pull/13980#issuecomment-450874188. So he can do:
```jsx
const {classes, fullScreen} = this.props

<Tabs variant={fullWidth ? 'fullWidth' : 'standard}
```
instead of 
```jsx
const {classes, fullScreen} = this.props

<Tabs variant={fullWidth ? 'fullWidth' : null}
```