### PR TITLE
[docs] Improve documentation for new component + ref behavior

### DIFF
--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -75,7 +75,7 @@ function escapeCell(value) {
 }
 
 function isElementTypeAcceptingRefProp(type) {
-  return type.raw === 'elementTypeAcceptingRef'
+  return type.raw === 'elementTypeAcceptingRef';
 }
 
 function generatePropDescription(prop) {
@@ -152,7 +152,8 @@ function generatePropDescription(prop) {
 
   let notes = '';
   if (isElementTypeAcceptingRefProp(type)) {
-    notes += '<br><sup>*</sup>Needs to forward ref if a function component.'
+    notes +=
+      '<br><sup>*</sup>[Needs to be able to hold a ref](/guides/composition/#Caveat with refs).';
   }
 
   return `${deprecated}${jsDocText}${signature}${notes}`;

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -152,8 +152,7 @@ function generatePropDescription(prop) {
 
   let notes = '';
   if (isElementTypeAcceptingRefProp(type)) {
-    notes +=
-      '<br><sup>*</sup>[Needs to be able to hold a ref](/guides/composition/#Caveat with refs).';
+    notes += '<br>[Needs to be able to hold a ref](/guides/composition#caveat-with-refs).';
   }
 
   return `${deprecated}${jsDocText}${signature}${notes}`;
@@ -163,7 +162,7 @@ function generatePropType(type) {
   switch (type.name) {
     case 'custom': {
       if (isElementTypeAcceptingRefProp(type)) {
-        return `element type<sup>*</sup>`;
+        return `element type`;
       }
 
       const deprecatedInfo = getDeprecatedInfo(type);

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -74,7 +74,13 @@ function escapeCell(value) {
     .replace(/\|/g, '\\|');
 }
 
-function generatePropDescription(description, type) {
+function isElementTypeAcceptingRefProp(type) {
+  return type.raw === 'elementTypeAcceptingRef'
+}
+
+function generatePropDescription(prop) {
+  const { description } = prop;
+  const type = prop.flowType || prop.type;
   let deprecated = '';
 
   if (type.name === 'custom') {
@@ -144,12 +150,21 @@ function generatePropDescription(description, type) {
     }
   }
 
-  return `${deprecated}${jsDocText}${signature}`;
+  let notes = '';
+  if (isElementTypeAcceptingRefProp(type)) {
+    notes += '<br><sup>*</sup>Needs to forward ref if a function component.'
+  }
+
+  return `${deprecated}${jsDocText}${signature}${notes}`;
 }
 
 function generatePropType(type) {
   switch (type.name) {
     case 'custom': {
+      if (isElementTypeAcceptingRefProp(type)) {
+        return `element type<sup>*</sup>`;
+      }
+
       const deprecatedInfo = getDeprecatedInfo(type);
       if (deprecatedInfo !== false) {
         return generatePropType({
@@ -223,7 +238,7 @@ function generateProps(reactAPI) {
       throw new Error(`The "${propRaw}"" property is missing a description`);
     }
 
-    const description = generatePropDescription(prop.description, prop.flowType || prop.type);
+    const description = generatePropDescription(prop);
 
     if (description === null) {
       return textProps;

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -131,32 +131,31 @@ You can find the details in the [TypeScript guide](/guides/typescript#usage-of-c
 
 Some components such as `ButtonBase` (and therefore `Button`) require access to the 
 underlying DOM node. This was previously done with `ReactDOM.findDOMNode(this)`.
-However `findDOMNode` was deprecated (which disqualifies its usage in react's concurrent mode)
+ However `findDOMNode` was deprecated (which disqualifies its usage in React's concurrent mode)
 in favour of component refs and ref forwarding. 
 
-It is therefore necessary that the components you pass to the `component` prop
-can hold refs. This includes:
+It is therefore necessary that the component you pass to the `component` prop
+can hold a ref. This includes:
 
 - class components
 - ref forwarding components (`React.forwardRef`)
 - built-in components e.g. `div` or `a`
 
 If this is not the case we will issue a prop type warning similar to:
-> Invalid prop `component` supplied to ButtonBase. Expected an element type that can hold a ref.
+> Invalid prop `component` supplied to `ComponentName`. Expected an element type that can hold a ref.
 
-In addition react will also issue a warning.
+In addition React will issue a warning.
 
-To find out if the material-ui component you're using has this requirement check
+To find out if the Material-UI component you're using has this requirement, check
 out the the props API documentation for that component. If you need to forward refs
-the expected type for the `component` will have a <sup>*</sup> next to it and the description
-will link to this section.
+the description will link to this section.
 
-# caveat with React.StrictMode or React.unstable_ConcurrentMode
+# Caveat with React.StrictMode or React.unstable_ConcurrentMode
 
 If you pass class components to
-the `component` and don't run in strict mode you won't have to change anything
-since we can safely use `ReactDOM.findDOMNode`. For function components you have
-to wrap your component however in `React.forwardRef`:
+ the `component` prop and don't run in strict mode you won't have to change anything
+ since we can safely use `ReactDOM.findDOMNode`. For function components, however, you have
+ to wrap your component in `React.forwardRef`:
 
 ```diff
 - const MyButton = props => <div {...props} />

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -155,10 +155,9 @@ the description will link to this section.
 
 ### Caveat with StrictMode or unstable_ConcurrentMode
 
-If you pass class components to
- the `component` prop and don't run in strict mode you won't have to change anything
- since we can safely use `ReactDOM.findDOMNode`. For function components, however, you have
- to wrap your component in `React.forwardRef`:
+If you pass class components to the `component` prop and don't run in strict mode you won't have to change anything
+since we can safely use `ReactDOM.findDOMNode`. For function components, however, you have
+to wrap your component in `React.forwardRef`:
 
 ```diff
 - const MyButton = props => <div {...props} />

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -150,7 +150,7 @@ To find out if the Material-UI component you're using has this requirement, chec
 out the the props API documentation for that component. If you need to forward refs
 the description will link to this section.
 
-# Caveat with React.StrictMode or React.unstable_ConcurrentMode
+### Caveat with StrictMode or unstable_ConcurrentMode
 
 If you pass class components to
  the `component` prop and don't run in strict mode you won't have to change anything

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -146,6 +146,9 @@ If this is not the case we will issue a prop type warning similar to:
 
 In addition React will issue a warning.
 
+You can fix this warning by using `React.forwardRef`. Learn more about it in
+[this section in the official React docs](https://reactjs.org/docs/forwarding-refs.html).
+
 To find out if the Material-UI component you're using has this requirement, check
 out the the props API documentation for that component. If you need to forward refs
 the description will link to this section.

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -132,7 +132,27 @@ You can find the details in the [TypeScript guide](/guides/typescript#usage-of-c
 Some components such as `ButtonBase` (and therefore `Button`) require access to the 
 underlying DOM node. This was previously done with `ReactDOM.findDOMNode(this)`.
 However `findDOMNode` was deprecated (which disqualifies its usage in react's concurrent mode)
-in favour of component refs and ref forwarding. If you pass class components to
+in favour of component refs and ref forwarding. 
+
+It is therefore necessary that the components you pass to the `component` prop
+can hold refs. This includes:
+- class components
+- ref forwarding components (`React.forwardRef`)
+- built-in components e.g. `div` or `a`
+
+If this is not the case we will issue a prop type warning similar to:
+> Invalid prop `component` supplied to ButtonBase. Expected an element type that can hold a ref.
+
+In addition react will also issue a warning.
+
+To find out if the material-ui component you're using has this requirement check
+out the the props API documentation for that component. If you need to forward refs
+the expected type for the `component` will have a <sup>*</sup> next to it and the description
+will link to this section.
+
+# caveat with React.StrictMode or React.unstable_ConcurrentMode
+
+If you pass class components to
 the `component` and don't run in strict mode you won't have to change anything
 since we can safely use `ReactDOM.findDOMNode`. For function components you have
 to wrap your component however in `React.forwardRef`:

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -136,6 +136,7 @@ in favour of component refs and ref forwarding.
 
 It is therefore necessary that the components you pass to the `component` prop
 can hold refs. This includes:
+
 - class components
 - ref forwarding components (`React.forwardRef`)
 - built-in components e.g. `div` or `a`

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.js
@@ -21,10 +21,10 @@ function elementTypeAcceptingRef(props, propName, componentName, location, propF
   let warningHint;
 
   /**
-   * blacklisting instead of whitelisting
+   * Blacklisting instead of whitelisting
    *
-   * blacklisting will miss some components like React.Fragment. Those will at least
-   * trigger a warning in react.
+   * Blacklisting will miss some components, such as React.Fragment. Those will at least
+   * trigger a warning in React.
    * We can't whitelist because there is no safe way to detect React.forwardRef
    * or class components. Safe means there's no public API.
    *

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.js
@@ -1,0 +1,50 @@
+import * as PropTypes from 'prop-types';
+import React from 'react';
+import { isLazy, isMemo } from 'react-is';
+import chainPropTypes from './chainPropTypes';
+
+function isClassComponent(elementType) {
+  // elementType.prototype?.isReactComponent
+  const { prototype = {} } = elementType;
+
+  return Boolean(prototype.isReactComponent);
+}
+
+function elementTypeAcceptingRef(props, propName, componentName, location, propFullName) {
+  const propValue = props[propName];
+  const safePropName = propFullName || propName;
+
+  if (propValue == null) {
+    return null;
+  }
+
+  let warningHint;
+
+  /**
+   * blacklisting instead of whitelisting
+   *
+   * blacklisting will miss some components like React.Fragment. Those will at least
+   * trigger a warning in react.
+   * We can't whitelist because there is no safe way to detect React.forwardRef
+   * or class components. Safe means there's no public API.
+   *
+   */
+  if (isLazy(propValue)) {
+    warningHint = 'But you passed a React.lazy component.';
+  } else if (isMemo(propValue)) {
+    warningHint = 'But you passed a React.memo component.';
+  } else if (typeof propValue === 'function' && !isClassComponent(propValue)) {
+    warningHint = 'Did you accidentally provide a plain function component instead?';
+  }
+
+  if (warningHint !== undefined) {
+    return new Error(
+      `Invalid ${location} \`${safePropName}\` supplied to \`${componentName}\`. ` +
+        `Expected an element type that can hold a ref. ${warningHint}`,
+    );
+  }
+
+  return null;
+}
+
+export default chainPropTypes(PropTypes.elementType, elementTypeAcceptingRef);

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.js
@@ -25,7 +25,7 @@ function elementTypeAcceptingRef(props, propName, componentName, location, propF
    * Blacklisting will miss some components, such as React.Fragment. Those will at least
    * trigger a warning in React.
    * We can't whitelist because there is no safe way to detect React.forwardRef
-   * or class components. Safe means there's no public API.
+   * or class components. "Safe" means there's no public API.
    *
    */
   if (isLazy(propValue)) {

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.js
@@ -1,5 +1,4 @@
 import * as PropTypes from 'prop-types';
-import React from 'react';
 import { isLazy, isMemo } from 'react-is';
 import chainPropTypes from './chainPropTypes';
 
@@ -40,7 +39,8 @@ function elementTypeAcceptingRef(props, propName, componentName, location, propF
   if (warningHint !== undefined) {
     return new Error(
       `Invalid ${location} \`${safePropName}\` supplied to \`${componentName}\`. ` +
-        `Expected an element type that can hold a ref. ${warningHint}`,
+        `Expected an element type that can hold a ref. ${warningHint} ` +
+        'For more information see https://next.material-ui.com/guides/composition/#caveat-with-refs',
     );
   }
 

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
@@ -1,0 +1,131 @@
+/* eslint-disable react/prefer-stateless-function, react/no-multi-comp */
+import { assert } from 'chai';
+import * as PropTypes from 'prop-types';
+import React from 'react';
+import { createMount } from '@material-ui/core/test-utils';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
+import elementTypeAcceptingRef from './elementTypeAcceptingRef';
+
+describe('elementTypeAcceptingRef', () => {
+  let mount;
+
+  function checkPropType(elementType) {
+    PropTypes.checkPropTypes(
+      { component: elementTypeAcceptingRef },
+      { component: elementType },
+      'props',
+      'DummyComponent',
+    );
+  }
+
+  before(() => {
+    mount = createMount();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  beforeEach(() => {
+    consoleErrorMock.spy();
+  });
+
+  afterEach(() => {
+    consoleErrorMock.reset();
+    PropTypes.resetWarningCache();
+  });
+
+  describe('acceptance', () => {
+    function assertPass(Component, options = {}) {
+      const { failsOnMount = false, shouldMount = true } = options;
+
+      checkPropType(Component);
+      if (shouldMount) {
+        mount(<Component ref={React.createRef()} />);
+      }
+
+      assert.strictEqual(
+        consoleErrorMock.callCount(),
+        failsOnMount ? 1 : 0,
+        `but got '${consoleErrorMock.args()[0]}'`,
+      );
+    }
+
+    it('accepts nully values', () => {
+      assertPass(undefined, { shouldMount: false });
+      assertPass(null, { shouldMount: false });
+    });
+
+    it('accepts host components', () => {
+      assertPass('div');
+    });
+
+    it('class components', () => {
+      class Component extends React.Component {
+        render() {
+          return null;
+        }
+      }
+
+      assertPass(Component);
+    });
+
+    it('accepts pure class components', () => {
+      class Component extends React.PureComponent {
+        render() {
+          return null;
+        }
+      }
+
+      assertPass(Component);
+    });
+
+    it('accepts forwardRef', () => {
+      const Component = React.forwardRef(() => null);
+
+      assertPass(Component);
+    });
+
+    it('technically allows other exotics like strict mode', () => {
+      assertPass(React.StrictMode);
+    });
+
+    // undesired behavior
+    it('accepts Fragment', () => {
+      assertPass(React.Fragment, { failsOnMount: true });
+    });
+  });
+
+  describe('rejections', () => {
+    function assertFail(Component, hint) {
+      checkPropType(Component);
+
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'Invalid props `component` supplied to `DummyComponent`. ' +
+          `Expected an element type that can hold a ref. ${hint}`,
+      );
+    }
+
+    it('rejects function components', () => {
+      const Component = () => null;
+
+      assertFail(Component, 'Did you accidentally provide a plain function component instead?');
+    });
+
+    it('rejects memo', () => {
+      const Component = React.memo(() => React.createElement('div'));
+
+      // use actual hint once we don't have to mock React.useMemo
+      assertFail(Component, 'Did you accidentally provide a plain function component instead?');
+      // assertFail(Component, 'But you passed a React.memo component.');
+    });
+
+    it('rejects lazy', () => {
+      const Component = React.lazy(() => Promise.resolve({ default: () => null }));
+
+      assertFail(Component, 'But you passed a React.lazy component.');
+    });
+  });
+});

--- a/packages/material-ui-utils/src/index.js
+++ b/packages/material-ui-utils/src/index.js
@@ -1,4 +1,5 @@
 export { default as chainPropTypes } from './chainPropTypes';
+export { default as elementTypeAcceptingRef } from './elementTypeAcceptingRef';
 export { default as exactProp } from './exactProp';
 export { default as getDisplayName } from './getDisplayName';
 export { default as ponyfillGlobal } from './ponyfillGlobal';

--- a/packages/material-ui/scripts/rollup.config.js
+++ b/packages/material-ui/scripts/rollup.config.js
@@ -21,7 +21,13 @@ const commonjsOptions = {
   ignoreGlobal: true,
   include: /node_modules/,
   namedExports: {
-    '../../node_modules/react-is/index.js': ['ForwardRef', 'isValidElementType'],
+    '../../node_modules/prop-types/index.js': ['elementType'],
+    '../../node_modules/react-is/index.js': [
+      'ForwardRef',
+      'isLazy',
+      'isMemo',
+      'isValidElementType',
+    ],
   },
 };
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import clsx from 'clsx';
-import {elementTypeAcceptingRef} from '@material-ui/utils'
+import { elementTypeAcceptingRef } from '@material-ui/utils';
 import ownerWindow from '../utils/ownerWindow';
 import withForwardedRef from '../utils/withForwardedRef';
 import { setRef } from '../utils/reactHelpers';

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import clsx from 'clsx';
+import {elementTypeAcceptingRef} from '@material-ui/utils'
 import ownerWindow from '../utils/ownerWindow';
 import withForwardedRef from '../utils/withForwardedRef';
 import { setRef } from '../utils/reactHelpers';
@@ -359,10 +360,9 @@ ButtonBase.propTypes = {
   className: PropTypes.string,
   /**
    * The component used for the root node.
-   * Either a string to use a DOM element or a component. If a component is provided
-   * it must properly forward their refs via React.forwardRef.
+   * Either a string to use a DOM element or a component.
    */
-  component: PropTypes.elementType,
+  component: elementTypeAcceptingRef,
   /**
    * If `true`, the base button will be disabled.
    */

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -25,7 +25,7 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">centerRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component. If a component is provided it must properly forward their refs via React.forwardRef. |
+| <span class="prop-name">component</span> | <span class="prop-type">elementTypeAcceptingRef</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the base button will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">disableTouchRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the touch ripple effect will be disabled. |

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -25,7 +25,7 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">centerRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">element type<sup>*</sup></span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component.<br><sup>*</sup>Needs to forward ref if a function component. |
+| <span class="prop-name">component</span> | <span class="prop-type">element type<sup>*</sup></span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component.<br><sup>*</sup>[Needs to be able to hold a ref](/guides/composition/#Caveat with refs). |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the base button will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">disableTouchRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the touch ripple effect will be disabled. |

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -25,7 +25,7 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">centerRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">element type<sup>*</sup></span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component.<br><sup>*</sup>[Needs to be able to hold a ref](/guides/composition/#Caveat with refs). |
+| <span class="prop-name">component</span> | <span class="prop-type">element type</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component.<br>[Needs to be able to hold a ref](/guides/composition#caveat-with-refs). |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the base button will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">disableTouchRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the touch ripple effect will be disabled. |

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -25,7 +25,7 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">centerRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |   | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">elementTypeAcceptingRef</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">component</span> | <span class="prop-type">element type<sup>*</sup></span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component.<br><sup>*</sup>Needs to forward ref if a function component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |   | If `true`, the base button will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">disableTouchRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the touch ripple effect will be disabled. |


### PR DESCRIPTION
Adds a prop type warning if a the rendered component is overridden with a component that cannot hold ref when we need a ref e.g. `ButtonBase`:
> Invalid props `component` supplied to `ButtonBase`. Expected an element type that can hold a ref. Did you accidentally provide a plain function component instead?

In addition the composition docs have a more extensive explanation for this: https://deploy-preview-14883--material-ui.netlify.com/guides/composition/#caveat-with-refs

I fear this will already cause plenty of confusion in v4. I hope we can reduce some of it with additional prop types validation and docs. Will require some feedback if this is still confusing or not. I definitely have a blind spot since I spent plenty of time with this issue but I do remember that I had some problems wrapping my head around ref forwarding initially.

Todo:
- [x] link to official react docs (ref forwarding)
- [x] add composition docs link to prop types warning
