### PR TITLE
[docs] Update the styling of the TOC

### DIFF
--- a/docs/src/modules/components/AppContent.js
+++ b/docs/src/modules/components/AppContent.js
@@ -18,7 +18,7 @@ const styles = theme => ({
     },
     [theme.breakpoints.up('lg')]: {
       paddingLeft: theme.spacing(5),
-      paddingRight: theme.spacing(9),
+      paddingRight: theme.spacing(8),
       maxWidth: 'calc(100% - 240px - 167px)',
     },
   },

--- a/docs/src/modules/components/AppContent.js
+++ b/docs/src/modules/components/AppContent.js
@@ -12,13 +12,13 @@ const styles = theme => ({
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
     [theme.breakpoints.up('sm')]: {
-      paddingLeft: theme.spacing(4),
+      paddingLeft: theme.spacing(3),
       paddingRight: theme.spacing(4),
-      maxWidth: 'calc(100% - 167px)',
+      maxWidth: 'calc(100% - 175px)',
     },
     [theme.breakpoints.up('lg')]: {
       paddingLeft: theme.spacing(5),
-      paddingRight: theme.spacing(8),
+      paddingRight: theme.spacing(9),
       maxWidth: 'calc(100% - 240px - 167px)',
     },
   },

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -45,11 +45,6 @@ function getItems(contents) {
 }
 
 const styles = theme => ({
-  '@global': {
-    html: {
-      scrollBehavior: 'smooth',
-    },
-  },
   root: {
     top: 70 + 29,
     // Fix IE 11 position sticky issue.

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -161,7 +161,7 @@ class AppTableOfContents extends React.Component {
 
     let active;
 
-    for (let i = this.itemsClient.length -1; i >=0; i -= 1) {
+    for (let i = this.itemsClient.length - 1; i >= 0; i -= 1) {
       // No hash if we're near the top of the page
       if (document.documentElement.scrollTop < 200) {
         active = { hash: null };
@@ -173,8 +173,9 @@ class AppTableOfContents extends React.Component {
       warning(item.node, `Missing node on the item ${JSON.stringify(item, null, 2)}`);
 
       if (
-        item.node && (item.node.offsetTop < document.documentElement.scrollTop +
-        document.documentElement.clientHeight / 4)
+        item.node &&
+        item.node.offsetTop <
+          document.documentElement.scrollTop + document.documentElement.clientHeight / 8
       ) {
         active = item;
         break;

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -201,7 +201,7 @@ class AppTableOfContents extends React.Component {
     }
   };
 
-  handleClick = hash => {
+  handleClick = hash => () => {
     // Used to disable findActiveIndex if the page scrolls due to a click
     this.clicked = true;
     this.unsetClicked = setTimeout(() => {
@@ -235,7 +235,7 @@ class AppTableOfContents extends React.Component {
                     color={active === item2.hash ? 'textPrimary' : 'textSecondary'}
                     href={`#${item2.hash}`}
                     underline="none"
-                    onClick={() => this.handleClick(item2.hash)}
+                    onClick={this.handleClick(item2.hash)}
                     className={clsx(
                       classes.item,
                       active === item2.hash ? classes.active : undefined,
@@ -252,7 +252,7 @@ class AppTableOfContents extends React.Component {
                             color={active === item3.hash ? 'textPrimary' : 'textSecondary'}
                             href={`#${item3.hash}`}
                             underline="none"
-                            onClick={() => this.handleClick(item3.hash)}
+                            onClick={this.handleClick(item3.hash)}
                             className={clsx(
                               classes.item,
                               classes.secondaryItem,

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -78,13 +78,17 @@ const styles = theme => ({
   item: {
     fontSize: 13,
     padding: theme.spacing(0.5, 1),
+    borderLeft: '4px solid transparent',
+    boxSizing: 'content-box',
     '&:hover': {
-      backgroundColor:
-        theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900],
+      borderLeft: `4px solid ${
+        theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
+      }`,
     },
     '&$active': {
-      backgroundColor:
-        theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800],
+      borderLeft: `4px solid ${
+        theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800]
+      }`,
     },
   },
   active: {},

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -133,7 +133,6 @@ class AppTableOfContents extends React.Component {
         });
       }
     });
-    this.findActiveIndex();
     window.addEventListener('hashchange', this.handleHashChange);
   }
 
@@ -143,6 +142,7 @@ class AppTableOfContents extends React.Component {
     window.removeEventListener('hashchange', this.handleHashChange);
   }
 
+  // Update the active TOC entry if the hash changes through click on '#' icon
   handleHashChange = () => {
     const hash = window.location.hash.substring(1);
 

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -87,7 +87,7 @@ const styles = theme => ({
         theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800],
     },
   },
-  active: {}
+  active: {},
 });
 
 function checkDuplication(uniq, item) {

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -9,6 +9,7 @@ import EventListener from 'react-event-listener';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
+import Collapse from '@material-ui/core/Collapse';
 import { textToHash } from '@material-ui/docs/MarkdownElement/MarkdownElement';
 import Link from 'docs/src/modules/components/Link';
 
@@ -237,9 +238,13 @@ class AppTableOfContents extends React.Component {
                   >
                     <span dangerouslySetInnerHTML={{ __html: item2.text }} />
                   </Link>
-                  {item2.hash === active ||
-                  (item2.children.length > 0 &&
-                    item2.children.some(item3 => item3.hash === active)) ? (
+                  <Collapse
+                    in={
+                      item2.hash === active ||
+                      (item2.children.length > 0 &&
+                        item2.children.some(item3 => item3.hash === active))
+                    }
+                  >
                     <ul className={classes.ul}>
                       {item2.children.map(item3 => (
                         <li key={item3.text}>
@@ -261,7 +266,7 @@ class AppTableOfContents extends React.Component {
                         </li>
                       ))}
                     </ul>
-                  ) : null}
+                  </Collapse>
                 </li>
               ))}
             </Typography>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -27,7 +27,7 @@ const styles = theme => ({
     order: 2,
     position: 'sticky',
     wordBreak: 'break-word',
-    height: 'calc(100vh - 70px)',
+    height: 'calc(100vh - 70px - 29px)',
     overflowY: 'auto',
     padding: theme.spacing(2, 2, 2, 0),
     display: 'none',
@@ -134,16 +134,29 @@ class AppTableOfContents extends React.Component {
       }
     });
     this.findActiveIndex();
+    window.addEventListener('hashchange', this.handleHashChange);
   }
 
   componentWillUnmount() {
     this.handleScroll.cancel();
     clearTimeout(this.unsetClicked);
+    window.removeEventListener('hashchange', this.handleHashChange);
   }
 
+  handleHashChange = () => {
+    const hash = window.location.hash.substring(1);
+
+    if (this.state.active !== hash) {
+      this.setState({
+        active: hash,
+      });
+    }
+  };
+
   findActiveIndex = () => {
+    // Don't set the active index based on scroll if a link was just clicked
     if (this.state.clicked) {
-      return
+      return;
     }
 
     let active;
@@ -167,13 +180,15 @@ class AppTableOfContents extends React.Component {
       this.setState({
         active: active.hash,
       });
+
+      window.history.replaceState(null, null, `#${active.hash}`);
     }
   };
 
-  handleClick = (hash) => {
-    // Disable findActiveIndex if the page scrolls due to clicking on the index.
+  handleClick = hash => {
+    // Used to disable findActiveIndex if the page scrolls due to click
     this.setState({ clicked: true });
-    this.unsetClicked = setTimeout(() => this.setState({ clicked: false }), 1000);
+    this.unsetClicked = setTimeout(() => this.setState({ clicked: false }), 500);
 
     if (this.state.active !== hash) {
       this.setState({

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -49,7 +49,7 @@ const styles = theme => ({
     top: 70 + 29,
     // Fix IE 11 position sticky issue.
     marginTop: 70 + 29,
-    width: 167,
+    width: 175,
     flexShrink: 0,
     order: 2,
     position: 'sticky',
@@ -72,7 +72,7 @@ const styles = theme => ({
   },
   item: {
     fontSize: 13,
-    padding: theme.spacing(0.5, 1),
+    padding: theme.spacing(0.5, 0, 0.5, 1),
     borderLeft: '4px solid transparent',
     boxSizing: 'content-box',
     '&:hover': {
@@ -85,6 +85,9 @@ const styles = theme => ({
         theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800]
       }`,
     },
+  },
+  secondaryItem: {
+    paddingLeft: theme.spacing(2.5)
   },
   active: {},
 });
@@ -102,6 +105,9 @@ class AppTableOfContents extends React.Component {
     this.findActiveIndex();
   }, 166); // Corresponds to 10 frames at 60 Hz.
 
+
+  clicked = false;
+
   constructor(props) {
     super();
     this.itemsServer = getItems(props.contents);
@@ -110,8 +116,6 @@ class AppTableOfContents extends React.Component {
   state = {
     active: null,
   };
-
-  clicked = false;
 
   componentDidMount() {
     this.itemsClient = [];
@@ -250,9 +254,9 @@ class AppTableOfContents extends React.Component {
                             onClick={() => this.handleClick(item3.hash)}
                             className={clsx(
                               classes.item,
+                              classes.secondaryItem,
                               active === item3.hash ? classes.active : undefined,
                             )}
-                            style={{ paddingLeft: 16 }}
                           >
                             <span dangerouslySetInnerHTML={{ __html: item3.text }} />
                           </Link>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -161,7 +161,7 @@ class AppTableOfContents extends React.Component {
 
     let active;
 
-    for (let i = 0; i < this.itemsClient.length; i += 1) {
+    for (let i = this.itemsClient.length -1; i >=0; i -= 1) {
       // No hash if we're near the top of the page
       if (document.documentElement.scrollTop < 200) {
         active = { hash: null };
@@ -173,9 +173,8 @@ class AppTableOfContents extends React.Component {
       warning(item.node, `Missing node on the item ${JSON.stringify(item, null, 2)}`);
 
       if (
-        item.node &&
-        (document.documentElement.scrollTop < item.node.offsetTop + 100 ||
-          i === this.itemsClient.length - 1)
+        item.node && (item.node.offsetTop < document.documentElement.scrollTop +
+        document.documentElement.clientHeight / 4)
       ) {
         active = item;
         break;
@@ -237,7 +236,9 @@ class AppTableOfContents extends React.Component {
                   >
                     <span dangerouslySetInnerHTML={{ __html: item2.text }} />
                   </Link>
-                  {item2.hash === active || item2.children.length > 0 && item2.children.some(item3 => (item3.hash === active)) ? (
+                  {item2.hash === active ||
+                  (item2.children.length > 0 &&
+                    item2.children.some(item3 => item3.hash === active)) ? (
                     <ul className={classes.ul}>
                       {item2.children.map(item3 => (
                         <li key={item3.text}>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -198,9 +198,9 @@ class AppTableOfContents extends React.Component {
   };
 
   handleClick = hash => {
-    // Used to disable findActiveIndex if the page scrolls due to click
+    // Used to disable findActiveIndex if the page scrolls due to a click
     this.setState({ clicked: true });
-    this.unsetClicked = setTimeout(() => this.setState({ clicked: false }), 500);
+    this.unsetClicked = setTimeout(() => this.setState({ clicked: false }), 1000);
 
     if (this.state.active !== hash) {
       this.setState({
@@ -237,7 +237,7 @@ class AppTableOfContents extends React.Component {
                   >
                     <span dangerouslySetInnerHTML={{ __html: item2.text }} />
                   </Link>
-                  {item2.children.length > 0 ? (
+                  {item2.hash === active || item2.children.length > 0 && item2.children.some(item3 => (item3.hash === active)) ? (
                     <ul className={classes.ul}>
                       {item2.children.map(item3 => (
                         <li key={item3.text}>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -9,7 +9,6 @@ import EventListener from 'react-event-listener';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
-import Collapse from '@material-ui/core/Collapse';
 import { textToHash } from '@material-ui/docs/MarkdownElement/MarkdownElement';
 import Link from 'docs/src/modules/components/Link';
 
@@ -239,13 +238,9 @@ class AppTableOfContents extends React.Component {
                   >
                     <span dangerouslySetInnerHTML={{ __html: item2.text }} />
                   </Link>
-                  <Collapse
-                    in={
-                      item2.hash === active ||
-                      (item2.children.length > 0 &&
-                        item2.children.some(item3 => item3.hash === active))
-                    }
-                  >
+                  {item2.hash === active ||
+                  (item2.children.length > 0 &&
+                    item2.children.some(item3 => item3.hash === active)) ? (
                     <ul className={classes.ul}>
                       {item2.children.map(item3 => (
                         <li key={item3.text}>
@@ -266,7 +261,7 @@ class AppTableOfContents extends React.Component {
                         </li>
                       ))}
                     </ul>
-                  </Collapse>
+                  ) : null}
                 </li>
               ))}
             </Typography>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -79,15 +79,16 @@ const styles = theme => ({
   item: {
     fontSize: 13,
     padding: theme.spacing(0.5, 1),
-    '&:hover:not($itemActive)': {
+    '&:hover': {
       backgroundColor:
         theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900],
     },
+    '&$active': {
+      backgroundColor:
+        theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800],
+    },
   },
-  itemActive: {
-    backgroundColor:
-      theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800],
-  },
+  active: {}
 });
 
 function checkDuplication(uniq, item) {
@@ -233,7 +234,7 @@ class AppTableOfContents extends React.Component {
                     onClick={() => this.handleClick(item2.hash)}
                     className={clsx(
                       classes.item,
-                      active === item2.hash ? classes.itemActive : undefined,
+                      active === item2.hash ? classes.active : undefined,
                     )}
                   >
                     <span dangerouslySetInnerHTML={{ __html: item2.text }} />
@@ -256,7 +257,7 @@ class AppTableOfContents extends React.Component {
                             onClick={() => this.handleClick(item3.hash)}
                             className={clsx(
                               classes.item,
-                              active === item3.hash ? classes.itemActive : undefined,
+                              active === item3.hash ? classes.active : undefined,
                             )}
                             style={{ paddingLeft: 16 }}
                           >

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -253,15 +253,14 @@ class AppTableOfContents extends React.Component {
                             color={active === item3.hash ? 'textPrimary' : 'textSecondary'}
                             href={`#${item3.hash}`}
                             underline="none"
-                            // variant="caption"
                             onClick={() => this.handleClick(item3.hash)}
                             className={clsx(
                               classes.item,
                               active === item3.hash ? classes.itemActive : undefined,
                             )}
-                            style={{ paddingLeft: 12 }}
+                            style={{ paddingLeft: 16 }}
                           >
-                            <span dangerouslySetInnerHTML={{ __html: `- ${item3.text}` }} />
+                            <span dangerouslySetInnerHTML={{ __html: item3.text }} />
                           </Link>
                         </li>
                       ))}

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -87,7 +87,7 @@ const styles = theme => ({
     },
   },
   secondaryItem: {
-    paddingLeft: theme.spacing(2.5)
+    paddingLeft: theme.spacing(2.5),
   },
   active: {},
 });
@@ -104,7 +104,6 @@ class AppTableOfContents extends React.Component {
   handleScroll = throttle(() => {
     this.findActiveIndex();
   }, 166); // Corresponds to 10 frames at 60 Hz.
-
 
   clicked = false;
 
@@ -205,7 +204,9 @@ class AppTableOfContents extends React.Component {
   handleClick = hash => {
     // Used to disable findActiveIndex if the page scrolls due to a click
     this.clicked = true;
-    this.unsetClicked = setTimeout(() => {this.clicked = false}, 1000);
+    this.unsetClicked = setTimeout(() => {
+      this.clicked = false;
+    }, 1000);
 
     if (this.state.active !== hash) {
       this.setState({

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -238,9 +238,7 @@ class AppTableOfContents extends React.Component {
                   >
                     <span dangerouslySetInnerHTML={{ __html: item2.text }} />
                   </Link>
-                  {item2.hash === active ||
-                  (item2.children.length > 0 &&
-                    item2.children.some(item3 => item3.hash === active)) ? (
+                  {item2.children.length > 0 ? (
                     <ul className={classes.ul}>
                       {item2.children.map(item3 => (
                         <li key={item3.text}>

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -162,6 +162,12 @@ class AppTableOfContents extends React.Component {
     let active;
 
     for (let i = 0; i < this.itemsClient.length; i += 1) {
+      // No hash if we're near the top of the page
+      if (document.documentElement.scrollTop < 200) {
+        active = { hash: null };
+        break;
+      }
+
       const item = this.itemsClient[i];
 
       warning(item.node, `Missing node on the item ${JSON.stringify(item, null, 2)}`);
@@ -181,7 +187,13 @@ class AppTableOfContents extends React.Component {
         active: active.hash,
       });
 
-      window.history.replaceState(null, null, `#${active.hash}`);
+      window.history.replaceState(
+        null,
+        null,
+        active.hash === null
+          ? `${window.location.pathname}${window.location.search}`
+          : `#${active.hash}`,
+      );
     }
   };
 

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -109,8 +109,9 @@ class AppTableOfContents extends React.Component {
 
   state = {
     active: null,
-    clicked: false,
   };
+
+  clicked = false;
 
   componentDidMount() {
     this.itemsClient = [];
@@ -155,7 +156,7 @@ class AppTableOfContents extends React.Component {
 
   findActiveIndex = () => {
     // Don't set the active index based on scroll if a link was just clicked
-    if (this.state.clicked) {
+    if (this.clicked) {
       return;
     }
 
@@ -199,8 +200,8 @@ class AppTableOfContents extends React.Component {
 
   handleClick = hash => {
     // Used to disable findActiveIndex if the page scrolls due to a click
-    this.setState({ clicked: true });
-    this.unsetClicked = setTimeout(() => this.setState({ clicked: false }), 1000);
+    this.clicked = true;
+    this.unsetClicked = setTimeout(() => {this.clicked = false}, 1000);
 
     if (this.state.active !== hash) {
       this.setState({

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -12,6 +12,38 @@ import Typography from '@material-ui/core/Typography';
 import { textToHash } from '@material-ui/docs/MarkdownElement/MarkdownElement';
 import Link from 'docs/src/modules/components/Link';
 
+let itemsCollector;
+const renderer = new marked.Renderer();
+renderer.heading = (text, level) => {
+  if (level === 2) {
+    itemsCollector.push({
+      text,
+      level,
+      hash: textToHash(text),
+      children: [],
+    });
+  } else if (level === 3) {
+    if (!itemsCollector[itemsCollector.length - 1]) {
+      throw new Error(`Missing parent level for: ${text}`);
+    }
+
+    itemsCollector[itemsCollector.length - 1].children.push({
+      text,
+      level,
+      hash: textToHash(text),
+    });
+  }
+};
+
+function getItems(contents) {
+  itemsCollector = [];
+  marked(contents.join(''), {
+    renderer,
+  });
+
+  return itemsCollector;
+}
+
 const styles = theme => ({
   '@global': {
     html: {
@@ -56,38 +88,6 @@ const styles = theme => ({
       theme.palette.type === 'light' ? theme.palette.grey[300] : theme.palette.grey[800],
   },
 });
-
-let itemsCollector;
-const renderer = new marked.Renderer();
-renderer.heading = (text, level) => {
-  if (level === 2) {
-    itemsCollector.push({
-      text,
-      level,
-      hash: textToHash(text),
-      children: [],
-    });
-  } else if (level === 3) {
-    if (!itemsCollector[itemsCollector.length - 1]) {
-      throw new Error(`Missing parent level for: ${text}`);
-    }
-
-    itemsCollector[itemsCollector.length - 1].children.push({
-      text,
-      level,
-      hash: textToHash(text),
-    });
-  }
-};
-
-function getItems(contents) {
-  itemsCollector = [];
-  marked(contents.join(''), {
-    renderer,
-  });
-
-  return itemsCollector;
-}
 
 function checkDuplication(uniq, item) {
   warning(!uniq[item.hash], `Table of content: duplicated \`${item.hash}\` item`);

--- a/docs/src/pages/style/icons/FontAwesome.js
+++ b/docs/src/pages/style/icons/FontAwesome.js
@@ -27,7 +27,7 @@ class FontAwesome extends React.Component {
   componentDidMount() {
     loadCSS(
       'https://use.fontawesome.com/releases/v5.1.0/css/all.css',
-      document.querySelector('#font-awesome'),
+      document.querySelector('#font-awesome-css'),
     );
   }
 

--- a/packages/material-ui-docs/src/MarkdownElement/MarkdownElement.js
+++ b/packages/material-ui-docs/src/MarkdownElement/MarkdownElement.js
@@ -105,7 +105,7 @@ const styles = theme => ({
     fontSize: 16,
     color: theme.palette.text.primary,
     '& .anchor-link': {
-      marginTop: -96, // Offset for the anchor.
+      marginTop: -96 - 29, // Offset for the anchor.
       position: 'absolute',
     },
     '& pre, & pre[class*="language-"]': {

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -60,7 +60,7 @@ class MyDocument extends Document {
           */}
           <link href="https://fonts.gstatic.com" rel="preconnect" crossOrigin="anonymous" />
           <style id="material-icon-font" />
-          <style id="font-awesome" />
+          <style id="font-awesome-css" />
           <style id="app-search" />
           <style id="insertion-point-jss" />
         </Head>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This is a good page to compare the before and after:
- https://next.material-ui.com/style/icons/
- https://deploy-preview-14520--material-ui.netlify.com/style/icons/

In addition to the change of styling (updated again since first commit):
- ~~Smooth scrolling~~ *(removed out of consideration for those subject to motion sickness.)*
- Add the current hash to the URL *(subject to ongoing discussion)*
- Fix an issue where the current logic selects the next section when you scroll past a heading.
- Fix an issue where the correct TOC item is not selected when clicking '#' links near the bottom of the page.
- Fix an issue where the correct TOC item is not selected when clicking TOC links for sections near the bottom of the page.
- Remove an unneeded call to `findActiveIndex()` in `componentDidMount()`.
- Fix a duplicate id (`font-awesome`) on http://localhost:3000/style/icons.
