### PR TITLE
[docs] Migrate docs' buttons page to hooks

### DIFF
--- a/docs/src/pages/demos/buttons/ContainedButtons.js
+++ b/docs/src/pages/demos/buttons/ContainedButtons.js
@@ -1,19 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(1),
   },
   input: {
     display: 'none',
   },
-});
+}));
 
-function ContainedButtons(props) {
-  const { classes } = props;
+function ContainedButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Button variant="contained" className={classes.button}>
@@ -47,8 +47,4 @@ function ContainedButtons(props) {
   );
 }
 
-ContainedButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(ContainedButtons);
+export default ContainedButtons;

--- a/docs/src/pages/demos/buttons/ContainedButtons.tsx
+++ b/docs/src/pages/demos/buttons/ContainedButtons.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     button: {
       margin: theme.spacing(1),
@@ -11,10 +10,12 @@ const styles = (theme: Theme) =>
     input: {
       display: 'none',
     },
-  });
+  }),
+);
 
-function ContainedButtons(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function ContainedButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Button variant="contained" className={classes.button}>
@@ -48,8 +49,4 @@ function ContainedButtons(props: WithStyles<typeof styles>) {
   );
 }
 
-ContainedButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(ContainedButtons);
+export default ContainedButtons;

--- a/docs/src/pages/demos/buttons/CustomizedButtons.js
+++ b/docs/src/pages/demos/buttons/CustomizedButtons.js
@@ -1,13 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+
 import clsx from 'clsx';
-import { createMuiTheme, withStyles } from '@material-ui/core/styles';
+import { createMuiTheme, makeStyles } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   margin: {
     margin: theme.spacing(1),
   },
@@ -52,7 +52,7 @@ const styles = theme => ({
       boxShadow: '0 0 0 0.2rem rgba(0,123,255,.5)',
     },
   },
-});
+}));
 
 const theme = createMuiTheme({
   palette: {
@@ -60,8 +60,8 @@ const theme = createMuiTheme({
   },
 });
 
-function CustomizedButtons(props) {
-  const { classes } = props;
+function CustomizedButtons() {
+  const classes = useStyles();
 
   return (
     <div>
@@ -85,8 +85,4 @@ function CustomizedButtons(props) {
   );
 }
 
-CustomizedButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(CustomizedButtons);
+export default CustomizedButtons;

--- a/docs/src/pages/demos/buttons/CustomizedButtons.js
+++ b/docs/src/pages/demos/buttons/CustomizedButtons.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import clsx from 'clsx';
 import { createMuiTheme, makeStyles } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';

--- a/docs/src/pages/demos/buttons/CustomizedButtons.tsx
+++ b/docs/src/pages/demos/buttons/CustomizedButtons.tsx
@@ -1,19 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import {
-  createMuiTheme,
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-} from '@material-ui/core/styles';
+import { createMuiTheme, createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     margin: {
       margin: theme.spacing(1),
@@ -59,7 +53,8 @@ const styles = (theme: Theme) =>
         boxShadow: '0 0 0 0.2rem rgba(0,123,255,.5)',
       },
     },
-  });
+  }),
+);
 
 const theme = createMuiTheme({
   palette: {
@@ -67,8 +62,8 @@ const theme = createMuiTheme({
   },
 });
 
-function CustomizedButtons(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function CustomizedButtons() {
+  const classes = useStyles();
 
   return (
     <div>
@@ -92,8 +87,4 @@ function CustomizedButtons(props: WithStyles<typeof styles>) {
   );
 }
 
-CustomizedButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(CustomizedButtons);
+export default CustomizedButtons;

--- a/docs/src/pages/demos/buttons/CustomizedButtons.tsx
+++ b/docs/src/pages/demos/buttons/CustomizedButtons.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { createMuiTheme, createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';

--- a/docs/src/pages/demos/buttons/FloatingActionButtons.js
+++ b/docs/src/pages/demos/buttons/FloatingActionButtons.js
@@ -1,23 +1,23 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 import Icon from '@material-ui/core/Icon';
 import DeleteIcon from '@material-ui/icons/Delete';
 import NavigationIcon from '@material-ui/icons/Navigation';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   fab: {
     margin: theme.spacing(1),
   },
   extendedIcon: {
     marginRight: theme.spacing(1),
   },
-});
+}));
 
