### PR TITLE
Add color property for passing to Fab component

### DIFF
--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -160,6 +160,7 @@ class SpeedDial extends React.Component {
       children: childrenProp,
       classes,
       className: classNameProp,
+      color: colorProp,
       hidden,
       icon: iconProp,
       onClick,
@@ -246,7 +247,7 @@ class SpeedDial extends React.Component {
           {...TransitionProps}
         >
           <Fab
-            color="primary"
+            color={colorProp}
             onKeyDown={this.handleKeyboardNavigation}
             aria-label={ariaLabel}
             aria-haspopup="true"
@@ -304,6 +305,10 @@ SpeedDial.propTypes = {
    */
   className: PropTypes.string,
   /**
+   * The color of the Fab component. It supports those theme colors that make sense for the Fab component.
+   */
+  color: PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary']),
+  /**
    * The direction the actions open relative to the floating action button.
    */
   direction: PropTypes.oneOf(['up', 'down', 'left', 'right']),
@@ -358,6 +363,7 @@ SpeedDial.propTypes = {
 };
 
 SpeedDial.defaultProps = {
+  color: 'primary',
   hidden: false,
   direction: 'up',
   TransitionComponent: Zoom,


### PR DESCRIPTION
The SpeedDial component uses the Fab component but provides no way to specify the color of the embedded Fab component.  This PR adds a color property to the SpeedDial component which controls the color of the Fab components - it's a direct pass-through and accepts the same values as the Fab component.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
