### PR TITLE
[performance] Add live pages

### DIFF
--- a/pages/performance/table-component.js
+++ b/pages/performance/table-component.js
@@ -1,0 +1,61 @@
+/* eslint-disable react/no-array-index-key */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import NoSsr from '@material-ui/core/NoSsr';
+
+const createComponent = defaultComponent => {
+  const MyComponent = React.forwardRef(function MyComponent(props, ref) {
+    const { component: Component = defaultComponent, ...other } = props;
+
+    return <Component ref={ref} {...other} />;
+  });
+
+  MyComponent.propTypes = {
+    component: PropTypes.elementType,
+  };
+
+  return MyComponent;
+};
+
+const Table = createComponent('table');
+const TableHead = createComponent('thead');
+const TableRow = createComponent('tr');
+const TableCell = createComponent('td');
+const TableBody = createComponent('tbody');
+
+const data = { name: 'Frozen yoghurt', calories: 159, fat: 6.0, carbs: 24, protein: 4.0 };
+const rows = Array.from(new Array(100)).map(() => data);
+
+function TableComponent() {
+  return (
+    <NoSsr defer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Dessert (100g serving)</TableCell>
+            <TableCell>Calories</TableCell>
+            <TableCell>Fat (g)</TableCell>
+            <TableCell>Carbs (g)</TableCell>
+            <TableCell>Protein (g)</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell component="th" scope="row">
+                {row.name}
+              </TableCell>
+              <TableCell>{row.calories}</TableCell>
+              <TableCell>{row.fat}</TableCell>
+              <TableCell>{row.carbs}</TableCell>
+              <TableCell>{row.protein}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </NoSsr>
+  );
+}
+
+export default TableComponent;

--- a/pages/performance/table-emotion.js
+++ b/pages/performance/table-emotion.js
@@ -1,0 +1,64 @@
+/* eslint-disable react/no-array-index-key */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+import NoSsr from '@material-ui/core/NoSsr';
+
+const createComponent = defaultComponent => {
+  const MyComponent = React.forwardRef(function MyComponent(props, ref) {
+    const { component: Component = defaultComponent, ...other } = props;
+
+    return <Component ref={ref} {...other} />;
+  });
+
+  MyComponent.propTypes = {
+    component: PropTypes.elementType,
+  };
+
+  return styled(MyComponent)`
+    background: pink;
+  `;
+};
+
+const Table = createComponent('table');
+const TableHead = createComponent('thead');
+const TableRow = createComponent('tr');
+const TableCell = createComponent('td');
+const TableBody = createComponent('tbody');
+
+const data = { name: 'Frozen yoghurt', calories: 159, fat: 6.0, carbs: 24, protein: 4.0 };
+const rows = Array.from(new Array(100)).map(() => data);
+
+function TableEmotion() {
+  return (
+    <NoSsr defer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Dessert (100g serving)</TableCell>
+            <TableCell>Calories</TableCell>
+            <TableCell>Fat (g)</TableCell>
+            <TableCell>Carbs (g)</TableCell>
+            <TableCell>Protein (g)</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell component="th" scope="row">
+                {row.name}
+              </TableCell>
+              <TableCell>{row.calories}</TableCell>
+              <TableCell>{row.fat}</TableCell>
+              <TableCell>{row.carbs}</TableCell>
+              <TableCell>{row.protein}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </NoSsr>
+  );
+}
+
+export default TableEmotion;

--- a/pages/performance/table-hook.js
+++ b/pages/performance/table-hook.js
@@ -1,0 +1,69 @@
+/* eslint-disable react/no-array-index-key */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/styles';
+import NoSsr from '@material-ui/core/NoSsr';
+
+const createComponent = defaultComponent => {
+  const useStyles = makeStyles({
+    root: {
+      background: 'pink',
+    },
+  });
+
+  const MyComponent = React.forwardRef(function MyComponent(props, ref) {
+    const { component: Component = defaultComponent, ...other } = props;
+    const classes = useStyles();
+
+    return <Component ref={ref} {...other} className={classes.root} />;
+  });
+
+  MyComponent.propTypes = {
+    component: PropTypes.elementType,
+  };
+
+  return MyComponent;
+};
+
+const Table = createComponent('table');
+const TableHead = createComponent('thead');
+const TableRow = createComponent('tr');
+const TableCell = createComponent('td');
+const TableBody = createComponent('tbody');
+
+const data = { name: 'Frozen yoghurt', calories: 159, fat: 6.0, carbs: 24, protein: 4.0 };
+const rows = Array.from(new Array(100)).map(() => data);
+
+function TableHook() {
+  return (
+    <NoSsr defer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Dessert (100g serving)</TableCell>
+            <TableCell>Calories</TableCell>
+            <TableCell>Fat (g)</TableCell>
+            <TableCell>Carbs (g)</TableCell>
+            <TableCell>Protein (g)</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell component="th" scope="row">
+                {row.name}
+              </TableCell>
+              <TableCell>{row.calories}</TableCell>
+              <TableCell>{row.fat}</TableCell>
+              <TableCell>{row.carbs}</TableCell>
+              <TableCell>{row.protein}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </NoSsr>
+  );
+}
+
+export default TableHook;

