### PR TITLE
[docs] Add ts demos for menus, fixes ClickAwayListener onClickAway type

### DIFF
--- a/docs/src/pages/demos/menus/FadeMenu.tsx
+++ b/docs/src/pages/demos/menus/FadeMenu.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Fade from '@material-ui/core/Fade';
+
+interface State {
+  anchorEl: null | HTMLElement;
+}
+
+class FadeMenu extends React.Component {
+  state: State = {
+    anchorEl: null,
+  };
+
+  handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  render() {
+    const { anchorEl } = this.state;
+    const open = Boolean(anchorEl);
+
+    return (
+      <div>
+        <Button
+          aria-owns={open ? 'fade-menu' : undefined}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+        >
+          Open with fade transition
+        </Button>
+        <Menu
+          id="fade-menu"
+          anchorEl={anchorEl}
+          open={open}
+          onClose={this.handleClose}
+          TransitionComponent={Fade}
+        >
+          <MenuItem onClick={this.handleClose}>Profile</MenuItem>
+          <MenuItem onClick={this.handleClose}>My account</MenuItem>
+          <MenuItem onClick={this.handleClose}>Logout</MenuItem>
+        </Menu>
+      </div>
+    );
+  }
+}
+
+export default FadeMenu;

--- a/docs/src/pages/demos/menus/ListItemComposition.tsx
+++ b/docs/src/pages/demos/menus/ListItemComposition.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MenuList from '@material-ui/core/MenuList';
+import MenuItem from '@material-ui/core/MenuItem';
+import Paper from '@material-ui/core/Paper';
+import { createStyles, withStyles, Theme, WithStyles } from '@material-ui/core/styles';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import InboxIcon from '@material-ui/icons/MoveToInbox';
+import DraftsIcon from '@material-ui/icons/Drafts';
+import SendIcon from '@material-ui/icons/Send';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    menuItem: {
+      '&:focus': {
+        backgroundColor: theme.palette.primary.main,
+        '& $primary, & $icon': {
+          color: theme.palette.common.white,
+        },
+      },
+    },
+    primary: {},
+    icon: {},
+  });
+
+interface Props extends WithStyles<typeof styles> {}
+
+function ListItemComposition(props: Props) {
+  const { classes } = props;
+
+  return (
+    <Paper>
+      <MenuList>
+        <MenuItem className={classes.menuItem}>
+          <ListItemIcon className={classes.icon}>
+            <SendIcon />
+          </ListItemIcon>
+          <ListItemText classes={{ primary: classes.primary }} inset primary="Sent mail" />
+        </MenuItem>
+        <MenuItem className={classes.menuItem}>
+          <ListItemIcon className={classes.icon}>
+            <DraftsIcon />
+          </ListItemIcon>
+          <ListItemText classes={{ primary: classes.primary }} inset primary="Drafts" />
+        </MenuItem>
+        <MenuItem className={classes.menuItem}>
+          <ListItemIcon className={classes.icon}>
+            <InboxIcon />
+          </ListItemIcon>
+          <ListItemText classes={{ primary: classes.primary }} inset primary="Inbox" />
+        </MenuItem>
+      </MenuList>
+    </Paper>
+  );
+}
+
+ListItemComposition.propTypes = {
+  classes: PropTypes.object.isRequired as any,
+};
+
+export default withStyles(styles)(ListItemComposition);

