### PR TITLE
[docs] Add Tooltip TypeScript demos

### DIFF
--- a/docs/src/pages/demos/tooltips/ControlledTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/ControlledTooltips.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+
+function ControlledTooltips() {
+  const [open, setOpen] = React.useState(false);
+
+  function handleTooltipClose() {
+    setOpen(false);
+  }
+
+  function handleTooltipOpen() {
+    setOpen(true);
+  }
+
+  return (
+    <Tooltip onClose={handleTooltipClose} onOpen={handleTooltipOpen} open={open} title="Add">
+      <Button>Controlled</Button>
+    </Tooltip>
+  );
+}
+
+export default ControlledTooltips;

--- a/docs/src/pages/demos/tooltips/CustomizedTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/CustomizedTooltips.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+
+function arrowGenerator(color: string) {
+  return {
+    '&[x-placement*="bottom"] $arrow': {
+      top: 0,
+      left: 0,
+      marginTop: '-0.95em',
+      width: '3em',
+      height: '1em',
+      '&::before': {
+        borderWidth: '0 1em 1em 1em',
+        borderColor: `transparent transparent ${color} transparent`,
+      },
+    },
+    '&[x-placement*="top"] $arrow': {
+      bottom: 0,
+      left: 0,
+      marginBottom: '-0.95em',
+      width: '3em',
+      height: '1em',
+      '&::before': {
+        borderWidth: '1em 1em 0 1em',
+        borderColor: `${color} transparent transparent transparent`,
+      },
+    },
+    '&[x-placement*="right"] $arrow': {
+      left: 0,
+      marginLeft: '-0.95em',
+      height: '3em',
+      width: '1em',
+      '&::before': {
+        borderWidth: '1em 1em 1em 0',
+        borderColor: `transparent ${color} transparent transparent`,
+      },
+    },
+    '&[x-placement*="left"] $arrow': {
+      right: 0,
+      marginRight: '-0.95em',
+      height: '3em',
+      width: '1em',
+      '&::before': {
+        borderWidth: '1em 0 1em 1em',
+        borderColor: `transparent transparent transparent ${color}`,
+      },
+    },
+  };
+}
+
+const useStyles = makeStyles((theme: Theme) => createStyles({
+  button: {
+    margin: theme.spacing(1),
+  },
+  lightTooltip: {
+    backgroundColor: theme.palette.common.white,
+    color: 'rgba(0, 0, 0, 0.87)',
+    boxShadow: theme.shadows[1],
+    fontSize: 11,
+  },
+  arrowPopper: arrowGenerator(theme.palette.grey[700]),
+  arrow: {
+    position: 'absolute',
+    fontSize: 6,
+    width: '3em',
+    height: '3em',
+    '&::before': {
+      content: '""',
+      margin: 'auto',
+      display: 'block',
+      width: 0,
+      height: 0,
+      borderStyle: 'solid',
+    },
+  },
+  bootstrapPopper: arrowGenerator(theme.palette.common.black),
+  bootstrapTooltip: {
+    backgroundColor: theme.palette.common.black,
+  },
+  bootstrapPlacementLeft: {
+    margin: '0 8px',
+  },
+  bootstrapPlacementRight: {
+    margin: '0 8px',
+  },
+  bootstrapPlacementTop: {
+    margin: '8px 0',
+  },
+  bootstrapPlacementBottom: {
+    margin: '8px 0',
+  },
+  htmlPopper: arrowGenerator('#dadde9'),
+  htmlTooltip: {
+    backgroundColor: '#f5f5f9',
+    color: 'rgba(0, 0, 0, 0.87)',
+    maxWidth: 220,
+    fontSize: theme.typography.pxToRem(12),
+    border: '1px solid #dadde9',
+    '& b': {
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+  },
+}));
+
+function CustomizedTooltips() {
+  const classes = useStyles();
+  const [arrowRef, setArrowRef] = React.useState<HTMLSpanElement | null>(null);
+
+  return (
+    <div>
+      <Tooltip title="Add" classes={{ tooltip: classes.lightTooltip }}>
+        <Button className={classes.button}>Light</Button>
+      </Tooltip>
+      <Tooltip
+        title={
+          <React.Fragment>
+            Add
+            <span className={classes.arrow} ref={setArrowRef} />
+          </React.Fragment>
+        }
+        classes={{ popper: classes.arrowPopper }}
+        PopperProps={{
+          popperOptions: {
+            modifiers: {
+              arrow: {
+                enabled: Boolean(arrowRef),
+                element: arrowRef,
+              },
+            },
+          },
+        }}
+      >
+        <Button className={classes.button}>Arrow</Button>
+      </Tooltip>
+      <Tooltip
+        title={
+          <React.Fragment>
+            Add
+            <span className={classes.arrow} ref={setArrowRef} />
+          </React.Fragment>
+        }
+        classes={{
+          tooltip: classes.bootstrapTooltip,
+          popper: classes.bootstrapPopper,
+          tooltipPlacementLeft: classes.bootstrapPlacementLeft,
+          tooltipPlacementRight: classes.bootstrapPlacementRight,
+          tooltipPlacementTop: classes.bootstrapPlacementTop,
+          tooltipPlacementBottom: classes.bootstrapPlacementBottom,
+        }}
+        PopperProps={{
+          popperOptions: {
+            modifiers: {
+              arrow: {
+                enabled: Boolean(arrowRef),
+                element: arrowRef,
+              },
+            },
+          },
+        }}
+      >
+        <Button className={classes.button}>Bootstrap</Button>
+      </Tooltip>
+      <Tooltip
+        classes={{
+          popper: classes.htmlPopper,
+          tooltip: classes.htmlTooltip,
+        }}
+        PopperProps={{
+          popperOptions: {
+            modifiers: {
+              arrow: {
+                enabled: Boolean(arrowRef),
+                element: arrowRef,
+              },
+            },
+          },
+        }}
+        title={
+          <React.Fragment>
+            <Typography color="inherit">Tooltip with HTML</Typography>
+            <em>{"And here's"}</em> <b>{'some'}</b> <u>{'amazing content'}</u>.{' '}
+            {"It's very engaging. Right?"}
+            <span className={classes.arrow} ref={setArrowRef} />
+          </React.Fragment>
+        }
+      >
+        <Button className={classes.button}>HTML</Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+export default CustomizedTooltips;

--- a/docs/src/pages/demos/tooltips/CustomizedTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/CustomizedTooltips.tsx
@@ -51,59 +51,61 @@ function arrowGenerator(color: string) {
   };
 }
 
-const useStyles = makeStyles((theme: Theme) => createStyles({
-  button: {
-    margin: theme.spacing(1),
-  },
-  lightTooltip: {
-    backgroundColor: theme.palette.common.white,
-    color: 'rgba(0, 0, 0, 0.87)',
-    boxShadow: theme.shadows[1],
-    fontSize: 11,
-  },
-  arrowPopper: arrowGenerator(theme.palette.grey[700]),
-  arrow: {
-    position: 'absolute',
-    fontSize: 6,
-    width: '3em',
-    height: '3em',
-    '&::before': {
-      content: '""',
-      margin: 'auto',
-      display: 'block',
-      width: 0,
-      height: 0,
-      borderStyle: 'solid',
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    button: {
+      margin: theme.spacing(1),
     },
-  },
-  bootstrapPopper: arrowGenerator(theme.palette.common.black),
-  bootstrapTooltip: {
-    backgroundColor: theme.palette.common.black,
-  },
-  bootstrapPlacementLeft: {
-    margin: '0 8px',
-  },
-  bootstrapPlacementRight: {
-    margin: '0 8px',
-  },
-  bootstrapPlacementTop: {
-    margin: '8px 0',
-  },
-  bootstrapPlacementBottom: {
-    margin: '8px 0',
-  },
-  htmlPopper: arrowGenerator('#dadde9'),
-  htmlTooltip: {
-    backgroundColor: '#f5f5f9',
-    color: 'rgba(0, 0, 0, 0.87)',
-    maxWidth: 220,
-    fontSize: theme.typography.pxToRem(12),
-    border: '1px solid #dadde9',
-    '& b': {
-      fontWeight: theme.typography.fontWeightMedium,
+    lightTooltip: {
+      backgroundColor: theme.palette.common.white,
+      color: 'rgba(0, 0, 0, 0.87)',
+      boxShadow: theme.shadows[1],
+      fontSize: 11,
     },
-  },
-}));
+    arrowPopper: arrowGenerator(theme.palette.grey[700]),
+    arrow: {
+      position: 'absolute',
+      fontSize: 6,
+      width: '3em',
+      height: '3em',
+      '&::before': {
+        content: '""',
+        margin: 'auto',
+        display: 'block',
+        width: 0,
+        height: 0,
+        borderStyle: 'solid',
+      },
+    },
+    bootstrapPopper: arrowGenerator(theme.palette.common.black),
+    bootstrapTooltip: {
+      backgroundColor: theme.palette.common.black,
+    },
+    bootstrapPlacementLeft: {
+      margin: '0 8px',
+    },
+    bootstrapPlacementRight: {
+      margin: '0 8px',
+    },
+    bootstrapPlacementTop: {
+      margin: '8px 0',
+    },
+    bootstrapPlacementBottom: {
+      margin: '8px 0',
+    },
+    htmlPopper: arrowGenerator('#dadde9'),
+    htmlTooltip: {
+      backgroundColor: '#f5f5f9',
+      color: 'rgba(0, 0, 0, 0.87)',
+      maxWidth: 220,
+      fontSize: theme.typography.pxToRem(12),
+      border: '1px solid #dadde9',
+      '& b': {
+        fontWeight: theme.typography.fontWeightMedium,
+      },
+    },
+  }),
+);
 
 function CustomizedTooltips() {
   const classes = useStyles();

--- a/docs/src/pages/demos/tooltips/DelayTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/DelayTooltips.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+
+function DelayTooltips() {
+  return (
+    <Tooltip title="Add" enterDelay={500} leaveDelay={200}>
+      <Button>[500ms, 200ms]</Button>
+    </Tooltip>
+  );
+}
+
+export default DelayTooltips;

--- a/docs/src/pages/demos/tooltips/DisabledTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/DisabledTooltips.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+
+function DisabledTooltips() {
+  return (
+    <Tooltip title="You don't have permission to do this">
+      <span>
+        <Button disabled>A Disabled Button</Button>
+      </span>
+    </Tooltip>
+  );
+}
+
+export default DisabledTooltips;

--- a/docs/src/pages/demos/tooltips/InteractiveTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/InteractiveTooltips.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles, createStyles, Theme, WithStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+
+const styles = (theme: Theme) => createStyles({
+  button: {
+    margin: theme.spacing(1),
+  },
+});
+
+function InteractiveTooltips(props: WithStyles<typeof styles>) {
+  const { classes } = props;
+
+  return (
+    <div>
+      <Tooltip title="Add" interactive>
+        <Button className={classes.button}>Interactive</Button>
+      </Tooltip>
+      <Tooltip title="Add">
+        <Button className={classes.button}>Non Interactive</Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+InteractiveTooltips.propTypes = {
+  classes: PropTypes.object.isRequired,
+} as any;
+
+export default withStyles(styles)(InteractiveTooltips);

--- a/docs/src/pages/demos/tooltips/InteractiveTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/InteractiveTooltips.tsx
@@ -4,11 +4,12 @@ import { withStyles, createStyles, Theme, WithStyles } from '@material-ui/core/s
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = (theme: Theme) => createStyles({
-  button: {
-    margin: theme.spacing(1),
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    button: {
+      margin: theme.spacing(1),
+    },
+  });
 
 function InteractiveTooltips(props: WithStyles<typeof styles>) {
   const { classes } = props;

--- a/docs/src/pages/demos/tooltips/PositionedTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/PositionedTooltips.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles, createStyles, WithStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+
+const styles = createStyles({
+  root: {
+    width: 500,
+  },
+});
+
+function PositionedTooltips(props: WithStyles<typeof styles>) {
+  const { classes } = props;
+  return (
+    <div className={classes.root}>
+      <Grid container justify="center">
+        <Grid item>
+          <Tooltip title="Add" placement="top-start">
+            <Button>top-start</Button>
+          </Tooltip>
+          <Tooltip title="Add" placement="top">
+            <Button>top</Button>
+          </Tooltip>
+          <Tooltip title="Add" placement="top-end">
+            <Button>top-end</Button>
+          </Tooltip>
+        </Grid>
+      </Grid>
+      <Grid container justify="center">
+        <Grid item xs={6}>
+          <Tooltip title="Add" placement="left-start">
+            <Button>left-start</Button>
+          </Tooltip>
+          <br />
+          <Tooltip title="Add" placement="left">
+            <Button>left</Button>
+          </Tooltip>
+          <br />
+          <Tooltip title="Add" placement="left-end">
+            <Button>left-end</Button>
+          </Tooltip>
+        </Grid>
+        <Grid item container xs={6} alignItems="flex-end" direction="column">
+          <Grid item>
+            <Tooltip title="Add" placement="right-start">
+              <Button>right-start</Button>
+            </Tooltip>
+          </Grid>
+          <Grid item>
+            <Tooltip title="Add" placement="right">
+              <Button>right</Button>
+            </Tooltip>
+          </Grid>
+          <Grid item>
+            <Tooltip title="Add" placement="right-end">
+              <Button>right-end</Button>
+            </Tooltip>
+          </Grid>
+        </Grid>
+      </Grid>
+      <Grid container justify="center">
+        <Grid item>
+          <Tooltip title="Add" placement="bottom-start">
+            <Button>bottom-start</Button>
+          </Tooltip>
+          <Tooltip title="Add" placement="bottom">
+            <Button>bottom</Button>
+          </Tooltip>
+          <Tooltip title="Add" placement="bottom-end">
+            <Button>bottom-end</Button>
+          </Tooltip>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+PositionedTooltips.propTypes = {
+  classes: PropTypes.object.isRequired,
+} as any;
+
+export default withStyles(styles)(PositionedTooltips);

--- a/docs/src/pages/demos/tooltips/SimpleTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/SimpleTooltips.tsx
@@ -7,16 +7,17 @@ import DeleteIcon from '@material-ui/icons/Delete';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = (theme: Theme) => createStyles({
-  fab: {
-    margin: theme.spacing(2),
-  },
-  absolute: {
-    position: 'absolute',
-    bottom: theme.spacing(2),
-    right: theme.spacing(3),
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    fab: {
+      margin: theme.spacing(2),
+    },
+    absolute: {
+      position: 'absolute',
+      bottom: theme.spacing(2),
+      right: theme.spacing(3),
+    },
+  });
 
 function SimpleTooltips(props: WithStyles<typeof styles>) {
   const { classes } = props;

--- a/docs/src/pages/demos/tooltips/SimpleTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/SimpleTooltips.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles, Theme, WithStyles, createStyles } from '@material-ui/core/styles';
+import AddIcon from '@material-ui/icons/Add';
+import Fab from '@material-ui/core/Fab';
+import DeleteIcon from '@material-ui/icons/Delete';
+import IconButton from '@material-ui/core/IconButton';
+import Tooltip from '@material-ui/core/Tooltip';
+
+const styles = (theme: Theme) => createStyles({
+  fab: {
+    margin: theme.spacing(2),
+  },
+  absolute: {
+    position: 'absolute',
+    bottom: theme.spacing(2),
+    right: theme.spacing(3),
+  },
+});
+
+function SimpleTooltips(props: WithStyles<typeof styles>) {
+  const { classes } = props;
+  return (
+    <div>
+      <Tooltip title="Delete">
+        <IconButton aria-label="Delete">
+          <DeleteIcon />
+        </IconButton>
+      </Tooltip>
+      <Tooltip title="Add" aria-label="Add">
+        <Fab color="primary" className={classes.fab}>
+          <AddIcon />
+        </Fab>
+      </Tooltip>
+      <Tooltip title="Add" aria-label="Add">
+        <Fab color="secondary" className={classes.absolute}>
+          <AddIcon />
+        </Fab>
+      </Tooltip>
+    </div>
+  );
+}
+
+SimpleTooltips.propTypes = {
+  classes: PropTypes.object.isRequired,
+} as any;
+
+export default withStyles(styles)(SimpleTooltips);

--- a/docs/src/pages/demos/tooltips/TransitionsTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/TransitionsTooltips.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+import Fade from '@material-ui/core/Fade';
+import Zoom from '@material-ui/core/Zoom';
+
+function TransitionsTooltips() {
+  return (
+    <div>
+      <Tooltip title="Add">
+        <Button>Grow</Button>
+      </Tooltip>
+      <Tooltip TransitionComponent={Fade} TransitionProps={{ timeout: 600 }} title="Add">
+        <Button>Fade</Button>
+      </Tooltip>
+      <Tooltip TransitionComponent={Zoom} title="Add">
+        <Button>Zoom</Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+export default TransitionsTooltips;

--- a/docs/src/pages/demos/tooltips/TriggersTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/TriggersTooltips.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+
+function TriggersTooltips() {
+  const [open, setOpen] = React.useState(false);
+
+  function handleTooltipClose() {
+    setOpen(false);
+  }
+
+  function handleTooltipOpen() {
+    setOpen(true);
+  }
+
+  return (
+    <div>
+      <Grid container justify="center">
+        <Grid item>
+          <Tooltip disableFocusListener title="Add">
+            <Button>Hover or touch</Button>
+          </Tooltip>
+        </Grid>
+        <Grid item>
+          <Tooltip disableHoverListener title="Add">
+            <Button>Focus or touch</Button>
+          </Tooltip>
+        </Grid>
+        <Grid item>
+          <Tooltip disableFocusListener disableTouchListener title="Add">
+            <Button>Hover</Button>
+          </Tooltip>
+        </Grid>
+        <Grid item>
+          <ClickAwayListener onClickAway={handleTooltipClose}>
+            <div>
+              <Tooltip
+                PopperProps={{
+                  disablePortal: true,
+                }}
+                onClose={handleTooltipClose}
+                open={open}
+                disableFocusListener
+                disableHoverListener
+                disableTouchListener
+                title="Add"
+              >
+                <Button onClick={handleTooltipOpen}>Click</Button>
+              </Tooltip>
+            </div>
+          </ClickAwayListener>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+export default TriggersTooltips;

--- a/docs/src/pages/demos/tooltips/VariableWidth.tsx
+++ b/docs/src/pages/demos/tooltips/VariableWidth.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles, Theme, createStyles, WithStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+
+const styles = (theme: Theme) => createStyles({
+  button: {
+    margin: theme.spacing(1),
+  },
+  customWidth: {
+    maxWidth: 500,
+  },
+  noMaxWidth: {
+    maxWidth: 'none',
+  },
+});
+
+const longText = `
+Aliquam eget finibus ante, non facilisis lectus. Sed vitae dignissim est, vel aliquam tellus.
+Praesent non nunc mollis, fermentum neque at, semper arcu.
+Nullam eget est sed sem iaculis gravida eget vitae justo.
+`;
+
+function VariableWidth({ classes }: WithStyles<typeof styles>) {
+  return (
+    <div>
+      <Tooltip title={longText}>
+        <Button className={classes.button}>Default Width [300px]</Button>
+      </Tooltip>
+      <Tooltip title={longText} classes={{ tooltip: classes.customWidth }}>
+        <Button className={classes.button}>Custom Width [500px]</Button>
+      </Tooltip>
+      <Tooltip title={longText} classes={{ tooltip: classes.noMaxWidth }}>
+        <Button className={classes.button}>No wrapping</Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+VariableWidth.propTypes = {
+  classes: PropTypes.object.isRequired,
+} as any;
+
+export default withStyles(styles)(VariableWidth);

--- a/docs/src/pages/demos/tooltips/VariableWidth.tsx
+++ b/docs/src/pages/demos/tooltips/VariableWidth.tsx
@@ -4,17 +4,18 @@ import { withStyles, Theme, createStyles, WithStyles } from '@material-ui/core/s
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = (theme: Theme) => createStyles({
-  button: {
-    margin: theme.spacing(1),
-  },
-  customWidth: {
-    maxWidth: 500,
-  },
-  noMaxWidth: {
-    maxWidth: 'none',
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    button: {
+      margin: theme.spacing(1),
+    },
+    customWidth: {
+      maxWidth: 500,
+    },
+    noMaxWidth: {
+      maxWidth: 'none',
+    },
+  });
 
 const longText = `
 Aliquam eget finibus ante, non facilisis lectus. Sed vitae dignissim est, vel aliquam tellus.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Here are the TypeScript demos for the tooltip components. A few of them did not need additional typing, so I did just create the corresponding `tsx` file for them.

However, I had a question while doing so: In CustomizedTooltip `useState` is used to create a ref. Is there a reason why the `useRef` hook is not used there?

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
