### PR TITLE
[ListItem] Add type test for button prop

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.spec.tsx
+++ b/packages/material-ui/src/ListItem/ListItem.spec.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ListItem from '@material-ui/core/ListItem';
+
+// button: boolean
+function BooleanButtonTest() {
+  // https://github.com/mui-org/material-ui/issues/14971
+
+  function EditableItemFail(props: { editable: boolean }) {
+    const { editable } = props;
+    // 'boolean' is not assignable to type 'true'
+    return <ListItem button={editable}>Editable? {editable}</ListItem>; // $ExpectError
+  }
+
+  function EditableItemValid(props: { editable: boolean }) {
+    const { editable } = props;
+    if (editable) {
+      <ListItem button>Editable? Yes</ListItem>;
+    }
+    return <ListItem>Editable? No</ListItem>;
+  }
+}


### PR DESCRIPTION
Since #13868 `button` is a discriminant for the props of `ListItem`. This means it can't be assigned `boolean`. Either `false` or `true` has to be used.

You can't pass the union of the possible types of discriminants in TypeScript.  A simplified illustration of this problem:

```ts
interface BookProps {
  isBook: 'yes';
}

interface MagazineProps {
  isBook: 'no';
}

interface OverloadedComponent {
  (props: BookProps | MagazineProps): void;
}

declare const SomeComponent: OverloadedComponent;

function Library(props: { isBook: 'yes'} | {isBook: 'no'}) {
  const { isBook } = props;
  SomeComponent(props);
  // This fails because `isBook` is of type `'yes' | 'no'`
  SomeComponent({ isBook });
}
```

Might be a limitation of TypeScript, might a bug.
/cc @pelotom 