### PR TITLE
[docs] Explain bootstrap issue for nextjs-hooks

### DIFF
--- a/examples/nextjs-hooks/src/bootstrap.js
+++ b/examples/nextjs-hooks/src/bootstrap.js
@@ -1,6 +1,6 @@
 import { install } from '@material-ui/styles';
 
-// WARNING: this step be done in a separate file like in this example.
+// WARNING: this step must be done in a separate file like in this example.
 // ES imports are hoisted to the top of the module.
 //
 // We will make @material-ui/styles the default style implementation

--- a/examples/nextjs-hooks/src/bootstrap.js
+++ b/examples/nextjs-hooks/src/bootstrap.js
@@ -1,6 +1,7 @@
 import { install } from '@material-ui/styles';
 
-// WARNING: this must be done in a separate file, as imports are hoisted.
+// WARNING: this step be done in a separate file like in this example.
+// ES imports are hoisted to the top of the module.
 //
 // We will make @material-ui/styles the default style implementation
 // for the core components in Material-UI v4.

--- a/examples/nextjs-hooks/src/bootstrap.js
+++ b/examples/nextjs-hooks/src/bootstrap.js
@@ -1,5 +1,7 @@
 import { install } from '@material-ui/styles';
 
+// WARNING: this must be done in a separate file, as imports are hoisted.
+//
 // We will make @material-ui/styles the default style implementation
 // for the core components in Material-UI v4.
 // This installation step is temporary.


### PR DESCRIPTION
Imports being hoisted, it's mandatory to keep the `install()` in a separate file.

If one is not warned about this, one may want to move this code directly into a page and thus will break server-side rendering of the styles.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
