### PR TITLE
[RadioGroup] Convert to a function component

### DIFF
--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -20,7 +20,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
   React.useImperativeHandle(actions, () => ({
     focus: () => {
       const radios = radiosRef.current;
-      if (!radios || !radios.length) {
+      if (!radios.length) {
         return;
       }
 

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -6,106 +6,104 @@ import warning from 'warning';
 import FormGroup from '../FormGroup';
 import { createChainedFunction, find } from '../utils/helpers';
 
-class RadioGroup extends React.Component {
-  radios = [];
-
-  constructor(props) {
-    super();
-    this.isControlled = props.value != null;
-
-    if (!this.isControlled) {
-      this.state = {
-        value: props.defaultValue,
-      };
+const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
+  const { actions, children, defaultValue, name, value: valueProp, onChange, ...other } = props;
+  const radiosRef = React.useRef([]);
+  const { current: isControlled } = React.useRef(props.value != null);
+  const [valueState, setValue] = React.useState(() => {
+    if (!isControlled) {
+      return defaultValue;
     }
-  }
+    return null;
+  });
 
-  componentDidUpdate() {
+  React.useImperativeHandle(actions, () => ({
+    focus: () => {
+      const radios = radiosRef.current;
+      if (!radios || !radios.length) {
+        return;
+      }
+
+      const focusRadios = radios.filter(n => !n.disabled);
+
+      if (!focusRadios.length) {
+        return;
+      }
+
+      const selectedRadio = find(focusRadios, n => n.checked);
+
+      if (selectedRadio) {
+        selectedRadio.focus();
+        return;
+      }
+
+      focusRadios[0].focus();
+    },
+  }));
+
+  React.useEffect(() => {
     warning(
-      this.isControlled === (this.props.value != null),
+      isControlled === (valueProp != null),
       [
         `Material-UI: A component is changing ${
-          this.isControlled ? 'a ' : 'an un'
-        }controlled RadioGroup to be ${this.isControlled ? 'un' : ''}controlled.`,
+          isControlled ? 'a ' : 'an un'
+        }controlled RadioGroup to be ${isControlled ? 'un' : ''}controlled.`,
         'Input elements should not switch from uncontrolled to controlled (or vice versa).',
         'Decide between using a controlled or uncontrolled RadioGroup ' +
           'element for the lifetime of the component.',
         'More info: https://fb.me/react-controlled-components',
       ].join('\n'),
     );
-  }
+  }, [valueProp, isControlled]);
 
-  focus = () => {
-    if (!this.radios || !this.radios.length) {
-      return;
+  const value = isControlled ? valueProp : valueState;
+
+  const handleChange = event => {
+    if (!isControlled) {
+      setValue(event.target.value);
     }
 
-    const focusRadios = this.radios.filter(n => !n.disabled);
-
-    if (!focusRadios.length) {
-      return;
-    }
-
-    const selectedRadio = find(focusRadios, n => n.checked);
-
-    if (selectedRadio) {
-      selectedRadio.focus();
-      return;
-    }
-
-    focusRadios[0].focus();
-  };
-
-  handleChange = event => {
-    if (!this.isControlled) {
-      this.setState({
-        value: event.target.value,
-      });
-    }
-
-    if (this.props.onChange) {
-      this.props.onChange(event, event.target.value);
+    if (onChange) {
+      onChange(event, event.target.value);
     }
   };
 
-  render() {
-    const { children, name, value: valueProp, onChange, ...other } = this.props;
+  radiosRef.current = [];
+  return (
+    <FormGroup role="radiogroup" ref={ref} defaultValue={defaultValue} {...other}>
+      {React.Children.map(children, child => {
+        if (!React.isValidElement(child)) {
+          return null;
+        }
 
-    const value = this.isControlled ? valueProp : this.state.value;
-    this.radios = [];
+        warning(
+          child.type !== React.Fragment,
+          [
+            "Material-UI: the RadioGroup component doesn't accept a Fragment as a child.",
+            'Consider providing an array instead.',
+          ].join('\n'),
+        );
 
-    return (
-      <FormGroup role="radiogroup" {...other}>
-        {React.Children.map(children, child => {
-          if (!React.isValidElement(child)) {
-            return null;
-          }
-
-          warning(
-            child.type !== React.Fragment,
-            [
-              "Material-UI: the RadioGroup component doesn't accept a Fragment as a child.",
-              'Consider providing an array instead.',
-            ].join('\n'),
-          );
-
-          return React.cloneElement(child, {
-            name,
-            inputRef: node => {
-              if (node) {
-                this.radios.push(node);
-              }
-            },
-            checked: value === child.props.value,
-            onChange: createChainedFunction(child.props.onChange, this.handleChange),
-          });
-        })}
-      </FormGroup>
-    );
-  }
-}
+        return React.cloneElement(child, {
+          name,
+          inputRef: node => {
+            if (node) {
+              radiosRef.current.push(node);
+            }
+          },
+          checked: value === child.props.value,
+          onChange: createChainedFunction(child.props.onChange, handleChange),
+        });
+      })}
+    </FormGroup>
+  );
+});
 
 RadioGroup.propTypes = {
+  /**
+   * @ignore
+   */
+  actions: PropTypes.shape({ current: PropTypes.object }),
   /**
    * The content of the component.
    */

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { act } from 'react-dom/test-utils';
 import { createMount, findOutermostIntrinsic, testRef } from '@material-ui/core/test-utils';
 import FormGroup from '../FormGroup';
 import Radio from '../Radio';
 import RadioGroup from './RadioGroup';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
+import { act } from 'react-dom/test-utils';
 
 describe('<RadioGroup />', () => {
   let mount;
@@ -20,14 +20,7 @@ describe('<RadioGroup />', () => {
   });
 
   function findRadio(wrapper, value) {
-    return wrapper.find(`SwitchBase[value="${value}"]`).first();
-  }
-
-  function findRadioInput(wrapper, value) {
-    return wrapper
-      .find(`SwitchBase[value="${value}"]`)
-      .first()
-      .find('input');
+    return wrapper.find(`input[value="${value}"]`).first();
   }
 
   it('does forward refs', () => {
@@ -67,7 +60,7 @@ describe('<RadioGroup />', () => {
       </RadioGroup>,
     );
 
-    findRadioInput(wrapper, 'one').simulate('change');
+    findRadio(wrapper, 'one').simulate('change');
     assert.strictEqual(findRadio(wrapper, 'one').props().checked, true);
   });
 
@@ -80,7 +73,7 @@ describe('<RadioGroup />', () => {
     );
 
     assert.strictEqual(findRadio(wrapper, 'zero').props().checked, true);
-    findRadioInput(wrapper, 'one').simulate('change');
+    findRadio(wrapper, 'one').simulate('change');
     assert.strictEqual(findRadio(wrapper, 'one').props().checked, true);
   });
 
@@ -198,7 +191,7 @@ describe('<RadioGroup />', () => {
       );
 
       const eventMock = 'something-to-match';
-      findRadioInput(wrapper, 'woofRadioGroup').simulate('change', { eventMock });
+      findRadio(wrapper, 'woofRadioGroup').simulate('change', { eventMock });
       assert.strictEqual(handleChange.callCount, 1);
       assert.strictEqual(handleChange.calledWithMatch({ eventMock }), true);
     });
@@ -213,7 +206,7 @@ describe('<RadioGroup />', () => {
         </RadioGroup>,
       );
 
-      findRadioInput(wrapper, 'woofRadioGroup').simulate('change');
+      findRadio(wrapper, 'woofRadioGroup').simulate('change');
       assert.strictEqual(handleChange1.callCount, 1);
       assert.strictEqual(handleChange2.callCount, 1);
     });
@@ -229,15 +222,13 @@ describe('<RadioGroup />', () => {
     });
 
     it('should warn when switching from controlled to uncontrolled', () => {
-      let wrapper;
+      const wrapper = mount(
+        <RadioGroup value="foo">
+          <Radio value="foo" />
+        </RadioGroup>,
+      );
 
       act(() => {
-        wrapper = mount(
-          <RadioGroup value="foo">
-            <Radio value="foo" />
-          </RadioGroup>,
-        );
-
         wrapper.setProps({ value: undefined });
       });
 
@@ -248,15 +239,13 @@ describe('<RadioGroup />', () => {
     });
 
     it('should warn when switching between uncontrolled to controlled', () => {
-      let wrapper;
+      const wrapper = mount(
+        <RadioGroup>
+          <Radio value="foo" />
+        </RadioGroup>,
+      );
 
       act(() => {
-        wrapper = mount(
-          <RadioGroup>
-            <Radio value="foo" />
-          </RadioGroup>,
-        );
-
         wrapper.setProps({ value: 'foo' });
       });
 

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -1,170 +1,184 @@
 import React from 'react';
 import { assert } from 'chai';
-import { spy } from 'sinon';
-import { createShallow, createMount } from '@material-ui/core/test-utils';
+import { spy, stub } from 'sinon';
+import { createMount, findOutermostIntrinsic, testRef } from '@material-ui/core/test-utils';
 import FormGroup from '../FormGroup';
 import Radio from '../Radio';
 import RadioGroup from './RadioGroup';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 
 describe('<RadioGroup />', () => {
-  let shallow;
   let mount;
 
   before(() => {
     mount = createMount();
-    shallow = createShallow();
   });
 
   after(() => {
     mount.cleanUp();
   });
 
+  function findRadio(wrapper, value) {
+    return wrapper.find(`SwitchBase[value="${value}"]`).first();
+  }
+
+  function findRadioInput(wrapper, value) {
+    return wrapper
+      .find(`SwitchBase[value="${value}"]`)
+      .first()
+      .find('input');
+  }
+
+  it('does forward refs', () => {
+    testRef(<RadioGroup />, mount);
+  });
+
   it('should render a FormGroup with the radiogroup role', () => {
-    const wrapper = shallow(<RadioGroup value="" />);
-    assert.strictEqual(wrapper.type(), FormGroup);
-    assert.strictEqual(wrapper.props().role, 'radiogroup');
+    const wrapper = mount(<RadioGroup value="" />);
+    assert.strictEqual(wrapper.childAt(0).type(), FormGroup);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).props().role, 'radiogroup');
   });
 
   it('should fire the onBlur callback', () => {
     const handleBlur = spy();
-    const wrapper = shallow(<RadioGroup value="" onBlur={handleBlur} />);
-    const event = {};
-    wrapper.simulate('blur', event);
+    const wrapper = mount(<RadioGroup value="" onBlur={handleBlur} />);
+
+    const eventMock = 'something-to-match';
+    wrapper.simulate('blur', { eventMock });
     assert.strictEqual(handleBlur.callCount, 1);
-    assert.strictEqual(handleBlur.args[0][0], event);
+    assert.strictEqual(handleBlur.calledWithMatch({ eventMock }), true);
   });
 
   it('should fire the onKeyDown callback', () => {
     const handleKeyDown = spy();
-    const wrapper = shallow(<RadioGroup value="" onKeyDown={handleKeyDown} />);
-    const event = {};
-    wrapper.simulate('keyDown', event);
+    const wrapper = mount(<RadioGroup value="" onKeyDown={handleKeyDown} />);
+
+    const eventMock = 'something-to-match';
+    wrapper.simulate('keyDown', { eventMock });
     assert.strictEqual(handleKeyDown.callCount, 1);
-    assert.strictEqual(handleKeyDown.args[0][0], event);
+    assert.strictEqual(handleKeyDown.calledWithMatch({ eventMock }), true);
   });
 
   it('should support uncontrolled mode', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <RadioGroup name="group">
         <Radio value="one" />
       </RadioGroup>,
     );
 
-    const radio = wrapper.children().first();
-    const event = { target: { value: 'one' } };
-    radio.simulate('change', event, true);
-    assert.strictEqual(
-      wrapper
-        .children()
-        .first()
-        .props().checked,
-      true,
-    );
+    findRadioInput(wrapper, 'one').simulate('change');
+    assert.strictEqual(findRadio(wrapper, 'one').props().checked, true);
   });
 
   it('should support default value in uncontrolled mode', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <RadioGroup name="group" defaultValue="zero">
         <Radio value="zero" />
         <Radio value="one" />
       </RadioGroup>,
     );
 
-    assert.strictEqual(
-      wrapper
-        .children()
-        .first()
-        .props().checked,
-      true,
-    );
-
-    const radio = wrapper.children().last();
-    const event = { target: { value: 'one' } };
-    radio.simulate('change', event, true);
-
-    assert.strictEqual(
-      wrapper
-        .children()
-        .last()
-        .props().checked,
-      true,
-    );
+    assert.strictEqual(findRadio(wrapper, 'zero').props().checked, true);
+    findRadioInput(wrapper, 'one').simulate('change');
+    assert.strictEqual(findRadio(wrapper, 'one').props().checked, true);
   });
 
   describe('imperative focus()', () => {
-    let wrapper;
-
-    beforeEach(() => {
-      wrapper = shallow(<RadioGroup value="" />);
-    });
-
     it('should focus the first non-disabled radio', () => {
-      const radios = [
-        { disabled: true, focus: spy() },
-        { disabled: false, focus: spy() },
-        { disabled: false, focus: spy() },
-      ];
-      wrapper.instance().radios = radios;
-      wrapper.instance().focus();
+      const actionsRef = React.createRef();
+      const oneRadioOnFocus = spy();
 
-      assert.strictEqual(radios[1].focus.callCount, 1);
+      mount(
+        <RadioGroup actions={actionsRef} value="">
+          <Radio value="zero" disabled />
+          <Radio value="one" onFocus={oneRadioOnFocus} />
+          <Radio value="two" />
+        </RadioGroup>,
+      );
+
+      actionsRef.current.focus();
+      assert.strictEqual(oneRadioOnFocus.callCount, 1);
     });
 
     it('should not focus any radios if all are disabled', () => {
-      const radios = [
-        { disabled: true, focus: spy() },
-        { disabled: true, focus: spy() },
-        { disabled: true, focus: spy() },
-      ];
-      wrapper.instance().radios = radios;
-      wrapper.instance().focus();
+      const actionsRef = React.createRef();
+      const zeroRadioOnFocus = spy();
+      const oneRadioOnFocus = spy();
+      const twoRadioOnFocus = spy();
 
-      assert.strictEqual(radios[0].focus.callCount, 0);
-      assert.strictEqual(radios[1].focus.callCount, 0);
-      assert.strictEqual(radios[2].focus.callCount, 0);
+      mount(
+        <RadioGroup actions={actionsRef} value="">
+          <Radio value="zero" disabled onFocus={zeroRadioOnFocus} />
+          <Radio value="one" disabled onFocus={oneRadioOnFocus} />
+          <Radio value="two" disabled onFocus={twoRadioOnFocus} />
+        </RadioGroup>,
+      );
+
+      actionsRef.current.focus();
+
+      assert.strictEqual(zeroRadioOnFocus.callCount, 0);
+      assert.strictEqual(oneRadioOnFocus.callCount, 0);
+      assert.strictEqual(twoRadioOnFocus.callCount, 0);
     });
 
     it('should focus the selected radio', () => {
-      const radios = [
-        { disabled: true, focus: spy() },
-        { disabled: false, focus: spy() },
-        { disabled: false, checked: true, focus: spy() },
-        { disabled: false, focus: spy() },
-      ];
-      wrapper.instance().radios = radios;
-      wrapper.instance().focus();
+      const actionsRef = React.createRef();
+      const zeroRadioOnFocus = spy();
+      const oneRadioOnFocus = spy();
+      const twoRadioOnFocus = spy();
+      const threeRadioOnFocus = spy();
 
-      assert.strictEqual(radios[0].focus.callCount, 0);
-      assert.strictEqual(radios[1].focus.callCount, 0);
-      assert.strictEqual(radios[2].focus.callCount, 1);
-      assert.strictEqual(radios[3].focus.callCount, 0);
+      mount(
+        <RadioGroup actions={actionsRef} value="two">
+          <Radio value="zero" disabled onFocus={zeroRadioOnFocus} />
+          <Radio value="one" onFocus={oneRadioOnFocus} />
+          <Radio value="two" onFocus={twoRadioOnFocus} />
+          <Radio value="three" onFocus={threeRadioOnFocus} />
+        </RadioGroup>,
+      );
+
+      actionsRef.current.focus();
+
+      assert.strictEqual(zeroRadioOnFocus.callCount, 0);
+      assert.strictEqual(oneRadioOnFocus.callCount, 0);
+      assert.strictEqual(twoRadioOnFocus.callCount, 1);
+      assert.strictEqual(threeRadioOnFocus.callCount, 0);
     });
 
     it('should focus the non-disabled radio rather than the disabled selected radio', () => {
-      const radios = [
-        { disabled: true, focus: spy() },
-        { disabled: true, focus: spy() },
-        { disabled: true, checked: true, focus: spy() },
-        { disabled: false, focus: spy() },
-      ];
-      wrapper.instance().radios = radios;
-      wrapper.instance().focus();
+      const actionsRef = React.createRef();
+      const zeroRadioOnFocus = spy();
+      const oneRadioOnFocus = spy();
+      const twoRadioOnFocus = spy();
+      const threeRadioOnFocus = spy();
 
-      assert.strictEqual(radios[0].focus.callCount, 0);
-      assert.strictEqual(radios[1].focus.callCount, 0);
-      assert.strictEqual(radios[2].focus.callCount, 0);
-      assert.strictEqual(radios[3].focus.callCount, 1);
+      mount(
+        <RadioGroup actions={actionsRef} value="two">
+          <Radio value="zero" disabled onFocus={zeroRadioOnFocus} />
+          <Radio value="one" disabled onFocus={oneRadioOnFocus} />
+          <Radio value="two" disabled onFocus={twoRadioOnFocus} />
+          <Radio value="three" onFocus={threeRadioOnFocus} />
+        </RadioGroup>,
+      );
+
+      actionsRef.current.focus();
+
+      assert.strictEqual(zeroRadioOnFocus.callCount, 0);
+      assert.strictEqual(oneRadioOnFocus.callCount, 0);
+      assert.strictEqual(twoRadioOnFocus.callCount, 0);
+      assert.strictEqual(threeRadioOnFocus.callCount, 1);
     });
 
     it('should be able to focus with no radios', () => {
-      wrapper.instance().radios = [];
-      wrapper.instance().focus();
+      const actionsRef = React.createRef();
+      mount(<RadioGroup actions={actionsRef} value="" />);
+
+      actionsRef.current.focus();
     });
   });
 
   it('should accept invalid child', () => {
-    shallow(
+    mount(
       <RadioGroup value="">
         <Radio />
         {null}
@@ -175,60 +189,44 @@ describe('<RadioGroup />', () => {
   describe('prop: onChange', () => {
     it('should fire onChange', () => {
       const handleChange = spy();
-      const wrapper = shallow(
+      const wrapper = mount(
         <RadioGroup value="" onChange={handleChange}>
-          <Radio />
+          <Radio value="woofRadioGroup" />
           <Radio />
         </RadioGroup>,
       );
 
-      const internalRadio = wrapper.children().first();
-      const event = { target: { value: 'woofRadioGroup' } };
-      internalRadio.simulate('change', event, true);
+      const eventMock = 'something-to-match';
+      findRadioInput(wrapper, 'woofRadioGroup').simulate('change', { eventMock });
       assert.strictEqual(handleChange.callCount, 1);
-      assert.strictEqual(handleChange.calledWith(event), true);
+      assert.strictEqual(handleChange.calledWithMatch({ eventMock }), true);
     });
 
     it('should chain the onChange property', () => {
       const handleChange1 = spy();
       const handleChange2 = spy();
-      const wrapper = shallow(
+      const wrapper = mount(
         <RadioGroup value="" onChange={handleChange1}>
-          <Radio onChange={handleChange2} />
+          <Radio value="woofRadioGroup" onChange={handleChange2} />
           <Radio />
         </RadioGroup>,
       );
 
-      const internalRadio = wrapper.children().first();
-      internalRadio.simulate('change', { target: { value: 'woofRadioGroup' } }, true);
+      findRadioInput(wrapper, 'woofRadioGroup').simulate('change');
       assert.strictEqual(handleChange1.callCount, 1);
       assert.strictEqual(handleChange2.callCount, 1);
-    });
-  });
-
-  describe('register internal radios to this.radio', () => {
-    it('should add a child', () => {
-      const wrapper = mount(
-        <RadioGroup value="">
-          <Radio />
-        </RadioGroup>,
-      );
-      assert.strictEqual(wrapper.instance().radios.length, 1);
-    });
-
-    it('should keep radios empty', () => {
-      const wrapper = mount(<RadioGroup value="" />);
-      assert.strictEqual(wrapper.instance().radios.length, 0);
     });
   });
 
   describe('warnings', () => {
     beforeEach(() => {
       consoleErrorMock.spy();
+      stub(React, 'useEffect').callsFake(React.useLayoutEffect);
     });
 
     afterEach(() => {
       consoleErrorMock.reset();
+      React.useEffect.restore();
     });
 
     it('should warn when switching from controlled to uncontrolled', () => {
@@ -237,6 +235,7 @@ describe('<RadioGroup />', () => {
           <Radio value="foo" />
         </RadioGroup>,
       );
+
       wrapper.setProps({ value: undefined });
       assert.include(
         consoleErrorMock.args()[0][0],
@@ -251,6 +250,7 @@ describe('<RadioGroup />', () => {
         </RadioGroup>,
       );
       wrapper.setProps({ value: 'foo' });
+      wrapper.update();
       assert.include(
         consoleErrorMock.args()[0][0],
         'A component is changing an uncontrolled RadioGroup to be controlled.',

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
-import { spy, stub } from 'sinon';
+import { spy } from 'sinon';
+import { act } from 'react-dom/test-utils';
 import { createMount, findOutermostIntrinsic, testRef } from '@material-ui/core/test-utils';
 import FormGroup from '../FormGroup';
 import Radio from '../Radio';
@@ -221,22 +222,25 @@ describe('<RadioGroup />', () => {
   describe('warnings', () => {
     beforeEach(() => {
       consoleErrorMock.spy();
-      stub(React, 'useEffect').callsFake(React.useLayoutEffect);
     });
 
     afterEach(() => {
       consoleErrorMock.reset();
-      React.useEffect.restore();
     });
 
     it('should warn when switching from controlled to uncontrolled', () => {
-      const wrapper = mount(
-        <RadioGroup value="foo">
-          <Radio value="foo" />
-        </RadioGroup>,
-      );
+      let wrapper;
 
-      wrapper.setProps({ value: undefined });
+      act(() => {
+        wrapper = mount(
+          <RadioGroup value="foo">
+            <Radio value="foo" />
+          </RadioGroup>,
+        );
+
+        wrapper.setProps({ value: undefined });
+      });
+
       assert.include(
         consoleErrorMock.args()[0][0],
         'A component is changing a controlled RadioGroup to be uncontrolled.',
@@ -244,13 +248,18 @@ describe('<RadioGroup />', () => {
     });
 
     it('should warn when switching between uncontrolled to controlled', () => {
-      const wrapper = mount(
-        <RadioGroup>
-          <Radio value="foo" />
-        </RadioGroup>,
-      );
-      wrapper.setProps({ value: 'foo' });
-      wrapper.update();
+      let wrapper;
+
+      act(() => {
+        wrapper = mount(
+          <RadioGroup>
+            <Radio value="foo" />
+          </RadioGroup>,
+        );
+
+        wrapper.setProps({ value: 'foo' });
+      });
+
       assert.include(
         consoleErrorMock.args()[0][0],
         'A component is changing an uncontrolled RadioGroup to be controlled.',

--- a/packages/material-ui/src/test-utils/testRef.d.ts
+++ b/packages/material-ui/src/test-utils/testRef.d.ts
@@ -3,10 +3,14 @@ import createMount from './createMount';
 
 /**
  * Utility method to make assertions about the ref on an element
- * @param onRef - Make your assertions here
+ * @param element - The element should have a component wrapped
+ *                                       in withStyles as the root
+ * @param mount - Should be returnvalue of createMount
+ * @param onRef - Callback, first arg is the ref.
+ *                           Assert that the ref is a DOM node by default
  */
 export default function testRef<T>(
   element: React.ReactElement<{ innerRef: React.RefObject<T> }>,
   mount: ReturnType<typeof createMount>,
-  onRef: (ref: T) => void,
+  onRef?: (ref: T) => void,
 ): void;

--- a/packages/material-ui/src/test-utils/testRef.js
+++ b/packages/material-ui/src/test-utils/testRef.js
@@ -7,7 +7,7 @@ function assertDOMNode(node) {
 }
 
 /**
- *
+ * Utility method to make assertions about the ref on an element
  * @param {React.ReactElement} element - The element should have a component wrapped
  *                                       in withStyles as the root
  * @param {function} mount - Should be returnvalue of createMount


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Todo
- [x] Convert RadioGroup to function component
- [x] Forward ref to RadioGroup
- [x] Provide focus via actions prop for consistency
- [x] Adjust tests and test ref is forwarded