### PR TITLE
[styles] Document the CSS prefixing strategy on the server

### DIFF
--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -16,13 +16,18 @@ Because Googlebot uses a web rendering service (WRS) to index the page content, 
 [WRS is based on Chrome 41](https://developers.google.com/search/docs/guides/rendering).
 You can expect Material-UI's components to render without major issues.
 
-### Server-Side rendering
-Be aware that some CSS features might require an additional postprocessing step
-that adds vendor specific prefixes. These prefixes are automatically added on the
-client thanks to [`jss-plugin-vendor-prefixer`](https://www.npmjs.com/package/jss-plugin-vendor-prefixer). 
-The CSS served on this documentation is processed with [`autoprefixer`](https://www.npmjs.com/package/autoprefixer).
-
 ## Server
 
 Because Material-UI supports server-side rendering, we need to support the latest, stable releases of [Node.js](https://github.com/nodejs/node).
 We try to support the [last active LTS version](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v6.x** and newer versions.
+
+### CSS prefixing
+
+Be aware that some CSS features [require](https://github.com/cssinjs/jss/issues/279) an additional postprocessing step
+that adds vendor specific prefixes.
+These prefixes are automatically added on the client thanks to [`jss-plugin-vendor-prefixer`](https://www.npmjs.com/package/jss-plugin-vendor-prefixer). 
+
+The CSS served on this documentation is processed with [`autoprefixer`](https://www.npmjs.com/package/autoprefixer).
+You can use [the documentation implementation](https://github.com/mui-org/material-ui/blob/47aa5aeaec1d4ac2c08fd0e84277d6b91e497557/pages/_document.js#L123) as inspiration.
+Be aware that it has an implication with the performance of the page.
+It's a must do for static pages, but it needs to be put in balance with not doing anything when rendering dynamic pages.

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -16,6 +16,12 @@ Because Googlebot uses a web rendering service (WRS) to index the page content, 
 [WRS is based on Chrome 41](https://developers.google.com/search/docs/guides/rendering).
 You can expect Material-UI's components to render without major issues.
 
+### Server-Side rendering
+Be aware that some CSS features might require an additional postprocessing step
+that adds vendor specific prefixes. These prefixes are automatically added on the
+client thanks to [`jss-plugin-vendor-prefixer`](https://www.npmjs.com/package/jss-plugin-vendor-prefixer). 
+The CSS served on this documentation is processed with [`autoprefixer`](https://www.npmjs.com/package/autoprefixer).
+
 ## Server
 
 Because Material-UI supports server-side rendering, we need to support the latest, stable releases of [Node.js](https://github.com/nodejs/node).


### PR DESCRIPTION
Switch to standard CSS properties wherever the same values are used. `jss-plugin-vendor-prefixer` will do the rest.