### PR TITLE
[test] Fix unwrapCreateStyles tests for windows

### DIFF
--- a/packages/babel-plugin-unwrap-createStyles/test/.gitattributes
+++ b/packages/babel-plugin-unwrap-createStyles/test/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Additional fix for #14683

After @joshwooding's fixes in #14726 I still had two tests failing on Windows. These two tests succeed if I do **not** have `autocrlf=true`, but then several other tests fail instead. This commit ensures (via .gitattributes) that the expected results for the `unwrapCreateStyles` tests will have lf instead of crlf. This then gives me a clean execution of the unit tests.