### PR TITLE
[Tabs] Fix an infinite loop

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -256,11 +256,11 @@ class Tabs extends React.Component {
       const { scrollWidth, clientWidth } = this.tabsRef;
       const scrollLeft = getNormalizedScrollLeft(this.tabsRef, theme.direction);
 
+      // use 1 for the potential rounding error with browser zooms.
       const showLeftScroll =
-        theme.direction === 'rtl' ? scrollWidth > clientWidth + scrollLeft : scrollLeft > 0;
-
+        theme.direction === 'rtl' ? scrollLeft < scrollWidth - clientWidth - 1 : scrollLeft > 1;
       const showRightScroll =
-        theme.direction === 'rtl' ? scrollLeft > 0 : scrollWidth > clientWidth + scrollLeft;
+        theme.direction !== 'rtl' ? scrollLeft < scrollWidth - clientWidth - 1 : scrollLeft > 1;
 
       if (
         showLeftScroll !== this.state.showLeftScroll ||

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -25,7 +25,7 @@ const findScrollButton = (wrapper, direction) => wrapper.find(`button[aria-label
 const hasLeftScrollButton = wrapper => findScrollButton(wrapper, 'left').exists();
 const hasRightScrollButton = wrapper => findScrollButton(wrapper, 'right').exists();
 
-describe('<Tabs />', () => {
+describe.only('<Tabs />', () => {
   let mount;
   let classes;
   let render;
@@ -512,6 +512,19 @@ describe('<Tabs />', () => {
 
         assert.strictEqual(hasLeftScrollButton(wrapper), true);
         assert.strictEqual(hasRightScrollButton(wrapper), true);
+      });
+
+      it('should not set scroll button states if difference is only one pixel', () => {
+        const wrapper = mount(tabs);
+
+        setFakeTabs(wrapper, {
+          scrollLeft: 0,
+          scrollWidth: 101,
+          clientWidth: 100,
+        });
+
+        assert.strictEqual(hasLeftScrollButton(wrapper), false);
+        assert.strictEqual(hasRightScrollButton(wrapper), false);
       });
     });
   });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -25,7 +25,7 @@ const findScrollButton = (wrapper, direction) => wrapper.find(`button[aria-label
 const hasLeftScrollButton = wrapper => findScrollButton(wrapper, 'left').exists();
 const hasRightScrollButton = wrapper => findScrollButton(wrapper, 'right').exists();
 
-describe.only('<Tabs />', () => {
+describe('<Tabs />', () => {
   let mount;
   let classes;
   let render;
@@ -482,7 +482,7 @@ describe.only('<Tabs />', () => {
       it('should set only left scroll button state', () => {
         const wrapper = mount(tabs);
 
-        setFakeTabs(wrapper, { scrollLeft: 1 });
+        setFakeTabs(wrapper, { scrollLeft: 2 });
 
         assert.strictEqual(hasLeftScrollButton(wrapper), true);
         assert.strictEqual(hasRightScrollButton(wrapper), false);
@@ -505,7 +505,7 @@ describe.only('<Tabs />', () => {
         const wrapper = mount(tabs);
 
         setFakeTabs(wrapper, {
-          scrollLeft: 1,
+          scrollLeft: 2,
           scrollWidth: 110,
           clientWidth: 100,
         });


### PR DESCRIPTION
- [ X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

I want the area for the scroll buttons of tabs to disappear when no scroll button should be displayed. Therefore I used CSS Override and set the width (or in this case the flexBasis) to 0:

```js
MuiTabs: {
  scrollButtons: {
    flexBasis: 0
  }
}
```

This works fine most of the times, but in Edge with "weird" browser zoom factors, such as 105% it leads to an infinite loop. (I have not been able to reproduce this behavior with the standard zoom factors that are available in chrome...)

The code realizes that it needs to enable the left scroll button because the scrollWidth is bigger than the clientWidth. It then comes to the code and should realize that the scrollWidth is no longer bigger than (clientWidth + scrollLeft), but for some reason there seems to be a rounding issue for the scrollWidth property which leads to the scrollWidth property being 1px bigger than the (clientWidth + scrollLeft) property. 

I fixed this by adding a "+ 1" to the condition to ignore rounding issues.
