### PR TITLE
[chip] Support pressing delete to delete a chip

### DIFF
--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -260,7 +260,7 @@ const Chip = React.forwardRef(function Chip(props, ref) {
     }
 
     const key = event.key;
-    if (key === ' ' || key === 'Enter' || key === 'Backspace' || key === 'Escape') {
+    if (key === ' ' || key === 'Enter' || key === 'Backspace' || key === 'Delete' || key === 'Escape') {
       event.preventDefault();
     }
   };
@@ -278,7 +278,7 @@ const Chip = React.forwardRef(function Chip(props, ref) {
     const key = event.key;
     if (onClick && (key === ' ' || key === 'Enter')) {
       onClick(event);
-    } else if (onDelete && key === 'Backspace') {
+    } else if (onDelete && (key === 'Backspace' || key === 'Delete')) {
       onDelete(event);
     } else if (key === 'Escape' && chipRef) {
       chipRef.current.blur();

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -286,7 +286,7 @@ const Chip = React.forwardRef(function Chip(props, ref) {
       onClick(event);
     } else if (onDelete && (key === 'Backspace' || key === 'Delete')) {
       onDelete(event);
-    } else if (key === 'Escape' && chipRef) {
+    } else if (key === 'Escape' && chipRef.current) {
       chipRef.current.blur();
     }
   };

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -260,7 +260,8 @@ const Chip = React.forwardRef(function Chip(props, ref) {
     }
 
     const key = event.key;
-    if (key === ' ' || key === 'Enter' || key === 'Backspace' || key === 'Delete' || key === 'Escape') {
+    if (key === ' ' || key === 'Enter' || key === 'Backspace'
+      || key === 'Delete' || key === 'Escape') {
       event.preventDefault();
     }
   };

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -260,8 +260,13 @@ const Chip = React.forwardRef(function Chip(props, ref) {
     }
 
     const key = event.key;
-    if (key === ' ' || key === 'Enter' || key === 'Backspace'
-      || key === 'Delete' || key === 'Escape') {
+    if (
+      key === ' ' ||
+      key === 'Enter' ||
+      key === 'Backspace' ||
+      key === 'Delete' ||
+      key === 'Escape'
+    ) {
       event.preventDefault();
     }
   };

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -471,6 +471,29 @@ describe('<Chip />', () => {
       });
     });
 
+    describe('onDelete is defined and `delete` is pressed', () => {
+      it('should call onDelete', () => {
+        const preventDefaultSpy = spy();
+        const onDeleteSpy = spy();
+        const wrapper = mount(<Chip classes={{}} onDelete={onDeleteSpy} />);
+
+        const backspaceKeyDown = {
+          preventDefault: preventDefaultSpy,
+          key: 'delete',
+        };
+        wrapper.find('div').simulate('keyDown', backspaceKeyDown);
+        assert.strictEqual(preventDefaultSpy.callCount, 1);
+        assert.strictEqual(onDeleteSpy.callCount, 0);
+
+        const backspaceKeyUp = {
+          key: 'delete',
+        };
+        wrapper.find('div').simulate('keyUp', backspaceKeyUp);
+        assert.strictEqual(onDeleteSpy.callCount, 1);
+        assert.strictEqual(onDeleteSpy.args[0][0].keyCode, backspaceKeyUp.keyCode);
+      });
+    });
+
     describe('has children that generate events', () => {
       let onClickSpy;
       let onDeleteSpy;

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -475,22 +475,22 @@ describe('<Chip />', () => {
       it('should call onDelete', () => {
         const preventDefaultSpy = spy();
         const onDeleteSpy = spy();
-        const wrapper = mount(<Chip classes={{}} onDelete={onDeleteSpy} />);
+        const wrapper2 = mount(<ChipNaked classes={{}} onDelete={onDeleteSpy} />);
 
-        const backspaceKeyDown = {
+        const deleteKeyDown = {
           preventDefault: preventDefaultSpy,
-          key: 'delete',
+          key: 'Delete',
         };
-        wrapper.find('div').simulate('keyDown', backspaceKeyDown);
+        wrapper2.find('div').simulate('keyDown', deleteKeyDown);
         assert.strictEqual(preventDefaultSpy.callCount, 1);
         assert.strictEqual(onDeleteSpy.callCount, 0);
 
-        const backspaceKeyUp = {
-          key: 'delete',
+        const deleteKeyUp = {
+          key: 'Delete',
         };
-        wrapper.find('div').simulate('keyUp', backspaceKeyUp);
+        wrapper2.find('div').simulate('keyUp', deleteKeyUp);
         assert.strictEqual(onDeleteSpy.callCount, 1);
-        assert.strictEqual(onDeleteSpy.args[0][0].keyCode, backspaceKeyUp.keyCode);
+        assert.strictEqual(onDeleteSpy.args[0][0].keyCode, deleteKeyUp.keyCode);
       });
     });
 

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -377,7 +377,7 @@ describe('<Chip />', () => {
       it('should call onKeyDown when a key is pressed', () => {
         const anyKeydownEvent = { key: 'p' };
         const onKeyDownSpy = spy();
-        const wrapper = mount(<Chip classes={{}} onKeyDown={onKeyDownSpy} />);
+        const wrapper = mount(<Chip onKeyDown={onKeyDownSpy} />);
         wrapper.find('div').simulate('keyDown', anyKeydownEvent);
         assert.strictEqual(onKeyDownSpy.callCount, 1);
         assert.strictEqual(onKeyDownSpy.args[0][0].keyCode, anyKeydownEvent.keyCode);
@@ -448,11 +448,11 @@ describe('<Chip />', () => {
       });
     });
 
-    describe('onDelete is defined and `backspace` is pressed', () => {
-      it('should call onDelete', () => {
+    describe('prop: onDelete', () => {
+      it('should call onDelete `backspace` is pressed', () => {
         const preventDefaultSpy = spy();
         const onDeleteSpy = spy();
-        const wrapper = mount(<Chip classes={{}} onDelete={onDeleteSpy} />);
+        const wrapper = mount(<Chip onDelete={onDeleteSpy} />);
 
         const backspaceKeyDown = {
           preventDefault: preventDefaultSpy,
@@ -469,28 +469,26 @@ describe('<Chip />', () => {
         assert.strictEqual(onDeleteSpy.callCount, 1);
         assert.strictEqual(onDeleteSpy.args[0][0].keyCode, backspaceKeyUp.keyCode);
       });
-    });
 
-    describe('onDelete is defined and `delete` is pressed', () => {
-      it('should call onDelete', () => {
+      it('should call onDelete `delete` is pressed', () => {
         const preventDefaultSpy = spy();
         const onDeleteSpy = spy();
-        const wrapper2 = mount(<ChipNaked classes={{}} onDelete={onDeleteSpy} />);
+        const wrapper = mount(<Chip onDelete={onDeleteSpy} />);
 
-        const deleteKeyDown = {
+        const backspaceKeyDown = {
           preventDefault: preventDefaultSpy,
           key: 'Delete',
         };
-        wrapper2.find('div').simulate('keyDown', deleteKeyDown);
+        wrapper.find('div').simulate('keyDown', backspaceKeyDown);
         assert.strictEqual(preventDefaultSpy.callCount, 1);
         assert.strictEqual(onDeleteSpy.callCount, 0);
 
-        const deleteKeyUp = {
+        const backspaceKeyUp = {
           key: 'Delete',
         };
-        wrapper2.find('div').simulate('keyUp', deleteKeyUp);
+        wrapper.find('div').simulate('keyUp', backspaceKeyUp);
         assert.strictEqual(onDeleteSpy.callCount, 1);
-        assert.strictEqual(onDeleteSpy.args[0][0].keyCode, deleteKeyUp.keyCode);
+        assert.strictEqual(onDeleteSpy.args[0][0].keyCode, backspaceKeyUp.keyCode);
       });
     });
 
@@ -509,7 +507,6 @@ describe('<Chip />', () => {
 
         wrapper = mount(
           <Chip
-            classes={{}}
             onClick={onClickSpy}
             onDelete={onDeleteSpy}
             onKeyDown={onKeyDownSpy}


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

If it is a built-in feature that the chip handles the backspace key to trigger a delete event, it should probably also support the delete key. I need to handle deleting chips with the delete button, I could do it exterior to the component but I figure it would be more idiomatic to follow the existing flow.