### PR TITLE
[Grid] Fix zeroMinWidth proptype warning

### DIFF
--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -385,7 +385,7 @@ if (process.env.NODE_ENV !== 'production') {
     spacing: requireProp('container'),
     wrap: requireProp('container'),
     xs: requireProp('item'),
-    zeroMinWidth: requireProp('zeroMinWidth'),
+    zeroMinWidth: requireProp('item'),
   };
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #14959. Thankyou @oliviertassinari for finding the solution so quickly. I couldn't think of anything useful to add to a test. Please let me know if there is anything else I can do