### PR TITLE
[Popper] Add ClickAwayListener documentation

### DIFF
--- a/docs/src/pages/utils/popper/popper.md
+++ b/docs/src/pages/utils/popper/popper.md
@@ -14,8 +14,10 @@ Some important features of the `Popper` component:
 - 📦 Less than [10 KB gzipped](/size-snapshot).
 - The children is [`Portal`](/utils/portal/) to the body of the document to avoid rendering problems.
 You can disable this behavior with `disablePortal`.
-- The scroll and click away aren't blocked like with the [`Popover`](/utils/popover/) component.
+- The scroll isn't blocked like with the [`Popover`](/utils/popover/) component.
 The placement of the popper updates with the available area in the viewport.
+- Clicking away does not hide the `Popper` component. 
+  If you need this behavior, you can use [`ClickAwayListener`](utils/click-away-listener/) - see the example in the [menu documentation section](/demos/menus/#menulist-composition).
 - The `anchorEl` is passed as the reference object to create a new `Popper.js` instance.
 
 ## Simple Popper


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This PR links to an example showing how to have `Popper` + `ClickAwayListener` in the `Popper` page.