### PR TITLE
[examples] Fix download link in example README

### DIFF
--- a/examples/nextjs-hooks/README.md
+++ b/examples/nextjs-hooks/README.md
@@ -5,7 +5,7 @@
 Download the example [or clone the repo](https://github.com/mui-org/material-ui):
 
 ```sh
-curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs
+curl https://codeload.github.com/mui-org/material-ui/tar.gz/master | tar -xz --strip=2  material-ui-master/examples/nextjs-hooks
 cd nextjs
 ```
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
In the download command in the README.md file of the nextjs-hooks example was a mistake:
the download link was the link to the example without hooks, and I have fixed it now 
