### PR TITLE
[Modal] Ignore event.defaultPrevented

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -156,16 +156,13 @@ class Modal extends React.Component {
   };
 
   handleKeyDown = event => {
-    // event.defaultPrevented:
+    // We don't take event.defaultPrevented into account:
     //
-    // Ignore events that have been `event.preventDefault()` marked.
-    // preventDefault() is meant to stop default behaviours like
+    // event.preventDefault() is meant to stop default behaviours like
     // clicking a checkbox to check it, hitting a button to submit a form,
     // and hitting left arrow to move the cursor in a text input etc.
-    // Only special HTML elements have these default bahaviours.
-    //
-    // To remove in v4.
-    if (event.key !== 'Escape' || !this.isTopModal() || event.defaultPrevented) {
+    // Only special HTML elements have these default behaviors.
+    if (event.key !== 'Escape' || !this.isTopModal()) {
       return;
     }
 

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -324,15 +324,15 @@ describe('<Modal />', () => {
       assert.strictEqual(onCloseSpy.callCount, 0);
     });
 
-    it('should not be call when defaultPrevented', () => {
+    it('should be call when defaultPrevented', () => {
       topModalStub.returns(true);
-      wrapper.setProps({ disableEscapeKeyDown: true, manager: { isTopModal: topModalStub } });
-      event = { key: 'Escape', defaultPrevented: true };
+      wrapper.setProps({ manager: { isTopModal: topModalStub } });
+      event = { key: 'Escape', defaultPrevented: true, stopPropagation: () => {} };
 
       instance.handleKeyDown(event);
       assert.strictEqual(topModalStub.callCount, 1);
-      assert.strictEqual(onEscapeKeyDownSpy.callCount, 0);
-      assert.strictEqual(onCloseSpy.callCount, 0);
+      assert.strictEqual(onEscapeKeyDownSpy.callCount, 1);
+      assert.strictEqual(onCloseSpy.callCount, 1);
     });
   });
 


### PR DESCRIPTION
Follow up on #13470. The change was encouraged by @stevemao. 

### Breaking change

The new logic closes the Modal even if `event.preventDefault()` is called on the keydown escape event.
`event.preventDefault()` is meant to stop default behaviours like clicking a checkbox to check it, hitting a button to submit a form, and hitting left arrow to move the cursor in a text input etc. Only special HTML elements have these default behaviors. People should use `event.stopPropagation()` if they don't want to trigger a `onClose` event on the modal.
