### PR TITLE
[docs] Better server-side rendering example

### DIFF
--- a/docs/src/pages/guides/server-rendering/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering.md
@@ -123,10 +123,10 @@ function renderFullPage(html, css) {
     <html>
       <head>
         <title>Material-UI</title>
+        <style id="jss-server-side">${css}</style>
       </head>
       <body>
         <div id="root">${html}</div>
-        <style id="jss-server-side">${css}</style>
       </body>
     </html>
   `;

--- a/examples/ssr/server.js
+++ b/examples/ssr/server.js
@@ -18,11 +18,11 @@ function renderFullPage(html, css) {
     <html>
       <head>
         <title>Material-UI</title>
+        <style id="jss-server-side">${css}</style>
       </head>
       <body>
         <script async src="build/bundle.js"></script>
         <div id="root">${html}</div>
-        <style id="jss-server-side">${css}</style>
       </body>
     </html>
   `;


### PR DESCRIPTION
I found that, if i follow this example exactly i still get a small flicker because the browser will load the HTML before reading the styling.

With this simple change you get no flicker whatsoever.

I am PRing to master as this does not change any actual code - and there's no reason it should not be on the documentation with immediate effect.