### PR TITLE
[styles] Make CSSProperties public

### DIFF
--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -13,7 +13,7 @@ declare module '@material-ui/styles' {
   export { default as StylesProvider } from '@material-ui/styles/StylesProvider';
   export { default as ThemeProvider } from '@material-ui/styles/ThemeProvider';
   export { default as useTheme } from '@material-ui/styles/useTheme';
-  export { default as withStyles, StyleRules, WithStyles } from '@material-ui/styles/withStyles';
+  export { default as withStyles, CSSProperties, StyleRules, WithStyles } from '@material-ui/styles/withStyles';
   export { default as withTheme, WithTheme } from '@material-ui/styles/withTheme';
 }
 

--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -13,7 +13,12 @@ declare module '@material-ui/styles' {
   export { default as StylesProvider } from '@material-ui/styles/StylesProvider';
   export { default as ThemeProvider } from '@material-ui/styles/ThemeProvider';
   export { default as useTheme } from '@material-ui/styles/useTheme';
-  export { default as withStyles, CSSProperties, StyleRules, WithStyles } from '@material-ui/styles/withStyles';
+  export {
+    default as withStyles,
+    CSSProperties,
+    StyleRules,
+    WithStyles,
+  } from '@material-ui/styles/withStyles';
   export { default as withTheme, WithTheme } from '@material-ui/styles/withTheme';
 }
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Similar to https://github.com/mui-org/material-ui/pull/14362

Usage
```
import { makeStyles, StyleRules, CSSProperties  } from '@material-ui/styles';

const useStyles = makeStyles((theme: Theme): StyleRules<Props, 'option'> =>
  createStyles({
    option: (props: Props): CSSProperties => {
      backgroundColor: 'red',
    },
  }),
);
```

It does not make sense to import from `withStyles` when you want to type returnType
```
import { makeStyles, StyleRules,  } from '@material-ui/styles';
import { CSSProperties } from '@material-ui/styles/withStyles';
```