### PR TITLE
[MenuList] Wrap focus by default, add disableListWrap

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of the @material-ui/core modules',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '95.6 KB',
+    limit: '95.7 KB',
   },
   {
     name: 'The size of the @material-ui/styles modules',

--- a/packages/material-ui/src/MenuList/MenuList.d.ts
+++ b/packages/material-ui/src/MenuList/MenuList.d.ts
@@ -3,6 +3,7 @@ import { StandardProps } from '..';
 import { ListProps, ListClassKey } from '../List';
 
 export interface MenuListProps extends StandardProps<ListProps, MenuListClassKey, 'onKeyDown'> {
+  disableListWrap?: boolean;
   onKeyDown?: React.ReactEventHandler<React.KeyboardEvent<any>>;
 }
 

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -59,11 +59,15 @@ class MenuList extends React.Component {
       event.preventDefault();
       if (currentFocus.nextElementSibling) {
         currentFocus.nextElementSibling.focus();
+      } else if (!this.props.disableListWrap) {
+        list.firstChild.focus();
       }
     } else if (key === 'up') {
       event.preventDefault();
       if (currentFocus.previousElementSibling) {
         currentFocus.previousElementSibling.focus();
+      } else if (!this.props.disableListWrap) {
+        list.lastChild.focus();
       }
     }
 
@@ -121,7 +125,7 @@ class MenuList extends React.Component {
   }
 
   render() {
-    const { children, className, onBlur, onKeyDown, ...other } = this.props;
+    const { children, className, onBlur, onKeyDown, disableListWrap, ...other } = this.props;
 
     return (
       <List
@@ -172,6 +176,10 @@ MenuList.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * If `true`, the menu items will not wrap focus.
+   */
+  disableListWrap: PropTypes.bool,
+  /**
    * @ignore
    */
   onBlur: PropTypes.func,
@@ -179,6 +187,10 @@ MenuList.propTypes = {
    * @ignore
    */
   onKeyDown: PropTypes.func,
+};
+
+MenuList.defaultProps = {
+  disableListWrap: false,
 };
 
 export default MenuList;

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -318,6 +318,7 @@ class SelectInput extends React.Component {
           {...MenuProps}
           MenuListProps={{
             role: 'listbox',
+            disableListWrap: true,
             ...MenuProps.MenuListProps,
           }}
           PaperProps={{

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -52,8 +52,13 @@ describe('<Menu> integration', () => {
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
-    it('should keep focus on the 3rd item (last item) when down arrow is pressed', () => {
+    it('should switch focus from the 3rd item to the 1st item when down arrow is pressed', () => {
       TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('down') });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
+    });
+
+    it('should switch focus from the 1st item to the 3rd item when up arrow is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('up') });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -69,8 +69,13 @@ describe('<MenuList> integration', () => {
       assertMenuItemFocused(wrapper, 0);
     });
 
-    it('should still have the first item tabIndexed', () => {
+    it('should select the last item when pressing up', () => {
       wrapper.simulate('keyDown', { which: keycode('up') });
+      assertMenuItemTabIndexed(wrapper, 3);
+    });
+
+    it('should select the first item when pressing dowm', () => {
+      wrapper.simulate('keyDown', { which: keycode('down') });
       assertMenuItemTabIndexed(wrapper, 0);
     });
 

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -19,6 +19,7 @@ import MenuList from '@material-ui/core/MenuList';
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | MenuList contents, normally `MenuItem`s. |
+| <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> |  <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
 
 Any other properties supplied will be spread to the root element ([List](/api/list/)).
 

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -19,7 +19,7 @@ import MenuList from '@material-ui/core/MenuList';
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | MenuList contents, normally `MenuItem`s. |
-| <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> |  <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
+| <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
 
 Any other properties supplied will be spread to the root element ([List](/api/list/)).
 


### PR DESCRIPTION
resolves a feature mentioned in issue #13865 

The MenuList component now wraps by default, gave disableListWrap prop for users to opt-out, updated docs accordingly.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
