### PR TITLE
[docs] Improve scroll discoverability for long Dialogs

### DIFF
--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.hooks.js
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.hooks.js
@@ -9,6 +9,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
 import Dialog from '@material-ui/core/Dialog';
+import Divider from '@material-ui/core/Divider';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -66,6 +67,7 @@ function ConfirmationDialogRaw(props) {
       {...otherProps}
     >
       <DialogTitle id="confirmation-dialog-title">Phone Ringtone</DialogTitle>
+      <Divider />
       <DialogContent>
         <RadioGroup
           ref={radioGroupRef}
@@ -79,6 +81,7 @@ function ConfirmationDialogRaw(props) {
           ))}
         </RadioGroup>
       </DialogContent>
+      <Divider />
       <DialogActions>
         <Button onClick={handleCancel} color="primary">
           Cancel

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.js
@@ -9,6 +9,7 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogActions from '@material-ui/core/DialogActions';
 import Dialog from '@material-ui/core/Dialog';
+import Divider from '@material-ui/core/Divider';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import Radio from '@material-ui/core/Radio';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -74,6 +75,7 @@ class ConfirmationDialogRaw extends React.Component {
         {...other}
       >
         <DialogTitle id="confirmation-dialog-title">Phone Ringtone</DialogTitle>
+        <Divider />
         <DialogContent>
           <RadioGroup
             ref={ref => {
@@ -89,6 +91,7 @@ class ConfirmationDialogRaw extends React.Component {
             ))}
           </RadioGroup>
         </DialogContent>
+        <Divider />
         <DialogActions>
           <Button onClick={this.handleCancel} color="primary">
             Cancel

--- a/docs/src/pages/demos/dialogs/ScrollDialog.hooks.js
+++ b/docs/src/pages/demos/dialogs/ScrollDialog.hooks.js
@@ -7,6 +7,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import Divider from '@material-ui/core/Divider';
 
 function ScrollDialog() {
   const [open, setOpen] = React.useState(false);
@@ -21,6 +22,8 @@ function ScrollDialog() {
     setOpen(false);
   }
 
+  const withDivider = scroll === 'paper';
+
   return (
     <div>
       <Button onClick={handleClickOpen('paper')}>scroll=paper</Button>
@@ -32,6 +35,7 @@ function ScrollDialog() {
         aria-labelledby="scroll-dialog-title"
       >
         <DialogTitle id="scroll-dialog-title">Subscribe</DialogTitle>
+        {withDivider && <Divider />}
         <DialogContent>
           <DialogContentText>
             {Array.apply(null, Array(50))
@@ -44,6 +48,7 @@ Praesent commodo cursus magna, vel scelerisque nisl consectetur et.`,
               .join('\n')}
           </DialogContentText>
         </DialogContent>
+        {withDivider && <Divider />}
         <DialogActions>
           <Button onClick={handleClose} color="primary">
             Cancel

--- a/docs/src/pages/demos/dialogs/ScrollDialog.js
+++ b/docs/src/pages/demos/dialogs/ScrollDialog.js
@@ -7,6 +7,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogContentText from '@material-ui/core/DialogContentText';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import Divider from '@material-ui/core/Divider';
 
 class ScrollDialog extends React.Component {
   state = {
@@ -23,17 +24,21 @@ class ScrollDialog extends React.Component {
   };
 
   render() {
+    const { open, scroll } = this.state;
+    const withDivider = scroll === 'paper';
+
     return (
       <div>
         <Button onClick={this.handleClickOpen('paper')}>scroll=paper</Button>
         <Button onClick={this.handleClickOpen('body')}>scroll=body</Button>
         <Dialog
-          open={this.state.open}
+          open={open}
           onClose={this.handleClose}
-          scroll={this.state.scroll}
+          scroll={scroll}
           aria-labelledby="scroll-dialog-title"
         >
           <DialogTitle id="scroll-dialog-title">Subscribe</DialogTitle>
+          {withDivider && <Divider />}
           <DialogContent>
             <DialogContentText>
               {Array.apply(null, Array(50))
@@ -46,6 +51,7 @@ Praesent commodo cursus magna, vel scelerisque nisl consectetur et.`,
                 .join('\n')}
             </DialogContentText>
           </DialogContent>
+          {withDivider && <Divider />}
           <DialogActions>
             <Button onClick={this.handleClose} color="primary">
               Cancel


### PR DESCRIPTION
Improves discoverability of scroll behavior for long `<Dialog scroll="paper" />`. `scroll=body` would not requires this because content doesn't underflow header/footer. Follows https://material.io/design/components/dialogs.html#confirmation-dialog

Changed:
- https://deploy-preview-14735--material-ui.netlify.com/demos/dialogs/#scrolling-long-content