### PR TITLE
[typescript] Add regression test for popular hoc interop

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/react-dom": "^16.0.9",
     "@types/react-router-dom": "^4.3.1",
     "@types/react-text-mask": "^5.4.2",
-    "@types/styled-components": "^4.1.8",
+    "@types/styled-components": "^4.1.11",
     "accept-language": "^3.0.18",
     "argos-cli": "^0.0.9",
     "autoprefixer": "^9.0.0",

--- a/packages/material-ui/test/typescript/hoc-interop.spec.tsx
+++ b/packages/material-ui/test/typescript/hoc-interop.spec.tsx
@@ -27,8 +27,7 @@ const filledProps = {
 // styled
 {
   const StyledTextField = styled(TextField)``;
-  // $ExpectError
-  <StyledTextField variant="filled" {...filledProps} />; // undesired
+  <StyledTextField variant="filled" {...filledProps} />;
   // $ExpectError
   <StyledTextField {...filledProps} />; // desired
 }

--- a/packages/material-ui/test/typescript/hoc-interop.spec.tsx
+++ b/packages/material-ui/test/typescript/hoc-interop.spec.tsx
@@ -1,0 +1,54 @@
+/**
+ * tests type interop between our components and popular higher-order components.
+ *
+ * It's a common pattern to use some form of Pick or Omit in hocs which don't have
+ * a desired outcome when operating on union types.
+ *
+ * We use our TextField component since it has a union type as props
+ *
+ * See https://github.com/Microsoft/TypeScript/issues/28339 for in-depth discussion
+ */
+
+import TextField, { TextFieldProps } from '@material-ui/core/TextField';
+import emotionStyled from '@emotion/styled';
+import * as React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router';
+import styled from 'styled-components';
+
+const filledProps = {
+  InputProps: { classes: { inputAdornedStart: 'adorned' } },
+};
+
+// baseline behavvior
+<TextField variant="filled" {...filledProps} />;
+// $ExpectError
+<TextField {...filledProps} />; // desired
+
+// styled
+{
+  const StyledTextField = styled(TextField)``;
+  // $ExpectError
+  <StyledTextField variant="filled" {...filledProps} />; // undesired
+  // $ExpectError
+  <StyledTextField {...filledProps} />; // desired
+}
+
+// @emotion/styled
+{
+  const StyledTextField = emotionStyled(TextField)``;
+  // $ExpectError
+  <StyledTextField variant="filled" {...filledProps} />; // undesired
+  // $ExpectError
+  <StyledTextField {...filledProps} />; // desired
+}
+
+// react-router
+{
+  type RouterTextFieldProps = TextFieldProps & RouteComponentProps;
+  const RouterTextField: React.FunctionComponent<RouterTextFieldProps> = () => null;
+  const TextFieldWithRouter = withRouter(RouterTextField);
+  // $ExpectError
+  <TextFieldWithRouter variant="filled" {...filledProps} />; // undesired
+  // $ExpectError
+  <TextFieldWithRouter {...filledProps} />; // desired
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,6 +1895,14 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-native@*":
+  version "0.57.38"
+  resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.57.38.tgz#2ff6ed1a7cc207afbfd87bf496513d96931d1446"
+  integrity sha512-bmY2ad/vQgP0HMT7Q7EQzirDBt5ibp+kBHclTnY7/i5MrdqE1oY+3b9NkDg3ohXlumr7p5stAG6I55nhfeUV6Q==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/react" "*"
+
 "@types/react-router-dom@^4.3.1":
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-4.3.1.tgz#71fe2918f8f60474a891520def40a63997dafe04"
@@ -1934,13 +1942,13 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/styled-components@^4.1.8":
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.8.tgz#15c8a53bb4b9066e528fafb7558963dee5690ae0"
-  integrity sha512-NrG0wmB9Rafy5i00GFxUM/uEge148bX2QPr+Q/MI2fXrew6WOp1hN2A3YEG0AeT45z47CMdJ3BEffPsdQCWayA==
+"@types/styled-components@^4.1.11":
+  version "4.1.11"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-4.1.11.tgz#1bd97988a69be550ef8a967b87827ff943f21c4e"
+  integrity sha512-AMuEwRLqV8T9T7+OV7KnMMODKRxcEAEDGd59pJDFcjx9TTVQmUzBqw7TtNVGh1poxJsm3Iv7SURpgdUr28E7Xw==
   dependencies:
-    "@types/node" "*"
     "@types/react" "*"
+    "@types/react-native" "*"
     csstype "^2.2.0"
 
 "@webassemblyjs/ast@1.7.11":


### PR DESCRIPTION
Showcase support of different hoc declarations with union props.

@pelotom Now that we have an official recommendation to use conditionals for a distributive omit (https://github.com/Microsoft/TypeScript/issues/28339#issuecomment-467220238) I think it's ok to use union props.

Since `styled-components` already accepted the fix (used in ad3ea9f398d65d0ee7ec57034d179374d7e4ba0d) I'd hope other popular hocs would accept the fix as well:
```ts
export type Omit<T, K extends keyof T> = T extends unknown ? Pick<T, Exclude<keyof T, K>> : never;
```