### PR TITLE
[styles] Warn if missing ThemeProvider

### DIFF
--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -7,9 +7,7 @@ import ThemeContext from './ThemeContext';
 import { StylesContext } from './StylesProvider';
 import { increment } from './indexCounter';
 import getStylesCreator from './getStylesCreator';
-
-// We use the same empty object to ref count the styles that don't need a theme object.
-const noopTheme = {};
+import noopTheme from './noopTheme';
 
 // Helper to debug
 // let id = 0;

--- a/packages/material-ui-styles/src/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles.test.js
@@ -58,8 +58,7 @@ describe('makeStyles', () => {
   });
 
   describe('warnings', () => {
-    const styles = { root: {} };
-    const mountWithProps = createGetClasses(styles);
+    const mountWithProps = createGetClasses({ root: {} });
 
     beforeEach(() => {
       consoleErrorMock.spy();
@@ -99,6 +98,16 @@ describe('makeStyles', () => {
         consoleErrorMock.args()[0][0],
         'Material-UI: the key `root` provided to the classes property is not valid',
       );
+    });
+
+    it('should warn if missing theme', () => {
+      const styles = theme => ({ root: { padding: theme.spacing(2) } });
+      const mountWithProps2 = createGetClasses(styles);
+      assert.throw(() => {
+        mountWithProps2({});
+      });
+      assert.strictEqual(consoleErrorMock.callCount(), 4);
+      assert.include(consoleErrorMock.args()[1][0], 'the `styles` argument provided is invalid');
     });
   });
 

--- a/packages/material-ui-styles/src/noopTheme.js
+++ b/packages/material-ui-styles/src/noopTheme.js
@@ -1,0 +1,4 @@
+// We use the same empty object to ref count the styles that don't need a theme object.
+const noopTheme = {};
+
+export default noopTheme;


### PR DESCRIPTION
Closes #14577

This is a tradeoff, people might not need the theme when using the `styled()` method.
This is taking the boldest path: it introduces a warning. We will see how people react to this warning.
The advantage is that it's providing a clear resolution path. But most importantly, people can complain about it, we can use their input to evaluate the relevance of the warning. 
Let me know what you think about it.

Also, we will wrap the @material-ui/styles modules in @material-ui/core/styles to provide a default theme, this warning won't be triggered: #14560.