### PR TITLE
[IconButton] Implement a new edge prop

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -93,7 +93,7 @@ const styles = theme => ({
     flex: '1 1 auto',
   },
   title: {
-    marginLeft: 24,
+    marginLeft: theme.spacing(2),
     flex: '0 1 auto',
   },
   appBar: {

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -215,7 +215,7 @@ class AppFrame extends React.Component {
                 </Typography>
                 <Toolbar>
                   <IconButton
-                    edge="left"
+                    edge="start"
                     color="inherit"
                     aria-label="Open drawer"
                     onClick={this.handleDrawerOpen}
@@ -305,7 +305,7 @@ class AppFrame extends React.Component {
                   </Tooltip>
                   <Tooltip title={t('github')} enterDelay={300}>
                     <IconButton
-                      edge="right"
+                      edge="end"
                       component="a"
                       color="inherit"
                       href="https://github.com/mui-org/material-ui"

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -215,6 +215,7 @@ class AppFrame extends React.Component {
                 </Typography>
                 <Toolbar>
                   <IconButton
+                    edge="left"
                     color="inherit"
                     aria-label="Open drawer"
                     onClick={this.handleDrawerOpen}
@@ -304,6 +305,7 @@ class AppFrame extends React.Component {
                   </Tooltip>
                   <Tooltip title={t('github')} enterDelay={300}>
                     <IconButton
+                      edge="right"
                       component="a"
                       color="inherit"
                       href="https://github.com/mui-org/material-ui"

--- a/docs/src/pages/demos/app-bar/BottomAppBar.js
+++ b/docs/src/pages/demos/app-bar/BottomAppBar.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
@@ -17,39 +17,6 @@ import MenuIcon from '@material-ui/icons/Menu';
 import AddIcon from '@material-ui/icons/Add';
 import SearchIcon from '@material-ui/icons/Search';
 import MoreIcon from '@material-ui/icons/MoreVert';
-
-const styles = theme => ({
-  text: {
-    paddingTop: theme.spacing(2),
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(2),
-  },
-  paper: {
-    paddingBottom: 50,
-  },
-  list: {
-    marginBottom: theme.spacing(2),
-  },
-  subHeader: {
-    backgroundColor: theme.palette.background.paper,
-  },
-  appBar: {
-    top: 'auto',
-    bottom: 0,
-  },
-  toolbar: {
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-  fabButton: {
-    position: 'absolute',
-    zIndex: 1,
-    top: -30,
-    left: 0,
-    right: 0,
-    margin: '0 auto',
-  },
-});
 
 const messages = [
   {
@@ -100,6 +67,36 @@ const messages = [
   },
 ];
 
+const styles = theme => ({
+  text: {
+    padding: theme.spacing(2, 2, 0),
+  },
+  paper: {
+    paddingBottom: 50,
+  },
+  list: {
+    marginBottom: theme.spacing(2),
+  },
+  subheader: {
+    backgroundColor: theme.palette.background.paper,
+  },
+  appBar: {
+    top: 'auto',
+    bottom: 0,
+  },
+  grow: {
+    flexGrow: 1,
+  },
+  fabButton: {
+    position: 'absolute',
+    zIndex: 1,
+    top: -30,
+    left: 0,
+    right: 0,
+    margin: '0 auto',
+  },
+});
+
 function BottomAppBar(props) {
   const { classes } = props;
   return (
@@ -111,33 +108,32 @@ function BottomAppBar(props) {
         </Typography>
         <List className={classes.list}>
           {messages.map(({ id, primary, secondary, person }) => (
-            <Fragment key={id}>
-              {id === 1 && <ListSubheader className={classes.subHeader}>Today</ListSubheader>}
-              {id === 3 && <ListSubheader className={classes.subHeader}>Yesterday</ListSubheader>}
+            <React.Fragment key={id}>
+              {id === 1 && <ListSubheader className={classes.subheader}>Today</ListSubheader>}
+              {id === 3 && <ListSubheader className={classes.subheader}>Yesterday</ListSubheader>}
               <ListItem button>
                 <Avatar alt="Profile Picture" src={person} />
                 <ListItemText primary={primary} secondary={secondary} />
               </ListItem>
-            </Fragment>
+            </React.Fragment>
           ))}
         </List>
       </Paper>
       <AppBar position="fixed" color="primary" className={classes.appBar}>
-        <Toolbar className={classes.toolbar}>
+        <Toolbar>
           <IconButton edge="start" color="inherit" aria-label="Open drawer">
             <MenuIcon />
           </IconButton>
           <Fab color="secondary" aria-label="Add" className={classes.fabButton}>
             <AddIcon />
           </Fab>
-          <div>
-            <IconButton color="inherit">
-              <SearchIcon />
-            </IconButton>
-            <IconButton edge="end" color="inherit">
-              <MoreIcon />
-            </IconButton>
-          </div>
+          <div className={classes.grow} />
+          <IconButton color="inherit">
+            <SearchIcon />
+          </IconButton>
+          <IconButton edge="end" color="inherit">
+            <MoreIcon />
+          </IconButton>
         </Toolbar>
       </AppBar>
     </React.Fragment>

--- a/docs/src/pages/demos/app-bar/BottomAppBar.js
+++ b/docs/src/pages/demos/app-bar/BottomAppBar.js
@@ -124,7 +124,7 @@ function BottomAppBar(props) {
       </Paper>
       <AppBar position="fixed" color="primary" className={classes.appBar}>
         <Toolbar className={classes.toolbar}>
-          <IconButton color="inherit" aria-label="Open drawer">
+          <IconButton edge="left" color="inherit" aria-label="Open drawer">
             <MenuIcon />
           </IconButton>
           <Fab color="secondary" aria-label="Add" className={classes.fabButton}>
@@ -134,7 +134,7 @@ function BottomAppBar(props) {
             <IconButton color="inherit">
               <SearchIcon />
             </IconButton>
-            <IconButton color="inherit">
+            <IconButton edge="right" color="inherit">
               <MoreIcon />
             </IconButton>
           </div>

--- a/docs/src/pages/demos/app-bar/BottomAppBar.js
+++ b/docs/src/pages/demos/app-bar/BottomAppBar.js
@@ -124,7 +124,7 @@ function BottomAppBar(props) {
       </Paper>
       <AppBar position="fixed" color="primary" className={classes.appBar}>
         <Toolbar className={classes.toolbar}>
-          <IconButton edge="left" color="inherit" aria-label="Open drawer">
+          <IconButton edge="start" color="inherit" aria-label="Open drawer">
             <MenuIcon />
           </IconButton>
           <Fab color="secondary" aria-label="Add" className={classes.fabButton}>
@@ -134,7 +134,7 @@ function BottomAppBar(props) {
             <IconButton color="inherit">
               <SearchIcon />
             </IconButton>
-            <IconButton edge="right" color="inherit">
+            <IconButton edge="end" color="inherit">
               <MoreIcon />
             </IconButton>
           </div>

--- a/docs/src/pages/demos/app-bar/BottomAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/BottomAppBar.tsx
@@ -127,7 +127,7 @@ function BottomAppBar(props: Props) {
       </Paper>
       <AppBar position="fixed" color="primary" className={classes.appBar}>
         <Toolbar className={classes.toolbar}>
-          <IconButton color="inherit" aria-label="Open drawer">
+          <IconButton edge="left" color="inherit" aria-label="Open drawer">
             <MenuIcon />
           </IconButton>
           <Fab color="secondary" aria-label="Add" className={classes.fabButton}>
@@ -137,7 +137,7 @@ function BottomAppBar(props: Props) {
             <IconButton color="inherit">
               <SearchIcon />
             </IconButton>
-            <IconButton color="inherit">
+            <IconButton edge="right" color="inherit">
               <MoreIcon />
             </IconButton>
           </div>

--- a/docs/src/pages/demos/app-bar/BottomAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/BottomAppBar.tsx
@@ -127,7 +127,7 @@ function BottomAppBar(props: Props) {
       </Paper>
       <AppBar position="fixed" color="primary" className={classes.appBar}>
         <Toolbar className={classes.toolbar}>
-          <IconButton edge="left" color="inherit" aria-label="Open drawer">
+          <IconButton edge="start" color="inherit" aria-label="Open drawer">
             <MenuIcon />
           </IconButton>
           <Fab color="secondary" aria-label="Add" className={classes.fabButton}>
@@ -137,7 +137,7 @@ function BottomAppBar(props: Props) {
             <IconButton color="inherit">
               <SearchIcon />
             </IconButton>
-            <IconButton edge="right" color="inherit">
+            <IconButton edge="end" color="inherit">
               <MoreIcon />
             </IconButton>
           </div>

--- a/docs/src/pages/demos/app-bar/BottomAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/BottomAppBar.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
@@ -17,40 +17,6 @@ import MenuIcon from '@material-ui/icons/Menu';
 import AddIcon from '@material-ui/icons/Add';
 import SearchIcon from '@material-ui/icons/Search';
 import MoreIcon from '@material-ui/icons/MoreVert';
-
-const styles = (theme: Theme) =>
-  createStyles({
-    text: {
-      paddingTop: theme.spacing(2),
-      paddingLeft: theme.spacing(2),
-      paddingRight: theme.spacing(2),
-    },
-    paper: {
-      paddingBottom: 50,
-    },
-    list: {
-      marginBottom: theme.spacing(2),
-    },
-    subHeader: {
-      backgroundColor: theme.palette.background.paper,
-    },
-    appBar: {
-      top: 'auto',
-      bottom: 0,
-    },
-    toolbar: {
-      alignItems: 'center',
-      justifyContent: 'space-between',
-    },
-    fabButton: {
-      position: 'absolute',
-      zIndex: 1,
-      top: -30,
-      left: 0,
-      right: 0,
-      margin: '0 auto',
-    },
-  });
 
 const messages = [
   {
@@ -101,6 +67,37 @@ const messages = [
   },
 ];
 
+const styles = (theme: Theme) =>
+  createStyles({
+    text: {
+      padding: theme.spacing(2, 2, 0),
+    },
+    paper: {
+      paddingBottom: 50,
+    },
+    list: {
+      marginBottom: theme.spacing(2),
+    },
+    subheader: {
+      backgroundColor: theme.palette.background.paper,
+    },
+    appBar: {
+      top: 'auto',
+      bottom: 0,
+    },
+    grow: {
+      flexGrow: 1,
+    },
+    fabButton: {
+      position: 'absolute',
+      zIndex: 1,
+      top: -30,
+      left: 0,
+      right: 0,
+      margin: '0 auto',
+    },
+  });
+
 export interface Props extends WithStyles<typeof styles> {}
 
 function BottomAppBar(props: Props) {
@@ -114,33 +111,32 @@ function BottomAppBar(props: Props) {
         </Typography>
         <List className={classes.list}>
           {messages.map(({ id, primary, secondary, person }) => (
-            <Fragment key={id}>
-              {id === 1 && <ListSubheader className={classes.subHeader}>Today</ListSubheader>}
-              {id === 3 && <ListSubheader className={classes.subHeader}>Yesterday</ListSubheader>}
+            <React.Fragment key={id}>
+              {id === 1 && <ListSubheader className={classes.subheader}>Today</ListSubheader>}
+              {id === 3 && <ListSubheader className={classes.subheader}>Yesterday</ListSubheader>}
               <ListItem button>
                 <Avatar alt="Profile Picture" src={person} />
                 <ListItemText primary={primary} secondary={secondary} />
               </ListItem>
-            </Fragment>
+            </React.Fragment>
           ))}
         </List>
       </Paper>
       <AppBar position="fixed" color="primary" className={classes.appBar}>
-        <Toolbar className={classes.toolbar}>
+        <Toolbar>
           <IconButton edge="start" color="inherit" aria-label="Open drawer">
             <MenuIcon />
           </IconButton>
           <Fab color="secondary" aria-label="Add" className={classes.fabButton}>
             <AddIcon />
           </Fab>
-          <div>
-            <IconButton color="inherit">
-              <SearchIcon />
-            </IconButton>
-            <IconButton edge="end" color="inherit">
-              <MoreIcon />
-            </IconButton>
-          </div>
+          <div className={classes.grow} />
+          <IconButton color="inherit">
+            <SearchIcon />
+          </IconButton>
+          <IconButton edge="end" color="inherit">
+            <MoreIcon />
+          </IconButton>
         </Toolbar>
       </AppBar>
     </React.Fragment>

--- a/docs/src/pages/demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.js
@@ -26,7 +26,7 @@ function ButtonAppBar(props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit" className={classes.grow}>

--- a/docs/src/pages/demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.js
@@ -8,17 +8,17 @@ import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 
-const styles = {
+const styles = theme => ({
   root: {
     flexGrow: 1,
   },
-  grow: {
+  menuButton: {
+    marginRight: theme.spacing(2),
+  },
+  title: {
     flexGrow: 1,
   },
-  menuButton: {
-    marginRight: 20,
-  },
-};
+});
 
 function ButtonAppBar(props) {
   const { classes } = props;
@@ -29,7 +29,7 @@ function ButtonAppBar(props) {
           <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" color="inherit" className={classes.grow}>
+          <Typography variant="h6" color="inherit" className={classes.title}>
             News
           </Typography>
           <Button color="inherit">Login</Button>

--- a/docs/src/pages/demos/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.js
@@ -16,7 +16,6 @@ const styles = {
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
 };
@@ -27,7 +26,7 @@ function ButtonAppBar(props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit" className={classes.grow}>

--- a/docs/src/pages/demos/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.tsx
@@ -16,7 +16,6 @@ const styles = createStyles({
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
 });
@@ -29,7 +28,7 @@ function ButtonAppBar(props: Props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit" className={classes.grow}>

--- a/docs/src/pages/demos/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.tsx
@@ -28,7 +28,7 @@ function ButtonAppBar(props: Props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit" className={classes.grow}>

--- a/docs/src/pages/demos/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/ButtonAppBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -8,17 +8,18 @@ import Button from '@material-ui/core/Button';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 
-const styles = createStyles({
-  root: {
-    flexGrow: 1,
-  },
-  grow: {
-    flexGrow: 1,
-  },
-  menuButton: {
-    marginRight: 20,
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+    },
+    title: {
+      flexGrow: 1,
+    },
+  });
 
 export interface Props extends WithStyles<typeof styles> {}
 
@@ -31,7 +32,7 @@ function ButtonAppBar(props: Props) {
           <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" color="inherit" className={classes.grow}>
+          <Typography variant="h6" color="inherit" className={classes.title}>
             News
           </Typography>
           <Button color="inherit">Login</Button>

--- a/docs/src/pages/demos/app-bar/DenseAppBar.js
+++ b/docs/src/pages/demos/app-bar/DenseAppBar.js
@@ -12,7 +12,6 @@ const styles = {
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -18,
     marginRight: 10,
   },
 };
@@ -23,7 +22,7 @@ function DenseAppBar(props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar variant="dense">
-          <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit">

--- a/docs/src/pages/demos/app-bar/DenseAppBar.js
+++ b/docs/src/pages/demos/app-bar/DenseAppBar.js
@@ -22,7 +22,7 @@ function DenseAppBar(props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar variant="dense">
-          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit">

--- a/docs/src/pages/demos/app-bar/DenseAppBar.js
+++ b/docs/src/pages/demos/app-bar/DenseAppBar.js
@@ -7,14 +7,14 @@ import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 
-const styles = {
+const styles = theme => ({
   root: {
     flexGrow: 1,
   },
   menuButton: {
-    marginRight: 10,
+    marginRight: theme.spacing(2),
   },
-};
+});
 
 function DenseAppBar(props) {
   const { classes } = props;

--- a/docs/src/pages/demos/app-bar/DenseAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/DenseAppBar.tsx
@@ -12,7 +12,6 @@ const styles = createStyles({
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -18,
     marginRight: 10,
   },
 });
@@ -25,7 +24,7 @@ function DenseAppBar(props: Props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar variant="dense">
-          <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit">

--- a/docs/src/pages/demos/app-bar/DenseAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/DenseAppBar.tsx
@@ -1,20 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 
-const styles = createStyles({
-  root: {
-    flexGrow: 1,
-  },
-  menuButton: {
-    marginRight: 10,
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+    },
+  });
 
 export interface Props extends WithStyles<typeof styles> {}
 

--- a/docs/src/pages/demos/app-bar/DenseAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/DenseAppBar.tsx
@@ -24,7 +24,7 @@ function DenseAppBar(props: Props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar variant="dense">
-          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit">

--- a/docs/src/pages/demos/app-bar/MenuAppBar.hooks.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.hooks.js
@@ -52,7 +52,7 @@ function MenuAppBar() {
       </FormGroup>
       <AppBar position="static">
         <Toolbar>
-          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit" className={classes.grow}>

--- a/docs/src/pages/demos/app-bar/MenuAppBar.hooks.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.hooks.js
@@ -20,7 +20,6 @@ const useStyles = makeStyles({
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
 });
@@ -53,7 +52,7 @@ function MenuAppBar() {
       </FormGroup>
       <AppBar position="static">
         <Toolbar>
-          <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+          <IconButton edge="left" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
           <Typography variant="h6" color="inherit" className={classes.grow}>

--- a/docs/src/pages/demos/app-bar/MenuAppBar.hooks.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.hooks.js
@@ -12,17 +12,17 @@ import FormGroup from '@material-ui/core/FormGroup';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   root: {
     flexGrow: 1,
   },
-  grow: {
+  menuButton: {
+    marginRight: theme.spacing(2),
+  },
+  title: {
     flexGrow: 1,
   },
-  menuButton: {
-    marginRight: 20,
-  },
-});
+}));
 
 function MenuAppBar() {
   const classes = useStyles();
@@ -55,7 +55,7 @@ function MenuAppBar() {
           <IconButton edge="start" className={classes.menuButton} color="inherit" aria-label="Menu">
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" color="inherit" className={classes.grow}>
+          <Typography variant="h6" color="inherit" className={classes.title}>
             Photos
           </Typography>
           {auth && (

--- a/docs/src/pages/demos/app-bar/MenuAppBar.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.js
@@ -13,17 +13,17 @@ import FormGroup from '@material-ui/core/FormGroup';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 
-const styles = {
+const styles = theme => ({
   root: {
     flexGrow: 1,
   },
-  grow: {
+  menuButton: {
+    marginRight: theme.spacing(2),
+  },
+  title: {
     flexGrow: 1,
   },
-  menuButton: {
-    marginRight: 20,
-  },
-};
+});
 
 class MenuAppBar extends React.Component {
   state = {
@@ -68,7 +68,7 @@ class MenuAppBar extends React.Component {
             >
               <MenuIcon />
             </IconButton>
-            <Typography variant="h6" color="inherit" className={classes.grow}>
+            <Typography variant="h6" color="inherit" className={classes.title}>
               Photos
             </Typography>
             {auth && (

--- a/docs/src/pages/demos/app-bar/MenuAppBar.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.js
@@ -61,7 +61,7 @@ class MenuAppBar extends React.Component {
         <AppBar position="static">
           <Toolbar>
             <IconButton
-              align="left"
+              edge="left"
               className={classes.menuButton}
               color="inherit"
               aria-label="Menu"
@@ -74,6 +74,7 @@ class MenuAppBar extends React.Component {
             {auth && (
               <div>
                 <IconButton
+                  edge="right"
                   aria-owns={open ? 'menu-appbar' : undefined}
                   aria-haspopup="true"
                   onClick={this.handleMenu}

--- a/docs/src/pages/demos/app-bar/MenuAppBar.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.js
@@ -61,7 +61,7 @@ class MenuAppBar extends React.Component {
         <AppBar position="static">
           <Toolbar>
             <IconButton
-              edge="left"
+              edge="start"
               className={classes.menuButton}
               color="inherit"
               aria-label="Menu"
@@ -74,7 +74,7 @@ class MenuAppBar extends React.Component {
             {auth && (
               <div>
                 <IconButton
-                  edge="right"
+                  edge="end"
                   aria-owns={open ? 'menu-appbar' : undefined}
                   aria-haspopup="true"
                   onClick={this.handleMenu}

--- a/docs/src/pages/demos/app-bar/MenuAppBar.js
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.js
@@ -21,7 +21,6 @@ const styles = {
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
 };
@@ -61,7 +60,12 @@ class MenuAppBar extends React.Component {
         </FormGroup>
         <AppBar position="static">
           <Toolbar>
-            <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+            <IconButton
+              align="left"
+              className={classes.menuButton}
+              color="inherit"
+              aria-label="Menu"
+            >
               <MenuIcon />
             </IconButton>
             <Typography variant="h6" color="inherit" className={classes.grow}>

--- a/docs/src/pages/demos/app-bar/MenuAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.tsx
@@ -21,7 +21,6 @@ const styles = createStyles({
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
 });
@@ -68,7 +67,12 @@ class MenuAppBar extends React.Component<Props, State> {
         </FormGroup>
         <AppBar position="static">
           <Toolbar>
-            <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+            <IconButton
+              align="left"
+              className={classes.menuButton}
+              color="inherit"
+              aria-label="Menu"
+            >
               <MenuIcon />
             </IconButton>
             <Typography variant="h6" color="inherit" className={classes.grow}>

--- a/docs/src/pages/demos/app-bar/MenuAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.tsx
@@ -68,7 +68,7 @@ class MenuAppBar extends React.Component<Props, State> {
         <AppBar position="static">
           <Toolbar>
             <IconButton
-              edge="left"
+              edge="start"
               className={classes.menuButton}
               color="inherit"
               aria-label="Menu"
@@ -81,7 +81,7 @@ class MenuAppBar extends React.Component<Props, State> {
             {auth && (
               <div>
                 <IconButton
-                  edge="right"
+                  edge="end"
                   aria-owns={open ? 'menu-appbar' : undefined}
                   aria-haspopup="true"
                   onClick={this.handleMenu}

--- a/docs/src/pages/demos/app-bar/MenuAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
@@ -13,17 +13,18 @@ import FormGroup from '@material-ui/core/FormGroup';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 
-const styles = createStyles({
-  root: {
-    flexGrow: 1,
-  },
-  grow: {
-    flexGrow: 1,
-  },
-  menuButton: {
-    marginRight: 20,
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+    },
+    title: {
+      flexGrow: 1,
+    },
+  });
 
 export interface Props extends WithStyles<typeof styles> {}
 
@@ -75,7 +76,7 @@ class MenuAppBar extends React.Component<Props, State> {
             >
               <MenuIcon />
             </IconButton>
-            <Typography variant="h6" color="inherit" className={classes.grow}>
+            <Typography variant="h6" color="inherit" className={classes.title}>
               Photos
             </Typography>
             {auth && (

--- a/docs/src/pages/demos/app-bar/MenuAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/MenuAppBar.tsx
@@ -68,7 +68,7 @@ class MenuAppBar extends React.Component<Props, State> {
         <AppBar position="static">
           <Toolbar>
             <IconButton
-              align="left"
+              edge="left"
               className={classes.menuButton}
               color="inherit"
               aria-label="Menu"
@@ -81,6 +81,7 @@ class MenuAppBar extends React.Component<Props, State> {
             {auth && (
               <div>
                 <IconButton
+                  edge="right"
                   aria-owns={open ? 'menu-appbar' : undefined}
                   aria-haspopup="true"
                   onClick={this.handleMenu}

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.hooks.js
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.hooks.js
@@ -17,14 +17,11 @@ import NotificationsIcon from '@material-ui/icons/Notifications';
 import MoreIcon from '@material-ui/icons/MoreVert';
 
 const useStyles = makeStyles(theme => ({
-  root: {
-    width: '100%',
-  },
   grow: {
     flexGrow: 1,
   },
   menuButton: {
-    marginRight: 20,
+    marginRight: theme.spacing(2),
   },
   title: {
     display: 'none',
@@ -48,7 +45,7 @@ const useStyles = makeStyles(theme => ({
     },
   },
   searchIcon: {
-    width: theme.spacing(9),
+    width: theme.spacing(7),
     height: '100%',
     position: 'absolute',
     pointerEvents: 'none',
@@ -58,13 +55,9 @@ const useStyles = makeStyles(theme => ({
   },
   inputRoot: {
     color: 'inherit',
-    width: '100%',
   },
   inputInput: {
-    paddingTop: theme.spacing(1),
-    paddingRight: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
-    paddingLeft: theme.spacing(10),
+    padding: theme.spacing(1, 1, 1, 7),
     transition: theme.transitions.create('width'),
     width: '100%',
     [theme.breakpoints.up('md')]: {
@@ -157,7 +150,7 @@ function PrimarySearchAppBar() {
   );
 
   return (
-    <div className={classes.root}>
+    <div className={classes.grow}>
       <AppBar position="static">
         <Toolbar>
           <IconButton

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.hooks.js
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.hooks.js
@@ -161,7 +161,7 @@ function PrimarySearchAppBar() {
       <AppBar position="static">
         <Toolbar>
           <IconButton
-            edge="left"
+            edge="start"
             className={classes.menuButton}
             color="inherit"
             aria-label="Open drawer"
@@ -196,7 +196,7 @@ function PrimarySearchAppBar() {
               </Badge>
             </IconButton>
             <IconButton
-              edge="right"
+              edge="end"
               aria-owns={isMenuOpen ? 'material-appbar' : undefined}
               aria-haspopup="true"
               onClick={handleProfileMenuOpen}

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.hooks.js
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.hooks.js
@@ -24,7 +24,6 @@ const useStyles = makeStyles(theme => ({
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
   title: {
@@ -161,7 +160,12 @@ function PrimarySearchAppBar() {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton className={classes.menuButton} color="inherit" aria-label="Open drawer">
+          <IconButton
+            edge="left"
+            className={classes.menuButton}
+            color="inherit"
+            aria-label="Open drawer"
+          >
             <MenuIcon />
           </IconButton>
           <Typography className={classes.title} variant="h6" color="inherit" noWrap>
@@ -192,6 +196,7 @@ function PrimarySearchAppBar() {
               </Badge>
             </IconButton>
             <IconButton
+              edge="right"
               aria-owns={isMenuOpen ? 'material-appbar' : undefined}
               aria-haspopup="true"
               onClick={handleProfileMenuOpen}

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.js
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.js
@@ -18,14 +18,11 @@ import NotificationsIcon from '@material-ui/icons/Notifications';
 import MoreIcon from '@material-ui/icons/MoreVert';
 
 const styles = theme => ({
-  root: {
-    width: '100%',
-  },
   grow: {
     flexGrow: 1,
   },
   menuButton: {
-    marginRight: 20,
+    marginRight: theme.spacing(2),
   },
   title: {
     display: 'none',
@@ -49,7 +46,7 @@ const styles = theme => ({
     },
   },
   searchIcon: {
-    width: theme.spacing(9),
+    width: theme.spacing(7),
     height: '100%',
     position: 'absolute',
     pointerEvents: 'none',
@@ -59,13 +56,9 @@ const styles = theme => ({
   },
   inputRoot: {
     color: 'inherit',
-    width: '100%',
   },
   inputInput: {
-    paddingTop: theme.spacing(1),
-    paddingRight: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
-    paddingLeft: theme.spacing(10),
+    padding: theme.spacing(1, 1, 1, 7),
     transition: theme.transitions.create('width'),
     width: '100%',
     [theme.breakpoints.up('md')]: {
@@ -162,7 +155,7 @@ class PrimarySearchAppBar extends React.Component {
     );
 
     return (
-      <div className={classes.root}>
+      <div className={classes.grow}>
         <AppBar position="static">
           <Toolbar>
             <IconButton

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.js
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.js
@@ -25,7 +25,6 @@ const styles = theme => ({
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
   title: {
@@ -166,7 +165,12 @@ class PrimarySearchAppBar extends React.Component {
       <div className={classes.root}>
         <AppBar position="static">
           <Toolbar>
-            <IconButton className={classes.menuButton} color="inherit" aria-label="Open drawer">
+            <IconButton
+              edge="left"
+              className={classes.menuButton}
+              color="inherit"
+              aria-label="Open drawer"
+            >
               <MenuIcon />
             </IconButton>
             <Typography className={classes.title} variant="h6" color="inherit" noWrap>
@@ -197,6 +201,7 @@ class PrimarySearchAppBar extends React.Component {
                 </Badge>
               </IconButton>
               <IconButton
+                edge="right"
                 aria-owns={isMenuOpen ? 'material-appbar' : undefined}
                 aria-haspopup="true"
                 onClick={this.handleProfileMenuOpen}

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.js
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.js
@@ -166,7 +166,7 @@ class PrimarySearchAppBar extends React.Component {
         <AppBar position="static">
           <Toolbar>
             <IconButton
-              edge="left"
+              edge="start"
               className={classes.menuButton}
               color="inherit"
               aria-label="Open drawer"
@@ -201,7 +201,7 @@ class PrimarySearchAppBar extends React.Component {
                 </Badge>
               </IconButton>
               <IconButton
-                edge="right"
+                edge="end"
                 aria-owns={isMenuOpen ? 'material-appbar' : undefined}
                 aria-haspopup="true"
                 onClick={this.handleProfileMenuOpen}

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.tsx
@@ -26,7 +26,6 @@ const styles = (theme: Theme) =>
       flexGrow: 1,
     },
     menuButton: {
-      marginLeft: -12,
       marginRight: 20,
     },
     title: {
@@ -174,7 +173,12 @@ class PrimarySearchAppBar extends React.Component<Props, State> {
       <div className={classes.root}>
         <AppBar position="static">
           <Toolbar>
-            <IconButton className={classes.menuButton} color="inherit" aria-label="Open drawer">
+            <IconButton
+              edge="left"
+              className={classes.menuButton}
+              color="inherit"
+              aria-label="Open drawer"
+            >
               <MenuIcon />
             </IconButton>
             <Typography className={classes.title} variant="h6" color="inherit" noWrap>
@@ -205,6 +209,7 @@ class PrimarySearchAppBar extends React.Component<Props, State> {
                 </Badge>
               </IconButton>
               <IconButton
+                edge="right"
                 aria-owns={isMenuOpen ? 'material-appbar' : undefined}
                 aria-haspopup="true"
                 onClick={this.handleProfileMenuOpen}

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.tsx
@@ -174,7 +174,7 @@ class PrimarySearchAppBar extends React.Component<Props, State> {
         <AppBar position="static">
           <Toolbar>
             <IconButton
-              edge="left"
+              edge="start"
               className={classes.menuButton}
               color="inherit"
               aria-label="Open drawer"
@@ -209,7 +209,7 @@ class PrimarySearchAppBar extends React.Component<Props, State> {
                 </Badge>
               </IconButton>
               <IconButton
-                edge="right"
+                edge="end"
                 aria-owns={isMenuOpen ? 'material-appbar' : undefined}
                 aria-haspopup="true"
                 onClick={this.handleProfileMenuOpen}

--- a/docs/src/pages/demos/app-bar/PrimarySearchAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/PrimarySearchAppBar.tsx
@@ -19,14 +19,11 @@ import MoreIcon from '@material-ui/icons/MoreVert';
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {
-      width: '100%',
-    },
     grow: {
       flexGrow: 1,
     },
     menuButton: {
-      marginRight: 20,
+      marginRight: theme.spacing(2),
     },
     title: {
       display: 'none',
@@ -50,7 +47,7 @@ const styles = (theme: Theme) =>
       },
     },
     searchIcon: {
-      width: theme.spacing(9),
+      width: theme.spacing(7),
       height: '100%',
       position: 'absolute',
       pointerEvents: 'none',
@@ -60,13 +57,9 @@ const styles = (theme: Theme) =>
     },
     inputRoot: {
       color: 'inherit',
-      width: '100%',
     },
     inputInput: {
-      paddingTop: theme.spacing(1),
-      paddingRight: theme.spacing(1),
-      paddingBottom: theme.spacing(1),
-      paddingLeft: theme.spacing(10),
+      padding: theme.spacing(1, 1, 1, 7),
       transition: theme.transitions.create('width'),
       width: '100%',
       [theme.breakpoints.up('md')]: {
@@ -170,7 +163,7 @@ class PrimarySearchAppBar extends React.Component<Props, State> {
     );
 
     return (
-      <div className={classes.root}>
+      <div className={classes.grow}>
         <AppBar position="static">
           <Toolbar>
             <IconButton

--- a/docs/src/pages/demos/app-bar/SearchAppBar.js
+++ b/docs/src/pages/demos/app-bar/SearchAppBar.js
@@ -18,7 +18,6 @@ const styles = theme => ({
     flexGrow: 1,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
   title: {
@@ -76,7 +75,12 @@ function SearchAppBar(props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton className={classes.menuButton} color="inherit" aria-label="Open drawer">
+          <IconButton
+            edge="left"
+            className={classes.menuButton}
+            color="inherit"
+            aria-label="Open drawer"
+          >
             <MenuIcon />
           </IconButton>
           <Typography className={classes.title} variant="h6" color="inherit" noWrap>

--- a/docs/src/pages/demos/app-bar/SearchAppBar.js
+++ b/docs/src/pages/demos/app-bar/SearchAppBar.js
@@ -12,15 +12,13 @@ import SearchIcon from '@material-ui/icons/Search';
 
 const styles = theme => ({
   root: {
-    width: '100%',
-  },
-  grow: {
     flexGrow: 1,
   },
   menuButton: {
-    marginRight: 20,
+    marginRight: theme.spacing(2),
   },
   title: {
+    flexGrow: 1,
     display: 'none',
     [theme.breakpoints.up('sm')]: {
       display: 'block',
@@ -41,7 +39,7 @@ const styles = theme => ({
     },
   },
   searchIcon: {
-    width: theme.spacing(9),
+    width: theme.spacing(7),
     height: '100%',
     position: 'absolute',
     pointerEvents: 'none',
@@ -51,13 +49,9 @@ const styles = theme => ({
   },
   inputRoot: {
     color: 'inherit',
-    width: '100%',
   },
   inputInput: {
-    paddingTop: theme.spacing(1),
-    paddingRight: theme.spacing(1),
-    paddingBottom: theme.spacing(1),
-    paddingLeft: theme.spacing(10),
+    padding: theme.spacing(1, 1, 1, 7),
     transition: theme.transitions.create('width'),
     width: '100%',
     [theme.breakpoints.up('sm')]: {
@@ -86,7 +80,6 @@ function SearchAppBar(props) {
           <Typography className={classes.title} variant="h6" color="inherit" noWrap>
             Material-UI
           </Typography>
-          <div className={classes.grow} />
           <div className={classes.search}>
             <div className={classes.searchIcon}>
               <SearchIcon />

--- a/docs/src/pages/demos/app-bar/SearchAppBar.js
+++ b/docs/src/pages/demos/app-bar/SearchAppBar.js
@@ -76,7 +76,7 @@ function SearchAppBar(props) {
       <AppBar position="static">
         <Toolbar>
           <IconButton
-            edge="left"
+            edge="start"
             className={classes.menuButton}
             color="inherit"
             aria-label="Open drawer"

--- a/docs/src/pages/demos/app-bar/SearchAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/SearchAppBar.tsx
@@ -79,7 +79,7 @@ function SearchAppBar(props: Props) {
       <AppBar position="static">
         <Toolbar>
           <IconButton
-            edge="left"
+            edge="start"
             className={classes.menuButton}
             color="inherit"
             aria-label="Open drawer"

--- a/docs/src/pages/demos/app-bar/SearchAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/SearchAppBar.tsx
@@ -13,15 +13,13 @@ import SearchIcon from '@material-ui/icons/Search';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      width: '100%',
-    },
-    grow: {
       flexGrow: 1,
     },
     menuButton: {
-      marginRight: 20,
+      marginRight: theme.spacing(2),
     },
     title: {
+      flexGrow: 1,
       display: 'none',
       [theme.breakpoints.up('sm')]: {
         display: 'block',
@@ -42,7 +40,7 @@ const styles = (theme: Theme) =>
       },
     },
     searchIcon: {
-      width: theme.spacing(9),
+      width: theme.spacing(7),
       height: '100%',
       position: 'absolute',
       pointerEvents: 'none',
@@ -52,13 +50,9 @@ const styles = (theme: Theme) =>
     },
     inputRoot: {
       color: 'inherit',
-      width: '100%',
     },
     inputInput: {
-      paddingTop: theme.spacing(1),
-      paddingRight: theme.spacing(1),
-      paddingBottom: theme.spacing(1),
-      paddingLeft: theme.spacing(10),
+      padding: theme.spacing(1, 1, 1, 7),
       transition: theme.transitions.create('width'),
       width: '100%',
       [theme.breakpoints.up('sm')]: {
@@ -89,7 +83,6 @@ function SearchAppBar(props: Props) {
           <Typography className={classes.title} variant="h6" color="inherit" noWrap>
             Material-UI
           </Typography>
-          <div className={classes.grow} />
           <div className={classes.search}>
             <div className={classes.searchIcon}>
               <SearchIcon />

--- a/docs/src/pages/demos/app-bar/SearchAppBar.tsx
+++ b/docs/src/pages/demos/app-bar/SearchAppBar.tsx
@@ -19,7 +19,6 @@ const styles = (theme: Theme) =>
       flexGrow: 1,
     },
     menuButton: {
-      marginLeft: -12,
       marginRight: 20,
     },
     title: {
@@ -79,7 +78,12 @@ function SearchAppBar(props: Props) {
     <div className={classes.root}>
       <AppBar position="static">
         <Toolbar>
-          <IconButton className={classes.menuButton} color="inherit" aria-label="Open drawer">
+          <IconButton
+            edge="left"
+            className={classes.menuButton}
+            color="inherit"
+            aria-label="Open drawer"
+          >
             <MenuIcon />
           </IconButton>
           <Typography className={classes.title} variant="h6" color="inherit" noWrap>

--- a/docs/src/pages/demos/dialogs/FullScreenDialog.hooks.js
+++ b/docs/src/pages/demos/dialogs/FullScreenDialog.hooks.js
@@ -13,14 +13,15 @@ import Typography from '@material-ui/core/Typography';
 import CloseIcon from '@material-ui/icons/Close';
 import Slide from '@material-ui/core/Slide';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(theme => ({
   appBar: {
     position: 'relative',
   },
-  flex: {
+  title: {
+    marginLeft: theme.spacing(2),
     flex: 1,
   },
-});
+}));
 
 function Transition(props) {
   return <Slide direction="up" {...props} />;
@@ -46,10 +47,10 @@ function FullScreenDialog() {
       <Dialog fullScreen open={open} onClose={handleClose} TransitionComponent={Transition}>
         <AppBar className={classes.appBar}>
           <Toolbar>
-            <IconButton color="inherit" onClick={handleClose} aria-label="Close">
+            <IconButton edge="start" color="inherit" onClick={handleClose} aria-label="Close">
               <CloseIcon />
             </IconButton>
-            <Typography variant="h6" color="inherit" className={classes.flex}>
+            <Typography variant="h6" color="inherit" className={classes.title}>
               Sound
             </Typography>
             <Button color="inherit" onClick={handleClose}>

--- a/docs/src/pages/demos/dialogs/FullScreenDialog.js
+++ b/docs/src/pages/demos/dialogs/FullScreenDialog.js
@@ -55,7 +55,12 @@ class FullScreenDialog extends React.Component {
         >
           <AppBar className={classes.appBar}>
             <Toolbar>
-              <IconButton color="inherit" onClick={this.handleClose} aria-label="Close">
+              <IconButton
+                edge="start"
+                color="inherit"
+                onClick={this.handleClose}
+                aria-label="Close"
+              >
                 <CloseIcon />
               </IconButton>
               <Typography variant="h6" color="inherit" className={classes.flex}>

--- a/docs/src/pages/demos/drawers/MiniDrawer.hooks.js
+++ b/docs/src/pages/demos/drawers/MiniDrawer.hooks.js
@@ -40,7 +40,6 @@ const useStyles = makeStyles(theme => ({
     }),
   },
   menuButton: {
-    marginLeft: 12,
     marginRight: 36,
   },
   hide: {
@@ -104,11 +103,12 @@ function MiniDrawer() {
           [classes.appBarShift]: open,
         })}
       >
-        <Toolbar disableGutters={!open}>
+        <Toolbar>
           <IconButton
             color="inherit"
             aria-label="Open drawer"
             onClick={handleDrawerOpen}
+            edge="start"
             className={clsx(classes.menuButton, {
               [classes.hide]: open,
             })}

--- a/docs/src/pages/demos/drawers/PersistentDrawerLeft.hooks.js
+++ b/docs/src/pages/demos/drawers/PersistentDrawerLeft.hooks.js
@@ -39,8 +39,7 @@ const useStyles = makeStyles(theme => ({
     }),
   },
   menuButton: {
-    marginLeft: 12,
-    marginRight: 20,
+    marginRight: theme.spacing(2),
   },
   hide: {
     display: 'none',
@@ -99,11 +98,12 @@ function PersistentDrawerLeft() {
           [classes.appBarShift]: open,
         })}
       >
-        <Toolbar disableGutters={!open}>
+        <Toolbar>
           <IconButton
             color="inherit"
             aria-label="Open drawer"
             onClick={handleDrawerOpen}
+            edge="start"
             className={clsx(classes.menuButton, open && classes.hide)}
           >
             <MenuIcon />

--- a/docs/src/pages/demos/drawers/PersistentDrawerRight.hooks.js
+++ b/docs/src/pages/demos/drawers/PersistentDrawerRight.hooks.js
@@ -38,9 +38,8 @@ const useStyles = makeStyles(theme => ({
     }),
     marginRight: drawerWidth,
   },
-  menuButton: {
-    marginLeft: 12,
-    marginRight: 20,
+  title: {
+    flexGrow: 1,
   },
   hide: {
     display: 'none',
@@ -99,18 +98,19 @@ function PersistentDrawerRight() {
           [classes.appBarShift]: open,
         })}
       >
-        <Toolbar disableGutters={!open}>
+        <Toolbar>
+          <Typography variant="h6" color="inherit" noWrap className={classes.title}>
+            Persistent drawer
+          </Typography>
           <IconButton
             color="inherit"
             aria-label="Open drawer"
+            edge="end"
             onClick={handleDrawerOpen}
-            className={clsx(classes.menuButton, open && classes.hide)}
+            className={clsx(open && classes.hide)}
           >
             <MenuIcon />
           </IconButton>
-          <Typography variant="h6" color="inherit" noWrap>
-            Persistent drawer
-          </Typography>
         </Toolbar>
       </AppBar>
       <main

--- a/docs/src/pages/demos/drawers/ResponsiveDrawer.hooks.js
+++ b/docs/src/pages/demos/drawers/ResponsiveDrawer.hooks.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles(theme => ({
     },
   },
   menuButton: {
-    marginRight: 20,
+    marginRight: theme.spacing(2),
     [theme.breakpoints.up('sm')]: {
       display: 'none',
     },
@@ -93,6 +93,7 @@ function ResponsiveDrawer(props) {
           <IconButton
             color="inherit"
             aria-label="Open drawer"
+            edge="start"
             onClick={handleDrawerToggle}
             className={classes.menuButton}
           >

--- a/docs/src/pages/demos/snackbars/CustomizedSnackbars.hooks.js
+++ b/docs/src/pages/demos/snackbars/CustomizedSnackbars.hooks.js
@@ -64,6 +64,7 @@ function MySnackbarContentWrapper(props) {
       }
       action={[
         <IconButton
+          edge="end"
           key="close"
           aria-label="Close"
           color="inherit"

--- a/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.hooks.js
+++ b/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.hooks.js
@@ -22,7 +22,6 @@ const useStyles = makeStyles(theme => ({
     backgroundColor: theme.palette.background.paper,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
   button: {
@@ -77,7 +76,12 @@ function FabIntegrationSnackbar() {
       <div className={classes.appFrame}>
         <AppBar position="static" color="primary">
           <Toolbar>
-            <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+            <IconButton
+              edge="left"
+              className={classes.menuButton}
+              color="inherit"
+              aria-label="Menu"
+            >
               <MenuIcon />
             </IconButton>
             <Typography variant="h6" color="inherit">

--- a/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.hooks.js
+++ b/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.hooks.js
@@ -77,7 +77,7 @@ function FabIntegrationSnackbar() {
         <AppBar position="static" color="primary">
           <Toolbar>
             <IconButton
-              edge="left"
+              edge="start"
               className={classes.menuButton}
               color="inherit"
               aria-label="Menu"

--- a/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.js
+++ b/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.js
@@ -82,7 +82,7 @@ class FabIntegrationSnackbar extends React.Component {
           <AppBar position="static" color="primary">
             <Toolbar>
               <IconButton
-                edge="left"
+                edge="start"
                 className={classes.menuButton}
                 color="inherit"
                 aria-label="Menu"

--- a/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.js
+++ b/docs/src/pages/demos/snackbars/FabIntegrationSnackbar.js
@@ -23,7 +23,6 @@ const styles = theme => ({
     backgroundColor: theme.palette.background.paper,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
   button: {
@@ -82,7 +81,12 @@ class FabIntegrationSnackbar extends React.Component {
         <div className={classes.appFrame}>
           <AppBar position="static" color="primary">
             <Toolbar>
-              <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+              <IconButton
+                edge="left"
+                className={classes.menuButton}
+                color="inherit"
+                aria-label="Menu"
+              >
                 <MenuIcon />
               </IconButton>
               <Typography variant="h6" color="inherit">

--- a/docs/src/pages/getting-started/page-layout-examples/dashboard/Dashboard.js
+++ b/docs/src/pages/getting-started/page-layout-examples/dashboard/Dashboard.js
@@ -50,7 +50,6 @@ const styles = theme => ({
     }),
   },
   menuButton: {
-    marginLeft: 12,
     marginRight: 36,
   },
   menuButtonHidden: {
@@ -120,8 +119,9 @@ class Dashboard extends React.Component {
           position="absolute"
           className={clsx(classes.appBar, this.state.open && classes.appBarShift)}
         >
-          <Toolbar disableGutters={!this.state.open} className={classes.toolbar}>
+          <Toolbar className={classes.toolbar}>
             <IconButton
+              edge="start"
               color="inherit"
               aria-label="Open drawer"
               onClick={this.handleDrawerOpen}

--- a/docs/src/pages/style/color/ColorDemo.js
+++ b/docs/src/pages/style/color/ColorDemo.js
@@ -25,7 +25,6 @@ const styles = theme => ({
     height: 24,
   },
   menuButton: {
-    marginLeft: -12,
     marginRight: 20,
   },
   code: {
@@ -68,7 +67,12 @@ function ColorDemo(props) {
         <div className={classes.statusBar} style={{ backgroundColor: primary.dark }} />
         <AppBar position="static" style={{ backgroundColor: primary.main }}>
           <Toolbar style={{ color: primary.contrastText }}>
-            <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
+            <IconButton
+              edge="left"
+              className={classes.menuButton}
+              color="inherit"
+              aria-label="Menu"
+            >
               <MenuIcon />
             </IconButton>
             <Typography variant="h6" color="inherit">

--- a/docs/src/pages/style/color/ColorDemo.js
+++ b/docs/src/pages/style/color/ColorDemo.js
@@ -68,7 +68,7 @@ function ColorDemo(props) {
         <AppBar position="static" style={{ backgroundColor: primary.main }}>
           <Toolbar style={{ color: primary.contrastText }}>
             <IconButton
-              edge="left"
+              edge="start"
               className={classes.menuButton}
               color="inherit"
               aria-label="Menu"

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -69,20 +69,25 @@ export const styles = theme => {
 };
 
 const AppBar = React.forwardRef(function AppBar(props, ref) {
-  const { children, classes, className: classNameProp, color, position, ...other } = props;
-
-  const className = clsx(
-    classes.root,
-    classes[`position${capitalize(position)}`],
-    {
-      [classes[`color${capitalize(color)}`]]: color !== 'inherit',
-      'mui-fixed': position === 'fixed', // Useful for the Dialog
-    },
-    classNameProp,
-  );
+  const { children, classes, className, color, position, ...other } = props;
 
   return (
-    <Paper square component="header" elevation={4} className={className} ref={ref} {...other}>
+    <Paper
+      square
+      component="header"
+      elevation={4}
+      className={clsx(
+        classes.root,
+        classes[`position${capitalize(position)}`],
+        {
+          [classes[`color${capitalize(color)}`]]: color !== 'inherit',
+          'mui-fixed': position === 'fixed', // Useful for the Dialog
+        },
+        className,
+      )}
+      ref={ref}
+      {...other}
+    >
       {children}
     </Paper>
   );

--- a/packages/material-ui/src/IconButton/IconButton.d.ts
+++ b/packages/material-ui/src/IconButton/IconButton.d.ts
@@ -5,6 +5,7 @@ import { OverridableComponent, SimplifiedPropsOf, OverrideProps } from '../Overr
 
 declare const IconButton: ExtendButtonBase<{
   props: {
+    align?: 'left' | 'right';
     color?: PropTypes.Color;
     disabled?: boolean;
     disableRipple?: boolean;
@@ -16,6 +17,8 @@ declare const IconButton: ExtendButtonBase<{
 
 export type IconButtonClassKey =
   | 'root'
+  | 'alignLeft'
+  | 'alignRight'
   | 'colorInherit'
   | 'colorPrimary'
   | 'colorSecondary'

--- a/packages/material-ui/src/IconButton/IconButton.d.ts
+++ b/packages/material-ui/src/IconButton/IconButton.d.ts
@@ -5,7 +5,7 @@ import { OverridableComponent, SimplifiedPropsOf, OverrideProps } from '../Overr
 
 declare const IconButton: ExtendButtonBase<{
   props: {
-    edge?: 'left' | 'right' | false;
+    edge?: 'start' | 'end' | false;
     color?: PropTypes.Color;
     disabled?: boolean;
     disableRipple?: boolean;
@@ -17,8 +17,8 @@ declare const IconButton: ExtendButtonBase<{
 
 export type IconButtonClassKey =
   | 'root'
-  | 'edgeLeft'
-  | 'edgeRight'
+  | 'edgeStart'
+  | 'edgeEnd'
   | 'colorInherit'
   | 'colorPrimary'
   | 'colorSecondary'

--- a/packages/material-ui/src/IconButton/IconButton.d.ts
+++ b/packages/material-ui/src/IconButton/IconButton.d.ts
@@ -5,7 +5,7 @@ import { OverridableComponent, SimplifiedPropsOf, OverrideProps } from '../Overr
 
 declare const IconButton: ExtendButtonBase<{
   props: {
-    align?: 'left' | 'right';
+    edge?: 'left' | 'right' | false;
     color?: PropTypes.Color;
     disabled?: boolean;
     disableRipple?: boolean;
@@ -17,8 +17,8 @@ declare const IconButton: ExtendButtonBase<{
 
 export type IconButtonClassKey =
   | 'root'
-  | 'alignLeft'
-  | 'alignRight'
+  | 'edgeLeft'
+  | 'edgeRight'
   | 'colorInherit'
   | 'colorPrimary'
   | 'colorSecondary'

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -36,15 +36,15 @@ export const styles = theme => ({
       color: theme.palette.action.disabled,
     },
   },
-  /* Styles applied to the root element if `align="left"`. */
-  alignLeft: {
+  /* Styles applied to the root element if `edge="left"`. */
+  edgeLeft: {
     marginLeft: -12,
     '$sizeSmall&': {
       marginLeft: -3,
     },
   },
-  /* Styles applied to the root element if `align="right"`. */
-  alignRight: {
+  /* Styles applied to the root element if `edge="right"`. */
+  edgeRight: {
     marginRight: -12,
     '$sizeSmall&': {
       marginRight: -3,
@@ -97,7 +97,7 @@ export const styles = theme => ({
  * regarding the available icon options.
  */
 const IconButton = React.forwardRef(function IconButton(props, ref) {
-  const { align, children, classes, className, color, disabled, size, ...other } = props;
+  const { edge, children, classes, className, color, disabled, size, ...other } = props;
 
   return (
     <ButtonBase
@@ -107,8 +107,8 @@ const IconButton = React.forwardRef(function IconButton(props, ref) {
           [classes[`color${capitalize(color)}`]]: color !== 'default',
           [classes.disabled]: disabled,
           [classes[`size${capitalize(size)}`]]: size !== 'medium',
-          [classes.alignLeft]: align === 'left',
-          [classes.alignRight]: align === 'right',
+          [classes.edgeLeft]: edge === 'left',
+          [classes.edgeRight]: edge === 'right',
         },
         className,
       )}
@@ -124,13 +124,6 @@ const IconButton = React.forwardRef(function IconButton(props, ref) {
 });
 
 IconButton.propTypes = {
-  /**
-   * If given, uses a negative margin to counteract the padding on one
-   * side (this is often helpful for aligning the left or right
-   * side of the icon with content above or below, without ruining the border
-   * size and shape).
-   */
-  align: PropTypes.oneOf(['left', 'right']),
   /**
    * The icon element.
    */
@@ -170,6 +163,13 @@ IconButton.propTypes = {
    * If `true`, the button will be disabled.
    */
   disabled: PropTypes.bool,
+  /**
+   * If given, uses a negative margin to counteract the padding on one
+   * side (this is often helpful for aligning the left or right
+   * side of the icon with content above or below, without ruining the border
+   * size and shape).
+   */
+  edge: PropTypes.oneOf(['left', 'right', false]),
   /**
    * The size of the button.
    * `small` is equivalent to the dense button styling.

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -36,6 +36,20 @@ export const styles = theme => ({
       color: theme.palette.action.disabled,
     },
   },
+  /* Styles applied to the root element if `align="left"`. */
+  alignLeft: {
+    marginLeft: -12,
+    '$sizeSmall&': {
+      marginLeft: -3,
+    },
+  },
+  /* Styles applied to the root element if `align="right"`. */
+  alignRight: {
+    marginRight: -12,
+    '$sizeSmall&': {
+      marginRight: -3,
+    },
+  },
   /* Styles applied to the root element if `color="inherit"`. */
   colorInherit: {
     color: 'inherit',
@@ -83,7 +97,7 @@ export const styles = theme => ({
  * regarding the available icon options.
  */
 const IconButton = React.forwardRef(function IconButton(props, ref) {
-  const { children, classes, className, color, disabled, size, ...other } = props;
+  const { align, children, classes, className, color, disabled, size, ...other } = props;
 
   return (
     <ButtonBase
@@ -93,6 +107,8 @@ const IconButton = React.forwardRef(function IconButton(props, ref) {
           [classes[`color${capitalize(color)}`]]: color !== 'default',
           [classes.disabled]: disabled,
           [classes[`size${capitalize(size)}`]]: size !== 'medium',
+          [classes.alignLeft]: align === 'left',
+          [classes.alignRight]: align === 'right',
         },
         className,
       )}
@@ -108,6 +124,13 @@ const IconButton = React.forwardRef(function IconButton(props, ref) {
 });
 
 IconButton.propTypes = {
+  /**
+   * If given, uses a negative margin to counteract the padding on one
+   * side (this is often helpful for aligning the left or right
+   * side of the icon with content above or below, without ruining the border
+   * size and shape).
+   */
+  align: PropTypes.oneOf(['left', 'right']),
   /**
    * The icon element.
    */

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -36,15 +36,15 @@ export const styles = theme => ({
       color: theme.palette.action.disabled,
     },
   },
-  /* Styles applied to the root element if `edge="left"`. */
-  edgeLeft: {
+  /* Styles applied to the root element if `edge="start"`. */
+  edgeStart: {
     marginLeft: -12,
     '$sizeSmall&': {
       marginLeft: -3,
     },
   },
-  /* Styles applied to the root element if `edge="right"`. */
-  edgeRight: {
+  /* Styles applied to the root element if `edge="end"`. */
+  edgeEnd: {
     marginRight: -12,
     '$sizeSmall&': {
       marginRight: -3,
@@ -107,8 +107,8 @@ const IconButton = React.forwardRef(function IconButton(props, ref) {
           [classes[`color${capitalize(color)}`]]: color !== 'default',
           [classes.disabled]: disabled,
           [classes[`size${capitalize(size)}`]]: size !== 'medium',
-          [classes.edgeLeft]: edge === 'left',
-          [classes.edgeRight]: edge === 'right',
+          [classes.edgeStart]: edge === 'start',
+          [classes.edgeEnd]: edge === 'end',
         },
         className,
       )}
@@ -169,7 +169,7 @@ IconButton.propTypes = {
    * side of the icon with content above or below, without ruining the border
    * size and shape).
    */
-  edge: PropTypes.oneOf(['left', 'right', false]),
+  edge: PropTypes.oneOf(['start', 'end', false]),
   /**
    * The size of the button.
    * `small` is equivalent to the dense button styling.

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -105,16 +105,16 @@ describe('<IconButton />', () => {
   describe('prop: edge', () => {
     it('edge="start" should render the right class', () => {
       const wrapper = mount(<IconButton edge="start">book</IconButton>);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeLeft), true);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeStart), true);
     });
     it('edge="end" should render the right class', () => {
       const wrapper = mount(<IconButton edge="end">book</IconButton>);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeRight), true);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeEnd), true);
     });
     it('no edge should render the right class', () => {
       const wrapper = mount(<IconButton>book</IconButton>);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeLeft), false);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeRight), false);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeStart), false);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeEnd), false);
     });
   });
 

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -103,13 +103,16 @@ describe('<IconButton />', () => {
   });
 
   describe('prop: align', () => {
-    it('should render the right class', () => {
-      let wrapper;
-      wrapper = mount(<IconButton align="left">book</IconButton>);
+    it('align="left" should render the right class', () => {
+      const wrapper = mount(<IconButton align="left">book</IconButton>);
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignLeft), true);
-      wrapper = mount(<IconButton align="right">book</IconButton>);
+    });
+    it('align="right" should render the right class', () => {
+      const wrapper = mount(<IconButton align="right">book</IconButton>);
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignRight), true);
-      wrapper = mount(<IconButton>book</IconButton>);
+    });
+    it('no align should render the right class', () => {
+      const wrapper = mount(<IconButton>book</IconButton>);
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignLeft), false);
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignRight), false);
     });

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -103,12 +103,12 @@ describe('<IconButton />', () => {
   });
 
   describe('prop: edge', () => {
-    it('edge="left" should render the right class', () => {
-      const wrapper = mount(<IconButton edge="left">book</IconButton>);
+    it('edge="start" should render the right class', () => {
+      const wrapper = mount(<IconButton edge="start">book</IconButton>);
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeLeft), true);
     });
-    it('edge="right" should render the right class', () => {
-      const wrapper = mount(<IconButton edge="right">book</IconButton>);
+    it('edge="end" should render the right class', () => {
+      const wrapper = mount(<IconButton edge="end">book</IconButton>);
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeRight), true);
     });
     it('no edge should render the right class', () => {

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -102,19 +102,19 @@ describe('<IconButton />', () => {
     });
   });
 
-  describe('prop: align', () => {
-    it('align="left" should render the right class', () => {
-      const wrapper = mount(<IconButton align="left">book</IconButton>);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignLeft), true);
+  describe('prop: edge', () => {
+    it('edge="left" should render the right class', () => {
+      const wrapper = mount(<IconButton edge="left">book</IconButton>);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeLeft), true);
     });
-    it('align="right" should render the right class', () => {
-      const wrapper = mount(<IconButton align="right">book</IconButton>);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignRight), true);
+    it('edge="right" should render the right class', () => {
+      const wrapper = mount(<IconButton edge="right">book</IconButton>);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeRight), true);
     });
-    it('no align should render the right class', () => {
+    it('no edge should render the right class', () => {
       const wrapper = mount(<IconButton>book</IconButton>);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignLeft), false);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignRight), false);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeLeft), false);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.edgeRight), false);
     });
   });
 

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -102,6 +102,19 @@ describe('<IconButton />', () => {
     });
   });
 
+  describe('prop: align', () => {
+    it('should render the right class', () => {
+      let wrapper;
+      wrapper = mount(<IconButton align="left">book</IconButton>);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignLeft), true);
+      wrapper = mount(<IconButton align="right">book</IconButton>);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignRight), true);
+      wrapper = mount(<IconButton>book</IconButton>);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignLeft), false);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.alignRight), false);
+    });
+  });
+
   describe('prop: disabled', () => {
     it('should disable the component', () => {
       const wrapper = shallow(<IconButton disabled>book</IconButton>);

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -17,14 +17,14 @@ regarding the available icon options.
 
 ## Props
 
-| Name | Type | Default | Description |
-|:-----|:-----|:--------|:------------|
-| <span class="prop-name">align</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'<br></span> |   | If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape). |
-| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The icon element. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
-| <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'<br></span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
+| Name                                    | Type                                                                                                                                                   | Default                                     | Description                                                                                                                                                                                                            |
+| :-------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span>                                                                                                                    |                                             | The icon element.                                                                                                                                                                                                      |
+| <span class="prop-name">classes</span>  | <span class="prop-type">object</span>                                                                                                                  |                                             | Override or extend the styles applied to the component. See [CSS API](#css) below for more details.                                                                                                                    |
+| <span class="prop-name">color</span>    | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component.                                                                                                                         |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span>                                                                                                                    | <span class="prop-default">false</span>     | If `true`, the button will be disabled.                                                                                                                                                                                |
+| <span class="prop-name">edge</span>     | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;false<br></span>                                           |                                             | If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape). |
+| <span class="prop-name">size</span>     | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'<br></span>                                                                    | <span class="prop-default">'medium'</span>  | The size of the button. `small` is equivalent to the dense button styling.                                                                                                                                             |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
@@ -33,18 +33,17 @@ Any other properties supplied will be spread to the root element ([ButtonBase](/
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">alignLeft</span> | Styles applied to the root element if `align="left"`.
-| <span class="prop-name">alignRight</span> | Styles applied to the root element if `align="right"`.
-| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">label</span> | Styles applied to the children container element.
+| Name                                          | Description                                                |
+| :-------------------------------------------- | :--------------------------------------------------------- |
+| <span class="prop-name">root</span>           | Styles applied to the root element.                        |
+| <span class="prop-name">edgeLeft</span>       | Styles applied to the root element if `edge="left"`.       |
+| <span class="prop-name">edgeRight</span>      | Styles applied to the root element if `edge="right"`.      |
+| <span class="prop-name">colorInherit</span>   | Styles applied to the root element if `color="inherit"`.   |
+| <span class="prop-name">colorPrimary</span>   | Styles applied to the root element if `color="primary"`.   |
+| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`. |
+| <span class="prop-name">disabled</span>       | Styles applied to the root element if `disabled={true}`.   |
+| <span class="prop-name">sizeSmall</span>      | Styles applied to the root element if `size="small"`.      |
+| <span class="prop-name">label</span>          | Styles applied to the children container element.          |
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/IconButton/IconButton.js)
@@ -62,4 +61,3 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 - [Buttons](/demos/buttons/)
 - [Grid List](/demos/grid-list/)
-

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -23,7 +23,7 @@ regarding the available icon options.
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
-| <span class="prop-name">edge</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;false<br></span> |   | If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape). |
+| <span class="prop-name">edge</span> | <span class="prop-type">enum:&nbsp;'start'&nbsp;&#124;<br>&nbsp;'end'&nbsp;&#124;<br>&nbsp;false<br></span> |   | If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape). |
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'<br></span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
@@ -37,8 +37,8 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">edgeLeft</span> | Styles applied to the root element if `edge="left"`.
-| <span class="prop-name">edgeRight</span> | Styles applied to the root element if `edge="right"`.
+| <span class="prop-name">edgeStart</span> | Styles applied to the root element if `edge="start"`.
+| <span class="prop-name">edgeEnd</span> | Styles applied to the root element if `edge="end"`.
 | <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
 | <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -17,14 +17,14 @@ regarding the available icon options.
 
 ## Props
 
-| Name                                    | Type                                                                                                                                                   | Default                                     | Description                                                                                                                                                                                                            |
-| :-------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------------------------------ | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <span class="prop-name">children</span> | <span class="prop-type">node</span>                                                                                                                    |                                             | The icon element.                                                                                                                                                                                                      |
-| <span class="prop-name">classes</span>  | <span class="prop-type">object</span>                                                                                                                  |                                             | Override or extend the styles applied to the component. See [CSS API](#css) below for more details.                                                                                                                    |
-| <span class="prop-name">color</span>    | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component.                                                                                                                         |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span>                                                                                                                    | <span class="prop-default">false</span>     | If `true`, the button will be disabled.                                                                                                                                                                                |
-| <span class="prop-name">edge</span>     | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;false<br></span>                                           |                                             | If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape). |
-| <span class="prop-name">size</span>     | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'<br></span>                                                                    | <span class="prop-default">'medium'</span>  | The size of the button. `small` is equivalent to the dense button styling.                                                                                                                                             |
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The icon element. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
+| <span class="prop-name">edge</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;false<br></span> |   | If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape). |
+| <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'<br></span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
@@ -33,17 +33,18 @@ Any other properties supplied will be spread to the root element ([ButtonBase](/
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-| Name                                          | Description                                                |
-| :-------------------------------------------- | :--------------------------------------------------------- |
-| <span class="prop-name">root</span>           | Styles applied to the root element.                        |
-| <span class="prop-name">edgeLeft</span>       | Styles applied to the root element if `edge="left"`.       |
-| <span class="prop-name">edgeRight</span>      | Styles applied to the root element if `edge="right"`.      |
-| <span class="prop-name">colorInherit</span>   | Styles applied to the root element if `color="inherit"`.   |
-| <span class="prop-name">colorPrimary</span>   | Styles applied to the root element if `color="primary"`.   |
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`. |
-| <span class="prop-name">disabled</span>       | Styles applied to the root element if `disabled={true}`.   |
-| <span class="prop-name">sizeSmall</span>      | Styles applied to the root element if `size="small"`.      |
-| <span class="prop-name">label</span>          | Styles applied to the children container element.          |
+
+| Name | Description |
+|:-----|:------------|
+| <span class="prop-name">root</span> | Styles applied to the root element.
+| <span class="prop-name">edgeLeft</span> | Styles applied to the root element if `edge="left"`.
+| <span class="prop-name">edgeRight</span> | Styles applied to the root element if `edge="right"`.
+| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
+| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">label</span> | Styles applied to the children container element.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/IconButton/IconButton.js)
@@ -61,3 +62,4 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 - [Buttons](/demos/buttons/)
 - [Grid List](/demos/grid-list/)
+

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -19,6 +19,7 @@ regarding the available icon options.
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">align</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'<br></span> |   | If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape). |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The icon element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
@@ -36,6 +37,8 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
+| <span class="prop-name">alignLeft</span> | Styles applied to the root element if `align="left"`.
+| <span class="prop-name">alignRight</span> | Styles applied to the root element if `align="right"`.
 | <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
 | <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

One of the most common things we all have to do with `IconButton`s is apply `marginLeft: -12` or
`marginRight: -12` to counteract the padding and fix the icon's horizontal alignment with content above or below.  ([It's common in your demos too](https://github.com/mui-org/material-ui/search?q=marginLeft%3A+-12&unscoped_q=marginLeft%3A+-12))

It gets a bit tedious to fix every case with JSS styles.  Let's make it easier for ourselves! ✨ 

With this PR, `<IconButton align="left">` will apply `marginLeft: -12` and `align="right"` will apply `marginRight: -12`.  For `size="small"`, it will use `-3` for the margin instead.
