### PR TITLE
[Tooltip] Add tooltip anchor

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -4,6 +4,7 @@ import { TransitionProps } from '../transitions/transition';
 
 export interface TooltipProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title'> {
+  anchor?: 'children' | 'cursor';
   children: React.ReactElement<any>;
   disableFocusListener?: boolean;
   disableHoverListener?: boolean;

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -141,7 +141,7 @@ class Tooltip extends React.Component {
   };
 
   handleEnter = event => {
-    const { children, enterDelay } = this.props;
+    const { anchor, children, enterDelay } = this.props;
     const childrenProps = children.props;
 
     if (event.type === 'mouseover' && childrenProps.onMouseOver) {
@@ -150,6 +150,37 @@ class Tooltip extends React.Component {
 
     if (this.ignoreNonTouchEvents && event.type !== 'touchstart') {
       return;
+    }
+
+    this.anchorEl = this.childrenRef;
+    if (event.type !== 'focus' && anchor === 'cursor') {
+      event.persist();
+
+      let clientX = event.clientX;
+      let clientY = event.clientY;
+      if (event.type === 'touchstart' && event.targetTouches.length) {
+        clientX = event.targetTouches[0].clientX;
+        clientY = event.targetTouches[0].clientY;
+      }
+
+      this.anchorEl = {
+        getBoundingClientRect: () => ({
+          left: clientX,
+          right: clientX,
+          top: clientY,
+          bottom: clientY,
+          width: 0,
+          height: 0,
+          x: clientX,
+          y: clientY,
+        }),
+        get clientWidth() {
+          return window.innerWidth;
+        },
+        get clientHeight() {
+          return window.innerHeight;
+        },
+      };
     }
 
     // Remove the title ahead of time.
@@ -339,7 +370,7 @@ class Tooltip extends React.Component {
             [classes.popperInteractive]: interactive,
           })}
           placement={placement}
-          anchorEl={this.childrenRef}
+          anchorEl={this.anchorEl}
           open={open}
           id={childrenProps['aria-describedby']}
           transition
@@ -372,6 +403,10 @@ class Tooltip extends React.Component {
 }
 
 Tooltip.propTypes = {
+  /**
+   * Anchor from which the tooltip will open.
+   */
+  anchor: PropTypes.oneOf(['children', 'cursor']),
   /**
    * Tooltip reference element.
    */
@@ -478,6 +513,7 @@ Tooltip.propTypes = {
 };
 
 Tooltip.defaultProps = {
+  anchor: 'children',
   disableFocusListener: false,
   disableHoverListener: false,
   disableTouchListener: false,

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -18,6 +18,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">anchor</span> | <span class="prop-type">enum:&nbsp;'children'&nbsp;&#124;<br>&nbsp;'cursor'<br></span> | <span class="prop-default">'children'</span> | Anchor from which the tooltip will open. |
 | <span class="prop-name required">children *</span> | <span class="prop-type">element</span> |   | Tooltip reference element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css-api) below for more details. |
 | <span class="prop-name">disableFocusListener</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Do not respond to focus events. |


### PR DESCRIPTION
This adds an `anchor` prop to `Tooltip` which can be either `"children"` (default) or `"cursor"`. When set to `"cursor"` the tooltip's root will be set to the event's X/Y position for both touch and cursor events else it will default to the child element. `"children"` will of course set it to the child element.

The `"cursor"` anchor works best with an enter delay of some kind... though maybe it should only trigger after the cursor has been still for a certain delay (like the native `title` attribute).

Maybe there could also be a `"cursor-sticky"` anchor where the tooltip follows the cursor around when it moves?

If you all like this I can add some demos. 😀

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #14270