### PR TITLE
[Tooltip] Improve legibility

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import warning from 'warning';
 import clsx from 'clsx';
 import RootRef from '../RootRef';
+import { fade } from '../styles/colorManipulator';
 import withStyles from '../styles/withStyles';
 import { capitalize } from '../utils/helpers';
 import Grow from '../Grow';
@@ -20,7 +21,7 @@ export const styles = theme => ({
   },
   /* Styles applied to the tooltip (label wrapper) element. */
   tooltip: {
-    backgroundColor: 'rgba(97, 97, 97, 0.9)',
+    backgroundColor: fade(theme.palette.grey[700], 0.9),
     borderRadius: theme.shape.borderRadius,
     color: theme.palette.common.white,
     fontFamily: theme.typography.fontFamily,

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -12,7 +12,6 @@ export const styles = theme => ({
   /* Styles applied to the Popper component. */
   popper: {
     zIndex: theme.zIndex.tooltip,
-    opacity: 0.9,
     pointerEvents: 'none',
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
@@ -21,7 +20,7 @@ export const styles = theme => ({
   },
   /* Styles applied to the tooltip (label wrapper) element. */
   tooltip: {
-    backgroundColor: theme.palette.grey[700],
+    backgroundColor: 'rgba(97, 97, 97, 0.9)',
     borderRadius: theme.shape.borderRadius,
     color: theme.palette.common.white,
     fontFamily: theme.typography.fontFamily,
@@ -29,12 +28,14 @@ export const styles = theme => ({
     fontSize: theme.typography.pxToRem(10),
     lineHeight: `${theme.typography.round(14 / 10)}em`,
     maxWidth: 300,
+    fontWeight: theme.typography.fontWeightMedium,
   },
   /* Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch. */
   touch: {
     padding: '8px 16px',
     fontSize: theme.typography.pxToRem(14),
     lineHeight: `${theme.typography.round(16 / 14)}em`,
+    fontWeight: theme.typography.fontWeightRegular,
   },
   /* Styles applied to the tooltip (label wrapper) element if `placement` contains "left". */
   tooltipPlacementLeft: {


### PR DESCRIPTION
...and increase font weight on desktop to improve readability

The specs only tell us about the background color and opacity (instead of setting the opacity of the whole element).

Increasing the font weight a bit improves the readability of a 10px font on normal desktop displays (i.e. no high-dpi ones). It's an opinionated change.

![image](https://user-images.githubusercontent.com/5544859/53300030-654c3180-3842-11e9-9835-42240a5436c6.png)

Before:
![image](https://user-images.githubusercontent.com/5544859/53300079-d1c73080-3842-11e9-8020-df6050365ab8.png)

After:
![image](https://user-images.githubusercontent.com/5544859/53300089-ee636880-3842-11e9-8b44-7a995d358aa6.png)


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
