### PR TITLE
Add unelevated button support

### DIFF
--- a/docs/src/pages/demos/buttons/ButtonSizes.js
+++ b/docs/src/pages/demos/buttons/ButtonSizes.js
@@ -55,6 +55,17 @@ function ButtonSizes() {
         </Button>
       </div>
       <div>
+        <Button variant="unelevated" size="small" color="primary" className={classes.margin}>
+          Small
+        </Button>
+        <Button variant="unelevated" size="medium" color="primary" className={classes.margin}>
+          Medium
+        </Button>
+        <Button variant="unelevated" size="large" color="primary" className={classes.margin}>
+          Large
+        </Button>
+      </div>
+      <div>
         <Fab size="small" color="secondary" aria-label="Add" className={classes.margin}>
           <AddIcon />
         </Fab>

--- a/docs/src/pages/demos/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/demos/buttons/ButtonSizes.tsx
@@ -57,6 +57,17 @@ function ButtonSizes() {
         </Button>
       </div>
       <div>
+        <Button variant="unelevated" size="small" color="primary" className={classes.margin}>
+          Small
+        </Button>
+        <Button variant="unelevated" size="medium" color="primary" className={classes.margin}>
+          Medium
+        </Button>
+        <Button variant="unelevated" size="large" color="primary" className={classes.margin}>
+          Large
+        </Button>
+      </div>
+      <div>
         <Fab size="small" color="secondary" aria-label="Add" className={classes.margin}>
           <AddIcon />
         </Fab>

--- a/docs/src/pages/demos/buttons/UnelevatedButtons.js
+++ b/docs/src/pages/demos/buttons/UnelevatedButtons.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+
+const styles = theme => ({
+  button: {
+    margin: theme.spacing(1),
+  },
+  input: {
+    display: 'none',
+  },
+});
+
+function UnelevatedButtons(props) {
+  const { classes } = props;
+  return (
+    <div>
+      <Button variant="unelevated" className={classes.button}>
+        Default
+      </Button>
+      <Button variant="unelevated" color="primary" className={classes.button}>
+        Primary
+      </Button>
+      <Button variant="unelevated" color="secondary" className={classes.button}>
+        Secondary
+      </Button>
+      <Button variant="unelevated" color="secondary" disabled className={classes.button}>
+        Disabled
+      </Button>
+      <Button variant="unelevated" href="#unelevated-buttons" className={classes.button}>
+        Link
+      </Button>
+      <input
+        accept="image/*"
+        className={classes.input}
+        id="unelevated-button-file"
+        multiple
+        type="file"
+      />
+      <label htmlFor="unelevated-button-file">
+        <Button variant="unelevated" component="span" className={classes.button}>
+          Upload
+        </Button>
+      </label>
+    </div>
+  );
+}
+
+UnelevatedButtons.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+export default withStyles(styles)(UnelevatedButtons);

--- a/docs/src/pages/demos/buttons/UnelevatedButtons.tsx
+++ b/docs/src/pages/demos/buttons/UnelevatedButtons.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    button: {
+      margin: theme.spacing(1),
+    },
+    input: {
+      display: 'none',
+    },
+  });
+
+function UnelevatedButtons(props: WithStyles<typeof styles>) {
+  const { classes } = props;
+  return (
+    <div>
+      <Button variant="unelevated" className={classes.button}>
+        Default
+      </Button>
+      <Button variant="unelevated" color="primary" className={classes.button}>
+        Primary
+      </Button>
+      <Button variant="unelevated" color="secondary" className={classes.button}>
+        Secondary
+      </Button>
+      <Button variant="unelevated" color="secondary" disabled className={classes.button}>
+        Disabled
+      </Button>
+      <Button variant="unelevated" href="#unelevated-buttons" className={classes.button}>
+        Link
+      </Button>
+      <input
+        accept="image/*"
+        className={classes.input}
+        id="unelevated-button-file"
+        multiple
+        type="file"
+      />
+      <label htmlFor="unelevated-button-file">
+        <Button variant="unelevated" component="span" className={classes.button}>
+          Upload
+        </Button>
+      </label>
+    </div>
+  );
+}
+
+UnelevatedButtons.propTypes = {
+  classes: PropTypes.object.isRequired,
+} as any;
+
+export default withStyles(styles)(UnelevatedButtons);

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -25,6 +25,14 @@ The last example of this demo show how to use an upload button.
 
 {{"demo": "pages/demos/buttons/ContainedButtons.js"}}
 
