### PR TITLE
[core] Disable CircleCI on l10n

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,7 +230,10 @@ workflows:
   version: 2
   pipeline:
     jobs:
-      - checkout
+      - checkout:
+          filters:
+            branches:
+              ignore: l10n
       - test_unit:
           requires:
             - checkout


### PR DESCRIPTION
Crowding creates hundreds of commit, one for each file changed. CircleCI fails to deduplicate the builds. We have to disable it. Netlify is still here to make sure we don't break the documentation generation.