### PR TITLE
[core] Fix Prettier on next branch

### DIFF
--- a/scripts/listChangedFiles.js
+++ b/scripts/listChangedFiles.js
@@ -27,7 +27,7 @@ async function execGitCmd(args) {
 }
 
 async function listChangedFiles() {
-  const mergeBase = await execGitCmd(['rev-parse', 'origin/master']);
+  const mergeBase = await execGitCmd(['rev-parse', 'origin/next']);
   const gitDiff = await execGitCmd(['diff', '--name-only', mergeBase]);
   const gitLs = await execGitCmd(['ls-files', '--others', '--exclude-standard']);
   return new Set([...gitDiff, ...gitLs]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Points listChangedFiles to next branch

Thanks @mbrookes for reporting it 😄