### PR TITLE
[theme] Prepare the deprecation of theme.mixins.gutters

### DIFF
--- a/docs/src/pages/demos/paper/PaperSheet.js
+++ b/docs/src/pages/demos/paper/PaperSheet.js
@@ -6,9 +6,7 @@ import Typography from '@material-ui/core/Typography';
 
 const styles = theme => ({
   root: {
-    ...theme.mixins.gutters(),
-    paddingTop: theme.spacing(2),
-    paddingBottom: theme.spacing(2),
+    padding: theme.spacing(3, 2),
   },
 });
 

--- a/docs/src/pages/demos/paper/PaperSheet.tsx
+++ b/docs/src/pages/demos/paper/PaperSheet.tsx
@@ -7,9 +7,7 @@ import Typography from '@material-ui/core/Typography';
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      ...theme.mixins.gutters(),
-      paddingTop: theme.spacing(2),
-      paddingBottom: theme.spacing(2),
+      padding: theme.spacing(3, 2),
     },
   });
 

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -134,11 +134,11 @@ const DecoratedComponent = withStyles(styles)(
 // Allow nested pseudo selectors
 withStyles(theme =>
   createStyles({
-    guttered: theme.mixins.gutters({
+    guttered: {
       '&:hover': {
         textDecoration: 'none',
       },
-    }),
+    },
     listItem: {
       '&:hover $listItemIcon': {
         visibility: 'inherit',

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.js
@@ -30,8 +30,8 @@ export const styles = theme => ({
   /* Styles applied to the title and subtitle container element. */
   titleWrap: {
     flexGrow: 1,
-    marginLeft: theme.mixins.gutters().paddingLeft,
-    marginRight: theme.mixins.gutters().paddingRight,
+    marginLeft: 16,
+    marginRight: 16,
     color: theme.palette.common.white,
     overflow: 'hidden',
   },

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -11,7 +11,14 @@ export const styles = theme => ({
     alignItems: 'center',
   },
   /* Styles applied to the root element if `disableGutters={false}`. */
-  gutters: theme.mixins.gutters(),
+  gutters: {
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    [theme.breakpoints.up('sm')]: {
+      paddingLeft: theme.spacing(3),
+      paddingRight: theme.spacing(3),
+    },
+  },
   /* Styles applied to the root element if `variant="regular"`. */
   regular: theme.mixins.toolbar,
   /* Styles applied to the root element if `variant="dense"`. */

--- a/packages/material-ui/src/styles/createMixins.js
+++ b/packages/material-ui/src/styles/createMixins.js
@@ -1,15 +1,36 @@
+// import warning from 'warning';
+
 export default function createMixins(breakpoints, spacing, mixins) {
   return {
-    gutters: (styles = {}) => ({
-      paddingLeft: spacing(2),
-      paddingRight: spacing(2),
-      ...styles,
-      [breakpoints.up('sm')]: {
-        paddingLeft: spacing(3),
-        paddingRight: spacing(3),
-        ...styles[breakpoints.up('sm')],
-      },
-    }),
+    gutters: (styles = {}) => {
+      // To deprecate in v4.1
+      //       warning(
+      //         false,
+      //         [
+      //           'Material-UI: theme.mixins.gutters() is deprecated.',
+      //           'You can use the source of the mixin directly:',
+      //           `
+      // paddingLeft: theme.spacing(2),
+      // paddingRight: theme.spacing(2),
+      // [theme.breakpoints.up('sm')]: {
+      //   paddingLeft: theme.spacing(3),
+      //   paddingRight: theme.spacing(3),
+      // },
+      // `,
+      //         ].join('\n'),
+      //       );
+
+      return {
+        paddingLeft: spacing(2),
+        paddingRight: spacing(2),
+        ...styles,
+        [breakpoints.up('sm')]: {
+          paddingLeft: spacing(3),
+          paddingRight: spacing(3),
+          ...styles[breakpoints.up('sm')],
+        },
+      };
+    },
     toolbar: {
       minHeight: 56,
       [`${breakpoints.up('xs')} and (orientation: landscape)`]: {

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -241,11 +241,11 @@ const DecoratedComponent = withStyles(styles)(
 // Allow nested pseudo selectors
 withStyles(theme =>
   createStyles({
-    guttered: theme.mixins.gutters({
+    guttered: {
       '&:hover': {
         textDecoration: 'none',
       },
-    }),
+    },
     listItem: {
       '&:hover $listItemIcon': {
         visibility: 'inherit',


### PR DESCRIPTION
Closes #11539. I'm not aware of any valid use case for `theme.mixins.gutters`. Most of the time, people would be better off with custom CSS or the Box API: https://material-ui.com/system/spacing/.
We have the following plan of action:
- [x] v4: remove usage from the documentation
- [ ] v4.1: introduce a deprecation.
- [ ] v5: remove the mixin. It will reduce the bundle size a bit. The default theme is a common dependency of all the components, it's important to minimize its size.