### PR TITLE
[TextField] Remove the support for a rare edge-case

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -172,14 +172,7 @@ class InputBase extends React.Component {
     }
   }
 
-  componentDidUpdate(prevProps) {
-    // Book keep the focused state.
-    if (!prevProps.disabled && this.props.disabled) {
-      const { muiFormControl } = this.props;
-      if (muiFormControl && muiFormControl.onBlur) {
-        muiFormControl.onBlur();
-      }
-    }
+  componentDidUpdate() {
     if (this.isControlled) {
       this.checkDirty(this.props);
     } // else performed in the onChange

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -75,8 +75,7 @@ describe('<InputBase />', () => {
     });
 
     it('should reset the focused state', () => {
-      const handleBlur = spy();
-      const wrapper = mount(<InputBase muiFormControl={{ onBlur: handleBlur }} />);
+      const wrapper = mount(<InputBase />);
       // We simulate a focused input that is getting disabled.
       setState(wrapper, {
         focused: true,
@@ -85,7 +84,6 @@ describe('<InputBase />', () => {
         disabled: true,
       });
       assert.strictEqual(wrapper.find('InputBase').state().focused, false);
-      assert.strictEqual(handleBlur.callCount, 1);
     });
 
     // IE 11 bug


### PR DESCRIPTION
### Breaking change

You should control the text field component either at the TextField (FormControl) level or at the InputBase (Input, FilledInput, OutlinedInput) level. Don't mix the two approaches.