### PR TITLE
[TablePagination] Only raise a warning when the page is out of range

### DIFF
--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -68,7 +68,7 @@ export const styles = theme => ({
 /**
  * A `TableCell` based component for placing inside `TableFooter` for pagination.
  */
-function TablePagination (props) {
+function TablePagination(props) {
   const {
     ActionsComponent,
     backIconButtonProps,

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { componentPropType } from '@material-ui/utils';
+import { componentPropType, chainPropTypes } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
 import InputBase from '../InputBase';
 import MenuItem from '../MenuItem';
@@ -68,98 +68,86 @@ export const styles = theme => ({
 /**
  * A `TableCell` based component for placing inside `TableFooter` for pagination.
  */
-class TablePagination extends React.Component {
-  // This logic would be better handled on userside.
-  // However, we have it just in case.
-  componentDidUpdate() {
-    const { count, onChangePage, page, rowsPerPage } = this.props;
-    const newLastPage = Math.max(0, Math.ceil(count / rowsPerPage) - 1);
-    if (page > newLastPage) {
-      onChangePage(null, newLastPage);
-    }
+function TablePagination (props) {
+  const {
+    ActionsComponent,
+    backIconButtonProps,
+    classes,
+    colSpan: colSpanProp,
+    component: Component,
+    count,
+    labelDisplayedRows,
+    labelRowsPerPage,
+    nextIconButtonProps,
+    onChangePage,
+    onChangeRowsPerPage,
+    page,
+    rowsPerPage,
+    rowsPerPageOptions,
+    SelectProps = {},
+    ...other
+  } = props;
+
+  let colSpan;
+
+  if (Component === TableCell || Component === 'td') {
+    colSpan = colSpanProp || 1000; // col-span over everything
   }
 
-  render() {
-    const {
-      ActionsComponent,
-      backIconButtonProps,
-      classes,
-      colSpan: colSpanProp,
-      component: Component,
-      count,
-      labelDisplayedRows,
-      labelRowsPerPage,
-      nextIconButtonProps,
-      onChangePage,
-      onChangeRowsPerPage,
-      page,
-      rowsPerPage,
-      rowsPerPageOptions,
-      SelectProps = {},
-      ...other
-    } = this.props;
+  const MenuItemComponent = SelectProps.native ? 'option' : MenuItem;
 
-    let colSpan;
-
-    if (Component === TableCell || Component === 'td') {
-      colSpan = colSpanProp || 1000; // col-span over everything
-    }
-
-    const MenuItemComponent = SelectProps.native ? 'option' : MenuItem;
-
-    return (
-      <Component className={classes.root} colSpan={colSpan} {...other}>
-        <Toolbar className={classes.toolbar}>
-          <div className={classes.spacer} />
-          {rowsPerPageOptions.length > 1 && (
-            <Typography color="inherit" variant="caption" className={classes.caption}>
-              {labelRowsPerPage}
-            </Typography>
-          )}
-          {rowsPerPageOptions.length > 1 && (
-            <Select
-              classes={{
-                root: classes.selectRoot,
-                select: classes.select,
-                icon: classes.selectIcon,
-              }}
-              input={<InputBase className={classes.input} />}
-              value={rowsPerPage}
-              onChange={onChangeRowsPerPage}
-              {...SelectProps}
-            >
-              {rowsPerPageOptions.map(rowsPerPageOption => (
-                <MenuItemComponent
-                  className={classes.menuItem}
-                  key={rowsPerPageOption}
-                  value={rowsPerPageOption}
-                >
-                  {rowsPerPageOption}
-                </MenuItemComponent>
-              ))}
-            </Select>
-          )}
+  return (
+    <Component className={classes.root} colSpan={colSpan} {...other}>
+      <Toolbar className={classes.toolbar}>
+        <div className={classes.spacer} />
+        {rowsPerPageOptions.length > 1 && (
           <Typography color="inherit" variant="caption" className={classes.caption}>
-            {labelDisplayedRows({
-              from: count === 0 ? 0 : page * rowsPerPage + 1,
-              to: Math.min(count, (page + 1) * rowsPerPage),
-              count,
-              page,
-            })}
+            {labelRowsPerPage}
           </Typography>
-          <ActionsComponent
-            className={classes.actions}
-            backIconButtonProps={backIconButtonProps}
-            count={count}
-            nextIconButtonProps={nextIconButtonProps}
-            onChangePage={onChangePage}
-            page={page}
-            rowsPerPage={rowsPerPage}
-          />
-        </Toolbar>
-      </Component>
-    );
-  }
+        )}
+        {rowsPerPageOptions.length > 1 && (
+          <Select
+            classes={{
+              root: classes.selectRoot,
+              select: classes.select,
+              icon: classes.selectIcon,
+            }}
+            input={<InputBase className={classes.input} />}
+            value={rowsPerPage}
+            onChange={onChangeRowsPerPage}
+            {...SelectProps}
+          >
+            {rowsPerPageOptions.map(rowsPerPageOption => (
+              <MenuItemComponent
+                className={classes.menuItem}
+                key={rowsPerPageOption}
+                value={rowsPerPageOption}
+              >
+                {rowsPerPageOption}
+              </MenuItemComponent>
+            ))}
+          </Select>
+        )}
+        <Typography color="inherit" variant="caption" className={classes.caption}>
+          {labelDisplayedRows({
+            from: count === 0 ? 0 : page * rowsPerPage + 1,
+            to: Math.min(count, (page + 1) * rowsPerPage),
+            count,
+            page,
+          })}
+        </Typography>
+        <ActionsComponent
+          className={classes.actions}
+          backIconButtonProps={backIconButtonProps}
+          count={count}
+          nextIconButtonProps={nextIconButtonProps}
+          onChangePage={onChangePage}
+          page={page}
+          rowsPerPage={rowsPerPage}
+        />
+      </Toolbar>
+    </Component>
+  );
 }
 
 TablePagination.propTypes = {
@@ -219,7 +207,17 @@ TablePagination.propTypes = {
   /**
    * The zero-based index of the current page.
    */
-  page: PropTypes.number.isRequired,
+  page: chainPropTypes(PropTypes.number.isRequired, props => {
+    const { count, page, rowsPerPage } = props;
+    const newLastPage = Math.max(0, Math.ceil(count / rowsPerPage) - 1);
+    if (page < 0 || page > newLastPage) {
+      return new Error(
+        'Material-UI: The page prop of a TablePagination is out of range ' +
+        `(0 to ${newLastPage}, but page is ${page}).`,
+      );
+    }
+    return null;
+  }),
   /**
    * The number of rows per page.
    */

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -211,10 +211,13 @@ TablePagination.propTypes = {
     const { count, page, rowsPerPage } = props;
     const newLastPage = Math.max(0, Math.ceil(count / rowsPerPage) - 1);
     if (page < 0 || page > newLastPage) {
-      return new Error(
+      const message =
         'Material-UI: The page prop of a TablePagination is out of range ' +
-        `(0 to ${newLastPage}, but page is ${page}).`,
-      );
+        `(0 to ${newLastPage}, but page is ${page}).`;
+
+      // change error message slightly on every check to prevent caching when testing
+      // which would not trigger console errors on subsequent fails
+      return new Error(`${message}${process.env.NODE_ENV === 'test' ? Date.now() : ''}`);
     }
     return null;
   }),

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -212,7 +212,7 @@ TablePagination.propTypes = {
     const newLastPage = Math.max(0, Math.ceil(count / rowsPerPage) - 1);
     if (page < 0 || page > newLastPage) {
       const message =
-        'Material-UI: The page prop of a TablePagination is out of range ' +
+        'Material-UI: the page prop of a TablePagination is out of range ' +
         `(0 to ${newLastPage}, but page is ${page}).`;
 
       // change error message slightly on every check to prevent caching when testing

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -244,13 +244,13 @@ describe('<TablePagination />', () => {
           count={10}
           onChangePage={noop}
           onChangeRowsPerPage={noop}
-        />
+        />,
       );
       assert.strictEqual(consoleErrorMock.callCount(), 1, 'should call console.error');
-      assert.match(
+      // eslint-disable-next-line max-len
+      assert.include(
         consoleErrorMock.args()[0][0],
-        // eslint-disable-next-line max-len
-        /Material-UI: The page prop of a TablePagination is out of range \(0 to 1, but page is 2\)./,
+        'Material-UI: The page prop of a TablePagination is out of range (0 to 1, but page is 2).',
       );
     });
 

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -18,12 +18,10 @@ describe('<TablePagination />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     mount = createMount();
-    consoleErrorMock.spy();
   });
 
   after(() => {
     mount.cleanUp();
-    consoleErrorMock.reset();
   });
 
   it('should render a TableCell', () => {
@@ -236,24 +234,6 @@ describe('<TablePagination />', () => {
       assert.strictEqual(page, 0);
     });
 
-    it('should raise a warning if the page prop is out of range', () => {
-      shallow(
-        <TablePagination
-          page={2}
-          rowsPerPage={5}
-          count={10}
-          onChangePage={noop}
-          onChangeRowsPerPage={noop}
-        />,
-      );
-      console.log(consoleErrorMock.args())
-      assert.strictEqual(consoleErrorMock.callCount(), 1, 'should call console.error');
-      assert.include(
-        consoleErrorMock.args()[0][0],
-        'Material-UI: The page prop of a TablePagination is out of range (0 to 1, but page is 2).',
-      );
-    });
-
     it('should display 0 as start number if the table is empty ', () => {
       const wrapper = mount(
         <table>
@@ -299,6 +279,40 @@ describe('<TablePagination />', () => {
 
       assert.strictEqual(wrapper.text().indexOf('Rows per page'), -1);
       assert.strictEqual(wrapper.find(Select).length, 0);
+    });
+  });
+
+  describe('warning', () => {
+    before(() => {
+      consoleErrorMock.spy();
+    });
+
+    after(() => {
+      consoleErrorMock.reset();
+    });
+
+    it('should raise a warning if the page prop is out of range', () => {
+      assert.strictEqual(consoleErrorMock.callCount(), 0);
+      mount(
+        <table>
+          <TableFooter>
+            <TableRow>
+              <TablePagination
+                page={2}
+                rowsPerPage={5}
+                count={10}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+              />
+            </TableRow>
+          </TableFooter>
+        </table>,
+      );
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'Material-UI: the page prop of a TablePagination is out of range (0 to 1, but page is 2).',
+      );
     });
   });
 });

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Select from '../Select';
 import IconButton from '../IconButton';
 import TableFooter from '../TableFooter';
@@ -17,10 +18,12 @@ describe('<TablePagination />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     mount = createMount();
+    consoleErrorMock.spy();
   });
 
   after(() => {
     mount.cleanUp();
+    consoleErrorMock.reset();
   });
 
   it('should render a TableCell', () => {
@@ -233,33 +236,22 @@ describe('<TablePagination />', () => {
       assert.strictEqual(page, 0);
     });
 
-    it('should handle too high pages after changing rowsPerPage', () => {
-      let page = 2;
-      function ExampleTable(props) {
-        // setProps only works on the mounted root element, so wrap the table
-        return (
-          <table>
-            <TableFooter>
-              <TableRow>
-                <TablePagination
-                  count={11}
-                  page={page}
-                  onChangePage={(event, nextPage) => {
-                    page = nextPage;
-                  }}
-                  onChangeRowsPerPage={noop}
-                  {...props}
-                />
-              </TableRow>
-            </TableFooter>
-          </table>
-        );
-      }
-
-      const wrapper = mount(<ExampleTable rowsPerPage={5} />);
-      wrapper.setProps({ rowsPerPage: 10 });
-      // now, the third page doesn't exist anymore
-      assert.strictEqual(page, 1);
+    it('should raise a warning if the page prop is out of range', () => {
+      shallow(
+        <TablePagination
+          page={2}
+          rowsPerPage={5}
+          count={10}
+          onChangePage={noop}
+          onChangeRowsPerPage={noop}
+        />
+      );
+      assert.strictEqual(consoleErrorMock.callCount(), 1, 'should call console.error');
+      assert.match(
+        consoleErrorMock.args()[0][0],
+        // eslint-disable-next-line max-len
+        /Material-UI: The page prop of a TablePagination is out of range \(0 to 1, but page is 2\)./,
+      );
     });
 
     it('should display 0 as start number if the table is empty ', () => {
@@ -285,35 +277,6 @@ describe('<TablePagination />', () => {
           .text(),
         '0-0 of 0',
       );
-    });
-
-    it('should call onChangePage with 0 if the table becomes empty', () => {
-      let page = 1;
-      function ExampleTable(props) {
-        // setProps only works on the mounted root element, so wrap the table
-        return (
-          <table>
-            <TableFooter>
-              <TableRow>
-                <TablePagination
-                  page={1}
-                  rowsPerPage={5}
-                  onChangePage={(event, newPage) => {
-                    page = newPage;
-                  }}
-                  onChangeRowsPerPage={noop}
-                  {...props}
-                />
-              </TableRow>
-            </TableFooter>
-          </table>
-        );
-      }
-
-      const wrapper = mount(<ExampleTable count={10} />);
-      wrapper.setProps({ count: 0 });
-      // now, there is one page, which is empty
-      assert.strictEqual(page, 0);
     });
 
     it('should hide the rows per page selector if there are less than two options', () => {

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -247,7 +247,6 @@ describe('<TablePagination />', () => {
         />,
       );
       assert.strictEqual(consoleErrorMock.callCount(), 1, 'should call console.error');
-      // eslint-disable-next-line max-len
       assert.include(
         consoleErrorMock.args()[0][0],
         'Material-UI: The page prop of a TablePagination is out of range (0 to 1, but page is 2).',

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -246,6 +246,7 @@ describe('<TablePagination />', () => {
           onChangeRowsPerPage={noop}
         />,
       );
+      console.log(consoleErrorMock.args())
       assert.strictEqual(consoleErrorMock.callCount(), 1, 'should call console.error');
       assert.include(
         consoleErrorMock.args()[0][0],

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -28,7 +28,7 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 | <span class="prop-name">nextIconButtonProps</span> | <span class="prop-type">object</span> |   | Properties applied to the next arrow [`IconButton`](/api/icon-button/) element. |
 | <span class="prop-name required">onChangePage *</span> | <span class="prop-type">func</span> |   | Callback fired when the page is changed.<br><br>**Signature:**<br>`function(event: object, page: number) => void`<br>*event:* The event source of the callback<br>*page:* The page selected |
 | <span class="prop-name">onChangeRowsPerPage</span> | <span class="prop-type">func</span> |   | Callback fired when the number of rows per page is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
-| <span class="prop-name required">page *</span> | <span class="prop-type">number</span> |   | The zero-based index of the current page. |
+| <span class="prop-name">page</span> | <span class="prop-type">number</span> |   | The zero-based index of the current page. |
 | <span class="prop-name required">rowsPerPage *</span> | <span class="prop-type">number</span> |   | The number of rows per page. |
 | <span class="prop-name">rowsPerPageOptions</span> | <span class="prop-type">array</span> | <span class="prop-default">[10, 25, 50, 100]</span> | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |
 | <span class="prop-name">SelectProps</span> | <span class="prop-type">object</span> |   | Properties applied to the rows per page [`Select`](/api/select/) element. |

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -28,7 +28,7 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 | <span class="prop-name">nextIconButtonProps</span> | <span class="prop-type">object</span> |   | Properties applied to the next arrow [`IconButton`](/api/icon-button/) element. |
 | <span class="prop-name required">onChangePage *</span> | <span class="prop-type">func</span> |   | Callback fired when the page is changed.<br><br>**Signature:**<br>`function(event: object, page: number) => void`<br>*event:* The event source of the callback<br>*page:* The page selected |
 | <span class="prop-name">onChangeRowsPerPage</span> | <span class="prop-type">func</span> |   | Callback fired when the number of rows per page is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback |
-| <span class="prop-name">page</span> | <span class="prop-type">number</span> |   | The zero-based index of the current page. |
+| <span class="prop-name required">page *</span> | <span class="prop-type">number</span> |   | The zero-based index of the current page. |
 | <span class="prop-name required">rowsPerPage *</span> | <span class="prop-type">number</span> |   | The number of rows per page. |
 | <span class="prop-name">rowsPerPageOptions</span> | <span class="prop-type">array</span> | <span class="prop-default">[10, 25, 50, 100]</span> | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |
 | <span class="prop-name">SelectProps</span> | <span class="prop-type">object</span> |   | Properties applied to the rows per page [`Select`](/api/select/) element. |


### PR DESCRIPTION
Don't call onChangePage when the page goes out of range but raise a warning instead.
This closes #13995.

:warning: This is a breaking change. If this gets merged, I'll add a comment to #13663 accordingly.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

### Breaking change

The `TablePagination` component does no longer try to fix invalid (`page`, `count`, `rowsPerPage`) property combinations. It raises a warning instead.