### PR TITLE
[chip] Fix role prop when not clickable

### DIFF
--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -290,7 +290,6 @@ class Chip extends React.Component {
       onDelete,
       onKeyDown,
       onKeyUp,
-      tabIndex: tabIndexProp,
       variant,
       ...other
     } = this.props;
@@ -357,12 +356,6 @@ class Chip extends React.Component {
       });
     }
 
-    let tabIndex = tabIndexProp;
-
-    if (!tabIndex) {
-      tabIndex = onClick || onDelete || clickable ? 0 : -1;
-    }
-
     warning(
       !avatar || !icon,
       'Material-UI: the Chip component can not handle the avatar ' +
@@ -373,7 +366,7 @@ class Chip extends React.Component {
       <Component
         role={clickable ? 'button' : undefined}
         className={className}
-        tabIndex={clickable ? tabIndex : undefined}
+        tabIndex={clickable || onDelete ? 0 : undefined}
         onClick={onClick}
         onKeyDown={this.handleKeyDown}
         onKeyUp={this.handleKeyUp}
@@ -455,10 +448,6 @@ Chip.propTypes = {
    * @ignore
    */
   onKeyUp: PropTypes.func,
-  /**
-   * @ignore
-   */
-  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -371,9 +371,9 @@ class Chip extends React.Component {
 
     return (
       <Component
-        role={clickable ? 'button' : 'presentation'}
+        role={clickable ? 'button' : undefined}
         className={className}
-        tabIndex={tabIndex}
+        tabIndex={clickable ? tabIndex : undefined}
         onClick={onClick}
         onKeyDown={this.handleKeyDown}
         onKeyUp={this.handleKeyUp}

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -371,7 +371,7 @@ class Chip extends React.Component {
 
     return (
       <Component
-        role="button"
+        role={clickable ? 'button' : 'presentation'}
         className={className}
         tabIndex={tabIndex}
         onClick={onClick}

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -364,7 +364,7 @@ class Chip extends React.Component {
 
     return (
       <Component
-        role={clickable ? 'button' : undefined}
+        role={clickable || onDelete ? 'button' : undefined}
         className={className}
         tabIndex={clickable || onDelete ? 0 : undefined}
         onClick={onClick}

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -30,7 +30,6 @@ describe('<Chip />', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-Chip'), true);
       assert.strictEqual(wrapper.props()['data-my-prop'], 'woofChip');
-      assert.strictEqual(wrapper.props().tabIndex, -1);
 
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass(classes.colorPrimary), false);
@@ -85,11 +84,12 @@ describe('<Chip />', () => {
       assert.strictEqual(wrapper.props().tabIndex, 0);
     });
 
-    it('should apply user value of tabIndex', () => {
+    it('should apply user values of tabIndex and role', () => {
       wrapper = shallow(
         // eslint-disable-next-line jsx-a11y/tabindex-no-positive
-        <Chip onClick={() => {}} tabIndex={5} />,
+        <Chip onClick={() => {}} role="presentation" tabIndex={5} />,
       );
+      assert.strictEqual(wrapper.props().role, 'presentation');
       assert.strictEqual(wrapper.props().tabIndex, 5);
     });
 

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -30,6 +30,7 @@ describe('<Chip />', () => {
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass('my-Chip'), true);
       assert.strictEqual(wrapper.props()['data-my-prop'], 'woofChip');
+      assert.strictEqual(wrapper.props().tabIndex, undefined);
 
       assert.strictEqual(wrapper.hasClass(classes.root), true);
       assert.strictEqual(wrapper.hasClass(classes.colorPrimary), false);
@@ -84,12 +85,11 @@ describe('<Chip />', () => {
       assert.strictEqual(wrapper.props().tabIndex, 0);
     });
 
-    it('should apply user values of tabIndex and role', () => {
+    it('should apply user value of tabIndex', () => {
       wrapper = shallow(
         // eslint-disable-next-line jsx-a11y/tabindex-no-positive
-        <Chip onClick={() => {}} role="presentation" tabIndex={5} />,
+        <Chip onClick={() => {}} tabIndex={5} />,
       );
-      assert.strictEqual(wrapper.props().role, 'presentation');
       assert.strictEqual(wrapper.props().tabIndex, 5);
     });
 


### PR DESCRIPTION
Following the spec (https://www.w3.org/WAI/PF/aria/roles#button) the `button` role should only be specified when element is interactive. It can be considered an a11y issue that `Chip` component is declared to be clickable when it is not.

My personal use cases is a style exists to add `cursor: pointer` to all `[role=button]`, so those elements erroneously appear to be clickable.

~Fix is pretty straightforward, I used already-available `clickable` variable to check if it is interactiv, and otherwise use `presentation` role value.~

As discussed with @eps1lon (https://github.com/mui-org/material-ui/pull/14365#discussion_r), I made both `role` and `tabIndex` props appened only if Chip is interactive (clickable or deletable)