### PR TITLE
Update CardMedia.d.ts

### DIFF
--- a/packages/material-ui/src/CardMedia/CardMedia.d.ts
+++ b/packages/material-ui/src/CardMedia/CardMedia.d.ts
@@ -6,7 +6,8 @@ export interface CardMediaProps
   alt?: string;
   component?: React.ElementType<CardMediaProps>;
   image?: string;
-  src?: string;
+  src?: string;    
+  height?: string;
 }
 
 export type CardMediaClassKey = 'root' | 'media';

--- a/packages/material-ui/src/CardMedia/CardMedia.d.ts
+++ b/packages/material-ui/src/CardMedia/CardMedia.d.ts
@@ -3,6 +3,7 @@ import { StandardProps } from '..';
 
 export interface CardMediaProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, CardMediaClassKey> {
+  alt?: string;
   component?: React.ElementType<CardMediaProps>;
   image?: string;
   src?: string;


### PR DESCRIPTION
Adds the alt and height key to the card media type definition.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
