### PR TITLE
[Menu] Cascading Menu

### DIFF
--- a/docs/src/pages/demos/menus/CascadingMenu.js
+++ b/docs/src/pages/demos/menus/CascadingMenu.js
@@ -6,37 +6,37 @@ import SubMenu from './SubMenu';
 
 const items = [
   {
-    key: "1",
-    item: "Item 1"
+    key: '1',
+    item: 'Item 1',
   },
   {
-    key: "2",
-    item: "Item 2"
+    key: '2',
+    item: 'Item 2',
   },
   {
-    key: "3",
-    item: "Item 3"
+    key: '3',
+    item: 'Item 3',
   },
   {
-    key: "1stsub",
-    item: "More Items",
-    child: "first-cascade",
+    key: '1stsub',
+    item: 'More Items',
+    child: 'first-cascade',
     subItems: [
       {
-        key: "more1",
-        item: "SubItem 1"
+        key: 'more1',
+        item: 'SubItem 1',
       },
       {
-        key: "more2",
-        item: "SubItem 2"
+        key: 'more2',
+        item: 'SubItem 2',
       },
       {
-        key: "more3",
-        item: "SubItem 3"
+        key: 'more3',
+        item: 'SubItem 3',
       },
       {
-        key: "secondsub",
-        item: "More Subitems",
+        key: 'secondsub',
+        item: 'More Subitems',
         child: 'second-cascade',
         subItems: [
           {
@@ -46,30 +46,30 @@ const items = [
             subItems: [
               {
                 key: '1234',
-                item: 'Last Item'
+                item: 'Last Item',
               },
               {
                 key: '2222',
-                item: 'Last Item'
-              }
-            ]
-          }
-        ]
-      }
-    ]
-  }
+                item: 'Last Item',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 class CascadingMenu extends React.Component {
   state = {
     anchorEl: null,
-    anchorItems: {}
+    anchorItems: {},
   };
 
-  handleClick = (e) => {
+  handleClick = e => {
     this.setState({
-      anchorEl: e.target
-    })
+      anchorEl: e.target,
+    });
   };
 
   handleClose = () => {
@@ -77,34 +77,34 @@ class CascadingMenu extends React.Component {
   };
 
   handleSubMenuOpen = (key, e) => {
-    this.setState((prevState) => {
+    this.setState(prevState => {
       const anchorItems = Object.assign({}, prevState.anchorItems, {
         [key]: {
-          anchorEl:  e.target,
-          open: true
-        }
+          anchorEl: e.target,
+          open: true,
+        },
       });
-      return {anchorItems};
+      return { anchorItems };
     });
-  }
+  };
 
-  handleSubMenuClose = (key) => {
-    this.setState((prevState) => {
+  handleSubMenuClose = key => {
+    this.setState(prevState => {
       const anchorItems = Object.assign({}, prevState.anchorItems, {
         [key]: {
-          anchorEl:  null,
-          open: false
-        }
+          anchorEl: null,
+          open: false,
+        },
       });
-      return {anchorItems};
+      return { anchorItems };
     });
-  }
+  };
 
-  renderItems = (item) => {
+  renderItems = item => {
     const { anchorItems } = this.state;
     const { open = false, anchorEl = {} } = anchorItems[item.key] || {};
 
-    if(item.subItems) {
+    if (item.subItems) {
       return (
         <SubMenu
           key={item.key}
@@ -118,16 +118,13 @@ class CascadingMenu extends React.Component {
       );
     }
     return (
-      <MenuItem
-        key={item.key}
-        style={{display: "flex", justifyContent: "space-between"}}
-      >
+      <MenuItem key={item.key} style={{ display: 'flex', justifyContent: 'space-between' }}>
         {item.item}
       </MenuItem>
     );
-  }
+  };
 
-  renderMenuItems = (menuItems) => menuItems.map(item => this.renderItems(item))
+  renderMenuItems = menuItems => menuItems.map(item => this.renderItems(item));
 
   render() {
     const { anchorEl } = this.state;
@@ -135,7 +132,7 @@ class CascadingMenu extends React.Component {
 
     return (
       <div>
-         <Button
+        <Button
           aria-owns={open ? 'cascading-menu' : undefined}
           aria-haspopup="true"
           onClick={this.handleClick}
@@ -147,15 +144,13 @@ class CascadingMenu extends React.Component {
           anchorEl={anchorEl}
           open={open}
           onClose={this.handleClose}
-          anchorOrigin={{ vertical: "top", horizontal: "right" }}
-          transformOrigin={{ vertical: "top", horizontal: "left" }}
+          anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         >
-          {
-            this.renderMenuItems(items)
-          }
+          {this.renderMenuItems(items)}
         </Menu>
       </div>
-    )   
+    );
   }
 }
 

--- a/docs/src/pages/demos/menus/CascadingMenu.js
+++ b/docs/src/pages/demos/menus/CascadingMenu.js
@@ -89,14 +89,17 @@ class CascadingMenu extends React.Component {
   };
 
   handleCloseCascade = () => {
-    this.setState({
-      anchorItems: {}
-    }, () => {
-      this.setState({
-        anchorEl: null
-      })
-    });
-  }
+    this.setState(
+      {
+        anchorItems: {},
+      },
+      () => {
+        this.setState({
+          anchorEl: null,
+        });
+      },
+    );
+  };
 
   renderItems = item => {
     const { anchorItems } = this.state;
@@ -116,7 +119,11 @@ class CascadingMenu extends React.Component {
       );
     }
     return (
-      <MenuItem key={item.key} style={{ display: 'flex', justifyContent: 'space-between' }} onClick={this.handleCloseCascade}>
+      <MenuItem
+        key={item.key}
+        style={{ display: 'flex', justifyContent: 'space-between' }}
+        onClick={this.handleCloseCascade}
+      >
         {item.item}
       </MenuItem>
     );

--- a/docs/src/pages/demos/menus/CascadingMenu.js
+++ b/docs/src/pages/demos/menus/CascadingMenu.js
@@ -1,0 +1,162 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import SubMenu from './SubMenu';
+
+const items = [
+  {
+    key: "1",
+    item: "Item 1"
+  },
+  {
+    key: "2",
+    item: "Item 2"
+  },
+  {
+    key: "3",
+    item: "Item 3"
+  },
+  {
+    key: "1stsub",
+    item: "More Items",
+    child: "first-cascade",
+    subItems: [
+      {
+        key: "more1",
+        item: "SubItem 1"
+      },
+      {
+        key: "more2",
+        item: "SubItem 2"
+      },
+      {
+        key: "more3",
+        item: "SubItem 3"
+      },
+      {
+        key: "secondsub",
+        item: "More Subitems",
+        child: 'second-cascade',
+        subItems: [
+          {
+            key: 'thirdsub',
+            item: 'Check more',
+            child: 'third-cascade',
+            subItems: [
+              {
+                key: '1234',
+                item: 'Last Item'
+              },
+              {
+                key: '2222',
+                item: 'Last Item'
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+];
+
+class CascadingMenu extends React.Component {
+  state = {
+    anchorEl: null,
+    anchorItems: {}
+  };
+
+  handleClick = (e) => {
+    this.setState({
+      anchorEl: e.target
+    })
+  };
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  handleSubMenuOpen = (key, e) => {
+    this.setState((prevState) => {
+      const anchorItems = Object.assign({}, prevState.anchorItems, {
+        [key]: {
+          anchorEl:  e.target,
+          open: true
+        }
+      });
+      return {anchorItems};
+    });
+  }
+
+  handleSubMenuClose = (key) => {
+    this.setState((prevState) => {
+      const anchorItems = Object.assign({}, prevState.anchorItems, {
+        [key]: {
+          anchorEl:  null,
+          open: false
+        }
+      });
+      return {anchorItems};
+    });
+  }
+
+  renderItems = (item) => {
+    const { anchorItems } = this.state;
+    const { open = false, anchorEl = {} } = anchorItems[item.key] || {};
+
+    if(item.subItems) {
+      return (
+        <SubMenu
+          key={item.key}
+          open={open}
+          anchorEl={anchorEl}
+          item={item}
+          onSubMenuOpen={this.handleSubMenuOpen}
+          onSubMenuClose={this.handleSubMenuClose}
+          renderItems={this.renderItems}
+        />
+      );
+    }
+    return (
+      <MenuItem
+        key={item.key}
+        style={{display: "flex", justifyContent: "space-between"}}
+      >
+        {item.item}
+      </MenuItem>
+    );
+  }
+
+  renderMenuItems = (menuItems) => menuItems.map(item => this.renderItems(item))
+
+  render() {
+    const { anchorEl } = this.state;
+    const open = Boolean(anchorEl);
+
+    return (
+      <div>
+         <Button
+          aria-owns={open ? 'cascading-menu' : undefined}
+          aria-haspopup="true"
+          onClick={this.handleClick}
+        >
+          Open for submenu
+        </Button>
+        <Menu
+          id="cascading-menu"
+          anchorEl={anchorEl}
+          open={open}
+          onClose={this.handleClose}
+          anchorOrigin={{ vertical: "top", horizontal: "right" }}
+          transformOrigin={{ vertical: "top", horizontal: "left" }}
+        >
+          {
+            this.renderMenuItems(items)
+          }
+        </Menu>
+      </div>
+    )   
+  }
+}
+
+export default CascadingMenu;

--- a/docs/src/pages/demos/menus/CascadingMenu.js
+++ b/docs/src/pages/demos/menus/CascadingMenu.js
@@ -100,6 +100,16 @@ class CascadingMenu extends React.Component {
     });
   };
 
+  handleCloseCascade = () => {
+    this.setState({
+      anchorItems: {}
+    }, () => {
+      this.setState({
+        anchorEl: null
+      })
+    });
+  }
+
   renderItems = item => {
     const { anchorItems } = this.state;
     const { open = false, anchorEl = {} } = anchorItems[item.key] || {};
@@ -118,7 +128,7 @@ class CascadingMenu extends React.Component {
       );
     }
     return (
-      <MenuItem key={item.key} style={{ display: 'flex', justifyContent: 'space-between' }}>
+      <MenuItem key={item.key} style={{ display: 'flex', justifyContent: 'space-between' }} onClick={this.handleCloseCascade}>
         {item.item}
       </MenuItem>
     );

--- a/docs/src/pages/demos/menus/CascadingMenu.js
+++ b/docs/src/pages/demos/menus/CascadingMenu.js
@@ -88,18 +88,6 @@ class CascadingMenu extends React.Component {
     });
   };
 
-  handleSubMenuClose = key => {
-    this.setState(prevState => {
-      const anchorItems = Object.assign({}, prevState.anchorItems, {
-        [key]: {
-          anchorEl: null,
-          open: false,
-        },
-      });
-      return { anchorItems };
-    });
-  };
-
   handleCloseCascade = () => {
     this.setState({
       anchorItems: {}
@@ -122,7 +110,7 @@ class CascadingMenu extends React.Component {
           anchorEl={anchorEl}
           item={item}
           onSubMenuOpen={this.handleSubMenuOpen}
-          onSubMenuClose={this.handleSubMenuClose}
+          onSubMenuClose={this.handleCloseCascade}
           renderItems={this.renderItems}
         />
       );

--- a/docs/src/pages/demos/menus/SubMenu.js
+++ b/docs/src/pages/demos/menus/SubMenu.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import ArrowRightIcon from "@material-ui/icons/KeyboardArrowRight";
+
+class SubMenu extends React.Component {
+  handleSubMenuOpen = (e) => {
+    const {item, onSubMenuOpen} = this.props;
+    e.persist();
+    onSubMenuOpen(item.key, e);
+  }
+
+  handleSubMenuClose = (e) => {
+    const {item, onSubMenuClose} = this.props;
+    onSubMenuClose(item.key, e);
+  }
+
+  render() {
+    const {item, open, anchorEl, renderItems} = this.props;
+    return (
+      <React.Fragment key={item.key}>
+        <MenuItem
+          onClick={this.handleSubMenuOpen}
+          aria-owns={item.child}
+        >
+          {item.item}
+          <ArrowRightIcon />
+        </MenuItem>
+        <Menu
+          open={open}
+          anchorEl={anchorEl}
+          onClose={this.handleSubMenuClose}
+          anchorOrigin={{ vertical: "top", horizontal: "right" }}
+          transformOrigin={{ vertical: "top", horizontal: "left" }}
+        >
+          {
+            item.subItems.map(subItem => renderItems(subItem))
+          }
+        </Menu>
+      </React.Fragment>
+    )
+  }
+}
+
+SubMenu.propTypes = {
+  anchorEl: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  item: PropTypes.object.isRequired,
+  onSubMenuClose: PropTypes.func.isRequired,
+  onSubMenuOpen: PropTypes.func.isRequired,
+  open: PropTypes.bool.isRequired,
+  renderItems: PropTypes.func.isRequired
+}
+
+export default SubMenu;

--- a/docs/src/pages/demos/menus/SubMenu.js
+++ b/docs/src/pages/demos/menus/SubMenu.js
@@ -2,28 +2,25 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import ArrowRightIcon from "@material-ui/icons/KeyboardArrowRight";
+import ArrowRightIcon from '@material-ui/icons/KeyboardArrowRight';
 
 class SubMenu extends React.Component {
-  handleSubMenuOpen = (e) => {
-    const {item, onSubMenuOpen} = this.props;
+  handleSubMenuOpen = e => {
+    const { item, onSubMenuOpen } = this.props;
     e.persist();
     onSubMenuOpen(item.key, e);
-  }
+  };
 
-  handleSubMenuClose = (e) => {
-    const {item, onSubMenuClose} = this.props;
+  handleSubMenuClose = e => {
+    const { item, onSubMenuClose } = this.props;
     onSubMenuClose(item.key, e);
-  }
+  };
 
   render() {
-    const {item, open, anchorEl, renderItems} = this.props;
+    const { item, open, anchorEl, renderItems } = this.props;
     return (
       <React.Fragment key={item.key}>
-        <MenuItem
-          onClick={this.handleSubMenuOpen}
-          aria-owns={item.child}
-        >
+        <MenuItem onClick={this.handleSubMenuOpen} aria-owns={item.child}>
           {item.item}
           <ArrowRightIcon />
         </MenuItem>
@@ -31,15 +28,13 @@ class SubMenu extends React.Component {
           open={open}
           anchorEl={anchorEl}
           onClose={this.handleSubMenuClose}
-          anchorOrigin={{ vertical: "top", horizontal: "right" }}
-          transformOrigin={{ vertical: "top", horizontal: "left" }}
+          anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+          transformOrigin={{ vertical: 'top', horizontal: 'left' }}
         >
-          {
-            item.subItems.map(subItem => renderItems(subItem))
-          }
+          {item.subItems.map(subItem => renderItems(subItem))}
         </Menu>
       </React.Fragment>
-    )
+    );
   }
 }
 
@@ -49,7 +44,7 @@ SubMenu.propTypes = {
   onSubMenuClose: PropTypes.func.isRequired,
   onSubMenuOpen: PropTypes.func.isRequired,
   open: PropTypes.bool.isRequired,
-  renderItems: PropTypes.func.isRequired
-}
+  renderItems: PropTypes.func.isRequired,
+};
 
 export default SubMenu;

--- a/docs/src/pages/demos/menus/menus-de.md
+++ b/docs/src/pages/demos/menus/menus-de.md
@@ -69,3 +69,9 @@ For more advanced use cases you might be able to take advantage of:
 There is a 3rd party package [`material-ui-popup-state`](https://github.com/jcoreio/material-ui-popup-state) that takes care of menu state for you in most cases.
 
 {{"demo": "pages/demos/menus/MenuPopupState.js"}}
+
+## Cascading menu
+
+Open submenus
+
+{{"demo": "pages/demos/menus/CascadingMenu.js"}}

--- a/docs/src/pages/demos/menus/menus-es.md
+++ b/docs/src/pages/demos/menus/menus-es.md
@@ -69,3 +69,9 @@ Para usos más avanzados tal vez puedas aprovercharte de:
 There is a 3rd party package [`material-ui-popup-state`](https://github.com/jcoreio/material-ui-popup-state) that takes care of menu state for you in most cases.
 
 {{"demo": "pages/demos/menus/MenuPopupState.js"}}
+
+## Cascading menu
+
+Open submenus
+
+{{"demo": "pages/demos/menus/CascadingMenu.js"}}

--- a/docs/src/pages/demos/menus/menus-fr.md
+++ b/docs/src/pages/demos/menus/menus-fr.md
@@ -69,3 +69,9 @@ Pour des cas d'utilisation plus avancés, vous pourrez peut-être tirer parti de
 Il existe un package tiers [`material-ui-popup-state`](https://github.com/jcoreio/material-ui-popup-state) qui gère l’état du menu pour vous dans la plupart des cas.
 
 {{"demo": "pages/demos/menus/MenuPopupState.js"}}
+
+## Cascading menu
+
+Open submenus
+
+{{"demo": "pages/demos/menus/CascadingMenu.js"}}

--- a/docs/src/pages/demos/menus/menus-ja.md
+++ b/docs/src/pages/demos/menus/menus-ja.md
@@ -69,3 +69,9 @@ For more advanced use cases you might be able to take advantage of:
 There is a 3rd party package [`material-ui-popup-state`](https://github.com/jcoreio/material-ui-popup-state) that takes care of menu state for you in most cases.
 
 {{"demo": "pages/demos/menus/MenuPopupState.js"}}
+
+## Cascading menu
+
+Open submenus
+
+{{"demo": "pages/demos/menus/CascadingMenu.js"}}

--- a/docs/src/pages/demos/menus/menus-pt.md
+++ b/docs/src/pages/demos/menus/menus-pt.md
@@ -69,3 +69,9 @@ For more advanced use cases you might be able to take advantage of:
 There is a 3rd party package [`material-ui-popup-state`](https://github.com/jcoreio/material-ui-popup-state) that takes care of menu state for you in most cases.
 
 {{"demo": "pages/demos/menus/MenuPopupState.js"}}
+
+## Cascading menu
+
+Open submenus
+
+{{"demo": "pages/demos/menus/CascadingMenu.js"}}

--- a/docs/src/pages/demos/menus/menus-ru.md
+++ b/docs/src/pages/demos/menus/menus-ru.md
@@ -69,3 +69,9 @@ If the height of a menu prevents all menu items from being displayed, the menu c
 Существует сторонний пакет [`material-ui-popup-state`](https://github.com/jcoreio/material-ui-popup-state), который, в большинстве случаев, заботится о состоянии всплывающего меню за вас.
 
 {{"demo": "pages/demos/menus/MenuPopupState.js"}}
+
+## Cascading menu
+
+Open submenus
+
+{{"demo": "pages/demos/menus/CascadingMenu.js"}}

--- a/docs/src/pages/demos/menus/menus-zh.md
+++ b/docs/src/pages/demos/menus/menus-zh.md
@@ -69,3 +69,9 @@ components: Menu, MenuItem, MenuList, ClickAwayListener, Popover, Popper
 这里有一个第三方包 [`material-ui-popup-state`](https://github.com/jcoreio/material-ui-popup-state) 在大部分情况下，它都能帮你处理好菜单状态
 
 {{"demo": "pages/demos/menus/MenuPopupState.js"}}
+
+## Cascading menu
+
+Open submenus
+
+{{"demo": "pages/demos/menus/CascadingMenu.js"}}

--- a/docs/src/pages/demos/menus/menus.md
+++ b/docs/src/pages/demos/menus/menus.md
@@ -77,3 +77,9 @@ For more advanced use cases you might be able to take advantage of:
 There is a 3rd party package [`material-ui-popup-state`](https://github.com/jcoreio/material-ui-popup-state) that takes care of menu state for you in most cases.
 
 {{"demo": "pages/demos/menus/MenuPopupState.js"}}
+
+## Cascading menu
+
+Open submenus
+
+{{"demo": "pages/demos/menus/CascadingMenu.js"}}


### PR DESCRIPTION
Fixes #11723 

Supports 'n' Cascades with recursion.

- [ ] Keyboard navigation doesn't work on the sub-menu - **WIP**
- [x] On clicking a sub-menu item, the parent menu closes before the child
- [x] On clicking away when the sub-menu is open, the transition causes the menus to become "disconnected".
- [x] ARIA
- [ ] Support for "open on mouse-over" (optional but desirable)
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
