### PR TITLE
[TypeScript] Fix the type for "InputBaseProps"

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface InputBaseProps
   extends StandardProps<
-    React.HTMLAttributes<HTMLDivElement>,
+    React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement>,
     InputBaseClassKey,
     'onChange' | 'onKeyUp' | 'onKeyDown' | 'defaultValue'
   > {


### PR DESCRIPTION
According to the latest `react` type definitions, we should use `React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement>` as the first type argument of `StandardProps` that `InputBaseProps` extends from. Otherwise, the build will break.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
