### PR TITLE
[core] Drop node 6 support

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -3,4 +3,4 @@ edge >= 14
 firefox >= 52
 chrome >= 49
 safari >= 10
-node 6.11
+node 8.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: /tmp/material-ui
   docker:
-    - image: circleci/node:10.14
+    - image: circleci/node:8.15
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.
@@ -155,7 +155,7 @@ jobs:
     # This isn't user facing code.
     # Let's take advantage of the most up to date node version.
     docker:
-      - image: circleci/node:10.14
+      - image: circleci/node:8.15
     steps:
       - checkout
       - *restore_yarn_offline_mirror
@@ -220,7 +220,7 @@ jobs:
   test_regressions:
     <<: *defaults
     docker:
-      - image: circleci/node:10.14
+      - image: circleci/node:8.15
       - image: selenium/standalone-chrome:3.11.0
     steps:
       - checkout

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms-de.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms-de.md
@@ -14,7 +14,7 @@ Because Googlebot uses a web rendering service (WRS) to index the page content, 
 
 ## Server
 
-Because Material-UI supports server-side rendering, we need to support the latest, stable releases of [Node.js](https://github.com/nodejs/node). We try to support the [last active LTS version](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v6.x** and newer versions.
+Because Material-UI supports server-side rendering, we need to support the latest, stable releases of [Node.js](https://github.com/nodejs/node). We try to support the [last active LTS version](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v8.x** and newer versions.
 
 ### CSS prefixing
 

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms-de.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms-de.md
@@ -14,7 +14,7 @@ Because Googlebot uses a web rendering service (WRS) to index the page content, 
 
 ## Server
 
-Because Material-UI supports server-side rendering, we need to support the latest, stable releases of [Node.js](https://github.com/nodejs/node). We try to support the [last active LTS version](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v8.x** and newer versions.
+Because Material-UI supports server-side rendering, we need to support the latest, stable releases of [Node.js](https://github.com/nodejs/node). We try to support the [last active LTS version](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v6.x** and newer versions.
 
 ### CSS prefixing
 

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -19,7 +19,7 @@ You can expect Material-UI's components to render without major issues.
 ## Server
 
 Because Material-UI supports server-side rendering, we need to support the latest, stable releases of [Node.js](https://github.com/nodejs/node).
-We try to support the [last active LTS version](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v6.x** and newer versions.
+We try to support the [LTS version in maintenance](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v8.x** and newer versions.
 
 ### CSS prefixing
 

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -19,7 +19,7 @@ You can expect Material-UI's components to render without major issues.
 ## Server
 
 Because Material-UI supports server-side rendering, we need to support the latest, stable releases of [Node.js](https://github.com/nodejs/node).
-We try to support the [LTS version in maintenance](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v8.x** and newer versions.
+We also try to support the [LTS versions that are in maintenance](https://github.com/nodejs/Release#lts-schedule1). Right now, we support **node v8.x** and newer versions.
 
 ### CSS prefixing
 

--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {},
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/packages/material-ui-codemod/package.json
+++ b/packages/material-ui-codemod/package.json
@@ -32,6 +32,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -47,6 +47,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -56,6 +56,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -50,6 +50,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -59,6 +59,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -47,6 +47,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/packages/material-ui-utils/package.json
+++ b/packages/material-ui-utils/package.json
@@ -46,6 +46,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -69,6 +69,6 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   }
 }


### PR DESCRIPTION
[Node 6 will reach end of life in April 2019](https://github.com/nodejs/Release#release-schedule). The upcoming v4 provides a good opportunity to drop support for it (although a little bit to early depending on our release date).

Testing node 8 in CI which helps testing node 8 support. We never actually ran our tests with node 6. Might not work due to previous issues encountered in #13818.

Part of #13663

### Breaking change

Require node >= 8 (was 6 previously)