### PR TITLE
[test] Increase the Codecov threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,5 +2,5 @@ coverage:
   status:
     patch:
       default:
-        threshold: 0.0%
+        threshold: 2.0%
 comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,8 @@
 coverage:
   status:
-    patch:
+    project:
       default:
-        threshold: 2.0%
+        target: auto
+        threshold: 1%
+    patch: off
 comment: false


### PR DESCRIPTION
Continuation of #14764, we have had [mul](https://github.com/mui-org/material-ui/pull/14593)ti[ple](https://github.com/mui-org/material-ui/pull/14757) builds failing after removing code. Codecov struggles to report the coverage correctly. In order to ignore this noise (-0.05%), I'm proposing to increase the Codecov threshold. A build will fail if the code coverage reduction is greater than 2%. This should allow to catch unintended test file removal or regression in the coverage pipeline while still allowing us to refactor with ease. For instance, #13676 coverage reduction was only about -0.5%.