### PR TITLE
[SpeedDialAction] Pass onTouchEnd event onto called onClick handler

### DIFF
--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -88,10 +88,10 @@ class SpeedDialAction extends React.Component {
         onTouchStart: () => {
           startTime = new Date();
         },
-        onTouchEnd: () => {
+        onTouchEnd: (e) => {
           // only perform action if the touch is a tap, i.e. not long press
           if (new Date() - startTime < 500) {
-            onClick();
+            onClick(e);
           }
         },
       };

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -88,10 +88,10 @@ class SpeedDialAction extends React.Component {
         onTouchStart: () => {
           startTime = new Date();
         },
-        onTouchEnd: e => {
+        onTouchEnd: event => {
           // only perform action if the touch is a tap, i.e. not long press
           if (new Date() - startTime < 500) {
-            onClick(e);
+            onClick(event);
           }
         },
       };

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -88,7 +88,7 @@ class SpeedDialAction extends React.Component {
         onTouchStart: () => {
           startTime = new Date();
         },
-        onTouchEnd: (e) => {
+        onTouchEnd: e => {
           // only perform action if the touch is a tap, i.e. not long press
           if (new Date() - startTime < 500) {
             onClick(e);


### PR DESCRIPTION
The SpeedDialAction component treats the onClick property specially to support touch interfaces. 
 However, when using`onTouchStart/onTouchEnd` it doesn't pass the `Event` object onto `onClick` which prevents things like calling `preventDefault()`.  This PR forwards the `Event` object passed to `onTouchEnd` onto `onClick`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
