### PR TITLE
[PopoverProps] Add EventTarget as option to anchorEl prop

### DIFF
--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -19,7 +19,7 @@ export type PopoverReference = 'anchorEl' | 'anchorPosition' | 'none';
 export interface PopoverProps
   extends StandardProps<ModalProps & Partial<TransitionHandlerProps>, PopoverClassKey, 'children'> {
   action?: (actions: PopoverActions) => void;
-  anchorEl?: null | HTMLElement | ((element: HTMLElement) => HTMLElement);
+  anchorEl?: null | HTMLElement | ((element: HTMLElement) => HTMLElement) | EventTarget;
   anchorOrigin?: PopoverOrigin;
   anchorPosition?: PopoverPosition;
   anchorReference?: PopoverReference;


### PR DESCRIPTION
- [X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

I followed the example: https://codesandbox.io/s/8m0w3loo9
But typescript is complaining showing the error msg:
``` Type 'EventTarget' is not assignable to type 'HTMLElement | ((element: HTMLElement) => HTMLElement)'. ```

In order to be able to use `event.currentTarget` as `anchorEl` I added the `EventTarget` type.

