### PR TITLE
[Popover] Correct warning for tall component

### DIFF
--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -178,7 +178,7 @@ class Popover extends React.Component {
     }
 
     warning(
-      elemRect.height < heightThreshold || !elemRect.height || !heightThreshold,
+      elemRect.height <= heightThreshold || !elemRect.height || !heightThreshold,
       [
         'Material-UI: the popover component is too tall.',
         `Some part of it can not be seen on the screen (${elemRect.height - heightThreshold}px).`,


### PR DESCRIPTION
Closes #14893

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
