### PR TITLE
[docs] Targeted edit button URL

### DIFF
--- a/docs/src/modules/components/EditPage.js
+++ b/docs/src/modules/components/EditPage.js
@@ -21,9 +21,9 @@ function EditPage(props) {
       }
       target="_blank"
       rel="noopener"
-      data-ga-event-category="l10n"
-      data-ga-event-action="edit"
-      data-ga-event-label={userLanguage}
+      data-ga-event-category={userLanguage === 'en' ? undefined : 'l10n'}
+      data-ga-event-action={userLanguage === 'en' ? undefined : 'edit-button'}
+      data-ga-event-label={userLanguage === 'en' ? undefined : userLanguage}
     >
       {t('editPage')}
     </Button>

--- a/docs/src/modules/components/EditPage.js
+++ b/docs/src/modules/components/EditPage.js
@@ -3,8 +3,13 @@ import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import { connect } from 'react-redux';
 
+const LANGUAGES = { zh: 'zh-CN', pt: 'pt-BZ', es: 'es-ES' };
+const CROWDIN_ROOT_URL = 'https://translate.material-ui.com/project/material-ui-docs/';
+
 function EditPage(props) {
   const { markdownLocation, sourceCodeRootUrl, t, userLanguage } = props;
+  const crowdInLanguage = LANGUAGES[userLanguage] || userLanguage;
+  const crowdInPath = markdownLocation.substring(0, markdownLocation.lastIndexOf('/'));
 
   return (
     <Button
@@ -12,8 +17,13 @@ function EditPage(props) {
       href={
         userLanguage === 'en'
           ? `${sourceCodeRootUrl}${markdownLocation}`
-          : 'https://translate.material-ui.com/'
+          : `${CROWDIN_ROOT_URL}${crowdInLanguage}#/master${crowdInPath}`
       }
+      target="_blank"
+      rel="noopener"
+      data-ga-event-category="l10n"
+      data-ga-event-action="edit"
+      data-ga-event-label={userLanguage}
     >
       {t('editPage')}
     </Button>


### PR DESCRIPTION
We can't link directly to the page to be edited, as the CrowdIn URL for the file is just a number, but I noticed that we can target the containing directory.

Also added analytics attributes.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
