### PR TITLE
[docs] Investigate IE 11 crash

### DIFF
--- a/docs/src/modules/components/bootstrap.js
+++ b/docs/src/modules/components/bootstrap.js
@@ -1,7 +1,3 @@
-// Use the same helper as Babel to avoid bundle bloat.
-import 'core-js/modules/es6.array.find-index';
-import 'core-js/modules/es6.set';
-
 // Disable auto highlighting
 // https://github.com/PrismJS/prism/issues/765
 if (process.browser) {

--- a/next.config.js
+++ b/next.config.js
@@ -33,7 +33,19 @@ module.exports = {
       );
     }
 
+    const originalEntry = config.entry;
+    const entry = async () => {
+      const entries = await originalEntry();
+
+      if (entries['main.js'] && !entries['main.js'].includes('./pages/polyfills.js')) {
+        entries['main.js'].unshift('./pages/polyfills.js');
+      }
+
+      return entries;
+    };
+
     return Object.assign({}, config, {
+      entry,
       plugins,
       node: {
         fs: 'empty',

--- a/pages/polyfills.js
+++ b/pages/polyfills.js
@@ -1,0 +1,6 @@
+// Use the same helper as Babel to avoid bundle bloat.
+import 'core-js/modules/es6.array.find-index';
+import 'core-js/modules/es6.map';
+import 'core-js/modules/es6.set';
+import 'core-js/modules/es6.symbol';
+import 'core-js/fn/symbol/iterator';


### PR DESCRIPTION
Investigating #14774

```bash
git bisect good ba4332d00a5f951cfc33dcffa5924cc7999b8f05
# first bad commit: [440c9f6320d669319b5a3524b2705d73e795e698] [core] Upgrade dependencies and devDependencies (#14493)
```

440c9f6320d669319b5a3524b2705d73e795e698 regenerated the whole lockfile. Might be just `next` might be some other dependency. Might be a good idea to branch of ba4332d00a5f951cfc33dcffa5924cc7999b8f05 and increment by canaries instead of majors.

Already spent a couple of hours on this issue. Working with `next.js` is pretty frustrating so I'll doubt I spend much more time on the issue. Maybe it will fix itself someday.

No idea why netlify is crashing. It's working locally.