### PR TITLE
[core] Remove keycode()

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -22,7 +22,7 @@ module.exports = [
     name: 'The size of the @material-ui/core modules',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '95.3 KB',
+    limit: '94.5 KB',
   },
   {
     name: 'The size of the @material-ui/styles modules',
@@ -41,6 +41,19 @@ module.exports = [
     webpack: true,
     path: 'packages/material-ui/build/styles/colorManipulator.js',
     limit: '900 B',
+  },
+  {
+    name: 'The size of the @material-ui/core/Button component',
+    webpack: true,
+    path: 'packages/material-ui/build/Button/index.js',
+    limit: '27.0 KB',
+  },
+  {
+    // vs https://bundlephobia.com/result?p=react-modal
+    name: 'The size of the @material-ui/core/Modal component',
+    webpack: true,
+    path: 'packages/material-ui/build/Modal/index.js',
+    limit: '27.0 KB',
   },
   {
     // vs https://bundlephobia.com/result?p=react-popper

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import keycode from 'keycode';
 import compose from 'recompose/compose';
 import EventListener from 'react-event-listener';
 import PropTypes from 'prop-types';
@@ -141,8 +140,12 @@ const styles = theme => ({
 
 class AppSearch extends React.Component {
   handleKeyDown = event => {
+    // Use event.keyCode to support IE 11
     if (
-      ['/', 's'].indexOf(keycode(event)) !== -1 &&
+      [
+        191, // '/'
+        83, // 's'
+      ].indexOf(event.keyCode) !== -1 &&
       document.activeElement.nodeName.toLowerCase() === 'body' &&
       document.activeElement !== this.inputRef
     ) {

--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.hooks.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.hooks.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import deburr from 'lodash/deburr';
-import keycode from 'keycode';
 import Downshift from 'downshift';
 import { makeStyles } from '@material-ui/styles';
 import TextField from '@material-ui/core/TextField';
@@ -116,7 +115,7 @@ function DownshiftMultiple(props) {
   const [selectedItem, setSelectedItem] = React.useState([]);
 
   function handleKeyDown(event) {
-    if (selectedItem.length && !inputValue.length && keycode(event) === 'backspace') {
+    if (selectedItem.length && !inputValue.length && event.key === 'Backspace') {
       setSelectedItem(selectedItem.slice(0, selectedItem.length - 1));
     }
   }

--- a/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationDownshift.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import deburr from 'lodash/deburr';
-import keycode from 'keycode';
 import Downshift from 'downshift';
 import { withStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
@@ -118,7 +117,7 @@ class DownshiftMultiple extends React.Component {
 
   handleKeyDown = event => {
     const { inputValue, selectedItem } = this.state;
-    if (selectedItem.length && !inputValue.length && keycode(event) === 'backspace') {
+    if (selectedItem.length && !inputValue.length && event.key === 'Backspace') {
       this.setState({
         selectedItem: selectedItem.slice(0, selectedItem.length - 1),
       });

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import keycode from 'keycode';
 import classNames from 'classnames';
 import withStyles from '@material-ui/core/styles/withStyles';
 import ButtonBase from '@material-ui/core/ButtonBase';
@@ -271,25 +270,25 @@ class Slider extends React.Component {
     const step = this.props.step || onePercent;
     let value;
 
-    switch (keycode(event)) {
-      case 'home':
+    switch (event.key) {
+      case 'Home':
         value = min;
         break;
-      case 'end':
+      case 'End':
         value = max;
         break;
-      case 'page up':
+      case 'PageUp':
         value = currentValue + onePercent * 10;
         break;
-      case 'page down':
+      case 'PageDown':
         value = currentValue - onePercent * 10;
         break;
-      case 'right':
-      case 'up':
+      case 'ArrowRight':
+      case 'ArrowUp':
         value = currentValue + step;
         break;
-      case 'left':
-      case 'down':
+      case 'ArrowLeft':
+      case 'ArrowDown':
         value = currentValue - step;
         break;
       default:

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -56,7 +56,6 @@
     "jss-nested": "^6.0.1",
     "jss-props-sort": "^6.0.0",
     "jss-vendor-prefixer": "^7.0.0",
-    "keycode": "^2.1.9",
     "normalize-scroll-left": "^0.1.2",
     "popper.js": "^1.14.1",
     "prop-types": "^15.6.0",

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
-import keycode from 'keycode';
 import { componentPropType } from '@material-ui/utils';
 import ownerWindow from '../utils/ownerWindow';
 import withStyles from '../styles/withStyles';
@@ -164,10 +163,15 @@ class ButtonBase extends React.Component {
 
   handleKeyDown = event => {
     const { component, focusRipple, onKeyDown, onClick } = this.props;
-    const key = keycode(event);
 
     // Check if key is already down to avoid repeats being counted as multiple activations
-    if (focusRipple && !this.keyDown && this.state.focusVisible && this.ripple && key === 'space') {
+    if (
+      focusRipple &&
+      !this.keyDown &&
+      this.state.focusVisible &&
+      this.ripple &&
+      event.key === ' '
+    ) {
       this.keyDown = true;
       event.persist();
       this.ripple.stop(event, () => {
@@ -184,7 +188,7 @@ class ButtonBase extends React.Component {
       event.target === event.currentTarget &&
       component &&
       component !== 'button' &&
-      (key === 'space' || key === 'enter') &&
+      (event.key === ' ' || event.key === 'Enter') &&
       !(this.button.tagName === 'A' && this.button.href)
     ) {
       event.preventDefault();
@@ -195,12 +199,7 @@ class ButtonBase extends React.Component {
   };
 
   handleKeyUp = event => {
-    if (
-      this.props.focusRipple &&
-      keycode(event) === 'space' &&
-      this.ripple &&
-      this.state.focusVisible
-    ) {
+    if (this.props.focusRipple && event.key === ' ' && this.ripple && this.state.focusVisible) {
       this.keyDown = false;
       event.persist();
       this.ripple.stop(event, () => {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import keycode from 'keycode';
 import { assert } from 'chai';
 import PropTypes from 'prop-types';
 import { spy, useFakeTimers } from 'sinon';
@@ -239,7 +238,10 @@ describe('<ButtonBase />', () => {
 
     it('should stop pulsate and start a ripple when the space button is pressed', () => {
       wrapper.instance().ripple = { stop: spy((event, cb) => cb()), start: spy() };
-      wrapper.simulate('keyDown', { which: 32, keyCode: 32, key: ' ', persist: () => {} });
+      wrapper.simulate('keyDown', {
+        key: ' ',
+        persist: () => {},
+      });
 
       assert.strictEqual(wrapper.instance().ripple.stop.callCount, 1);
       assert.strictEqual(wrapper.instance().ripple.start.callCount, 1);
@@ -247,10 +249,12 @@ describe('<ButtonBase />', () => {
 
     it('should stop and re-pulsate when space bar is released', () => {
       wrapper.instance().ripple = { stop: spy((event, cb) => cb()), pulsate: spy() };
-      wrapper.simulate('keyUp', { which: 32, keyCode: 32, key: ' ', persist: () => {} });
+      wrapper.simulate('keyUp', {
+        key: ' ',
+        persist: () => {},
+      });
 
       assert.strictEqual(wrapper.instance().ripple.stop.callCount, 1);
-
       assert.strictEqual(wrapper.instance().ripple.pulsate.callCount, 1);
     });
 
@@ -305,7 +309,7 @@ describe('<ButtonBase />', () => {
       }
 
       const event = new window.Event('keyup');
-      event.which = keycode('tab');
+      event.keyCode = 9; // Tab
       window.dispatchEvent(event);
     });
 
@@ -343,7 +347,7 @@ describe('<ButtonBase />', () => {
       button.focus();
 
       const event = new window.Event('keyup');
-      event.which = keycode('tab');
+      event.keyCode = 9; // Tab
       window.dispatchEvent(event);
     });
 
@@ -493,7 +497,7 @@ describe('<ButtonBase />', () => {
         wrapper.setState({ focusVisible: true });
 
         const eventPersistSpy = spy();
-        event = { persist: eventPersistSpy, keyCode: keycode('space') };
+        event = { persist: eventPersistSpy, key: ' ' };
 
         instance = wrapper.instance();
         instance.keyDown = false;
@@ -516,7 +520,7 @@ describe('<ButtonBase />', () => {
         );
 
         const eventPersistSpy = spy();
-        event = { persist: eventPersistSpy, keyCode: undefined };
+        event = { persist: eventPersistSpy, key: undefined };
 
         instance = wrapper.instance();
         instance.keyDown = false;
@@ -540,7 +544,7 @@ describe('<ButtonBase />', () => {
 
         event = {
           preventDefault: spy(),
-          keyCode: keycode('space'),
+          key: ' ',
           target: 'target',
           currentTarget: 'target',
         };
@@ -564,7 +568,7 @@ describe('<ButtonBase />', () => {
         );
         event = {
           preventDefault: spy(),
-          keyCode: keycode('enter'),
+          key: 'Enter',
           target: 'target',
           currentTarget: 'target',
         };
@@ -583,7 +587,7 @@ describe('<ButtonBase />', () => {
         );
         event = {
           preventDefault: spy(),
-          keyCode: keycode('enter'),
+          key: 'Enter',
           target: 'target',
           currentTarget: 'target',
         };
@@ -624,7 +628,7 @@ describe('<ButtonBase />', () => {
         assert.strictEqual(wrapper.find(TouchRipple).length, 0);
 
         const eventPersistSpy = spy();
-        event = { persist: eventPersistSpy, keyCode: keycode('space') };
+        event = { persist: eventPersistSpy, key: ' ' };
 
         instance = wrapper.instance();
         instance.keyDown = false;

--- a/packages/material-ui/src/ButtonBase/focusVisible.js
+++ b/packages/material-ui/src/ButtonBase/focusVisible.js
@@ -1,4 +1,3 @@
-import keycode from 'keycode';
 import warning from 'warning';
 import ownerDocument from '../utils/ownerDocument';
 
@@ -37,10 +36,20 @@ export function detectFocusVisible(instance, element, callback, attempt = 1) {
   }, instance.focusVisibleCheckTime);
 }
 
-const FOCUS_KEYS = ['tab', 'enter', 'space', 'esc', 'up', 'down', 'left', 'right'];
+const FOCUS_KEYS = [
+  9, // 'Tab',
+  13, // 'Enter',
+  27, // 'Escape',
+  32, // ' ',
+  37, // 'ArrowLeft',
+  38, // 'ArrowUp',
+  39, // 'ArrowRight',
+  40, // 'ArrowDown',
+];
 
 function isFocusKey(event) {
-  return FOCUS_KEYS.indexOf(keycode(event)) > -1;
+  // Use event.keyCode to support IE 11
+  return FOCUS_KEYS.indexOf(event.keyCode) > -1;
 }
 
 const handleKeyUpEvent = event => {

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import keycode from 'keycode';
 import warning from 'warning';
 import { componentPropType } from '@material-ui/utils';
 import CancelIcon from '../internal/svg-icons/Cancel';
@@ -248,8 +247,8 @@ class Chip extends React.Component {
       return;
     }
 
-    const key = keycode(event);
-    if (key === 'space' || key === 'enter' || key === 'backspace' || key === 'esc') {
+    const key = event.key;
+    if (key === ' ' || key === 'Enter' || key === 'Backspace' || key === 'Escape') {
       event.preventDefault();
     }
   };
@@ -266,13 +265,12 @@ class Chip extends React.Component {
       return;
     }
 
-    const key = keycode(event);
-
-    if (onClick && (key === 'space' || key === 'enter')) {
+    const key = event.key;
+    if (onClick && (key === ' ' || key === 'Enter')) {
       onClick(event);
-    } else if (onDelete && key === 'backspace') {
+    } else if (onDelete && key === 'Backspace') {
       onDelete(event);
-    } else if (key === 'esc' && this.chipRef) {
+    } else if (key === 'Escape' && this.chipRef) {
       this.chipRef.blur();
     }
   };

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import keycode from 'keycode';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import CheckBox from '../internal/svg-icons/CheckBox';
@@ -349,7 +348,7 @@ describe('<Chip />', () => {
 
     describe('onKeyDown is defined', () => {
       it('should call onKeyDown when a key is pressed', () => {
-        const anyKeydownEvent = { keycode: keycode('p') };
+        const anyKeydownEvent = { key: 'p' };
         const onKeyDownSpy = spy();
         wrapper = mount(<Chip classes={{}} onKeyDown={onKeyDownSpy} />);
         wrapper.find('div').simulate('keyDown', anyKeydownEvent);
@@ -365,7 +364,7 @@ describe('<Chip />', () => {
         wrapper2.instance().chipRef.blur = handleBlur;
         wrapper2.find('div').simulate('keyUp', {
           preventDefault: () => {},
-          keyCode: keycode('esc'),
+          key: 'Escape',
         });
         assert.strictEqual(handleBlur.callCount, 1);
       });
@@ -386,14 +385,14 @@ describe('<Chip />', () => {
         const preventDefaultSpy = spy();
         const spaceKeyDown = {
           preventDefault: preventDefaultSpy,
-          keyCode: keycode('space'),
+          key: ' ',
         };
         wrapper.find('div').simulate('keyDown', spaceKeyDown);
         assert.strictEqual(preventDefaultSpy.callCount, 1);
         assert.strictEqual(onClickSpy.callCount, 0);
 
         const spaceKeyUp = {
-          keyCode: keycode('space'),
+          key: ' ',
         };
         wrapper.find('div').simulate('keyUp', spaceKeyUp);
         assert.strictEqual(onClickSpy.callCount, 1);
@@ -404,14 +403,14 @@ describe('<Chip />', () => {
         const preventDefaultSpy = spy();
         const enterKeyDown = {
           preventDefault: preventDefaultSpy,
-          keyCode: keycode('enter'),
+          key: 'Enter',
         };
         wrapper.find('div').simulate('keyDown', enterKeyDown);
         assert.strictEqual(preventDefaultSpy.callCount, 1);
         assert.strictEqual(onClickSpy.callCount, 0);
 
         const enterKeyUp = {
-          keyCode: keycode('enter'),
+          key: 'Enter',
         };
         wrapper.find('div').simulate('keyUp', enterKeyUp);
         assert.strictEqual(onClickSpy.callCount, 1);
@@ -427,14 +426,14 @@ describe('<Chip />', () => {
 
         const backspaceKeyDown = {
           preventDefault: preventDefaultSpy,
-          keyCode: keycode('backspace'),
+          key: 'Backspace',
         };
         wrapper2.find('div').simulate('keyDown', backspaceKeyDown);
         assert.strictEqual(preventDefaultSpy.callCount, 1);
         assert.strictEqual(onDeleteSpy.callCount, 0);
 
         const backspaceKeyUp = {
-          keyCode: keycode('backspace'),
+          key: 'Backspace',
         };
         wrapper2.find('div').simulate('keyUp', backspaceKeyUp);
         assert.strictEqual(onDeleteSpy.callCount, 1);
@@ -472,27 +471,27 @@ describe('<Chip />', () => {
       });
 
       it('should not call onDelete for child event', () => {
-        wrapper.find('.child-input').simulate('keyDown', { keyCode: keycode('backspace') });
+        wrapper.find('.child-input').simulate('keyDown', { key: 'Backspace' });
         assert.strictEqual(onDeleteSpy.callCount, 0);
       });
 
       it('should not call onClick for child event when `space` is pressed', () => {
-        wrapper.find('.child-input').simulate('keyDown', { keyCode: keycode('space') });
+        wrapper.find('.child-input').simulate('keyDown', { key: ' ' });
         assert.strictEqual(onClickSpy.callCount, 0);
       });
 
       it('should not call onClick for child event when `enter` is pressed', () => {
-        wrapper.find('.child-input').simulate('keyDown', { keyCode: keycode('enter') });
+        wrapper.find('.child-input').simulate('keyDown', { key: 'Enter' });
         assert.strictEqual(onClickSpy.callCount, 0);
       });
 
       it('should call handlers for child event', () => {
         onKeyDownSpy.resetHistory();
-        wrapper.find('.child-input').simulate('keyDown', { keyCode: keycode('p') });
+        wrapper.find('.child-input').simulate('keyDown', { key: 'p' });
         assert.strictEqual(onKeyDownSpy.callCount, 1);
 
         onKeyUpSpy.resetHistory();
-        wrapper.find('.child-input').simulate('keyUp', { keyCode: keycode('p') });
+        wrapper.find('.child-input').simulate('keyUp', { key: 'p' });
         assert.strictEqual(onKeyUpSpy.callCount, 1);
       });
     });

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -83,8 +83,8 @@ class Menu extends React.Component {
     }
   };
 
-  handleListKeyDown = (event, key) => {
-    if (key === 'tab') {
+  handleListKeyDown = event => {
+    if (event.key === 'Tab') {
       event.preventDefault();
 
       if (this.props.onClose) {

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import keycode from 'keycode';
 import warning from 'warning';
 import ownerDocument from '../utils/ownerDocument';
 import List from '../List';
@@ -43,11 +42,11 @@ class MenuList extends React.Component {
 
   handleKeyDown = event => {
     const list = this.listRef;
-    const key = keycode(event);
+    const key = event.key;
     const currentFocus = ownerDocument(list).activeElement;
 
     if (
-      (key === 'up' || key === 'down') &&
+      (key === 'ArrowUp' || key === 'ArrowDown') &&
       (!currentFocus || (currentFocus && !list.contains(currentFocus)))
     ) {
       if (this.selectedItemRef) {
@@ -55,30 +54,30 @@ class MenuList extends React.Component {
       } else {
         list.firstChild.focus();
       }
-    } else if (key === 'down') {
+    } else if (key === 'ArrowDown') {
       event.preventDefault();
       if (currentFocus.nextElementSibling) {
         currentFocus.nextElementSibling.focus();
       } else if (!this.props.disableListWrap) {
         list.firstChild.focus();
       }
-    } else if (key === 'up') {
+    } else if (key === 'ArrowUp') {
       event.preventDefault();
       if (currentFocus.previousElementSibling) {
         currentFocus.previousElementSibling.focus();
       } else if (!this.props.disableListWrap) {
         list.lastChild.focus();
       }
-    } else if (key === 'home') {
+    } else if (key === 'Home') {
       event.preventDefault();
       list.firstChild.focus();
-    } else if (key === 'end') {
+    } else if (key === 'End') {
       event.preventDefault();
       list.lastChild.focus();
     }
 
     if (this.props.onKeyDown) {
-      this.props.onKeyDown(event, key);
+      this.props.onKeyDown(event);
     }
   };
 

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import warning from 'warning';
-import keycode from 'keycode';
 import { componentPropType } from '@material-ui/utils';
 import ownerDocument from '../utils/ownerDocument';
 import RootRef from '../RootRef';
@@ -167,7 +166,7 @@ class Modal extends React.Component {
     }
   };
 
-  handleDocumentKeyDown = event => {
+  handleKeyDown = event => {
     // event.defaultPrevented:
     //
     // Ignore events that have been `event.preventDefault()` marked.
@@ -177,7 +176,7 @@ class Modal extends React.Component {
     // Only special HTML elements have these default bahaviours.
     //
     // To remove in v4.
-    if (keycode(event) !== 'esc' || !this.isTopModal() || event.defaultPrevented) {
+    if (event.key !== 'Escape' || !this.isTopModal() || event.defaultPrevented) {
       return;
     }
 
@@ -325,7 +324,7 @@ class Modal extends React.Component {
         <div
           data-mui-test="Modal"
           ref={this.handleModalRef}
-          onKeyDown={this.handleDocumentKeyDown}
+          onKeyDown={this.handleKeyDown}
           role="presentation"
           className={classNames('mui-fixed', classes.root, className, {
             [classes.hidden]: exited,

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
 import PropTypes from 'prop-types';
-import keycode from 'keycode';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createShallow, createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
 import Fade from '../Fade';
@@ -234,7 +233,7 @@ describe('<Modal />', () => {
     });
   });
 
-  describe('handleDocumentKeyDown()', () => {
+  describe('handleKeyDown()', () => {
     let wrapper;
     let instance;
     let onEscapeKeyDownSpy;
@@ -252,13 +251,13 @@ describe('<Modal />', () => {
       instance = wrapper.instance();
     });
 
-    it('should have handleDocumentKeyDown', () => {
-      assert.notStrictEqual(instance.handleDocumentKeyDown, undefined);
-      assert.strictEqual(typeof instance.handleDocumentKeyDown, 'function');
+    it('should have handleKeyDown', () => {
+      assert.notStrictEqual(instance.handleKeyDown, undefined);
+      assert.strictEqual(typeof instance.handleKeyDown, 'function');
     });
 
     it('when not mounted should not call onEscapeKeyDown and onClose', () => {
-      instance.handleDocumentKeyDown(undefined);
+      instance.handleKeyDown({});
       assert.strictEqual(onEscapeKeyDownSpy.callCount, 0);
       assert.strictEqual(onCloseSpy.callCount, 0);
     });
@@ -267,8 +266,8 @@ describe('<Modal />', () => {
       topModalStub.returns(false);
       wrapper.setProps({ manager: { isTopModal: topModalStub } });
 
-      instance.handleDocumentKeyDown({
-        keyCode: keycode('esc'),
+      instance.handleKeyDown({
+        key: 'Escape',
       });
       assert.strictEqual(topModalStub.callCount, 1);
       assert.strictEqual(onEscapeKeyDownSpy.callCount, 0);
@@ -278,9 +277,9 @@ describe('<Modal />', () => {
     it('when mounted, TopModal and event not esc should not call given functions', () => {
       topModalStub.returns(true);
       wrapper.setProps({ manager: { isTopModal: topModalStub } });
-      event = { keyCode: keycode('j') }; // Not 'esc'
+      event = { key: 'j' }; // Not 'esc'
 
-      instance.handleDocumentKeyDown(event);
+      instance.handleKeyDown(event);
       assert.strictEqual(topModalStub.callCount, 0);
       assert.strictEqual(onEscapeKeyDownSpy.callCount, 0);
       assert.strictEqual(onCloseSpy.callCount, 0);
@@ -289,9 +288,9 @@ describe('<Modal />', () => {
     it('should call onEscapeKeyDown and onClose', () => {
       topModalStub.returns(true);
       wrapper.setProps({ manager: { isTopModal: topModalStub } });
-      event = { keyCode: keycode('esc'), stopPropagation: () => {} };
+      event = { key: 'Escape', stopPropagation: () => {} };
 
-      instance.handleDocumentKeyDown(event);
+      instance.handleKeyDown(event);
       assert.strictEqual(topModalStub.callCount, 1);
       assert.strictEqual(onEscapeKeyDownSpy.callCount, 1);
       assert.strictEqual(onEscapeKeyDownSpy.calledWith(event), true);
@@ -302,9 +301,9 @@ describe('<Modal />', () => {
     it('when disableEscapeKeyDown should call only onClose', () => {
       topModalStub.returns(true);
       wrapper.setProps({ disableEscapeKeyDown: true, manager: { isTopModal: topModalStub } });
-      event = { keyCode: keycode('esc'), stopPropagation: () => {} };
+      event = { key: 'Escape', stopPropagation: () => {} };
 
-      instance.handleDocumentKeyDown(event);
+      instance.handleKeyDown(event);
       assert.strictEqual(topModalStub.callCount, 1);
       assert.strictEqual(onEscapeKeyDownSpy.callCount, 1);
       assert.strictEqual(onEscapeKeyDownSpy.calledWith(event), true);
@@ -314,9 +313,9 @@ describe('<Modal />', () => {
     it('should not be call when defaultPrevented', () => {
       topModalStub.returns(true);
       wrapper.setProps({ disableEscapeKeyDown: true, manager: { isTopModal: topModalStub } });
-      event = { keyCode: keycode('esc'), defaultPrevented: true };
+      event = { key: 'Escape', defaultPrevented: true };
 
-      instance.handleDocumentKeyDown(event);
+      instance.handleKeyDown(event);
       assert.strictEqual(topModalStub.callCount, 1);
       assert.strictEqual(onEscapeKeyDownSpy.callCount, 0);
       assert.strictEqual(onCloseSpy.callCount, 0);

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import keycode from 'keycode';
 import warning from 'warning';
 import { componentPropType } from '@material-ui/utils';
 import Menu from '../Menu/Menu';
@@ -130,7 +129,7 @@ class SelectInput extends React.Component {
       return;
     }
 
-    if (['space', 'up', 'down'].indexOf(keycode(event)) !== -1) {
+    if ([' ', 'ArrowUp', 'ArrowDown'].indexOf(event.key) !== -1) {
       event.preventDefault();
       // Opening the menu is going to blur the. It will be focused back when closed.
       this.ignoreNextBlur = true;

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import keycode from 'keycode';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import Menu from '../Menu';
 import Portal from '../Portal';
@@ -97,9 +96,7 @@ describe('<SelectInput />', () => {
   describe('prop: readOnly', () => {
     it('should not trigger any event with readOnly', () => {
       const wrapper = shallow(<SelectInput {...defaultProps} readOnly />);
-      wrapper
-        .find(`.${defaultProps.classes.select}`)
-        .simulate('keyDown', { which: keycode('down') });
+      wrapper.find(`.${defaultProps.classes.select}`).simulate('keyDown', { key: 'ArrowDown' });
       assert.strictEqual(wrapper.state().open, false);
     });
   });
@@ -223,11 +220,9 @@ describe('<SelectInput />', () => {
       assert.strictEqual(handleBlur.args[0][0].target.name, 'blur-testing');
     });
 
-    ['space', 'up', 'down'].forEach(key => {
+    [' ', 'ArrowUp', 'ArrowDown'].forEach(key => {
       it(`'should open menu when pressed ${key} key on select`, () => {
-        wrapper
-          .find(`.${defaultProps.classes.select}`)
-          .simulate('keyDown', { which: keycode(key) });
+        wrapper.find(`.${defaultProps.classes.select}`).simulate('keyDown', { key });
         assert.strictEqual(wrapper.state().open, true);
         assert.strictEqual(instance.ignoreNextBlur, true);
       });

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import keycode from 'keycode';
 import { assert } from 'chai';
 import TestUtils from 'react-dom/test-utils';
 import { createMount } from 'packages/material-ui/src/test-utils';
@@ -43,42 +42,58 @@ describe('<Menu> integration', () => {
     });
 
     it('should change focus to the 2nd item when down arrow is pressed', () => {
-      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('down') });
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowDown',
+      });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
     });
 
     it('should change focus to the 3rd item when down arrow is pressed', () => {
-      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('down') });
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowDown',
+      });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
     it('should switch focus from the 3rd item to the 1st item when down arrow is pressed', () => {
-      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('down') });
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowDown',
+      });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
     });
 
     it('should switch focus from the 1st item to the 3rd item when up arrow is pressed', () => {
-      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('up') });
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowUp',
+      });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
     it('should switch focus from the 3rd item to the 1st item when home key is pressed', () => {
-      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('home') });
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'Home',
+      });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
     });
 
     it('should switch focus from the 1st item to the 3rd item when end key is pressed', () => {
-      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('end') });
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'End',
+      });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
     it('should keep focus on the last item when a key with no associated action is pressed', () => {
-      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('right') });
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowRight',
+      });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
 
     it('should change focus to the 2nd item when up arrow is pressed', () => {
-      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), { which: keycode('up') });
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowUp',
+      });
       assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
     });
 
@@ -157,7 +172,7 @@ describe('<Menu> integration', () => {
       assert.strictEqual(wrapper.state().open, true);
       const list = portalLayer.querySelector('ul');
       TestUtils.Simulate.keyDown(list, {
-        which: keycode('tab'),
+        key: 'Tab',
       });
       assert.strictEqual(wrapper.state().open, false);
     });

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import keycode from 'keycode';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import MenuList from 'packages/material-ui/src/MenuList';
@@ -70,24 +69,24 @@ describe('<MenuList> integration', () => {
     });
 
     it('should select the last item when pressing up', () => {
-      wrapper.simulate('keyDown', { which: keycode('up') });
+      wrapper.simulate('keyDown', { key: 'ArrowUp' });
       assertMenuItemTabIndexed(wrapper, 3);
     });
 
     it('should select the first item when pressing dowm', () => {
-      wrapper.simulate('keyDown', { which: keycode('down') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
       assertMenuItemTabIndexed(wrapper, 0);
     });
 
     it('should still have the first item tabIndexed', () => {
-      wrapper.simulate('keyDown', { which: keycode('down') });
-      wrapper.simulate('keyDown', { which: keycode('up') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
+      wrapper.simulate('keyDown', { key: 'ArrowUp' });
       assertMenuItemFocused(wrapper, 0);
     });
 
     it('should focus the second item 1', () => {
       wrapper.instance().focus();
-      wrapper.simulate('keyDown', { which: keycode('down') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
       assertMenuItemTabIndexed(wrapper, 1);
       assertMenuItemFocused(wrapper, 1);
     });
@@ -111,7 +110,7 @@ describe('<MenuList> integration', () => {
 
     it('should reset the tabIndex to the focused element when calling resetTabIndex', () => {
       wrapper.instance().focus();
-      wrapper.simulate('keyDown', { which: keycode('down') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
       wrapper.instance().setTabIndex(2);
       wrapper.instance().resetTabIndex();
 
@@ -128,25 +127,25 @@ describe('<MenuList> integration', () => {
     });
 
     it('should focus the second item 2', () => {
-      wrapper.simulate('keyDown', { which: keycode('down') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
       assertMenuItemTabIndexed(wrapper, 1);
       assertMenuItemFocused(wrapper, 1);
     });
 
     it('should focus the third item', () => {
-      wrapper.simulate('keyDown', { which: keycode('down') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
       assertMenuItemTabIndexed(wrapper, 2);
       assertMenuItemFocused(wrapper, 2);
     });
 
     it('should focus the first item if not focused', () => {
       resetWrapper();
-      wrapper.simulate('keyDown', { which: keycode('down') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
       assertMenuItemTabIndexed(wrapper, 0);
       assertMenuItemFocused(wrapper, 0);
 
       resetWrapper();
-      wrapper.simulate('keyDown', { which: keycode('up') });
+      wrapper.simulate('keyDown', { key: 'ArrowUp' });
       assertMenuItemTabIndexed(wrapper, 0);
       assertMenuItemFocused(wrapper, 0);
     });
@@ -180,19 +179,19 @@ describe('<MenuList> integration', () => {
 
     it('should focus the third item', () => {
       wrapper.instance().focus();
-      wrapper.simulate('keyDown', { which: keycode('down') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
       assertMenuItemTabIndexed(wrapper, 2);
       assertMenuItemFocused(wrapper, 2);
     });
 
     it('should focus the preselected item if not focused', () => {
       resetWrapper();
-      wrapper.simulate('keyDown', { which: keycode('down') });
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
       assertMenuItemTabIndexed(wrapper, 1);
       assertMenuItemFocused(wrapper, 1);
 
       resetWrapper();
-      wrapper.simulate('keyDown', { which: keycode('up') });
+      wrapper.simulate('keyDown', { key: 'ArrowUp' });
       assertMenuItemTabIndexed(wrapper, 1);
       assertMenuItemFocused(wrapper, 1);
     });


### PR DESCRIPTION
All of `keyCode`, `which`, `charCode` and `keyIdentifier` are deprecated. The [key property](https://w3c.github.io/uievents/#dom-keyboardevent-key) is the new standard.
As of the time of this writing, the key property is supported by all major browsers as of : Firefox 52, Chrome 55, Safari 10.1, Opera 46. Except Internet Explorer 11 which has : non-standard key identifiers.
React synthetic event normalize all of that: https://github.com/facebook/react/blob/10a7a5b5ced683125d68584a78084faac3197846/packages/react-dom/src/events/getEventKey.js#L79 so we can apply this simple change:
```diff
-import keycode from 'keycode';

-const key = keycode(event);
+const key = event.key;
```
Removing the keycode dependency saves us [860 B gzipped](https://bundlephobia.com/result?p=keycode@2.2.0)