### PR TITLE
[SwipeableDrawer] Ignore open swipe if it didn't start on the swipe area

### DIFF
--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -35,7 +35,7 @@ export const styles = theme => ({
 /**
  * @ignore - internal component.
  */
-function SwipeArea(props) {
+const SwipeArea = React.forwardRef(function SwipeArea(props, ref) {
   const { anchor, classes, className, width, ...other } = props;
 
   return (
@@ -44,10 +44,11 @@ function SwipeArea(props) {
       style={{
         [isHorizontal(props) ? 'width' : 'height']: width,
       }}
+      ref={ref}
       {...other}
     />
   );
-}
+});
 
 SwipeArea.propTypes = {
   /**

--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -35,7 +35,7 @@ export const styles = theme => ({
 /**
  * @ignore - internal component.
  */
-const SwipeArea = React.forwardRef(function SwipeArea(props, ref) {
+const SwipeArea = React.forwardRef((props, ref) => {
   const { anchor, classes, className, width, ...other } = props;
 
   return (

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -34,6 +34,7 @@ class SwipeableDrawer extends React.Component {
   state = {};
 
   isSwiping = null;
+  swipeAreaRef = React.createRef();
 
   componentDidMount() {
     if (this.props.variant === 'temporary') {
@@ -158,7 +159,7 @@ class SwipeableDrawer extends React.Component {
         : event.touches[0].clientY;
 
     if (!open) {
-      if (disableSwipeToOpen) {
+      if (disableSwipeToOpen || event.target !== this.swipeAreaRef.current) {
         return;
       }
       if (isHorizontal(this.props)) {
@@ -390,9 +391,14 @@ class SwipeableDrawer extends React.Component {
           anchor={anchor}
           {...other}
         />
-        {!disableDiscovery && !disableSwipeToOpen && variant === 'temporary' && (
+        {!disableSwipeToOpen && variant === 'temporary' && (
           <NoSsr>
-            <SwipeArea anchor={anchor} width={swipeAreaWidth} {...SwipeAreaProps} />
+            <SwipeArea
+              anchor={anchor}
+              innerRef={this.swipeAreaRef}
+              width={swipeAreaWidth}
+              {...SwipeAreaProps}
+            />
           </NoSsr>
         )}
       </React.Fragment>

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -195,7 +195,7 @@ class SwipeableDrawer extends React.Component {
   };
 
   handleBodyTouchMove = event => {
-    // the ref may be null when a parent component updates while swiping
+    // The ref may be null when a parent component updates while swiping.
     if (!this.paperRef) return;
 
     const anchor = getAnchor(this.props);

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -34,6 +34,7 @@ class SwipeableDrawer extends React.Component {
   state = {};
 
   isSwiping = null;
+
   swipeAreaRef = React.createRef();
 
   componentDidMount() {


### PR DESCRIPTION
This is a copy of #15036. I accidentially created a branch in this repository. I fixed my setup, won't happen again. :grimacing:

---

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes #15035 (and my issue/pr ratio :sweat_smile:).

Note: The `SwipeArea` is now also mounted if discovery is disabled, because it is required for swiping. We need to keep the swiping logic at the body because the close swipe can start anywhere. Using `onTouchStart` of the swipe area would lead to a lot of duplicate code (or breaking discovery, resulting in even more code).

If this gets merged (I'm currently experiencing this issue in a 3.x.x project), I'm happy to forward-port the fix to `next`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
