### PR TITLE
[core] Remove typings for `/es` build

### DIFF
--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -128,10 +128,7 @@ async function run() {
     await addLicense(packageData);
 
     // TypeScript
-    await Promise.all([
-      typescriptCopy({ from: srcPath, to: buildPath }),
-      typescriptCopy({ from: srcPath, to: path.resolve(buildPath, './es') }),
-    ]);
+    await typescriptCopy({ from: srcPath, to: buildPath });
 
     await createModulePackages({ from: srcPath, to: buildPath });
   } catch (err) {


### PR DESCRIPTION
BREAKING (ts-only)
```diff
- import Button from '@material-ui/core/es/Button'
+ // aliased @material-ui/core to @material-ui/core/es in tsconfig and build pipeline
+ import Button from '@material-ui/core/Button'
```

Extensive explanation in #14392

Closes #14392