-function FloatingActionButtons(props) {
-  const { classes } = props;
+function FloatingActionButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Fab color="primary" aria-label="Add" className={classes.fab}>
@@ -37,8 +37,4 @@ function FloatingActionButtons(props) {
   );
 }
 
-FloatingActionButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(FloatingActionButtons);
+export default FloatingActionButtons;

--- a/docs/src/pages/demos/buttons/FloatingActionButtons.tsx
+++ b/docs/src/pages/demos/buttons/FloatingActionButtons.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 import Icon from '@material-ui/core/Icon';
 import DeleteIcon from '@material-ui/icons/Delete';
 import NavigationIcon from '@material-ui/icons/Navigation';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     fab: {
       margin: theme.spacing(1),
@@ -15,10 +14,12 @@ const styles = (theme: Theme) =>
     extendedIcon: {
       marginRight: theme.spacing(1),
     },
-  });
+  }),
+);
 
-function FloatingActionButtons(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function FloatingActionButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Fab color="primary" aria-label="Add" className={classes.fab}>
@@ -38,8 +39,4 @@ function FloatingActionButtons(props: WithStyles<typeof styles>) {
   );
 }
 
-FloatingActionButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(FloatingActionButtons);
+export default FloatingActionButtons;

--- a/docs/src/pages/demos/buttons/IconButtons.js
+++ b/docs/src/pages/demos/buttons/IconButtons.js
@@ -1,23 +1,23 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Icon from '@material-ui/core/Icon';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 import PhotoCamera from '@material-ui/icons/PhotoCamera';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(1),
   },
   input: {
     display: 'none',
   },
-});
+}));
 
-function IconButtons(props) {
-  const { classes } = props;
+function IconButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <IconButton className={classes.button} aria-label="Delete">
@@ -42,8 +42,4 @@ function IconButtons(props) {
   );
 }
 
-IconButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(IconButtons);
+export default IconButtons;

--- a/docs/src/pages/demos/buttons/IconButtons.tsx
+++ b/docs/src/pages/demos/buttons/IconButtons.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Icon from '@material-ui/core/Icon';
 import IconButton from '@material-ui/core/IconButton';
 import DeleteIcon from '@material-ui/icons/Delete';
 import AddShoppingCartIcon from '@material-ui/icons/AddShoppingCart';
 import PhotoCamera from '@material-ui/icons/PhotoCamera';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     button: {
       margin: theme.spacing(1),
@@ -15,10 +14,12 @@ const styles = (theme: Theme) =>
     input: {
       display: 'none',
     },
-  });
+  }),
+);
 
-function IconButtons(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function IconButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <IconButton className={classes.button} aria-label="Delete">
@@ -43,8 +44,4 @@ function IconButtons(props: WithStyles<typeof styles>) {
   );
 }
 
-IconButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(IconButtons);
+export default IconButtons;

--- a/docs/src/pages/demos/buttons/IconLabelButtons.js
+++ b/docs/src/pages/demos/buttons/IconLabelButtons.js
@@ -1,15 +1,14 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Button from '@material-ui/core/Button';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import KeyboardVoiceIcon from '@material-ui/icons/KeyboardVoice';
 import Icon from '@material-ui/core/Icon';
 import SaveIcon from '@material-ui/icons/Save';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(1),
   },
@@ -22,10 +21,11 @@ const styles = theme => ({
   iconSmall: {
     fontSize: 20,
   },
-});
+}));
 
