### PR TITLE
[Table] Fix demo parse rowsPerPage value as an integer

### DIFF
--- a/docs/src/pages/demos/tables/CustomPaginationActionsTable.js
+++ b/docs/src/pages/demos/tables/CustomPaginationActionsTable.js
@@ -128,7 +128,7 @@ function CustomPaginationActionsTable() {
   }
 
   function handleChangeRowsPerPage(event) {
-    setRowsPerPage(event.target.value);
+    setRowsPerPage(parseInt(event.target.value, 10));
   }
 
   return (


### PR DESCRIPTION
The pagination example has a bug where the rowsPerPage field is set to a string when you click on the dropdown. This is because `handleChangeRowsPerPage` method uses `event.target.value` which is a string value.

To replicate this bug. Set page size to `10` then back to `5` and then click the next page button and you'll see that page 2 doesn't show 5 elements instead it shows 10. The `rowsPerPage` value is not recognized and I traced it down to it being set as a string instead of an integer.

Working example: https://codesandbox.io/s/52y11rp96p

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
