### PR TITLE
[core] Use frozen-lockfile by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ install_js: &install_js
     name: Install js dependencies
     command: |
       yarn config set yarn-offline-mirror ~/.cache/npm-packages-offline-cache/v1
-      yarn --frozen-lockfile
+      yarn
 restore_yarn_cache: &restore_yarn_cache
   restore_cache:
     key: v2-yarn-sha-{{ checksum "yarn.lock" }}

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,2 @@
+install.--frozen-lockfile true
 network-timeout 150000


### PR DESCRIPTION
~Revert `--frozen-lockfile` change from #14050~

~@rosskevin Didn't explain why he thought this was good. We have a dedicated CI task to check if the lockfile doesn't match `package.json`. This flag makes this task useless.~ I doesn't completely.

~I would hope that CI and local development use the same dependencies which is what this lockfile is for. This also means that we test with the latest versions of our dependencies not (possibly) outdated versions from the lockfile.~
Running `yarn` locally creates a diff because `frozen-lockfile` is not default. This enables `frozen-lockfile` following yarnpkg/yarn##4147. 