### PR TITLE
core: fix jss v10 types being used

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha 'packages/material-ui/**/*.test.js' 'packages/material-ui-utils/**/*.test.js' 'packages/material-ui-styles/**/*.test.js' && nyc report --reporter=html",
     "test:karma": "cross-env NODE_ENV=test karma start test/karma.conf.js --single-run",
     "test:regressions": "webpack --config test/regressions/webpack.config.js && rimraf test/regressions/screenshots/chrome/* && vrtest run --config test/vrtest.config.js --record",
-    "typescript": "tslint -p tsconfig.json \"packages/*/{src,test}/**/*.{ts,tsx}\"",
+    "typescript": "lerna run typescript",
     "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN"
   },
   "peerDependencies": {

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -31,7 +31,8 @@
     "build:copy-files": "babel-node --config-file ../../babel.config.js ./scripts/copy-files.js",
     "build:typings": "babel-node --config-file ../../babel.config.js ./scripts/create-typings.js",
     "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:typings && yarn build:copy-files",
-    "release": "yarn build && npm publish build"
+    "release": "yarn build && npm publish build",
+    "typescript": "tslint -p tsconfig.json \"src/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
     "@material-ui/core": "^3.0.0",

--- a/packages/material-ui-icons/tsconfig.json
+++ b/packages/material-ui-icons/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig"
+}

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -29,7 +29,8 @@
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore *.test.js",
     "build:copy-files": "babel-node --config-file ../../babel.config.js ./scripts/copy-files.js",
     "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:es && yarn build:copy-files",
-    "release": "yarn build && npm publish build"
+    "release": "yarn build && npm publish build",
+    "typescript": "tslint -p tsconfig.json \"src/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
     "@material-ui/core": "^3.0.0",

--- a/packages/material-ui-lab/tsconfig.json
+++ b/packages/material-ui-lab/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig"
+}

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -29,7 +29,8 @@
     "build:copy-files": "babel-node --config-file ../../babel.config.js ./scripts/copy-files.js",
     "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:es && yarn build:copy-files",
     "release": "yarn build && npm publish build",
-    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui-styles/**/*.test.js'"
+    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui-styles/**/*.test.js'",
+    "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
     "react": "^16.7.0-alpha.2",

--- a/packages/material-ui-styles/tsconfig.json
+++ b/packages/material-ui-styles/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig"
+}

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -28,7 +28,8 @@
     "build:copy-files": "babel-node --config-file ../../babel.config.js ./scripts/copy-files.js",
     "build": "yarn build:es2015 && yarn build:es2015modules && yarn build:es && yarn build:umd && yarn build:copy-files",
     "release": "yarn build && npm publish build",
-    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/**/*.test.js'"
+    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui/**/*.test.js'",
+    "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
     "react": "^16.3.0",

--- a/packages/material-ui/src/styles/createGenerateClassName.d.ts
+++ b/packages/material-ui/src/styles/createGenerateClassName.d.ts
@@ -1,4 +1,4 @@
-import { GenerateId } from 'jss';
+import { GenerateClassName } from 'jss';
 
 export interface GenerateClassNameOptions {
   dangerouslyUseGlobalCSS?: boolean;
@@ -6,4 +6,6 @@ export interface GenerateClassNameOptions {
   seed?: string;
 }
 
-export default function createGenerateClassName(options?: GenerateClassNameOptions): GenerateId;
+export default function createGenerateClassName(
+  options?: GenerateClassNameOptions,
+): GenerateClassName;

--- a/packages/material-ui/src/styles/jssPreset.d.ts
+++ b/packages/material-ui/src/styles/jssPreset.d.ts
@@ -1,3 +1,3 @@
-import { JssOptions } from 'jss';
+import { JSSOptions } from 'jss';
 
-export default function jssPreset(): JssOptions;
+export default function jssPreset(): JSSOptions;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -28,7 +28,8 @@ export interface StylesCreator {
   themingEnabled: boolean;
 }
 
-export interface WithStylesOptions extends JSS.StyleSheetFactoryOptions {
+export interface WithStylesOptions<ClassKey extends string = string>
+  extends JSS.CreateStyleSheetOptions<ClassKey> {
   flip?: boolean;
   withTheme?: boolean;
   name?: string;
@@ -57,7 +58,10 @@ export interface StyledComponentProps<ClassKey extends string = string> {
   innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
-export default function withStyles<ClassKey extends string, Options extends WithStylesOptions = {}>(
+export default function withStyles<
+  ClassKey extends string,
+  Options extends WithStylesOptions<ClassKey> = {}
+>(
   style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
   options?: Options,
 ): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey>>;

--- a/packages/material-ui/tsconfig.json
+++ b/packages/material-ui/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig",
+  "compilerOptions": {
+    "baseUrl": "../../",
+    "paths": {
+      "@material-ui/core": ["packages/material-ui/src"],
+      "@material-ui/core/*": ["packages/material-ui/src/*"],
+      "@material-ui/lab": ["packages/material-ui-lab/src"],
+      "@material-ui/lab/*": ["packages/material-ui-lab/src/*"],
+      "jss": ["node_modules/@types/jss"]
+    }
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
Problem: `<workspace_root>/package.json` forces every `jss` version to v10 which has breaking changes compared to v9. However `@material-ui/core` still uses v9 at compile-time (and run-time if the stable styling solution is used).
Solution: use path mapping in tsconfig to resolve the version used in core to v9 while any other package remains on v10.

Closes #14040