### PR TITLE
[core] Fix some peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.21",
     "babel-plugin-unwrap-createStyles": "link:packages/babel-plugin-unwrap-createStyles",
     "chai": "^4.1.2",
+    "classnames": "^2.2.6",
     "clean-css": "^4.1.11",
     "clipboard-copy": "^2.0.0",
     "cross-env": "^5.1.1",
@@ -150,6 +151,7 @@
     "nyc": "^13.0.0",
     "postcss": "^7.0.0",
     "prettier": "^1.8.2",
+    "prop-types": "^15.6.0",
     "puppeteer": "^1.5.0",
     "raw-loader": "^1.0.0",
     "react": "^16.8.0",
@@ -190,6 +192,7 @@
     "url-loader": "^1.0.1",
     "vrtest": "^0.2.0",
     "webfontloader": "^1.6.28",
+    "webpack": "^4.28.4",
     "webpack-bundle-analyzer": "^3.0.0",
     "webpack-cli": "^3.2.3"
   },

--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -28,6 +28,7 @@
     "@emotion/core": "^10.0.0",
     "@emotion/styled": "^10.0.0",
     "benchmark": "^2.1.4",
+    "emotion": "^10.0.7",
     "emotion-server": "^10.0.6",
     "nodemod": "^1.5.19",
     "styled-system": "^3.1.11"

--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -31,7 +31,7 @@
     "test": "exit 0"
   },
   "peerDependencies": {
-    "@material-ui/core": "^3.0.0",
+    "@material-ui/core": "^3.0.0 || ^4.0.0-alpha",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3544,7 +3544,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.3, classnames@^2.2.5, classnames@~2.2.5:
+classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6, classnames@~2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -4049,6 +4049,16 @@ create-emotion-server@10.0.0:
     html-tokenize "^2.0.0"
     multipipe "^1.0.2"
     through "^2.3.8"
+
+create-emotion@^10.0.7:
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/create-emotion/-/create-emotion-10.0.7.tgz#608d69c550e2f57827383762d416a9ddf75d8bed"
+  integrity sha512-2T6vvvh7XN/MvI3far2SXeQ5s7wti/dae6jKuHxkK4IA1IKdYocKTujZ+r56azZ8fguq3Qj4ua1AJ2vHCq7VTg==
+  dependencies:
+    "@emotion/cache" "^10.0.7"
+    "@emotion/serialize" "^0.11.4"
+    "@emotion/sheet" "0.9.2"
+    "@emotion/utils" "0.11.1"
 
 create-emotion@^9.2.12:
   version "9.2.12"
@@ -5032,6 +5042,14 @@ emotion-theming@^10.0.5:
     "@emotion/weak-memoize" "0.2.2"
     hoist-non-react-statics "^2.3.1"
     object-assign "^4.1.1"
+
+emotion@^10.0.7:
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/emotion/-/emotion-10.0.7.tgz#74ea432c7004c2bd5452d017d52e307a7a31a835"
+  integrity sha512-k1gGBoel9rlHvHIUVHyk4iJPsRaDsrpr7vKivOmdJAH2Va+smxIYvsjjzXnxTeqJt5IwcVBareuoAJMxeShG/w==
+  dependencies:
+    babel-plugin-emotion "^10.0.7"
+    create-emotion "^10.0.7"
 
 emotion@^9.1.2:
   version "9.2.12"


### PR DESCRIPTION
Reduces noise from peer dependency warnings that were not problematic since the referenced packages were transitive dependencies.

These warnings are removed:
```
warning " > babel-loader@8.0.5" has unmet peer dependency "webpack@>=2".
warning " > css-loader@2.1.0" has unmet peer dependency "webpack@^4.0.0".
warning " > eslint-import-resolver-webpack@0.11.0" has unmet peer dependency "webpack@>=1.11.0".
warning "karma-webpack > webpack-dev-middleware@2.0.6" has unmet peer dependency "webpack@^2.2.0 || ^3.0.0 || ^4.0.0-alpha || ^4.0.0-beta || ^4.0.0".
warning " > material-ui-pickers@2.2.1" has unmet peer dependency "prop-types@^15.6.0".
warning " > notistack@0.4.2" has unmet peer dependency "prop-types@^15.6.2".
warning " > notistack@0.4.2" has unmet peer dependency "classnames@^2.2.6".
warning " > raw-loader@1.0.0" has unmet peer dependency "webpack@^4.3.0".
warning " > react-final-form@4.0.2" has unmet peer dependency "prop-types@^15.6.0".
warning " > react-frame-component@4.0.2" has unmet peer dependency "prop-types@^15.5.9".
warning " > url-loader@1.1.2" has unmet peer dependency "webpack@^3.0.0 || ^4.0.0".
warning " > webpack-cli@3.2.3" has unmet peer dependency "webpack@4.x.x".
warning " > @material-ui/docs@4.0.0-alpha.0" has incorrect peer dependency "@material-ui/core@^3.0.0".
warning "workspace-aggregator-de8304da-e48d-4e15-b331-ca3b44f22ad6 > @material-ui/benchmark > emotion-server@10.0.7" has unmet peer dependency "emotion@^10.0.0".
```