### PR TITLE
[utils] Add support for forwardRef components in getDisplayName

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
     'react/no-find-dom-node': 'off',
 
     'jsx-a11y/no-autofocus': 'off', // We are a library, people do what they want.
+    'prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
     'prefer-destructuring': 'off', // Destructuring harm grep potential.
     'consistent-this': ['error', 'self'],
     'max-len': [
@@ -90,7 +91,7 @@ module.exports = {
     'mocha/no-sibling-hooks': 'error',
     'mocha/no-skipped-tests': 'error',
     'mocha/no-top-level-hooks': 'error',
-    'mocha/prefer-arrow-callback': 'error',
+    'mocha/prefer-arrow-callback': ['error', { allowNamedFunctions: true }],
     'mocha/valid-suite-description': 'error',
   },
 };

--- a/.size-limit.js
+++ b/.size-limit.js
@@ -28,13 +28,13 @@ module.exports = [
     name: 'The size of the @material-ui/core modules',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '91.3 KB',
+    limit: '91.2 KB',
   },
   {
     name: 'The size of the @material-ui/styles modules',
     webpack: true,
     path: 'packages/material-ui-styles/build/index.js',
-    limit: '16.3 KB',
+    limit: '16.4 KB',
   },
   {
     name: 'The size of the @material-ui/system modules',

--- a/packages/material-ui-utils/src/getDisplayName.js
+++ b/packages/material-ui-utils/src/getDisplayName.js
@@ -1,4 +1,4 @@
-// Fork of recompose/getDisplayName with added IE 11 support
+import { ForwardRef } from 'react-is';
 
 // Simplified polyfill for IE 11 support
 // https://github.com/JamesMGreene/Function.name/blob/58b314d4a983110c3682f1228f845d39ccca1817/Function.name.js#L3
@@ -9,16 +9,53 @@ export function getFunctionName(fn) {
   return name || '';
 }
 
+/**
+ * @param {function} Component
+ * @param {string} fallback
+ * @returns {string | undefined}
+ */
+function getFunctionComponentName(Component, fallback = '') {
+  return Component.displayName || Component.name || getFunctionName(Component) || fallback;
+}
+
+function getWrappedName(outerType, innerType, wrapperName) {
+  const functionName = getFunctionComponentName(innerType);
+  return (
+    outerType.displayName || (functionName !== '' ? `${wrapperName}(${functionName})` : wrapperName)
+  );
+}
+
+/**
+ * cherry-pick from
+ * https://github.com/facebook/react/blob/769b1f270e1251d9dbdce0fcbd9e92e502d059b8/packages/shared/getComponentName.js
+ * originally forked from recompose/getDisplayName with added IE 11 support
+ *
+ * @param {React.ReactType} Component
+ * @returns {string | undefined}
+ */
 function getDisplayName(Component) {
+  if (Component == null) {
+    return undefined;
+  }
+
   if (typeof Component === 'string') {
     return Component;
   }
 
-  if (!Component) {
-    return undefined;
+  if (typeof Component === 'function') {
+    return getFunctionComponentName(Component, 'Component');
   }
 
-  return Component.displayName || Component.name || getFunctionName(Component) || 'Component';
+  if (typeof Component === 'object') {
+    switch (Component.$$typeof) {
+      case ForwardRef:
+        return getWrappedName(Component, Component.render, 'ForwardRef');
+      default:
+        return undefined;
+    }
+  }
+
+  return undefined;
 }
 
 export default getDisplayName;

--- a/packages/material-ui-utils/src/getDisplayName.test.js
+++ b/packages/material-ui-utils/src/getDisplayName.test.js
@@ -27,6 +27,19 @@ describe('utils/getDisplayName.js', () => {
 
       const AndAnotherComponent = () => <div />;
 
+      const AnonymousForwardRefComponent = React.forwardRef((props, ref) => (
+        <div {...props} ref={ref} />
+      ));
+
+      const ForwardRefComponent = React.forwardRef(function Div(props, ref) {
+        return <div {...props} ref={ref} />;
+      });
+
+      const NamedForwardRefComponent = React.forwardRef((props, ref) => (
+        <div {...props} ref={ref} />
+      ));
+      NamedForwardRefComponent.displayName = 'Div';
+
       assert.strictEqual(getDisplayName(SomeComponent), 'SomeComponent');
       assert.strictEqual(getDisplayName(SomeOtherComponent), 'CustomDisplayName');
       assert.strictEqual(getDisplayName(YetAnotherComponent), 'YetAnotherComponent');
@@ -34,6 +47,9 @@ describe('utils/getDisplayName.js', () => {
       assert.strictEqual(getDisplayName(() => <div />), 'Component');
       assert.strictEqual(getDisplayName('div'), 'div');
       assert.strictEqual(getDisplayName(), undefined);
+      assert.strictEqual(getDisplayName(AnonymousForwardRefComponent), 'ForwardRef');
+      assert.strictEqual(getDisplayName(ForwardRefComponent), 'ForwardRef(Div)');
+      assert.strictEqual(getDisplayName(NamedForwardRefComponent), 'Div');
     });
   });
 

--- a/packages/material-ui/scripts/rollup.config.js
+++ b/packages/material-ui/scripts/rollup.config.js
@@ -21,7 +21,7 @@ const commonjsOptions = {
   ignoreGlobal: true,
   include: /node_modules/,
   namedExports: {
-    '../../node_modules/react-is/index.js': ['isValidElementType'],
+    '../../node_modules/react-is/index.js': ['ForwardRef', 'isValidElementType'],
   },
 };
 

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -25,7 +25,7 @@ export const styles = {
   },
 };
 
-const Backdrop = React.forwardRef((props, ref) => {
+const Backdrop = React.forwardRef(function Backdrop(props, ref) {
   const { classes, className, invisible, open, transitionDuration, ...other } = props;
 
   return (
@@ -45,8 +45,6 @@ const Backdrop = React.forwardRef((props, ref) => {
     </Fade>
   );
 });
-
-Backdrop.displayName = 'Backdrop';
 
 Backdrop.propTypes = {
   /**

--- a/packages/material-ui/src/List/List.js
+++ b/packages/material-ui/src/List/List.js
@@ -29,7 +29,7 @@ export const styles = {
   },
 };
 
-const List = React.forwardRef((props, ref) => {
+const List = React.forwardRef(function List(props, ref) {
   const {
     children,
     classes,
@@ -62,8 +62,6 @@ const List = React.forwardRef((props, ref) => {
     </Component>
   );
 });
-
-List.displayName = 'List';
 
 List.propTypes = {
   /**

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -86,7 +86,7 @@ export const styles = theme => ({
 /**
  * Uses an additional container component if `ListItemSecondaryAction` is the last child.
  */
-const ListItem = React.forwardRef((props, ref) => {
+const ListItem = React.forwardRef(function ListItem(props, ref) {
   const {
     alignItems,
     button,
@@ -176,8 +176,6 @@ const ListItem = React.forwardRef((props, ref) => {
     </MergeListContext>
   );
 });
-
-ListItem.displayName = 'ListItem';
 
 ListItem.propTypes = {
   /**

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -27,7 +27,7 @@ export const styles = theme => ({
   selected: {},
 });
 
-const MenuItem = React.forwardRef((props, ref) => {
+const MenuItem = React.forwardRef(function MenuItem(props, ref) {
   const { classes, className, component, disableGutters, role, selected, ...other } = props;
 
   return (
@@ -51,8 +51,6 @@ const MenuItem = React.forwardRef((props, ref) => {
     />
   );
 });
-
-MenuItem.displayName = 'MenuItem';
 
 MenuItem.propTypes = {
   /**

--- a/packages/material-ui/src/MenuList/MenuList.test.js
+++ b/packages/material-ui/src/MenuList/MenuList.test.js
@@ -28,7 +28,6 @@ describe('<MenuList />', () => {
     });
 
     it('should render a List', () => {
-      assert.strictEqual(wrapper.name(), 'List');
       assert.strictEqual(wrapper.props()['data-test'], 'hi');
       assert.strictEqual(wrapper.hasClass('test-class'), true);
     });

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -26,7 +26,7 @@ export const styles = theme => {
   };
 };
 
-const Paper = React.forwardRef((props, ref) => {
+const Paper = React.forwardRef(function Paper(props, ref) {
   const {
     classes,
     className: classNameProp,
@@ -52,8 +52,6 @@ const Paper = React.forwardRef((props, ref) => {
 
   return <Component className={className} ref={ref} {...other} />;
 });
-
-Paper.displayName = 'Paper';
 
 Paper.propTypes = {
   /**


### PR DESCRIPTION
Cherry picked logic from reacts `shared/getComponentName` to handle `forwardRef` components.

Allows to skip setting `displayName` manually which also affected production bundles. We can remove this logic while retaining a meaningful `displayName` in a dev environment.

I suspect that this also helps folks that used display name selectors in enzyme and problematic testing habits. They should now get original e.g. `Backdrop` function component instead of the `forwardRef` wrapper.