### PR TITLE
[TableSortLabel] Increase size and show on hover

### DIFF
--- a/docs/src/pages/demos/tables/EnhancedTable.hooks.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.hooks.js
@@ -81,19 +81,13 @@ function EnhancedTableHead(props) {
               padding={row.disablePadding ? 'none' : 'default'}
               sortDirection={orderBy === row.id ? order : false}
             >
-              <Tooltip
-                title="Sort"
-                placement={row.numeric ? 'bottom-end' : 'bottom-start'}
-                enterDelay={300}
+              <TableSortLabel
+                active={orderBy === row.id}
+                direction={order}
+                onClick={createSortHandler(row.id)}
               >
-                <TableSortLabel
-                  active={orderBy === row.id}
-                  direction={order}
-                  onClick={createSortHandler(row.id)}
-                >
-                  {row.label}
-                </TableSortLabel>
-              </Tooltip>
+                {row.label}
+              </TableSortLabel>
             </TableCell>
           ),
           this,

--- a/docs/src/pages/demos/tables/EnhancedTable.js
+++ b/docs/src/pages/demos/tables/EnhancedTable.js
@@ -83,19 +83,13 @@ class EnhancedTableHead extends React.Component {
                 padding={row.disablePadding ? 'none' : 'default'}
                 sortDirection={orderBy === row.id ? order : false}
               >
-                <Tooltip
-                  title="Sort"
-                  placement={row.numeric ? 'bottom-end' : 'bottom-start'}
-                  enterDelay={300}
+                <TableSortLabel
+                  active={orderBy === row.id}
+                  direction={order}
+                  onClick={this.createSortHandler(row.id)}
                 >
-                  <TableSortLabel
-                    active={orderBy === row.id}
-                    direction={order}
-                    onClick={this.createSortHandler(row.id)}
-                  >
-                    {row.label}
-                  </TableSortLabel>
-                </Tooltip>
+                  {row.label}
+                </TableSortLabel>
               </TableCell>
             ),
             this,

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -18,6 +18,10 @@ export const styles = theme => ({
     alignItems: 'center',
     '&:hover': {
       color: theme.palette.text.primary,
+      '& $icon': {
+        opacity: 1,
+        color: theme.palette.text.secondary,
+      },
     },
     '&:focus': {
       color: theme.palette.text.primary,
@@ -26,8 +30,9 @@ export const styles = theme => ({
   /* Styles applied to the root element if `active={true}`. */
   active: {
     color: theme.palette.text.primary,
-    '& $icon': {
+    '& $icon, &:hover $icon': {
       opacity: 1,
+      color: theme.palette.text.primary,
     },
   },
   /* Styles applied to the icon component. */
@@ -75,7 +80,7 @@ function TableSortLabel(props) {
       {...other}
     >
       {children}
-      {hideSortIcon && !active ? null : (
+      {hideSortIcon ? null : (
         <IconComponent
           className={clsx(classes.icon, classes[`iconDirection${capitalize(direction)}`])}
         />

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -80,7 +80,7 @@ function TableSortLabel(props) {
       {...other}
     >
       {children}
-      {hideSortIcon ? null : (
+      {hideSortIcon && !active ? null : (
         <IconComponent
           className={clsx(classes.icon, classes[`iconDirection${capitalize(direction)}`])}
         />

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -32,7 +32,7 @@ export const styles = theme => ({
   },
   /* Styles applied to the icon component. */
   icon: {
-    height: 16,
+    height: 18,
     marginRight: 4,
     marginLeft: 4,
     opacity: 0,
@@ -40,7 +40,7 @@ export const styles = theme => ({
       duration: theme.transitions.duration.shorter,
     }),
     userSelect: 'none',
-    width: 16,
+    width: 18,
   },
   /* Styles applied to the icon component if `direction="desc"`. */
   iconDirectionDesc: {

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -16,6 +16,9 @@ export const styles = theme => ({
     justifyContent: 'flex-start',
     flexDirection: 'inherit',
     alignItems: 'center',
+    '&:focus': {
+      color: theme.palette.text.primary,
+    },
     '&:hover': {
       color: theme.palette.text.primary,
       '& $icon': {
@@ -23,18 +26,17 @@ export const styles = theme => ({
         color: theme.palette.text.secondary,
       },
     },
-    '&:focus': {
+    '&$active': {
       color: theme.palette.text.primary,
+      // && instead of & is a workaround for https://github.com/cssinjs/jss/issues/1045
+      '&& $icon': {
+        opacity: 1,
+        color: theme.palette.text.primary,
+      },
     },
   },
   /* Styles applied to the root element if `active={true}`. */
-  active: {
-    color: theme.palette.text.primary,
-    '& $icon, &:hover $icon': {
-      opacity: 1,
-      color: theme.palette.text.primary,
-    },
-  },
+  active: {},
   /* Styles applied to the icon component. */
   icon: {
     height: 18,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR updates the table sort label to be [spec-compliant](https://material.io/design/components/data-tables.html#anatomy) again. :tada: 

As seen here, the icon size is 18px now (with 3px padding, simmilar to `<IconButton size="small" />` (not merged yet):
![image](https://user-images.githubusercontent.com/5544859/53299330-b7885500-3838-11e9-977f-fde91845ee59.png)

As seen here, the arrow is now visible (in a less opaque color) when hovering the label. This improves the visibility of the sorting feature and reduces surprises when clicking on it.

![image](https://user-images.githubusercontent.com/5544859/53299345-e0104f00-3838-11e9-996f-abae951ffa38.png)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