--- a/docs/src/pages/demos/menus/LongMenu.tsx
+++ b/docs/src/pages/demos/menus/LongMenu.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import IconButton from '@material-ui/core/IconButton';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+
+const options = [
+  'None',
+  'Atria',
+  'Callisto',
+  'Dione',
+  'Ganymede',
+  'Hangouts Call',
+  'Luna',
+  'Oberon',
+  'Phobos',
+  'Pyxis',
+  'Sedna',
+  'Titania',
+  'Triton',
+  'Umbriel',
+];
+
+const ITEM_HEIGHT = 48;
+
+interface State {
+  anchorEl: null | HTMLElement;
+}
+
+class LongMenu extends React.Component {
+  state: State = {
+    anchorEl: null,
+  };
+
+  handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  render() {
+    const { anchorEl } = this.state;
+    const open = Boolean(anchorEl);
+
+    return (
+      <div>
+        <IconButton
+          aria-label="More"
+          aria-owns={open ? 'long-menu' : undefined}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+        >
+          <MoreVertIcon />
+        </IconButton>
+        <Menu
+          id="long-menu"
+          anchorEl={anchorEl}
+          open={open}
+          onClose={this.handleClose}
+          PaperProps={{
+            style: {
+              maxHeight: ITEM_HEIGHT * 4.5,
+              width: 200,
+            },
+          }}
+        >
+          {options.map(option => (
+            <MenuItem key={option} selected={option === 'Pyxis'} onClick={this.handleClose}>
+              {option}
+            </MenuItem>
+          ))}
+        </Menu>
+      </div>
+    );
+  }
+}
+
+export default LongMenu;

--- a/docs/src/pages/demos/menus/MenuListComposition.tsx
+++ b/docs/src/pages/demos/menus/MenuListComposition.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ChangeEvent } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
@@ -7,19 +7,28 @@ import Paper from '@material-ui/core/Paper';
 import Popper from '@material-ui/core/Popper';
 import MenuItem from '@material-ui/core/MenuItem';
 import MenuList from '@material-ui/core/MenuList';
-import { withStyles } from '@material-ui/core/styles';
+import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
-  root: {
-    display: 'flex',
-  },
-  paper: {
-    marginRight: theme.spacing(2),
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    paper: {
+      marginRight: theme.spacing(2),
+    },
+  });
 
