### PR TITLE
[Divider] Remove Divider inset prop

### DIFF
--- a/docs/src/pages/demos/dividers/dividers.md
+++ b/docs/src/pages/demos/dividers/dividers.md
@@ -23,8 +23,6 @@ The examples below show two ways of achieving this.
 
 ## Inset Dividers
 
-The `inset` property has now been deprecated. You should now use `variant="inset"`.
-
 {{"demo": "pages/demos/dividers/InsetDividers.js"}}
 
 ## Subheader Dividers

--- a/packages/material-ui/src/Divider/Divider.d.ts
+++ b/packages/material-ui/src/Divider/Divider.d.ts
@@ -5,7 +5,6 @@ export interface DividerProps
   extends StandardProps<React.HTMLAttributes<HTMLHRElement>, DividerClassKey> {
   absolute?: boolean;
   component?: React.ReactType<DividerProps>;
-  inset?: boolean;
   light?: boolean;
   variant?: 'fullWidth' | 'inset' | 'middle';
 }

--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { chainPropTypes } from '@material-ui/utils';
 import withStyles from '../styles/withStyles';
 import { fade } from '../styles/colorManipulator';
 
@@ -37,23 +36,14 @@ export const styles = theme => ({
 });
 
 const Divider = React.forwardRef(function Divider(props, ref) {
-  const {
-    absolute,
-    classes,
-    className,
-    component: Component,
-    inset,
-    light,
-    variant,
-    ...other
-  } = props;
+  const { absolute, classes, className, component: Component, light, variant, ...other } = props;
 
   return (
     <Component
       className={clsx(
         classes.root,
         {
-          [classes.inset]: inset || variant === 'inset',
+          [classes.inset]: variant === 'inset',
           [classes.middle]: variant === 'middle',
           [classes.absolute]: absolute,
           [classes.light]: light,
@@ -85,22 +75,6 @@ Divider.propTypes = {
    * Either a string to use a DOM element or a component.
    */
   component: PropTypes.elementType,
-  /**
-   * If `true`, the divider will be indented.
-   * __WARNING__: `inset` is deprecated.
-   * Instead use `variant="inset"`.
-   */
-  inset: chainPropTypes(PropTypes.bool, props => {
-    if (props.inset) {
-      return new Error(
-        'Material-UI: you are using the deprecated `inset` property ' +
-          'that will be removed in the next major release. The property `variant="inset"` ' +
-          'is equivalent and should be used instead.',
-      );
-    }
-
-    return null;
-  }),
   /**
    * If `true`, the divider will have a lighter color.
    */

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { assert } from 'chai';
 import { createShallow, getClasses } from '@material-ui/core/test-utils';
 import Divider from './Divider';
-import consoleErrorMock from 'test/utils/consoleErrorMock';
 
 describe('<Divider />', () => {
   let shallow;
@@ -31,21 +30,6 @@ describe('<Divider />', () => {
   it('should set the light class', () => {
     const wrapper = shallow(<Divider light />);
     assert.strictEqual(wrapper.hasClass(classes.light), true);
-  });
-
-  describe('prop: inset', () => {
-    before(() => {
-      consoleErrorMock.spy();
-    });
-
-    after(() => {
-      consoleErrorMock.reset();
-    });
-
-    it('should set the inset class', () => {
-      const wrapper = shallow(<Divider inset />);
-      assert.strictEqual(wrapper.hasClass(classes.inset), true);
-    });
   });
 
   describe('prop: variant', () => {

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -21,7 +21,6 @@ import Divider from '@material-ui/core/Divider';
 | <span class="prop-name">absolute</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Absolutely position the element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'hr'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">inset</span> | <span class="prop-type">bool</span> |   | If `true`, the divider will be indented. __WARNING__: `inset` is deprecated. Instead use `variant="inset"`. |
 | <span class="prop-name">light</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the divider will have a lighter color. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'fullWidth'&nbsp;&#124;<br>&nbsp;'inset'&nbsp;&#124;<br>&nbsp;'middle'<br></span> | <span class="prop-default">'fullWidth'</span> | The variant to use. |
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Removes the deprecated Divider inset prop

### Breaking change

```diff
-<Divider inset />
+<Divider variant="inset" />
```