### PR TITLE
[docs] Content's max width changed for large displays

### DIFF
--- a/docs/src/modules/components/AppContent.js
+++ b/docs/src/modules/components/AppContent.js
@@ -19,7 +19,7 @@ const styles = theme => ({
     [theme.breakpoints.up('lg')]: {
       paddingLeft: theme.spacing(5),
       paddingRight: theme.spacing(9),
-      maxWidth: 'calc(100% - 240px - 167px)',
+      maxWidth: theme.breakpoints.width('lg'),
     },
   },
 });

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -114,6 +114,7 @@ const styles = theme => ({
   },
   drawer: {
     [theme.breakpoints.up('lg')]: {
+      flexShrink: 0,
       width: 240,
     },
   },

--- a/pages/index.js
+++ b/pages/index.js
@@ -34,6 +34,9 @@ const styles = theme => ({
   root: {
     flex: '1 0 100%',
   },
+  drawer: {
+    width: 0,
+  },
   hero: {
     paddingTop: 64 + 29,
     backgroundColor: theme.palette.background.paper,
@@ -113,7 +116,7 @@ class HomePage extends React.Component {
     const { classes, t } = this.props;
 
     return (
-      <AppFrame>
+      <AppFrame classes={{ drawer: classes.drawer }}>
         <div className={classes.root}>
           <Head />
           <div className={classes.hero}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Fixed max-width for large displays, so that Scrollable Tabs demo is accurate on 4k displays.
Closes #14926