### PR TITLE
added isRequired to children proptypes

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -153,7 +153,9 @@ class Modal extends React.Component {
     if (this.props.closeAfterTransition) {
       this.props.manager.remove(this);
     }
-    this.setState({ exited: true });
+    this.setState({
+      exited: true,
+    });
   };
 
   handleBackdropClick = event => {
@@ -321,11 +323,11 @@ class Modal extends React.Component {
         onRendered={this.handleRendered}
       >
         {/*
-          Marking an element with the role presentation indicates to assistive technology
-          that this element should be ignored; it exists to support the web application and
-          is not meant for humans to interact with directly.
-          https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
-        */}
+                  Marking an element with the role presentation indicates to assistive technology
+                  that this element should be ignored; it exists to support the web application and
+                  is not meant for humans to interact with directly.
+                  https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interactions.md
+                */}
         <div
           data-mui-test="Modal"
           ref={this.handleModalRef}
@@ -338,8 +340,8 @@ class Modal extends React.Component {
         >
           {hideBackdrop ? null : (
             <BackdropComponent open={open} onClick={this.handleBackdropClick} {...BackdropProps} />
-          )}
-          <RootRef rootRef={this.onRootRef}>{React.cloneElement(children, childProps)}</RootRef>
+          )}{' '}
+          <RootRef rootRef={this.onRootRef}> {React.cloneElement(children, childProps)} </RootRef>
         </div>
       </Portal>
     );
@@ -358,7 +360,7 @@ Modal.propTypes = {
   /**
    * A single child content element.
    */
-  children: PropTypes.element,
+  children: PropTypes.element.isRequired,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css-api) below for more details.
@@ -471,4 +473,7 @@ Modal.defaultProps = {
   manager: new ModalManager(),
 };
 
-export default withStyles(styles, { flip: false, name: 'MuiModal' })(Modal);
+export default withStyles(styles, {
+  flip: false,
+  name: 'MuiModal',
+})(Modal);

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -30,7 +30,7 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">BackdropComponent</span> | <span class="prop-type">Component</span> | <span class="prop-default">Backdrop</span> | A backdrop component. This property enables custom backdrop rendering. |
 | <span class="prop-name">BackdropProps</span> | <span class="prop-type">object</span> |   | Properties applied to the [`Backdrop`](/api/backdrop/) element. |
-| <span class="prop-name">children</span> | <span class="prop-type">element</span> |   | A single child content element. |
+| <span class="prop-name required">children *</span> | <span class="prop-type">element</span> |   | A single child content element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">closeAfterTransition</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | When set to true the Modal waits until a nested Transition is completed before closing. |
 | <span class="prop-name">container</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br></span> |   | A node, component instance, or function that returns either. The `container` will have the portal children appended to it. |


### PR DESCRIPTION
- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Modal without children does not trigger proptypes warning. 