### PR TITLE
[Dialog] Remove scroll prop

### DIFF
--- a/docs/src/pages/demos/dialogs/ScrollDialog.hooks.js
+++ b/docs/src/pages/demos/dialogs/ScrollDialog.hooks.js
@@ -10,11 +10,9 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 
 function ScrollDialog() {
   const [open, setOpen] = React.useState(false);
-  const [scroll, setScroll] = React.useState('paper');
 
-  const handleClickOpen = scrollType => () => {
+  const handleClickOpen = () => {
     setOpen(true);
-    setScroll(scrollType);
   };
 
   function handleClose() {
@@ -23,12 +21,10 @@ function ScrollDialog() {
 
   return (
     <div>
-      <Button onClick={handleClickOpen('paper')}>scroll=paper</Button>
-      <Button onClick={handleClickOpen('body')}>scroll=body</Button>
+      <Button onClick={handleClickOpen}>open</Button>
       <Dialog
         open={open}
         onClose={handleClose}
-        scroll={scroll}
         aria-labelledby="scroll-dialog-title"
       >
         <DialogTitle id="scroll-dialog-title">Subscribe</DialogTitle>

--- a/docs/src/pages/demos/dialogs/ScrollDialog.js
+++ b/docs/src/pages/demos/dialogs/ScrollDialog.js
@@ -11,11 +11,10 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 class ScrollDialog extends React.Component {
   state = {
     open: false,
-    scroll: 'paper',
   };
 
-  handleClickOpen = scroll => () => {
-    this.setState({ open: true, scroll });
+  handleClickOpen =  () => {
+    this.setState({ open: true });
   };
 
   handleClose = () => {
@@ -25,12 +24,10 @@ class ScrollDialog extends React.Component {
   render() {
     return (
       <div>
-        <Button onClick={this.handleClickOpen('paper')}>scroll=paper</Button>
-        <Button onClick={this.handleClickOpen('body')}>scroll=body</Button>
+        <Button onClick={this.handleClickOpen}>open</Button>
         <Dialog
           open={this.state.open}
           onClose={this.handleClose}
-          scroll={this.state.scroll}
           aria-labelledby="scroll-dialog-title"
         >
           <DialogTitle id="scroll-dialog-title">Subscribe</DialogTitle>

--- a/docs/src/pages/demos/dialogs/dialogs.md
+++ b/docs/src/pages/demos/dialogs/dialogs.md
@@ -98,9 +98,6 @@ Follow the [Modal accessibility section](/utils/modal/#accessibility).
 
 When dialogs become too long for the user’s viewport or device, they scroll.
 
-- `scroll=paper` the content of the dialog scrolls within the paper element.
-- `scroll=body` the content of the dialog scrolls within the body element.
-
 Try the demo below to see what we mean:
 
 {{"demo": "pages/demos/dialogs/ScrollDialog.js"}}

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -7,7 +7,6 @@ import Fade from '../Fade';
 export const styles = {
   /* Styles applied to the root element. */
   root: {
-    zIndex: -1,
     position: 'fixed',
     right: 0,
     bottom: 0,

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -12,7 +12,6 @@ export interface DialogProps
   maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false;
   PaperComponent?: React.ComponentType<PaperProps>;
   PaperProps?: Partial<PaperProps>;
-  scroll?: 'body' | 'paper';
   TransitionComponent?: React.ComponentType<TransitionProps>;
   transitionDuration?: TransitionProps['timeout'];
   TransitionProps?: TransitionProps;
@@ -21,11 +20,9 @@ export interface DialogProps
 export type DialogClassKey =
   | 'root'
   | 'scrollPaper'
-  | 'scrollBody'
   | 'container'
   | 'paper'
   | 'paperScrollPaper'
-  | 'paperScrollBody'
   | 'paperWidthFalse'
   | 'paperWidthXs'
   | 'paperWidthSm'

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -203,7 +203,7 @@ class Dialog extends React.Component {
         closeAfterTransition
         disableBackdropClick={disableBackdropClick}
         disableEscapeKeyDown={disableEscapeKeyDown}
-        onBackdropClick={onBackdropClick}
+        onBackdropClick={this.handleBackdropClick}
         onEscapeKeyDown={onEscapeKeyDown}
         onClose={onClose}
         open={open}
@@ -222,12 +222,7 @@ class Dialog extends React.Component {
           onExited={onExited}
           {...TransitionProps}
         >
-          <div
-            className={clsx(classes.container, classes[`scroll${capitalize(scroll)}`])}
-            onClick={this.handleBackdropClick}
-            onMouseDown={this.handleMouseDown}
-            role="document"
-          >
+          <div className={clsx(classes.container, classes[`scroll${capitalize(scroll)}`])}>
             <PaperComponent
               elevation={24}
               {...PaperProps}
@@ -241,6 +236,7 @@ class Dialog extends React.Component {
                 },
                 PaperProps.className,
               )}
+              onMouseDown={this.handleMouseDown}
             >
               {children}
             </PaperComponent>

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -25,11 +25,6 @@ export const styles = theme => ({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  /* Styles applied to the root element if `scroll="body"`. */
-  scrollBody: {
-    overflowY: 'auto',
-    overflowX: 'hidden',
-  },
   /* Styles applied to the container element. */
   container: {
     height: '100%',
@@ -55,10 +50,6 @@ export const styles = theme => ({
   paperScrollPaper: {
     flex: '0 1 auto',
     maxHeight: 'calc(100% - 96px)',
-  },
-  /* Styles applied to the `Paper` component if `scroll="body"`. */
-  paperScrollBody: {
-    margin: '48px auto',
   },
   /* Styles applied to the `Paper` component if `maxWidth=false`. */
   paperWidthFalse: {
@@ -186,7 +177,6 @@ class Dialog extends React.Component {
       open,
       PaperComponent,
       PaperProps = {},
-      scroll,
       TransitionComponent,
       transitionDuration,
       TransitionProps,
@@ -195,7 +185,7 @@ class Dialog extends React.Component {
 
     return (
       <Modal
-        className={clsx(classes.root, className)}
+        className={clsx(classes.root, classes.container, classes.scrollPaper,className)}
         BackdropProps={{
           transitionDuration,
           ...BackdropProps,
@@ -222,25 +212,23 @@ class Dialog extends React.Component {
           onExited={onExited}
           {...TransitionProps}
         >
-          <div className={clsx(classes.container, classes[`scroll${capitalize(scroll)}`])}>
-            <PaperComponent
-              elevation={24}
-              {...PaperProps}
-              className={clsx(
-                classes.paper,
-                classes[`paperScroll${capitalize(scroll)}`],
-                classes[`paperWidth${capitalize(String(maxWidth))}`],
-                {
-                  [classes.paperFullScreen]: fullScreen,
-                  [classes.paperFullWidth]: fullWidth,
-                },
-                PaperProps.className,
-              )}
-              onMouseDown={this.handleMouseDown}
-            >
-              {children}
-            </PaperComponent>
-          </div>
+          <PaperComponent
+            elevation={24}
+            {...PaperProps}
+            className={clsx(
+              classes.paper,
+              classes.paperScrollPaper,
+              classes[`paperWidth${capitalize(String(maxWidth))}`],
+              {
+                [classes.paperFullScreen]: fullScreen,
+                [classes.paperFullWidth]: fullWidth,
+              },
+              PaperProps.className,
+            )}
+            onMouseDown={this.handleMouseDown}
+          >
+            {children}
+          </PaperComponent>
         </TransitionComponent>
       </Modal>
     );
@@ -340,10 +328,6 @@ Dialog.propTypes = {
    */
   PaperProps: PropTypes.object,
   /**
-   * Determine the container for scrolling the dialog.
-   */
-  scroll: PropTypes.oneOf(['body', 'paper']),
-  /**
    * The component used for the transition.
    */
   TransitionComponent: PropTypes.elementType,
@@ -368,7 +352,6 @@ Dialog.defaultProps = {
   fullWidth: false,
   maxWidth: 'sm',
   PaperComponent: Paper,
-  scroll: 'paper',
   TransitionComponent: Fade,
   transitionDuration: { enter: duration.enteringScreen, exit: duration.leavingScreen },
 };


### PR DESCRIPTION
Had a hard time finding a proper way to test this behavior on a mounted component. Looks like this implements the same feature while getting rid of some internal gotchas (onBackdropClick not actually being fired from the Backdrop, opinionated `role="document"` that looked like it was only attached to appease the linter etc.

@joshwooding did most of the work to fix #13648. Could you take a look if this is still good? 

If this is accepted I'll improve the tests later to use `mount`. Don't think the tests give use much confidence here anyway since it relies heavily on event bubbling/capturing. Would be better to have a real e2e test here.