### PR TITLE
[Link] Color property is defined with a wrong type

### DIFF
--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -8,7 +8,6 @@ export interface LinkProps
     LinkClassKey,
     'component'
   > {
-  color?: PropTypes.Color;
   component?: React.ReactType<LinkProps>;
   TypographyClasses?: TypographyProps['classes'];
   underline?: 'none' | 'hover' | 'always';

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -89,6 +89,7 @@ Link.propTypes = {
    * The color of the link.
    */
   color: PropTypes.oneOf([
+    'default',
     'error',
     'inherit',
     'primary',

--- a/pages/api/link.md
+++ b/pages/api/link.md
@@ -20,7 +20,7 @@ import Link from '@material-ui/core/Link';
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children *</span> | <span class="prop-type">node</span> |   | The content of the link. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'error', 'inherit', 'primary', 'secondary', 'textPrimary', 'textSecondary'<br></span> | <span class="prop-default">'primary'</span> | The color of the link. |
+| <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'default', 'error', 'inherit', 'primary', 'secondary', 'textPrimary', 'textSecondary'<br></span> | <span class="prop-default">'primary'</span> | The color of the link. |
 | <span class="prop-name">component</span> | <span class="prop-type">element type</span> | <span class="prop-default">'a'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">TypographyClasses</span> | <span class="prop-type">object</span> |   | `classes` property applied to the [`Typography`](/api/typography/) element. |
 | <span class="prop-name">underline</span> | <span class="prop-type">enum:&nbsp;'none'&nbsp;&#124;<br>&nbsp;'hover'&nbsp;&#124;<br>&nbsp;'always'<br></span> | <span class="prop-default">'hover'</span> | Controls when the link should have an underline. |


### PR DESCRIPTION
According to documentation `LinkProps.color` property can contain one value from the next enum: 
`'error', 'inherit', 'primary', 'secondary', 'textPrimary', 'textSecondary'`.

Declaration of `color` property on `LinkProps` interface contains only `'inherit' | 'primary' | 'secondary' | 'default'` and it is overriding enum values provided by `TypographyProps.color` which is contain proper enum values.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
