### PR TITLE
[InputBase] Fix the `InputBaseComponentProps` type

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -55,9 +55,7 @@ export interface InputBaseProps
 }
 
 export interface InputBaseComponentProps
-  extends React.HTMLAttributes<
-    HTMLInputElement | HTMLTextAreaElement
-  > {
+  extends React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
   // Accommodate arbitrary additional props coming from the `inputProps` prop
   [arbitrary: string]: any;
 }

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -54,7 +54,7 @@ export interface InputBaseProps
   onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
 }
 
-export interface InputBaseComponentProps extends InputBaseProps {
+export interface InputBaseComponentProps extends React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
   // Accommodate arbitrary additional props coming from the `inputProps` prop
   [arbitrary: string]: any;
 }

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -54,7 +54,10 @@ export interface InputBaseProps
   onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
 }
 
-export interface InputBaseComponentProps extends React.HTMLAttributes<HTMLInputElement | HTMLTextAreaElement> {
+export interface InputBaseComponentProps
+  extends React.HTMLAttributes<
+    HTMLInputElement | HTMLTextAreaElement
+  > {
   // Accommodate arbitrary additional props coming from the `inputProps` prop
   [arbitrary: string]: any;
 }

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -797,6 +797,7 @@ const TextFieldTest = () => (
         },
       }}
     />
+    <Input inputComponent="input" />
   </div>
 );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

related to #14068 

The reason for the PR is:


According to the implementation here:
```jsx
/**
   * The component used for the native input.
   * Either a string to use a DOM element or a component.
   */
  inputComponent: componentPropType,
```
 `inputComponent` can be a string, `<input/>`, `<textarea/>`, or any custom component that user defines, but here in `InputBase.d.ts`, the type is constrained to `InputBaseComponentProps`, which inherits from `InputBaseProps`, which limits to `React.HTMLAttributes<HTMLDivElement>`.