### PR TITLE
[Box] Update BoxProps to temporarily allow any props

### DIFF
--- a/packages/material-ui/src/Box/Box.d.ts
+++ b/packages/material-ui/src/Box/Box.d.ts
@@ -4,6 +4,7 @@ export interface BoxProps extends React.HTMLAttributes<HTMLElement> {
   component?: React.ElementType;
   // styled API
   clone?: boolean;
+  [styledProp: string]: any;
 }
 
 declare const Box: React.ComponentType<BoxProps>;


### PR DESCRIPTION
- BoxProps are currently too limiting and will throw errors when using any styled props, such as `ml` or `fontWeight`
- This change temporarily allows any props to be used with Box while more comprehensive types are being developed