### PR TITLE
[Button] New filled variant override example

### DIFF
--- a/docs/src/pages/demos/text-fields/CustomizedInputs.js
+++ b/docs/src/pages/demos/text-fields/CustomizedInputs.js
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 import { withStyles, MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import Input from '@material-ui/core/Input';
 import InputBase from '@material-ui/core/InputBase';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import InputLabel from '@material-ui/core/InputLabel';
 import TextField from '@material-ui/core/TextField';
 import FormControl from '@material-ui/core/FormControl';
+import FilledInput from '@material-ui/core/FilledInput';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
@@ -62,13 +64,27 @@ const styles = theme => ({
       '"Segoe UI Symbol"',
     ].join(','),
     '&:focus': {
-      borderRadius: 4,
-      borderColor: '#80bdff',
-      boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+      boxShadow: `${fade(theme.palette.primary.main, 0.25)} 0 0 0 0.2rem`,
+      borderColor: theme.palette.primary.main,
     },
   },
   bootstrapFormLabel: {
     fontSize: 18,
+  },
+  redditRoot: {
+    border: '1px solid #e2e2e1',
+    overflow: 'hidden',
+    borderRadius: 4,
+    backgroundColor: '#fcfcfb',
+    transition: theme.transitions.create(['border-color', 'box-shadow']),
+    '&:hover': {
+      backgroundColor: '#fff',
+    },
+    '&.focused': {
+      backgroundColor: '#fff',
+      boxShadow: `${fade(theme.palette.primary.main, 0.25)} 0 0 0 2px`,
+      borderColor: theme.palette.primary.main,
+    },
   },
 });
 
@@ -144,6 +160,18 @@ function CustomizedInputs(props) {
           classes={{
             root: classes.bootstrapRoot,
             input: classes.bootstrapInput,
+          }}
+        />
+      </FormControl>
+      <FormControl className={classes.margin} variant="filled">
+        <InputLabel htmlFor="reddit-input">Reddit</InputLabel>
+        <FilledInput
+          id="reddit-input"
+          defaultValue="react-reddit"
+          disableUnderline
+          classes={{
+            root: classes.redditRoot,
+            focused: 'focused',
           }}
         />
       </FormControl>

--- a/docs/src/pages/demos/text-fields/CustomizedInputs.tsx
+++ b/docs/src/pages/demos/text-fields/CustomizedInputs.tsx
@@ -10,9 +10,11 @@ import {
 } from '@material-ui/core/styles';
 import Input from '@material-ui/core/Input';
 import InputBase from '@material-ui/core/InputBase';
+import { fade } from '@material-ui/core/styles/colorManipulator';
 import InputLabel from '@material-ui/core/InputLabel';
 import TextField from '@material-ui/core/TextField';
 import FormControl from '@material-ui/core/FormControl';
+import FilledInput from '@material-ui/core/FilledInput';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
@@ -70,13 +72,27 @@ const styles = (theme: Theme) =>
         '"Segoe UI Symbol"',
       ].join(','),
       '&:focus': {
-        borderRadius: 4,
-        borderColor: '#80bdff',
-        boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+        boxShadow: `${fade(theme.palette.primary.main, 0.25)} 0 0 0 0.2rem`,
+        borderColor: theme.palette.primary.main,
       },
     },
     bootstrapFormLabel: {
       fontSize: 18,
+    },
+    redditRoot: {
+      border: '1px solid #e2e2e1',
+      overflow: 'hidden',
+      borderRadius: 4,
+      backgroundColor: '#fcfcfb',
+      transition: theme.transitions.create(['border-color', 'box-shadow']),
+      '&:hover': {
+        backgroundColor: '#fff',
+      },
+      '&.focused': {
+        backgroundColor: '#fff',
+        boxShadow: `${fade(theme.palette.primary.main, 0.25)} 0 0 0 2px`,
+        borderColor: theme.palette.primary.main,
+      },
     },
   });
 
@@ -152,6 +168,18 @@ function CustomizedInputs(props: Props) {
           classes={{
             root: classes.bootstrapRoot,
             input: classes.bootstrapInput,
+          }}
+        />
+      </FormControl>
+      <FormControl className={classes.margin} variant="filled">
+        <InputLabel htmlFor="reddit-input">Reddit</InputLabel>
+        <FilledInput
+          id="reddit-input"
+          defaultValue="react-reddit"
+          disableUnderline
+          classes={{
+            root: classes.redditRoot,
+            focused: 'focused',
           }}
         />
       </FormControl>


### PR DESCRIPTION
We have a customization example for the standard and outlined variant, but none for the filled. 

![capture d ecran 2019-03-03 a 18 06 45](https://user-images.githubusercontent.com/3165635/53698693-8384d500-3de0-11e9-9951-3e0a5ae42e13.png)

I wish we had a size=small implementation, the demo would be even better.