### PR TITLE
[InputBase] Add missing TypeScript class keys

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -71,7 +71,9 @@ export type InputBaseClassKey =
   | 'inputDisabled'
   | 'inputMultiline'
   | 'inputType'
-  | 'inputTypeSearch';
+  | 'inputTypeSearch'
+  | 'adornedEnd'
+  | 'adornedStart'
 
 declare const InputBase: React.ComponentType<InputBaseProps>;
 

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -63,17 +63,19 @@ export type InputBaseClassKey =
   | 'formControl'
   | 'focused'
   | 'disabled'
+  | 'adornedEnd'
+  | 'adornedStart'
   | 'error'
+  | 'marginDense'
   | 'multiline'
   | 'fullWidth'
   | 'input'
   | 'inputMarginDense'
-  | 'inputDisabled'
   | 'inputMultiline'
   | 'inputType'
   | 'inputTypeSearch'
-  | 'adornedEnd'
-  | 'adornedStart';
+  | 'inputAdornedStart'
+  | 'inputAdornedEnd';
 
 declare const InputBase: React.ComponentType<InputBaseProps>;
 

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -73,7 +73,7 @@ export type InputBaseClassKey =
   | 'inputType'
   | 'inputTypeSearch'
   | 'adornedEnd'
-  | 'adornedStart'
+  | 'adornedStart';
 
 declare const InputBase: React.ComponentType<InputBaseProps>;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR adds 2 typings of `adornedStart` | `adornedEnd` class keys. They are working for the overrides but missing in ts typings

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
