### PR TITLE
[Transitions] Updated react-transition-group to 2.5.3

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -40,7 +40,7 @@
     "@material-ui/system": "^4.0.0-alpha.0",
     "@material-ui/utils": "^4.0.0-alpha.0",
     "@types/jss": "^9.5.6",
-    "@types/react-transition-group": "^2.0.8",
+    "@types/react-transition-group": "^2.0.16",
     "brcast": "^3.0.1",
     "clsx": "^1.0.2",
     "csstype": "^2.5.2",
@@ -60,7 +60,7 @@
     "popper.js": "^1.14.1",
     "prop-types": "^15.7.2",
     "react-event-listener": "^0.6.2",
-    "react-transition-group": "^2.2.1",
+    "react-transition-group": "^2.5.3",
     "warning": "^4.0.1"
   },
   "sideEffects": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,10 +1904,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@^2.0.8":
-  version "2.0.15"
-  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.15.tgz#e5ee3fe558832e141cc6041bdd54caea7b787af8"
-  integrity sha512-S0QnNzbHoWXDbKBl/xk5dxA4FT+BNlBcI3hku991cl8Cz3ytOkUMcCRtzdX11eb86E131bSsQqy5WrPCdJYblw==
+"@types/react-transition-group@^2.0.16":
+  version "2.0.16"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-2.0.16.tgz#2dcb9e396ab385ee19c4af1c9caa469a14cd042f"
+  integrity sha512-FUJEx2BGJPU1qVQoWd9v7wpOwnCPTWhcE4iTaU5prry9SvwiI11lCXOci8Nz9cM/Fuf650l7Skg6nlVeCYjPFA==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

I want to update react-transition-group to version 2.5.3 because of a [fix for setState while unmounting](https://github.com/reactjs/react-transition-group/issues/164).

I don't think there are any breaking changes in the version history and I tested the documentation locally, all seems fine.