### PR TITLE
[Button] Fix typing for type-attribute

### DIFF
--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -11,7 +11,7 @@ declare const Button: ExtendButtonBase<{
     fullWidth?: boolean;
     href?: string;
     size?: 'small' | 'medium' | 'large';
-    type?: string;
+    type?: 'submit' | 'reset' | 'button';
     variant?: 'text' | 'outlined' | 'contained';
   };
   defaultComponent: 'button';

--- a/packages/material-ui/src/Fab/Fab.d.ts
+++ b/packages/material-ui/src/Fab/Fab.d.ts
@@ -10,7 +10,7 @@ declare const Fab: ExtendButtonBase<{
     disableRipple?: boolean;
     href?: string;
     size?: 'small' | 'medium' | 'large';
-    type?: string;
+    type?: 'submit' | 'reset' | 'button';
     variant?: 'round' | 'extended';
   };
   defaultComponent: 'button';


### PR DESCRIPTION
Narrow typing for the `type` attribute in Button and Fab to be compatible with latest typings for react.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #15075
Closes #15076