+## Unelevated Buttons
+
+[Unelevated buttons](https://material.io/design/components/buttons.html#unelevated-button)
+are medium-emphasis, distinguished by their use fill but no elevation.
+They contain actions that are important to your app.
+
+{{"demo": "pages/demos/buttons/UnelevatedButtons.js"}}
+
 ## Text Buttons
 
 [Text buttons](https://material.io/design/components/buttons.html#text-button)

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -12,7 +12,7 @@ declare const Button: ExtendButtonBase<{
     href?: string;
     size?: 'small' | 'medium' | 'large';
     type?: 'submit' | 'reset' | 'button';
-    variant?: 'text' | 'outlined' | 'contained';
+    variant?: 'text' | 'outlined' | 'contained' | 'unelevated';
   };
   defaultComponent: 'button';
   classKey: ButtonClassKey;
@@ -32,6 +32,9 @@ export type ButtonClassKey =
   | 'contained'
   | 'containedPrimary'
   | 'containedSecondary'
+  | 'unelevated'
+  | 'unelevatedPrimary'
+  | 'unelevatedSecondary'
   | 'focusVisible'
   | 'disabled'
   | 'colorInherit'

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -159,6 +159,49 @@ export const styles = theme => ({
       },
     },
   },
+  /* Styles applied to the root element if `variant="unelevated"`. */
+  unelevated: {
+    color: theme.palette.getContrastText(theme.palette.grey[300]),
+    backgroundColor: theme.palette.grey[300],
+    '&$disabled': {
+      color: theme.palette.action.disabled,
+      backgroundColor: theme.palette.action.disabledBackground,
+    },
+    '&:hover': {
+      backgroundColor: theme.palette.grey.A100,
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: theme.palette.grey[300],
+      },
+      '&$disabled': {
+        backgroundColor: theme.palette.action.disabledBackground,
+      },
+    },
+  },
+  /* Styles applied to the root element if `variant="unelevated"` and `color="primary"`. */
+  unelevatedPrimary: {
+    color: theme.palette.primary.contrastText,
+    backgroundColor: theme.palette.primary.main,
+    '&:hover': {
+      backgroundColor: theme.palette.primary.dark,
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: theme.palette.primary.main,
+      },
+    },
+  },
+  /* Styles applied to the root element if `variant="unelevated"` and `color="secondary"`. */
+  unelevatedSecondary: {
+    color: theme.palette.secondary.contrastText,
+    backgroundColor: theme.palette.secondary.main,
+    '&:hover': {
+      backgroundColor: theme.palette.secondary.dark,
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: theme.palette.secondary.main,
+      },
+    },
+  },
   /* Styles applied to the ButtonBase root element if the button is keyboard focused. */
   focusVisible: {},
   /* Styles applied to the root element if `disabled={true}`. */
