### PR TITLE
[slider] Fix onChange not being fired on single touch

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -354,6 +354,7 @@ class Slider extends React.Component {
 
     const value = this.calculateValueFromPercent(event);
     const newValue = valueReducer(value, this.props, event);
+    this.emitChange(event, value);
 
     document.body.addEventListener('touchend', this.handleTouchEnd);
 

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -120,7 +120,7 @@ describe('<Slider />', () => {
     touchEvent.changedTouches = touchList([{ identifier: 2 }]);
     document.body.dispatchEvent(touchEvent);
 
-    assert.strictEqual(handleChange.callCount, 0, 'should not have called the handleChange cb');
+    assert.strictEqual(handleChange.callCount, 1, 'should have called the handleChange cb');
     assert.strictEqual(handleDragStart.callCount, 1, 'should have called the handleDragStart cb');
     assert.strictEqual(handleDragEnd.callCount, 0, 'should not have called the handleDragEnd cb');
 
@@ -131,7 +131,7 @@ describe('<Slider />', () => {
     touchEvent.changedTouches = touchList([{ identifier: 1 }]);
     document.body.dispatchEvent(touchEvent);
 
-    assert.strictEqual(handleChange.callCount, 1, 'should have called the handleChange cb');
+    assert.strictEqual(handleChange.callCount, 2, 'should have called the handleChange cb');
     assert.strictEqual(handleDragStart.callCount, 1, 'should have called the handleDragStart cb');
     assert.strictEqual(handleDragEnd.callCount, 1, 'should have called the handleDragEnd cb');
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

# Description of fix

This fix intends to fix the problem described in #13278. However, the underlying behavior seems to have changed a bit since that bug was reported, so I cannot guarantee that this is a fix for the same issue. In that issue, this problem is described as more pronounced on dev tools compared to device but in my experience it happens on both, albeit in slightly different ways.

# How to reproduce

## In Firefox:
1. Turn on "responsive design mode", and enable "touch simulation" to get device-like behavior 
2. Go to https://material-ui.com/lab/slider/
3. Click *and hold* the mouse on the "Simple slider". Note that the slider does not move until you move your mouse or release the mouse button

## In Chrome:
1. Turn on "device toolbar", to get device-like behavior 
2. Go to https://material-ui.com/lab/slider/
3. Click the mouse on the "Simple slider". Note that the slider does not move, even when the mouse button is released.

## In Firefox Mobile and Chrome Mobile:
1. Go to https://material-ui.com/lab/slider/
2. Tap the "Simple slider". Note that the dot does not move, even when you stop tapping. 
Note: I expect this to be *very* hard to reproduce on devices with high resolution touch screens (it is quite easy once you get the hang of it on my phone though)

# Notes 

- I had to change a test in order for this to go through. It is hard for me to evaluate the effects of doing so. I am prepared to work on a different change if this approach is deemed inadequate 
- This would replace PR #13615 as the reporter seems to have abandoned that effort.