### PR TITLE
[Dialog] Support for print

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -14,7 +14,11 @@ import Paper from '../Paper';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
-  root: {},
+  root: {
+    '@media print': {
+      position: 'absolute',
+    },
+  },
   /* Styles applied to the root element if `scroll="paper"`. */
   scrollPaper: {
     display: 'flex',
@@ -29,6 +33,9 @@ export const styles = theme => ({
   /* Styles applied to the container element. */
   container: {
     height: '100%',
+    '@media print': {
+      height: 'auto',
+    },
     // We disable the focus ring for mouse, touch and keyboard users.
     outline: 'none',
   },
@@ -39,6 +46,10 @@ export const styles = theme => ({
     margin: 48,
     position: 'relative',
     overflowY: 'auto', // Fix IE 11 issue, to remove at some point.
+    '@media print': {
+      overflowY: 'visible',
+      boxShadow: 'none',
+    },
   },
   /* Styles applied to the `Paper` component if `scroll="paper"`. */
   paperScrollPaper: {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

I've added some css rules, as suggested by @oliviertassinari,  for fixing the print of fullscreen dialogs

Closes #14655