### PR TITLE
[createSpacing] Narrow return type

### DIFF
--- a/packages/material-ui/src/styles/createSpacing.d.ts
+++ b/packages/material-ui/src/styles/createSpacing.d.ts
@@ -1,18 +1,17 @@
 /* tslint:disable:unified-signatures */
 
 export type SpacingArgument = number | string;
-export type SpacingReturnType = number | string;
 
 export interface Spacing {
-  (value1: SpacingArgument): SpacingReturnType;
-  (value1: SpacingArgument, value2: SpacingArgument): SpacingReturnType;
-  (value1: SpacingArgument, value2: SpacingArgument, value3: SpacingArgument): SpacingReturnType;
+  (value1: SpacingArgument): number;
+  (value1: SpacingArgument, value2: SpacingArgument): string;
+  (value1: SpacingArgument, value2: SpacingArgument, value3: SpacingArgument): string;
   (
     value1: SpacingArgument,
     value2: SpacingArgument,
     value3: SpacingArgument,
     value4: SpacingArgument,
-  ): SpacingReturnType;
+  ): string;
 }
 
 export type SpacingOptions = number | Spacing;

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -155,10 +155,10 @@ const theme2 = createMuiTheme({
   },
 });
 
-const t1 = createMuiTheme().spacing(1);
-const t2 = createMuiTheme().spacing(1, 2);
-const t3 = createMuiTheme().spacing(1, 2, 3);
-const t4 = createMuiTheme().spacing(1, 2, 3, 4);
+const t1: number = createMuiTheme().spacing(1);
+const t2: string = createMuiTheme().spacing(1, 2);
+const t3: string = createMuiTheme().spacing(1, 2, 3);
+const t4: string = createMuiTheme().spacing(1, 2, 3, 4);
 // $ExpectError
 const t5 = createMuiTheme().spacing(1, 2, 3, 4, 5);
 


### PR DESCRIPTION
See https://github.com/mui-org/material-ui/blob/a574657cb29a23594ad052fb78f972e6d3404586/packages/material-ui/src/styles/createSpacing.js#L37-L39

Single argument number return type assumed in https://github.com/mui-org/material-ui/blob/8f76893fac477609fedb07c785ebd4bced3eb70c/docs/src/pages/demos/buttons/ButtonBases.js#L67

Issue uncovered in #14739. Filing separate PR for changelog and proper git blame.