### PR TITLE
[MenuItem] Remove fixed height

### DIFF
--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -10,8 +10,10 @@ export const styles = theme => ({
   /* Styles applied to the root element. */
   root: {
     ...theme.typography.subtitle1,
-    height: 24,
-    boxSizing: 'content-box',
+    minHeight: 48,
+    paddingTop: 4,
+    paddingBottom: 4,
+    boxSizing: 'border-box',
     width: 'auto',
     overflow: 'hidden',
     whiteSpace: 'nowrap',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #6216 

### Breaking change

Remove the fixed height of the menu Item. The padding and line-height are used by the browser to compute the height.