### PR TITLE
[test] Ignore the image load issue

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -40,12 +40,11 @@ const blacklistSuite = [
 
   // Less important
   'docs-layouts',
+
+  // Image load issue
   'docs-getting-started-page-layout-examples-album',
   'docs-getting-started-page-layout-examples-blog',
-  'docs-getting-started-page-layout-examples-checkout',
-  'docs-getting-started-page-layout-examples-dashboard',
-  'docs-getting-started-page-layout-examples-pricing',
-  'docs-getting-started-page-layout-examples-sign-in',
+  'docs-getting-started-page-layout-examples-sign-in-side',
 
   // Useless
   'docs-', // Home


### PR DESCRIPTION
I have noticed a flaky visual regression test. Some example layout pages load a random image from unsplash. The simplest option, for now, is to disable these tests. In the future, if we have a regression in these demos, we should be able to find a better tradeoff with more effort. 