### PR TITLE
[core] Improve a11y for Collapse, ExpansionPanel and Grow

### DIFF
--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -24,7 +24,7 @@ export const styles = theme => ({
   // eslint-disable-next-line max-len
   /* Styles applied to the container element when the transition has exited and `collapsedHeight` != 0px. */
   hidden: {
-    vibility: 'hidden',
+    visibility: 'hidden',
   },
   /* Styles applied to the outer wrapper element. */
   wrapper: {

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -106,7 +106,7 @@ class ExpansionPanel extends React.Component {
       children: childrenProp,
       classes,
       className: classNameProp,
-      CollapseProps: CollapsePropsProp,
+      CollapseProps,
       defaultExpanded,
       disabled,
       expanded: expandedProp,
@@ -143,12 +143,6 @@ class ExpansionPanel extends React.Component {
       return child;
     });
 
-    const CollapseProps = !expanded
-      ? {
-          'aria-hidden': 'true',
-        }
-      : null;
-
     return (
       <Paper
         className={clsx(
@@ -165,7 +159,7 @@ class ExpansionPanel extends React.Component {
         {...other}
       >
         {summary}
-        <Collapse in={expanded} timeout="auto" {...CollapseProps} {...CollapsePropsProp}>
+        <Collapse in={expanded} timeout="auto" {...CollapseProps}>
           {children}
         </Collapse>
       </Paper>

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -29,9 +29,6 @@ describe('<ExpansionPanel />', () => {
     assert.strictEqual(wrapper.props().square, false);
     assert.strictEqual(wrapper.instance().isControlled, false);
 
-    const collapse = wrapper.find(Collapse);
-    assert.strictEqual(collapse.props()['aria-hidden'], 'true');
-
     wrapper.setProps({ expanded: true });
     assert.strictEqual(wrapper.state().expanded, false);
   });

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -128,7 +128,7 @@ class ExpansionPanelSummary extends React.Component {
         disableRipple
         disabled={disabled}
         component="div"
-        aria-expanded={Boolean(expanded)}
+        aria-expanded={expanded}
         className={clsx(
           classes.root,
           {

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -128,7 +128,7 @@ class ExpansionPanelSummary extends React.Component {
         disableRipple
         disabled={disabled}
         component="div"
-        aria-expanded={expanded}
+        aria-expanded={Boolean(expanded)}
         className={clsx(
           classes.root,
           {

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -97,7 +97,7 @@ describe('<ExpansionPanelSummary />', () => {
   describe('prop: onChange', () => {
     it('fires onChange if the summary control is clicked', () => {
       const handleChange = spy();
-      const wrapper = mount(<ExpansionPanelSummary onChange={handleChange} />);
+      const wrapper = mount(<ExpansionPanelSummary expanded={false} onChange={handleChange} />);
 
       const control = findOutermostIntrinsic(wrapper.find('[aria-expanded]'));
       const eventMock = 'woofExpansionPanelSummary';

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -1,7 +1,13 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
+import {
+  createShallow,
+  createMount,
+  findOutermostIntrinsic,
+  getClasses,
+  unwrap,
+} from '@material-ui/core/test-utils';
 import ButtonBase from '../ButtonBase';
 import ExpansionPanelSummary from './ExpansionPanelSummary';
 
@@ -89,22 +95,16 @@ describe('<ExpansionPanelSummary />', () => {
   });
 
   describe('prop: onChange', () => {
-    it('should propagate call to onChange prop', () => {
-      const eventMock = 'woofExpansionPanelSummary';
+    it('fires onChange if the summary control is clicked', () => {
       const handleChange = spy();
-      const wrapper = mount(<ExpansionPanelSummaryNaked classes={{}} onChange={handleChange} />);
-      wrapper.instance().handleChange(eventMock);
-      assert.strictEqual(handleChange.callCount, 1);
-      assert.strictEqual(handleChange.calledWith(eventMock), true);
-    });
+      const wrapper = mount(<ExpansionPanelSummary onChange={handleChange} />);
 
-    it('should not propagate call to onChange prop', () => {
+      const control = findOutermostIntrinsic(wrapper.find('[aria-expanded]'));
       const eventMock = 'woofExpansionPanelSummary';
-      const handleChange = spy();
-      const wrapper = mount(<ExpansionPanelSummaryNaked classes={{}} onChange={handleChange} />);
-      wrapper.setProps({ onChange: undefined });
-      wrapper.instance().handleChange(eventMock);
-      assert.strictEqual(handleChange.callCount, 0);
+      control.simulate('click', { eventMock });
+
+      assert.strictEqual(handleChange.callCount, 1);
+      assert.strictEqual(handleChange.calledWithMatch({ eventMock }), true);
     });
   });
 

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -120,7 +120,7 @@ class Grow extends React.Component {
             style: {
               opacity: 0,
               transform: getScale(0.75),
-              visiblity: state === 'exited' && !inProp ? 'hidden' : undefined,
+              visibility: state === 'exited' && !inProp ? 'hidden' : undefined,
               ...styles[state],
               ...style,
               ...children.props.style,


### PR DESCRIPTION
- remove redundant `aria-hidden`, `visibility` is a better alternative
- add explicit boolean cast to `aria-expanded` in `ExpansionPanelSummary`. `aria-expanded={undefined}` will not appear in the DOM

Also in this PR: It's not `vibility` or `visiblity`. It's `visibility`.