### PR TITLE
[Dialog] Fix backdrop click affecting dialog content

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 // @inheritedComponent Modal
 
 import React from 'react';
@@ -38,12 +36,14 @@ export const styles = theme => ({
     },
     // We disable the focus ring for mouse, touch and keyboard users.
     outline: 'none',
+    pointerEvents: 'none',
   },
   /* Styles applied to the `Paper` component. */
   paper: {
     display: 'flex',
     flexDirection: 'column',
     margin: 48,
+    pointerEvents: 'auto',
     position: 'relative',
     overflowY: 'auto', // Fix IE 11 issue, to remove at some point.
     '@media print': {
@@ -141,12 +141,6 @@ class Dialog extends React.Component {
   };
 
   handleBackdropClick = event => {
-    // Ignore the events not coming from the "backdrop"
-    // We don't want to close the dialog when clicking the dialog content.
-    if (event.target !== event.currentTarget) {
-      return;
-    }
-
     // Make sure the event starts and ends on the same DOM element.
     if (event.target !== this.mouseDownTarget) {
       return;
@@ -199,11 +193,12 @@ class Dialog extends React.Component {
         BackdropProps={{
           transitionDuration,
           ...BackdropProps,
+          onMouseDown: this.handleMouseDown,
         }}
         closeAfterTransition
         disableBackdropClick={disableBackdropClick}
         disableEscapeKeyDown={disableEscapeKeyDown}
-        onBackdropClick={onBackdropClick}
+        onBackdropClick={this.handleBackdropClick}
         onEscapeKeyDown={onEscapeKeyDown}
         onClose={onClose}
         open={open}
@@ -222,12 +217,7 @@ class Dialog extends React.Component {
           onExited={onExited}
           {...TransitionProps}
         >
-          <div
-            className={clsx(classes.container, classes[`scroll${capitalize(scroll)}`])}
-            onClick={this.handleBackdropClick}
-            onMouseDown={this.handleMouseDown}
-            role="document"
-          >
+          <div className={clsx(classes.container, classes[`scroll${capitalize(scroll)}`])}>
             <PaperComponent
               elevation={24}
               {...PaperProps}

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -239,10 +239,6 @@ class Modal extends React.Component {
       childProps.onExited = createChainedFunction(this.handleExited, children.props.onExited);
     }
 
-    if (children.props.role === undefined) {
-      childProps.role = children.props.role || 'document';
-    }
-
     if (children.props.tabIndex === undefined) {
       childProps.tabIndex = children.props.tabIndex || '-1';
     }


### PR DESCRIPTION
- [ ] check unit tests

Different take on #14717. Has the nice side effect of fixing clicks on the perceived backdrop affecting the dialog.

### current
![mui-dialog-container-click-next](https://user-images.githubusercontent.com/12292047/53802943-79c7b280-3f43-11e9-971c-c0fcf25d5f23.gif)

### pr
![mui-dialog-container-click-pr](https://user-images.githubusercontent.com/12292047/53802950-7cc2a300-3f43-11e9-8189-9ea68c585fe5.gif)
