### PR TITLE
[styles] Make TypeScript definitions  for ThemeProvider and getThemeProps generic

### DIFF
--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -47,15 +47,14 @@ declare module '@material-ui/styles/createStyles' {
 
 declare module '@material-ui/styles/getThemeProps' {
   import { ComponentsPropsList } from '@material-ui/core/styles/props';
-  import { Theme } from '@material-ui/core';
 
-  interface NamedParams<K extends keyof ComponentsPropsList> {
+  interface NamedParams<K extends keyof ComponentsPropsList, Theme> {
     name: K;
     props: ComponentsPropsList[K];
     theme?: Theme;
   }
-  export default function getThemeProps<Name extends keyof ComponentsPropsList>(
-    params: NamedParams<Name>,
+  export default function getThemeProps<Name extends keyof ComponentsPropsList, Theme>(
+    params: NamedParams<Name, Theme>,
   ): ComponentsPropsList[Name];
 }
 
@@ -199,15 +198,12 @@ declare module '@material-ui/styles/StylesProvider' {
 }
 
 declare module '@material-ui/styles/ThemeProvider' {
-  import { Theme } from '@material-ui/core';
-
-  const ThemeContext: React.Context<Theme>;
-
-  export interface ThemeProviderProps {
+  export interface ThemeProviderProps<Theme> {
     children: React.ReactNode;
     theme: Theme | ((outerTheme: Theme) => Theme);
   }
-  const ThemeProvider: React.ComponentType<ThemeProviderProps>;
+  type ThemeProvider<T> = React.ComponentType<ThemeProviderProps<T>>;
+  const ThemeProvider: ThemeProvider<any>;
   export default ThemeProvider;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #14431 

The usage with the generic `ThemeProvider` would be:

```javascript
import { ThemeProvider } from '@material-ui/styles';

// for example
type MyTheme = {
   customColor: string
}

const MyThemeProvider: ThemeProvider<MyTheme> = ThemeProvider;
...
<MyThemeProvider
          theme={{
            customColor: 'red'
          }}
        >
...
```

I changed also the types for `getThemeProps` to be generic, however, I could not see how exactly to test it. Is it an internal function? I don't see it documented anywhere.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
