### PR TITLE
[ci] Various size snapshot enhancements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,6 +171,9 @@ jobs:
           name: Can we generate the @material-ui/core build?
           command: cd packages/material-ui && yarn build
       - run:
+          name: Can we generate the @material-ui/lab build?
+          command: cd packages/material-ui-lab && yarn build
+      - run:
           name: Can we generate the @material-ui/styles build?
           command: cd packages/material-ui-styles && yarn build
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,12 @@ jobs:
       - run:
           name: Can we build the docs?
           command: yarn docs:build
+      # temporary workaround, proposing to size-limit to make webpack alias configureable
+      - run:
+          name: Prepare size snapshot
+          command: |
+            cd packages/material-ui/build && yarn link && cd ../../../ 
+            yarn link @material-ui/core
       - run:
           name: Create a size snapshot
           command: yarn size:snapshot

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,10 +182,13 @@ jobs:
       - run:
           name: Can we generate the @material-ui/system build?
           command: cd packages/material-ui-system && yarn build
+      - run:
+          name: Prepare persisting workspace
+          command: tar cfvz builds.tar.gz packages/*/build
       - persist_to_workspace:
           root: .
           paths: 
-            - packages/*/build
+            - builds.tar.gz
             # rollup snapshot
             - packages/material-ui/size-snapshot.json
       - run:
@@ -246,8 +249,9 @@ jobs:
       - run:
           name: Restore build
           command: |
-            sudo apt install -y rsync
-            rsync -a /tmp/workspace/ .
+            mv /tmp/workspace/builds.tar.gz ./
+            tar xfvz builds.tar.gz
+            mv /tmp/workspace/packages/material-ui/size-snapshot.json packages/material-ui/size-snapshot.json
       # Netlify already do it for us but we need to check the size.
       - run:
           name: Can we build the docs?

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -125,8 +125,6 @@ async function run() {
   const anyResultsChanges = results.filter(createComparisonFilter(1, 1));
 
   if (anyResultsChanges.length > 0) {
-    markdown('This PR introduced some changes to the bundle size.');
-
     const importantChanges = results
       .filter(createComparisonFilter(parsedSizeChangeThreshold, gzipSizeChangeThreshold))
       .filter(isPackageComparison)
@@ -173,7 +171,7 @@ async function run() {
     markdown(details);
   } else {
     // this can later be removed to reduce PR noise. It is kept for now for debug
-    // purposes only. DangerJS will swallow console.logs if completes successfully
+    // purposes only. DangerJS will swallow console.logs if it completes successfully
     markdown(`No bundle size changes comparing ${commitRange}`);
   }
 }

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -78,15 +78,23 @@ function addPercent(change, goodEmoji = '', badEmooji = ':small_red_triangle:') 
 
 /**
  * Generates a Markdown table
- * @param {string[]} headers
+ * @param {{ label: string, align: 'left' | 'center' | 'right'}[]} headers
  * @param {string[][]} body
  * @returns {string}
  */
 function generateMDTable(headers, body) {
-  const tableHeaders = [headers.join(' | '), headers.map(() => ' --- ').join(' | ')];
+  const headerRow = headers.map(header => header.label);
+  const alignmentRow = headers.map(header => {
+    if (header.align === 'right') {
+      return ' ---:';
+    }
+    if (header.align === 'center') {
+      return ':---:';
+    }
+    return ' --- ';
+  });
 
-  const tablebody = body.map(r => r.join(' | '));
-  return `${tableHeaders.join('\n')}\n${tablebody.join('\n')}`;
+  return [headerRow, alignmentRow, ...body].map(row => row.join(' | ')).join('\n');
 }
 
 function generateEmphasizedChange([bundle, { parsed, gzip }]) {
@@ -131,23 +139,23 @@ async function run() {
 
     const detailsTable = generateMDTable(
       [
-        'bundle',
-        'parsed diff',
-        'gzip diff',
-        'prev parsed',
-        'current parsed',
-        'prev gzip',
-        'current gzip',
+        { label: 'bundle' },
+        { label: 'parsed diff', align: 'right' },
+        { label: 'gzip diff', align: 'right' },
+        { label: 'prev parsed', align: 'right' },
+        { label: 'current parsed', align: 'right' },
+        { label: 'prev gzip', align: 'right' },
+        { label: 'current gzip', align: 'right' },
       ],
       results.map(([bundle, { parsed, gzip }]) => {
         return [
           bundle,
           addPercent(parsed.relativeDiff),
           addPercent(gzip.relativeDiff),
-          parsed.previous,
-          parsed.current,
-          gzip.previous,
-          gzip.current,
+          parsed.previous.toLocaleString(),
+          parsed.current.toLocaleString(),
+          gzip.previous.toLocaleString(),
+          gzip.current.toLocaleString(),
         ];
       }),
     );

--- a/scripts/createSizeSnapshot.js
+++ b/scripts/createSizeSnapshot.js
@@ -70,6 +70,11 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui/build/styles/createMuiTheme.js',
     },
     {
+      name: '@material-ui/lab',
+      webpack: true,
+      path: 'packages/material-ui-lab/build/index.js',
+    },
+    {
       name: '@material-ui/styles',
       webpack: true,
       path: 'packages/material-ui-styles/build/index.js',


### PR DESCRIPTION
- renames `material-size-bot` to `mui-pr-bot` (explicit about material-ui <-> material, more generic about purpose)
- test `@material-ui/lab` build in `test_build`
- add `@material-ui/lab` to size snapshot
- add thousand sep to size snapshot table
- right align sizes in size snapshot table