### PR TITLE
Better SSR example

### DIFF
--- a/docs/src/pages/guides/server-rendering/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering.md
@@ -123,10 +123,10 @@ function renderFullPage(html, css) {
     <html>
       <head>
         <title>Material-UI</title>
+        <style id="jss-server-side">${css}</style>
       </head>
       <body>
         <div id="root">${html}</div>
-        <style id="jss-server-side">${css}</style>
       </body>
     </html>
   `;


### PR DESCRIPTION
I've realised that if you don't put the style tag above the elements that are being styled then you still get a flicker while chrome has loaded the content but not the styles.

This simple change to the example means that you don't get a flicker at all!
