### PR TITLE
[ci] Report codecoverage changes instead of failing

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,4 @@
-coverage:
-  status:
-    patch:
-      default:
-        threshold: 0.0%
-comment: false
+comment:
+  layout: "diff"
+  # testing, yes for production
+  require_changes: no


### PR DESCRIPTION
Would like to hear some opinions if this is to spammy.

Going to simply remove the threshold for now (since we don't require 100% project coverage anymore). Will investigate if we can add this behavior into the dangerfile.js. This would make it less spammy.