### PR TITLE
[Tabs] Update so that tabs keep equal widths

### DIFF
--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -77,6 +77,7 @@ export const styles = theme => ({
   fullWidth: {
     flexShrink: 1,
     flexGrow: 1,
+    flexBasis: 0,
     maxWidth: 'none',
   },
   /* Styles applied to the root element if `wrapped={true}`. */


### PR DESCRIPTION
Without this, the content in the tab label will too easily cause the tabs to have uneven width.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
