### PR TITLE
[docs] Update bundle size strategy

### DIFF
--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -4,11 +4,10 @@
 
 ## Bundle size matters
 
-The bundle size of Material-UI is taken very seriously, so
-[size-limit](https://github.com/ai/size-limit) is used to prevent introducing any size regression.
-The size of the bundle is checked at each commit:
-- When importing **all the components**. This lets us spot any [unwanted bundle size increase](https://github.com/mui-org/material-ui/blob/master/.size-limit.js#L30).
-- When importing **a single component**. This lets us estimate [the overhead of our core dependencies](https://github.com/mui-org/material-ui/blob/master/.size-limit.js#L24). (styling, theming, etc.: ~18 kB gzipped)
+The bundle size of Material-UI is taken very seriously. We take size snapshots
+on every commit for every package and critical parts of those packages ([view latest snapshot](/size-snapshot)). 
+Combined with [dangerJS](https://danger.systems/js/) we can inspect
+[detailed bundle size changes](<(https://github.com/mui-org/material-ui/pull/14638#issuecomment-466658459)>) on every Pull Request.
 
 ## How to reduce the bundle size?
 

--- a/docs/src/pages/layout/use-media-query/use-media-query.md
+++ b/docs/src/pages/layout/use-media-query/use-media-query.md
@@ -10,7 +10,7 @@ Some of the key features:
 
 - ⚛️ It has an idiomatic React API.
 - 🚀 It's performant, it observes the document to detect when its media queries change, instead of polling the values periodically.
-- 📦 Less than [700 B gzipped](https://github.com/mui-org/material-ui/blob/master/.size-limit.js).
+- 📦 [1 kB gzipped](/size-snapshot).
 - 💄 It's an alternative to react-responsive and react-media that aims for simplicity.
 - 🤖 It supports Server-side rendering.
 

--- a/docs/src/pages/utils/popper/popper.md
+++ b/docs/src/pages/utils/popper/popper.md
@@ -11,7 +11,7 @@ Some important features of the `Popper` component:
 
 - 🕷 Popper relies on the 3rd party library ([Popper.js](https://github.com/FezVrasta/popper.js)) for perfect positioning.
 - 💄 It's an alternative API to react-popper. It aims for simplicity.
-- 📦 Less than [10 KB gzipped](https://github.com/mui-org/material-ui/blob/master/.size-limit.js).
+- 📦 Less than [10 KB gzipped](/size-snapshot).
 - The children is [`Portal`](/utils/portal/) to the body of the document to avoid rendering problems.
 You can disable this behavior with `disablePortal`.
 - The scroll and click away aren't blocked like with the [`Popover`](/utils/popover/) component.

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -10,6 +10,7 @@
 /utils/popovers/ /utils/popover/ 301
 /utils/popovers /utils/popover/ 301
 /guides/migration-v0.x /guides/migration-v0x/ 301
+/size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/next/latest/size-snapshot.json 200
 
 # Legacy
 /v0.20.0 https://v0.material-ui.com/v0.20.0


### PR DESCRIPTION
Closes #14627

I looked into adding redirects after a deploy finished on netlify or uploading additional files but it doesn't look like this is supported. 

We could just move the build of the deploy to CI and then upload the full deploy. That's however way more code compared to simply changing a redirect when we switch default branches.

See https://github.com/eps1lon/persist-size-snapshot/commit/89f132e1c6cdeb841bfac9710d6568f450261175