### PR TITLE
[slider] Fix for slider thumb wrapper exceeding the parent element size

### DIFF
--- a/docs/src/pages/lab/slider/CustomIconSlider.js
+++ b/docs/src/pages/lab/slider/CustomIconSlider.js
@@ -37,7 +37,7 @@ class CustomIconSlider extends React.Component {
       <div className={classes.root}>
         <Typography id="slider-image">Image thumb</Typography>
         <Slider
-          classes={{ container: classes.slider }}
+          classes={{ root: classes.slider }}
           value={value}
           aria-labelledby="slider-image"
           onChange={this.handleChange}
@@ -55,7 +55,7 @@ class CustomIconSlider extends React.Component {
           aria-labelledby="slider-icon"
           onChange={this.handleChange}
           classes={{
-            container: classes.slider,
+            root: classes.slider,
             thumbIconWrapper: classes.thumbIconWrapper,
           }}
           thumb={<LensIcon style={{ color: '#2196f3' }} />}

--- a/docs/src/pages/lab/slider/DisabledSlider.js
+++ b/docs/src/pages/lab/slider/DisabledSlider.js
@@ -17,9 +17,9 @@ function DisabledSlider(props) {
 
   return (
     <div className={classes.root}>
-      <Slider classes={{ container: classes.slider }} value={0} disabled />
-      <Slider classes={{ container: classes.slider }} value={50} disabled />
-      <Slider classes={{ container: classes.slider }} value={100} disabled />
+      <Slider classes={{ root: classes.slider }} value={0} disabled />
+      <Slider classes={{ root: classes.slider }} value={50} disabled />
+      <Slider classes={{ root: classes.slider }} value={100} disabled />
     </div>
   );
 }

--- a/docs/src/pages/lab/slider/SimpleSlider.js
+++ b/docs/src/pages/lab/slider/SimpleSlider.js
@@ -30,7 +30,7 @@ class SimpleSlider extends React.Component {
       <div className={classes.root}>
         <Typography id="label">Slider label</Typography>
         <Slider
-          classes={{ container: classes.slider }}
+          classes={{ root: classes.slider }}
           value={value}
           aria-labelledby="label"
           onChange={this.handleChange}

--- a/docs/src/pages/lab/slider/StepSlider.js
+++ b/docs/src/pages/lab/slider/StepSlider.js
@@ -28,7 +28,7 @@ class StepSlider extends React.Component {
     return (
       <div className={classes.root}>
         <Slider
-          classes={{ container: classes.slider }}
+          classes={{ root: classes.slider }}
           value={value}
           min={0}
           max={6}

--- a/docs/src/pages/lab/slider/VerticalSlider.js
+++ b/docs/src/pages/lab/slider/VerticalSlider.js
@@ -29,7 +29,7 @@ class VerticalSlider extends React.Component {
     return (
       <div className={classes.root}>
         <Slider
-          classes={{ container: classes.slider }}
+          classes={{ container: classes.root }}
           value={value}
           onChange={this.handleChange}
           vertical

--- a/docs/src/pages/lab/slider/VerticalSlider.js
+++ b/docs/src/pages/lab/slider/VerticalSlider.js
@@ -29,7 +29,7 @@ class VerticalSlider extends React.Component {
     return (
       <div className={classes.root}>
         <Slider
-          classes={{ container: classes.root }}
+          classes={{ root: classes.slider }}
           value={value}
           onChange={this.handleChange}
           vertical

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -61,6 +61,7 @@ export const styles = theme => {
       overflow: 'hidden',
       padding: overflowSize,
       margin: -overflowSize,
+      boxSizing: 'border-box',
       '&$vertical': {
         height: `calc(100% + ${overflowSize * 2}px)`,
       },

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -45,24 +45,24 @@ export const styles = theme => {
     /* Styles applied to the root element. */
     root: {
       position: 'relative',
-      width: `calc(100% + ${overflowSize * 2}px)`,
-      overflow: 'hidden',
-      padding: overflowSize,
-      margin: -overflowSize,
+      width: '100%',
       cursor: 'pointer',
       WebkitTapHighlightColor: 'transparent',
       '&$disabled': {
         cursor: 'no-drop',
       },
       '&$vertical': {
-        height: `calc(100% + ${overflowSize * 2}px)`,
+        height: '100%',
       },
     },
     /* Styles applied to the container element. */
     container: {
-      position: 'relative',
+      width: `calc(100% + ${overflowSize * 2}px)`,
+      overflow: 'hidden',
+      padding: overflowSize,
+      margin: -overflowSize,
       '&$vertical': {
-        height: '100%',
+        height: `calc(100% + ${overflowSize * 2}px)`,
       },
     },
     /* Styles applied to the track elements. */

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -19,7 +19,7 @@ export const styles = theme => {
     commonTransitionsOptions,
   );
   const thumbTransitions = theme.transitions.create(
-    ['transform', 'box-shadow', 'top', 'left'],
+    ['transform', 'box-shadow'],
     commonTransitionsOptions,
   );
 
@@ -35,18 +35,27 @@ export const styles = theme => {
    */
   const pressedOutlineRadius = 9;
 
+  /**
+   * We need to give some overflow so that the button and tap
+   * highlight can be shown with overlay hidden.
+   */
+  const overflowSize = 24;
+
   return {
     /* Styles applied to the root element. */
     root: {
       position: 'relative',
-      width: '100%',
+      width: `calc(100% + ${overflowSize * 2}px)`,
+      overflow: 'hidden',
+      padding: overflowSize,
+      margin: -overflowSize,
       cursor: 'pointer',
       WebkitTapHighlightColor: 'transparent',
       '&$disabled': {
         cursor: 'no-drop',
       },
       '&$vertical': {
-        height: '100%',
+        height: `calc(100% + ${overflowSize * 2}px)`,
       },
     },
     /* Styles applied to the container element. */
@@ -98,13 +107,15 @@ export const styles = theme => {
     },
     /* Styles applied to the thumb wrapper element. */
     thumbWrapper: {
-      width: 0,
-      height: 0,
       position: 'relative',
       zIndex: 2,
       transition: thumbTransitions,
       '&$activated': {
         transition: 'none',
+      },
+      '&$vertical': {
+        bottom: 0,
+        height: '100%',
       },
     },
     /* Styles applied to the thumb element. */
@@ -539,14 +550,12 @@ class Slider extends React.Component {
     const trackBeforeClasses = classNames(classes.track, classes.trackBefore, commonClasses);
     const trackAfterClasses = classNames(classes.track, classes.trackAfter, commonClasses);
 
-    // we use top and left rather than a transform so the thumb wrapper
-    // size doesn't get out of bounds
-    const thumbTransformFunction = vertical ? 'top' : 'left';
+    const thumbTransformFunction = vertical ? 'translateY' : 'translateX';
     const thumbDirectionInverted = vertical || theme.direction === 'rtl';
     const inlineTrackBeforeStyles = this.calculateTrackPartStyles(percent);
     const inlineTrackAfterStyles = this.calculateTrackPartStyles(100 - percent);
     const inlineThumbStyles = {
-      [thumbTransformFunction]: `${thumbDirectionInverted ? 100 - percent : percent}%`,
+      transform: `${thumbTransformFunction}(${thumbDirectionInverted ? 100 - percent : percent}%)`,
     };
 
     /** Start Thumb Icon Logic Here */

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -19,7 +19,7 @@ export const styles = theme => {
     commonTransitionsOptions,
   );
   const thumbTransitions = theme.transitions.create(
-    ['transform', 'box-shadow'],
+    ['transform', 'box-shadow', 'top', 'left'],
     commonTransitionsOptions,
   );
 
@@ -98,15 +98,13 @@ export const styles = theme => {
     },
     /* Styles applied to the thumb wrapper element. */
     thumbWrapper: {
+      width: 0,
+      height: 0,
       position: 'relative',
       zIndex: 2,
       transition: thumbTransitions,
       '&$activated': {
         transition: 'none',
-      },
-      '&$vertical': {
-        bottom: 0,
-        height: '100%',
       },
     },
     /* Styles applied to the thumb element. */
@@ -541,12 +539,14 @@ class Slider extends React.Component {
     const trackBeforeClasses = classNames(classes.track, classes.trackBefore, commonClasses);
     const trackAfterClasses = classNames(classes.track, classes.trackAfter, commonClasses);
 
-    const thumbTransformFunction = vertical ? 'translateY' : 'translateX';
+    // we use top and left rather than a transform so the thumb wrapper
+    // size doesn't get out of bounds
+    const thumbTransformFunction = vertical ? 'top' : 'left';
     const thumbDirectionInverted = vertical || theme.direction === 'rtl';
     const inlineTrackBeforeStyles = this.calculateTrackPartStyles(percent);
     const inlineTrackAfterStyles = this.calculateTrackPartStyles(100 - percent);
     const inlineThumbStyles = {
-      transform: `${thumbTransformFunction}(${thumbDirectionInverted ? 100 - percent : percent}%)`,
+      [thumbTransformFunction]: `${thumbDirectionInverted ? 100 - percent : percent}%`,
     };
 
     /** Start Thumb Icon Logic Here */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Today I found an issue with the slider inside an scrollable area (a dialog)
The more to the right the thum was, the more scroll area that would be shown in the dialog, such as here:

![mui-slider-issue](https://user-images.githubusercontent.com/6306796/52741398-85bff480-2fd5-11e9-9c1f-7ad58f1ddbd1.jpg)

Apparently the issue is that the thumb uses a width/height of 100% + a transform, which would transform it to be outside of the track area.

The fix I applied was setting the width and height to 0, while using the top and left properties to position the thumb wrapper, therefore it never exceeds the track area.

I tried the dev docs example page and it seems to work ok.

PS: I tried playing with overflow hidden, but it did not help.