### PR TITLE
[docs] Handle the exactProp usage in the API generation

### DIFF
--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -81,6 +81,8 @@ function buildDocs(options) {
     return;
   }
 
+  const spread = !src.match(/ = exactProp\(/);
+
   // eslint-disable-next-line global-require, import/no-dynamic-require
   const component = require(componentObject.filename);
   const name = path.parse(componentObject.filename).name;
@@ -137,6 +139,7 @@ function buildDocs(options) {
   reactAPI.styles = styles;
   reactAPI.pagesMarkdown = pagesMarkdown;
   reactAPI.src = src;
+  reactAPI.spread = spread;
 
   // if (reactAPI.name !== 'TableCell') {
   //   return;

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -249,14 +249,16 @@ function generateProps(reactAPI) {
     return textProps;
   }, text);
 
-  text = `${text}
+  if (reactAPI.spread) {
+    text = `${text}
 Any other properties supplied will be spread to the root element (${
-    reactAPI.inheritance
-      ? `[${reactAPI.inheritance.component}](${_rewriteUrlForNextExport(
-          reactAPI.inheritance.pathname,
-        )})`
-      : 'native element'
-  }).`;
+      reactAPI.inheritance
+        ? `[${reactAPI.inheritance.component}](${_rewriteUrlForNextExport(
+            reactAPI.inheritance.pathname,
+          )})`
+        : 'native element'
+    }).`;
+  }
 
   return text;
 }

--- a/packages/material-ui/src/RootRef/RootRef.js
+++ b/packages/material-ui/src/RootRef/RootRef.js
@@ -59,8 +59,7 @@ class RootRef extends React.Component {
   }
 
   render() {
-    const { rootRef, children, ...remainingProps } = this.props;
-    return React.cloneElement(children, remainingProps);
+    return this.props.children;
   }
 }
 

--- a/packages/material-ui/src/RootRef/RootRef.js
+++ b/packages/material-ui/src/RootRef/RootRef.js
@@ -59,7 +59,8 @@ class RootRef extends React.Component {
   }
 
   render() {
-    return this.props.children;
+    const { rootRef, children, ...remainingProps } = this.props;
+    return React.cloneElement(children, remainingProps);
   }
 }
 

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -20,7 +20,6 @@ Kickstart an elegant, consistent, and simple baseline to build upon.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> | <span class="prop-default">null</span> | You can wrap a node. |
 
-Any other properties supplied will be spread to the root element (native element).
 
 ## Demos
 

--- a/pages/api/mui-theme-provider.md
+++ b/pages/api/mui-theme-provider.md
@@ -25,5 +25,4 @@ This component should preferably be used at **the root of your component tree**.
 | <span class="prop-name">sheetsManager</span> | <span class="prop-type">object</span> |   | The sheetsManager is used to deduplicate style sheet injection in the page. It's deduplicating using the (theme, styles) couple. On the server, you should provide a new instance for each request. |
 | <span class="prop-name required">theme *</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br></span> |   | A theme object. |
 
-Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/no-ssr.md
+++ b/pages/api/no-ssr.md
@@ -28,7 +28,6 @@ This component can be useful in a variety of situations:
 | <span class="prop-name">defer</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will not only prevent server-side rendering. It will also defer the rendering of the children into a different screen frame. |
 | <span class="prop-name">fallback</span> | <span class="prop-type">node</span> | <span class="prop-default">null</span> | The fallback content to display. |
 
-Any other properties supplied will be spread to the root element (native element).
 
 ## Demos
 

--- a/pages/api/portal.md
+++ b/pages/api/portal.md
@@ -24,7 +24,6 @@ that exists outside the DOM hierarchy of the parent component.
 | <span class="prop-name">disablePortal</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the portal behavior. The children stay within it's parent DOM hierarchy. |
 | <span class="prop-name">onRendered</span> | <span class="prop-type">func</span> |   | Callback fired once the children has been mounted into the `container`. |
 
-Any other properties supplied will be spread to the root element (native element).
 
 ## Demos
 

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -48,5 +48,4 @@ class MyComponent extends React.Component {
 | <span class="prop-name required">children *</span> | <span class="prop-type">element</span> |   | The wrapped element. |
 | <span class="prop-name required">rootRef *</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |   | Provide a way to access the DOM node of the wrapped element. You can provide a callback ref or a `React.createRef()` ref. |
 
-Any other properties supplied will be spread to the root element (native element).
 


### PR DESCRIPTION
The documentation for `RootRef` says that "Any other properties supplied will be spread to the root element (native element)." (https://material-ui.com/api/root-ref/#props), but the implementation didn't do this. This fixes that.

In case I interpreted the documentation wrong, I'd still like to propose this change regardless because it's an inexpensive quality of life change that shouldn't break any existing code.

I was using a component that would control its children via their props -- specifically an `Accordion` component that would make sure that only one `AccordionPanel` was open at a time. Something like:

```js
<Accordion maxOpen={1}>
  <AccordionPanel>Some content</AccordionPanel>
  <AccordionPanel>Some other content</AccordionPanel>
</Accordion>
```

Wrapping the `AccordionPanel` in `RootRef` breaks this -- and this PR fixes it.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
