### PR TITLE
[InputBase] added start/endAdornment to accept react Components

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -11,7 +11,8 @@ export interface InputBaseProps
   autoFocus?: boolean;
   defaultValue?: Array<string | number | boolean | object> | string | number | boolean | object;
   disabled?: boolean;
-  endAdornment?: React.ReactNode;
+  endAdornment?: React.ReactNode | React.Component | string;
+  endAdornmentProps?: React.Props<any>;
   error?: boolean;
   fullWidth?: boolean;
   id?: string;
@@ -35,7 +36,8 @@ export interface InputBaseProps
   }) => React.ReactNode;
   rows?: string | number;
   rowsMax?: string | number;
-  startAdornment?: React.ReactNode;
+  startAdornment?: React.ReactNode | React.Component | string;
+  startAdornmentProps?: React.Props<any>;
   type?: string;
   value?: Array<string | number | boolean | object> | string | number | boolean | object;
   onFilled?: () => void;

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -139,6 +139,19 @@ export const styles = theme => {
   };
 };
 
+
+function toComponent(componentOrString) {
+  if (typeof componentOrString === 'function') {
+    return {
+      component: componentOrString,
+    };
+  }
+  return {
+    component: componentOrString,
+    useFlatComponent: true
+  }
+}
+
 /**
  * `InputBase` contains as few styles as possible.
  * It aims to be a simple building block for creating an input.
@@ -290,6 +303,7 @@ class InputBase extends React.Component {
       defaultValue,
       disabled,
       endAdornment,
+      endAdornmentProps,
       error,
       fullWidth,
       id,
@@ -314,6 +328,7 @@ class InputBase extends React.Component {
       rows,
       rowsMax,
       startAdornment,
+      startAdornmentProps,
       type,
       value,
       ...other
@@ -394,6 +409,8 @@ class InputBase extends React.Component {
       };
     }
 
+    const StartAdornment = toComponent(startAdornment);
+    const EndAdornment = toComponent(endAdornment);
     return (
       <div className={className} onClick={this.handleClick} {...other}>
         {renderPrefix
@@ -403,7 +420,11 @@ class InputBase extends React.Component {
               focused,
             })
           : null}
-        {startAdornment}
+
+        {StartAdornment.useFlatComponent ?
+          StartAdornment.component :
+          <StartAdornment.component {...startAdornmentProps} />
+        }
         <FormControlContext.Provider value={null}>
           <InputComponent
             aria-invalid={fcs.error}
@@ -428,7 +449,10 @@ class InputBase extends React.Component {
             {...inputProps}
           />
         </FormControlContext.Provider>
-        {endAdornment}
+        {EndAdornment.useFlatComponent ?
+          EndAdornment.component :
+          <EndAdornment.component {...endAdornmentProps} />
+        }
       </div>
     );
   }
@@ -474,7 +498,15 @@ InputBase.propTypes = {
   /**
    * End `InputAdornment` for this component.
    */
-  endAdornment: PropTypes.node,
+  endAdornment: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object,
+    PropTypes.string
+  ]),
+  /**
+   * End Props passed `endAdornment` component.
+   */
+  endAdornmentProps: PropTypes.object,
   /**
    * If `true`, the input will indicate an error. This is normally obtained via context from
    * FormControl.
@@ -581,7 +613,15 @@ InputBase.propTypes = {
   /**
    * Start `InputAdornment` for this component.
    */
-  startAdornment: PropTypes.node,
+  startAdornment: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.object,
+    PropTypes.string
+  ]),
+  /**
+   * Start Props passed `StartAdornment` component.
+   */
+  startAdornmentProps: PropTypes.object,
   /**
    * Type of the input element. It should be a valid HTML5 input type.
    */

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -467,7 +467,7 @@ describe('<InputBase />', () => {
   });
 
   describe('prop: startAdornment, prop: endAdornment', () => {
-    it('should render adornment before input', () => {
+    it('should render adornment before input jsx', () => {
       const wrapper = mount(
         <InputBase startAdornment={<InputAdornment position="start">$</InputAdornment>} />,
       );
@@ -480,7 +480,7 @@ describe('<InputBase />', () => {
       );
     });
 
-    it('should render adornment after input', () => {
+    it('should render adornment after input jsx', () => {
       const wrapper = mount(
         <InputBase endAdornment={<InputAdornment position="end">$</InputAdornment>} />,
       );
@@ -492,6 +492,64 @@ describe('<InputBase />', () => {
         InputAdornment,
       );
     });
+
+
+    it('should render adornment before input string', () => {
+      const id = `id:${Math.random()}`;
+      const wrapper = mount(
+        <InputBase startAdornment={id} />,
+      );
+
+      assert.include(wrapper.html(), id);
+    });
+
+    it('should render adornment after input string', () => {
+      const id = `id:${Math.random()}`;
+      const wrapper = mount(
+        <InputBase endAdornment={id} />,
+      );
+
+      assert.include(wrapper.html(), id);
+    });
+
+
+    const StartHelloWorld = (props) => <div>{props.helloWorld || 'START'}</div>;
+    StartHelloWorld.propTypes = {
+        helloWorld: PropTypes.string
+    }
+    const EndHelloWorld = (props) => <div>{props.helloWorld || 'END'}</div>;
+    EndHelloWorld.propTypes = {
+        helloWorld: PropTypes.string
+    }
+
+    it('should allow react component as value', () => {
+      const wrapper = mount(
+        <>
+        <InputBase
+          startAdornment={StartHelloWorld}
+          endAdornment={EndHelloWorld}
+        />
+        </>
+      );
+      assert.equal(wrapper.find(StartHelloWorld).text(), 'START');
+      assert.equal(wrapper.find(EndHelloWorld).text(), 'END');
+    });
+
+    it('should allow react component as value with props', () => {
+      const wrapper = mount(
+        <>
+        <InputBase
+          startAdornment={StartHelloWorld}
+          startAdornmentProps={{ helloWorld: 'start' }}
+          endAdornment={EndHelloWorld}
+          endAdornmentProps={{ helloWorld: 'end' }}
+        />
+        </>
+      );
+      assert.equal(wrapper.find(StartHelloWorld).text(), 'start');
+      assert.equal(wrapper.find(EndHelloWorld).text(), 'end');
+    });
+
   });
 
   describe('prop: inputRef', () => {


### PR DESCRIPTION
Hi,

i added the feature to pass react component to start/endAdornment so enable a lifecycle to the these parts.

I 'm not sure if i should add something to the documentation, if you think so I would investigate into that?

Meno
P.S.
const EndHelloWorld = (props) => <div>{props.helloWorld || 'END'}</div>;
<InputBase startAdornment={StartHelloWorld} />