### PR TITLE
[slider] Fix a11y issues with the handle

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -564,13 +564,7 @@ class Slider extends React.Component {
 
     return (
       <Component
-        role="slider"
         className={className}
-        aria-disabled={disabled}
-        aria-valuenow={value}
-        aria-valuemin={min}
-        aria-valuemax={max}
-        aria-orientation={vertical ? 'vertical' : 'horizontal'}
         onClick={this.handleClick}
         onMouseDown={this.handleMouseDown}
         onTouchStartCapture={this.handleTouchStart}
@@ -584,6 +578,10 @@ class Slider extends React.Component {
           <div className={trackBeforeClasses} style={inlineTrackBeforeStyles} />
           <div className={thumbWrapperClasses} style={inlineThumbStyles}>
             <ButtonBase
+              aria-valuenow={value}
+              aria-valuemin={min}
+              aria-valuemax={max}
+              aria-orientation={vertical ? 'vertical' : 'horizontal'}
               className={thumbClasses}
               disabled={disabled}
               disableRipple
@@ -592,6 +590,7 @@ class Slider extends React.Component {
               onTouchStartCapture={this.handleTouchStart}
               onTouchMove={this.handleTouchMove}
               onFocusVisible={this.handleFocus}
+              role="slider"
             >
               {ThumbIcon}
             </ButtonBase>

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { spy } from 'sinon';
 import { assert } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import {
+  createMount,
+  createShallow,
+  getClasses,
+  wrapsIntrinsicElement,
+} from '@material-ui/core/test-utils';
 import Slider, { defaultValueReducer } from './Slider';
 
 function touchList(touchArray) {
@@ -19,6 +24,13 @@ describe('<Slider />', () => {
     classes = getClasses(<Slider value={0} />);
     mount = createMount();
   });
+
+  function findHandle(wrapper) {
+    // Will also match any other react component if not filtered. They won't appear in the DOM
+    // and are therefore an implementation detail. We're interested in what the user
+    // interacts with.
+    return wrapper.find('[role="slider"]').filterWhere(wrapsIntrinsicElement);
+  }
 
   it('should render a div', () => {
     const wrapper = shallow(<Slider value={0} />);
@@ -195,10 +207,10 @@ describe('<Slider />', () => {
     });
 
     it('should render thumb with the disabled classes', () => {
-      const button = wrapper.find('button');
+      const handle = findHandle(wrapper);
 
-      assert.strictEqual(button.hasClass(classes.thumb), true);
-      assert.strictEqual(button.hasClass(classes.disabled), true);
+      assert.strictEqual(handle.hasClass(classes.thumb), true);
+      assert.strictEqual(handle.hasClass(classes.disabled), true);
     });
 
     it('should render tracks with the disabled classes', () => {
@@ -213,12 +225,8 @@ describe('<Slider />', () => {
       assert.strictEqual(handleChange.callCount, 0);
     });
 
-    it('should disable its thumb', () => {
-      assert.ok(wrapper.find('button').props().disabled);
-    });
-
     it('should signal that it is disabled', () => {
-      assert.ok(wrapper.find('[role="slider"]').props()['aria-disabled']);
+      assert.ok(findHandle(wrapper).props().disabled);
     });
   });
 
@@ -275,34 +283,34 @@ describe('<Slider />', () => {
 
     it('should reach right edge value', () => {
       wrapper.setProps({ value: 90 });
-      const button = wrapper.find('button');
+      const handle = findHandle(wrapper);
 
-      button.prop('onKeyDown')(moveRightEvent);
+      handle.prop('onKeyDown')(moveRightEvent);
       assert.strictEqual(wrapper.prop('value'), 100);
 
-      button.prop('onKeyDown')(moveRightEvent);
+      handle.prop('onKeyDown')(moveRightEvent);
       assert.strictEqual(wrapper.prop('value'), 108);
 
-      button.prop('onKeyDown')(moveLeftEvent);
+      handle.prop('onKeyDown')(moveLeftEvent);
       assert.strictEqual(wrapper.prop('value'), 100);
 
-      button.prop('onKeyDown')(moveLeftEvent);
+      handle.prop('onKeyDown')(moveLeftEvent);
       assert.strictEqual(wrapper.prop('value'), 90);
     });
 
     it('should reach left edge value', () => {
       wrapper.setProps({ value: 20 });
-      const button = wrapper.find('button');
-      button.prop('onKeyDown')(moveLeftEvent);
+      const handle = findHandle(wrapper);
+      handle.prop('onKeyDown')(moveLeftEvent);
       assert.strictEqual(wrapper.prop('value'), 10);
 
-      button.prop('onKeyDown')(moveLeftEvent);
+      handle.prop('onKeyDown')(moveLeftEvent);
       assert.strictEqual(wrapper.prop('value'), 6);
 
-      button.prop('onKeyDown')(moveRightEvent);
+      handle.prop('onKeyDown')(moveRightEvent);
       assert.strictEqual(wrapper.prop('value'), 10);
 
-      button.prop('onKeyDown')(moveRightEvent);
+      handle.prop('onKeyDown')(moveRightEvent);
       assert.strictEqual(wrapper.prop('value'), 20);
     });
   });

--- a/packages/material-ui/src/test-utils/findOutermostIntrinsic.js
+++ b/packages/material-ui/src/test-utils/findOutermostIntrinsic.js
@@ -1,9 +1,19 @@
 /**
+ * checks if a given react wrapper wraps an intrinsic element i.e. a DOM node
+ *
+ * @param {import('enzyme').ReactWrapper} reactWrapper
+ * @returns {boolean} true if the given reactWrapper wraps an intrinsic element
+ */
+export function wrapsIntrinsicElement(reactWrapper) {
+  return typeof reactWrapper.type() === 'string';
+}
+
+/**
  * like ReactWrapper#getDOMNode() but returns a ReactWrapper
  *
  * @param {import('enzyme').ReactWrapper} reactWrapper
  * @returns {import('enzyme').ReactWrapper} the wrapper for the outermost DOM node
  */
 export default function findOutermostIntrinsic(reactWrapper) {
-  return reactWrapper.findWhere(n => n.exists() && typeof n.type() === 'string').first();
+  return reactWrapper.findWhere(n => n.exists() && wrapsIntrinsicElement(n)).first();
 }

--- a/packages/material-ui/src/test-utils/index.js
+++ b/packages/material-ui/src/test-utils/index.js
@@ -1,7 +1,7 @@
 export { default as createShallow } from './createShallow';
 export { default as createMount } from './createMount';
 export { default as createRender } from './createRender';
-export { default as findOutermostIntrinsic } from './findOutermostIntrinsic';
+export { default as findOutermostIntrinsic, wrapsIntrinsicElement } from './findOutermostIntrinsic';
 export { default as getClasses } from './getClasses';
 export { default as testRef } from './testRef';
 export { default as unwrap } from './unwrap';


### PR DESCRIPTION
Closes #14456 

- [`slider` role on MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_slider_role) 
- [WAI-ARIA 1.0: slider](https://www.w3.org/WAI/PF/aria/roles#slider): Not explicit about the element that should hold the `role`
- [WAI-ARIA Authoring practices: slider](https://www.w3.org/TR/wai-aria-practices/examples/slider/slider-1.html): Implement the documented roles
- [material web components](https://material-components.github.io/material-components-web-catalog/#/component/slider): Match our previous incorrect implementation