--- a/pages/performance/table-mui.js
+++ b/pages/performance/table-mui.js
@@ -1,0 +1,45 @@
+/* eslint-disable react/no-array-index-key */
+
+import React from 'react';
+import NoSsr from '@material-ui/core/NoSsr';
+import Table from '@material-ui/core/Table';
+import TableBody from '@material-ui/core/TableBody';
+import TableCell from '@material-ui/core/TableCell';
+import TableHead from '@material-ui/core/TableHead';
+import TableRow from '@material-ui/core/TableRow';
+
+const data = { name: 'Frozen yoghurt', calories: 159, fat: 6.0, carbs: 24, protein: 4.0 };
+const rows = Array.from(new Array(100)).map(() => data);
+
+function TableMui() {
+  return (
+    <NoSsr defer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Dessert (100g serving)</TableCell>
+            <TableCell>Calories</TableCell>
+            <TableCell>Fat (g)</TableCell>
+            <TableCell>Carbs (g)</TableCell>
+            <TableCell>Protein (g)</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell component="th" scope="row">
+                {row.name}
+              </TableCell>
+              <TableCell>{row.calories}</TableCell>
+              <TableCell>{row.fat}</TableCell>
+              <TableCell>{row.carbs}</TableCell>
+              <TableCell>{row.protein}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </NoSsr>
+  );
+}
+
+export default TableMui;

--- a/pages/performance/table-raw.js
+++ b/pages/performance/table-raw.js
@@ -1,0 +1,38 @@
+/* eslint-disable react/no-array-index-key */
+
+import React from 'react';
+import NoSsr from '@material-ui/core/NoSsr';
+
+const data = { name: 'Frozen yoghurt', calories: 159, fat: 6.0, carbs: 24, protein: 4.0 };
+const rows = Array.from(new Array(100)).map(() => data);
+
+function TableRaw() {
+  return (
+    <NoSsr defer>
+      <table>
+        <thead>
+          <tr>
+            <th>Dessert (100g serving)</th>
+            <th>Calories</th>
+            <th>Fat (g)</th>
+            <th>Carbs (g)</th>
+            <th>Protein (g)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, index) => (
+            <tr key={index}>
+              <th scope="row">{row.name}</th>
+              <td>{row.calories}</td>
+              <td>{row.fat}</td>
+              <td>{row.carbs}</td>
+              <td>{row.protein}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </NoSsr>
+  );
+}
+
+export default TableRaw;

--- a/pages/performance/table-styled-components.js
+++ b/pages/performance/table-styled-components.js
@@ -1,0 +1,64 @@
+/* eslint-disable react/no-array-index-key */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import NoSsr from '@material-ui/core/NoSsr';
+
+const createComponent = defaultComponent => {
+  const MyComponent = React.forwardRef(function MyComponent(props, ref) {
+    const { component: Component = defaultComponent, ...other } = props;
+
+    return <Component ref={ref} {...other} />;
+  });
+
+  MyComponent.propTypes = {
+    component: PropTypes.elementType,
+  };
+
+  return styled(MyComponent)`
+    background: pink;
+  `;
+};
+
+const Table = createComponent('table');
+const TableHead = createComponent('thead');
+const TableRow = createComponent('tr');
+const TableCell = createComponent('td');
+const TableBody = createComponent('tbody');
+
+const data = { name: 'Frozen yoghurt', calories: 159, fat: 6.0, carbs: 24, protein: 4.0 };
+const rows = Array.from(new Array(100)).map(() => data);
+
+function TableStyledComponents() {
+  return (
+    <NoSsr defer>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>Dessert (100g serving)</TableCell>
+            <TableCell>Calories</TableCell>
+            <TableCell>Fat (g)</TableCell>
+            <TableCell>Carbs (g)</TableCell>
+            <TableCell>Protein (g)</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.map((row, index) => (
+            <TableRow key={index}>
+              <TableCell component="th" scope="row">
+                {row.name}
+              </TableCell>
+              <TableCell>{row.calories}</TableCell>
+              <TableCell>{row.fat}</TableCell>
+              <TableCell>{row.carbs}</TableCell>
+              <TableCell>{row.protein}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </NoSsr>
+  );
+}
+
+export default TableStyledComponents;


### PR DESCRIPTION
I have added new stress test pages so we can more easily benchmark the changes. I would like to create a way to automate the tests, sample many iterations. All we have with those pages, is an order of magnitude as well as a debug env. It's not accurate enough!
- raw: 15ms
- component: 25ms
- hook: 65ms
- sc: 70ms
- emotions: 80ms
- mui: 120ms