### PR TITLE
[MobileStepper] Support variant "text"

### DIFF
--- a/docs/src/pages/demos/steppers/SwipeableTextMobileStepper.js
+++ b/docs/src/pages/demos/steppers/SwipeableTextMobileStepper.js
@@ -100,6 +100,7 @@ function SwipeableTextMobileStepper() {
       <MobileStepper
         steps={maxSteps}
         position="static"
+        variant="text"
         activeStep={activeStep}
         nextButton={
           <Button size="small" onClick={handleNext} disabled={activeStep === maxSteps - 1}>

--- a/docs/src/pages/demos/steppers/TextMobileStepper.js
+++ b/docs/src/pages/demos/steppers/TextMobileStepper.js
@@ -83,6 +83,7 @@ function TextMobileStepper() {
       <MobileStepper
         steps={maxSteps}
         position="static"
+        variant="text"
         activeStep={activeStep}
         nextButton={
           <Button size="small" onClick={handleNext} disabled={activeStep === maxSteps - 1}>

--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -64,7 +64,7 @@ const MobileStepper = React.forwardRef(function MobileStepper(props, ref) {
     activeStep,
     backButton,
     classes,
-    className: classNameProp,
+    className,
     LinearProgressProps,
     nextButton,
     position,
@@ -73,25 +73,31 @@ const MobileStepper = React.forwardRef(function MobileStepper(props, ref) {
     ...other
   } = props;
 
-  const className = clsx(classes.root, classes[`position${capitalize(position)}`], classNameProp);
-
   return (
-    <Paper square elevation={0} className={className} ref={ref} {...other}>
+    <Paper
+      square
+      elevation={0}
+      className={clsx(classes.root, classes[`position${capitalize(position)}`], className)}
+      ref={ref}
+      {...other}
+    >
       {backButton}
       {variant === 'text' && (
-        <div>
+        <React.Fragment>
           {activeStep + 1} / {steps}
-        </div>
+        </React.Fragment>
       )}
       {variant === 'dots' && (
         <div className={classes.dots}>
-          {[...new Array(steps)].map((_, index) => {
-            const dotClassName = clsx(classes.dot, {
-              [classes.dotActive]: index === activeStep,
-            });
-            // eslint-disable-next-line react/no-array-index-key
-            return <div key={index} className={dotClassName} />;
-          })}
+          {[...new Array(steps)].map((_, index) => (
+            <div
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+              className={clsx(classes.dot, {
+                [classes.dotActive]: index === activeStep,
+              })}
+            />
+          ))}
         </div>
       )}
       {variant === 'progress' && (

--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -78,6 +78,11 @@ const MobileStepper = React.forwardRef(function MobileStepper(props, ref) {
   return (
     <Paper square elevation={0} className={className} ref={ref} {...other}>
       {backButton}
+      {variant === 'text' && (
+        <div>
+          {activeStep + 1} / {steps}
+        </div>
+      )}
       {variant === 'dots' && (
         <div className={classes.dots}>
           {[...new Array(steps)].map((_, index) => {

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -149,9 +149,16 @@ describe('<MobileStepper />', () => {
     assert.strictEqual(nextButton.props().disabled, true);
   });
 
-  it('should render just two buttons when supplied with variant text', () => {
-    const wrapper = shallow(<MobileStepper variant="text" {...defaultProps} />);
-    assert.lengthOf(wrapper.children(), 2);
+  it('should render two buttons and text displaying progress when supplied with variant text', () => {
+    const props = {
+      steps: defaultProps.steps,
+      activeStep: 0,
+      nextButton: defaultProps.nextButton,
+      backButton: defaultProps.backButton,
+    };
+    const wrapper = shallow(<MobileStepper variant="text" {...props} />);
+    assert.lengthOf(wrapper.children(), 3);
+    assert.strictEqual(wrapper.childAt(1).text(), `${props.activeStep + 1} / ${props.steps}`);
   });
 
   it('should render dots when supplied with variant dots', () => {

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { assert } from 'chai';
 import {
   createMount,
-  createShallow,
   describeConformance,
   getClasses,
+  findOutermostIntrinsic,
 } from '@material-ui/core/test-utils';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
 import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
@@ -15,7 +15,6 @@ import MobileStepper from './MobileStepper';
 
 describe('<MobileStepper />', () => {
   let mount;
-  let shallow;
   let classes;
   const defaultProps = {
     steps: 2,
@@ -35,7 +34,6 @@ describe('<MobileStepper />', () => {
 
   before(() => {
     mount = createMount();
-    shallow = createShallow({ dive: true });
     classes = getClasses(<MobileStepper {...defaultProps} />);
   });
 
@@ -57,125 +55,113 @@ describe('<MobileStepper />', () => {
   });
 
   it('should render with the bottom class if position prop is set to bottom', () => {
-    const wrapper = shallow(<MobileStepper position="bottom" {...defaultProps} />);
-    assert.strictEqual(wrapper.hasClass(classes.positionBottom), true);
+    const wrapper = mount(<MobileStepper {...defaultProps} position="bottom" />);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.positionBottom), true);
   });
 
   it('should render with the top class if position prop is set to top', () => {
-    const wrapper = shallow(<MobileStepper position="top" {...defaultProps} />);
-    assert.strictEqual(wrapper.hasClass(classes.positionTop), true);
+    const wrapper = mount(<MobileStepper {...defaultProps} position="top" />);
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.positionTop), true);
   });
 
   it('should render two buttons', () => {
-    const wrapper = shallow(<MobileStepper {...defaultProps} />);
+    const wrapper = mount(<MobileStepper {...defaultProps} />);
     assert.lengthOf(wrapper.find(Button), 2);
   });
 
   it('should render the back button', () => {
-    const wrapper = shallow(<MobileStepper {...defaultProps} />);
-    const backButton = wrapper.childAt(0);
-    assert.strictEqual(backButton.childAt(1).text(), 'Back');
+    const wrapper = mount(<MobileStepper {...defaultProps} />);
+    const backButton = findOutermostIntrinsic(wrapper).childAt(0);
+    assert.strictEqual(backButton.text(), 'Back');
     assert.lengthOf(backButton.find(KeyboardArrowLeft), 1);
   });
 
   it('should render next button', () => {
-    const wrapper = shallow(<MobileStepper {...defaultProps} />);
-    const nextButton = wrapper.childAt(2);
+    const wrapper = mount(<MobileStepper {...defaultProps} />);
+    const nextButton = findOutermostIntrinsic(wrapper).childAt(2);
     assert.strictEqual(nextButton.childAt(0).text(), 'Next');
     assert.lengthOf(nextButton.find(KeyboardArrowRight), 1);
   });
 
   it('should render backButton custom text', () => {
-    const props = {
-      steps: defaultProps.steps,
-      nextButton: defaultProps.nextButton,
-      backButton: (
-        <Button>
-          <KeyboardArrowLeft />
-          Past
-        </Button>
-      ),
-    };
-    const wrapper = shallow(<MobileStepper {...props} />);
+    const wrapper = mount(
+      <MobileStepper
+        {...defaultProps}
+        backButton={
+          <Button>
+            <KeyboardArrowLeft />
+            Past
+          </Button>
+        }
+      />,
+    );
     assert.strictEqual(
-      wrapper
+      findOutermostIntrinsic(wrapper)
         .childAt(0)
-        .childAt(1)
         .text(),
       'Past',
     );
   });
 
   it('should render nextButton custom text', () => {
-    const props = {
-      steps: defaultProps.steps,
-      nextButton: (
-        <Button>
-          Future
-          <KeyboardArrowRight />
-        </Button>
-      ),
-      backButton: defaultProps.backButton,
-    };
-    const wrapper = shallow(<MobileStepper {...props} />);
+    const wrapper = mount(
+      <MobileStepper
+        {...defaultProps}
+        nextButton={
+          <Button>
+            Future
+            <KeyboardArrowRight />
+          </Button>
+        }
+      />,
+    );
     assert.strictEqual(
-      wrapper
+      findOutermostIntrinsic(wrapper)
         .childAt(2)
-        .childAt(0)
         .text(),
       'Future',
     );
   });
 
   it('should render disabled backButton', () => {
-    const props = {
-      steps: defaultProps.steps,
-      nextButton: defaultProps.nextButton,
-      backButton: <Button disabled>back</Button>,
-    };
-    const wrapper = shallow(<MobileStepper {...props} />);
-    const backButton = wrapper.childAt(0);
+    const wrapper = mount(
+      <MobileStepper {...defaultProps} backButton={<Button disabled>back</Button>} />,
+    );
+    const backButton = findOutermostIntrinsic(wrapper).childAt(0);
     assert.strictEqual(backButton.props().disabled, true);
   });
 
   it('should render disabled nextButton', () => {
-    const props = {
-      steps: defaultProps.steps,
-      nextButton: <Button disabled>back</Button>,
-      backButton: defaultProps.backButton,
-    };
-    const wrapper = shallow(<MobileStepper {...props} />);
-    const nextButton = wrapper.childAt(2);
+    const wrapper = mount(
+      <MobileStepper {...defaultProps} nextButton={<Button disabled>back</Button>} />,
+    );
+    const nextButton = findOutermostIntrinsic(wrapper).childAt(2);
     assert.strictEqual(nextButton.props().disabled, true);
   });
 
   it('should render two buttons and text displaying progress when supplied with variant text', () => {
-    const props = {
-      steps: defaultProps.steps,
-      activeStep: 0,
-      nextButton: defaultProps.nextButton,
-      backButton: defaultProps.backButton,
-    };
-    const wrapper = shallow(<MobileStepper variant="text" {...props} />);
-    assert.lengthOf(wrapper.children(), 3);
-    assert.strictEqual(wrapper.childAt(1).text(), `${props.activeStep + 1} / ${props.steps}`);
+    const wrapper = mount(
+      <MobileStepper {...defaultProps} variant="text" activeStep={1} steps={3} />,
+    );
+    assert.strictEqual(wrapper.text(), 'Back2 / 3Next');
   });
 
   it('should render dots when supplied with variant dots', () => {
-    const wrapper = shallow(<MobileStepper variant="dots" {...defaultProps} />);
-    assert.lengthOf(wrapper.children(), 3);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.dots), true);
+    const wrapper = mount(<MobileStepper {...defaultProps} variant="dots" />);
+    const outermost = findOutermostIntrinsic(wrapper);
+    assert.lengthOf(outermost.children(), 3);
+    assert.strictEqual(outermost.childAt(1).hasClass(classes.dots), true);
   });
 
   it('should render a dot for each step when using dots variant', () => {
-    const wrapper = shallow(<MobileStepper variant="dots" {...defaultProps} />);
+    const wrapper = mount(<MobileStepper {...defaultProps} variant="dots" />);
     assert.lengthOf(wrapper.find(`.${classes.dot}`), 2);
   });
 
   it('should render the first dot as active if activeStep is not set', () => {
-    const wrapper = shallow(<MobileStepper variant="dots" {...defaultProps} />);
+    const wrapper = mount(<MobileStepper {...defaultProps} variant="dots" />);
     assert.strictEqual(
-      wrapper
+      findOutermostIntrinsic(wrapper)
         .childAt(1)
         .childAt(0)
         .hasClass(classes.dotActive),
@@ -184,9 +170,9 @@ describe('<MobileStepper />', () => {
   });
 
   it('should honor the activeStep prop', () => {
-    const wrapper = shallow(<MobileStepper variant="dots" activeStep={1} {...defaultProps} />);
+    const wrapper = mount(<MobileStepper {...defaultProps} variant="dots" activeStep={1} />);
     assert.strictEqual(
-      wrapper
+      findOutermostIntrinsic(wrapper)
         .childAt(1)
         .childAt(1)
         .hasClass(classes.dotActive),
@@ -195,21 +181,24 @@ describe('<MobileStepper />', () => {
   });
 
   it('should render a <LinearProgress /> when supplied with variant progress', () => {
-    const wrapper = shallow(<MobileStepper variant="progress" {...defaultProps} />);
+    const wrapper = mount(<MobileStepper {...defaultProps} variant="progress" />);
     assert.lengthOf(wrapper.find(LinearProgress), 1);
   });
 
   it('should calculate the <LinearProgress /> value correctly', () => {
-    const props = { backButton: defaultProps.backButton, nextButton: defaultProps.nextButton };
-    let wrapper = shallow(<MobileStepper variant="progress" steps={3} {...props} />);
+    let wrapper = mount(<MobileStepper {...defaultProps} variant="progress" steps={3} />);
     let linearProgressProps = wrapper.find(LinearProgress).props();
     assert.strictEqual(linearProgressProps.value, 0);
 
-    wrapper = shallow(<MobileStepper variant="progress" steps={3} activeStep={1} {...props} />);
+    wrapper = mount(
+      <MobileStepper {...defaultProps} variant="progress" steps={3} activeStep={1} />,
+    );
     linearProgressProps = wrapper.find(LinearProgress).props();
     assert.strictEqual(linearProgressProps.value, 50);
 
-    wrapper = shallow(<MobileStepper variant="progress" steps={3} activeStep={2} {...props} />);
+    wrapper = mount(
+      <MobileStepper {...defaultProps} variant="progress" steps={3} activeStep={2} />,
+    );
     linearProgressProps = wrapper.find(LinearProgress).props();
     assert.strictEqual(linearProgressProps.value, 100);
   });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

MobileStepper changed to add "1 / 2" when variant "text" is used. 
I also changed the test to reflect this. 

If I made a mistake with this, please let me know so I can see where I can rectify that in future. I tried following the Contributing guide exactly.

- [ X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
