### PR TITLE
[Box]  Add better typescript support for Box component.

### DIFF
--- a/packages/material-ui/src/Box/Box.d.ts
+++ b/packages/material-ui/src/Box/Box.d.ts
@@ -1,9 +1,69 @@
 import * as React from 'react';
 
-export interface BoxProps extends React.HTMLAttributes<HTMLElement> {
+export interface BoxProps
+  extends React.HTMLAttributes<HTMLElement>,
+    Pick<
+      React.CSSProperties,
+      | 'alignContent'
+      | 'alignItems'
+      | 'alignSelf'
+      | 'border'
+      | 'borderBottom'
+      | 'borderColor'
+      | 'borderLeft'
+      | 'borderRadius'
+      | 'borderRight'
+      | 'borderTop'
+      | 'bottom'
+      | 'boxShadow'
+      | 'color'
+      | 'cursor'
+      | 'display'
+      | 'flex'
+      | 'flexDirection'
+      | 'flexGrow'
+      | 'flexShrink'
+      | 'flexWrap'
+      | 'fontFamily'
+      | 'fontSize'
+      | 'fontWeight'
+      | 'height'
+      | 'justifyContent'
+      | 'left'
+      | 'maxHeight'
+      | 'maxWidth'
+      | 'minHeight'
+      | 'minWidth'
+      | 'overflowX'
+      | 'overflowY'
+      | 'position'
+      | 'right'
+      | 'textAlign'
+      | 'top'
+      | 'width'
+      | 'zIndex'
+    > {
   component?: React.ElementType;
   // styled API
   clone?: boolean;
+  // Box specific props
+  bgcolor?: string;
+  displayPrint?: string;
+  m?: string | number;
+  mb?: string | number;
+  ml?: string | number;
+  mr?: string | number;
+  mt?: string | number;
+  mx?: string | number;
+  my?: string | number;
+  order?: string | number;
+  p?: string | number;
+  pb?: string | number;
+  pl?: string | number;
+  pr?: string | number;
+  pt?: string | number;
+  px?: string | number;
+  py?: string | number;
 }
 
 declare const Box: React.ComponentType<BoxProps>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
I've added all typings for Box component in typescript.
This means that now if you use typescript, you have better support for Box component and editor auto-completion works better.
It supports all the props that are mentioned in [docs API](https://material-ui.com/system/api/).
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
