### PR TITLE
[core] Add eslint-plugin-react-hooks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     ecmaVersion: 7,
     sourceType: 'module',
   },
-  plugins: ['babel', 'mocha', 'material-ui'],
+  plugins: ['babel', 'mocha', 'material-ui', 'react-hooks'],
   settings: {
     'import/resolver': {
       webpack: {
@@ -79,6 +79,8 @@ module.exports = {
         eventHandlerPropPrefix: 'on',
       },
     ],
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
     'react/jsx-filename-extension': ['error', { extensions: ['.js'] }], // airbnb is using .jsx
     'material-ui/docgen-ignore-before-comment': 'error',
     'mocha/handle-done-callback': 'error',

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -129,7 +129,7 @@ function getItemsClient(items) {
 }
 
 function useThrottledOnScroll(callback, delay) {
-  const throttledCallback = React.useMemo(() => throttle(callback, delay), [delay]);
+  const throttledCallback = React.useMemo(() => throttle(callback, delay), [callback, delay]);
 
   /* eslint-disable-next-line consistent-return */
   React.useEffect(() => {
@@ -140,7 +140,7 @@ function useThrottledOnScroll(callback, delay) {
         window.removeEventListener('scroll', throttledCallback);
       };
     }
-  }, [throttledCallback]);
+  }, [delay, throttledCallback]);
 }
 
 function AppTableOfContents(props) {
@@ -152,7 +152,7 @@ function AppTableOfContents(props) {
   const clickedRef = React.useRef(false);
   const unsetClickedRef = React.useRef(null);
 
-  const findActiveIndex = () => {
+  const findActiveIndex = React.useCallback(() => {
     // Don't set the active index based on scroll if a link was just clicked
     if (clickedRef.current) {
       return;
@@ -191,7 +191,7 @@ function AppTableOfContents(props) {
           : `#${active.hash}`,
       );
     }
-  };
+  }, [activeState]);
 
   // Update the active TOC entry if the hash changes through click on '#' icon
   const handleHashChange = () => {
@@ -214,7 +214,7 @@ function AppTableOfContents(props) {
       clearTimeout(unsetClickedRef.current);
       window.removeEventListener('hashchange', handleHashChange);
     };
-  }, []);
+  }, [handleHashChange]);
 
   React.useEffect(() => {
     setItemsServer(getItemsServer(contents, itemsCollectorRef));
@@ -223,7 +223,7 @@ function AppTableOfContents(props) {
   React.useEffect(() => {
     itemsClientRef.current = getItemsClient(itemsCollectorRef.current);
     findActiveIndex();
-  }, [itemsServer]);
+  }, [findActiveIndex]);
 
   const handleClick = hash => () => {
     // Used to disable findActiveIndex if the page scrolls due to a click

--- a/docs/src/pages/demos/progress/CircularDeterminate.hooks.js
+++ b/docs/src/pages/demos/progress/CircularDeterminate.hooks.js
@@ -10,14 +10,15 @@ const useStyles = makeStyles(theme => ({
 
 function CircularDeterminate() {
   const classes = useStyles();
-  const [completed, setCompleted] = React.useState(0);
-
-  function progress() {
-    setCompleted(completed >= 100 ? 0 : completed + 1);
-  }
+  const [progress, setProgress] = React.useState(0);
 
   React.useEffect(() => {
-    const timer = setInterval(progress, 20);
+    function tick() {
+      // reset when reaching 100%
+      setProgress(oldProgress => (oldProgress >= 100 ? 0 : oldProgress + 1));
+    }
+
+    const timer = setInterval(tick, 20);
     return () => {
       clearInterval(timer);
     };
@@ -25,11 +26,11 @@ function CircularDeterminate() {
 
   return (
     <div>
-      <CircularProgress className={classes.progress} variant="determinate" value={completed} />
+      <CircularProgress className={classes.progress} variant="determinate" value={progress} />
       <CircularProgress
         className={classes.progress}
         variant="determinate"
-        value={completed}
+        value={progress}
         color="secondary"
       />
     </div>

--- a/docs/src/pages/demos/progress/CircularIntegration.hooks.js
+++ b/docs/src/pages/demos/progress/CircularIntegration.hooks.js
@@ -44,24 +44,23 @@ function CircularIntegration() {
   const classes = useStyles();
   const [loading, setLoading] = React.useState(false);
   const [success, setSuccess] = React.useState(false);
-  let timer = null;
+  const timer = React.useRef(null);
 
   const buttonClassname = clsx({
     [classes.buttonSuccess]: success,
   });
 
-  React.useEffect(
-    () => () => {
-      clearInterval(timer);
-    },
-    [],
-  );
+  React.useEffect(() => {
+    return () => {
+      clearTimeout(timer.current);
+    };
+  }, []);
 
   function handleButtonClick() {
     if (!loading) {
       setSuccess(false);
       setLoading(true);
-      timer = setTimeout(() => {
+      timer.current = setTimeout(() => {
         setSuccess(true);
         setLoading(false);
       }, 2000);

--- a/docs/src/pages/demos/progress/CircularStatic.hooks.js
+++ b/docs/src/pages/demos/progress/CircularStatic.hooks.js
@@ -12,11 +12,11 @@ function CircularStatic() {
   const classes = useStyles();
   const [completed, setCompleted] = React.useState(0);
 
-  function progress() {
-    setCompleted(prevCompleted => (prevCompleted >= 100 ? 0 : prevCompleted + 10));
-  }
-
   React.useEffect(() => {
+    function progress() {
+      setCompleted(prevCompleted => (prevCompleted >= 100 ? 0 : prevCompleted + 10));
+    }
+
     const timer = setInterval(progress, 1000);
     return () => {
       clearInterval(timer);

--- a/docs/src/pages/demos/progress/LinearBuffer.hooks.js
+++ b/docs/src/pages/demos/progress/LinearBuffer.hooks.js
@@ -13,20 +13,27 @@ function LinearBuffer() {
   const [completed, setCompleted] = React.useState(0);
   const [buffer, setBuffer] = React.useState(10);
 
-  function progress() {
-    if (completed > 100) {
-      setCompleted(0);
-      setBuffer(10);
-    } else {
-      const diff = Math.random() * 10;
-      const diff2 = Math.random() * 10;
-      setCompleted(completed + diff);
-      setBuffer(completed + diff + diff2);
-    }
-  }
+  const progress = React.useRef();
+  React.useEffect(() => {
+    progress.current = () => {
+      if (completed > 100) {
+        setCompleted(0);
+        setBuffer(10);
+      } else {
+        const diff = Math.random() * 10;
+        const diff2 = Math.random() * 10;
+        setCompleted(completed + diff);
+        setBuffer(completed + diff + diff2);
+      }
+    };
+  });
 
   React.useEffect(() => {
-    const timer = setInterval(progress, 500);
+    function tick() {
+      progress.current();
+    }
+    const timer = setInterval(tick, 500);
+
     return () => {
       clearInterval(timer);
     };

--- a/docs/src/pages/demos/progress/LinearDeterminate.hooks.js
+++ b/docs/src/pages/demos/progress/LinearDeterminate.hooks.js
@@ -12,16 +12,17 @@ function LinearDeterminate() {
   const classes = useStyles();
   const [completed, setCompleted] = React.useState(0);
 
-  function progress() {
-    if (completed === 100) {
-      setCompleted(0);
-    } else {
-      const diff = Math.random() * 10;
-      setCompleted(Math.min(completed + diff, 100));
-    }
-  }
-
   React.useEffect(() => {
+    function progress() {
+      setCompleted(oldCompleted => {
+        if (oldCompleted === 100) {
+          return 0;
+        }
+        const diff = Math.random() * 10;
+        return Math.min(oldCompleted + diff, 100);
+      });
+    }
+
     const timer = setInterval(progress, 500);
     return () => {
       clearInterval(timer);

--- a/docs/src/pages/demos/selects/NativeSelects.hooks.js
+++ b/docs/src/pages/demos/selects/NativeSelects.hooks.js
@@ -29,15 +29,12 @@ function NativeSelects() {
   const [state, setState] = React.useState({
     age: '',
     name: 'hai',
-    labelWidth: 0,
   });
-  const inputLabelRef = React.useRef(null);
 
+  const inputLabelRef = React.useRef(null);
+  const [labelWidth, setLabelWidth] = React.useState(0);
   React.useEffect(() => {
-    setState({
-      ...state,
-      labelWidth: ReactDOM.findDOMNode(inputLabelRef.current).offsetWidth,
-    });
+    setLabelWidth(ReactDOM.findDOMNode(inputLabelRef.current).offsetWidth);
   }, []);
 
   const handleChange = name => event => {
@@ -200,11 +197,7 @@ function NativeSelects() {
           value={state.age}
           onChange={handleChange('age')}
           input={
-            <OutlinedInput
-              name="age"
-              labelWidth={state.labelWidth}
-              id="outlined-age-native-simple"
-            />
+            <OutlinedInput name="age" labelWidth={labelWidth} id="outlined-age-native-simple" />
           }
         >
           <option value="" />

--- a/docs/src/pages/demos/selects/SimpleSelect.hooks.js
+++ b/docs/src/pages/demos/selects/SimpleSelect.hooks.js
@@ -26,25 +26,22 @@ const useStyles = makeStyles(theme => ({
 
 function SimpleSelect() {
   const classes = useStyles();
-  const [state, setState] = React.useState({
+  const [values, setValues] = React.useState({
     age: '',
     name: 'hai',
-    labelWidth: 0,
   });
-  const inputLabelRef = React.useRef(null);
 
+  const inputLabelRef = React.useRef(null);
+  const [labelWidth, setLabelWidth] = React.useState(0);
   React.useEffect(() => {
-    setState({
-      ...state,
-      labelWidth: ReactDOM.findDOMNode(inputLabelRef.current).offsetWidth,
-    });
+    setLabelWidth(ReactDOM.findDOMNode(inputLabelRef.current).offsetWidth);
   }, []);
 
   function handleChange(event) {
-    setState({
-      ...state,
+    setValues(oldValues => ({
+      ...oldValues,
       [event.target.name]: event.target.value,
-    });
+    }));
   }
 
   return (
@@ -52,7 +49,7 @@ function SimpleSelect() {
       <FormControl className={classes.formControl}>
         <InputLabel htmlFor="age-simple">Age</InputLabel>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
           inputProps={{
             name: 'age',
@@ -70,7 +67,7 @@ function SimpleSelect() {
       <FormControl className={classes.formControl}>
         <InputLabel htmlFor="age-helper">Age</InputLabel>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
           input={<Input name="age" id="age-helper" />}
         >
@@ -85,7 +82,7 @@ function SimpleSelect() {
       </FormControl>
       <FormControl className={classes.formControl}>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
           displayEmpty
           name="age"
@@ -105,7 +102,7 @@ function SimpleSelect() {
           Age
         </InputLabel>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
           input={<Input name="age" id="age-label-placeholder" />}
           displayEmpty
@@ -124,7 +121,7 @@ function SimpleSelect() {
       <FormControl className={classes.formControl} disabled>
         <InputLabel htmlFor="name-disabled">Name</InputLabel>
         <Select
-          value={state.name}
+          value={values.name}
           onChange={handleChange}
           input={<Input name="name" id="name-disabled" />}
         >
@@ -140,7 +137,7 @@ function SimpleSelect() {
       <FormControl className={classes.formControl} error>
         <InputLabel htmlFor="name-error">Name</InputLabel>
         <Select
-          value={state.name}
+          value={values.name}
           onChange={handleChange}
           name="name"
           renderValue={value => `⚠️  - ${value}`}
@@ -158,7 +155,7 @@ function SimpleSelect() {
       <FormControl className={classes.formControl}>
         <InputLabel htmlFor="name-readonly">Name</InputLabel>
         <Select
-          value={state.name}
+          value={values.name}
           onChange={handleChange}
           input={<Input name="name" id="name-readonly" readOnly />}
         >
@@ -174,7 +171,7 @@ function SimpleSelect() {
       <FormControl className={classes.formControl}>
         <InputLabel htmlFor="age-auto-width">Age</InputLabel>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
           input={<Input name="age" id="age-auto-width" />}
           autoWidth
@@ -190,7 +187,7 @@ function SimpleSelect() {
       </FormControl>
       <FormControl className={classes.formControl}>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
           name="age"
           displayEmpty
@@ -208,7 +205,7 @@ function SimpleSelect() {
       <FormControl required className={classes.formControl}>
         <InputLabel htmlFor="age-required">Age</InputLabel>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
           name="age"
           inputProps={{
@@ -230,11 +227,9 @@ function SimpleSelect() {
           Age
         </InputLabel>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
-          input={
-            <OutlinedInput labelWidth={state.labelWidth} name="age" id="outlined-age-simple" />
-          }
+          input={<OutlinedInput labelWidth={labelWidth} name="age" id="outlined-age-simple" />}
         >
           <MenuItem value="">
             <em>None</em>
@@ -247,7 +242,7 @@ function SimpleSelect() {
       <FormControl variant="filled" className={classes.formControl}>
         <InputLabel htmlFor="filled-age-simple">Age</InputLabel>
         <Select
-          value={state.age}
+          value={values.age}
           onChange={handleChange}
           input={<FilledInput name="age" id="filled-age-simple" />}
         >

--- a/docs/src/pages/layout/use-media-query/UseWidth.js
+++ b/docs/src/pages/layout/use-media-query/UseWidth.js
@@ -3,10 +3,16 @@ import { ThemeProvider, useTheme } from '@material-ui/styles';
 import { unstable_useMediaQuery as useMediaQuery } from '@material-ui/core/useMediaQuery';
 import { createMuiTheme } from '@material-ui/core/styles';
 
+/**
+ * Be extremely careful using this component. It only works because the number of
+ * breakpoints in theme is static. It will break once you change the number of
+ * breakpoints. See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+ */
 function MyComponent() {
   const theme = useTheme();
   const width =
     [...theme.breakpoints.keys].reverse().reduce((output, key) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
       const matches = useMediaQuery(theme.breakpoints.only(key));
 
       return !output && matches ? key : output;

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "eslint-plugin-material-ui": "file:packages/eslint-plugin-material-ui",
     "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-react": "^7.4.0",
+    "eslint-plugin-react-hooks": "^1.2.0",
     "expect-puppeteer": "^3.5.1",
     "fg-loadcss": "^2.0.1",
     "final-form": "^4.11.0",

--- a/packages/material-ui-styles/src/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles.js
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import React from 'react';
 import warning from 'warning';
 import { getDynamicStyles } from 'jss';

--- a/packages/material-ui-styles/src/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles.test.js
@@ -324,11 +324,13 @@ describe('makeStyles', () => {
 
       const StyledComponent = () => {
         // Simulate react-hot-loader behavior
+        /* eslint-disable react-hooks/rules-of-hooks */
         if (hmr) {
           useStyles2();
         } else {
           useStyles1();
         }
+        /* eslint-enable react-hooks/rules-of-hooks */
 
         return <div />;
       };

--- a/packages/material-ui-styles/src/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles.js
@@ -52,6 +52,8 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
     let more = other;
 
     if (typeof name === 'string' || withTheme) {
+      // name and withTheme are invariant in the outer scope
+      // eslint-disable-next-line react-hooks/rules-of-hooks
       theme = useTheme();
 
       if (name) {

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -89,7 +89,7 @@ function TrapFocus(props) {
         lastFocus.current = null;
       }
     };
-  }, [open]);
+  }, [disableAutoFocus, disableEnforceFocus, disableRestoreFocus, isEnabled, open]);
 
   return (
     <React.Fragment>

--- a/packages/material-ui/src/useMediaQuery/unstable_useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/unstable_useMediaQuery.js
@@ -3,40 +3,22 @@ import React from 'react';
 // This variable will be true once the server-side hydration is completed.
 let hydrationCompleted = false;
 
-function useMounted() {
-  const mountedRef = React.useRef(false);
-
-  React.useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  return mountedRef.current;
-}
-
 function useMediaQuery(queryInput, options = {}) {
   const query = queryInput.replace('@media ', '');
-  const {
-    defaultMatches: defaultMatchesInput = false,
-    noSsr = false,
-    ssrMatchMedia = null,
-  } = options;
+  const { defaultMatches = false, noSsr = false, ssrMatchMedia = null } = options;
 
-  let defaultMatches = defaultMatchesInput;
-  const mounted = useMounted();
+  const [matches, setMatches] = React.useState(() => {
+    if (hydrationCompleted || noSsr) {
+      return window.matchMedia(query).matches;
+    }
+    if (ssrMatchMedia) {
+      return ssrMatchMedia(query).matches;
+    }
 
-  if (mounted) {
     // Once the component is mounted, we rely on the
     // event listeners to return the correct matches value.
-  } else if (hydrationCompleted || noSsr) {
-    defaultMatches = window.matchMedia(query).matches;
-  } else if (ssrMatchMedia) {
-    defaultMatches = ssrMatchMedia(query).matches;
-  }
-
-  const [matches, setMatches] = React.useState(defaultMatches);
+    return defaultMatches;
+  });
 
   React.useEffect(() => {
     hydrationCompleted = true;

--- a/packages/material-ui/src/useMediaQuery/unstable_useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/unstable_useMediaQuery.js
@@ -42,9 +42,7 @@ function useMediaQuery(queryInput, options = {}) {
     hydrationCompleted = true;
 
     const queryList = window.matchMedia(query);
-    if (matches !== queryList.matches) {
-      setMatches(queryList.matches);
-    }
+    setMatches(queryList.matches);
 
     function handleMatchesChange(event) {
       setMatches(event.matches);

--- a/packages/material-ui/src/useMediaQuery/unstable_useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/unstable_useMediaQuery.js
@@ -36,12 +36,6 @@ function useMediaQuery(queryInput, options = {}) {
     defaultMatches = ssrMatchMedia(query).matches;
   }
 
-  // Early exit for server-side rendering performance.
-  /* istanbul ignore if */
-  if (typeof window === 'undefined') {
-    return defaultMatches;
-  }
-
   const [matches, setMatches] = React.useState(defaultMatches);
 
   React.useEffect(() => {

--- a/packages/material-ui/src/useMediaQuery/unstable_useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/unstable_useMediaQuery.js
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import React from 'react';
 
 // This variable will be true once the server-side hydration is completed.
@@ -18,7 +16,7 @@ function useMounted() {
   return mountedRef.current;
 }
 
-function unstable_useMediaQuery(queryInput, options = {}) {
+function useMediaQuery(queryInput, options = {}) {
   const query = queryInput.replace('@media ', '');
   const {
     defaultMatches: defaultMatchesInput = false,
@@ -71,4 +69,4 @@ export function testReset() {
   hydrationCompleted = false;
 }
 
-export default unstable_useMediaQuery;
+export default useMediaQuery;

--- a/packages/material-ui/src/useMediaQuery/unstable_useMediaQueryTheme.js
+++ b/packages/material-ui/src/useMediaQuery/unstable_useMediaQueryTheme.js
@@ -1,10 +1,8 @@
-/* eslint-disable camelcase */
-
 import { useTheme } from '@material-ui/styles';
 import useMediaQuery from './unstable_useMediaQuery';
 import getThemeProps from '../styles/getThemeProps';
 
-function unstable_useMediaQueryTheme(query, options) {
+function useMediaQueryTheme(query, options) {
   const theme = useTheme();
   const props = getThemeProps({
     theme,
@@ -15,4 +13,4 @@ function unstable_useMediaQueryTheme(query, options) {
   return useMediaQuery(query, { ...props, ...options });
 }
 
-export default unstable_useMediaQueryTheme;
+export default useMediaQueryTheme;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5480,6 +5480,11 @@ eslint-plugin-mocha@^5.0.0:
   dependencies:
     ramda "^0.26.1"
 
+eslint-plugin-react-hooks@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.2.0.tgz#a1c78e792b8d7d3e9c2a2aad28df80b9b5cd1101"
+  integrity sha512-pb/pwyHg0K3Ss/8loSwCGRSXIsvPBHWfzcP/6jeei0SgWBOyXRbcKFpGxolg0xSmph0jQKLyM27B74clbZM/YQ==
+
 eslint-plugin-react@^7.4.0:
   version "7.12.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz#b1ecf26479d61aee650da612e425c53a99f48c8c"


### PR DESCRIPTION
For reviewers: Commits are atomic. Review should be done on a per-commit basis.

Closes #14628

### Summary 
- `react-hooks` initially reported ✖ 23 problems (9 errors, 14 warnings)
- fixed in 16 commits of which 6 fixed bugs, 5 were just for the linter, 2 improved perf, 2 false positives and 1 made for cleaner code

#### 4e4ad7f5e6d088cc421340660304d1891cc77249
[next](https://next--material-ui.netlify.com/demos/progress/#circular-determinate) vs. [PR](https://deploy-preview-14629--material-ui.netlify.com/demos/progress/#circular-determinate)

Nothing was working at all. Reason were stale closures.

#### ab8cf71f8d607e7aba6b5b7ad6e3024abc517ded
[next](https://next--material-ui.netlify.com/demos/progress/#interactive-integration) vs. [PR](https://deploy-preview-14629--material-ui.netlify.com/demos/progress/#interactive-integration)

Leaky demo:
0. Use hooks version
1. click button (progress starts)
2. switch to js version
3. wait
4. "Can't perform a React state update on an unmounted component"

Reason were stale closures.

#### d3bdef79b73e624ba50bdc83584789387b3eee8c
Linter appeasement in it's current state but the same pattern cause other bugs. Would not consider false positive personally.

#### c57640809873c872bd7a1fdd563e952f48f10bc7
Clear false positive because hooks have a naming convention. Public interface stays the same.

#### 190f8fc019692feeb416819e209afe403d6c23ac
Statement about server performance is misleading. No false positive for me personally because it might be abused.

#### 0f36d3254730dc170494a41dc53f4426d6b0324c
Caught redundant bailout which was only useful in alpha.

#### c47fd8821d65a93e4c259742e3fe64ba01cdb29b
Probably the most complicated diff. No test failed so either we have untested behavior or this is actually a perf improvement (reduces number of window.matchMedia calls to 1 instead of n).

#### 1072aaa018d57160bfcbcb392c6df60fc27d93ad
False positive. We need to test this behavior. 

#### b7b897beb075e7ef9e033935f586cb026ab5cdc3
Might be a bug in the plugin. I had another instance where it seemed to recognize invariants from the outer scope.

#### a6737b680e97e1edd19b74859cc26384649d00cd
[next](https://next--material-ui.netlify.com/demos/progress/#linear-determinate) vs [PR](https://deploy-preview-14629--material-ui.netlify.com/demos/progress/#linear-determinate)
Similar issues to other progress demos

#### d6fa9d2b9a699daa91b62847e25f90ebf205eb65
Cleaner code

#### b1570683c1536eb935d70e1126c8d215098ef318
[next](https://next--material-ui.netlify.com/demos/progress/#linear-buffer) vs [PR](https://deploy-preview-14629--material-ui.netlify.com/demos/progress/#linear-buffer)
Fix was a little bit more complicated. SImilar bug to other progress demos

#### c35ec2a6d22019d2cbe31597fbce008547eb12a8
Not a bug in our docs but if used in other apps can lead to bugs. 

#### 49f3eb045f694fee9ab9b27e1f89b659f6ac1cfb
Looks like it fixed #14628 /cc @mbrookes 

#### ffe2a628ea6e7b0c5d17fe59155b47d9dd441f90
Potential bug depending on usage.

#### 6b798187aeea22418c8ff3ae2304ecdd39138667
Needs investigation. False positive for now.