@@ -200,6 +243,7 @@ const Button = React.forwardRef(function Button(props, ref) {
     ...other
   } = props;
 
+  const unelevated = variant === 'unelevated';
   const contained = variant === 'contained';
   const text = variant === 'text';
   const className = clsx(
@@ -211,6 +255,9 @@ const Button = React.forwardRef(function Button(props, ref) {
       [classes.contained]: contained,
       [classes.containedPrimary]: contained && color === 'primary',
       [classes.containedSecondary]: contained && color === 'secondary',
+      [classes.unelevated]: unelevated,
+      [classes.unelevatedPrimary]: unelevated && color === 'primary',
+      [classes.unelevatedSecondary]: unelevated && color === 'secondary',
       [classes.outlined]: variant === 'outlined',
       [classes.outlinedPrimary]: variant === 'outlined' && color === 'primary',
       [classes.outlinedSecondary]: variant === 'outlined' && color === 'secondary',
@@ -297,7 +344,7 @@ Button.propTypes = {
   /**
    * The variant to use.
    */
-  variant: PropTypes.oneOf(['text', 'outlined', 'contained']),
+  variant: PropTypes.oneOf(['text', 'outlined', 'contained', 'unelevated']),
 };
 
 Button.defaultProps = {

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -12,23 +12,21 @@ filename: /packages/material-ui/src/Button/Button.js
 import Button from '@material-ui/core/Button';
 ```
 
-
-
 ## Props
 
-| Name | Type | Default | Description |
-|:-----|:-----|:--------|:------------|
-| <span class="prop-name required">children *</span> | <span class="prop-type">node</span> |   | The content of the button. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
-| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
-| <span class="prop-name">disableFocusRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
-| <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |   | If `true`, the ripple effect will be disabled. |
-| <span class="prop-name">fullWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will take up the full width of its container. |
-| <span class="prop-name">href</span> | <span class="prop-type">string</span> |   | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
-| <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'contained'<br></span> | <span class="prop-default">'text'</span> | The variant to use. |
+| Name                                                | Type                                                                                                                                                    | Default                                     | Description                                                                                              |
+| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------ | :------------------------------------------------------------------------------------------------------- |
+| <span class="prop-name required">children \*</span> | <span class="prop-type">node</span>                                                                                                                     |                                             | The content of the button.                                                                               |
+| <span class="prop-name">classes</span>              | <span class="prop-type">object</span>                                                                                                                   |                                             | Override or extend the styles applied to the component. See [CSS API](#css) below for more details.      |
+| <span class="prop-name">color</span>                | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span>  | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component.           |
+| <span class="prop-name">component</span>            | <span class="prop-type">elementType</span>                                                                                                              | <span class="prop-default">'button'</span>  | The component used for the root node. Either a string to use a DOM element or a component.               |
+| <span class="prop-name">disabled</span>             | <span class="prop-type">bool</span>                                                                                                                     | <span class="prop-default">false</span>     | If `true`, the button will be disabled.                                                                  |
+| <span class="prop-name">disableFocusRipple</span>   | <span class="prop-type">bool</span>                                                                                                                     | <span class="prop-default">false</span>     | If `true`, the keyboard focus ripple will be disabled. `disableRipple` must also be true.                |
+| <span class="prop-name">disableRipple</span>        | <span class="prop-type">bool</span>                                                                                                                     |                                             | If `true`, the ripple effect will be disabled.                                                           |
+| <span class="prop-name">fullWidth</span>            | <span class="prop-type">bool</span>                                                                                                                     | <span class="prop-default">false</span>     | If `true`, the button will take up the full width of its container.                                      |
+| <span class="prop-name">href</span>                 | <span class="prop-type">string</span>                                                                                                                   |                                             | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
+| <span class="prop-name">size</span>                 | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span>                                        | <span class="prop-default">'medium'</span>  | The size of the button. `small` is equivalent to the dense button styling.                               |
+| <span class="prop-name">variant</span>              | <span class="prop-type">enum:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'contained'&nbsp;&#124;<br>&nbsp;'unelevated'<br></span> | <span class="prop-default">'text'</span>    | The variant to use.                                                                                      |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
@@ -37,26 +35,28 @@ Any other properties supplied will be spread to the root element ([ButtonBase](/
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">label</span> | Styles applied to the span element that wraps the children.
-| <span class="prop-name">text</span> | Styles applied to the root element if `variant="text"`.
-| <span class="prop-name">textPrimary</span> | Styles applied to the root element if `variant="text"` and `color="primary"`.
-| <span class="prop-name">textSecondary</span> | Styles applied to the root element if `variant="text"` and `color="secondary"`.
-| <span class="prop-name">outlined</span> | Styles applied to the root element if `variant="outlined"`.
-| <span class="prop-name">outlinedPrimary</span> | Styles applied to the root element if `variant="outlined"` and `color="primary"`.
-| <span class="prop-name">outlinedSecondary</span> | Styles applied to the root element if `variant="outlined"` and `color="secondary"`.
-| <span class="prop-name">contained</span> | Styles applied to the root element if `variant="contained"`.
-| <span class="prop-name">containedPrimary</span> | Styles applied to the root element if `variant="contained"` and `color="primary"`.
-| <span class="prop-name">containedSecondary</span> | Styles applied to the root element if `variant="contained"` and `color="secondary"`.
-| <span class="prop-name">focusVisible</span> | Styles applied to the ButtonBase root element if the button is keyboard focused.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.
-| <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
+| Name                                               | Description                                                                           |
+| :------------------------------------------------- | :------------------------------------------------------------------------------------ |
+| <span class="prop-name">root</span>                | Styles applied to the root element.                                                   |
+| <span class="prop-name">label</span>               | Styles applied to the span element that wraps the children.                           |
+| <span class="prop-name">text</span>                | Styles applied to the root element if `variant="text"`.                               |
+| <span class="prop-name">textPrimary</span>         | Styles applied to the root element if `variant="text"` and `color="primary"`.         |
+| <span class="prop-name">textSecondary</span>       | Styles applied to the root element if `variant="text"` and `color="secondary"`.       |
+| <span class="prop-name">outlined</span>            | Styles applied to the root element if `variant="outlined"`.                           |
+| <span class="prop-name">outlinedPrimary</span>     | Styles applied to the root element if `variant="outlined"` and `color="primary"`.     |
+| <span class="prop-name">outlinedSecondary</span>   | Styles applied to the root element if `variant="outlined"` and `color="secondary"`.   |
+| <span class="prop-name">contained</span>           | Styles applied to the root element if `variant="contained"`.                          |
+| <span class="prop-name">containedPrimary</span>    | Styles applied to the root element if `variant="contained"` and `color="primary"`.    |
+| <span class="prop-name">containedSecondary</span>  | Styles applied to the root element if `variant="contained"` and `color="secondary"`.  |
+| <span class="prop-name">unelevated</span>          | Styles applied to the root element if `variant="unelevated"`.                         |
+| <span class="prop-name">unelevatedPrimary</span>   | Styles applied to the root element if `variant="unelevated"` and `color="primary"`.   |
+| <span class="prop-name">unelevatedSecondary</span> | Styles applied to the root element if `variant="unelevated"` and `color="secondary"`. |
+| <span class="prop-name">focusVisible</span>        | Styles applied to the ButtonBase root element if the button is keyboard focused.      |
+| <span class="prop-name">disabled</span>            | Styles applied to the root element if `disabled={true}`.                              |
+| <span class="prop-name">colorInherit</span>        | Styles applied to the root element if `color="inherit"`.                              |
+| <span class="prop-name">sizeSmall</span>           | Styles applied to the root element if `size="small"`.                                 |
+| <span class="prop-name">sizeLarge</span>           | Styles applied to the root element if `size="large"`.                                 |
+| <span class="prop-name">fullWidth</span>           | Styles applied to the root element if `fullWidth={true}`.                             |
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/Button/Button.js)
@@ -73,4 +73,3 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 ## Demos
 
 - [Buttons](/demos/buttons/)
-

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -12,21 +12,23 @@ filename: /packages/material-ui/src/Button/Button.js
 import Button from '@material-ui/core/Button';
 ```
 
+
+
 ## Props
 
-| Name                                                | Type                                                                                                                                                    | Default                                     | Description                                                                                              |
-| :-------------------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------ | :------------------------------------------------------------------------------------------------------- |
-| <span class="prop-name required">children \*</span> | <span class="prop-type">node</span>                                                                                                                     |                                             | The content of the button.                                                                               |
-| <span class="prop-name">classes</span>              | <span class="prop-type">object</span>                                                                                                                   |                                             | Override or extend the styles applied to the component. See [CSS API](#css) below for more details.      |
-| <span class="prop-name">color</span>                | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span>  | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component.           |
-| <span class="prop-name">component</span>            | <span class="prop-type">elementType</span>                                                                                                              | <span class="prop-default">'button'</span>  | The component used for the root node. Either a string to use a DOM element or a component.               |
-| <span class="prop-name">disabled</span>             | <span class="prop-type">bool</span>                                                                                                                     | <span class="prop-default">false</span>     | If `true`, the button will be disabled.                                                                  |
-| <span class="prop-name">disableFocusRipple</span>   | <span class="prop-type">bool</span>                                                                                                                     | <span class="prop-default">false</span>     | If `true`, the keyboard focus ripple will be disabled. `disableRipple` must also be true.                |
-| <span class="prop-name">disableRipple</span>        | <span class="prop-type">bool</span>                                                                                                                     |                                             | If `true`, the ripple effect will be disabled.                                                           |
-| <span class="prop-name">fullWidth</span>            | <span class="prop-type">bool</span>                                                                                                                     | <span class="prop-default">false</span>     | If `true`, the button will take up the full width of its container.                                      |
-| <span class="prop-name">href</span>                 | <span class="prop-type">string</span>                                                                                                                   |                                             | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
-| <span class="prop-name">size</span>                 | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span>                                        | <span class="prop-default">'medium'</span>  | The size of the button. `small` is equivalent to the dense button styling.                               |
-| <span class="prop-name">variant</span>              | <span class="prop-type">enum:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'contained'&nbsp;&#124;<br>&nbsp;'unelevated'<br></span> | <span class="prop-default">'text'</span>    | The variant to use.                                                                                      |
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name required">children *</span> | <span class="prop-type">node</span> |   | The content of the button. |
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'<br></span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
+| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'button'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
+| <span class="prop-name">disableFocusRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
+| <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |   | If `true`, the ripple effect will be disabled. |
+| <span class="prop-name">fullWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will take up the full width of its container. |
+| <span class="prop-name">href</span> | <span class="prop-type">string</span> |   | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
+| <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'contained'&nbsp;&#124;<br>&nbsp;'unelevated'<br></span> | <span class="prop-default">'text'</span> | The variant to use. |
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
@@ -35,28 +37,29 @@ Any other properties supplied will be spread to the root element ([ButtonBase](/
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-| Name                                               | Description                                                                           |
-| :------------------------------------------------- | :------------------------------------------------------------------------------------ |
-| <span class="prop-name">root</span>                | Styles applied to the root element.                                                   |
-| <span class="prop-name">label</span>               | Styles applied to the span element that wraps the children.                           |
-| <span class="prop-name">text</span>                | Styles applied to the root element if `variant="text"`.                               |
-| <span class="prop-name">textPrimary</span>         | Styles applied to the root element if `variant="text"` and `color="primary"`.         |
-| <span class="prop-name">textSecondary</span>       | Styles applied to the root element if `variant="text"` and `color="secondary"`.       |
-| <span class="prop-name">outlined</span>            | Styles applied to the root element if `variant="outlined"`.                           |
-| <span class="prop-name">outlinedPrimary</span>     | Styles applied to the root element if `variant="outlined"` and `color="primary"`.     |
-| <span class="prop-name">outlinedSecondary</span>   | Styles applied to the root element if `variant="outlined"` and `color="secondary"`.   |
-| <span class="prop-name">contained</span>           | Styles applied to the root element if `variant="contained"`.                          |
-| <span class="prop-name">containedPrimary</span>    | Styles applied to the root element if `variant="contained"` and `color="primary"`.    |
-| <span class="prop-name">containedSecondary</span>  | Styles applied to the root element if `variant="contained"` and `color="secondary"`.  |
-| <span class="prop-name">unelevated</span>          | Styles applied to the root element if `variant="unelevated"`.                         |
-| <span class="prop-name">unelevatedPrimary</span>   | Styles applied to the root element if `variant="unelevated"` and `color="primary"`.   |
-| <span class="prop-name">unelevatedSecondary</span> | Styles applied to the root element if `variant="unelevated"` and `color="secondary"`. |
-| <span class="prop-name">focusVisible</span>        | Styles applied to the ButtonBase root element if the button is keyboard focused.      |
-| <span class="prop-name">disabled</span>            | Styles applied to the root element if `disabled={true}`.                              |
-| <span class="prop-name">colorInherit</span>        | Styles applied to the root element if `color="inherit"`.                              |
-| <span class="prop-name">sizeSmall</span>           | Styles applied to the root element if `size="small"`.                                 |
-| <span class="prop-name">sizeLarge</span>           | Styles applied to the root element if `size="large"`.                                 |
-| <span class="prop-name">fullWidth</span>           | Styles applied to the root element if `fullWidth={true}`.                             |
+
+| Name | Description |
+|:-----|:------------|
+| <span class="prop-name">root</span> | Styles applied to the root element.
+| <span class="prop-name">label</span> | Styles applied to the span element that wraps the children.
+| <span class="prop-name">text</span> | Styles applied to the root element if `variant="text"`.
+| <span class="prop-name">textPrimary</span> | Styles applied to the root element if `variant="text"` and `color="primary"`.
+| <span class="prop-name">textSecondary</span> | Styles applied to the root element if `variant="text"` and `color="secondary"`.
+| <span class="prop-name">outlined</span> | Styles applied to the root element if `variant="outlined"`.
+| <span class="prop-name">outlinedPrimary</span> | Styles applied to the root element if `variant="outlined"` and `color="primary"`.
+| <span class="prop-name">outlinedSecondary</span> | Styles applied to the root element if `variant="outlined"` and `color="secondary"`.
+| <span class="prop-name">contained</span> | Styles applied to the root element if `variant="contained"`.
+| <span class="prop-name">containedPrimary</span> | Styles applied to the root element if `variant="contained"` and `color="primary"`.
+| <span class="prop-name">containedSecondary</span> | Styles applied to the root element if `variant="contained"` and `color="secondary"`.
+| <span class="prop-name">unelevated</span> | Styles applied to the root element if `variant="unelevated"`.
+| <span class="prop-name">unelevatedPrimary</span> | Styles applied to the root element if `variant="unelevated"` and `color="primary"`.
+| <span class="prop-name">unelevatedSecondary</span> | Styles applied to the root element if `variant="unelevated"` and `color="secondary"`.
+| <span class="prop-name">focusVisible</span> | Styles applied to the ButtonBase root element if the button is keyboard focused.
+| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
+| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.
+| <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/Button/Button.js)
@@ -73,3 +76,4 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 ## Demos
 
 - [Buttons](/demos/buttons/)
+


### PR DESCRIPTION
See https://material-components.github.io/material-components-web-catalog/#/component/button?type=unelevated

No design spec in material.io but in demo components of material-components-web you can see the unelevated option.