### PR TITLE
[docs] Add perf section to ExpansionPanel

### DIFF
--- a/docs/src/pages/demos/expansion-panels/expansion-panels.md
+++ b/docs/src/pages/demos/expansion-panels/expansion-panels.md
@@ -33,6 +33,16 @@ Multiple columns can be used to structure the content, and a helper text may be 
 
 {{"demo": "pages/demos/expansion-panels/DetailedExpansionPanel.js"}}
 
+## Performance
+
+The content of ExpansionPanels is mounted by default even if the panel is not expanded.
+This default behavior has server-side rendering and SEO in mind.
+If you render expensive component trees inside your panels or simply render many
+panels it might be a good idea to change this default behavior by enabling the
+`unmountOnExit` in `TransitionProps`: `<ExpansionPanel TransitionProps={{ unmountOnExit: true }} />`.
+As with any performance optimization this is not a silver bullet. Be sure to identify
+bottlenecks first and then try out these optimization strategies.
+
 ## Customized Expansion Panel
 
 If you have been reading the [overrides documentation page](/customization/overrides/)


### PR DESCRIPTION
Closes #10569

This is not something where we shouldn't be opinionated about the default value. The optimal choice depends on the particular use case:

- many, high-frequency toggle panels may want no initial mount but stay mounted after first expansion
- expensive, low-frequency toggle panels may want permanent unmountOnExit: true
- ssr with hydration may want to mount by default

Probably misrepresenting these cases but I wouldn't bother that much with finding the most common default behavior. Being explicit about the default behavior and suggesting possible workarounds should be preferred.