### PR TITLE
[Tooltip] Fix children focus detection

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -125,15 +125,14 @@ class Tooltip extends React.Component {
   };
 
   handleFocus = event => {
-    event.persist();
+    // Workaround for https://github.com/facebook/react/issues/7769
     // The autoFocus of React might trigger the event before the componentDidMount.
     // We need to account for this eventuality.
-    this.focusTimer = setTimeout(() => {
-      // We need to make sure the focus hasn't moved since the event was triggered.
-      if (this.childrenRef === document.activeElement) {
-        this.handleEnter(event);
-      }
-    });
+    if (!this.childrenRef) {
+      this.childrenRef = event.currentTarget;
+    }
+
+    this.handleEnter(event);
 
     const childrenProps = this.props.children.props;
     if (childrenProps.onFocus) {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { assert } from 'chai';
+import PropTypes from 'prop-types';
 import { spy, useFakeTimers } from 'sinon';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createShallow, createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
 import Popper from '../Popper';
 import Tooltip from './Tooltip';
+import Input from '../Input';
 import createMuiTheme from '../styles/createMuiTheme';
 
 function persist() {}
@@ -169,6 +171,28 @@ describe('<Tooltip />', () => {
   describe('mount', () => {
     it('should mount without any issue', () => {
       mount(<Tooltip {...defaultProps} open />);
+    });
+
+    it('should handle autoFocus + onFocus forwarding', () => {
+      const AutoFocus = props => (
+        <div>
+          {props.open ? (
+            <Tooltip title="Title">
+              <Input value="value" autoFocus />
+            </Tooltip>
+          ) : null}
+        </div>
+      );
+      AutoFocus.propTypes = {
+        open: PropTypes.bool,
+      };
+
+      const wrapper = mount(<AutoFocus />);
+      wrapper.setProps({ open: true });
+      assert.strictEqual(wrapper.find(Popper).props().open, false);
+      clock.tick(0);
+      wrapper.update();
+      assert.strictEqual(wrapper.find(Popper).props().open, true);
     });
   });
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request). This PR targets master, though I'm not sure if this qualifies as an "important" bugfix.

This fixes a bug (#14468) which made Tooltips unable to detect when some children elements had taken focus (and therefore, made it impossible for them to be displayed on focus, specifically in the case of TextFields)

Thanks to @oliviertassinari :slightly_smiling_face: 

Closes #14468