### PR TITLE
[FilledInput] Simplify border overrides

### DIFF
--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -77,7 +77,7 @@ export const styles = theme => {
         borderBottom: `1px solid ${theme.palette.text.primary}`,
       },
       '&$disabled:before': {
-        borderBottom: `1px dotted ${bottomLineColor}`,
+        borderBottomStyle: 'dotted',
       },
     },
     /* Styles applied to the root element if the component is focused. */


### PR DESCRIPTION
Simple fix for #14446.  Just changed the disable css style to only specify the border bottom style, instead of the entire border property.  This will make overrides a little simpler.

Thanks!

Closes #14446.