### PR TITLE
[docs] Migrate docs' badge page to hooks

### DIFF
--- a/docs/src/pages/demos/badges/CustomizedBadge.js
+++ b/docs/src/pages/demos/badges/CustomizedBadge.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   badge: {
     top: '50%',
     right: -3,
@@ -14,10 +14,10 @@ const styles = theme => ({
       theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
     }`,
   },
-});
+}));
 
-function CustomizedBadge(props) {
-  const { classes } = props;
+function CustomizedBadge() {
+  const classes = useStyles();
 
   return (
     <IconButton aria-label="Cart">
@@ -28,8 +28,4 @@ function CustomizedBadge(props) {
   );
 }
 
-CustomizedBadge.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(CustomizedBadge);
+export default CustomizedBadge;

--- a/docs/src/pages/demos/badges/CustomizedBadge.js
+++ b/docs/src/pages/demos/badges/CustomizedBadge.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
 import { makeStyles } from '@material-ui/core/styles';

--- a/docs/src/pages/demos/badges/CustomizedBadge.tsx
+++ b/docs/src/pages/demos/badges/CustomizedBadge.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
@@ -15,7 +14,7 @@ const useStyles = makeStyles((theme: Theme) =>
         theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
       }`,
     },
-  })
+  }),
 );
 
 function CustomizedBadge() {

--- a/docs/src/pages/demos/badges/CustomizedBadge.tsx
+++ b/docs/src/pages/demos/badges/CustomizedBadge.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
-import { withStyles, Theme, createStyles, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     badge: {
       top: '50%',
@@ -15,10 +15,11 @@ const styles = (theme: Theme) =>
         theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
       }`,
     },
-  });
+  })
+);
 
-function CustomizedBadge(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function CustomizedBadge() {
+  const classes = useStyles();
 
   return (
     <IconButton aria-label="Cart">
@@ -29,8 +30,4 @@ function CustomizedBadge(props: WithStyles<typeof styles>) {
   );
 }
 
-CustomizedBadge.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(CustomizedBadge);
+export default CustomizedBadge;

--- a/docs/src/pages/demos/badges/DotBadge.js
+++ b/docs/src/pages/demos/badges/DotBadge.js
@@ -1,18 +1,17 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
 import MailIcon from '@material-ui/icons/Mail';
 import Typography from '@material-ui/core/Typography';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   margin: {
     margin: theme.spacing(2),
   },
-});
+}));
 
-function DotBadge(props) {
-  const { classes } = props;
+function DotBadge() {
+  const classes = useStyles();
 
   return (
     <div>
@@ -31,8 +30,4 @@ function DotBadge(props) {
   );
 }
 
-DotBadge.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(DotBadge);
+export default DotBadge;

--- a/docs/src/pages/demos/badges/DotBadge.tsx
+++ b/docs/src/pages/demos/badges/DotBadge.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, Theme, createStyles, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
 import MailIcon from '@material-ui/icons/Mail';
 import Typography from '@material-ui/core/Typography';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     margin: {
       margin: theme.spacing(2),
     },
-  });
+  }),
+);
 
-function DotBadge(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function DotBadge() {
+  const classes = useStyles();
 
   return (
     <div>
@@ -32,8 +32,4 @@ function DotBadge(props: WithStyles<typeof styles>) {
   );
 }
 
-DotBadge.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(DotBadge);
+export default DotBadge;

--- a/docs/src/pages/demos/badges/SimpleBadge.js
+++ b/docs/src/pages/demos/badges/SimpleBadge.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
 import IconButton from '@material-ui/core/IconButton';
 import MailIcon from '@material-ui/icons/Mail';
@@ -10,17 +9,18 @@ import Tab from '@material-ui/core/Tab';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   margin: {
     margin: theme.spacing(2),
   },
   padding: {
     padding: theme.spacing(0, 2),
   },
-});
+}));
 
-function SimpleBadge(props) {
-  const { classes } = props;
+function SimpleBadge() {
+  const classes = useStyles();
+
   return (
     <div>
       <div>
@@ -59,8 +59,4 @@ function SimpleBadge(props) {
   );
 }
 
-SimpleBadge.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(SimpleBadge);
+export default SimpleBadge;

--- a/docs/src/pages/demos/badges/SimpleBadge.tsx
+++ b/docs/src/pages/demos/badges/SimpleBadge.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, Theme, createStyles, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
 import IconButton from '@material-ui/core/IconButton';
 import MailIcon from '@material-ui/icons/Mail';
@@ -10,7 +9,7 @@ import Tab from '@material-ui/core/Tab';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     margin: {
       margin: theme.spacing(2),
@@ -18,10 +17,12 @@ const styles = (theme: Theme) =>
     padding: {
       padding: theme.spacing(0, 2),
     },
-  });
+  }),
+);
 
-function SimpleBadge(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function SimpleBadge() {
+  const classes = useStyles();
+
   return (
     <div>
       <div>
@@ -60,8 +61,4 @@ function SimpleBadge(props: WithStyles<typeof styles>) {
   );
 }
 
-SimpleBadge.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(SimpleBadge);
+export default SimpleBadge;


### PR DESCRIPTION
**Description**
This PR migrates the doc's badge page to hooks. Relates to #15032.
 
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