-class MenuListComposition extends React.Component {
-  state = {
+interface Props extends WithStyles<typeof styles> {}
+
+interface State {
+  open: boolean;
+}
+
+class MenuListComposition extends React.Component<Props, State> {
+  anchorEl: HTMLElement | null | undefined;
+
+  state: State = {
     open: false,
   };
 
@@ -27,8 +36,8 @@ class MenuListComposition extends React.Component {
     this.setState(state => ({ open: !state.open }));
   };
 
-  handleClose = event => {
-    if (this.anchorEl.contains(event.target)) {
+  handleClose = (event: React.MouseEvent<EventTarget>) => {
+    if (this.anchorEl!.contains(event.target as HTMLElement)) {
       return;
     }
 
@@ -83,7 +92,7 @@ class MenuListComposition extends React.Component {
   }
 }
 
-MenuListComposition.propTypes = {
+(MenuListComposition as any).propTypes = {
   classes: PropTypes.object.isRequired,
 };
 

--- a/docs/src/pages/demos/menus/SimpleListMenu.tsx
+++ b/docs/src/pages/demos/menus/SimpleListMenu.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import MenuItem from '@material-ui/core/MenuItem';
+import Menu from '@material-ui/core/Menu';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: theme.palette.background.paper,
+    },
+  });
+
+const options = [
+  'Show some love to Material-UI',
+  'Show all notification content',
+  'Hide sensitive notification content',
+  'Hide all notification content',
+];
+
+interface Props extends WithStyles<typeof styles> {}
+
+interface State {
+  anchorEl: null | HTMLElement;
+  selectedIndex: number;
+}
+
+class SimpleListMenu extends React.Component<Props, State> {
+  state: State = {
+    anchorEl: null,
+    selectedIndex: 1,
+  };
+
+  handleClickListItem = (event: React.MouseEvent<HTMLElement>) => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleMenuItemClick = (event: React.MouseEvent<HTMLElement>, index: number) => {
+    this.setState({ selectedIndex: index, anchorEl: null });
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  render() {
+    const { classes } = this.props;
+    const { anchorEl } = this.state;
+
+    return (
+      <div className={classes.root}>
+        <List component="nav">
+          <ListItem
+            button
+            aria-haspopup="true"
+            aria-controls="lock-menu"
+            aria-label="When device is locked"
+            onClick={this.handleClickListItem}
+          >
+            <ListItemText
+              primary="When device is locked"
+              secondary={options[this.state.selectedIndex]}
+            />
+          </ListItem>
+        </List>
+        <Menu
+          id="lock-menu"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={this.handleClose}
+        >
+          {options.map((option, index) => (
+            <MenuItem
+              key={option}
+              disabled={index === 0}
+              selected={index === this.state.selectedIndex}
+              onClick={event => this.handleMenuItemClick(event, index)}
+            >
+              {option}
+            </MenuItem>
+          ))}
+        </Menu>
+      </div>
+    );
+  }
+}
+
+(SimpleListMenu as any).propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(SimpleListMenu);

--- a/docs/src/pages/demos/menus/SimpleMenu.tsx
+++ b/docs/src/pages/demos/menus/SimpleMenu.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+
+interface State {
+  anchorEl: null | HTMLButtonElement;
+}
+
+class SimpleMenu extends React.Component {
+  state: State = {
+    anchorEl: null,
+  };
+
+  handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    this.setState({ anchorEl: event.currentTarget });
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  render() {
+    const { anchorEl } = this.state;
+
+    return (
+      <div>
+        <Button
+          aria-owns={anchorEl ? 'simple-menu' : undefined}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+        >
+          Open Menu
+        </Button>
+        <Menu
+          id="simple-menu"
+          anchorEl={anchorEl}
+          open={Boolean(anchorEl)}
+          onClose={this.handleClose}
+        >
+          <MenuItem onClick={this.handleClose}>Profile</MenuItem>
+          <MenuItem onClick={this.handleClose}>My account</MenuItem>
+          <MenuItem onClick={this.handleClose}>Logout</MenuItem>
+        </Menu>
+      </div>
+    );
+  }
+}
+
+export default SimpleMenu;

--- a/docs/src/pages/demos/menus/TypographyMenu.tsx
+++ b/docs/src/pages/demos/menus/TypographyMenu.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import MenuList from '@material-ui/core/MenuList';
+import MenuItem from '@material-ui/core/MenuItem';
+import Paper from '@material-ui/core/Paper';
+import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import Typography from '@material-ui/core/Typography';
+import DraftsIcon from '@material-ui/icons/Drafts';
+import SendIcon from '@material-ui/icons/Send';
+import PriorityHighIcon from '@material-ui/icons/PriorityHigh';
+
+const styles = createStyles({
+  root: {
+    width: 230,
+  },
+});
+
+interface Props extends WithStyles<typeof styles> {}
+
+function TypographyMenu(props: Props) {
+  const { classes } = props;
+
+  return (
+    <Paper className={classes.root}>
+      <MenuList>
+        <MenuItem>
+          <ListItemIcon>
+            <SendIcon />
+          </ListItemIcon>
+          <Typography variant="inherit">A short message</Typography>
+        </MenuItem>
+        <MenuItem>
+          <ListItemIcon>
+            <PriorityHighIcon />
+          </ListItemIcon>
+          <Typography variant="inherit">A very long text that overflows</Typography>
+        </MenuItem>
+        <MenuItem>
+          <ListItemIcon>
+            <DraftsIcon />
+          </ListItemIcon>
+          <Typography variant="inherit" noWrap>
+            A very long text that overflows
+          </Typography>
+        </MenuItem>
+      </MenuList>
+    </Paper>
+  );
+}
+
+(TypographyMenu as any).propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(TypographyMenu);

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.d.ts
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.d.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 export interface ClickAwayListenerProps {
   children: React.ReactNode;
   mouseEvent?: 'onClick' | 'onMouseDown' | 'onMouseUp' | false;
-  onClickAway: (event: React.ChangeEvent<{}>) => void;
+  onClickAway: (event: React.MouseEvent<Document>) => void;
   touchEvent?: 'onTouchStart' | 'onTouchEnd' | false;
 }
 

--- a/pages/demos/menus.js
+++ b/pages/demos/menus.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/demos/menus', false, /\.md|\.js$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/demos/menus', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/demos/menus',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/demos/menus';
 
 function Page() {


### PR DESCRIPTION
Closes #14498: Description referenced supposedly broken SimpleMenu demo that is ported to typescript and working fine in this PR: https://5c65a0cf196dbd0008298bb6--material-ui.netlify.com/demos/menus/#simple-menu 