-function IconLabelButtons(props) {
-  const { classes } = props;
+function IconLabelButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Button variant="contained" color="secondary" className={classes.button}>
@@ -53,8 +53,4 @@ function IconLabelButtons(props) {
   );
 }
 
-IconLabelButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(IconLabelButtons);
+export default IconLabelButtons;

--- a/docs/src/pages/demos/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/demos/buttons/IconLabelButtons.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Button from '@material-ui/core/Button';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
 import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import KeyboardVoiceIcon from '@material-ui/icons/KeyboardVoice';
 import Icon from '@material-ui/core/Icon';
 import SaveIcon from '@material-ui/icons/Save';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     button: {
       margin: theme.spacing(1),
@@ -23,10 +22,12 @@ const styles = (theme: Theme) =>
     iconSmall: {
       fontSize: 20,
     },
-  });
+  }),
+);
 
-function IconLabelButtons(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function IconLabelButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Button variant="contained" color="secondary" className={classes.button}>
@@ -54,8 +55,4 @@ function IconLabelButtons(props: WithStyles<typeof styles>) {
   );
 }
 
-IconLabelButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(IconLabelButtons);
+export default IconLabelButtons;

--- a/docs/src/pages/demos/buttons/OutlinedButtons.js
+++ b/docs/src/pages/demos/buttons/OutlinedButtons.js
@@ -1,19 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(1),
   },
   input: {
     display: 'none',
   },
-});
+}));
 
-function OutlinedButtons(props) {
-  const { classes } = props;
+function OutlinedButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Button variant="outlined" className={classes.button}>
@@ -50,8 +50,4 @@ function OutlinedButtons(props) {
   );
 }
 
-OutlinedButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(OutlinedButtons);
+export default OutlinedButtons;

--- a/docs/src/pages/demos/buttons/OutlinedButtons.tsx
+++ b/docs/src/pages/demos/buttons/OutlinedButtons.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     button: {
       margin: theme.spacing(1),
@@ -11,10 +10,12 @@ const styles = (theme: Theme) =>
     input: {
       display: 'none',
     },
-  });
+  }),
+);
 
-function OutlinedButtons(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function OutlinedButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Button variant="outlined" className={classes.button}>
@@ -51,8 +52,4 @@ function OutlinedButtons(props: WithStyles<typeof styles>) {
   );
 }
 
-OutlinedButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(OutlinedButtons);
+export default OutlinedButtons;

--- a/docs/src/pages/demos/buttons/TextButtons.js
+++ b/docs/src/pages/demos/buttons/TextButtons.js
@@ -1,19 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(1),
   },
   input: {
     display: 'none',
   },
-});
+}));
 
-function TextButtons(props) {
-  const { classes } = props;
+function TextButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Button className={classes.button}>Default</Button>
@@ -45,8 +45,4 @@ function TextButtons(props) {
   );
 }
 
-TextButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(TextButtons);
+export default TextButtons;

--- a/docs/src/pages/demos/buttons/TextButtons.tsx
+++ b/docs/src/pages/demos/buttons/TextButtons.tsx
@@ -1,19 +1,21 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import React, { useState } from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 
-const styles = (theme: Theme) => ({
-  button: {
-    margin: theme.spacing(1),
-  },
-  input: {
-    display: 'none',
-  },
-});
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    button: {
+      margin: theme.spacing(1),
+    },
+    input: {
+      display: 'none',
+    },
+  }),
+);
 
-function TextButtons(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function TextButtons() {
+  const classes = useStyles();
+
   return (
     <div>
       <Button className={classes.button}>Default</Button>
@@ -45,8 +47,4 @@ function TextButtons(props: WithStyles<typeof styles>) {
   );
 }
 
-TextButtons.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(TextButtons);
+export default TextButtons;


### PR DESCRIPTION
**Description**
This PR migrates the doc's buttons page to hooks. Relates to #15032.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
