### PR TITLE
[core] Use official prop-type cache invalidation

### DIFF
--- a/packages/material-ui-styles/src/styled.js
+++ b/packages/material-ui-styles/src/styled.js
@@ -84,11 +84,7 @@ function styled(Component) {
        */
       clone: chainPropTypes(PropTypes.bool, props => {
         if (props.clone && props.component) {
-          return new Error(
-            `You can not use the clone and component properties at the same time.${
-              process.env.NODE_ENV === 'test' ? Date.now() : ''
-            }`,
-          );
+          return new Error('You can not use the clone and component properties at the same time.');
         }
         return null;
       }),

--- a/packages/material-ui-styles/src/styled.test.js
+++ b/packages/material-ui-styles/src/styled.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
+import PropTypes from 'prop-types';
 import styled from './styled';
 import { SheetsRegistry } from 'jss';
 import { createMount } from '@material-ui/core/test-utils';
@@ -85,6 +86,7 @@ describe('styled', () => {
 
     afterEach(() => {
       consoleErrorMock.reset();
+      PropTypes.resetWarningCache();
     });
 
     it('warns if it cant detect the secondary action properly', () => {

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -155,9 +155,7 @@ ExpansionPanel.propTypes = {
     if (summary.type === React.Fragment) {
       return new Error(
         "Material-UI: The ExpansionPanel doesn't accept a Fragment as a child. " +
-          `Consider providing an array instead.${
-            process.env.NODE_ENV === 'test' ? Date.now() : ''
-          }`,
+          'Consider providing an array instead.',
       );
     }
 

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -157,6 +157,7 @@ describe('<ExpansionPanel />', () => {
 
       afterEach(() => {
         consoleErrorMock.reset();
+        PropTypes.resetWarningCache();
       });
 
       /* works locally but doesn't catch the errors in test:karma 

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -117,9 +117,6 @@ IconButton.propTypes = {
           'Firefox will never trigger the event.',
           'You should move the onClick listener to the parent button element.',
           'https://github.com/mui-org/material-ui/issues/13957',
-          // Change error message slightly on every check to prevent caching when testing
-          // which would not trigger console errors on subsequent fails
-          process.env.NODE_ENV === 'test' ? Date.now() : '',
         ].join('\n'),
       );
     }

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -116,6 +116,7 @@ describe('<IconButton />', () => {
 
     afterEach(() => {
       consoleErrorMock.reset();
+      PropTypes.resetWarningCache();
     });
 
     it('should raise a warning', () => {

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -204,9 +204,7 @@ ListItem.propTypes = {
       return new Error(
         'Material-UI: you used an element after ListItemSecondaryAction. ' +
           'For ListItem to detect that it has a secondary action ' +
-          `you must pass it as the last child to ListItem.${
-            process.env.NODE_ENV === 'test' ? Date.now() : ''
-          }`,
+          'you must pass it as the last child to ListItem.',
       );
     }
 

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
+import PropTypes from 'prop-types';
 import { getClasses, createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import ListItemText from '../ListItemText';
@@ -175,6 +176,7 @@ describe('<ListItem />', () => {
 
       afterEach(() => {
         consoleErrorMock.reset();
+        PropTypes.resetWarningCache();
       });
 
       it('warns if it cant detect the secondary action properly', () => {

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -213,13 +213,10 @@ TablePagination.propTypes = {
     const { count, page, rowsPerPage } = props;
     const newLastPage = Math.max(0, Math.ceil(count / rowsPerPage) - 1);
     if (page < 0 || page > newLastPage) {
-      const message =
+      return new Error(
         'Material-UI: the page prop of a TablePagination is out of range ' +
-        `(0 to ${newLastPage}, but page is ${page}).`;
-
-      // change error message slightly on every check to prevent caching when testing
-      // which would not trigger console errors on subsequent fails
-      return new Error(`${message}${process.env.NODE_ENV === 'test' ? Date.now() : ''}`);
+          `(0 to ${newLastPage}, but page is ${page}).`,
+      );
     }
     return null;
   }),

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
+import PropTypes from 'prop-types';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Select from '../Select';
@@ -289,6 +290,7 @@ describe('<TablePagination />', () => {
 
     after(() => {
       consoleErrorMock.reset();
+      PropTypes.resetWarningCache();
     });
 
     it('should raise a warning if the page prop is out of range', () => {


### PR DESCRIPTION
Use more goodies from `prop-types@15.7`. Moves cache invalidation logic away from the implementation into the test.