### PR TITLE
[styles] 100% test coverage

### DIFF
--- a/.size-limit.js
+++ b/.size-limit.js
@@ -28,7 +28,7 @@ module.exports = [
     name: 'The size of the @material-ui/core modules',
     webpack: true,
     path: 'packages/material-ui/build/index.js',
-    limit: '91.5 KB',
+    limit: '91.2 KB',
   },
   {
     name: 'The theme object',
@@ -40,7 +40,7 @@ module.exports = [
     name: 'The size of the @material-ui/styles modules',
     webpack: true,
     path: 'packages/material-ui-styles/build/index.js',
-    limit: '15.7 KB',
+    limit: '15.4 KB',
   },
   {
     name: 'The size of the @material-ui/system modules',

--- a/package.json
+++ b/package.json
@@ -204,7 +204,8 @@
   "nyc": {
     "include": [
       "packages/material-ui/src/**/*.js",
-      "packages/material-ui-utils/src/**/*.js"
+      "packages/material-ui-utils/src/**/*.js",
+      "packages/material-ui-styles/src/**/*.js"
     ],
     "exclude": [
       "**/*.test.js"

--- a/packages/material-ui-styles/src/RefHolder.js
+++ b/packages/material-ui-styles/src/RefHolder.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// This is a temporary component, we should be able to remove it once all our components
+// implement forwardRef.
+class RefHolder extends React.Component {
+  render() {
+    return this.props.children;
+  }
+}
+
+RefHolder.propTypes = {
+  children: PropTypes.node,
+};
+
+export default RefHolder;

--- a/packages/material-ui-styles/src/StylesProvider.js
+++ b/packages/material-ui-styles/src/StylesProvider.js
@@ -35,19 +35,17 @@ function StylesProvider(props) {
   warning(
     typeof window !== 'undefined' || localOptions.sheetsManager,
     [
-      'Material-UI: you need to provide a sheetsManager to the StyleProvider ' +
+      'Material-UI: you need to provide a sheetsManager to the <StyleProvider> ' +
         'when rendering on the server.',
     ].join('\n'),
   );
 
+  const outerOptions = React.useContext(StylesContext);
+
   return (
-    <StylesContext.Consumer>
-      {outerOptions => (
-        <StylesContext.Provider value={{ ...outerOptions, ...localOptions }}>
-          {children}
-        </StylesContext.Provider>
-      )}
-    </StylesContext.Consumer>
+    <StylesContext.Provider value={{ ...outerOptions, ...localOptions }}>
+      {children}
+    </StylesContext.Provider>
   );
 }
 

--- a/packages/material-ui-styles/src/StylesProvider.test.js
+++ b/packages/material-ui-styles/src/StylesProvider.test.js
@@ -1,0 +1,110 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { assert } from 'chai';
+import { SheetsRegistry } from 'jss';
+import { createMount } from '@material-ui/core/test-utils';
+import StylesProvider, { StylesContext } from './StylesProvider';
+import makeStyles from './makeStyles';
+
+function Test() {
+  const options = React.useContext(StylesContext);
+  return <span options={options} />;
+}
+
+describe('StylesProvider', () => {
+  let mount;
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  it('should provide the options', () => {
+    const wrapper = mount(
+      <StylesProvider disableGeneration>
+        <Test />
+      </StylesProvider>,
+    );
+    assert.strictEqual(wrapper.find('span').props().options.disableGeneration, true);
+  });
+
+  it('should merge the themes', () => {
+    const wrapper = mount(
+      <StylesProvider>
+        <StylesProvider disableGeneration>
+          <Test />
+        </StylesProvider>
+      </StylesProvider>,
+    );
+    assert.strictEqual(wrapper.find('span').props().options.disableGeneration, true);
+  });
+
+  describe('server-side', () => {
+    // Only run the test on node.
+    if (!/jsdom/.test(window.navigator.userAgent)) {
+      return;
+    }
+
+    const useStyles = makeStyles({ root: { display: 'flex' } });
+    const Button = props => {
+      const classes = useStyles();
+      return <button type="button" className={classes.root} {...props} />;
+    };
+
+    function assertRendering(markup, sheetsRegistry) {
+      assert.notStrictEqual(markup.match('Hello World'), null);
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.strictEqual(sheetsRegistry.toString().length > 10, true);
+      assert.strictEqual(sheetsRegistry.registry[0].classes.root, 'Hook-root-vy1bts');
+      assert.deepEqual(sheetsRegistry.registry[0].classes, {
+        root: 'Hook-root-vy1bts',
+      });
+    }
+
+    it('should be able to extract the styles', () => {
+      const sheetsRegistry = new SheetsRegistry();
+
+      const markup = ReactDOMServer.renderToString(
+        <StylesProvider sheetsManager={new Map()} sheetsRegistry={sheetsRegistry}>
+          <Button>Hello World</Button>
+        </StylesProvider>,
+      );
+
+      assertRendering(markup, sheetsRegistry);
+    });
+
+    it('should be able to cache the sheets between two requests', () => {
+      const sheetsCache = new Map();
+
+      const sheetsRegistry1 = new SheetsRegistry();
+      const markup1 = ReactDOMServer.renderToString(
+        <StylesProvider
+          sheetsManager={new Map()}
+          sheetsCache={sheetsCache}
+          sheetsRegistry={sheetsRegistry1}
+        >
+          <Button>Hello World</Button>
+        </StylesProvider>,
+      );
+      assertRendering(markup1, sheetsRegistry1);
+
+      const sheetsRegistry2 = new SheetsRegistry();
+      const markup2 = ReactDOMServer.renderToString(
+        <StylesProvider
+          sheetsManager={new Map()}
+          sheetsCache={sheetsCache}
+          sheetsRegistry={sheetsRegistry2}
+        >
+          <Button>Hello World</Button>
+        </StylesProvider>,
+      );
+      assertRendering(markup2, sheetsRegistry2);
+
+      // The most important check:
+      assert.strictEqual(sheetsRegistry1.registry[0], sheetsRegistry2.registry[0]);
+    });
+  });
+});

--- a/packages/material-ui-styles/src/ThemeProvider.js
+++ b/packages/material-ui-styles/src/ThemeProvider.js
@@ -3,27 +3,19 @@ import PropTypes from 'prop-types';
 import warning from 'warning';
 import { exactProp } from '@material-ui/utils';
 import ThemeContext from './ThemeContext';
+import useTheme from './useTheme';
 
 // To support composition of theme.
 function mergeOuterLocalTheme(outerTheme, localTheme) {
   if (typeof localTheme === 'function') {
-    warning(
-      outerTheme,
-      [
-        'Material-UI: you are providing a theme function property ' +
-          'to the ThemeProvider component:',
-        '<ThemeProvider theme={outerTheme => outerTheme} />',
-        'However, no outer theme is present.',
-        'Make sure a theme is already injected higher in the React tree ' +
-          'or provide a theme object.',
-      ].join('\n'),
-    );
-
     const mergedTheme = localTheme(outerTheme);
 
     warning(
       mergedTheme,
-      'Material-UI: return an object from your theme function, i.e. theme={() => ({})}!',
+      [
+        'Material-UI: you should return an object from your theme function, i.e.',
+        '<ThemeProvider theme={() => ({})} />',
+      ].join('\n'),
     );
 
     return mergedTheme;
@@ -39,17 +31,23 @@ function mergeOuterLocalTheme(outerTheme, localTheme) {
  */
 function ThemeProvider(props) {
   const { children, theme: localTheme } = props;
+  const outerTheme = useTheme();
 
-  return (
-    <ThemeContext.Consumer>
-      {outerTheme => {
-        const theme =
-          outerTheme === null ? localTheme : mergeOuterLocalTheme(outerTheme, localTheme);
-
-        return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
-      }}
-    </ThemeContext.Consumer>
+  warning(
+    outerTheme !== null || typeof localTheme !== 'function',
+    [
+      'Material-UI: you are providing a theme function property ' +
+        'to the ThemeProvider component:',
+      '<ThemeProvider theme={outerTheme => outerTheme} />',
+      '',
+      'However, no outer theme is present.',
+      'Make sure a theme is already injected higher in the React tree ' +
+        'or provide a theme object.',
+    ].join('\n'),
   );
+
+  const theme = outerTheme === null ? localTheme : mergeOuterLocalTheme(outerTheme, localTheme);
+  return <ThemeContext.Provider value={theme}>{children}</ThemeContext.Provider>;
 }
 
 ThemeProvider.propTypes = {

--- a/packages/material-ui-styles/src/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import { assert } from 'chai';
+import { createMount } from '@material-ui/core/test-utils';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
+import useTheme from './useTheme';
+import ThemeProvider from './ThemeProvider';
+
+describe('ThemeProvider', () => {
+  let mount;
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  it('should provide the theme', () => {
+    function Test() {
+      const theme = useTheme();
+
+      return <span>{theme.foo}</span>;
+    }
+
+    const wrapper = mount(
+      <ThemeProvider theme={{ foo: 'foo' }}>
+        <Test />
+      </ThemeProvider>,
+    );
+    assert.strictEqual(wrapper.text(), 'foo');
+  });
+
+  it('should merge the themes', () => {
+    function Test() {
+      const theme = useTheme();
+
+      return (
+        <span>
+          {theme.foo}
+          {theme.bar}
+        </span>
+      );
+    }
+
+    const wrapper = mount(
+      <ThemeProvider theme={{ bar: 'bar' }}>
+        <ThemeProvider theme={{ foo: 'foo' }}>
+          <Test />
+        </ThemeProvider>
+      </ThemeProvider>,
+    );
+    assert.strictEqual(wrapper.text(), 'foobar');
+  });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      consoleErrorMock.spy();
+    });
+
+    afterEach(() => {
+      consoleErrorMock.reset();
+    });
+
+    it('should warn about missing provider', () => {
+      mount(
+        <ThemeProvider theme={theme => theme}>
+          <div />
+        </ThemeProvider>,
+      );
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(consoleErrorMock.args()[0][0], 'However, no outer theme is present.');
+    });
+
+    it('should warn about wrong theme function', () => {
+      mount(
+        <ThemeProvider theme={{ bar: 'bar' }}>
+          <ThemeProvider theme={() => {}}>
+            <div />
+          </ThemeProvider>
+          ,
+        </ThemeProvider>,
+      );
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'you should return an object from your theme function',
+      );
+    });
+  });
+});

--- a/packages/material-ui-styles/src/createGenerateClassName.js
+++ b/packages/material-ui-styles/src/createGenerateClassName.js
@@ -60,7 +60,7 @@ export default function createGenerateClassName(options = {}) {
     }
 
     // Help with debuggability.
-    if (styleSheet && styleSheet.options.classNamePrefix) {
+    if (styleSheet.options.classNamePrefix) {
       return `${safePrefix(styleSheet.options.classNamePrefix)}-${rule.key}-${seed}${suffix}`;
     }
 

--- a/packages/material-ui-styles/src/createGenerateClassName.test.js
+++ b/packages/material-ui-styles/src/createGenerateClassName.test.js
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 import createGenerateClassName from './createGenerateClassName';
 
 describe('createGenerateClassName', () => {
@@ -215,5 +216,48 @@ describe('createGenerateClassName', () => {
       ),
       'classNamePrefix-key2-b6l15m',
     );
+  });
+
+  describe('classNamePrefix', () => {
+    it('should work without a classNamePrefix', () => {
+      const rule = { key: 'root' };
+      const styleSheet = {
+        rules: { raw: {} },
+        options: {},
+      };
+      const generateClassName2 = createGenerateClassName();
+      assert.strictEqual(generateClassName2(rule, styleSheet), 'root-11u5x61');
+    });
+  });
+
+  describe('production', () => {
+    // Only run the test on node.
+    if (!/jsdom/.test(window.navigator.userAgent)) {
+      return;
+    }
+
+    let nodeEnv;
+    const env = process.env;
+
+    before(() => {
+      nodeEnv = env.NODE_ENV;
+      env.NODE_ENV = 'production';
+      consoleErrorMock.spy();
+    });
+
+    after(() => {
+      env.NODE_ENV = nodeEnv;
+      consoleErrorMock.reset();
+    });
+
+    it('should output a short representation', () => {
+      const rule = { key: 'root' };
+      const styleSheet = {
+        rules: { raw: {} },
+        options: {},
+      };
+      const generateClassName2 = createGenerateClassName();
+      assert.strictEqual(generateClassName2(rule, styleSheet), 'jss11u5x61');
+    });
   });
 });

--- a/packages/material-ui-styles/src/getStylesCreator.js
+++ b/packages/material-ui-styles/src/getStylesCreator.js
@@ -12,7 +12,8 @@ function getStylesCreator(stylesOrCreator) {
   warning(
     typeof stylesOrCreator === 'object' || themingEnabled,
     [
-      'Material-UI: the first argument provided to withStyles() is invalid.',
+      'Material-UI: the first argument provided to withStyles(styles)' +
+        ' or makeStyles(styles) is invalid.',
       'You need to provide a function generating the styles or a styles object.',
     ].join('\n'),
   );

--- a/packages/material-ui-styles/src/getThemeProps.js
+++ b/packages/material-ui-styles/src/getThemeProps.js
@@ -3,7 +3,7 @@
 function getThemeProps(params) {
   const { theme, name, props } = params;
 
-  if (!theme.props || !name || !theme.props[name]) {
+  if (!theme || !theme.props || !theme.props[name]) {
     return props;
   }
 

--- a/packages/material-ui-styles/src/install.js
+++ b/packages/material-ui-styles/src/install.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 /* eslint-disable no-underscore-dangle */
 
 import { ponyfillGlobal } from '@material-ui/utils';

--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -175,7 +175,7 @@ function makeStyles(stylesOrCreator, options = {}) {
     // An explicit value provided by the developers.
     name,
     // Help with debuggability.
-    meta: metaOption,
+    classNamePrefix: classNamePrefixOption,
     defaultTheme: defaultThemeOption,
     Component,
     ...stylesOptions2
@@ -184,13 +184,13 @@ function makeStyles(stylesOrCreator, options = {}) {
   const listenToTheme = stylesCreator.themingEnabled || typeof name === 'string';
   const defaultTheme = defaultThemeOption || noopTheme;
 
-  const meta = name || metaOption || 'Hook';
+  const classNamePrefix = name || classNamePrefixOption || 'Hook';
 
   stylesCreator.options = {
     index: increment(),
     name,
-    meta,
-    classNamePrefix: meta,
+    meta: classNamePrefix,
+    classNamePrefix,
   };
 
   return (props = {}) => {

--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -1,7 +1,10 @@
 import React from 'react';
+import warning from 'warning';
+import { getDynamicStyles } from 'jss';
+import mergeClasses from './mergeClasses';
+import multiKeyStore from './multiKeyStore';
 import ThemeContext from './ThemeContext';
 import { StylesContext } from './StylesProvider';
-import { attach, update, detach, getClasses } from './withStyles';
 import { increment } from './indexCounter';
 import getStylesCreator from './getStylesCreator';
 
@@ -11,19 +14,181 @@ const noopTheme = {};
 // Helper to debug
 // let id = 0;
 
+function getClasses({ classes, Component, state, stylesOptions }) {
+  if (stylesOptions.disableGeneration) {
+    return classes || {};
+  }
+
+  if (!state.cacheClasses) {
+    state.cacheClasses = {
+      // Cache for the finalized classes value.
+      value: null,
+      // Cache for the last used classes prop pointer.
+      lastProp: null,
+      // Cache for the last used rendered classes pointer.
+      lastJSS: {},
+    };
+  }
+
+  // Tracks if either the rendered classes or classes prop has changed,
+  // requiring the generation of a new finalized classes object.
+  let generate = false;
+
+  if (state.classes !== state.cacheClasses.lastJSS) {
+    state.cacheClasses.lastJSS = state.classes;
+    generate = true;
+  }
+  if (classes !== state.cacheClasses.lastProp) {
+    state.cacheClasses.lastProp = classes;
+    generate = true;
+  }
+
+  if (generate) {
+    state.cacheClasses.value = mergeClasses({
+      baseClasses: state.cacheClasses.lastJSS,
+      newClasses: classes,
+      Component,
+    });
+  }
+
+  return state.cacheClasses.value;
+}
+
+function attach({ state, props, theme, stylesOptions, stylesCreator, name }) {
+  if (stylesOptions.disableGeneration) {
+    return;
+  }
+
+  let sheetManager = multiKeyStore.get(stylesOptions.sheetsManager, stylesCreator, theme);
+
+  if (!sheetManager) {
+    sheetManager = {
+      refs: 0,
+      staticSheet: null,
+      dynamicStyles: null,
+    };
+    multiKeyStore.set(stylesOptions.sheetsManager, stylesCreator, theme, sheetManager);
+  }
+
+  const options = {
+    ...stylesCreator.options,
+    ...stylesOptions,
+    theme,
+    flip: typeof stylesOptions.flip === 'boolean' ? stylesOptions.flip : theme.direction === 'rtl',
+  };
+  options.generateId = options.generateClassName;
+
+  const sheetsRegistry = stylesOptions.sheetsRegistry;
+
+  if (sheetManager.refs === 0) {
+    let staticSheet;
+
+    if (stylesOptions.sheetsCache) {
+      staticSheet = multiKeyStore.get(stylesOptions.sheetsCache, stylesCreator, theme);
+    }
+
+    const styles = stylesCreator.create(theme, name);
+
+    if (!staticSheet) {
+      staticSheet = stylesOptions.jss.createStyleSheet(styles, {
+        link: false,
+        ...options,
+      });
+
+      staticSheet.attach();
+
+      if (stylesOptions.sheetsCache) {
+        multiKeyStore.set(stylesOptions.sheetsCache, stylesCreator, theme, staticSheet);
+      }
+    }
+
+    if (sheetsRegistry) {
+      sheetsRegistry.add(staticSheet);
+    }
+
+    sheetManager.dynamicStyles = getDynamicStyles(styles);
+    sheetManager.staticSheet = staticSheet;
+  }
+
+  if (sheetManager.dynamicStyles) {
+    const dynamicSheet = stylesOptions.jss.createStyleSheet(sheetManager.dynamicStyles, {
+      link: true,
+      ...options,
+    });
+
+    warning(props, 'Material-UI: properties missing.');
+
+    dynamicSheet.update(props).attach();
+
+    state.dynamicSheet = dynamicSheet;
+
+    if (sheetsRegistry) {
+      sheetsRegistry.add(dynamicSheet);
+    }
+
+    state.classes = mergeClasses({
+      baseClasses: sheetManager.staticSheet.classes,
+      newClasses: dynamicSheet.classes,
+    });
+  } else {
+    state.classes = sheetManager.staticSheet.classes;
+  }
+
+  sheetManager.refs += 1;
+}
+
+function update({ state, props }) {
+  if (state.dynamicSheet) {
+    state.dynamicSheet.update(props);
+  }
+}
+
+function detach({ state, theme, stylesOptions, stylesCreator }) {
+  if (stylesOptions.disableGeneration) {
+    return;
+  }
+
+  const sheetManager = multiKeyStore.get(stylesOptions.sheetsManager, stylesCreator, theme);
+  sheetManager.refs -= 1;
+  const sheetsRegistry = stylesOptions.sheetsRegistry;
+
+  if (sheetManager.refs === 0) {
+    multiKeyStore.delete(stylesOptions.sheetsManager, stylesCreator, theme);
+    stylesOptions.jss.removeStyleSheet(sheetManager.staticSheet);
+
+    if (sheetsRegistry) {
+      sheetsRegistry.remove(sheetManager.staticSheet);
+    }
+  }
+
+  if (state.dynamicSheet) {
+    stylesOptions.jss.removeStyleSheet(state.dynamicSheet);
+
+    if (sheetsRegistry) {
+      sheetsRegistry.remove(state.dynamicSheet);
+    }
+  }
+}
+
 function makeStyles(stylesOrCreator, options = {}) {
-  const { withTheme = false, name, defaultTheme: defaultThemeOption, ...stylesOptions2 } = options;
+  const {
+    // An explicit value provided by the developers.
+    name,
+    // Help with debuggability.
+    meta: metaOption,
+    defaultTheme: defaultThemeOption,
+    Component,
+    ...stylesOptions2
+  } = options;
   const stylesCreator = getStylesCreator(stylesOrCreator);
-  const listenToTheme = stylesCreator.themingEnabled || typeof name === 'string' || withTheme;
+  const listenToTheme = stylesCreator.themingEnabled || typeof name === 'string';
   const defaultTheme = defaultThemeOption || noopTheme;
 
-  const meta = name || 'Hook';
+  const meta = name || metaOption || 'Hook';
 
   stylesCreator.options = {
     index: increment(),
-    // Use for the global CSS option
     name,
-    // Help with debuggability.
     meta,
     classNamePrefix: meta,
   };
@@ -85,7 +250,7 @@ function makeStyles(stylesOrCreator, options = {}) {
 
     return getClasses({
       classes: props.classes,
-      Component: undefined,
+      Component,
       state,
       stylesOptions,
     });

--- a/packages/material-ui-styles/src/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles.test.js
@@ -1,7 +1,13 @@
 import { assert } from 'chai';
 import React from 'react';
+import { SheetsRegistry } from 'jss';
+import { act } from 'react-dom/test-utils';
 import { createMount } from '@material-ui/core/test-utils';
+import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 import makeStyles from './makeStyles';
+import StylesProvider from './StylesProvider';
+import ThemeProvider from './ThemeProvider';
 
 describe('makeStyles', () => {
   let mount;
@@ -13,18 +19,17 @@ describe('makeStyles', () => {
    */
   function createGetClasses(styles) {
     const useStyles = makeStyles(styles);
-    let classes = {};
+    const output = {};
 
     function TestComponent(props) {
-      classes = useStyles(props);
-      return null;
+      output.classes = useStyles(props);
+      return <div />;
     }
 
-    return function getClasses(props) {
-      mount(<TestComponent {...props} />);
-
-      // clone
-      return { ...classes };
+    return function mountWithProps(props) {
+      const wrapper = mount(<TestComponent {...props} />);
+      output.wrapper = wrapper;
+      return output;
     };
   }
 
@@ -36,15 +41,323 @@ describe('makeStyles', () => {
     mount.cleanUp();
   });
 
-  it('appends classes', () => {
+  it('should accept a classes property', () => {
     const styles = { root: {} };
-    const getClasses = createGetClasses(styles);
+    const mountWithProps = createGetClasses(styles);
+    const { classes: baseClasses } = mountWithProps();
+    const { classes: extendedClasses } = mountWithProps({ classes: { root: 'h1' } });
+    assert.strictEqual(extendedClasses.root, `${baseClasses.root} h1`);
+  });
 
-    const baseClasses = getClasses();
+  it('should ignore undefined property', () => {
+    const styles = { root: {} };
+    const mountWithProps = createGetClasses(styles);
+    const { classes: baseClasses } = mountWithProps();
+    const { classes: extendedClasses } = mountWithProps({ classes: { root: undefined } });
+    assert.strictEqual(extendedClasses.root, baseClasses.root);
+  });
 
-    const additionalClass = 'another-class';
-    const extendedClasses = getClasses({ classes: { root: additionalClass } });
+  describe('warnings', () => {
+    const styles = { root: {} };
+    const mountWithProps = createGetClasses(styles);
 
-    assert.strictEqual(extendedClasses.root, `${baseClasses.root} ${additionalClass}`);
+    beforeEach(() => {
+      consoleErrorMock.spy();
+    });
+
+    afterEach(() => {
+      consoleErrorMock.reset();
+    });
+
+    it('should warn if providing a unknown key', () => {
+      const { classes: baseClasses } = mountWithProps();
+      const { classes: extendedClasses } = mountWithProps({ classes: { bar: 'foo' } });
+      assert.deepEqual(extendedClasses, { root: baseClasses.root, bar: 'undefined foo' });
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'Material-UI: the key `bar` provided to the classes property is not implemented',
+      );
+    });
+
+    it('should warn if providing a string', () => {
+      mountWithProps({ classes: 'foo' });
+      assert.strictEqual(consoleErrorMock.callCount() >= 1, true);
+      const args = consoleErrorMock.args();
+      assert.include(
+        consoleErrorMock.args()[args.length - 1][0],
+        'You might want to use the className property instead',
+      );
+    });
+
+    it('should warn if providing a non string', () => {
+      const { classes: baseClasses } = mountWithProps();
+      const { classes: extendedClasses } = mountWithProps({ classes: { root: {} } });
+      assert.deepEqual(extendedClasses, { root: `${baseClasses.root} [object Object]` });
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'Material-UI: the key `root` provided to the classes property is not valid',
+      );
+    });
+  });
+
+  describe('classes memoization', () => {
+    let mountWithProps;
+
+    before(() => {
+      const styles = { root: {} };
+      mountWithProps = createGetClasses(styles);
+    });
+
+    it('should recycle with no classes property', () => {
+      const output = mountWithProps();
+      const classes1 = output.classes;
+      output.wrapper.update();
+      const classes2 = output.classes;
+      assert.strictEqual(classes1, classes2);
+    });
+
+    it('should recycle even when a classes property is provided', () => {
+      const inputClasses = { root: 'foo' };
+      const output = mountWithProps({ classes: inputClasses });
+      const classes1 = output.classes;
+      output.wrapper.setProps({
+        classes: inputClasses,
+      });
+      const classes2 = output.classes;
+      assert.strictEqual(classes1, classes2);
+    });
+
+    it('should invalidate the cache', () => {
+      const { classes } = mountWithProps();
+      const output = mountWithProps({ classes: { root: 'foo' } });
+      const classes1 = output.classes;
+      assert.deepEqual(classes1, {
+        root: `${classes.root} foo`,
+      });
+      output.wrapper.setProps({
+        classes: { root: 'bar' },
+      });
+      const classes2 = output.classes;
+      assert.notStrictEqual(classes1, classes2);
+      assert.deepEqual(classes2, {
+        root: `${classes.root} bar`,
+      });
+    });
+  });
+
+  describe('integration', () => {
+    let sheetsRegistry;
+
+    beforeEach(() => {
+      sheetsRegistry = new SheetsRegistry();
+    });
+
+    it('should run lifecycles with no theme', () => {
+      const useStyles = makeStyles({ root: { display: 'flex' } });
+      const StyledComponent = () => {
+        useStyles();
+        return <div />;
+      };
+
+      const wrapper = mount(
+        <ThemeProvider theme={createMuiTheme()}>
+          <StylesProvider sheetsRegistry={sheetsRegistry}>
+            <StyledComponent />
+          </StylesProvider>
+        </ThemeProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Hook-root-vy1bts' });
+      wrapper.update();
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Hook-root-vy1bts' });
+      wrapper.setProps({ theme: createMuiTheme() });
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Hook-root-vy1bts' });
+
+      wrapper.unmount();
+      assert.strictEqual(sheetsRegistry.registry.length, 0);
+    });
+
+    it('should work when depending on a theme', () => {
+      const useStyles = makeStyles(theme => ({ root: { padding: theme.spacing(1) } }), {
+        name: 'MuiTextField',
+      });
+      const StyledComponent = () => {
+        useStyles();
+        return <div />;
+      };
+
+      const wrapper = mount(
+        <ThemeProvider theme={createMuiTheme()}>
+          <StylesProvider sheetsRegistry={sheetsRegistry}>
+            <StyledComponent />
+          </StylesProvider>
+        </ThemeProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root-tyxeaf' });
+      act(() => {
+        wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
+      });
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root-lu46bw' });
+    });
+
+    it('should support the overrides key', () => {
+      const useStyles = makeStyles(
+        {
+          root: {
+            padding: 8,
+            margin: [1, 3],
+          },
+        },
+        {
+          name: 'MuiTextField',
+        },
+      );
+      const StyledComponent = () => {
+        useStyles();
+        return <div />;
+      };
+
+      mount(
+        <ThemeProvider
+          theme={createMuiTheme({
+            overrides: {
+              MuiTextField: {
+                root: {
+                  padding: 9,
+                  margin: [2, 2, 3],
+                },
+              },
+            },
+          })}
+        >
+          <StylesProvider sheetsRegistry={sheetsRegistry}>
+            <StyledComponent />
+          </StylesProvider>
+        </ThemeProvider>,
+      );
+
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].rules.raw, {
+        root: { padding: 9, margin: [2, 2, 3] },
+      });
+    });
+
+    it('should handle dynamic properties', () => {
+      const useStyles = makeStyles({
+        root: props => ({ margin: 8, padding: props.padding || 8 }),
+      });
+      const StyledComponent = props => {
+        const classes = useStyles(props);
+        return <div className={classes.root} />;
+      };
+
+      const Test = props => (
+        <StylesProvider sheetsRegistry={sheetsRegistry}>
+          <StyledComponent {...props} />
+        </StylesProvider>
+      );
+
+      const wrapper = mount(<Test />);
+      assert.strictEqual(sheetsRegistry.registry.length, 2);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Hook-root-1cjflis' });
+      assert.deepEqual(sheetsRegistry.registry[1].classes, { root: 'Hook-root-1' });
+      assert.deepEqual(sheetsRegistry.registry[1].rules.map.root.style, {
+        margin: '8px',
+        padding: '8px',
+      });
+      act(() => {
+        wrapper.setProps({ padding: 4 });
+      });
+      assert.strictEqual(sheetsRegistry.registry.length, 2);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Hook-root-1cjflis' });
+      assert.deepEqual(sheetsRegistry.registry[1].classes, { root: 'Hook-root-1' });
+      assert.deepEqual(sheetsRegistry.registry[1].rules.map.root.style, {
+        margin: '8px',
+        padding: '4px',
+      });
+    });
+  });
+
+  describe('options: disableGeneration', () => {
+    it('should not generate the styles', () => {
+      const sheetsRegistry = new SheetsRegistry();
+      const Empty = () => <div />;
+      const useStyles = makeStyles({ root: { padding: 8 } });
+      const StyledComponent = () => {
+        const classes = useStyles();
+        return <Empty classes={classes} />;
+      };
+
+      const wrapper = mount(
+        <StylesProvider sheetsRegistry={sheetsRegistry} disableGeneration>
+          <StyledComponent />
+        </StylesProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry.length, 0);
+      assert.deepEqual(wrapper.find(Empty).props().classes, {});
+      wrapper.unmount();
+      assert.strictEqual(sheetsRegistry.registry.length, 0);
+    });
+  });
+
+  // To fix, for the next pull request
+  // describe.skip('HMR with same state', () => {
+  //   it('should take the new stylesCreator into account', () => {
+  //     const styles1 = { root: { padding: 1 } };
+  //     const StyledComponent1 = withStyles(styles1, { name: 'MuiTextField' })(Empty);
+  //     const wrapper = mount(<StyledComponent1 />);
+
+  //     const styles2 = { root: { padding: 2 } };
+  //     const StyledComponent2 = withStyles(styles2, { name: 'MuiTextField' })(Empty);
+
+  //     // Simulate react-hot-loader behavior
+  //     wrapper.instance().componentDidUpdate = StyledComponent2.prototype.componentDidUpdate;
+
+  //     const classes1 = wrapper.childAt(0).props().classes.root;
+  //     wrapper.setProps({});
+  //     wrapper.update();
+  //     const classes2 = wrapper.childAt(0).props().classes.root;
+
+  //     assert.notStrictEqual(classes1, classes2, 'should generate new classes');
+  //   });
+  // });
+
+  describe('classname quality', () => {
+    let sheetsRegistry;
+
+    beforeEach(() => {
+      sheetsRegistry = new SheetsRegistry();
+    });
+
+    it('should use the displayName', () => {
+      const useStyles1 = makeStyles({ root: { padding: 8 } });
+      const StyledComponent1 = () => {
+        useStyles1();
+        return <div />;
+      };
+
+      const useStyles2 = makeStyles({ root: { padding: 8 } }, { name: 'Fooo' });
+      const StyledComponent2 = () => {
+        useStyles2();
+        return <div />;
+      };
+
+      mount(
+        <StylesProvider sheetsRegistry={sheetsRegistry}>
+          <StyledComponent1 />
+          <StyledComponent2 />
+        </StylesProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry[0].options.classNamePrefix, 'Hook');
+      assert.strictEqual(sheetsRegistry.registry[0].options.name, undefined);
+      assert.strictEqual(sheetsRegistry.registry[1].options.classNamePrefix, 'Fooo');
+      assert.strictEqual(sheetsRegistry.registry[1].options.name, 'Fooo');
+    });
   });
 });

--- a/packages/material-ui-styles/src/styled.js
+++ b/packages/material-ui-styles/src/styled.js
@@ -21,6 +21,21 @@ function omit(input, fields) {
 // Using components as a low-level styling construct can be simpler.
 function styled(Component) {
   const componentCreator = (style, options) => {
+    let filterProps;
+    let propTypes = {};
+
+    if (style.filterProps) {
+      filterProps = style.filterProps;
+      delete style.filterProps;
+    }
+
+    /* eslint-disable react/forbid-foreign-prop-types */
+    if (style.propTypes) {
+      propTypes = style.propTypes;
+      delete style.propTypes;
+    }
+    /* eslint-enable react/forbid-foreign-prop-types */
+
     function StyledComponent(props) {
       const {
         children,
@@ -39,9 +54,8 @@ function styled(Component) {
       }
 
       let spread = other;
-      if (style.filterProps) {
-        const omittedProps = style.filterProps;
-        spread = omit(spread, omittedProps);
+      if (filterProps) {
+        spread = omit(spread, filterProps);
       }
 
       if (typeof children === 'function') {
@@ -70,8 +84,13 @@ function styled(Component) {
        */
       clone: chainPropTypes(PropTypes.bool, props => {
         if (props.clone && props.component) {
-          throw new Error('You can not use the clone and component properties at the same time.');
+          return new Error(
+            `You can not use the clone and component properties at the same time.${
+              process.env.NODE_ENV === 'test' ? Date.now() : ''
+            }`,
+          );
         }
+        return null;
       }),
       /**
        * The component used for the root node.
@@ -79,7 +98,7 @@ function styled(Component) {
        */
       component: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
       theme: PropTypes.object,
-      ...(style.propTypes || {}),
+      ...propTypes,
     };
 
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/material-ui-styles/src/styled.test.js
+++ b/packages/material-ui-styles/src/styled.test.js
@@ -4,10 +4,20 @@ import styled from './styled';
 import { SheetsRegistry } from 'jss';
 import { createMount } from '@material-ui/core/test-utils';
 import { createGenerateClassName } from '@material-ui/styles';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 import StylesProvider from './StylesProvider';
 
 describe('styled', () => {
   let mount;
+  const StyledButton = styled('button')({
+    background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
+    borderRadius: 3,
+    border: 0,
+    color: 'white',
+    height: 48,
+    padding: '0 30px',
+    boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
+  });
 
   before(() => {
     mount = createMount();
@@ -18,16 +28,6 @@ describe('styled', () => {
   });
 
   it('should work as expected', () => {
-    const StyledButton = styled('button')({
-      background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
-      borderRadius: 3,
-      border: 0,
-      color: 'white',
-      height: 48,
-      padding: '0 30px',
-      boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
-    });
-
     const sheetsRegistry = new SheetsRegistry();
     const generateClassName = createGenerateClassName();
 
@@ -39,5 +39,69 @@ describe('styled', () => {
 
     assert.strictEqual(sheetsRegistry.registry.length, 1);
     assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Styled-button--root-1ds4xjv' });
+  });
+
+  describe('prop: clone', () => {
+    it('should be able to clone the child element', () => {
+      const wrapper = mount(
+        <StyledButton clone>
+          <div>Styled Components</div>
+        </StyledButton>,
+      );
+      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
+      wrapper.setProps({
+        clone: false,
+      });
+      assert.strictEqual(wrapper.getDOMNode().nodeName, 'BUTTON');
+    });
+  });
+
+  it('should filter some props', () => {
+    const style = props => ({
+      background: props.color,
+      borderRadius: 3,
+      border: 0,
+      color: 'white',
+      height: 48,
+      padding: '0 30px',
+      boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
+    });
+    style.filterProps = ['color'];
+    style.propTypes = {};
+    const StyledDiv = styled('div')(style);
+    const wrapper = mount(
+      <StyledDiv data-test="enzyme" color="blue">
+        Styled Components
+      </StyledDiv>,
+    );
+    assert.strictEqual(wrapper.find('div').props().color, undefined);
+    assert.strictEqual(wrapper.find('div').props()['data-test'], 'enzyme');
+  });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      consoleErrorMock.spy();
+    });
+
+    afterEach(() => {
+      consoleErrorMock.reset();
+    });
+
+    it('warns if it cant detect the secondary action properly', () => {
+      mount(
+        <StyledButton clone component="div">
+          <div>Styled Components</div>
+        </StyledButton>,
+      );
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'You can not use the clone and component properties at the same time',
+      );
+    });
+  });
+
+  it('should accept a child function', () => {
+    mount(<StyledButton>{props => <div {...props}>Styled Components</div>}</StyledButton>);
   });
 });

--- a/packages/material-ui-styles/src/useTheme.js
+++ b/packages/material-ui-styles/src/useTheme.js
@@ -1,6 +1,8 @@
 import React from 'react';
+import warning from 'warning';
 import ThemeContext from './ThemeContext';
 
-export default function useTheme() {
+export default function useTheme(_) {
+  warning(!_, "Material-UI: useTheme() doesn't accept any argument.");
   return React.useContext(ThemeContext);
 }

--- a/packages/material-ui-styles/src/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles.js
@@ -1,189 +1,31 @@
-/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
-import { getDynamicStyles } from 'jss';
 import { getDisplayName } from '@material-ui/utils';
-import { increment } from './indexCounter';
-import mergeClasses from './mergeClasses';
-import multiKeyStore from './multiKeyStore';
-import getStylesCreator from './getStylesCreator';
+import makeStyles from './makeStyles';
+import RefHolder from './RefHolder';
 import getThemeProps from './getThemeProps';
 import hoistStatics from './hoistInternalStatics';
-import { StylesContext } from './StylesProvider';
-import ThemeContext from './ThemeContext';
-
-// We use the same empty object to ref count the styles that don't need a theme object.
-const noopTheme = {};
-
-export function getClasses({ classes, Component, state, stylesOptions }) {
-  if (stylesOptions.disableGeneration) {
-    return classes || {};
-  }
-
-  if (!state.cacheClasses) {
-    state.cacheClasses = {
-      // Cache for the finalized classes value.
-      value: null,
-      // Cache for the last used classes prop pointer.
-      lastProp: null,
-      // Cache for the last used rendered classes pointer.
-      lastJSS: {},
-    };
-  }
-
-  // Tracks if either the rendered classes or classes prop has changed,
-  // requiring the generation of a new finalized classes object.
-  let generate = false;
-
-  if (state.classes !== state.cacheClasses.lastJSS) {
-    state.cacheClasses.lastJSS = state.classes;
-    generate = true;
-  }
-  if (classes !== state.cacheClasses.lastProp) {
-    state.cacheClasses.lastProp = classes;
-    generate = true;
-  }
-
-  if (generate) {
-    state.cacheClasses.value = mergeClasses({
-      baseClasses: state.cacheClasses.lastJSS,
-      newClasses: classes,
-      Component,
-    });
-  }
-
-  return state.cacheClasses.value;
-}
-
-export function attach({ state, props, theme, stylesOptions, stylesCreator, name }) {
-  if (stylesOptions.disableGeneration) {
-    return;
-  }
-
-  let sheetManager = multiKeyStore.get(stylesOptions.sheetsManager, stylesCreator, theme);
-
-  if (!sheetManager) {
-    sheetManager = {
-      refs: 0,
-      staticSheet: null,
-      dynamicStyles: null,
-    };
-    multiKeyStore.set(stylesOptions.sheetsManager, stylesCreator, theme, sheetManager);
-  }
-
-  const options = {
-    ...stylesCreator.options,
-    ...stylesOptions,
-    theme,
-    flip: typeof stylesOptions.flip === 'boolean' ? stylesOptions.flip : theme.direction === 'rtl',
-  };
-  options.generateId = options.generateClassName;
-
-  const sheetsRegistry = stylesOptions.sheetsRegistry;
-
-  if (sheetManager.refs === 0) {
-    let staticSheet;
-
-    if (stylesOptions.sheetsCache) {
-      staticSheet = multiKeyStore.get(stylesOptions.sheetsCache, stylesCreator, theme);
-    }
-
-    const styles = stylesCreator.create(theme, name);
-
-    if (!staticSheet) {
-      staticSheet = stylesOptions.jss.createStyleSheet(styles, {
-        link: false,
-        ...options,
-      });
-
-      staticSheet.attach();
-
-      if (stylesOptions.sheetsCache) {
-        multiKeyStore.set(stylesOptions.sheetsCache, stylesCreator, theme, staticSheet);
-      }
-    }
-
-    if (sheetsRegistry) {
-      sheetsRegistry.add(staticSheet);
-    }
-
-    sheetManager.dynamicStyles = getDynamicStyles(styles);
-    sheetManager.staticSheet = staticSheet;
-  }
-
-  if (sheetManager.dynamicStyles) {
-    const dynamicSheet = stylesOptions.jss.createStyleSheet(sheetManager.dynamicStyles, {
-      link: true,
-      ...options,
-    });
-
-    warning(props, 'Material-UI: properties missing.');
-
-    dynamicSheet.update(props).attach();
-
-    state.dynamicSheet = dynamicSheet;
-
-    if (sheetsRegistry) {
-      sheetsRegistry.add(dynamicSheet);
-    }
-
-    state.classes = mergeClasses({
-      baseClasses: sheetManager.staticSheet.classes,
-      newClasses: dynamicSheet.classes,
-    });
-  } else {
-    state.classes = sheetManager.staticSheet.classes;
-  }
-
-  sheetManager.refs += 1;
-}
-
-export function update({ state, props }) {
-  if (state.dynamicSheet) {
-    state.dynamicSheet.update(props);
-  }
-}
-
-export function detach({ state, theme, stylesOptions, stylesCreator }) {
-  if (stylesOptions.disableGeneration) {
-    return;
-  }
-
-  const sheetManager = multiKeyStore.get(stylesOptions.sheetsManager, stylesCreator, theme);
-  sheetManager.refs -= 1;
-  const sheetsRegistry = stylesOptions.sheetsRegistry;
-
-  if (sheetManager.refs === 0) {
-    multiKeyStore.delete(stylesOptions.sheetsManager, stylesCreator, theme);
-    stylesOptions.jss.removeStyleSheet(sheetManager.staticSheet);
-
-    if (sheetsRegistry) {
-      sheetsRegistry.remove(sheetManager.staticSheet);
-    }
-  }
-
-  if (state.dynamicSheet) {
-    stylesOptions.jss.removeStyleSheet(state.dynamicSheet);
-
-    if (sheetsRegistry) {
-      sheetsRegistry.remove(state.dynamicSheet);
-    }
-  }
-}
+import useTheme from './useTheme';
 
 // Link a style sheet with a component.
 // It does not modify the component passed to it;
 // instead, it returns a new component, with a `classes` property.
 const withStyles = (stylesOrCreator, options = {}) => Component => {
-  const { withTheme = false, name, defaultTheme: defaultThemeOption, ...stylesOptions2 } = options;
-  const stylesCreator = getStylesCreator(stylesOrCreator);
-  const listenToTheme = stylesCreator.themingEnabled || typeof name === 'string' || withTheme;
-  const defaultTheme = defaultThemeOption || noopTheme;
+  const { withTheme = false, name, ...otherOptions } = options;
+
+  if (process.env.NODE_ENV !== 'production' && Component === undefined) {
+    throw new Error(
+      [
+        'You are calling withStyles(styles)(Component) with an undefined component.',
+        'You may have forgotten to import it.',
+      ].join('\n'),
+    );
+  }
 
   let meta = name;
 
-  if (process.env.NODE_ENV !== 'production' && !meta) {
+  if (process.env.NODE_ENV !== 'production' && !name) {
     // Provide a better DX outside production.
     meta = getDisplayName(Component);
     warning(
@@ -195,133 +37,40 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
     );
   }
 
-  stylesCreator.options = {
-    // Side effect.
-    index: increment(),
-    // Use for the global CSS option.
+  const useStyles = makeStyles(stylesOrCreator, {
+    ...otherOptions,
+    Component,
     name: name || Component.displayName,
-    // Help with debuggability.
     meta,
-    classNamePrefix: meta,
-  };
+  });
 
-  class WithStylesInner extends React.Component {
-    constructor() {
-      super();
-      this.state = {
-        styles: {},
-      };
-    }
+  const WithStyles = React.forwardRef(function WithStyles(props, ref) {
+    const { classes: classesProp, innerRef, ...other } = props;
+    const classes = useStyles(props);
 
-    componentDidUpdate() {
-      update({
-        props: this.props,
-        state: this.state.styles,
-      });
-    }
+    let theme;
+    let more = other;
 
-    componentWillUnmount() {
-      detach({
-        state: this.state.styles,
-        stylesCreator,
-        stylesOptions: this.props.stylesOptions,
-        theme: this.props.theme,
-      });
-    }
+    if (typeof name === 'string' || withTheme) {
+      theme = useTheme();
 
-    render() {
-      const { classes, theme, innerRef, stylesOptions, ...other } = this.props;
-
-      const oldTheme = this.theme;
-      this.theme = theme;
-
-      if (oldTheme !== theme) {
-        attach({
-          name,
-          props: this.props,
-          state: this.state.styles,
-          stylesCreator,
-          stylesOptions,
-          theme,
-        });
-
-        if (oldTheme) {
-          // Rerender the component so the underlying component gets the theme update.
-          // By theme update we mean receiving and applying the new class names.
-          setTimeout(() => {
-            detach({
-              state: this.state.styles,
-              stylesCreator,
-              stylesOptions,
-              theme: oldTheme,
-            });
-          });
-        }
+      if (name) {
+        more = getThemeProps({ theme, name, props: other });
       }
 
-      const more = getThemeProps({ theme, name, props: other });
-
       // Provide the theme to the wrapped component.
-      // So we don't have to use the `withTheme` Higher-order Component.
+      // So we don't have to use the `withTheme()` Higher-order Component.
       if (withTheme) {
         more.theme = theme;
       }
-
-      return (
-        <Component
-          ref={innerRef}
-          classes={getClasses({
-            classes,
-            Component,
-            state: this.state.styles,
-            stylesOptions,
-          })}
-          {...more}
-        />
-      );
     }
-  }
 
-  WithStylesInner.propTypes = {
-    /**
-     * Override or extend the styles applied to the component.
-     */
-    classes: PropTypes.object,
-    innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    stylesOptions: PropTypes.object.isRequired,
-    theme: PropTypes.object,
-  };
-
-  const WithStyles = React.forwardRef((props, ref) => (
-    <StylesContext.Consumer>
-      {stylesOptions1 => {
-        const stylesOptions = {
-          ...stylesOptions1,
-          ...stylesOptions2,
-        };
-
-        return listenToTheme ? (
-          <ThemeContext.Consumer>
-            {theme => (
-              <WithStylesInner
-                stylesOptions={stylesOptions}
-                ref={ref}
-                theme={theme || defaultTheme}
-                {...props}
-              />
-            )}
-          </ThemeContext.Consumer>
-        ) : (
-          <WithStylesInner
-            stylesOptions={stylesOptions}
-            ref={ref}
-            theme={defaultTheme}
-            {...props}
-          />
-        );
-      }}
-    </StylesContext.Consumer>
-  ));
+    return (
+      <RefHolder ref={ref}>
+        <Component ref={innerRef} classes={classes} {...more} />
+      </RefHolder>
+    );
+  });
 
   WithStyles.propTypes = {
     /**
@@ -339,12 +88,6 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
   }
 
   hoistStatics(WithStyles, Component);
-
-  if (process.env.NODE_ENV !== 'production') {
-    // Exposed for test purposes.
-    WithStyles.Naked = Component;
-    WithStyles.options = options;
-  }
 
   return WithStyles;
 };

--- a/packages/material-ui-styles/src/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles.js
@@ -23,13 +23,13 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
     );
   }
 
-  let meta = name;
+  let classNamePrefix = name;
 
   if (process.env.NODE_ENV !== 'production' && !name) {
     // Provide a better DX outside production.
-    meta = getDisplayName(Component);
+    classNamePrefix = getDisplayName(Component);
     warning(
-      typeof meta === 'string',
+      typeof classNamePrefix === 'string',
       [
         'Material-UI: the component displayName is invalid. It needs to be a string.',
         `Please fix the following component: ${Component}.`,
@@ -41,7 +41,7 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
     ...otherOptions,
     Component,
     name: name || Component.displayName,
-    meta,
+    classNamePrefix,
   });
 
   const WithStyles = React.forwardRef(function WithStyles(props, ref) {

--- a/packages/material-ui-styles/src/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles.test.js
@@ -1,10 +1,27 @@
 import { assert } from 'chai';
 import React from 'react';
+import PropTypes from 'prop-types';
+import { SheetsRegistry } from 'jss';
+import { act } from 'react-dom/test-utils';
 import { Input } from '@material-ui/core';
+import { createMount } from '@material-ui/core/test-utils';
 import { isMuiElement } from '@material-ui/core/utils/reactHelpers';
+import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
+import StylesProvider from './StylesProvider';
+import ThemeProvider from './ThemeProvider';
 import withStyles from './withStyles';
 
 describe('withStyles', () => {
+  let mount;
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
   it('does not hoist statics', () => {
     const Test = () => null;
     Test.someStatic = 'will not get hoisted';
@@ -19,5 +36,215 @@ describe('withStyles', () => {
     const StyledInput = withStyles({})(Input);
 
     assert.strictEqual(isMuiElement(<StyledInput />, ['Input']), true);
+  });
+
+  it('should forward the properties', () => {
+    const Test = props => <div>{props.foo}</div>;
+    Test.propTypes = {
+      foo: PropTypes.any,
+    };
+    const StyledComponent = withStyles({})(Test);
+    const wrapper = mount(<StyledComponent foo="bar" />);
+    assert.strictEqual(wrapper.text(), 'bar');
+  });
+
+  it('should work with no theme', () => {
+    const Test = props => <div>{props.foo}</div>;
+    Test.propTypes = {
+      foo: PropTypes.any,
+    };
+    const StyledComponent = withStyles({}, { name: 'Foo' })(Test);
+    const wrapper = mount(<StyledComponent foo="bar" />);
+    assert.strictEqual(wrapper.text(), 'bar');
+  });
+
+  describe('integration', () => {
+    let sheetsRegistry;
+    const Empty = () => <div />;
+
+    beforeEach(() => {
+      sheetsRegistry = new SheetsRegistry();
+    });
+
+    it('should run lifecycles with no theme', () => {
+      const styles = { root: { display: 'flex' } };
+      const StyledComponent = withStyles(styles)(Empty);
+      const wrapper = mount(
+        <ThemeProvider theme={createMuiTheme()}>
+          <StylesProvider sheetsRegistry={sheetsRegistry}>
+            <StyledComponent />
+          </StylesProvider>
+        </ThemeProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Empty-root-vy1bts' });
+      wrapper.update();
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Empty-root-vy1bts' });
+      wrapper.setProps({ theme: createMuiTheme() });
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Empty-root-vy1bts' });
+
+      wrapper.unmount();
+      assert.strictEqual(sheetsRegistry.registry.length, 0);
+    });
+
+    it('should support theme.props', () => {
+      const styles = { root: { display: 'flex' } };
+      const StyledComponent = withStyles(styles, { name: 'MuiFoo' })(Empty);
+
+      const wrapper = mount(
+        <ThemeProvider
+          theme={createMuiTheme({
+            props: {
+              MuiFoo: {
+                foo: 'bar',
+              },
+            },
+          })}
+        >
+          <StyledComponent foo={undefined} />
+        </ThemeProvider>,
+      );
+
+      assert.strictEqual(wrapper.find(Empty).props().foo, 'bar');
+      wrapper.unmount();
+    });
+
+    it('should work when depending on a theme', () => {
+      const styles = theme => ({ root: { padding: theme.spacing(1) } });
+      const StyledComponent = withStyles(styles, { name: 'MuiTextField' })(Empty);
+
+      const wrapper = mount(
+        <ThemeProvider theme={createMuiTheme()}>
+          <StylesProvider sheetsRegistry={sheetsRegistry}>
+            <StyledComponent />
+          </StylesProvider>
+        </ThemeProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root-tyxeaf' });
+      act(() => {
+        wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
+      });
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root-lu46bw' });
+    });
+
+    it('should support the overrides key', () => {
+      const styles = { root: { padding: 8 } };
+      const StyledComponent = withStyles(styles, { name: 'MuiTextField' })(Empty);
+
+      mount(
+        <ThemeProvider
+          theme={createMuiTheme({
+            overrides: {
+              MuiTextField: {
+                root: {
+                  padding: 9,
+                },
+              },
+            },
+          })}
+        >
+          <StylesProvider sheetsRegistry={sheetsRegistry}>
+            <StyledComponent />
+          </StylesProvider>
+        </ThemeProvider>,
+      );
+
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].rules.raw, { root: { padding: 9 } });
+    });
+
+    describe('options: disableGeneration', () => {
+      it('should not generate the styles', () => {
+        const styles = { root: { display: 'flex' } };
+        const StyledComponent = withStyles(styles)(Empty);
+
+        const wrapper = mount(
+          <StylesProvider sheetsRegistry={sheetsRegistry} disableGeneration>
+            <StyledComponent />
+          </StylesProvider>,
+        );
+        assert.strictEqual(sheetsRegistry.registry.length, 0);
+        assert.deepEqual(wrapper.find(Empty).props().classes, {});
+        wrapper.unmount();
+        assert.strictEqual(sheetsRegistry.registry.length, 0);
+      });
+    });
+  });
+
+  // To fix for a new pull request
+  // describe('HMR with same state', () => {
+  //   it('should take the new stylesCreator into account', () => {
+  //     const styles1 = { root: { padding: 1 } };
+  //     const StyledComponent1 = withStyles(styles1, { name: 'MuiTextField' })(Empty);
+  //     const wrapper = mount(<StyledComponent1 />);
+
+  //     const styles2 = { root: { padding: 2 } };
+  //     const StyledComponent2 = withStyles(styles2, { name: 'MuiTextField' })(Empty);
+
+  //     // Simulate react-hot-loader behavior
+  //     wrapper.instance().componentDidUpdate = StyledComponent2.prototype.componentDidUpdate;
+
+  //     const classes1 = wrapper.childAt(0).props().classes.root;
+  //     wrapper.setProps({});
+  //     wrapper.update();
+  //     const classes2 = wrapper.childAt(0).props().classes.root;
+
+  //     assert.notStrictEqual(classes1, classes2, 'should generate new classes');
+  //   });
+  // });
+
+  describe('classname quality', () => {
+    it('should use the displayName', () => {
+      const sheetsRegistry = new SheetsRegistry();
+      // Uglified
+      const a = () => <div />;
+      const StyledComponent1 = withStyles({ root: { padding: 1 } })(a);
+      const fooo = () => <div />;
+      const StyledComponent2 = withStyles({ root: { padding: 1 } })(fooo);
+      const AppFrame = () => <div />;
+      AppFrame.displayName = 'AppLayout';
+      const StyledComponent3 = withStyles({ root: { padding: 1 } })(AppFrame);
+
+      mount(
+        <StylesProvider sheetsRegistry={sheetsRegistry}>
+          <StyledComponent1 />
+          <StyledComponent2 />
+          <StyledComponent3 />
+        </StylesProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry[0].options.classNamePrefix, 'a');
+      assert.strictEqual(sheetsRegistry.registry[0].options.name, undefined);
+      assert.strictEqual(sheetsRegistry.registry[1].options.classNamePrefix, 'fooo');
+      assert.strictEqual(sheetsRegistry.registry[1].options.name, undefined);
+      assert.strictEqual(sheetsRegistry.registry[2].options.classNamePrefix, 'AppLayout');
+      assert.strictEqual(sheetsRegistry.registry[2].options.name, 'AppLayout');
+    });
+  });
+
+  it('should throw is the import is invalid', () => {
+    assert.throw(
+      () => withStyles({})(undefined),
+      'You are calling withStyles(styles)(Component) with an undefined component',
+    );
+  });
+
+  describe('option: withTheme', () => {
+    it('should inject the theme', () => {
+      const styles = { root: { padding: 1 } };
+      const StyledComponent = withStyles(styles, { withTheme: true })(props => (
+        <option theme={props.theme} />
+      ));
+      const theme = {};
+      const wrapper = mount(
+        <ThemeProvider theme={theme}>
+          <StyledComponent />
+        </ThemeProvider>,
+      );
+      assert.strictEqual(wrapper.find('option').props().theme, theme);
+    });
   });
 });

--- a/packages/material-ui-styles/src/withTheme.js
+++ b/packages/material-ui-styles/src/withTheme.js
@@ -2,11 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getDisplayName } from '@material-ui/utils';
 import hoistStatics from './hoistInternalStatics';
-import ThemeContext from './ThemeContext';
+import useTheme from './useTheme';
+import RefHolder from './RefHolder';
 
 // Provide the theme object as a property to the input component.
+// It's an alternative API to useTheme().
+// We encourage the usage of useTheme() where possible.
 const withTheme = Component => {
-  /* istanbul ignore if */
   if (process.env.NODE_ENV !== 'production' && Component === undefined) {
     throw new Error(
       [
@@ -16,14 +18,15 @@ const withTheme = Component => {
     );
   }
 
-  const WithTheme = props => (
-    <ThemeContext.Consumer>
-      {theme => {
-        const { innerRef, ...other } = props;
-        return <Component theme={theme} ref={innerRef} {...other} />;
-      }}
-    </ThemeContext.Consumer>
-  );
+  const WithTheme = React.forwardRef(function WithTheme(props, ref) {
+    const { innerRef, ...other } = props;
+    const theme = useTheme();
+    return (
+      <RefHolder ref={ref}>
+        <Component theme={theme} ref={innerRef} {...other} />
+      </RefHolder>
+    );
+  });
 
   WithTheme.propTypes = {
     /**

--- a/packages/material-ui-styles/src/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme.test.js
@@ -51,4 +51,11 @@ describe('withTheme', () => {
 
     assert.strictEqual(isMuiElement(<ThemedInput />, ['Input']), true);
   });
+
+  it('should throw is the import is invalid', () => {
+    assert.throw(
+      () => withTheme(undefined),
+      'You are calling withTheme(Component) with an undefined component',
+    );
+  });
 });

--- a/packages/material-ui-utils/src/getDisplayName.test.js
+++ b/packages/material-ui-utils/src/getDisplayName.test.js
@@ -46,10 +46,12 @@ describe('utils/getDisplayName.js', () => {
       assert.strictEqual(getDisplayName(AndAnotherComponent), 'AndAnotherComponent');
       assert.strictEqual(getDisplayName(() => <div />), 'Component');
       assert.strictEqual(getDisplayName('div'), 'div');
-      assert.strictEqual(getDisplayName(), undefined);
       assert.strictEqual(getDisplayName(AnonymousForwardRefComponent), 'ForwardRef');
       assert.strictEqual(getDisplayName(ForwardRefComponent), 'ForwardRef(Div)');
       assert.strictEqual(getDisplayName(NamedForwardRefComponent), 'Div');
+      assert.strictEqual(getDisplayName(), undefined);
+      assert.strictEqual(getDisplayName({}), undefined);
+      assert.strictEqual(getDisplayName(false), undefined);
     });
   });
 

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -96,7 +96,7 @@ describe('<Breadcrumbs />', () => {
     assert.strictEqual(wrapper.find(BreadcrumbSeparator).length, 8);
   });
 
-  describe('warning', () => {
+  describe('warnings', () => {
     beforeEach(() => {
       consoleErrorMock.spy();
     });

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -282,7 +282,7 @@ describe('<TablePagination />', () => {
     });
   });
 
-  describe('warning', () => {
+  describe('warnings', () => {
     before(() => {
       consoleErrorMock.spy();
     });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -49,7 +49,7 @@ describe('<Tabs />', () => {
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
 
-  describe('warning', () => {
+  describe('warnings', () => {
     before(() => {
       consoleErrorMock.spy();
     });

--- a/packages/material-ui/src/styles/createSpacing.test.js
+++ b/packages/material-ui/src/styles/createSpacing.test.js
@@ -30,7 +30,7 @@ describe('createSpacing', () => {
     assert.strictEqual(spacing(1, 2), '0.25rem 0.5rem');
   });
 
-  describe('warning', () => {
+  describe('warnings', () => {
     beforeEach(() => {
       consoleErrorMock.spy();
     });

--- a/pages/index.js
+++ b/pages/index.js
@@ -14,6 +14,7 @@ import AppFrame from 'docs/src/modules/components/AppFrame';
 import Link from 'docs/src/modules/components/Link';
 import Head from 'docs/src/modules/components/Head';
 import loadScript from 'docs/src/modules/utils/loadScript';
+import compose from 'docs/src/modules/utils/compose';
 
 let dependenciesLoaded = false;
 
@@ -201,8 +202,9 @@ HomePage.propTypes = {
   t: PropTypes.func.isRequired,
 };
 
-const Page = withStyles(styles)(HomePage);
-
-export default connect(state => ({
-  t: state.options.t,
-}))(Page);
+export default compose(
+  connect(state => ({
+    t: state.options.t,
+  })),
+  withStyles(styles),
+)(HomePage);


### PR DESCRIPTION
We don't keep track of the test coverage for the @material-ui/styles package. This has allowed us to quickly ship the new style hook API. It's time to improve the test coverage.

**Before**
Coverage ~80% 

**After**
![capture d ecran 2019-02-18 a 17 42 23](https://user-images.githubusercontent.com/3165635/52965213-950fbb00-33a4-11e9-8c2f-db10fb51e153.png)

After this pull request, I can look into #13607.

--- 

The `withStyles()` React dev tool overhead is down from 4 components to 2. Thank you React for shipping the hook API!

**Before**
![capture d ecran 2019-02-18 a 17 49 04](https://user-images.githubusercontent.com/3165635/52965607-84137980-33a5-11e9-8409-826f939ecdda.png)

**After**
![capture d ecran 2019-02-18 a 17 45 48](https://user-images.githubusercontent.com/3165635/52965472-2e3ed180-33a5-11e9-9106-03e23909a7d4.png)

We might get it down to 1 component as we improve the ref story of Material-UI.
