### PR TITLE
[TextField] Reduce the specificity

### DIFF
--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -73,7 +73,7 @@ export const styles = theme => {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      '&:hover:not($disabled):not($focused):not($error):before': {
+      '&:hover:before': {
         borderBottom: `1px solid ${theme.palette.text.primary}`,
       },
       '&$disabled:before': {

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -62,7 +62,7 @@ export const styles = theme => {
         }),
         pointerEvents: 'none', // Transparent to the hover style.
       },
-      '&:hover:not($disabled):not($focused):not($error):before': {
+      '&:hover:not($disabled):before': {
         borderBottom: `2px solid ${theme.palette.text.primary}`,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -18,7 +18,7 @@ export const styles = theme => {
       '& $notchedOutline': {
         borderColor,
       },
-      '&:hover:not($disabled):not($focused):not($error) $notchedOutline': {
+      '&:hover $notchedOutline': {
         borderColor: theme.palette.text.primary,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {


### PR DESCRIPTION
Reducing the selectors' specificity helps with overrides. I'm not aware of any negative side effects generated by the changes.