### PR TITLE
[TypeScript] Add WithThemeCreator typing

### DIFF
--- a/packages/material-ui-styles/src/index.d.ts
+++ b/packages/material-ui-styles/src/index.d.ts
@@ -14,4 +14,4 @@ export {
   StyleRules,
   WithStyles,
 } from '@material-ui/styles/withStyles';
-export { default as withTheme, WithTheme } from '@material-ui/styles/withTheme';
+export { default as withTheme, WithTheme, withThemeCreator } from '@material-ui/styles/withTheme';

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -1,23 +1,25 @@
-import { PropInjector } from '@material-ui/core';
+import * as React from 'react';
+import { ConsistentWith, Omit, PropInjector } from '@material-ui/core';
 
 export interface WithThemeCreatorOption<Theme> {
   defaultTheme?: Theme;
 }
 
-export type WithThemeCreator<Theme> = (
-  option?: WithThemeCreatorOption<Theme>,
-) => PropInjector<WithTheme<Theme>, Partial<WithTheme<Theme>>>;
-
 export function withThemeCreator<Theme>(
   option?: WithThemeCreatorOption<Theme>,
-): WithThemeCreator<Theme>;
+): PropInjector<WithTheme<Theme>, Partial<WithTheme<Theme>>>;
 
 export interface WithTheme<Theme> {
   theme: Theme;
   innerRef?: React.Ref<any>;
 }
 
-export default function withTheme<Theme>(): PropInjector<
-  WithTheme<Theme>,
-  Partial<WithTheme<Theme>>
+export default function withTheme<
+  Theme,
+  C extends React.ComponentType<ConsistentWith<React.ComponentProps<C>, WithTheme<Theme>>>
+>(
+  component: C,
+): React.ComponentType<
+  Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof WithTheme<Theme>> &
+    Partial<WithTheme<Theme>>
 >;

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -1,5 +1,17 @@
 import { PropInjector } from '@material-ui/core';
 
+export interface WithThemeCreatorOption<Theme> {
+  defaultTheme?: Theme;
+}
+
+export type WithThemeCreator<Theme> = (
+  option?: WithThemeCreatorOption<Theme>,
+) => PropInjector<WithTheme<Theme>, Partial<WithTheme<Theme>>>;
+
+export function withThemeCreator<Theme>(
+  option?: WithThemeCreatorOption<Theme>,
+): WithThemeCreator<Theme>;
+
 export interface WithTheme<Theme> {
   theme: Theme;
   innerRef?: React.Ref<any>;

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-  createStyles,
-  withStyles,
-  withTheme,
-  WithTheme,
-  WithStyles,
-} from '@material-ui/styles';
+import { createStyles, withStyles, withTheme, WithTheme, WithStyles } from '@material-ui/styles';
 import Button from '@material-ui/core/Button/Button';
 import { Theme } from '@material-ui/core/styles';
 

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import {
   createStyles,
   withStyles,
-  ThemeProvider,
   withTheme,
   WithTheme,
   WithStyles,
@@ -68,9 +67,9 @@ const AnotherStyledSFC = withStyles({
 })(({ classes }: WithStyles<'root'>) => <div className={classes.root}>Stylish!</div>);
 
 // withTheme
-const ComponentWithTheme = withTheme<Theme>()(({ theme }: WithTheme<Theme>) => (
-  <div>{theme.spacing(1)}</div>
-));
+const ComponentWithTheme = withTheme<Theme, React.FunctionComponent<WithTheme<Theme>>>(
+  ({ theme }: WithTheme<Theme>) => <div>{theme.spacing(1)}</div>,
+);
 
 <ComponentWithTheme />;
 
@@ -84,12 +83,12 @@ const StyledComponent = withStyles(styles)(({ theme, classes }: AllTheProps) => 
 // missing prop theme
 <StyledComponent />; // $ExpectError
 
-const AllTheComposition = withTheme<Theme>()(StyledComponent);
+const AllTheComposition = withTheme<Theme, typeof StyledComponent>(StyledComponent);
 
 <AllTheComposition />;
 
 {
-  const Foo = withTheme<Theme>()(
+  const Foo = withTheme<Theme, React.ComponentClass<WithTheme<Theme>>>(
     class extends React.Component<WithTheme<Theme>> {
       render() {
         return null;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

@oliviertassinari In your big refactor you made the change
```diff
- export { default as withTheme } from './withTheme';
+ export { default as withTheme, withThemeCreator } from './withTheme';
```
But it wasn't added to the typing files. I made a try to type this...