### PR TITLE
[icons] Fix builder failing on Windows

### DIFF
--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -64,11 +64,11 @@ const svgo = new SVGO({
 /**
  * Return Pascal-Cased component name.
  *
- * @param {string} svgPath
+ * @param {string} destPath
  * @returns {string} class name
  */
 function getComponentName(destPath) {
-  const splitregex = new RegExp(`[${path.sep}-]+`);
+  const splitregex = new RegExp(`[\\${path.sep}-]+`);
 
   const parts = destPath
     .replace('.js', '')
@@ -93,9 +93,10 @@ async function generateIndex(options) {
 async function worker({ svgPath, options, renameFilter, template }) {
   process.stdout.write('.');
 
-  const svgPathObj = path.parse(svgPath);
+  const normalizedSvgPath = path.normalize(svgPath);
+  const svgPathObj = path.parse(normalizedSvgPath);
   const innerPath = path
-    .dirname(svgPath)
+    .dirname(normalizedSvgPath)
     .replace(options.svgDir, '')
     .replace(path.relative(process.cwd(), options.svgDir), ''); // for relative dirs
   const destPath = renameFilter(svgPathObj, innerPath, options);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Fixes #14683

getComponentName - path.sep returns `\` which breaks the regex it needs to be escaped.

worker - svgPath is returned with POSIX path seperators, normalizing fixes this and paths are then worked out correctly.

cc @ryancogswell 