### PR TITLE
[docs] fix specificity on font awesome material conflict

### DIFF
--- a/docs/src/pages/style/icons/FontAwesome.js
+++ b/docs/src/pages/style/icons/FontAwesome.js
@@ -11,6 +11,10 @@ const styles = theme => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'flex-end',
+    "& $icon, & $iconHover": {
+      fontFamily: "'Font Awesome 5 Free'",
+      fontWeight: 900
+    },
   },
   icon: {
     margin: theme.spacing.unit * 2,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This appears to be resolved on the *next* branch docs, so it might be of limited value, but when using `<Icon>add_circle</Icon>` the `.material-icons` class is automatically applied to the child element.

So when using font-awesome like this `<Icon className="fa fa-plus-circle">add_circle</Icon>`, the fa classes conflict with material

Both classes have the same specificity in determining `font-family`:

```css
.material-icons { font-family: 'Material Icons'; }
.fa, .far, .fas { font-family: "Font Awesome 5 Free"; }
```

So this leaves the 'winner' to be decided by the relatively arbitrary order of dom insertion of the `<link rel=stylesheet" >` 

In the current docs, material icons happens to come after fa, so it overwrites the font-family and interferes with the rendering on the [live docs page](https://material-ui.com/style/icons/#font-awesome).

In production, this might not affect many clients because people are unlikely to mix icon packs, but the docs page does.  One solution would be to [increase the specificity](https://material-ui.com/customization/overrides/#use-rulename-to-reference-a-local-rule-within-the-same-style-sheet) in the `FontAwesome` demo component so that if *fa* is used, it takes priority by nesting the fontfamily rule under root so it has double the selector strength like this:

```css
root: {
   ...
    "& $icon, & $iconHover": {
      fontFamily: "'Font Awesome 5 Free'",
      fontWeight: 900
    },
}
```

Here's the current Icons docs page:

![Font Awesome Docs](https://user-images.githubusercontent.com/4307307/54080731-82faab80-42c4-11e9-8124-9ce0ddcd6fe4.png)

And the order that the stylesheets load:

![image](https://user-images.githubusercontent.com/4307307/54080736-a02f7a00-42c4-11e9-9d91-021ae36aa3d4.png)

### [Here's a demo in CodeSandBox with the issue resolved](https://codesandbox.io/s/n5n1936m2j).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
