### PR TITLE
[docs] Minor next adjustments

### DIFF
--- a/docs/src/modules/utils/helpers.js
+++ b/docs/src/modules/utils/helpers.js
@@ -79,6 +79,12 @@ export function getDependencies(raw, options = {}) {
     react: reactVersion,
   };
   const versions = {
+    '@material-ui/core': 'next',
+    '@material-ui/icons': 'next',
+    '@material-ui/lab': 'next',
+    '@material-ui/styles': 'next',
+    '@material-ui/system': 'next',
+    '@material-ui/utils': 'next',
     'date-fns': 'next',
   };
   const re = /^import\s.*\sfrom\s+'([^']+)|import\s'([^']+)'/gm;

--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -23,7 +23,7 @@ const styles = theme => ({
   it('should handle @ dependencies', () => {
     assert.deepEqual(getDependencies(s1), {
       '@foo-bar/bip': 'latest',
-      '@material-ui/core': 'latest',
+      '@material-ui/core': 'next',
       'prop-types': 'latest',
       'react-dom': 'latest',
       react: 'latest',
@@ -46,7 +46,7 @@ const suggestions = [
 `;
 
     assert.deepEqual(getDependencies(s2), {
-      '@material-ui/core': 'latest',
+      '@material-ui/core': 'next',
       '@unexisting/thing': 'latest',
       'autosuggest-highlight': 'latest',
       'prop-types': 'latest',
@@ -59,7 +59,7 @@ const suggestions = [
   it('should support next dependencies', () => {
     assert.deepEqual(getDependencies(s1, { reactVersion: 'next' }), {
       '@foo-bar/bip': 'latest',
-      '@material-ui/core': 'latest',
+      '@material-ui/core': 'next',
       'prop-types': 'latest',
       'react-dom': 'next',
       react: 'next',
@@ -81,7 +81,7 @@ import { MuiPickersUtilsProvider, TimePicker, DatePicker } from 'material-ui-pic
       'date-fns': 'next',
       '@date-io/date-fns': 'latest',
       'material-ui-pickers': 'latest',
-      '@material-ui/core': 'latest',
+      '@material-ui/core': 'next',
       'prop-types': 'latest',
       'react-dom': 'latest',
       react: 'latest',
@@ -91,7 +91,7 @@ import { MuiPickersUtilsProvider, TimePicker, DatePicker } from 'material-ui-pic
   it('can collect required @types packages', () => {
     assert.deepEqual(getDependencies(s1, { codeLanguage: 'TS' }), {
       '@foo-bar/bip': 'latest',
-      '@material-ui/core': 'latest',
+      '@material-ui/core': 'next',
       'prop-types': 'latest',
       'react-dom': 'latest',
       react: 'latest',

--- a/docs/src/pages/versions/LatestVersions.js
+++ b/docs/src/pages/versions/LatestVersions.js
@@ -56,7 +56,7 @@ function LatestVersions(props) {
                 variant="body2"
                 color="secondary"
                 rel="nofollow"
-                href="https://next--material-ui.netlify.com/"
+                href="https://next.material-ui.com/"
               >
                 Documentation
               </Link>


### PR DESCRIPTION
- prefer https://next.material-ui.com/ over https://next--material-ui.netlify.com/
- use `next` npm version tag in codesandbox demos