### PR TITLE
[CardHeader] fix typings of props

### DIFF
--- a/packages/material-ui/src/CardHeader/CardHeader.d.ts
+++ b/packages/material-ui/src/CardHeader/CardHeader.d.ts
@@ -6,7 +6,7 @@ export interface CardHeaderProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, CardHeaderClassKey, 'title'> {
   action?: React.ReactNode;
   avatar?: React.ReactNode;
-  component?: React.ReactType<CardHeaderProps>;
+  component?: string | React.ReactType<CardHeaderProps>;
   disableTypography?: boolean;
   subheader?: React.ReactNode;
   subheaderTypographyProps?: Partial<TypographyProps>;


### PR DESCRIPTION
When I provide a string for the `component` prop of `CardHeader` I get an error form typescript:

```
Type 'string' is not assignable to type 'ComponentClass<CardHeaderProps, any> | FunctionComponent<CardHeaderProps> | undefined'.
```

The [documentation](https://material-ui.com/api/card-header/) says that strings should be allowed for the prop.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
