### PR TITLE
[styles] Add test case for class extension with classes prop

### DIFF
--- a/packages/material-ui-styles/src/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles.test.js
@@ -1,0 +1,50 @@
+import { assert } from 'chai';
+import React from 'react';
+import { createMount } from '@material-ui/core/test-utils';
+import makeStyles from './makeStyles';
+
+describe('makeStyles', () => {
+  let mount;
+
+  /**
+   * returns a function that given the props for the styles object will return
+   * the css classes
+   * @param {object} styles argument for `makeStyles`
+   */
+  function createGetClasses(styles) {
+    const useStyles = makeStyles(styles);
+    let classes = {};
+
+    function TestComponent(props) {
+      classes = useStyles(props);
+      return null;
+    }
+
+    return function getClasses(props) {
+      mount(<TestComponent {...props} />);
+
+      // clone
+      return { ...classes };
+    };
+  }
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  it('appends classes', () => {
+    const styles = { root: {} };
+    const getClasses = createGetClasses(styles);
+
+    const baseClasses = getClasses();
+
+    const additionalClass = 'another-class';
+    const extendedClasses = getClasses({ classes: { root: additionalClass } });
+
+    assert.strictEqual(extendedClasses.root, `${baseClasses.root} ${additionalClass}`);
+  });
+});


### PR DESCRIPTION
Components created with `withStyles(styles)(Componet)` automatically would extend classnames if a `classes` prop was given. This is also supported in `makeStyles` but only if `props` are passed to the hook. This PR adds a test case for this behavior. 

I think it might also be good to add an example to the docs. We currently document that behavior for `withStyles` under https://material-ui.com/customization/css-in-js/#withstyles-styles-options-higher-order-component but https://material-ui.com/css-in-js/api/#makestyles-styles-options-hook mentions that the `props` argument in the hook is only  "[...] used for "interpolation" in the style sheet." which is incomplete.