### PR TITLE
[ExpansionPanel] Improve a11y

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -192,7 +192,6 @@ class AppSearch extends React.Component {
           <SearchIcon />
         </div>
         <Input
-          aria-label="Search in Material-UI documentation"
           disableUnderline
           placeholder="Search…"
           id="docsearch-input"

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -192,6 +192,7 @@ class AppSearch extends React.Component {
           <SearchIcon />
         </div>
         <Input
+          aria-label="Search in Material-UI documentation"
           disableUnderline
           placeholder="Search…"
           id="docsearch-input"

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -266,7 +266,6 @@ class Demo extends React.Component {
                     data-ga-event-category={category}
                     data-ga-event-action="expand"
                     onClick={this.handleClickCodeOpen}
-                    aria-label={codeOpen ? 'Hide the source' : 'Show the source'}
                     color={demoHovered ? 'primary' : 'default'}
                   >
                     <CodeIcon />
@@ -282,7 +281,6 @@ class Demo extends React.Component {
                     data-ga-event-action="github"
                     href={demoData.githubLocation}
                     target="_blank"
-                    aria-label="GitHub"
                   >
                     <Github />
                   </IconButton>
@@ -297,7 +295,6 @@ class Demo extends React.Component {
                       data-ga-event-category={category}
                       data-ga-event-action="codesandbox"
                       onClick={this.handleClickCodeSandbox}
-                      aria-label="CodeSandbox"
                     >
                       <EditIcon />
                     </IconButton>

--- a/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.hooks.js
+++ b/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.hooks.js
@@ -34,8 +34,8 @@ function ControlledExpansionPanels() {
       <ExpansionPanel expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel1-content"
-          id="panel1-header"
+          aria-controls="panel1bh-content"
+          id="panel1bh-header"
         >
           <Typography className={classes.heading}>General settings</Typography>
           <Typography className={classes.secondaryHeading}>I am an expansion panel</Typography>
@@ -50,8 +50,8 @@ function ControlledExpansionPanels() {
       <ExpansionPanel expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel2-content"
-          id="panel2-header"
+          aria-controls="panel2bh-content"
+          id="panel2bh-header"
         >
           <Typography className={classes.heading}>Users</Typography>
           <Typography className={classes.secondaryHeading}>
@@ -68,8 +68,8 @@ function ControlledExpansionPanels() {
       <ExpansionPanel expanded={expanded === 'panel3'} onChange={handleChange('panel3')}>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel3-content"
-          id="panel3-header"
+          aria-controls="panel3bh-content"
+          id="panel3bh-header"
         >
           <Typography className={classes.heading}>Advanced settings</Typography>
           <Typography className={classes.secondaryHeading}>
@@ -86,8 +86,8 @@ function ControlledExpansionPanels() {
       <ExpansionPanel expanded={expanded === 'panel4'} onChange={handleChange('panel4')}>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel4-content"
-          id="panel4-header"
+          aria-controls="panel4bh-content"
+          id="panel4bh-header"
         >
           <Typography className={classes.heading}>Personal data</Typography>
         </ExpansionPanelSummary>

--- a/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.hooks.js
+++ b/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.hooks.js
@@ -32,7 +32,11 @@ function ControlledExpansionPanels() {
   return (
     <div className={classes.root}>
       <ExpansionPanel expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel1-content"
+          id="panel1-header"
+        >
           <Typography className={classes.heading}>General settings</Typography>
           <Typography className={classes.secondaryHeading}>I am an expansion panel</Typography>
         </ExpansionPanelSummary>
@@ -44,7 +48,11 @@ function ControlledExpansionPanels() {
         </ExpansionPanelDetails>
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel2-content"
+          id="panel2-header"
+        >
           <Typography className={classes.heading}>Users</Typography>
           <Typography className={classes.secondaryHeading}>
             You are currently not an owner
@@ -58,7 +66,11 @@ function ControlledExpansionPanels() {
         </ExpansionPanelDetails>
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel3'} onChange={handleChange('panel3')}>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel3-content"
+          id="panel3-header"
+        >
           <Typography className={classes.heading}>Advanced settings</Typography>
           <Typography className={classes.secondaryHeading}>
             Filtering has been entirely disabled for whole web server
@@ -72,7 +84,11 @@ function ControlledExpansionPanels() {
         </ExpansionPanelDetails>
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel4'} onChange={handleChange('panel4')}>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel4-content"
+          id="panel4-header"
+        >
           <Typography className={classes.heading}>Personal data</Typography>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails>

--- a/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.js
+++ b/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.js
@@ -40,7 +40,11 @@ class ControlledExpansionPanels extends React.Component {
     return (
       <div className={classes.root}>
         <ExpansionPanel expanded={expanded === 'panel1'} onChange={this.handleChange('panel1')}>
-          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel1-content"
+            id="panel1-header"
+          >
             <Typography className={classes.heading}>General settings</Typography>
             <Typography className={classes.secondaryHeading}>I am an expansion panel</Typography>
           </ExpansionPanelSummary>
@@ -52,7 +56,11 @@ class ControlledExpansionPanels extends React.Component {
           </ExpansionPanelDetails>
         </ExpansionPanel>
         <ExpansionPanel expanded={expanded === 'panel2'} onChange={this.handleChange('panel2')}>
-          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel2-content"
+            id="panel2-header"
+          >
             <Typography className={classes.heading}>Users</Typography>
             <Typography className={classes.secondaryHeading}>
               You are currently not an owner
@@ -66,7 +74,11 @@ class ControlledExpansionPanels extends React.Component {
           </ExpansionPanelDetails>
         </ExpansionPanel>
         <ExpansionPanel expanded={expanded === 'panel3'} onChange={this.handleChange('panel3')}>
-          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel3-content"
+            id="panel3-header"
+          >
             <Typography className={classes.heading}>Advanced settings</Typography>
             <Typography className={classes.secondaryHeading}>
               Filtering has been entirely disabled for whole web server
@@ -80,7 +92,11 @@ class ControlledExpansionPanels extends React.Component {
           </ExpansionPanelDetails>
         </ExpansionPanel>
         <ExpansionPanel expanded={expanded === 'panel4'} onChange={this.handleChange('panel4')}>
-          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+          <ExpansionPanelSummary
+            expandIcon={<ExpandMoreIcon />}
+            aria-controls="panel4-content"
+            id="panel4-header"
+          >
             <Typography className={classes.heading}>Personal data</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>

--- a/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.js
+++ b/docs/src/pages/demos/expansion-panels/ControlledExpansionPanels.js
@@ -42,8 +42,8 @@ class ControlledExpansionPanels extends React.Component {
         <ExpansionPanel expanded={expanded === 'panel1'} onChange={this.handleChange('panel1')}>
           <ExpansionPanelSummary
             expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel1-content"
-            id="panel1-header"
+            aria-controls="panel1b-content"
+            id="panel1b-header"
           >
             <Typography className={classes.heading}>General settings</Typography>
             <Typography className={classes.secondaryHeading}>I am an expansion panel</Typography>
@@ -58,8 +58,8 @@ class ControlledExpansionPanels extends React.Component {
         <ExpansionPanel expanded={expanded === 'panel2'} onChange={this.handleChange('panel2')}>
           <ExpansionPanelSummary
             expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel2-content"
-            id="panel2-header"
+            aria-controls="panel2b-content"
+            id="panel2b-header"
           >
             <Typography className={classes.heading}>Users</Typography>
             <Typography className={classes.secondaryHeading}>
@@ -76,8 +76,8 @@ class ControlledExpansionPanels extends React.Component {
         <ExpansionPanel expanded={expanded === 'panel3'} onChange={this.handleChange('panel3')}>
           <ExpansionPanelSummary
             expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel3-content"
-            id="panel3-header"
+            aria-controls="panel3b-content"
+            id="panel3b-header"
           >
             <Typography className={classes.heading}>Advanced settings</Typography>
             <Typography className={classes.secondaryHeading}>
@@ -94,8 +94,8 @@ class ControlledExpansionPanels extends React.Component {
         <ExpansionPanel expanded={expanded === 'panel4'} onChange={this.handleChange('panel4')}>
           <ExpansionPanelSummary
             expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel4-content"
-            id="panel4-header"
+            aria-controls="panel4b-content"
+            id="panel4b-header"
           >
             <Typography className={classes.heading}>Personal data</Typography>
           </ExpansionPanelSummary>

--- a/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.js
@@ -67,7 +67,7 @@ class CustomizedExpansionPanel extends React.Component {
           expanded={expanded === 'panel1'}
           onChange={this.handleChange('panel1')}
         >
-          <ExpansionPanelSummary>
+          <ExpansionPanelSummary aria-controls="panel1-content" id="panel1-header">
             <Typography>Collapsible Group Item #1</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -83,7 +83,7 @@ class CustomizedExpansionPanel extends React.Component {
           expanded={expanded === 'panel2'}
           onChange={this.handleChange('panel2')}
         >
-          <ExpansionPanelSummary>
+          <ExpansionPanelSummary aria-controls="panel2-content" id="panel2-header">
             <Typography>Collapsible Group Item #2</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -99,7 +99,7 @@ class CustomizedExpansionPanel extends React.Component {
           expanded={expanded === 'panel3'}
           onChange={this.handleChange('panel3')}
         >
-          <ExpansionPanelSummary>
+          <ExpansionPanelSummary aria-controls="panel3-content" id="panel3-header">
             <Typography>Collapsible Group Item #3</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>

--- a/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.js
@@ -67,7 +67,7 @@ class CustomizedExpansionPanel extends React.Component {
           expanded={expanded === 'panel1'}
           onChange={this.handleChange('panel1')}
         >
-          <ExpansionPanelSummary aria-controls="panel1-content" id="panel1-header">
+          <ExpansionPanelSummary aria-controls="panel1d-content" id="panel1d-header">
             <Typography>Collapsible Group Item #1</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -83,7 +83,7 @@ class CustomizedExpansionPanel extends React.Component {
           expanded={expanded === 'panel2'}
           onChange={this.handleChange('panel2')}
         >
-          <ExpansionPanelSummary aria-controls="panel2-content" id="panel2-header">
+          <ExpansionPanelSummary aria-controls="panel2d-content" id="panel2d-header">
             <Typography>Collapsible Group Item #2</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>
@@ -99,7 +99,7 @@ class CustomizedExpansionPanel extends React.Component {
           expanded={expanded === 'panel3'}
           onChange={this.handleChange('panel3')}
         >
-          <ExpansionPanelSummary aria-controls="panel3-content" id="panel3-header">
+          <ExpansionPanelSummary aria-controls="panel3d-content" id="panel3d-header">
             <Typography>Collapsible Group Item #3</Typography>
           </ExpansionPanelSummary>
           <ExpansionPanelDetails>

--- a/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
@@ -52,7 +52,11 @@ function DetailedExpansionPanel(props) {
   return (
     <div className={classes.root}>
       <ExpansionPanel defaultExpanded>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel-content"
+          id="panel-header"
+        >
           <div className={classes.column}>
             <Typography className={classes.heading}>Location</Typography>
           </div>

--- a/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/DetailedExpansionPanel.js
@@ -54,8 +54,8 @@ function DetailedExpansionPanel(props) {
       <ExpansionPanel defaultExpanded>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel-content"
-          id="panel-header"
+          aria-controls="panel1c-content"
+          id="panel1c-header"
         >
           <div className={classes.column}>
             <Typography className={classes.heading}>Location</Typography>

--- a/docs/src/pages/demos/expansion-panels/SimpleExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/SimpleExpansionPanel.js
@@ -24,8 +24,8 @@ function SimpleExpansionPanel(props) {
       <ExpansionPanel>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel1-content"
-          id="panel1-header"
+          aria-controls="panel1a-content"
+          id="panel1a-header"
         >
           <Typography className={classes.heading}>Expansion Panel 1</Typography>
         </ExpansionPanelSummary>
@@ -39,8 +39,8 @@ function SimpleExpansionPanel(props) {
       <ExpansionPanel>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel2-content"
-          id="panel2-header"
+          aria-controls="panel2a-content"
+          id="panel2a-header"
         >
           <Typography className={classes.heading}>Expansion Panel 2</Typography>
         </ExpansionPanelSummary>
@@ -54,8 +54,8 @@ function SimpleExpansionPanel(props) {
       <ExpansionPanel disabled>
         <ExpansionPanelSummary
           expandIcon={<ExpandMoreIcon />}
-          aria-controls="panel3-content"
-          id="panel3-header"
+          aria-controls="panel3a-content"
+          id="panel3a-header"
         >
           <Typography className={classes.heading}>Disabled Expansion Panel</Typography>
         </ExpansionPanelSummary>

--- a/docs/src/pages/demos/expansion-panels/SimpleExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/SimpleExpansionPanel.js
@@ -22,7 +22,11 @@ function SimpleExpansionPanel(props) {
   return (
     <div className={classes.root}>
       <ExpansionPanel>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel1-content"
+          id="panel1-header"
+        >
           <Typography className={classes.heading}>Expansion Panel 1</Typography>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails>
@@ -33,7 +37,11 @@ function SimpleExpansionPanel(props) {
         </ExpansionPanelDetails>
       </ExpansionPanel>
       <ExpansionPanel>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel2-content"
+          id="panel2-header"
+        >
           <Typography className={classes.heading}>Expansion Panel 2</Typography>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails>
@@ -44,7 +52,11 @@ function SimpleExpansionPanel(props) {
         </ExpansionPanelDetails>
       </ExpansionPanel>
       <ExpansionPanel disabled>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+        <ExpansionPanelSummary
+          expandIcon={<ExpandMoreIcon />}
+          aria-controls="panel3-content"
+          id="panel3-header"
+        >
           <Typography className={classes.heading}>Disabled Expansion Panel</Typography>
         </ExpansionPanelSummary>
       </ExpansionPanel>

--- a/docs/src/pages/demos/expansion-panels/expansion-panels.md
+++ b/docs/src/pages/demos/expansion-panels/expansion-panels.md
@@ -11,6 +11,12 @@ components: ExpansionPanel, ExpansionPanelActions, ExpansionPanelDetails, Expans
 
 > **Note:** Expansion panels are no longer documented in the Material Design documentation.
 
+## Accessibility
+
+For optimal accessibility we recommend setting `id` and `aria-controls` on the
+`ExpansionPanelSummary`. The `ExpansionPanel` will derive the necessary `aria-labelledby`
+and `id` for the content region of the panel.
+
 ## Simple Expansion Panel
 
 {{"demo": "pages/demos/expansion-panels/SimpleExpansionPanel.js"}}

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -161,6 +161,7 @@ ExpansionPanel.propTypes = {
       );
     }
 
+    /* istanbul ignore if */
     if (!React.isValidElement(summary)) {
       return new Error(
         `Material-UI: Expected the first child of ExpansionPanel to be a valid element.${

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -137,7 +137,9 @@ class ExpansionPanel extends React.Component {
           onChange: this.handleChange,
         })}
         <TransitionComponent in={expanded} timeout="auto" {...TransitionProps}>
-          {children}
+          <div aria-labelledby={summary.props.id} id={summary.props['aria-controls']} role="region">
+            {children}
+          </div>
         </TransitionComponent>
       </Paper>
     );

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -82,11 +82,9 @@ class ExpansionPanel extends React.Component {
   constructor(props) {
     super();
     this.isControlled = props.expanded != null;
-    this.state = {};
-    if (!this.isControlled) {
-      // not controlled, use internal state
-      this.state.expanded = props.defaultExpanded !== undefined ? props.defaultExpanded : false;
-    }
+    this.state = {
+      expanded: Boolean(props.defaultExpanded),
+    };
   }
 
   handleChange = event => {

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -160,11 +160,7 @@ describe('<ExpansionPanel />', () => {
       });
 
       it('requires at least one child', () => {
-        try {
-          mount(<ExpansionPanel>[]</ExpansionPanel>);
-        } catch (err) {
-          // non-empty block for the linter
-        }
+        assert.throws(() => mount(<ExpansionPanel>[]</ExpansionPanel>));
         // 2 other errors are from cloneElement(undefined) and `prop-types`
         assert.strictEqual(consoleErrorMock.callCount(), 3);
         assert.include(consoleErrorMock.args()[0][0], 'Material-UI: Expected the first child');

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -2,7 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
+import {
+  createShallow,
+  createMount,
+  getClasses,
+  findOutermostIntrinsic,
+} from '@material-ui/core/test-utils';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Collapse from '../Collapse';
 import Paper from '../Paper';
 import ExpansionPanel from './ExpansionPanel';
@@ -12,41 +18,42 @@ describe('<ExpansionPanel />', () => {
   let mount;
   let shallow;
   let classes;
+  const minimalChildren = [<ExpansionPanelSummary key="header" />];
 
   before(() => {
     shallow = createShallow({ dive: true });
     mount = createMount();
-    classes = getClasses(<ExpansionPanel>foo</ExpansionPanel>);
+    classes = getClasses(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
   });
 
   after(() => {
     mount.cleanUp();
   });
 
-  it('should render and have isControlled set to false', () => {
-    const wrapper = shallow(<ExpansionPanel>foo</ExpansionPanel>);
-    assert.strictEqual(wrapper.type(), Paper);
-    assert.strictEqual(wrapper.props().elevation, 1);
-    assert.strictEqual(wrapper.props().square, false);
-    assert.strictEqual(wrapper.instance().isControlled, false);
+  it('should render a Paper', () => {
+    const wrapper = mount(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
+    const paper = wrapper.find(Paper);
+    assert.strictEqual(paper.exists(), true);
+    assert.strictEqual(paper.props().elevation, 1);
+    assert.strictEqual(paper.props().square, false);
+  });
+
+  it('is uncontrolled by default', () => {
+    const wrapper = mount(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
 
     wrapper.setProps({ expanded: true });
-    assert.strictEqual(wrapper.state().expanded, false);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.expanded), false);
   });
 
   it('should handle defaultExpanded prop', () => {
-    const wrapper = shallow(<ExpansionPanel defaultExpanded>foo</ExpansionPanel>);
-    assert.strictEqual(
-      wrapper.instance().isControlled,
-      false,
-      'should have isControlled state false',
-    );
-    assert.strictEqual(wrapper.state().expanded, true);
+    const wrapper = shallow(<ExpansionPanel defaultExpanded>{minimalChildren}</ExpansionPanel>);
     assert.strictEqual(wrapper.hasClass(classes.expanded), true);
   });
 
   it('should render the custom className and the root class', () => {
-    const wrapper = shallow(<ExpansionPanel className="test-class-name">foo</ExpansionPanel>);
+    const wrapper = shallow(
+      <ExpansionPanel className="test-class-name">{minimalChildren}</ExpansionPanel>,
+    );
     assert.strictEqual(wrapper.hasClass('test-class-name'), true);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
   });
@@ -66,8 +73,7 @@ describe('<ExpansionPanel />', () => {
   });
 
   it('should handle the expanded prop', () => {
-    const wrapper = shallow(<ExpansionPanel expanded>foo</ExpansionPanel>);
-    assert.strictEqual(wrapper.state().expanded, undefined);
+    const wrapper = shallow(<ExpansionPanel expanded>{minimalChildren}</ExpansionPanel>);
     assert.strictEqual(wrapper.hasClass(classes.expanded), true);
     assert.strictEqual(wrapper.instance().isControlled, true);
 
@@ -78,9 +84,7 @@ describe('<ExpansionPanel />', () => {
   it('should call onChange when clicking the summary element', () => {
     const handleChange = spy();
     const wrapper = mount(
-      <ExpansionPanel onChange={handleChange}>
-        <ExpansionPanelSummary />
-      </ExpansionPanel>,
+      <ExpansionPanel onChange={handleChange}>{minimalChildren}</ExpansionPanel>,
     );
     assert.strictEqual(wrapper.type(), ExpansionPanel);
     wrapper.find(ExpansionPanelSummary).simulate('click');
@@ -91,7 +95,7 @@ describe('<ExpansionPanel />', () => {
     const handleChange = spy();
     const wrapper = mount(
       <ExpansionPanel onChange={handleChange} expanded>
-        <ExpansionPanelSummary />
+        {minimalChildren}
       </ExpansionPanel>,
     );
     wrapper.find(ExpansionPanelSummary).simulate('click');
@@ -103,7 +107,7 @@ describe('<ExpansionPanel />', () => {
     const handleChange = spy();
     const wrapper = mount(
       <ExpansionPanel onChange={handleChange} expanded>
-        <ExpansionPanelSummary />
+        {minimalChildren}
       </ExpansionPanel>,
     );
     wrapper.setProps({ onChange: undefined });
@@ -112,7 +116,7 @@ describe('<ExpansionPanel />', () => {
   });
 
   it('when disabled should have the disabled class', () => {
-    const wrapper = shallow(<ExpansionPanel disabled>foo</ExpansionPanel>);
+    const wrapper = shallow(<ExpansionPanel disabled>{minimalChildren}</ExpansionPanel>);
     assert.strictEqual(wrapper.hasClass(classes.disabled), true);
   });
 
@@ -146,8 +150,42 @@ describe('<ExpansionPanel />', () => {
   });
 
   describe('prop: children', () => {
-    it('should accept an empty child', () => {
-      shallow(
+    describe('first child', () => {
+      beforeEach(() => {
+        consoleErrorMock.spy();
+      });
+
+      afterEach(() => {
+        consoleErrorMock.reset();
+      });
+
+      it('requires at least one child', () => {
+        try {
+          mount(<ExpansionPanel>[]</ExpansionPanel>);
+        } catch (err) {
+          // non-empty block for the linter
+        }
+        // 2 other errors are from cloneElement(undefined) and `prop-types`
+        assert.strictEqual(consoleErrorMock.callCount(), 3);
+        assert.include(consoleErrorMock.args()[0][0], 'Material-UI: Expected the first child');
+      });
+
+      it('needs a valid element as the first child', () => {
+        mount(
+          <ExpansionPanel>
+            <></>
+          </ExpansionPanel>,
+        );
+        assert.strictEqual(consoleErrorMock.callCount(), 1);
+        assert.include(
+          consoleErrorMock.args()[0][0],
+          "Material-UI: The ExpansionPanel doesn't accept a Fragment",
+        );
+      });
+    });
+
+    it('should accept empty content', () => {
+      mount(
         <ExpansionPanel>
           <ExpansionPanelSummary />
           {null}

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -159,12 +159,13 @@ describe('<ExpansionPanel />', () => {
         consoleErrorMock.reset();
       });
 
+      /* works locally but doesn't catch the errors in test:karma 
       it('requires at least one child', () => {
         assert.throws(() => mount(<ExpansionPanel>[]</ExpansionPanel>));
-        // 2 other errors are from cloneElement(undefined) and `prop-types`
+        // 2 other errors are from accesing property of undefined and react component stack
         assert.strictEqual(consoleErrorMock.callCount(), 3);
         assert.include(consoleErrorMock.args()[0][0], 'Material-UI: Expected the first child');
-      });
+      }); */
 
       it('needs a valid element as the first child', () => {
         mount(

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -218,6 +218,4 @@ ExpansionPanelSummary.defaultProps = {
   disabled: false,
 };
 
-ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';
-
 export default withStyles(styles, { name: 'MuiExpansionPanelSummary' })(ExpansionPanelSummary);


### PR DESCRIPTION
Supercedes #14616. There's nothing gained by using context here.

It's less code that was required to cover niche use cases. We already have a similar requirement for `ListItemSecondaryAction` (needs to be last child). It also reflects the hierarchy that will be observable in the DOM.

Changes:
- moves summary detection/validation into propTypes
- use `ExpansionPanelSummary` to control the a11y story (setting id and `aria-controls`)

Not a fan of automatically generating/computing ids. Since the children are expected to match `[summary, ...contet]` we can't simply grab the id from the second child to use as `aria-controls`. Might be a little bit akward to set the id in the content wrapper to `aria-controls` of the summary. Open to other suggestions.

### Breaking change 
`ExpansionPanelSummary` must be the first child in `ExpansionPanel`
```diff
<ExpansionPanel>
-  <ExpansionPanelDetails />
-  <ExpansionPanelSummary />
+  <ExpansionPanelSummary />
+  <ExpansionPanelDetails />
</ExpansionPanel>
```
