### PR TITLE
[TouchRipple] Remove findDOMNode usage

### DIFF
--- a/packages/material-ui/src/ButtonBase/TouchRipple.d.ts
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.d.ts
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { TransitionGroup } from 'react-transition-group';
 import { StandardProps } from '..';
 
 export type TouchRippleProps = StandardProps<
-  TransitionGroup.TransitionGroupProps,
+  React.HTMLAttributes<HTMLElement>,
   TouchRippleClassKey
 > & {
   center?: boolean;

--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
 import TransitionGroup from 'react-transition-group/TransitionGroup';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
@@ -119,6 +118,8 @@ class TouchRipple extends React.PureComponent {
     ripples: [],
   };
 
+  container = React.createRef();
+
   componentWillUnmount() {
     clearTimeout(this.startTimer);
   }
@@ -143,7 +144,7 @@ class TouchRipple extends React.PureComponent {
       this.ignoringMouseDown = true;
     }
 
-    const element = fakeElement ? null : ReactDOM.findDOMNode(this);
+    const element = fakeElement ? null : this.container.current;
     const rect = element
       ? element.getBoundingClientRect()
       : {
@@ -263,15 +264,11 @@ class TouchRipple extends React.PureComponent {
     const { center, classes, className, ...other } = this.props;
 
     return (
-      <TransitionGroup
-        component="span"
-        enter
-        exit
-        className={clsx(classes.root, className)}
-        {...other}
-      >
-        {this.state.ripples}
-      </TransitionGroup>
+      <span className={clsx(classes.root, className)} ref={this.container} {...other}>
+        <TransitionGroup component={null} enter exit>
+          {this.state.ripples}
+        </TransitionGroup>
+      </span>
     );
   }
 }

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -1,7 +1,14 @@
 import React from 'react';
 import { useFakeTimers } from 'sinon';
 import { assert } from 'chai';
-import { createShallow, createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
+import {
+  createShallow,
+  createMount,
+  findOutermostIntrinsic,
+  getClasses,
+  unwrap,
+} from '@material-ui/core/test-utils';
+import Ripple from './Ripple';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
 
 const cb = () => {};
@@ -22,22 +29,22 @@ describe('<TouchRipple />', () => {
     mount.cleanUp();
   });
 
-  it('should render a <ReactTransitionGroup> component', () => {
-    const wrapper = shallow(<TouchRipple />);
-    assert.strictEqual(wrapper.name(), 'TransitionGroup');
-    assert.strictEqual(wrapper.props().component, 'span');
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
+  it('should render a span', () => {
+    const wrapper = mount(<TouchRipple />);
+    const root = findOutermostIntrinsic(wrapper);
+    assert.strictEqual(root.type(), 'span');
+    assert.strictEqual(root.hasClass(classes.root), true);
   });
 
   it('should render the custom className', () => {
-    const wrapper = shallow(<TouchRipple className="test-class-name" />);
-    assert.strictEqual(wrapper.is('.test-class-name'), true);
+    const wrapper = mount(<TouchRipple className="test-class-name" />);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass('test-class-name'), true);
   });
 
   describe('prop: center', () => {
     it('should should compute the right ripple dimensions', () => {
-      const wrapper = shallow(<TouchRipple center />);
-      const instance = wrapper.instance();
+      const wrapper = mount(<TouchRipple center />);
+      const instance = wrapper.find('TouchRipple').instance();
       instance.start(
         {},
         {
@@ -46,7 +53,13 @@ describe('<TouchRipple />', () => {
         cb,
       );
       wrapper.update();
-      assert.strictEqual(wrapper.childAt(0).props().rippleSize, 1);
+      assert.strictEqual(
+        wrapper
+          .find(Ripple)
+          .at(0)
+          .props().rippleSize,
+        1,
+      );
     });
   });
 

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -196,7 +196,7 @@ ExpansionPanelSummary.propTypes = {
    */
   expandIcon: PropTypes.node,
   /**
-   * Properties applied to the `TouchRipple` element wrapping the expand icon.
+   * Properties applied to the `IconButton` element wrapping the expand icon.
    */
   IconButtonProps: PropTypes.object,
   /**

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -21,7 +21,7 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the expansion panel summary. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node</span> |   | The icon to display as the expand indicator. |
-| <span class="prop-name">IconButtonProps</span> | <span class="prop-type">object</span> |   | Properties applied to the `TouchRipple` element wrapping the expand icon. |
+| <span class="prop-name">IconButtonProps</span> | <span class="prop-type">object</span> |   | Properties applied to the `IconButton` element wrapping the expand icon. |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 


### PR DESCRIPTION
Use ref on the DOM element type instead of `findDOMNode(this)`.