### PR TITLE
[core] Fix webstorm autocompletion

### DIFF
--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -32,6 +32,7 @@ async function createModulePackages({ from, to }) {
       const packageJson = {
         sideEffects: false,
         module: path.join('../esm', directoryPackage, 'index.js'),
+        typings: './index.d.ts',
       };
       const packageJsonPath = path.join(to, directoryPackage, 'package.json');
 


### PR DESCRIPTION
Closes #14582

Some IDEs probably don't automatically discover files once a package.json was found. This should force them to discover the types.