### PR TITLE
[slider] Pass current value to onDragStart/onDragEnd callback

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.d.ts
+++ b/packages/material-ui-lab/src/Slider/Slider.d.ts
@@ -1,8 +1,5 @@
 import * as React from 'react';
 import { StandardProps } from '@material-ui/core';
-import { ButtonProps } from '@material-ui/core/Button';
-import { TransitionProps } from 'react-transition-group/Transition';
-import { TransitionHandlerProps } from '@material-ui/core/transitions/transition';
 
 /**
  * @param rawValue - the value inferred from the event in [min, max]

--- a/packages/material-ui-lab/src/Slider/Slider.d.ts
+++ b/packages/material-ui-lab/src/Slider/Slider.d.ts
@@ -1,5 +1,8 @@
 import * as React from 'react';
 import { StandardProps } from '@material-ui/core';
+import { ButtonProps } from '@material-ui/core/Button';
+import { TransitionProps } from 'react-transition-group/Transition';
+import { TransitionHandlerProps } from '@material-ui/core/transitions/transition';
 
 /**
  * @param rawValue - the value inferred from the event in [min, max]

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -352,10 +352,15 @@ class Slider extends React.Component {
     }
     this.setState({ currentState: 'activated' });
 
+    const { onDragStart, valueReducer } = this.props;
+
+    const value = this.calculateValueFromPercent(event);
+    const newValue = valueReducer(value, this.props, event);
+
     document.body.addEventListener('touchend', this.handleTouchEnd);
 
-    if (typeof this.props.onDragStart === 'function') {
-      this.props.onDragStart(event);
+    if (typeof onDragStart === 'function') {
+      onDragStart(event, newValue);
     }
   };
 
@@ -363,13 +368,18 @@ class Slider extends React.Component {
     event.preventDefault();
     this.setState({ currentState: 'activated' });
 
+    const { onDragStart, valueReducer } = this.props;
+
+    const value = this.calculateValueFromPercent(event);
+    const newValue = valueReducer(value, this.props, event);
+
     document.body.addEventListener('mouseenter', this.handleMouseEnter);
     document.body.addEventListener('mouseleave', this.handleMouseLeave);
     document.body.addEventListener('mousemove', this.handleMouseMove);
     document.body.addEventListener('mouseup', this.handleMouseUp);
 
-    if (typeof this.props.onDragStart === 'function') {
-      this.props.onDragStart(event);
+    if (typeof onDragStart === 'function') {
+      onDragStart(event, newValue);
     }
   };
 

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -323,15 +323,7 @@ class Slider extends React.Component {
   };
 
   handleClick = event => {
-    const { min, max, vertical } = this.props;
-    const percent = calculatePercent(
-      this.containerRef,
-      event,
-      vertical,
-      this.isReverted(),
-      this.touchId,
-    );
-    const value = percentToValue(percent, min, max);
+    const value = this.calculateValueFromPercent(event);
 
     this.emitChange(event, value, () => {
       this.playJumpAnimation();
@@ -414,20 +406,17 @@ class Slider extends React.Component {
   };
 
   handleMouseMove = event => {
-    const { min, max, vertical } = this.props;
-    const percent = calculatePercent(
-      this.containerRef,
-      event,
-      vertical,
-      this.isReverted(),
-      this.touchId,
-    );
-    const value = percentToValue(percent, min, max);
+    const value = this.calculateValueFromPercent(event);
 
     this.emitChange(event, value);
   };
 
   handleDragEnd(event) {
+    const { onDragEnd, valueReducer } = this.props;
+
+    const value = this.calculateValueFromPercent(event);
+    const newValue = valueReducer(value, this.props, event);
+
     this.setState({ currentState: 'normal' });
 
     document.body.removeEventListener('mouseenter', this.handleMouseEnter);
@@ -436,8 +425,8 @@ class Slider extends React.Component {
     document.body.removeEventListener('mouseup', this.handleMouseUp);
     document.body.removeEventListener('touchend', this.handleTouchEnd);
 
-    if (typeof this.props.onDragEnd === 'function') {
-      this.props.onDragEnd(event);
+    if (typeof onDragEnd === 'function') {
+      onDragEnd(event, newValue);
     }
   }
 
@@ -472,6 +461,18 @@ class Slider extends React.Component {
           }(${percent / 100})`,
         };
     }
+  }
+
+  calculateValueFromPercent(event) {
+    const { min, max, vertical } = this.props;
+    const percent = calculatePercent(
+      this.containerRef,
+      event,
+      vertical,
+      this.isReverted(),
+      this.touchId,
+    );
+    return percentToValue(percent, min, max);
   }
 
   playJumpAnimation() {

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -70,6 +70,22 @@ describe('<Slider />', () => {
     assert.strictEqual(handleChange.callCount, 1, 'should have called the handleChange cb');
     assert.strictEqual(handleDragStart.callCount, 1, 'should have called the handleDragStart cb');
     assert.strictEqual(handleDragEnd.callCount, 1, 'should have called the handleDragEnd cb');
+
+    assert.strictEqual(
+      handleChange.args[0].length,
+      2,
+      'should have called the handleDragEnd cb with 2 arguments',
+    );
+    assert.strictEqual(
+      handleDragStart.args[0].length,
+      1,
+      'should have called the handleDragEnd cb with 1 argument',
+    );
+    assert.strictEqual(
+      handleDragEnd.args[0].length,
+      2,
+      'should have called the handleDragEnd cb with 2 arguments',
+    );
   });
 
   it('should only listen to changes from the same touchpoint', () => {

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -78,8 +78,8 @@ describe('<Slider />', () => {
     );
     assert.strictEqual(
       handleDragStart.args[0].length,
-      1,
-      'should have called the handleDragEnd cb with 1 argument',
+      2,
+      'should have called the handleDragEnd cb with 2 argument',
     );
     assert.strictEqual(
       handleDragEnd.args[0].length,


### PR DESCRIPTION
As was discussed in https://github.com/mui-org/material-ui/issues/13132 this PR adds the current sliders value on the onDragStart/onDragEnd callback to work around some issues with the order of the callbacks. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes mui/material-ui#13132 