### PR TITLE
[docs] Improve demo source discoverability

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -95,6 +95,7 @@ class Demo extends React.Component {
   state = {
     anchorEl: null,
     codeOpen: false,
+    demoHovered: false,
   };
 
   handleClickMore = event => {
@@ -188,6 +189,10 @@ class Demo extends React.Component {
     }));
   };
 
+  handleDemoHover = event => {
+    this.setState({ demoHovered: event.type === 'mouseenter' });
+  };
+
   getDemoData = () => {
     const { codeVariant, demo, githubLocation } = this.props;
     if (codeVariant === CODE_VARIANTS.HOOK && demo.rawHooks) {
@@ -217,7 +222,8 @@ class Demo extends React.Component {
 
   render() {
     const { classes, codeVariant, demo, demoOptions } = this.props;
-    const { anchorEl, codeOpen } = this.state;
+    const { anchorEl, codeOpen, demoHovered } = this.state;
+    const showSourceHint = false;
     const category = demoOptions.demo;
     const demoData = this.getDemoData();
     const DemoComponent = demoData.js;
@@ -237,12 +243,18 @@ class Demo extends React.Component {
                 onLanguageClick={this.handleCodeLanguageClick}
               />
               <div>
-                <Tooltip title={codeOpen ? 'Hide the source' : 'Show the source'} placement="top">
+                <Tooltip
+                  key={showSourceHint}
+                  open={showSourceHint ? true : undefined}
+                  title={codeOpen ? 'Hide the source' : 'Show the source'}
+                  placement="top"
+                >
                   <IconButton
                     data-ga-event-category={category}
                     data-ga-event-action="expand"
                     onClick={this.handleClickCodeOpen}
                     aria-label={codeOpen ? 'Hide the source' : 'Show the source'}
+                    color={demoHovered ? 'primary' : 'default'}
                   >
                     <CodeIcon />
                   </IconButton>
@@ -325,6 +337,8 @@ class Demo extends React.Component {
           className={clsx(classes.demo, {
             [classes.demoHiddenHeader]: demoOptions.hideHeader,
           })}
+          onMouseEnter={this.handleDemoHover}
+          onMouseLeave={this.handleDemoHover}
         >
           <Frame>
             <DemoComponent />

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -190,7 +190,7 @@ class Demo extends React.Component {
   };
 
   handleClickCodeOpen = () => {
-    document.cookie = `knowsAboutShowSource=true;path=/;expires=Fri, 31 Dec 9999 23:59:59 GMT`;
+    document.cookie = `knowsAboutShowSource=true;path=/;max-age=31536000`;
     this.setState(state => ({
       codeOpen: !state.codeOpen,
       knowsAboutShowSource: true,

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -222,6 +222,7 @@ class Demo extends React.Component {
     const demoData = this.getDemoData();
     const DemoComponent = demoData.js;
     const sourceLanguage = demoData.codeVariant === CODE_VARIANTS.TS ? 'tsx' : 'jsx';
+    const Frame = demoOptions.iframe ? DemoFrame : React.Fragment;
 
     return (
       <div className={classes.root}>
@@ -325,13 +326,9 @@ class Demo extends React.Component {
             [classes.demoHiddenHeader]: demoOptions.hideHeader,
           })}
         >
-          {demoOptions.iframe ? (
-            <DemoFrame>
-              <DemoComponent />
-            </DemoFrame>
-          ) : (
+          <Frame>
             <DemoComponent />
-          )}
+          </Frame>
         </div>
       </div>
     );

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -97,11 +97,11 @@ class Demo extends React.Component {
     anchorEl: null,
     codeOpen: false,
     demoHovered: false,
-    knowsAboutShowSource: false,
+    sourceHintSeen: false,
   };
 
   componentDidMount() {
-    this.setState({ knowsAboutShowSource: getCookie('knowsAboutShowSource') });
+    this.setState({ sourceHintSeen: getCookie('sourceHintSeen') });
   }
 
   handleClickMore = event => {
@@ -190,10 +190,10 @@ class Demo extends React.Component {
   };
 
   handleClickCodeOpen = () => {
-    document.cookie = `knowsAboutShowSource=true;path=/;max-age=31536000`;
+    document.cookie = `sourceHintSeen=true;path=/;max-age=31536000`;
     this.setState(state => ({
       codeOpen: !state.codeOpen,
-      knowsAboutShowSource: true,
+      sourceHintSeen: true,
     }));
   };
 
@@ -230,8 +230,8 @@ class Demo extends React.Component {
 
   render() {
     const { classes, codeVariant, demo, demoOptions } = this.props;
-    const { anchorEl, codeOpen, demoHovered, knowsAboutShowSource } = this.state;
-    const showSourceHint = demoHovered && !knowsAboutShowSource;
+    const { anchorEl, codeOpen, demoHovered, sourceHintSeen } = this.state;
+    const showSourceHint = demoHovered && !sourceHintSeen;
     const category = demoOptions.demo;
     const demoData = this.getDemoData();
     const DemoComponent = demoData.js;

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -19,6 +19,7 @@ import DemoFrame from 'docs/src/modules/components/DemoFrame';
 import DemoLanguages from 'docs/src/modules/components/DemoLanguages';
 import getDemoConfig from 'docs/src/modules/utils/getDemoConfig';
 import compose from 'docs/src/modules/utils/compose';
+import { getCookie } from 'docs/src/modules/utils/helpers';
 import { ACTION_TYPES, CODE_VARIANTS } from 'docs/src/modules/constants';
 
 function compress(object) {
@@ -96,7 +97,12 @@ class Demo extends React.Component {
     anchorEl: null,
     codeOpen: false,
     demoHovered: false,
+    knowsAboutShowSource: false,
   };
+
+  componentDidMount() {
+    this.setState({ knowsAboutShowSource: getCookie('knowsAboutShowSource') });
+  }
 
   handleClickMore = event => {
     this.setState({ anchorEl: event.currentTarget });
@@ -184,8 +190,10 @@ class Demo extends React.Component {
   };
 
   handleClickCodeOpen = () => {
+    document.cookie = `knowsAboutShowSource=true;path=/;expires=Fri, 31 Dec 9999 23:59:59 GMT`;
     this.setState(state => ({
       codeOpen: !state.codeOpen,
+      knowsAboutShowSource: true,
     }));
   };
 
@@ -222,8 +230,8 @@ class Demo extends React.Component {
 
   render() {
     const { classes, codeVariant, demo, demoOptions } = this.props;
-    const { anchorEl, codeOpen, demoHovered } = this.state;
-    const showSourceHint = false;
+    const { anchorEl, codeOpen, demoHovered, knowsAboutShowSource } = this.state;
+    const showSourceHint = demoHovered && !knowsAboutShowSource;
     const category = demoOptions.demo;
     const demoData = this.getDemoData();
     const DemoComponent = demoData.js;


### PR DESCRIPTION
Puts emphasis on the toggle demo source button when hovering over the demo itself.

I experimented with opacity but this doesn't translate very well to the dark theme: Light theme has default .54 opacity meaning we can highlight it by increasing it. However, the dark theme already is at 1 so we can't emphasize it more.

I settled on switching from the `default` color to `primary` when hovering over the demo. This is following [material design](https://material.io/design/components/buttons.html#hierarchy-placement).

This also includes showing the tooltip on hover. This features is disabled for now. Should we only display the tooltip when the toggle was never clicked? How do we persist this? cookies, localStore?