### PR TITLE
[InputLabel] display: block as default

### DIFF
--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -12,7 +12,7 @@ export const styles = theme => ({
   /* Styles applied to the root element. */
   root: {
     display: 'block',
-    transformOrigin: 'top left'
+    transformOrigin: 'top left',
   },
   /* Styles applied to the root element if `focused={true}`. */
   focused: {},

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -11,7 +11,8 @@ import FormLabel from '../FormLabel';
 export const styles = theme => ({
   /* Styles applied to the root element. */
   root: {
-    transformOrigin: 'top left',
+    display: 'block',
+    transformOrigin: 'top left'
   },
   /* Styles applied to the root element if `focused={true}`. */
   focused: {},


### PR DESCRIPTION
Use `display: block` as the root style for `InputLabel`. This causes a shrunken `InputLabel` to actually shrink when used on it's own. Fixes #14663.