### PR TITLE
[core] Convert remaining classNames usage

### DIFF
--- a/docs/src/pages/demos/cards/RecipeReviewCard.hooks.js
+++ b/docs/src/pages/demos/cards/RecipeReviewCard.hooks.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/styles';
-import classnames from 'classnames';
+import clsx from 'clsx';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import CardMedia from '@material-ui/core/CardMedia';
@@ -85,7 +85,7 @@ function RecipeReviewCard() {
           <ShareIcon />
         </IconButton>
         <IconButton
-          className={classnames(classes.expand, {
+          className={clsx(classes.expand, {
             [classes.expandOpen]: expanded,
           })}
           onClick={handleExpandClick}

--- a/docs/src/pages/demos/cards/RecipeReviewCard.js
+++ b/docs/src/pages/demos/cards/RecipeReviewCard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
-import classnames from 'classnames';
+import clsx from 'clsx';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
 import CardMedia from '@material-ui/core/CardMedia';
@@ -88,7 +88,7 @@ class RecipeReviewCard extends React.Component {
             <ShareIcon />
           </IconButton>
           <IconButton
-            className={classnames(classes.expand, {
+            className={clsx(classes.expand, {
               [classes.expandOpen]: this.state.expanded,
             })}
             onClick={this.handleExpandClick}

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/Avatar.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/Avatar.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiAvatar from '@material-ui/core/Avatar';
 import { AVATAR } from '../../theme/core';
 
 const Avatar = ({ className, small, medium, ultraLarge, ...props }) => (
   <MuiAvatar
-    className={cx(
+    className={clsx(
       AVATAR.root,
       className,
       small && AVATAR.small,

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/Badge.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/Badge.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiBadge from '@material-ui/core/Badge';
 import { BADGE } from '../../theme/core';
 
 const Badge = ({ className, dotted, children, ...props }) => (
-  <MuiBadge className={cx(BADGE.root, className, dotted && BADGE.dotted)} {...props}>
+  <MuiBadge className={clsx(BADGE.root, className, dotted && BADGE.dotted)} {...props}>
     {children}
   </MuiBadge>
 );

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/Button.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/Button.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiButton from '@material-ui/core/Button';
 import { BUTTON } from '../../theme/core';
 
 const Button = ({ className, inverted, danger, ...props }) => (
   <MuiButton
-    className={cx(BUTTON.root, className, inverted && BUTTON.inverted, danger && BUTTON.danger)}
+    className={clsx(BUTTON.root, className, inverted && BUTTON.inverted, danger && BUTTON.danger)}
     {...props}
   />
 );

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/Chip.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/Chip.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiChip from '@material-ui/core/Chip';
 import { CHIP } from '../../theme/core';
 
 const Chip = ({ className, inverted, ...props }) => (
   <MuiChip
-    className={cx(CHIP.root, className, inverted && CHIP.inverted)}
+    className={clsx(CHIP.root, className, inverted && CHIP.inverted)}
     classes={{
       label: CHIP.label,
     }}

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/Divider.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/Divider.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiDivider from '@material-ui/core/Divider';
 import { DIVIDER } from '../../theme/core';
 
 const Divider = ({ className, vertical, ...props }) => (
-  <MuiDivider className={cx(DIVIDER.root, className, vertical && DIVIDER.vertical)} {...props} />
+  <MuiDivider className={clsx(DIVIDER.root, className, vertical && DIVIDER.vertical)} {...props} />
 );
 
 export default Divider;

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/Icon.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/Icon.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiIcon from '@material-ui/core/Icon';
 import { ICON } from '../../theme/core';
 
@@ -18,7 +18,7 @@ const Icon = ({
   ...props
 }) => (
   <MuiIcon
-    className={cx(
+    className={clsx(
       ICON.root,
       className,
       left && ICON.left,

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/IconButton.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/IconButton.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiIconButton from '@material-ui/core/IconButton';
 import { ICON_BUTTON } from '../../theme/core';
 
 const IconButton = ({ className, shaded, noPad, narrowPad, separated, linkInverted, ...props }) => (
   <MuiIconButton
-    className={cx(
+    className={clsx(
       ICON_BUTTON.root,
       className,
       shaded && ICON_BUTTON.shaded,

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/Toolbar.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/Toolbar.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiToolbar from '@material-ui/core/Toolbar';
 import { TOOLBAR } from '../../theme/core';
 
 const Toolbar = ({ className, narrow, ...props }) => (
-  <MuiToolbar className={cx(TOOLBAR.root, className, narrow && TOOLBAR.narrow)} {...props} />
+  <MuiToolbar className={clsx(TOOLBAR.root, className, narrow && TOOLBAR.narrow)} {...props} />
 );
 
 export default Toolbar;

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/Typography.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/Typography.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiTypography from '@material-ui/core/Typography';
 import { TEXT } from '../../theme/core';
 
@@ -16,7 +16,7 @@ const Typography = ({
   ...props
 }) => (
   <MuiTypography
-    className={cx(
+    className={clsx(
       TEXT.root,
       className,
       bold && TEXT.bold,

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/Card.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/Card.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCard from '@material-ui/core/Card';
 import { CARD } from '../../theme/core';
 
 const Card = ({ className, actionable, contained, spaceGrey, darkBlue, ...props }) => (
   <MuiCard
-    className={cx(
+    className={clsx(
       CARD.root,
       className,
       actionable && CARD.actionable,

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/CardActionArea.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/CardActionArea.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCardActionArea from '@material-ui/core/CardActionArea';
 import { CARD_ACTION_AREA } from '../../theme/core';
 
 const CardActionArea = ({ className, ...props }) => (
-  <MuiCardActionArea className={cx(CARD_ACTION_AREA.root, className)} {...props} />
+  <MuiCardActionArea className={clsx(CARD_ACTION_AREA.root, className)} {...props} />
 );
 
 export default CardActionArea;

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/CardActions.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/CardActions.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCardActions from '@material-ui/core/CardActions';
 import { CARD_ACTIONS } from '../../theme/core';
 
 const CardActions = ({ className, contained, ...props }) => (
   <MuiCardActions
-    className={cx(CARD_ACTIONS.root, className, contained && CARD_ACTIONS.contained)}
+    className={clsx(CARD_ACTIONS.root, className, contained && CARD_ACTIONS.contained)}
     classes={{
       action: CARD_ACTIONS.action,
     }}

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/CardContent.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/CardContent.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCardContent from '@material-ui/core/CardContent';
 import { CARD_CONTENT } from '../../theme/core';
 
 const CardContent = ({ className, ...props }) => (
-  <MuiCardContent className={cx(CARD_CONTENT.root, className)} {...props} />
+  <MuiCardContent className={clsx(CARD_CONTENT.root, className)} {...props} />
 );
 
 export default CardContent;

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/CardMedia.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/CardMedia.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCardActions from '@material-ui/core/CardActions';
 import { CARD_MEDIA } from '../../theme/core';
 
 const CardActions = ({ className, wideScreen, ...props }) => (
   <MuiCardActions
-    className={cx(CARD_MEDIA.root, className, wideScreen && CARD_MEDIA.wideScreen)}
+    className={clsx(CARD_MEDIA.root, className, wideScreen && CARD_MEDIA.wideScreen)}
     {...props}
   />
 );

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/Drawer.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/Drawer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiDrawer from '@material-ui/core/Drawer';
 import { DRAWER } from '../../theme/core';
 
@@ -16,7 +16,7 @@ const Drawer = ({
   ...props
 }) => (
   <MuiDrawer
-    className={cx(
+    className={clsx(
       DRAWER.root,
       className,
       header && DRAWER.header,

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/List.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/List.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiList from '@material-ui/core/List';
 import { LIST } from '../../theme/core';
 
 const List = ({ className, ...props }) => (
-  <MuiList className={cx(LIST.root, className)} {...props} />
+  <MuiList className={clsx(LIST.root, className)} {...props} />
 );
 
 export default List;

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/ListItem.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/ListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiListItem from '@material-ui/core/ListItem';
 import { LIST_ITEM } from '../../theme/core';
 
@@ -14,7 +14,7 @@ const ListItem = ({
   ...props
 }) => (
   <MuiListItem
-    className={cx(
+    className={clsx(
       LIST_ITEM.root,
       className,
       header && LIST_ITEM.header,

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/ListItemIcon.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/ListItemIcon.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiListItemIcon from '@material-ui/core/ListItemIcon';
 import { LIST_ITEM_ICON } from '../../theme/core';
 
 const ListItemIcon = ({ className, children, subcategory, ...props }) => (
   <MuiListItemIcon
-    className={cx(LIST_ITEM_ICON.root, className, subcategory && LIST_ITEM_ICON.subcategory)}
+    className={clsx(LIST_ITEM_ICON.root, className, subcategory && LIST_ITEM_ICON.subcategory)}
     {...props}
   >
     {children}

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/ListItemText.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/ListItemText.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiListItemText from '@material-ui/core/ListItemText';
 import { LIST_ITEM_TEXT } from '../../theme/core';
 
 const ListItemText = ({ className, category, subcategory, subcategoryPrimary, ...props }) => (
   <MuiListItemText
-    className={cx(
+    className={clsx(
       LIST_ITEM_TEXT.root,
       className,
       category && LIST_ITEM_TEXT.category,

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/Tab.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/Tab.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiTab from '@material-ui/core/Tab';
 import { TAB } from '../../theme/core';
 
 const Tab = ({ className, inverted, ...props }) => (
   <MuiTab
-    className={cx(TAB.root, className)}
+    className={clsx(TAB.root, className)}
     classes={{ label: TAB.label, selected: TAB.selected }}
     {...props}
   />

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/Tabs.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/Tabs.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiTabs from '@material-ui/core/Tabs';
 import { TABS } from '../../theme/core';
 
 const Tabs = ({ className, inverted, ...props }) => (
   <MuiTabs
-    className={cx(TABS.root, className, inverted && TABS.inverted)}
+    className={clsx(TABS.root, className, inverted && TABS.inverted)}
     classes={{ indicator: TABS.indicator }}
     {...props}
   />

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/AppBar.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/AppBar.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiAppBar from '@material-ui/core/AppBar';
 import { APP_BAR } from '../../theme/core';
 
 const AppBar = ({ className, shaded, ...props }) => (
   <MuiAppBar
     src="https://pbs.twimg.com/profile_images/1060539954361622533/-9ofKMvA_400x400.jpg"
-    className={cx(APP_BAR.root, className, shaded && APP_BAR.shaded)}
+    className={clsx(APP_BAR.root, className, shaded && APP_BAR.shaded)}
     {...props}
   />
 );

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/Avatar.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/Avatar.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiAvatar from '@material-ui/core/Avatar';
 import { AVATAR } from '../../theme/core';
 
 const Avatar = ({ className, bordered, link, small, medium, ultraLarge, ...props }) => (
   <MuiAvatar
-    className={cx(
+    className={clsx(
       AVATAR.root,
       className,
       bordered && AVATAR.bordered,

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/Badge.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/Badge.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiBadge from '@material-ui/core/Badge';
 import { BADGE } from '../../theme/core';
 
 const Badge = ({ className, dotted, number, children, ...props }) => (
   <MuiBadge
-    className={cx(BADGE.root, className, dotted && BADGE.dotted, number && BADGE.number)}
+    className={clsx(BADGE.root, className, dotted && BADGE.dotted, number && BADGE.number)}
     classes={{
       badge: BADGE.badge,
     }}

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/Button.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/Button.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiButton from '@material-ui/core/Button';
 import { BUTTON } from '../../theme/core';
 
 const Button = ({ className, large, inverted, danger, ...props }) => (
   <MuiButton
-    className={cx(
+    className={clsx(
       BUTTON.root,
       className,
       inverted && BUTTON.inverted,

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/Chip.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/Chip.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiChip from '@material-ui/core/Chip';
 import { CHIP } from '../../theme/core';
 
 const Chip = ({ className, inverted, ...props }) => (
   <MuiChip
-    className={cx(CHIP.root, className, inverted && CHIP.inverted)}
+    className={clsx(CHIP.root, className, inverted && CHIP.inverted)}
     classes={{
       label: CHIP.label,
     }}

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/Divider.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/Divider.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiDivider from '@material-ui/core/Divider';
 import { DIVIDER } from '../../theme/core';
 
 const Divider = ({ className, vertical, ...props }) => (
-  <MuiDivider className={cx(DIVIDER.root, className, vertical && DIVIDER.vertical)} {...props} />
+  <MuiDivider className={clsx(DIVIDER.root, className, vertical && DIVIDER.vertical)} {...props} />
 );
 
 export default Divider;

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/Icon.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/Icon.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiIcon from '@material-ui/core/Icon';
 import { ICON } from '../../theme/core';
 
@@ -20,7 +20,7 @@ const Icon = ({
   ...props
 }) => (
   <MuiIcon
-    className={cx(
+    className={clsx(
       ICON.root,
       className,
       left && ICON.left,

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/IconButton.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/IconButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiIconButton from '@material-ui/core/IconButton';
 import { ICON_BUTTON } from '../../theme/core';
 
@@ -15,7 +15,7 @@ const IconButton = ({
   ...props
 }) => (
   <MuiIconButton
-    className={cx(
+    className={clsx(
       ICON_BUTTON.root,
       className,
       shaded && ICON_BUTTON.shaded,

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/Toolbar.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/Toolbar.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiToolbar from '@material-ui/core/Toolbar';
 import { TOOLBAR } from '../../theme/core';
 
 const Toolbar = ({ className, narrow, ...props }) => (
-  <MuiToolbar className={cx(TOOLBAR.root, className, narrow && TOOLBAR.narrow)} {...props} />
+  <MuiToolbar className={clsx(TOOLBAR.root, className, narrow && TOOLBAR.narrow)} {...props} />
 );
 
 export default Toolbar;

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/Typography.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/Typography.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiTypography from '@material-ui/core/Typography';
 import { TEXT } from '../../theme/core';
 
@@ -23,7 +23,7 @@ const Typography = ({
   ...props
 }) => (
   <MuiTypography
-    className={cx(
+    className={clsx(
       TEXT.root,
       className,
       bold && TEXT.bold,

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/Card.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/Card.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCard from '@material-ui/core/Card';
 import { CARD } from '../../theme/core';
 
 const Card = ({ className, actionable, contained, spaceGrey, darkBlue, ...props }) => (
   <MuiCard
-    className={cx(
+    className={clsx(
       CARD.root,
       className,
       actionable && CARD.actionable,

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/CardActionArea.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/CardActionArea.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCardActionArea from '@material-ui/core/CardActionArea';
 import { CARD_ACTION_AREA } from '../../theme/core';
 
 const CardActionArea = ({ className, ...props }) => (
-  <MuiCardActionArea className={cx(CARD_ACTION_AREA.root, className)} {...props} />
+  <MuiCardActionArea className={clsx(CARD_ACTION_AREA.root, className)} {...props} />
 );
 
 export default CardActionArea;

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/CardActions.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/CardActions.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCardActions from '@material-ui/core/CardActions';
 import { CARD_ACTIONS } from '../../theme/core';
 
 const CardActions = ({ className, contained, ...props }) => (
   <MuiCardActions
-    className={cx(CARD_ACTIONS.root, className, contained && CARD_ACTIONS.contained)}
+    className={clsx(CARD_ACTIONS.root, className, contained && CARD_ACTIONS.contained)}
     classes={{
       action: CARD_ACTIONS.action,
     }}

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/CardContent.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/CardContent.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCardContent from '@material-ui/core/CardContent';
 import { CARD_CONTENT } from '../../theme/core';
 
 const CardContent = ({ className, ...props }) => (
-  <MuiCardContent className={cx(CARD_CONTENT.root, className)} {...props} />
+  <MuiCardContent className={clsx(CARD_CONTENT.root, className)} {...props} />
 );
 
 export default CardContent;

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/CardMedia.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/CardMedia.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiCardActions from '@material-ui/core/CardActions';
 import { CARD_MEDIA } from '../../theme/core';
 
 const CardActions = ({ className, wideScreen, ...props }) => (
   <MuiCardActions
-    className={cx(CARD_MEDIA.root, className, wideScreen && CARD_MEDIA.wideScreen)}
+    className={clsx(CARD_MEDIA.root, className, wideScreen && CARD_MEDIA.wideScreen)}
     {...props}
   />
 );

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/Drawer.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/Drawer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiDrawer from '@material-ui/core/Drawer';
 import { DRAWER } from '../../theme/core';
 
@@ -16,7 +16,7 @@ const Drawer = ({
   ...props
 }) => (
   <MuiDrawer
-    className={cx(
+    className={clsx(
       DRAWER.root,
       className,
       header && DRAWER.header,

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/InputAdornment.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/InputAdornment.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiInputAdornment from '@material-ui/core/InputAdornment';
 import { INPUT_ADORNMENT } from '../../theme/core';
 
 const InputAdornment = ({ className, flex, ...props }) => (
   <MuiInputAdornment
-    className={cx(INPUT_ADORNMENT.root, className)}
+    className={clsx(INPUT_ADORNMENT.root, className)}
     classes={{
       positionStart: INPUT_ADORNMENT.positionStart,
     }}

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/List.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/List.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiList from '@material-ui/core/List';
 import { LIST } from '../../theme/core';
 
 const List = ({ className, ...props }) => (
-  <MuiList className={cx(LIST.root, className)} {...props} />
+  <MuiList className={clsx(LIST.root, className)} {...props} />
 );
 
 export default List;

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/ListItem.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/ListItem.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiListItem from '@material-ui/core/ListItem';
 import { LIST_ITEM } from '../../theme/core';
 
@@ -14,7 +14,7 @@ const ListItem = ({
   ...props
 }) => (
   <MuiListItem
-    className={cx(
+    className={clsx(
       LIST_ITEM.root,
       className,
       header && LIST_ITEM.header,

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/ListItemIcon.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/ListItemIcon.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiListItemIcon from '@material-ui/core/ListItemIcon';
 import { LIST_ITEM_ICON } from '../../theme/core';
 
 const ListItemIcon = ({ className, children, subcategory, ...props }) => (
   <MuiListItemIcon
-    className={cx(LIST_ITEM_ICON.root, className, subcategory && LIST_ITEM_ICON.subcategory)}
+    className={clsx(LIST_ITEM_ICON.root, className, subcategory && LIST_ITEM_ICON.subcategory)}
     {...props}
   >
     {children}

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/ListItemText.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/ListItemText.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiListItemText from '@material-ui/core/ListItemText';
 import { LIST_ITEM_TEXT } from '../../theme/core';
 
 const ListItemText = ({ className, category, subcategory, subcategoryPrimary, ...props }) => (
   <MuiListItemText
-    className={cx(
+    className={clsx(
       LIST_ITEM_TEXT.root,
       className,
       category && LIST_ITEM_TEXT.category,

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/Tab.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/Tab.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiTab from '@material-ui/core/Tab';
 import { TAB } from '../../theme/core';
 
 const Tab = ({ className, onlyIcon, inverted, ...props }) => (
   <MuiTab
-    className={cx(TAB.root, className, onlyIcon && TAB.onlyIcon)}
+    className={clsx(TAB.root, className, onlyIcon && TAB.onlyIcon)}
     classes={{
       label: TAB.label,
       wrapper: TAB.wrapper,

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/Tabs.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/Tabs.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import cx from 'classnames';
+import clsx from 'clsx';
 import MuiTabs from '@material-ui/core/Tabs';
 import { TABS } from '../../theme/core';
 
 const Tabs = ({ className, underline, inverted, ...props }) => (
   <MuiTabs
-    className={cx(TABS.root, className, inverted && TABS.inverted, underline && TABS.underline)}
+    className={clsx(TABS.root, className, inverted && TABS.inverted, underline && TABS.underline)}
     classes={{ indicator: TABS.indicator }}
     {...props}
   />

--- a/docs/src/pages/versions/LatestVersions.js
+++ b/docs/src/pages/versions/LatestVersions.js
@@ -38,7 +38,11 @@ function LatestVersions(props) {
               </Link>
             </TableCell>
             <TableCell padding="dense">
-              <Link variant="body2" color="secondary" href="https://github.com/mui-org/material-ui/tree/master">
+              <Link
+                variant="body2"
+                color="secondary"
+                href="https://github.com/mui-org/material-ui/tree/master"
+              >
                 Source code
               </Link>
             </TableCell>
@@ -58,7 +62,11 @@ function LatestVersions(props) {
               </Link>
             </TableCell>
             <TableCell padding="dense">
-              <Link variant="body2" color="secondary" href="https://github.com/mui-org/material-ui/tree/next">
+              <Link
+                variant="body2"
+                color="secondary"
+                href="https://github.com/mui-org/material-ui/tree/next"
+              >
                 Source code
               </Link>
             </TableCell>

--- a/packages/material-ui/src/InputBase/Textarea.js
+++ b/packages/material-ui/src/InputBase/Textarea.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
+import clsx from 'clsx';
 import debounce from 'debounce'; // < 1kb payload overhead when lodash/debounce is > 3kb.
 import EventListener from 'react-event-listener';
 import withStyles from '../styles/withStyles';
@@ -162,7 +162,7 @@ class Textarea extends React.Component {
         <EventListener target="window" onResize={this.handleResize} />
         <textarea
           aria-hidden="true"
-          className={classnames(classes.textarea, classes.shadow)}
+          className={clsx(classes.textarea, classes.shadow)}
           readOnly
           ref={this.handleRefSinglelineShadow}
           rows="1"
@@ -171,7 +171,7 @@ class Textarea extends React.Component {
         />
         <textarea
           aria-hidden="true"
-          className={classnames(classes.textarea, classes.shadow)}
+          className={clsx(classes.textarea, classes.shadow)}
           defaultValue={defaultValue}
           readOnly
           ref={this.handleRefShadow}
@@ -181,7 +181,7 @@ class Textarea extends React.Component {
         />
         <textarea
           rows={rows}
-          className={classnames(classes.textarea, className)}
+          className={clsx(classes.textarea, className)}
           defaultValue={defaultValue}
           value={value}
           onChange={this.handleChange}


### PR DESCRIPTION
Followup on #14152 

Mostly changes in our docs. There was only once instance that could cause a bug mentioned in https://github.com/mui-org/material-ui/pull/14152#issuecomment-462870485: https://github.com/mui-org/material-ui/pull/14506/files#diff-b66f193a8970d7d9137168c42efe78c8