### PR TITLE
[docs] Document the migration from v3 to v4

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -123,7 +123,7 @@ function useThrottledOnScroll(callback, delay) {
 
   React.useEffect(() => {
     if (throttledCallback === noop) {
-      return null;
+      return () => {};
     }
 
     window.addEventListener('scroll', throttledCallback);

--- a/docs/src/pages/css-in-js/basics/basics.md
+++ b/docs/src/pages/css-in-js/basics/basics.md
@@ -1,4 +1,4 @@
-# Basics
+# @material-ui/styles
 
 <p class="description">You can leverage our styling solution, even if you are not using our components.</p>
 

--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -8,6 +8,7 @@ Feel free to submit a pull request to add more projects; we will accept them if 
 
 ## Material-UI Specific Projects
 
+- [Advanced Filter Builder](https://github.com/logipro/logi-filter-builder) Component will help your users create powerful filter criterias.
 - [create-mui-theme](https://react-theming.github.io/create-mui-theme/) Online tool for creating Material-UI themes via Material Design Color Tool
 - [dx-react-chart-material-ui](https://devexpress.github.io/devextreme-reactive/react/chart/) A chart for Material-UI that visualizes data using a variety of series types, including bar, line, area, scatter, pie, and more ([custom license](https://js.devexpress.com/licensing/)).
 - [dx-react-grid-material-ui](https://devexpress.github.io/devextreme-reactive/react/grid/) A data grid for Material-UI with paging, sorting, filtering, grouping and editing features ([custom license](https://js.devexpress.com/licensing/)).
@@ -18,18 +19,18 @@ Feel free to submit a pull request to add more projects; we will accept them if 
 - [material-ui-next-pickers](https://github.com/chingyawhao/material-ui-next-pickers) A datepicker or timepicker in Material UI Next or can be imported as a clock or calendar component.
 - [material-ui-pickers](https://github.com/dmtrKovalenko/material-ui-pickers) Components that implement Material Design date and time pickers for Material-UI.
 - [material-ui-popup-state](https://github.com/jcoreio/material-ui-popup-state) Render props component that manages state for menus, popovers, and poppers, cutting down on boilerplate significantly.
+- [material-ui-rating](https://github.com/TeamWertarbyte/material-ui-rating) Rate something with style.
 - [material-ui-theme-editor](https://in-your-saas.github.io/material-ui-theme-editor/) A tool to generate themes for your Material-UI applications by just selecting the colors and having a live preview.
 - [material-ui-time-picker](https://github.com/TeamWertarbyte/material-ui-time-picker) A TimePicker for Material-UI.
 - [mui-datatables](https://github.com/gregnb/mui-datatables) Responsive data tables for Material-UI with filtering, sorting, search and more.
 - [mui-downshift](https://github.com/techniq/mui-downshift) Thin layer over paypal's downshift to use Material-UI visual components.
+- [mui-tables](https://parkerself.gitbook.io/mui-table/) Customizable table for managing complex data. Features a summary row, de-duplication & merging, as well as filtering, search, etc.
 - [notistack](https://github.com/iamhosseindhv/notistack) Highly customisable notification snackbars that can be stacked on top of each other
 - [react-material-ui-typescript](https://github.com/goemen/react-material-ui-typescript) A boilerplate for React using Typescript, Material UI and Redux, React Router.
 - [react-media-material-ui](https://github.com/jcoreio/react-media-material-ui) Easily use breakpoints from your Material-UI theme with [react-media](https://github.com/ReactTraining/react-media).
 - [redux-form-material-ui](https://github.com/erikras/redux-form-material-ui) A set of wrapper components to facilitate using Material UI with Redux Form.
 - [uniforms-material](https://github.com/vazco/uniforms/tree/master/packages/uniforms-material) Material-UI wrapper components for Uniforms.
 - [Wertarbyte](https://mui.wertarbyte.com/) Wertarbyte are using Material-UI for many of their projects. This is a collection of complementary components they have built.
-- [Advanced Filter Builder](https://github.com/logipro/logi-filter-builder) Component will help your users create powerful filter criterias.
-- [mui-tables](https://parkerself.gitbook.io/mui-table/) Customizable table for managing complex data. Features a summary row, de-duplication & merging, as well as filtering, search, etc.
 
 ## Complementary Projects
 

--- a/docs/src/pages/guides/migration-v0x/migration-v0x.md
+++ b/docs/src/pages/guides/migration-v0x/migration-v0x.md
@@ -1,4 +1,4 @@
-# Migration From v0.x
+# Migration From v0.x to v1
 
 <p class="description">Yeah, v1 has been released! Take advantage of 2 years worth of effort.</p>
 

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -21,7 +21,7 @@ The *why* is covered in the release blog post: [*Work in progress, on Medium*](h
 
 ## Updating Your Dependencies
 
-The very first thing you will need to do is update your dependencies
+The very first thing you will need to do is update your dependencies.
 
 ### Update Material-UI version
 

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -95,7 +95,7 @@ You can use the new `display?: 'initial' | 'inline' | 'block';` property.
 
 ### Button
 
-- Remove the deprecated button flat, raised and fab variants:
+- Remove the deprecated button variants (flat, raised and fab):
 
   ```diff
   -<Button variant="raised" />

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -1,6 +1,6 @@
 # Migration From v3 to v4
 
-<p class="description">Yeah, v4 has been released!</p>
+<p class="description">Yeah, v4 alpha has been released!</p>
 
 Looking for the v3 docs? [Find them here](https://material-ui.com/versions/).
 
@@ -74,6 +74,13 @@ To use it correctly, you have to use the returned value.
 
 ### Typography
 
+- You can safely remove the next variant from the theme creation:
+
+  ```js
+  typography: {
+    useNextVariants: true,
+  },
+  ```
 - Remove the deprecated typography variants. You can upgrade by performing the following replacements:
   - display4 => h1
   - display3 => h2
@@ -86,7 +93,7 @@ To use it correctly, you have to use the returned value.
   - body1 (default) => body2 (default)
 - Remove the opinionated `display: block` default typograpghy style.
 You can use the new `display?: 'initial' | 'inline' | 'block';` property.
-- Rename the `headlineMapping` property to better align with its purpose.
+- Rename the `headlineMapping` property to `variantMapping` to better align with its purpose.
 
   ```diff
   -<MuiTypography headlineMapping={headlineMapping}>
@@ -144,15 +151,15 @@ You can use the new `display?: 'initial' | 'inline' | 'block';` property.
 
 ### Table
 
-- We have removed the deprecated numeric property.
+- Remove the deprecated `numeric` property.
 
   ```diff
   -<TableCell numeric>{row.calories}</TableCell>
   +<TableCell align="right">{row.calories}</TableCell>
   ```
-- We have removed the fixed height property on the table row.
-    The cell height is computed by the browser using the padding and line-height.
-- The `dense` mode was promoted to a different property:
+- Remove the fixed height CSS property on the `TableRow`.
+  The cell height is computed by the browser using the padding and line-height.
+- Move the `dense` mode to a different property:
 
   ```diff
   -<TableCell padding="dense" />
@@ -163,7 +170,7 @@ You can use the new `display?: 'initial' | 'inline' | 'block';` property.
 
 ### Tabs
 
-- We have removed the `labelContainer`, `label` and `labelWrapped` class keys for simplicity.
+- Remove the `labelContainer`, `label` and `labelWrapped` class keys for simplicity.
 This has allowed us to removed 2 intermediary DOM elements.
 You should be able to move the custom styles to the root class key.
 
@@ -171,7 +178,7 @@ You should be able to move the custom styles to the root class key.
 
 ### Node
 
-- Drop official node 6 support, you should upgrade to node 8.
+- [Drop official node 6 support](https://github.com/nodejs/Release/blob/eb91c94681ea968a69bf4a4fe85c656ed44263b3/README.md#release-schedule), you should upgrade to node 8.
 
 ### UMD
 

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -164,7 +164,7 @@ You can use the new `display?: 'initial' | 'inline' | 'block';` property.
 ### Tabs
 
 - We have removed the `labelContainer`, `label` and `labelWrapped` class keys for simplicity.
-It has allowed us to removed 2 intermediary DOM elements.
+This has allowed us to removed 2 intermediary DOM elements.
 You should be able to move the custom styles to the root class key.
 
   ![capture d ecran 2019-02-23 a 15 46 48](https://user-images.githubusercontent.com/3165635/53287870-53a35500-3782-11e9-9431-2d1a14a41be0.png)

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -45,7 +45,7 @@ yarn add @material-ui/core@next
 
 ### Update React version
 
-The minium required version of React was increased from `react@^16.3.0` to `react@^16.8.0`.
+The minimum required version of React was increased from `react@^16.3.0` to `react@^16.8.0`.
 This is allowing us to rely on the [Hooks](https://reactjs.org/docs/hooks-intro.html).
 
 ## Handling Breaking Changes

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -62,7 +62,7 @@ This allows us to rely on [Hooks](https://reactjs.org/docs/hooks-intro.html).
 ### Theme
 
 - The `theme.palette.augmentColor()` method no longer performs a side effect on its input color.
-In order to use it correctly, you have to use the output of this function.
+To use it correctly, you have to use the returned value.
 
   ```diff
   -const background = { main: color };

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -25,7 +25,7 @@ The very first thing you will need to do is update your dependencies
 
 ### Update Material-UI version
 
-You need update your `package.json` to use the latest version of Material-UI.
+You need to update your `package.json` to use the latest version of Material-UI.
 
 ```json
 "dependencies": {

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -5,14 +5,14 @@
 Looking for the v3 docs? [Find them here](https://material-ui.com/versions/).
 
 > This document is a work in progress.
-Have you upgraded your site and run into something that’s not covered here?
+Have you upgraded your site and run into something that's not covered here?
 [Add your changes on GitHub](https://github.com/mui-org/material-ui/blob/next/docs/src/pages/guides/migration-v3/migration-v3.md)
 
 ## Introduction
 
 This is a reference for upgrading your site from Material-UI v3 to v4.
-While there’s a lot covered here, you probably won’t need to do everything for your site.
-We’ll do our best to keep things easy to follow, and as sequential as possible so you can quickly get rocking on v4!
+While there's a lot covered here, you probably won't need to do everything for your site.
+We'll do our best to keep things easy to follow, and as sequential as possible so you can quickly get rocking on v4!
 
 ## Why you should migrate
 

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -116,7 +116,7 @@ You can use the new `display?: 'initial' | 'inline' | 'block';` property.
 
 ### TextField
 
-- You should be able to override all the styles of the FormLabel component using the css API of the InputLabel component. We do no longer need the `FormLabelClasses` property.
+- You should be able to override all the styles of the FormLabel component using the CSS API of the InputLabel component. The `FormLabelClasses` property has been removed.
 
   ```diff
   <InputLabel

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -159,7 +159,7 @@ You can use the new `display?: 'initial' | 'inline' | 'block';` property.
   +<TableCell size="small" />
   ```
 
-- The `TablePagination` component does no longer try to fix invalid (`page`, `count`, `rowsPerPage`) property combinations. It raises a warning instead.
+- The `TablePagination` component no longer tries to fix invalid (`page`, `count`, `rowsPerPage`) property combinations. It raises a warning instead.
 
 ### Tabs
 

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -1,0 +1,192 @@
+# Migration From v3 to v4
+
+<p class="description">Yeah, v4 has been released!</p>
+
+Looking for the v3 docs? [Find them here](https://material-ui.com/versions/).
+
+> This document is a work in progress.
+Have you upgraded your site and run into something that’s not covered here?
+[Add your changes on GitHub](https://github.com/mui-org/material-ui/blob/next/docs/src/pages/guides/migration-v3/migration-v3.md)
+
+## Introduction
+
+This is a reference for upgrading your site from Material-UI v3 to v4.
+While there’s a lot covered here, you probably won’t need to do everything for your site.
+We’ll do our best to keep things easy to follow, and as sequential as possible so you can quickly get rocking on v4!
+
+## Why you should migrate
+
+This documentation page covers the *how* of migrating from v3 to v4.
+The *why* is covered in the release blog post: [*Work in progress, on Medium*](https://medium.com/material-ui).
+
+## Updating Your Dependencies
+
+The very first thing you will need to do is update your dependencies
+
+### Update Material-UI version
+
+You need update your `package.json` to use the latest version of Material-UI.
+
+```json
+"dependencies": {
+  "@material-ui/core": "^4.0.0-alpha.0"
+}
+```
+
+Or run
+
+```sh
+npm install @material-ui/core@next
+
+or
+
+yarn add @material-ui/core@next
+```
+
+### Update React version
+
+The minium required version of React was increased from `react@^16.3.0` to `react@^16.8.0`.
+This is allowing us to rely on the [Hooks](https://reactjs.org/docs/hooks-intro.html).
+
+## Handling Breaking Changes
+
+### Styles
+
+- Remove the first option argument of `withTheme()`. The first argument was a placeholder for a potential future option. We have never found a need for it. It's time to remove this argument. It matches the emotion and styled-components API.
+
+  ```diff
+  -const DeepChild = withTheme()(DeepChildRaw);
+  +const DeepChild = withTheme(DeepChildRaw);
+  ```
+
+### Theme
+
+- The `theme.palette.augmentColor()` method no longer performs a side effect on its input color.
+In order to use it correctly, you have to use the output of this function.
+
+  ```diff
+  -const background = { main: color };
+  -theme.palette.augmentColor(background);
+  +const background = theme.palette.augmentColor({ main: color });
+
+  console.log({ background });
+  ```
+
+### Typography
+
+- Remove the deprecated typography variants. You can upgrade by performing the following replacements:
+  - display4 => h1
+  - display3 => h2
+  - display2 => h3
+  - display1 => h4
+  - headline => h5
+  - title => h6
+  - subheading => subtitle1
+  - body2 => body1
+  - body1 (default) => body2 (default)
+- Remove the opinionated `display: block` default typograpghy style.
+You can use the new `display?: 'initial' | 'inline' | 'block';` property.
+- Rename the `headlineMapping` property to better align with its purpose.
+
+  ```diff
+  -<MuiTypography headlineMapping={headlineMapping}>
+  +<MuiTypography variantMapping={variantMapping}>
+  ```
+
+### Button
+
+- Remove the deprecated button flat, raised and fab variants:
+
+  ```diff
+  -<Button variant="raised" />
+  +<Button variant="contained" />
+  ```
+
+  ```diff
+  -<Button variant="flat" />
+  +<Button variant="text" />
+  ```
+
+  ```diff
+  -import Button from '@material-ui/core/Button';
+  -<Button variant="fab" />
+  +import Fab from '@material-ui/core/Fab';
+  +<Fab />
+  ```
+
+### TextField
+
+- You should be able to override all the styles of the FormLabel component using the css API of the InputLabel component. We do no longer need the `FormLabelClasses` property.
+
+  ```diff
+  <InputLabel
+  - FormLabelClasses={{ asterisk: 'bar' } }
+  + classes={{ asterisk: 'bar' } }
+  >
+    Foo
+  </InputLabel>
+  ```
+
+### Grid
+
+- In order to support arbitrary spacing values and to remove the need to mentally county by 8, we are changing the spacing API:
+
+  ```diff
+    /**
+     * Defines the space between the type `item` component.
+     * It can only be used on a type `container` component.
+     */
+  -  spacing: PropTypes.oneOf([0, 8, 16, 24, 32, 40]),
+  +  spacing: PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+  ```
+
+  Going forward, you can use the theme to implement [a custom Grid spacing transformation function](https://material-ui.com/system/spacing/#transformation).
+
+### Table
+
+- We have removed the deprecated numeric property.
+
+  ```diff
+  -<TableCell numeric>{row.calories}</TableCell>
+  +<TableCell align="right">{row.calories}</TableCell>
+  ```
+- We have removed the fixed height property on the table row.
+    The cell height is computed by the browser using the padding and line-height.
+- The `dense` mode was promoted to a different property:
+
+  ```diff
+  -<TableCell padding="dense" />
+  +<TableCell size="small" />
+  ```
+
+- The `TablePagination` component does no longer try to fix invalid (`page`, `count`, `rowsPerPage`) property combinations. It raises a warning instead.
+
+### Tabs
+
+- We have removed the `labelContainer`, `label` and `labelWrapped` class keys for simplicity.
+It has allowed us to removed 2 intermediary DOM elements.
+You should be able to move the custom styles to the root class key.
+
+  ![capture d ecran 2019-02-23 a 15 46 48](https://user-images.githubusercontent.com/3165635/53287870-53a35500-3782-11e9-9431-2d1a14a41be0.png)
+
+### Node
+
+- Drop official node 6 support, you should upgrade to node 8.
+
+### UMD
+
+- This change eases the use of Material-UI with a CDN:
+
+  ```diff
+  const {
+    Button,
+    TextField,
+  -} = window['material-ui'];
+  +} = MaterialUI;
+  ```
+
+  It's consistent with the other React projects:
+
+  - material-ui => MaterialUI
+  - react-dom => ReactDOM
+  - prop-types => PropTypes

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -46,7 +46,7 @@ yarn add @material-ui/core@next
 ### Update React version
 
 The minimum required version of React was increased from `react@^16.3.0` to `react@^16.8.0`.
-This is allowing us to rely on the [Hooks](https://reactjs.org/docs/hooks-intro.html).
+This allows us to rely on [Hooks](https://reactjs.org/docs/hooks-intro.html).
 
 ## Handling Breaking Changes
 

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -1,9 +1,6 @@
 # @material-ui/system
 
-<p class="description">Style functions for building powerful design systems.</p>
-
-> ⚠️ `@material-ui/system` is experimental (alpha version).
-We are working on making it stable for Material-UI v4.
+<p class="description">Styled system & style functions for building powerful design systems.</p>
 
 ## Getting Started
 

--- a/packages/material-ui-lab/src/Container/Container.js
+++ b/packages/material-ui-lab/src/Container/Container.js
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 import { capitalize } from '@material-ui/core/utils/helpers';
 
-const styles = theme => ({
+export const styles = theme => ({
   root: {
     width: '100%',
     marginLeft: 'auto',
@@ -115,4 +115,4 @@ Container.defaultProps = {
   maxWidth: 'lg',
 };
 
-export default withStyles(styles)(Container);
+export default withStyles(styles, { name: 'MuiContainer' })(Container);

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -165,7 +165,7 @@ const pages = [
   },
   {
     pathname: '/css-in-js',
-    title: 'CSS in JS (alpha)',
+    title: 'CSS in JS',
     children: [
       {
         pathname: '/css-in-js/basics',
@@ -181,7 +181,7 @@ const pages = [
   },
   {
     pathname: '/system',
-    title: 'System (alpha)',
+    title: 'System',
     children: [
       {
         pathname: '/system/basics',
@@ -261,6 +261,10 @@ const pages = [
       },
       {
         pathname: '/guides/server-rendering',
+      },
+      {
+        pathname: '/guides/migration-v3',
+        title: 'Migration From v3',
       },
       {
         pathname: '/guides/migration-v0x',

--- a/pages/guides/migration-v3.js
+++ b/pages/guides/migration-v3.js
@@ -1,0 +1,18 @@
+import 'docs/src/modules/components/bootstrap';
+// --- Post bootstrap -----
+import React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+
+const req = require.context('docs/src/pages/guides/migration-v3', false, /\.md|\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/guides/migration-v3',
+  false,
+  /\.js$/,
+);
+const reqPrefix = 'pages/guides/migration-v3';
+
+function Page() {
+  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+}
+
+export default Page;

--- a/pages/lab/api/container.md
+++ b/pages/lab/api/container.md
@@ -26,6 +26,26 @@ import Container from '@material-ui/lab/Container';
 
 Any other properties supplied will be spread to the root element (native element).
 
+## CSS
+
+You can override all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+
+- `root`
+- `fixed`
+- `maxWidthXs`
+- `maxWidthSm`
+- `maxWidthMd`
+- `maxWidthLg`
+- `maxWidthXl`
+
+Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
+and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui-lab/src/Container/Container.js)
+for more detail.
+
+If using the `overrides` [key of the theme](/customization/themes/#css),
+you need to use the following style sheet name: `MuiContainer`.
+
 ## Demos
 
 - [Layout](/lab/layout/)

--- a/pages/lab/api/container.md
+++ b/pages/lab/api/container.md
@@ -43,7 +43,7 @@ Have a look at the [overriding with classes](/customization/overrides/#overridin
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui-lab/src/Container/Container.js)
 for more detail.
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
+If you are using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiContainer`.
 
 ## Demos

--- a/pages/lab/api/container.md
+++ b/pages/lab/api/container.md
@@ -39,11 +39,11 @@ This property accepts the following keys:
 - `maxWidthLg`
 - `maxWidthXl`
 
-Have a look at the [overriding with classes](/customization/overrides/#overriding-with-classes) section
+Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui-lab/src/Container/Container.js)
 for more detail.
 
-If you are using the `overrides` [key of the theme](/customization/themes/#css),
+If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiContainer`.
 
 ## Demos

--- a/pages/lab/api/container.md
+++ b/pages/lab/api/container.md
@@ -39,7 +39,7 @@ This property accepts the following keys:
 - `maxWidthLg`
 - `maxWidthXl`
 
-Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
+Have a look at the [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui-lab/src/Container/Container.js)
 for more detail.
 


### PR DESCRIPTION
Once the next version is advanced enough, we should be able to link (add a banner) from material-ui.com to next.material-ui.com.