### PR TITLE
[NoSsr] Add missing defer prop to TypeScript definition

### DIFF
--- a/packages/material-ui/src/NoSsr/NoSsr.d.ts
+++ b/packages/material-ui/src/NoSsr/NoSsr.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 export interface NoSsrProps {
   children: React.ReactNode;
+  defer?: boolean;
   fallback?: React.ReactNode;
 }
 


### PR DESCRIPTION
The NoSsr typescript definition seems to be missing the defer prop
https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/NoSsr/NoSsr.js#L64

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
