### PR TITLE
[docs] Improve wrapping docs

### DIFF
--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -9,11 +9,11 @@ we need a way to know the nature of the child elements a component receives.
 To solve this problem we tag some of our components when needed
 with a `muiName` static property.
 
-However, users like to wrap components in order to enhance them.
-That can conflict with our `muiName` solution. If you wrap a component verify if
+However, you may need to wrap a component in order to enhance it, 
+which can conflict with the muiName solution. If you wrap a component verify if
 that component has this static property set.
 If you encounter this issue, you need to:
-1. Hoist these properties.
+1. Copy these properties over.
 2. Use the same tag for your wrapping component that is used with the wrapped component.
 
 Let's see an example:

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -10,9 +10,10 @@ To solve this problem we tag some of our components when needed
 with a `muiName` static property.
 
 However, users like to wrap components in order to enhance them.
-That can conflict with our `muiName` solution.
+That can conflict with our `muiName` solution. If you wrap a component verify if
+that component has this static property set.
 If you encounter this issue, you need to:
-1. Forward the properties.
+1. Hoist these properties.
 2. Use the same tag for your wrapping component that is used with the wrapped component.
 
 Let's see an example:

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -20,7 +20,7 @@ Let's see an example:
 
 ```jsx
 const WrappedIcon = props => <Icon {...props} />;
-WrappedIcon.muiName = 'Icon';
+WrappedIcon.muiName = Icon.muiName;
 ```
 
 {{"demo": "pages/guides/composition/Composition.js"}}

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -10,7 +10,7 @@ To solve this problem we tag some of our components when needed
 with a `muiName` static property.
 
 However, you may need to wrap a component in order to enhance it, 
-which can conflict with the muiName solution. If you wrap a component verify if
+which can conflict with the `muiName` solution. If you wrap a component verify if
 that component has this static property set.
 If you encounter this issue, you need to:
 1. Copy these properties over.


### PR DESCRIPTION
Addresses #13916 point 2

Mainly to correct the wording from "forwarding" to ~"hoisting"~ "copy over" which is more common (see ~`hoist-non-react-statics`~ https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over).
