### PR TITLE
[test] Update enzyme

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,2 @@
---install.frozen-lockfile true
+
 network-timeout 150000

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,2 @@
-
+--install.frozen-lockfile true
 network-timeout 150000

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "dtslint": "^0.4.0",
     "emotion-theming": "^10.0.5",
     "enzyme": "^3.5.0",
-    "enzyme-adapter-react-16": "~1.10.0",
+    "enzyme-adapter-react-16": "^1.11.2",
     "eslint": "^5.9.0",
     "eslint-config-airbnb": "^17.0.0",
     "eslint-config-prettier": "^4.0.0",

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -53,16 +53,24 @@ describe('makeStyles', () => {
   it('should accept a classes property', () => {
     const styles = { root: {} };
     const mountWithProps = createGetClasses(styles);
-    const { classes: baseClasses } = mountWithProps();
-    const { classes: extendedClasses } = mountWithProps({ classes: { root: 'h1' } });
+    const output = mountWithProps();
+    const baseClasses = output.classes;
+    output.wrapper.setProps({
+      classes: { root: 'h1' },
+    });
+    const extendedClasses = output.classes;
     assert.strictEqual(extendedClasses.root, `${baseClasses.root} h1`);
   });
 
   it('should ignore undefined property', () => {
     const styles = { root: {} };
     const mountWithProps = createGetClasses(styles);
-    const { classes: baseClasses } = mountWithProps();
-    const { classes: extendedClasses } = mountWithProps({ classes: { root: undefined } });
+    const output = mountWithProps();
+    const baseClasses = output.classes;
+    output.wrapper.setProps({
+      classes: { root: undefined },
+    });
+    const extendedClasses = output.classes;
     assert.strictEqual(extendedClasses.root, baseClasses.root);
   });
 
@@ -78,8 +86,10 @@ describe('makeStyles', () => {
     });
 
     it('should warn if providing a unknown key', () => {
-      const { classes: baseClasses } = mountWithProps();
-      const { classes: extendedClasses } = mountWithProps({ classes: { bar: 'foo' } });
+      const output = mountWithProps();
+      const baseClasses = output.classes;
+      output.wrapper.setProps({ classes: { bar: 'foo' } });
+      const extendedClasses = output.classes;
       assert.deepEqual(extendedClasses, { root: baseClasses.root, bar: 'undefined foo' });
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
@@ -89,7 +99,8 @@ describe('makeStyles', () => {
     });
 
     it('should warn if providing a string', () => {
-      mountWithProps({ classes: 'foo' });
+      const output = mountWithProps();
+      output.wrapper.setProps({ classes: 'foo' });
       assert.strictEqual(consoleErrorMock.callCount() >= 1, true);
       const args = consoleErrorMock.args();
       assert.include(
@@ -99,8 +110,10 @@ describe('makeStyles', () => {
     });
 
     it('should warn if providing a non string', () => {
-      const { classes: baseClasses } = mountWithProps();
-      const { classes: extendedClasses } = mountWithProps({ classes: { root: {} } });
+      const output = mountWithProps();
+      const baseClasses = output.classes;
+      output.wrapper.setProps({ classes: { root: {} } });
+      const extendedClasses = output.classes;
       assert.deepEqual(extendedClasses, { root: `${baseClasses.root} [object Object]` });
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
@@ -148,8 +161,9 @@ describe('makeStyles', () => {
     });
 
     it('should invalidate the cache', () => {
-      const { classes } = mountWithProps();
-      const output = mountWithProps({ classes: { root: 'foo' } });
+      const output = mountWithProps();
+      const classes = output.classes;
+      output.wrapper.setProps({ classes: { root: 'foo' } });
       const classes1 = output.classes;
       assert.deepEqual(classes1, {
         root: `${classes.root} foo`,
@@ -225,9 +239,7 @@ describe('makeStyles', () => {
       );
       assert.strictEqual(sheetsRegistry.registry.length, 1);
       assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root-1' });
-      act(() => {
-        wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
-      });
+      wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
       assert.strictEqual(sheetsRegistry.registry.length, 1);
       assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root-2' });
     });
@@ -301,9 +313,7 @@ describe('makeStyles', () => {
         margin: '8px',
         padding: '8px',
       });
-      act(() => {
-        wrapper.setProps({ padding: 4 });
-      });
+      wrapper.setProps({ padding: 4 });
       assert.strictEqual(sheetsRegistry.registry.length, 2);
       assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Hook-root-1' });
       assert.deepEqual(sheetsRegistry.registry[1].classes, { root: 'Hook-root-2' });
@@ -369,9 +379,7 @@ describe('makeStyles', () => {
       });
 
       hmr = true;
-      act(() => {
-        wrapper.setProps({});
-      });
+      wrapper.setProps({});
       assert.strictEqual(sheetsRegistry.registry.length, 1);
       assert.deepEqual(sheetsRegistry.registry[0].rules.raw, {
         root: { padding: 4 },

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -2,7 +2,6 @@ import { assert } from 'chai';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { SheetsRegistry } from 'jss';
-import { act } from 'react-dom/test-utils';
 import { Input } from '@material-ui/core';
 import { createMount } from '@material-ui/core/test-utils';
 import { isMuiElement } from '@material-ui/core/utils';
@@ -191,9 +190,7 @@ describe('withStyles', () => {
       );
       assert.strictEqual(sheetsRegistry.registry.length, 1);
       assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root-1' });
-      act(() => {
-        wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
-      });
+      wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
       assert.strictEqual(sheetsRegistry.registry.length, 1);
       assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root-2' });
     });

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -33,18 +33,14 @@ describe('<BottomNavigationAction />', () => {
     testComponentPropWith: false,
   }));
 
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  it.only('should render a ButtonBase', () => {
+  it('should render a ButtonBase', () => {
     const wrapper = mount(<BottomNavigationAction icon={icon} />);
     const root = wrapper.find(`.${classes.root}`).first();
     assert.strictEqual(root.exists(), true);
     assert.strictEqual(root.type(), ButtonBase);
-    // remove this and the next test stops working
-    wrapper.unmount();
   });
 
-  // eslint-disable-next-line mocha/no-exclusive-tests
-  it.only('should render with the user and root classes', () => {
+  it('should render with the user and root classes', () => {
     const wrapper = mount(
       <BottomNavigationAction className="woofBottomNavigationAction" icon={icon} />,
     );

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -33,6 +33,26 @@ describe('<BottomNavigationAction />', () => {
     testComponentPropWith: false,
   }));
 
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  it.only('should render a ButtonBase', () => {
+    const wrapper = mount(<BottomNavigationAction icon={icon} />);
+    const root = wrapper.find(`.${classes.root}`).first();
+    assert.strictEqual(root.exists(), true);
+    assert.strictEqual(root.type(), ButtonBase);
+    // remove this and the next test stops working
+    wrapper.unmount();
+  });
+
+  // eslint-disable-next-line mocha/no-exclusive-tests
+  it.only('should render with the user and root classes', () => {
+    const wrapper = mount(
+      <BottomNavigationAction className="woofBottomNavigationAction" icon={icon} />,
+    );
+    const root = wrapper.find(`.${classes.root}.woofBottomNavigationAction`).first();
+    assert.strictEqual(root.exists(), true);
+    assert.strictEqual(root.hasClass('woofBottomNavigationAction'), true);
+  });
+
   it('should render with the selected and root classes', () => {
     const wrapper = mount(<BottomNavigationAction icon={icon} selected />);
     const root = wrapper.find(`.${classes.root}`).first();

--- a/packages/material-ui/src/GridListTile/GridListTile.test.js
+++ b/packages/material-ui/src/GridListTile/GridListTile.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount, describeConformance, getClasses } from '@material-ui/core/test-utils';
-import { act } from 'react-dom/test-utils';
 import { setRef } from '../utils/reactHelpers';
 import GridListTile from './GridListTile';
 
@@ -84,9 +83,7 @@ describe('<GridListTile />', () => {
         classList: { remove: spy(), add: spy() },
         removeEventListener: () => {},
       };
-      act(() => {
-        mountMockImage(imgEl);
-      });
+      mountMockImage(imgEl);
       assert.strictEqual(imgEl.classList.remove.callCount, 1);
       assert.strictEqual(imgEl.classList.remove.args[0][0], classes.imgFullWidth);
       assert.strictEqual(imgEl.classList.add.callCount, 1);
@@ -102,9 +99,7 @@ describe('<GridListTile />', () => {
         classList: { remove: spy(), add: spy() },
         removeEventListener: () => {},
       };
-      act(() => {
-        mountMockImage(imgEl);
-      });
+      mountMockImage(imgEl);
       assert.strictEqual(imgEl.classList.remove.callCount, 1);
       assert.strictEqual(imgEl.classList.remove.args[0][0], classes.imgFullHeight);
       assert.strictEqual(imgEl.classList.add.callCount, 1);
@@ -132,9 +127,7 @@ describe('<GridListTile />', () => {
         classList: { remove: spy(), add: spy() },
         removeEventListener: () => {},
       };
-      act(() => {
-        mountMockImage(imgEl);
-      });
+      mountMockImage(imgEl);
       assert.strictEqual(imgEl.classList.remove.callCount, 1);
       assert.strictEqual(imgEl.classList.remove.args[0][0], classes.imgFullHeight);
       assert.strictEqual(imgEl.classList.add.callCount, 1);

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -6,7 +6,6 @@ import FormGroup from '../FormGroup';
 import Radio from '../Radio';
 import RadioGroup from './RadioGroup';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { act } from 'react-dom/test-utils';
 
 describe('<RadioGroup />', () => {
   let mount;
@@ -228,10 +227,7 @@ describe('<RadioGroup />', () => {
         </RadioGroup>,
       );
 
-      act(() => {
-        wrapper.setProps({ value: undefined });
-      });
-
+      wrapper.setProps({ value: undefined });
       assert.include(
         consoleErrorMock.args()[0][0],
         'A component is changing a controlled RadioGroup to be uncontrolled.',
@@ -245,10 +241,7 @@ describe('<RadioGroup />', () => {
         </RadioGroup>,
       );
 
-      act(() => {
-        wrapper.setProps({ value: 'foo' });
-      });
-
+      wrapper.setProps({ value: 'foo' });
       assert.include(
         consoleErrorMock.args()[0][0],
         'A component is changing an uncontrolled RadioGroup to be controlled.',

--- a/packages/material-ui/src/test-utils/createMount.js
+++ b/packages/material-ui/src/test-utils/createMount.js
@@ -11,10 +11,16 @@ export default function createMount(options1 = {}) {
   window.document.body.insertBefore(attachTo, window.document.body.firstChild);
 
   const mountWithContext = function mountWithContext(node, options2 = {}) {
+    const { disableUnnmount = false, ...other2 } = options2;
+
+    if (!disableUnnmount) {
+      ReactDOM.unmountComponentAtNode(attachTo);
+    }
+
     return mount(node, {
       attachTo,
       ...other1,
-      ...options2,
+      ...other2,
     });
   };
 

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -40,7 +40,6 @@ describe('useMediaQuery', () => {
   });
 
   beforeEach(() => {
-    ReactDOM.unmountComponentAtNode(mount.attachTo);
     testReset();
     values = spy();
     window.matchMedia = createMatchMedia(1200, listeners);
@@ -51,7 +50,7 @@ describe('useMediaQuery', () => {
   });
 
   describe('option: defaultMatches', () => {
-    it('should be false by default', done => {
+    it('should be false by default', () => {
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)');
         values(matches);
@@ -61,14 +60,9 @@ describe('useMediaQuery', () => {
       const wrapper = mount(<Test />);
       assert.strictEqual(wrapper.text(), 'false');
       assert.strictEqual(values.callCount, 1);
-      setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'false');
-        assert.strictEqual(values.callCount, 1);
-        done();
-      });
     });
 
-    it('should take the option into account', done => {
+    it('should take the option into account', () => {
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
@@ -78,18 +72,13 @@ describe('useMediaQuery', () => {
       };
 
       const wrapper = mount(<Test />);
-      assert.strictEqual(wrapper.text(), 'true');
-      assert.strictEqual(values.callCount, 1);
-      setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'false');
-        assert.strictEqual(values.callCount, 2);
-        done();
-      });
+      assert.strictEqual(wrapper.text(), 'false');
+      assert.strictEqual(values.callCount, 2);
     });
   });
 
   describe('option: noSsr', () => {
-    it('should render once if the default value match the expectation', done => {
+    it('should render once if the default value match the expectation', () => {
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: false,
@@ -101,14 +90,9 @@ describe('useMediaQuery', () => {
       const wrapper = mount(<Test />);
       assert.strictEqual(wrapper.text(), 'false');
       assert.strictEqual(values.callCount, 1);
-      setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'false');
-        assert.strictEqual(values.callCount, 1);
-        done();
-      });
     });
 
-    it('should render twice if the default value does not match the expectation', done => {
+    it('should render twice if the default value does not match the expectation', () => {
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
@@ -118,16 +102,11 @@ describe('useMediaQuery', () => {
       };
 
       const wrapper = mount(<Test />);
-      assert.strictEqual(wrapper.text(), 'true');
-      assert.strictEqual(values.callCount, 1);
-      setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'false');
-        assert.strictEqual(values.callCount, 2);
-        done();
-      });
+      assert.strictEqual(wrapper.text(), 'false');
+      assert.strictEqual(values.callCount, 2);
     });
 
-    it('should render once if the default value does not match the expectation', done => {
+    it('should render once if the default value does not match the expectation', () => {
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
@@ -140,11 +119,6 @@ describe('useMediaQuery', () => {
       const wrapper = mount(<Test />);
       assert.strictEqual(wrapper.text(), 'false');
       assert.strictEqual(values.callCount, 1);
-      setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'false');
-        assert.strictEqual(values.callCount, 1);
-        done();
-      });
     });
   });
 
@@ -158,12 +132,9 @@ describe('useMediaQuery', () => {
     };
 
     let wrapper = mount(<Test />);
-    assert.strictEqual(wrapper.text(), 'true');
-    assert.strictEqual(values.callCount, 1);
+    assert.strictEqual(wrapper.text(), 'false');
+    assert.strictEqual(values.callCount, 2);
     setTimeout(() => {
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 2);
-
       ReactDOM.unmountComponentAtNode(mount.attachTo);
       wrapper = mount(<Test />);
       assert.strictEqual(wrapper.text(), 'false');
@@ -177,7 +148,7 @@ describe('useMediaQuery', () => {
     });
   });
 
-  it('should be able to change the query dynamically', done => {
+  it('should be able to change the query dynamically', () => {
     const Test = props => {
       const matches = useMediaQuery(props.query, {
         defaultMatches: true,
@@ -190,24 +161,14 @@ describe('useMediaQuery', () => {
     };
 
     const wrapper = mount(<Test query="(min-width:2000px)" />);
+    assert.strictEqual(wrapper.text(), 'false');
+    assert.strictEqual(values.callCount, 2);
+    wrapper.setProps({ query: '(min-width:100px)' });
     assert.strictEqual(wrapper.text(), 'true');
-    assert.strictEqual(values.callCount, 1);
-
-    setTimeout(() => {
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 2);
-
-      wrapper.setProps({ query: '(min-width:100px)' });
-      assert.strictEqual(values.callCount, 3);
-      setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'true');
-        assert.strictEqual(values.callCount, 4);
-        done();
-      });
-    });
+    assert.strictEqual(values.callCount, 4);
   });
 
-  it('should observe the media query', done => {
+  it('should observe the media query', () => {
     const Test = props => {
       const matches = useMediaQuery(props.query);
       values(matches);
@@ -218,21 +179,14 @@ describe('useMediaQuery', () => {
     };
 
     const wrapper = mount(<Test query="(min-width:2000px)" />);
-    assert.strictEqual(wrapper.text(), 'false');
     assert.strictEqual(values.callCount, 1);
+    assert.strictEqual(wrapper.text(), 'false');
 
-    setTimeout(() => {
-      assert.strictEqual(values.callCount, 1);
-      assert.strictEqual(wrapper.text(), 'false');
-
-      window.matchMedia = createMatchMedia(30000, listeners);
-      listeners[0]({
-        matches: true,
-      });
-      assert.strictEqual(wrapper.text(), 'true');
-      assert.strictEqual(values.callCount, 2);
-
-      done();
+    window.matchMedia = createMatchMedia(30000, listeners);
+    listeners[0]({
+      matches: true,
     });
+    assert.strictEqual(wrapper.text(), 'true');
+    assert.strictEqual(values.callCount, 2);
   });
 });

--- a/packages/material-ui/src/useMediaQuery/useMediaQueryTheme.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQueryTheme.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { ThemeProvider } from '@material-ui/styles';
-import { createMount } from '@material-ui/core/test-utils';
+import { createRender } from '@material-ui/core/test-utils';
 import mediaQuery from 'css-mediaquery';
 import { assert } from 'chai';
 import { spy } from 'sinon';
@@ -9,7 +8,7 @@ import { testReset } from './useMediaQuery';
 import useMediaQueryTheme from './useMediaQueryTheme';
 
 describe('useMediaQueryTheme', () => {
-  let mount;
+  let render;
   let values;
 
   // Only run the test on node.
@@ -19,7 +18,7 @@ describe('useMediaQueryTheme', () => {
   }
 
   before(() => {
-    mount = createMount();
+    render = createRender();
     if (!window.matchMedia) {
       window.matchMedia = query => ({
         matches: mediaQuery.match(query, {
@@ -32,16 +31,11 @@ describe('useMediaQueryTheme', () => {
   });
 
   beforeEach(() => {
-    ReactDOM.unmountComponentAtNode(mount.attachTo);
     testReset();
     values = spy();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
-  it('should use the ssr match media ponyfill', done => {
+  it('should use the ssr match media ponyfill', () => {
     function MyComponent() {
       const matches = useMediaQueryTheme('(min-width:2000px)');
       values(matches);
@@ -62,13 +56,8 @@ describe('useMediaQueryTheme', () => {
       );
     };
 
-    const wrapper = mount(<Test />);
+    const wrapper = render(<Test />);
     assert.strictEqual(wrapper.text(), 'true');
     assert.strictEqual(values.callCount, 1);
-    setTimeout(() => {
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 2);
-      done();
-    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5573,19 +5573,20 @@ entities@^1.1.1, entities@~1.1.1:
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.2.tgz#bdfa735299664dfafd34529ed4f8522a275fea56"
   integrity sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
 
-enzyme-adapter-react-16@~1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.10.0.tgz#12e5b6f4be84f9a2ef374acc2555f829f351fc6e"
-  integrity sha512-0QqwEZcBv1xEEla+a3H7FMci+y4ybLia9cZzsdIrId7qcig4MK0kqqf6iiCILH1lsKS6c6AVqL3wGPhCevv5aQ==
+enzyme-adapter-react-16@^1.11.2:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.11.2.tgz#8efeafb27e96873a5492fdef3f423693182eb9d4"
+  integrity sha512-2ruTTCPRb0lPuw/vKTXGVZVBZqh83MNDnakMhzxhpJcIbneEwNy2Cv0KvL97pl57/GOazJHflWNLjwWhex5AAA==
   dependencies:
-    enzyme-adapter-utils "^1.10.0"
+    enzyme-adapter-utils "^1.10.1"
     object.assign "^4.1.0"
     object.values "^1.1.0"
-    prop-types "^15.6.2"
-    react-is "^16.7.0"
+    prop-types "^15.7.2"
+    react-is "^16.8.4"
     react-test-renderer "^16.0.0-0"
+    semver "^5.6.0"
 
-enzyme-adapter-utils@^1.10.0:
+enzyme-adapter-utils@^1.10.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.10.1.tgz#58264efa19a7befdbf964fb7981a108a5452ac96"
   integrity sha512-oasinhhLoBuZsIkTe8mx0HiudtfErUtG0Ooe1FOplu/t4c9rOmyG5gtrBASK6u4whHIRWvv0cbZMElzNTR21SA==
@@ -11270,7 +11271,7 @@ react-is@16.6.3:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
-react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.2, react-is@^16.8.5:
+react-is@^16.5.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.2, react-is@^16.8.4, react-is@^16.8.5:
   version "16.8.5"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
   integrity sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ==


### PR DESCRIPTION
This is not meant to be merged.

`enzyme-adapter-react-16` started wrapping updates in `act` which results in very weird test behavior if we're not explicitly unmounting after the test.

Without unmounting subsequent test will sometimes return wrappers that do not exist from `mount`:
```js
const wrapper = mount(<List />);
assert.strictEqual(wrapper.exists(), true); // fails
```

Would be nice if somebody could investigate this issue. Not looking forward to rewriting every test to explicitly unmount afterEach.