### PR TITLE
[core] Add tslint deprecation rule

### DIFF
--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -30,9 +30,10 @@ const StyledExampleOne = withStyles(styles)(({ classes, text }: ComponentProps) 
 <StyledExampleOne text="I am styled!" />;
 
 // Example 2
-const Component: React.SFC<ComponentProps & WithStyles<typeof styles>> = ({ classes, text }) => (
-  <div className={classes.root}>{text}</div>
-);
+const Component: React.FunctionComponent<ComponentProps & WithStyles<typeof styles>> = ({
+  classes,
+  text,
+}) => <div className={classes.root}>{text}</div>;
 
 const StyledExampleTwo = withStyles(styles)(Component);
 <StyledExampleTwo text="I am styled!" />;
@@ -47,9 +48,10 @@ const styleRule = createStyles({
   },
 });
 
-const ComponentWithChildren: React.SFC<WithStyles<typeof styles>> = ({ classes, children }) => (
-  <div className={classes.root}>{children}</div>
-);
+const ComponentWithChildren: React.FunctionComponent<WithStyles<typeof styles>> = ({
+  classes,
+  children,
+}) => <div className={classes.root}>{children}</div>;
 
 const StyledExampleThree = withStyles(styleRule)(ComponentWithChildren);
 <StyledExampleThree />;
@@ -302,7 +304,7 @@ withStyles(theme =>
   // $ExpectError
   const StyledComponent = withStyles(styles)(Component);
 
-  // implicit SFC
+  // implicit FunctionComponent
   withStyles(styles)((props: Props) => null); // $ExpectError
   withStyles(styles)((props: Props & WithStyles<typeof styles>) => null); // $ExpectError
   withStyles(styles)((props: Props & { children?: React.ReactNode }) => null); // $ExpectError
@@ -312,8 +314,10 @@ withStyles(theme =>
 
   // explicit not but with "Property 'children' is missing in type 'ValidationMap<Props>'".
   // which is not helpful
-  const StatelessComponent: React.SFC<Props> = props => null;
-  const StatelessComponentWithStyles: React.SFC<Props & WithStyles<typeof styles>> = props => null;
+  const StatelessComponent: React.FunctionComponent<Props> = props => null;
+  const StatelessComponentWithStyles: React.FunctionComponent<
+    Props & WithStyles<typeof styles>
+  > = props => null;
   withStyles(styles)(StatelessComponent); // $ExpectError
   withStyles(styles)(StatelessComponentWithStyles); // $ExpectError
 }

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -917,7 +917,9 @@ const TableTest = () => {
 };
 
 const TabsTest = () => {
-  const TabContainer: React.SFC = props => <div style={{ padding: 20 }}>{props.children}</div>;
+  const TabContainer: React.FunctionComponent = props => (
+    <div style={{ padding: 20 }}>{props.children}</div>
+  );
 
   type ClassKey = 'root' | 'button';
 

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -37,9 +37,10 @@ const StyledExampleOne = withStyles(styles)(({ classes, text }: ComponentProps) 
 <StyledExampleOne text="I am styled!" />;
 
 // Example 2
-const Component: React.SFC<ComponentProps & WithStyles<typeof styles>> = ({ classes, text }) => (
-  <div className={classes.root}>{text}</div>
-);
+const Component: React.FunctionComponent<ComponentProps & WithStyles<typeof styles>> = ({
+  classes,
+  text,
+}) => <div className={classes.root}>{text}</div>;
 
 const StyledExampleTwo = withStyles(styles)(Component);
 <StyledExampleTwo text="I am styled!" />;
@@ -54,9 +55,10 @@ const styleRule = createStyles({
   },
 });
 
-const ComponentWithChildren: React.SFC<WithStyles<typeof styles>> = ({ classes, children }) => (
-  <div className={classes.root}>{children}</div>
-);
+const ComponentWithChildren: React.FunctionComponent<WithStyles<typeof styles>> = ({
+  classes,
+  children,
+}) => <div className={classes.root}>{children}</div>;
 
 const StyledExampleThree = withStyles(styleRule)(ComponentWithChildren);
 <StyledExampleThree />;
@@ -409,7 +411,7 @@ withStyles(theme =>
   // $ExpectError
   const StyledComponent = withStyles(styles)(Component);
 
-  // implicit SFC
+  // implicit FunctionComponent
   withStyles(styles)((props: Props) => null); // $ExpectError
   withStyles(styles)((props: Props & WithStyles<typeof styles>) => null); // $ExpectError
   withStyles(styles)((props: Props & { children?: React.ReactNode }) => null); // $ExpectError
@@ -419,8 +421,10 @@ withStyles(theme =>
 
   // explicit not but with "Property 'children' is missing in type 'ValidationMap<Props>'".
   // which is not helpful
-  const StatelessComponent: React.SFC<Props> = props => null;
-  const StatelessComponentWithStyles: React.SFC<Props & WithStyles<typeof styles>> = props => null;
+  const StatelessComponent: React.FunctionComponent<Props> = props => null;
+  const StatelessComponentWithStyles: React.FunctionComponent<
+    Props & WithStyles<typeof styles>
+  > = props => null;
   withStyles(styles)(StatelessComponent); // $ExpectError
   withStyles(styles)(StatelessComponentWithStyles); // $ExpectError
 }

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
     "extends": ["dtslint/dtslint.json"],
     "jsRules": {},
     "rules": {
+        "deprecation": true,
         "file-name-casing": false,
         "no-unnecessary-callback-wrapper": false,
         "no-unnecessary-generics": false,


### PR DESCRIPTION
Reports usage of deprecated API (`@deprecated` JSDOC tag). Mainly used at `@types/react` but might gain traction in other repos. 