### PR TITLE
[Slide] Attach ref to child instead of Transition

### DIFF
--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -7,6 +7,7 @@ import EventListener from 'react-event-listener';
 import debounce from 'debounce'; // < 1kb payload overhead when lodash/debounce is > 3kb.
 import Transition from 'react-transition-group/Transition';
 import ownerWindow from '../utils/ownerWindow';
+import { setRef } from '../utils/reactHelpers';
 import withTheme from '../styles/withTheme';
 import { duration } from '../styles/transitions';
 import { reflow, getTransitionProps } from '../transitions/utils';
@@ -85,8 +86,8 @@ class Slide extends React.Component {
           return;
         }
 
-        if (this.transitionRef) {
-          setTranslateValue(this.props, this.transitionRef);
+        if (this.childDOMNode) {
+          setTranslateValue(this.props, this.childDOMNode);
         }
       }, 166); // Corresponds to 10 frames at 60 Hz.
     }
@@ -177,9 +178,18 @@ class Slide extends React.Component {
     }
   };
 
+  /**
+   * used in cloneElement(children, { ref: handleRef })
+   */
+  handleRef = ref => {
+    // StrictMode ready
+    this.childDOMNode = ReactDOM.findDOMNode(ref);
+    setRef(this.props.children.ref, ref);
+  };
+
   updatePosition() {
-    if (this.transitionRef) {
-      setTranslateValue(this.props, this.transitionRef);
+    if (this.childDOMNode) {
+      setTranslateValue(this.props, this.childDOMNode);
     }
   }
 
@@ -206,13 +216,11 @@ class Slide extends React.Component {
           onExited={this.handleExited}
           appear
           in={inProp}
-          ref={ref => {
-            this.transitionRef = ReactDOM.findDOMNode(ref);
-          }}
           {...other}
         >
           {(state, childProps) => {
             return React.cloneElement(children, {
+              ref: this.handleRef,
               style: {
                 visibility: state === 'exited' && !inProp ? 'hidden' : undefined,
                 ...style,
@@ -229,7 +237,8 @@ class Slide extends React.Component {
 
 Slide.propTypes = {
   /**
-   * A single child content element.
+   * A single child content element. The component used as a child must be able
+   * to hold a ref.
    */
   children: PropTypes.element,
   /**

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -182,7 +182,7 @@ class Slide extends React.Component {
    * used in cloneElement(children, { ref: handleRef })
    */
   handleRef = ref => {
-    // StrictMode ready
+    // #StrictMode ready
     this.childDOMNode = ReactDOM.findDOMNode(ref);
     setRef(this.props.children.ref, ref);
   };

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -116,7 +116,7 @@ describe('<Slide />', () => {
       const wrapper = mount(
         <SlideNaked {...defaultProps} theme={createMuiTheme()} in={false} direction="left" />,
       );
-      const transition = wrapper.instance().transitionRef;
+      const transition = wrapper.instance().childDOMNode;
 
       const transition1 = transition.style.transform;
       wrapper.setProps({
@@ -233,7 +233,7 @@ describe('<Slide />', () => {
           <div>Foo</div>
         </SlideNaked>,
       );
-      const transition = wrapper.instance().transitionRef;
+      const transition = wrapper.instance().childDOMNode;
 
       assert.strictEqual(transition.style.visibility, 'hidden');
       assert.notStrictEqual(transition.style.transform, undefined);
@@ -260,7 +260,7 @@ describe('<Slide />', () => {
       const instance = wrapper.instance();
       instance.handleResize();
       clock.tick(166);
-      const transition = instance.transitionRef;
+      const transition = instance.childDOMNode;
 
       assert.notStrictEqual(transition.style.transform, undefined);
     });

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -30,6 +30,8 @@ class SwipeableDrawer extends React.Component {
 
   isSwiping = null;
 
+  paperRef = null;
+
   componentDidMount() {
     if (this.props.variant === 'temporary') {
       this.listenTouchStart();

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -19,7 +19,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">children</span> | <span class="prop-type">element</span> |   | A single child content element. |
+| <span class="prop-name">children</span> | <span class="prop-type">element</span> |   | A single child content element. The component used as a child must be able to hold a ref. |
 | <span class="prop-name">direction</span> | <span class="prop-type">enum:&nbsp;'left'&nbsp;&#124;<br>&nbsp;'right'&nbsp;&#124;<br>&nbsp;'up'&nbsp;&#124;<br>&nbsp;'down'<br></span> | <span class="prop-default">'down'</span> | Direction the child node will enter from. |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |   | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |


### PR DESCRIPTION
Allows strict mode compliant findDOMNode. Breaking if <Slide /> wraps components that cant't hold refs.

This is breaking for `Snackbar` as well if `Slide` is used as the `TransitionComponent` (default).
