### PR TITLE
nextButton comment fix

### DIFF
--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -130,7 +130,7 @@ MobileStepper.propTypes = {
    */
   LinearProgressProps: PropTypes.object,
   /**
-   * A next button element. For instance, it can be be a `Button` or a `IconButton`.
+   * A next button element. For instance, it can be a `Button` or an `IconButton`.
    */
   nextButton: PropTypes.node,
   /**


### PR DESCRIPTION
"...For instance, it can be be a `Button` or a `IconButton`." should be "For instance, it can be a `Button` or an `IconButton`".
