### PR TITLE
[docs] Update broken link to cssinjs.org in css-in-js

### DIFF
--- a/docs/src/pages/css-in-js/advanced/advanced.md
+++ b/docs/src/pages/css-in-js/advanced/advanced.md
@@ -54,14 +54,15 @@ JSS uses the concept of plugins to extend its core, allowing people to cherry-pi
 You pay the performance overhead for only what's you are using.
 All the plugins aren't available by default. We have added the following list:
 
-- [jss-global](http://cssinjs.org/jss-global/)
-- [jss-nested](http://cssinjs.org/jss-nested/)
-- [jss-camel-case](http://cssinjs.org/jss-camel-case/)
-- [jss-default-unit](http://cssinjs.org/jss-default-unit/)
-- [jss-vendor-prefixer](http://cssinjs.org/jss-vendor-prefixer/)
-- [jss-props-sort](http://cssinjs.org/jss-props-sort/)
+- [jss-plugin-rule-value-function](https://cssinjs.org/jss-plugin-rule-value-function/)
+- [jss-plugin-global](https://cssinjs.org/jss-plugin-global/)
+- [jss-plugin-nested](https://cssinjs.org/jss-plugin-nested/)
+- [jss-plugin-camel-case](https://cssinjs.org/jss-plugin-camel-case/)
+- [jss-plugin-default-unit](https://cssinjs.org/jss-plugin-default-unit/)
+- [jss-plugin-vendor-prefixer](https://cssinjs.org/jss-plugin-vendor-prefixer/)
+- [jss-plugin-props-sort](https://cssinjs.org/jss-plugin-props-sort/)
 
-It's a subset of [jss-preset-default](http://cssinjs.org/jss-preset-default/).
+It's a subset of [jss-preset-default](https://cssinjs.org/jss-preset-default/).
 Of course, you are free to add a new plugin. Here is an example with the [jss-rtl](https://github.com/alitaheri/jss-rtl) plugin.
 
 ```jsx
@@ -109,8 +110,8 @@ const useStyles = makeStyles({
 The CSS injected by Material-UI to style a component has the highest specificity possible as the `<link>` is injected at the bottom of the `<head>` to ensure the components always render correctly.
 
 You might, however, also want to override these styles, for example with styled-components.
-If you are experiencing a CSS injection order issue, JSS [provides a mechanism](https://github.com/cssinjs/jss/blob/master/docs/setup.md#specify-dom-insertion-point) to handle this situation.
-By adjusting the placement of the `insertionPoint` within your HTML head you can [control the order](http://cssinjs.org/js-api/#attach-style-sheets-in-a-specific-order) that the CSS rules are applied to your components.
+If you are experiencing a CSS injection order issue, JSS [provides a mechanism](https://github.com/cssinjs/jss/blob/master/docs/setup.md#specify-the-dom-insertion-point) to handle this situation.
+By adjusting the placement of the `insertionPoint` within your HTML head you can [control the order](https://cssinjs.org/jss-api#attach-style-sheets-in-a-specific-order) that the CSS rules are applied to your components.
 
 ### HTML comment
 
@@ -215,10 +216,10 @@ const useStyles = makeStyles({
 });
 ```
 
-It will generate a `AppBar-root-12` class name. However, the following CSS won't work:
+It will generate a `AppBar-root-5pbwdt` class name. However, the following CSS won't work:
 
 ```css
-.AppBar-root-12 {
+.AppBar-root-5pbwdt {
   opacity: 0.6;
 }
 ```
@@ -228,31 +229,31 @@ Thanks to the non-deterministic nature of our class names, we
 can implement optimizations for development and production.
 They are easy to debug in development and as short as possible in production:
 
-- In **development**, the class name will be: `.AppBar-root-12`, following this logic:
+- In **development**, the class name will be: `.AppBar-root-5pbwdt`, following this logic:
 
 ```js
 const sheetName = 'AppBar';
 const ruleName = 'root';
-const identifier = 12;
+const identifier = 5pbwdt;
 
 const className = `${sheetName}-${ruleName}-${identifier}`;
 ```
 
-- In **production**, the class name will be: `.jss12`, following this logic:
+- In **production**, the class name will be: `.jss5pbwdt`, following this logic:
 
 ```js
 const productionPrefix = 'jss';
-const identifier = 12;
+const identifier = 5pbwdt;
 
 const className = `${productionPrefix}-${identifier}`;
 ```
 
 If you don't like this default behavior, you can change it.
-JSS relies on the concept of [class name generator](http://cssinjs.org/js-api/#generate-your-own-class-names).
+JSS relies on the concept of [class name generator](https://cssinjs.org/jss-api/#generate-your-class-names).
 
 ## Global CSS
 
-We provide an option to make the class names **deterministic** with the [`dangerouslyUseGlobalCSS`](/css-in-js/api/#creategenerateclassname--options----class-name-generator) option. When turned on, the class names will look like this:
+We provide an option to make the class names **deterministic** with the [`dangerouslyUseGlobalCSS`](/css-in-js/api/#creategenerateclassname-options-class-name-generator) option. When turned on, the class names will look like this:
 
 - development: `.AppBar-root`
 - production: `.AppBar-root`

--- a/docs/src/pages/css-in-js/basics/basics.md
+++ b/docs/src/pages/css-in-js/basics/basics.md
@@ -39,7 +39,7 @@ npm install @material-ui/styles
 yarn add @material-ui/styles
 ```
 
-Please note that [react](https://www.npmjs.com/package/react) >= 16.7.0-alpha.0 and [react-dom](https://www.npmjs.com/package/react-dom) >= 16.7.0-alpha.0 are peer dependencies.
+Please note that [react](https://www.npmjs.com/package/react) >= 16.7.0-alpha.2 and [react-dom](https://www.npmjs.com/package/react-dom) >= 16.7.0-alpha.2 are peer dependencies.
 
 ### Migration for `@material-ui/core` users
 

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -273,7 +273,7 @@ Use the function signature if you need to have access to the theme. It's provide
   - `options.name` (*String* [optional]): The name of the style sheet. Useful for debugging.
     If the value isn't provided, it will try to fallback to the name of the component.
   - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, it follows `theme.direction`.
-  - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](https://cssinjs.org/jss-api?v=v10.0.0-alpha.7#create-style-sheet).
+  - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](https://cssinjs.org/jss-api#create-style-sheet).
 
 #### Returns
 

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -273,7 +273,7 @@ Use the function signature if you need to have access to the theme. It's provide
   - `options.name` (*String* [optional]): The name of the style sheet. Useful for debugging.
     If the value isn't provided, it will try to fallback to the name of the component.
   - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, it follows `theme.direction`.
-  - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](http://cssinjs.org/js-api/#create-style-sheet).
+  - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](https://cssinjs.org/jss-api?v=v10.0.0-alpha.7#create-style-sheet).
 
 #### Returns
 

--- a/docs/src/pages/customization/css-in-js/css-in-js.md
+++ b/docs/src/pages/customization/css-in-js/css-in-js.md
@@ -273,7 +273,7 @@ Use the function signature if you need to have access to the theme. It's provide
   - `options.name` (*String* [optional]): The name of the style sheet. Useful for debugging.
     If the value isn't provided, it will try to fallback to the name of the component.
   - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, it follows `theme.direction`.
-  - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](https://cssinjs.org/jss-api#create-style-sheet).
+  - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](http://cssinjs.org/js-api/#create-style-sheet).
 
 #### Returns
 

--- a/docs/src/pages/layout/use-media-query/use-media-query.md
+++ b/docs/src/pages/layout/use-media-query/use-media-query.md
@@ -7,7 +7,7 @@ title: Media queries in React for responsive design
 <p class="description">This is a CSS media query hook for React. It listens for matches to a CSS media query. It allows the rendering of components based on whether the query matches or not.</p>
 
 > ⚠️ `useMediaQuery` is unstable as hooks aren't stable yet, therefore it is exported with an unstable prefix.
-It depends on react >= 16.7.0-alpha.0, react-dom >= 16.7.0-alpha.0.
+It depends on react >= 16.7.0-alpha.2, react-dom >= 16.7.0-alpha.2.
 
 Some of the key features:
 - ⚛️ It has an idiomatic React API.


### PR DESCRIPTION
Link in docs returns a 404 because cssinjs.org updated their URLs to include an api version. Updated to match new URL structure.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
