### PR TITLE
[docs] Fix minor issues with demo action tooltips

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -90,6 +90,9 @@ const styles = theme => ({
       borderRadius: '0px !important',
     },
   },
+  tooltip: {
+    zIndex: theme.zIndex.appBar - 1,
+  },
 });
 
 class Demo extends React.Component {
@@ -252,6 +255,7 @@ class Demo extends React.Component {
               />
               <div>
                 <Tooltip
+                  classes={{ popper: classes.tooltip }}
                   key={showSourceHint}
                   open={showSourceHint ? true : undefined}
                   PopperProps={{ disablePortal: true }}
@@ -268,7 +272,11 @@ class Demo extends React.Component {
                     <CodeIcon />
                   </IconButton>
                 </Tooltip>
-                <Tooltip title="View the source on GitHub" placement="top">
+                <Tooltip
+                  classes={{ popper: classes.tooltip }}
+                  title="View the source on GitHub"
+                  placement="top"
+                >
                   <IconButton
                     data-ga-event-category={category}
                     data-ga-event-action="github"
@@ -280,7 +288,11 @@ class Demo extends React.Component {
                   </IconButton>
                 </Tooltip>
                 {demoOptions.hideEditButton ? null : (
-                  <Tooltip title="Edit in CodeSandbox" placement="top">
+                  <Tooltip
+                    classes={{ popper: classes.tooltip }}
+                    title="Edit in CodeSandbox"
+                    placement="top"
+                  >
                     <IconButton
                       data-ga-event-category={category}
                       data-ga-event-action="codesandbox"

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -254,6 +254,7 @@ class Demo extends React.Component {
                 <Tooltip
                   key={showSourceHint}
                   open={showSourceHint ? true : undefined}
+                  PopperProps={{ disablePortal: true }}
                   title={codeOpen ? 'Hide the source' : 'Show the source'}
                   placement="top"
                 >


### PR DESCRIPTION
- fixes source toggle tooltip being shown on small screens ddd71da47f8439b694d468f00f6e0537bf8e387b
- fixes tooltip being show in front of app bar 750d03aabc2ce159cd136d0e8030648c8c62f3a2
  I think this is the simplest solution. Determining what the best position should be would be very brittle. This should cover most edge cases. There are only a couple of pixels in which no indication of a tooltip would be visible.