### PR TITLE
[Link] Fix type declaration for props

### DIFF
--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -4,7 +4,7 @@ import { TypographyProps } from '../Typography';
 
 export interface LinkProps
   extends StandardProps<
-    React.HTMLAttributes<HTMLAnchorElement> & TypographyProps,
+    React.AnchorHTMLAttributes<HTMLAnchorElement> & TypographyProps,
     LinkClassKey,
     'component'
   > {


### PR DESCRIPTION
Derive from AnchorHTMLAttributes to add anchor specific properties like `href` to prop types of `Link`.  Otherwise tsc fails to compile when using arguably important properties like `href` and `target`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
