### PR TITLE
[InputLabel] Remove FormLabelClasses in favor of asterisk class

### DIFF
--- a/packages/material-ui/src/FormLabel/FormLabel.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.js
@@ -34,7 +34,7 @@ export const styles = theme => ({
   filled: {},
   /* Styles applied to the root element if `required={true}`. */
   required: {},
-  /* Styles applied to the asterisk element if `required={true}`. */
+  /* Styles applied to the asterisk element. */
   asterisk: {
     '&$error': {
       color: theme.palette.error.main,

--- a/packages/material-ui/src/FormLabel/FormLabel.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.js
@@ -34,6 +34,7 @@ export const styles = theme => ({
   filled: {},
   /* Styles applied to the root element if `required={true}`. */
   required: {},
+  /* Styles applied to the asterisk element if `required={true}`. */
   asterisk: {
     '&$error': {
       color: theme.palette.error.main,

--- a/packages/material-ui/src/InputLabel/InputLabel.d.ts
+++ b/packages/material-ui/src/InputLabel/InputLabel.d.ts
@@ -6,7 +6,6 @@ export interface InputLabelProps extends StandardProps<FormLabelProps, InputLabe
   disableAnimation?: boolean;
   disabled?: boolean;
   error?: boolean;
-  FormLabelClasses?: FormLabelProps['classes'];
   focused?: boolean;
   required?: boolean;
   shrink?: boolean;

--- a/packages/material-ui/src/InputLabel/InputLabel.d.ts
+++ b/packages/material-ui/src/InputLabel/InputLabel.d.ts
@@ -18,6 +18,7 @@ export type InputLabelClassKey =
   | 'disabled'
   | 'error'
   | 'required'
+  | 'asterisk'
   | 'formControl'
   | 'marginDense'
   | 'shrink'

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -126,7 +126,7 @@ function InputLabel(props) {
         disabled: classes.disabled,
         error: classes.error,
         required: classes.required,
-        ...classes,
+        asterisk: classes.asterisk,
       }}
       {...other}
     >

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -21,6 +21,8 @@ export const styles = theme => ({
   error: {},
   /* Styles applied to the root element if `required={true}`. */
   required: {},
+  /* Styles applied to the asterisk element if `required={true}`. */
+  asterisk: {},
   /* Styles applied to the root element if the component is a descendant of `FormControl`. */
   formControl: {
     position: 'absolute',
@@ -86,7 +88,6 @@ function InputLabel(props) {
     classes,
     className,
     disableAnimation,
-    FormLabelClasses,
     margin,
     muiFormControl,
     shrink: shrinkProp,
@@ -125,7 +126,7 @@ function InputLabel(props) {
         disabled: classes.disabled,
         error: classes.error,
         required: classes.required,
-        ...FormLabelClasses,
+        ...classes,
       }}
       {...other}
     >
@@ -141,7 +142,7 @@ InputLabel.propTypes = {
   children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
-   * See [CSS API](#css-api) below for more details.
+   * See [CSS API](#css) below for more details.
    */
   classes: PropTypes.object.isRequired,
   /**
@@ -164,10 +165,6 @@ InputLabel.propTypes = {
    * If `true`, the input of this label is focused.
    */
   focused: PropTypes.bool,
-  /**
-   * `classes` property applied to the [`FormLabel`](/api/form-label/) element.
-   */
-  FormLabelClasses: PropTypes.object,
   /**
    * If `dense`, will adjust vertical spacing. This is normally obtained via context from
    * FormControl.

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -21,7 +21,7 @@ export const styles = theme => ({
   error: {},
   /* Styles applied to the root element if `required={true}`. */
   required: {},
-  /* Styles applied to the asterisk element if `required={true}`. */
+  /* Styles applied to the asterisk element. */
   asterisk: {},
   /* Styles applied to the root element if the component is a descendant of `FormControl`. */
   formControl: {

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -35,10 +35,10 @@ describe('<InputLabel />', () => {
     assert.strictEqual(wrapper.hasClass(classes.animated), false);
   });
 
-  describe('prop: FormLabelClasses', () => {
-    it('should be able to change the FormLabel style', () => {
-      const wrapper = mount(<InputLabel FormLabelClasses={{ root: 'bar' }}>Foo</InputLabel>);
-      assert.include(wrapper.find('FormLabel').props().classes.root, 'bar');
+  describe('prop: classes', () => {
+    it('should be able to change the InputLabel style', () => {
+      const wrapper = mount(<InputLabel classes={{ root: 'bar' }}>Foo</InputLabel>);
+      assert.include(wrapper.find('InputLabel').props().classes.root, 'bar');
     });
   });
 

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -1048,7 +1048,7 @@ const PopoverTest = () => <Popover open ModalClasses={{ root: 'foo', hidden: 'ba
 
 const InputLabelTest = () => (
   <InputLabel
-    FormLabelClasses={{
+    classes={{
       root: 'foo',
       asterisk: 'foo',
       disabled: 'foo',

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -12,18 +12,20 @@ filename: /packages/material-ui/src/FormLabel/FormLabel.js
 import FormLabel from '@material-ui/core/FormLabel';
 ```
 
+
+
 ## Props
 
-| Name                                     | Type                                     | Default                                   | Description                                                                                             |
-| :--------------------------------------- | :--------------------------------------- | :---------------------------------------- | :------------------------------------------------------------------------------------------------------ |
-| <span class="prop-name">children</span>  | <span class="prop-type">node</span>      |                                           | The content of the component.                                                                           |
-| <span class="prop-name">classes</span>   | <span class="prop-type">object</span>    |                                           | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">Component</span> | <span class="prop-default">'label'</span> | The component used for the root node. Either a string to use a DOM element or a component.              |
-| <span class="prop-name">disabled</span>  | <span class="prop-type">bool</span>      |                                           | If `true`, the label should be displayed in a disabled state.                                           |
-| <span class="prop-name">error</span>     | <span class="prop-type">bool</span>      |                                           | If `true`, the label should be displayed in an error state.                                             |
-| <span class="prop-name">filled</span>    | <span class="prop-type">bool</span>      |                                           | If `true`, the label should use filled classes key.                                                     |
-| <span class="prop-name">focused</span>   | <span class="prop-type">bool</span>      |                                           | If `true`, the input of this label is focused (used by `FormGroup` components).                         |
-| <span class="prop-name">required</span>  | <span class="prop-type">bool</span>      |                                           | If `true`, the label will indicate that the input is required.                                          |
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">component</span> | <span class="prop-type">Component</span> | <span class="prop-default">'label'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the label should be displayed in a disabled state. |
+| <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label should be displayed in an error state. |
+| <span class="prop-name">filled</span> | <span class="prop-type">bool</span> |   | If `true`, the label should use filled classes key. |
+| <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused (used by `FormGroup` components). |
+| <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | If `true`, the label will indicate that the input is required. |
 
 Any other properties supplied will be spread to the root element (native element).
 
@@ -32,15 +34,16 @@ Any other properties supplied will be spread to the root element (native element
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-| Name                                    | Description                                                  |
-| :-------------------------------------- | :----------------------------------------------------------- |
-| <span class="prop-name">root</span>     | Styles applied to the root element.                          |
-| <span class="prop-name">focused</span>  | Styles applied to the root element if `focused={true}`.      |
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.     |
-| <span class="prop-name">error</span>    | Styles applied to the root element if `error={true}`.        |
-| <span class="prop-name">filled</span>   | Styles applied to the root element if `filled={true}`.       |
-| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.     |
-| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element if `required={true}`. |
+
+| Name | Description |
+|:-----|:------------|
+| <span class="prop-name">root</span> | Styles applied to the root element.
+| <span class="prop-name">focused</span> | Styles applied to the root element if `focused={true}`.
+| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">filled</span> | Styles applied to the root element if `filled={true}`.
+| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
+| <span class="prop-name">asterisk</span> | 
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormLabel/FormLabel.js)

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -18,14 +18,14 @@ import FormLabel from '@material-ui/core/FormLabel';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">Component</span> | <span class="prop-default">'label'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the label should be displayed in a disabled state. |
-| <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label should be displayed in an error state. |
-| <span class="prop-name">filled</span> | <span class="prop-type">bool</span> |   | If `true`, the label should use filled classes key. |
-| <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused (used by `FormGroup` components). |
-| <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | If `true`, the label will indicate that the input is required. |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the label should be displayed in a disabled state. |
+| <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label should be displayed in an error state. |
+| <span class="prop-name">filled</span> | <span class="prop-type">bool</span> |   | If `true`, the label should use filled classes key. |
+| <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused (used by `FormGroup` components). |
+| <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | If `true`, the label will indicate that the input is required. |
 
 Any other properties supplied will be spread to the root element (native element).
 
@@ -55,3 +55,4 @@ you need to use the following style sheet name: `MuiFormLabel`.
 ## Demos
 
 - [Selection Controls](/demos/selection-controls/)
+

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -43,7 +43,7 @@ This property accepts the following keys:
 | <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
 | <span class="prop-name">filled</span> | Styles applied to the root element if `filled={true}`.
 | <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
-| <span class="prop-name">asterisk</span> | 
+| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element if `required={true}`.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormLabel/FormLabel.js)

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -12,20 +12,18 @@ filename: /packages/material-ui/src/FormLabel/FormLabel.js
 import FormLabel from '@material-ui/core/FormLabel';
 ```
 
-
-
 ## Props
 
-| Name | Type | Default | Description |
-|:-----|:-----|:--------|:------------|
-| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">Component</span> | <span class="prop-default">'label'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the label should be displayed in a disabled state. |
-| <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label should be displayed in an error state. |
-| <span class="prop-name">filled</span> | <span class="prop-type">bool</span> |   | If `true`, the label should use filled classes key. |
-| <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused (used by `FormGroup` components). |
-| <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | If `true`, the label will indicate that the input is required. |
+| Name                                     | Type                                     | Default                                   | Description                                                                                             |
+| :--------------------------------------- | :--------------------------------------- | :---------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| <span class="prop-name">children</span>  | <span class="prop-type">node</span>      |                                           | The content of the component.                                                                           |
+| <span class="prop-name">classes</span>   | <span class="prop-type">object</span>    |                                           | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">component</span> | <span class="prop-type">Component</span> | <span class="prop-default">'label'</span> | The component used for the root node. Either a string to use a DOM element or a component.              |
+| <span class="prop-name">disabled</span>  | <span class="prop-type">bool</span>      |                                           | If `true`, the label should be displayed in a disabled state.                                           |
+| <span class="prop-name">error</span>     | <span class="prop-type">bool</span>      |                                           | If `true`, the label should be displayed in an error state.                                             |
+| <span class="prop-name">filled</span>    | <span class="prop-type">bool</span>      |                                           | If `true`, the label should use filled classes key.                                                     |
+| <span class="prop-name">focused</span>   | <span class="prop-type">bool</span>      |                                           | If `true`, the input of this label is focused (used by `FormGroup` components).                         |
+| <span class="prop-name">required</span>  | <span class="prop-type">bool</span>      |                                           | If `true`, the label will indicate that the input is required.                                          |
 
 Any other properties supplied will be spread to the root element (native element).
 
@@ -34,16 +32,15 @@ Any other properties supplied will be spread to the root element (native element
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focused</span> | Styles applied to the root element if `focused={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">filled</span> | Styles applied to the root element if `filled={true}`.
-| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
-| <span class="prop-name">asterisk</span> | 
+| Name                                    | Description                                                  |
+| :-------------------------------------- | :----------------------------------------------------------- |
+| <span class="prop-name">root</span>     | Styles applied to the root element.                          |
+| <span class="prop-name">focused</span>  | Styles applied to the root element if `focused={true}`.      |
+| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.     |
+| <span class="prop-name">error</span>    | Styles applied to the root element if `error={true}`.        |
+| <span class="prop-name">filled</span>   | Styles applied to the root element if `filled={true}`.       |
+| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.     |
+| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element if `required={true}`. |
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormLabel/FormLabel.js)
@@ -55,4 +52,3 @@ you need to use the following style sheet name: `MuiFormLabel`.
 ## Demos
 
 - [Selection Controls](/demos/selection-controls/)
-

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -43,7 +43,7 @@ This property accepts the following keys:
 | <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
 | <span class="prop-name">filled</span> | Styles applied to the root element if `filled={true}`.
 | <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
-| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element if `required={true}`.
+| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormLabel/FormLabel.js)

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -12,23 +12,20 @@ filename: /packages/material-ui/src/InputLabel/InputLabel.js
 import InputLabel from '@material-ui/core/InputLabel';
 ```
 
-
-
 ## Props
 
-| Name | Type | Default | Description |
-|:-----|:-----|:--------|:------------|
-| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The contents of the `InputLabel`. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
-| <span class="prop-name">disableAnimation</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the transition animation is disabled. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, apply disabled class. |
-| <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label will be displayed in an error state. |
-| <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused. |
-| <span class="prop-name">FormLabelClasses</span> | <span class="prop-type">object</span> |   | `classes` property applied to the [`FormLabel`](/api/form-label/) element. |
-| <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'<br></span> |   | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
-| <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | if `true`, the label will indicate that the input is required. |
-| <span class="prop-name">shrink</span> | <span class="prop-type">bool</span> |   | If `true`, the label is shrunk. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |   | The variant to use. |
+| Name                                            | Type                                                                                                                   | Default                                 | Description                                                                                         |
+| :---------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| <span class="prop-name">children</span>         | <span class="prop-type">node</span>                                                                                    |                                         | The contents of the `InputLabel`.                                                                   |
+| <span class="prop-name">classes</span>          | <span class="prop-type">object</span>                                                                                  |                                         | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">disableAnimation</span> | <span class="prop-type">bool</span>                                                                                    | <span class="prop-default">false</span> | If `true`, the transition animation is disabled.                                                    |
+| <span class="prop-name">disabled</span>         | <span class="prop-type">bool</span>                                                                                    |                                         | If `true`, apply disabled class.                                                                    |
+| <span class="prop-name">error</span>            | <span class="prop-type">bool</span>                                                                                    |                                         | If `true`, the label will be displayed in an error state.                                           |
+| <span class="prop-name">focused</span>          | <span class="prop-type">bool</span>                                                                                    |                                         | If `true`, the input of this label is focused.                                                      |
+| <span class="prop-name">margin</span>           | <span class="prop-type">enum:&nbsp;'dense'<br></span>                                                                  |                                         | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl.   |
+| <span class="prop-name">required</span>         | <span class="prop-type">bool</span>                                                                                    |                                         | if `true`, the label will indicate that the input is required.                                      |
+| <span class="prop-name">shrink</span>           | <span class="prop-type">bool</span>                                                                                    |                                         | If `true`, the label is shrunk.                                                                     |
+| <span class="prop-name">variant</span>          | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |                                         | The variant to use.                                                                                 |
 
 Any other properties supplied will be spread to the root element ([FormLabel](/api/form-label/)).
 
@@ -37,20 +34,20 @@ Any other properties supplied will be spread to the root element ([FormLabel](/a
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focused</span> | Styles applied to the root element if `focused={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
-| <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
-| <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
-| <span class="prop-name">shrink</span> | Styles applied to the `input` element if `shrink={true}`.
-| <span class="prop-name">animated</span> | Styles applied to the `input` element if `disableAnimation={false}`.
-| <span class="prop-name">filled</span> | Styles applied to the root element if `variant="filled"`.
-| <span class="prop-name">outlined</span> | Styles applied to the root element if `variant="outlined"`.
+| Name                                       | Description                                                                           |
+| :----------------------------------------- | :------------------------------------------------------------------------------------ |
+| <span class="prop-name">root</span>        | Styles applied to the root element.                                                   |
+| <span class="prop-name">focused</span>     | Styles applied to the root element if `focused={true}`.                               |
+| <span class="prop-name">disabled</span>    | Styles applied to the root element if `disabled={true}`.                              |
+| <span class="prop-name">error</span>       | Styles applied to the root element if `error={true}`.                                 |
+| <span class="prop-name">required</span>    | Styles applied to the root element if `required={true}`.                              |
+| <span class="prop-name">asterisk</span>    | Styles applied to the asterisk element if `required={true}`.                          |
+| <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`. |
+| <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.                               |
+| <span class="prop-name">shrink</span>      | Styles applied to the `input` element if `shrink={true}`.                             |
+| <span class="prop-name">animated</span>    | Styles applied to the `input` element if `disableAnimation={false}`.                  |
+| <span class="prop-name">filled</span>      | Styles applied to the root element if `variant="filled"`.                             |
+| <span class="prop-name">outlined</span>    | Styles applied to the root element if `variant="outlined"`.                           |
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputLabel/InputLabel.js)
@@ -67,4 +64,3 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 ## Demos
 
 - [Text Fields](/demos/text-fields/)
-

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -12,20 +12,23 @@ filename: /packages/material-ui/src/InputLabel/InputLabel.js
 import InputLabel from '@material-ui/core/InputLabel';
 ```
 
+
+
 ## Props
 
-| Name                                            | Type                                                                                                                   | Default                                 | Description                                                                                         |
-| :---------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- | :-------------------------------------------------------------------------------------------------- |
-| <span class="prop-name">children</span>         | <span class="prop-type">node</span>                                                                                    |                                         | The contents of the `InputLabel`.                                                                   |
-| <span class="prop-name">classes</span>          | <span class="prop-type">object</span>                                                                                  |                                         | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">disableAnimation</span> | <span class="prop-type">bool</span>                                                                                    | <span class="prop-default">false</span> | If `true`, the transition animation is disabled.                                                    |
-| <span class="prop-name">disabled</span>         | <span class="prop-type">bool</span>                                                                                    |                                         | If `true`, apply disabled class.                                                                    |
-| <span class="prop-name">error</span>            | <span class="prop-type">bool</span>                                                                                    |                                         | If `true`, the label will be displayed in an error state.                                           |
-| <span class="prop-name">focused</span>          | <span class="prop-type">bool</span>                                                                                    |                                         | If `true`, the input of this label is focused.                                                      |
-| <span class="prop-name">margin</span>           | <span class="prop-type">enum:&nbsp;'dense'<br></span>                                                                  |                                         | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl.   |
-| <span class="prop-name">required</span>         | <span class="prop-type">bool</span>                                                                                    |                                         | if `true`, the label will indicate that the input is required.                                      |
-| <span class="prop-name">shrink</span>           | <span class="prop-type">bool</span>                                                                                    |                                         | If `true`, the label is shrunk.                                                                     |
-| <span class="prop-name">variant</span>          | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |                                         | The variant to use.                                                                                 |
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The contents of the `InputLabel`. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">disableAnimation</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the transition animation is disabled. |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, apply disabled class. |
+| <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label will be displayed in an error state. |
+| <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused. |
+| <span class="prop-name">FormLabelClasses</span> | <span class="prop-type">object</span> |   | `classes` property applied to the [`FormLabel`](/api/form-label/) element. |
+| <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'<br></span> |   | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
+| <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | if `true`, the label will indicate that the input is required. |
+| <span class="prop-name">shrink</span> | <span class="prop-type">bool</span> |   | If `true`, the label is shrunk. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |   | The variant to use. |
 
 Any other properties supplied will be spread to the root element ([FormLabel](/api/form-label/)).
 
@@ -34,20 +37,20 @@ Any other properties supplied will be spread to the root element ([FormLabel](/a
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-| Name                                       | Description                                                                           |
-| :----------------------------------------- | :------------------------------------------------------------------------------------ |
-| <span class="prop-name">root</span>        | Styles applied to the root element.                                                   |
-| <span class="prop-name">focused</span>     | Styles applied to the root element if `focused={true}`.                               |
-| <span class="prop-name">disabled</span>    | Styles applied to the root element if `disabled={true}`.                              |
-| <span class="prop-name">error</span>       | Styles applied to the root element if `error={true}`.                                 |
-| <span class="prop-name">required</span>    | Styles applied to the root element if `required={true}`.                              |
-| <span class="prop-name">asterisk</span>    | Styles applied to the asterisk element if `required={true}`.                          |
-| <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`. |
-| <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.                               |
-| <span class="prop-name">shrink</span>      | Styles applied to the `input` element if `shrink={true}`.                             |
-| <span class="prop-name">animated</span>    | Styles applied to the `input` element if `disableAnimation={false}`.                  |
-| <span class="prop-name">filled</span>      | Styles applied to the root element if `variant="filled"`.                             |
-| <span class="prop-name">outlined</span>    | Styles applied to the root element if `variant="outlined"`.                           |
+
+| Name | Description |
+|:-----|:------------|
+| <span class="prop-name">root</span> | Styles applied to the root element.
+| <span class="prop-name">focused</span> | Styles applied to the root element if `focused={true}`.
+| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
+| <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
+| <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
+| <span class="prop-name">shrink</span> | Styles applied to the `input` element if `shrink={true}`.
+| <span class="prop-name">animated</span> | Styles applied to the `input` element if `disableAnimation={false}`.
+| <span class="prop-name">filled</span> | Styles applied to the root element if `variant="filled"`.
+| <span class="prop-name">outlined</span> | Styles applied to the root element if `variant="outlined"`.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputLabel/InputLabel.js)

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -44,7 +44,7 @@ This property accepts the following keys:
 | <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
 | <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
 | <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
-| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element if `required={true}`.
+| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element.
 | <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
 | <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
 | <span class="prop-name">shrink</span> | Styles applied to the `input` element if `shrink={true}`.

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -18,17 +18,17 @@ import InputLabel from '@material-ui/core/InputLabel';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The contents of the `InputLabel`. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The contents of the `InputLabel`. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">disableAnimation</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the transition animation is disabled. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, apply disabled class. |
-| <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label will be displayed in an error state. |
-| <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused. |
-| <span class="prop-name">FormLabelClasses</span> | <span class="prop-type">object</span> |   | `classes` property applied to the [`FormLabel`](/api/form-label/) element. |
-| <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'<br></span> |   | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
-| <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | if `true`, the label will indicate that the input is required. |
-| <span class="prop-name">shrink</span> | <span class="prop-type">bool</span> |   | If `true`, the label is shrunk. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |   | The variant to use. |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, apply disabled class. |
+| <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label will be displayed in an error state. |
+| <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused. |
+| <span class="prop-name">FormLabelClasses</span> | <span class="prop-type">object</span> |   | `classes` property applied to the [`FormLabel`](/api/form-label/) element. |
+| <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'<br></span> |   | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
+| <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | if `true`, the label will indicate that the input is required. |
+| <span class="prop-name">shrink</span> | <span class="prop-type">bool</span> |   | If `true`, the label is shrunk. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |   | The variant to use. |
 
 Any other properties supplied will be spread to the root element ([FormLabel](/api/form-label/)).
 
@@ -67,3 +67,4 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 ## Demos
 
 - [Text Fields](/demos/text-fields/)
+

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -19,12 +19,11 @@ import InputLabel from '@material-ui/core/InputLabel';
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The contents of the `InputLabel`. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disableAnimation</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the transition animation is disabled. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, apply disabled class. |
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> |   | If `true`, the label will be displayed in an error state. |
 | <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |   | If `true`, the input of this label is focused. |
-| <span class="prop-name">FormLabelClasses</span> | <span class="prop-type">object</span> |   | `classes` property applied to the [`FormLabel`](/api/form-label/) element. |
 | <span class="prop-name">margin</span> | <span class="prop-type">enum:&nbsp;'dense'<br></span> |   | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> |   | if `true`, the label will indicate that the input is required. |
 | <span class="prop-name">shrink</span> | <span class="prop-type">bool</span> |   | If `true`, the label is shrunk. |
@@ -45,6 +44,7 @@ This property accepts the following keys:
 | <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
 | <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
 | <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
+| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element if `required={true}`.
 | <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
 | <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
 | <span class="prop-name">shrink</span> | Styles applied to the `input` element if `shrink={true}`.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Fixes #14490

### Breaking change

You should be able to override all the styles of the FormLabel component using the css API of the InputLabel component. We do no longer need the `FormLabelClasses` property.
```diff
<InputLabel
- FormLabelClasses={{ asterisk: 'bar' }}
+ classes={{ asterisk: 'bar' }}
>
  Foo
</InputLabel>
```