### PR TITLE
[docs] Add ref forwarding to API docs

### DIFF
--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -273,9 +273,13 @@ function generateProps(reactAPI) {
     return textProps;
   }, text);
 
-  text = `${text}\nThe \`ref\` is ${
-    reactAPI.forwardsRefTo == null ? '**not** ' : ''
-  }forwarded to the root element.\n`;
+  let refHint = 'The `ref` is forwarded to the root element.';
+  if (reactAPI.forwardsRefTo == null) {
+    refHint = 'The component cannot hold a ref.';
+  } else if (reactAPI.forwardsRefTo === 'React.Component') {
+    refHint = 'The `ref` is attached to a component class.';
+  }
+  text = `${text}\n${refHint}\n`;
 
   if (reactAPI.spread) {
     text = `${text}

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -273,6 +273,10 @@ function generateProps(reactAPI) {
     return textProps;
   }, text);
 
+  text = `${text}\nThe \`ref\` is ${
+    reactAPI.forwardsRefTo == null ? '**not** ' : ''
+  }forwarded to the root element.\n`;
+
   if (reactAPI.spread) {
     text = `${text}
 Any other properties supplied will be spread to the root element (${

--- a/docs/src/modules/utils/parseTest.js
+++ b/docs/src/modules/utils/parseTest.js
@@ -1,0 +1,92 @@
+import * as babel from '@babel/core';
+import { readFile } from 'fs-extra';
+import * as path from 'path';
+
+const workspaceRoot = path.join(__dirname, '../../../../');
+const babelConfigPath = path.join(workspaceRoot, 'babel.config.js');
+
+function withExtension(filepath, extension) {
+  return path.join(
+    path.dirname(filepath),
+    path.basename(filepath, path.extname(filepath)) + extension,
+  );
+}
+
+/**
+ * @param {string} filename
+ * @param {string} configFilePath
+ */
+async function parseWithConfig(filename, configFilePath) {
+  const source = await readFile(filename, { encoding: 'utf8' });
+  const partialConfig = babel.loadPartialConfig({
+    configFile: configFilePath,
+    filename,
+  });
+  return babel.parseAsync(source, partialConfig.options);
+}
+
+function findConformanceDescriptor(program) {
+  const { types: t } = babel;
+
+  let descriptor = {};
+  babel.traverse(program, {
+    CallExpression(babelPath) {
+      const { node: callExpression } = babelPath;
+      const { callee } = callExpression;
+      if (t.isIdentifier(callee) && callee.name === 'describeConformance') {
+        // describeConformance(element, () => options);
+        descriptor = callExpression.arguments[1].body;
+      }
+    },
+  });
+
+  if (descriptor.type != null && !t.isObjectExpression(descriptor)) {
+    throw new Error(`Expected an object expression as a descriptor but found ${descriptor.type}`);
+  }
+
+  return descriptor;
+}
+
+// extracts the property of window.*
+function getRefInstance(valueNode) {
+  if (!babel.types.isMemberExpression(valueNode)) {
+    throw new Error('Expected window.*Element in refInstanceOf');
+  }
+
+  return valueNode.property.name;
+}
+
+/**
+ * @typedef {Object} ParseResult
+ * @property {string?} forwardsRefTo
+ */
+
+/**
+ *
+ * @param {string} componentFilename
+ * @returns {ParseResult}
+ */
+export default async function parseTest(componentFilename) {
+  const testFilename = withExtension(componentFilename, '.test.js');
+  const babelParseResult = await parseWithConfig(testFilename, babelConfigPath);
+  const descriptor = findConformanceDescriptor(babelParseResult.program);
+
+  const result = {
+    forwardsRefTo: undefined,
+  };
+
+  const { properties = [] } = descriptor;
+  properties.forEach(property => {
+    const key = property.key.name;
+
+    switch (key) {
+      case 'refInstanceof':
+        result.forwardsRefTo = getRefInstance(property.value);
+        break;
+      default:
+        break;
+    }
+  });
+
+  return result;
+}

--- a/docs/src/modules/utils/parseTest.js
+++ b/docs/src/modules/utils/parseTest.js
@@ -47,13 +47,23 @@ function findConformanceDescriptor(program) {
   return descriptor;
 }
 
-// extracts the property of window.*
+/**
+ *
+ * @param {import('@babel/core').Node} valueNode
+ */
 function getRefInstance(valueNode) {
   if (!babel.types.isMemberExpression(valueNode)) {
-    throw new Error('Expected window.*Element in refInstanceOf');
+    throw new Error('Expected a member expression in refInstanceof');
   }
 
-  return valueNode.property.name;
+  switch (valueNode.object.name) {
+    case 'window':
+      return valueNode.property.name;
+    case 'React':
+      return `React.${valueNode.property.name}`;
+    default:
+      throw new Error(`Unrecognized member expression starting with '${valueNode.object.name}'`);
+  }
 }
 
 /**

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -4,7 +4,7 @@ import { assert } from 'chai';
 import {
   createShallow,
   createMount,
-  findOutermostIntrinsic,
+  describeConformance,
   getClasses,
   unwrap,
 } from '@material-ui/core/test-utils';
@@ -29,17 +29,13 @@ describe('<TouchRipple />', () => {
     mount.cleanUp();
   });
 
-  it('should render a span', () => {
-    const wrapper = mount(<TouchRipple />);
-    const root = findOutermostIntrinsic(wrapper);
-    assert.strictEqual(root.type(), 'span');
-    assert.strictEqual(root.hasClass(classes.root), true);
-  });
-
-  it('should render the custom className', () => {
-    const wrapper = mount(<TouchRipple className="test-class-name" />);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass('test-class-name'), true);
-  });
+  describeConformance(<TouchRipple />, () => ({
+    classes,
+    inheritComponent: 'span',
+    mount,
+    refInstanceof: React.Component,
+    testComponentPropWith: false,
+  }));
 
   describe('prop: center', () => {
     it('should should compute the right ripple dimensions', () => {

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -23,6 +23,8 @@ import AppBar from '@material-ui/core/AppBar';
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br></span> | <span class="prop-default">'primary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">position</span> | <span class="prop-type">enum:&nbsp;'fixed', 'absolute', 'sticky', 'static', 'relative'<br></span> | <span class="prop-default">'fixed'</span> | The positioning type. The behavior of the different options is described [in the MDN web docs](https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Positioning). Note: `sticky` is not universally supported and will fall back to `static` when unavailable. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -27,6 +27,8 @@ import Avatar from '@material-ui/core/Avatar';
 | <span class="prop-name">src</span> | <span class="prop-type">string</span> |  | The `src` attribute for the `img` element. |
 | <span class="prop-name">srcSet</span> | <span class="prop-type">string</span> |  | The `srcSet` attribute for the `img` element. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/backdrop.md
+++ b/pages/api/backdrop.md
@@ -23,7 +23,7 @@ import Backdrop from '@material-ui/core/Backdrop';
 | <span class="prop-name required">open&nbsp;*</span> | <span class="prop-type">bool</span> |  | If `true`, the backdrop is open. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> |  | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/backdrop.md
+++ b/pages/api/backdrop.md
@@ -23,6 +23,8 @@ import Backdrop from '@material-ui/core/Backdrop';
 | <span class="prop-name required">open&nbsp;*</span> | <span class="prop-type">bool</span> |  | If `true`, the backdrop is open. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> |  | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -28,6 +28,8 @@ import Badge from '@material-ui/core/Badge';
 | <span class="prop-name">showZero</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Controls whether the badge is hidden when `badgeContent` is zero. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'dot'<br></span> | <span class="prop-default">'standard'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -25,6 +25,8 @@ import BottomNavigationAction from '@material-ui/core/BottomNavigationAction';
 | <span class="prop-name">showLabel</span> | <span class="prop-type">bool</span> |  | If `true`, the `BottomNavigationAction` will show its label. By default, only the selected `BottomNavigationAction` inside `BottomNavigation` will show its label. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | You can provide your own value. Otherwise, we fallback to the child position index. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -25,6 +25,8 @@ import BottomNavigation from '@material-ui/core/BottomNavigation';
 | <span class="prop-name">showLabels</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, all `BottomNavigationAction`s will show their labels. By default, only the selected `BottomNavigationAction` will show its label. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the currently selected `BottomNavigationAction`. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/breadcrumbs.md
+++ b/pages/api/breadcrumbs.md
@@ -26,6 +26,8 @@ import Breadcrumbs from '@material-ui/core/Breadcrumbs';
 | <span class="prop-name">maxItems</span> | <span class="prop-type">number</span> | <span class="prop-default">8</span> | Specifies the maximum number of breadcrumbs to display. When there are more than the maximum number, only the first and last will be shown, with an ellipsis in between. |
 | <span class="prop-name">separator</span> | <span class="prop-type">node</span> | <span class="prop-default">'/'</span> | Custom separator node. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## Demos

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -35,6 +35,8 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">TouchRippleProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `TouchRipple` element. |
 | <span class="prop-name">type</span> | <span class="prop-type">enum:&nbsp;'submit'&nbsp;&#124;<br>&nbsp;'reset'&nbsp;&#124;<br>&nbsp;'button'<br></span> | <span class="prop-default">'button'</span> | Used to control the button's purpose. This property passes the value to the `type` attribute of the native button component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -30,6 +30,8 @@ import Button from '@material-ui/core/Button';
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'contained'<br></span> | <span class="prop-default">'text'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/card-action-area.md
+++ b/pages/api/card-action-area.md
@@ -21,6 +21,8 @@ import CardActionArea from '@material-ui/core/CardActionArea';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -22,6 +22,8 @@ import CardActions from '@material-ui/core/CardActions';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disableActionSpacing</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the card actions do not have additional margin. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/card-content.md
+++ b/pages/api/card-content.md
@@ -21,6 +21,8 @@ import CardContent from '@material-ui/core/CardContent';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/card-header.md
+++ b/pages/api/card-header.md
@@ -28,6 +28,8 @@ import CardHeader from '@material-ui/core/CardHeader';
 | <span class="prop-name">title</span> | <span class="prop-type">node</span> |  | The content of the Card Title. |
 | <span class="prop-name">titleTypographyProps</span> | <span class="prop-type">object</span> |  | These props will be forwarded to the title (as long as disableTypography is not `true`). |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -23,6 +23,8 @@ import CardMedia from '@material-ui/core/CardMedia';
 | <span class="prop-name">image</span> | <span class="prop-type">string</span> |  | Image to be displayed as a background image. Either `image` or `src` prop must be specified. Note that caller must specify height otherwise the image will not be visible. |
 | <span class="prop-name">src</span> | <span class="prop-type">string</span> |  | An alias for `image` property. Available only with media components. Media components: `video`, `audio`, `picture`, `iframe`, `img`. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/card.md
+++ b/pages/api/card.md
@@ -21,6 +21,8 @@ import Card from '@material-ui/core/Card';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">raised</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the card will use raised styling. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -34,6 +34,8 @@ import Checkbox from '@material-ui/core/Checkbox';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">string</span> |  | The value of the component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([IconButton](/api/icon-button/)).
 
 ## CSS

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -30,6 +30,8 @@ Chips represent complex entities in small blocks, such as a contact.
 | <span class="prop-name">onDelete</span> | <span class="prop-type">func</span> |  | Callback function fired when the delete icon is clicked. If set, the delete icon will be shown. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'outlined'<br></span> | <span class="prop-default">'default'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -30,6 +30,8 @@ attribute to `true` on that region until it has finished loading.
 | <span class="prop-name">value</span> | <span class="prop-type">number</span> | <span class="prop-default">0</span> | The value of the progress indicator for the determinate and static variants. Value between 0 and 100. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'determinate'&nbsp;&#124;<br>&nbsp;'indeterminate'&nbsp;&#124;<br>&nbsp;'static'<br></span> | <span class="prop-default">'indeterminate'</span> | The variant to use. Use indeterminate when there is no progress value. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -24,7 +24,7 @@ For instance, if you need to hide a menu when people click anywhere else on your
 | <span class="prop-name required">onClickAway&nbsp;*</span> | <span class="prop-type">func</span> |  | Callback fired when a "click away" event is detected. |
 | <span class="prop-name">touchEvent</span> | <span class="prop-type">enum:&nbsp;'onTouchStart'&nbsp;&#124;<br>&nbsp;'onTouchEnd'&nbsp;&#124;<br>&nbsp;false<br></span> | <span class="prop-default">'onTouchEnd'</span> | The touch event to listen to. You can disable the listener by providing `false`. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element ([EventListener](https://github.com/oliviertassinari/react-event-listener/)).
 

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -24,6 +24,8 @@ For instance, if you need to hide a menu when people click anywhere else on your
 | <span class="prop-name required">onClickAway&nbsp;*</span> | <span class="prop-type">func</span> |  | Callback fired when a "click away" event is detected. |
 | <span class="prop-name">touchEvent</span> | <span class="prop-type">enum:&nbsp;'onTouchStart'&nbsp;&#124;<br>&nbsp;'onTouchEnd'&nbsp;&#124;<br>&nbsp;false<br></span> | <span class="prop-default">'onTouchEnd'</span> | The touch event to listen to. You can disable the listener by providing `false`. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([EventListener](https://github.com/oliviertassinari/react-event-listener/)).
 
 ## Inheritance

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -27,7 +27,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">duration.standard</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -27,7 +27,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">duration.standard</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
-The component cannot hold a ref.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -27,6 +27,8 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">duration.standard</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## CSS

--- a/pages/api/container.md
+++ b/pages/api/container.md
@@ -24,6 +24,8 @@ import Container from '@material-ui/core/Container';
 | <span class="prop-name">fixed</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Set the max-width to match the min-width of the current breakpoint. This is useful if you'd prefer to design for a fixed set of sizes instead of trying to accommodate a fully fluid viewport. It's fluid by default. |
 | <span class="prop-name">maxWidth</span> | <span class="prop-type">enum:&nbsp;'xs', 'sm', 'md', 'lg', 'xl', false<br></span> | <span class="prop-default">'lg'</span> | Determine the max-width of the container. The container width grows with the size of the screen. Set to `false` to disable `maxWidth`. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/container.md
+++ b/pages/api/container.md
@@ -24,7 +24,7 @@ import Container from '@material-ui/core/Container';
 | <span class="prop-name">fixed</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Set the max-width to match the min-width of the current breakpoint. This is useful if you'd prefer to design for a fixed set of sizes instead of trying to accommodate a fully fluid viewport. It's fluid by default. |
 | <span class="prop-name">maxWidth</span> | <span class="prop-type">enum:&nbsp;'xs', 'sm', 'md', 'lg', 'xl', false<br></span> | <span class="prop-default">'lg'</span> | Determine the max-width of the container. The container width grows with the size of the screen. Set to `false` to disable `maxWidth`. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -20,7 +20,7 @@ Kickstart an elegant, consistent, and simple baseline to build upon.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> | <span class="prop-default">null</span> | You can wrap a node. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 
 ## Demos

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -20,6 +20,8 @@ Kickstart an elegant, consistent, and simple baseline to build upon.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> | <span class="prop-default">null</span> | You can wrap a node. |
 
+The `ref` is **not** forwarded to the root element.
+
 
 ## Demos
 

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -22,6 +22,8 @@ import DialogActions from '@material-ui/core/DialogActions';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disableActionSpacing</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the dialog actions do not have additional margin. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -21,6 +21,8 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Typography](/api/typography/)).
 
 ## CSS

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -21,7 +21,7 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element ([Typography](/api/typography/)).
 

--- a/pages/api/dialog-content.md
+++ b/pages/api/dialog-content.md
@@ -22,6 +22,8 @@ import DialogContent from '@material-ui/core/DialogContent';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">dividers</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Display the top and bottom dividers. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/dialog-title.md
+++ b/pages/api/dialog-title.md
@@ -22,6 +22,8 @@ import DialogTitle from '@material-ui/core/DialogTitle';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disableTypography</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the children won't be wrapped by a typography component. For instance, this can be useful to render an h4 instead of the default h2. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -42,6 +42,8 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Modal](/api/modal/)).
 
 ## CSS

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -24,6 +24,8 @@ import Divider from '@material-ui/core/Divider';
 | <span class="prop-name">light</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the divider will have a lighter color. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'fullWidth'&nbsp;&#124;<br>&nbsp;'inset'&nbsp;&#124;<br>&nbsp;'middle'<br></span> | <span class="prop-default">'fullWidth'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -31,6 +31,8 @@ when `variant="temporary"` is set.
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'permanent'&nbsp;&#124;<br>&nbsp;'persistent'&nbsp;&#124;<br>&nbsp;'temporary'<br></span> | <span class="prop-default">'temporary'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/expansion-panel-actions.md
+++ b/pages/api/expansion-panel-actions.md
@@ -21,6 +21,8 @@ import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/expansion-panel-details.md
+++ b/pages/api/expansion-panel-details.md
@@ -21,6 +21,8 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">node</span> |  | The content of the expansion panel details. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -23,6 +23,8 @@ import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node</span> |  | The icon to display as the expand indicator. |
 | <span class="prop-name">IconButtonProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `IconButton` element wrapping the expand icon. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/expansion-panel.md
+++ b/pages/api/expansion-panel.md
@@ -27,6 +27,8 @@ import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 | <span class="prop-name">TransitionComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">Collapse</span> | The component used for the collapse effect. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS

--- a/pages/api/fab.md
+++ b/pages/api/fab.md
@@ -29,6 +29,8 @@ import Fab from '@material-ui/core/Fab';
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span> | <span class="prop-default">'large'</span> | The size of the button. `small` is equivalent to the dense button styling. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'round'&nbsp;&#124;<br>&nbsp;'extended'<br></span> | <span class="prop-default">'round'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -23,6 +23,8 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## Inheritance

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -23,7 +23,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 

--- a/pages/api/filled-input.md
+++ b/pages/api/filled-input.md
@@ -45,6 +45,8 @@ import FilledInput from '@material-ui/core/FilledInput';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value, required for a controlled component. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 
 ## CSS

--- a/pages/api/filled-input.md
+++ b/pages/api/filled-input.md
@@ -45,7 +45,7 @@ import FilledInput from '@material-ui/core/FilledInput';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value, required for a controlled component. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -30,6 +30,8 @@ Use this component if you want to display an extra label.
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">value</span> | <span class="prop-type">string</span> |  | The value of the component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -37,6 +37,8 @@ This context is used by the following components:
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the label will indicate that the input is required. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> | <span class="prop-default">'standard'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/form-group.md
+++ b/pages/api/form-group.md
@@ -24,6 +24,8 @@ For the `Radio`, you should be using the `RadioGroup` component instead of this 
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">row</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Display group of elements in a compact row. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -29,6 +29,8 @@ import FormHelperText from '@material-ui/core/FormHelperText';
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> |  | If `true`, the helper text should use required classes key. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -27,6 +27,8 @@ import FormLabel from '@material-ui/core/FormLabel';
 | <span class="prop-name">focused</span> | <span class="prop-type">bool</span> |  | If `true`, the input of this label is focused (used by `FormGroup` components). |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> |  | If `true`, the label will indicate that the input is required. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -25,6 +25,8 @@ import GridListTileBar from '@material-ui/core/GridListTileBar';
 | <span class="prop-name">title</span> | <span class="prop-type">node</span> |  | Title to be displayed on tile. |
 | <span class="prop-name">titlePosition</span> | <span class="prop-type">enum:&nbsp;'top'&nbsp;&#124;<br>&nbsp;'bottom'<br></span> | <span class="prop-default">'bottom'</span> | Position of the title bar. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -24,6 +24,8 @@ import GridListTile from '@material-ui/core/GridListTile';
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'li'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">rows</span> | <span class="prop-type">number</span> | <span class="prop-default">1</span> | Height of the tile in number of grid cells. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/grid-list.md
+++ b/pages/api/grid-list.md
@@ -25,6 +25,8 @@ import GridList from '@material-ui/core/GridList';
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'ul'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">spacing</span> | <span class="prop-type">number</span> | <span class="prop-default">4</span> | Number of px for the spacing between tiles. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -36,6 +36,8 @@ import Grid from '@material-ui/core/Grid';
 | <span class="prop-name">xs</span> | <span class="prop-type">enum:&nbsp;false, 'auto', true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br></span> | <span class="prop-default">false</span> | Defines the number of grids the component is going to use. It's applied for all the screen sizes with the lowest priority. |
 | <span class="prop-name">zeroMinWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, it sets `min-width: 0` on the item. Refer to the limitations section of the documentation to better understand the use case. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -36,7 +36,7 @@ import Grid from '@material-ui/core/Grid';
 | <span class="prop-name">xs</span> | <span class="prop-type">enum:&nbsp;false, 'auto', true, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12<br></span> | <span class="prop-default">false</span> | Defines the number of grids the component is going to use. It's applied for all the screen sizes with the lowest priority. |
 | <span class="prop-name">zeroMinWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, it sets `min-width: 0` on the item. Refer to the limitations section of the documentation to better understand the use case. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -24,7 +24,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">'auto'</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -24,6 +24,8 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">'auto'</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## Inheritance

--- a/pages/api/hidden.md
+++ b/pages/api/hidden.md
@@ -33,7 +33,7 @@ Responsively hides children based on the selected implementation.
 | <span class="prop-name">xsDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and down will be hidden. |
 | <span class="prop-name">xsUp</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and up will be hidden. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/hidden.md
+++ b/pages/api/hidden.md
@@ -33,6 +33,8 @@ Responsively hides children based on the selected implementation.
 | <span class="prop-name">xsDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and down will be hidden. |
 | <span class="prop-name">xsUp</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and up will be hidden. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## Demos

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -26,6 +26,8 @@ regarding the available icon options.
 | <span class="prop-name">edge</span> | <span class="prop-type">enum:&nbsp;'start'&nbsp;&#124;<br>&nbsp;'end'&nbsp;&#124;<br>&nbsp;false<br></span> |  | If given, uses a negative margin to counteract the padding on one side (this is often helpful for aligning the left or right side of the icon with content above or below, without ruining the border size and shape). |
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'<br></span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -24,6 +24,8 @@ import Icon from '@material-ui/core/Icon';
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'span'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">fontSize</span> | <span class="prop-type">enum:&nbsp;'inherit'&nbsp;&#124;<br>&nbsp;'default'&nbsp;&#124;<br>&nbsp;'small'&nbsp;&#124;<br>&nbsp;'large'<br></span> | <span class="prop-default">'default'</span> | The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/input-adornment.md
+++ b/pages/api/input-adornment.md
@@ -26,6 +26,8 @@ import InputAdornment from '@material-ui/core/InputAdornment';
 | <span class="prop-name">position</span> | <span class="prop-type">enum:&nbsp;'start'&nbsp;&#124;<br>&nbsp;'end'<br></span> |  | The position this adornment should appear relative to the `Input`. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. Note: If you are using the `TextField` component or the `FormControl` component you do not have to set this manually. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/input-base.md
+++ b/pages/api/input-base.md
@@ -46,6 +46,8 @@ It contains a load of style reset and some state logic.
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> | <span class="prop-default">'text'</span> | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value, required for a controlled component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -29,6 +29,8 @@ import InputLabel from '@material-ui/core/InputLabel';
 | <span class="prop-name">shrink</span> | <span class="prop-type">bool</span> |  | If `true`, the label is shrunk. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([FormLabel](/api/form-label/)).
 
 ## CSS

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -45,6 +45,8 @@ import Input from '@material-ui/core/Input';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value, required for a controlled component. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 
 ## CSS

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -45,7 +45,7 @@ import Input from '@material-ui/core/Input';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value, required for a controlled component. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -28,6 +28,8 @@ attribute to `true` on that region until it has finished loading.
 | <span class="prop-name">valueBuffer</span> | <span class="prop-type">number</span> |  | The value for the buffer variant. Value between 0 and 100. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'determinate'&nbsp;&#124;<br>&nbsp;'indeterminate'&nbsp;&#124;<br>&nbsp;'buffer'&nbsp;&#124;<br>&nbsp;'query'<br></span> | <span class="prop-default">'indeterminate'</span> | The variant to use. Use indeterminate or query when there is no progress value. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/link.md
+++ b/pages/api/link.md
@@ -26,6 +26,8 @@ import Link from '@material-ui/core/Link';
 | <span class="prop-name">underline</span> | <span class="prop-type">enum:&nbsp;'none'&nbsp;&#124;<br>&nbsp;'hover'&nbsp;&#124;<br>&nbsp;'always'<br></span> | <span class="prop-default">'hover'</span> | Controls when the link should have an underline. |
 | <span class="prop-name">variant</span> | <span class="prop-type">string</span> | <span class="prop-default">'inherit'</span> | Applies the theme typography styles. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Typography](/api/typography/)).
 
 ## CSS

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -22,6 +22,8 @@ and `align-items="flex-start"` mode styles to `Avatar`.
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The content of the component – normally `Avatar`. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -22,7 +22,7 @@ and `align-items="flex-start"` mode styles to `Avatar`.
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The content of the component – normally `Avatar`. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -21,6 +21,8 @@ A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The content of the component, normally `Icon`, `SvgIcon`, or a `@material-ui/icons` SVG icon element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/list-item-secondary-action.md
+++ b/pages/api/list-item-secondary-action.md
@@ -21,6 +21,8 @@ Must be used as the last child of ListItem to function properly.
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component, normally an `IconButton` or selection control. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -27,6 +27,8 @@ import ListItemText from '@material-ui/core/ListItemText';
 | <span class="prop-name">secondary</span> | <span class="prop-type">node</span> |  | The secondary content element. |
 | <span class="prop-name">secondaryTypographyProps</span> | <span class="prop-type">object</span> |  | These props will be forwarded to the secondary typography component (as long as disableTypography is not `true`). |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -31,6 +31,8 @@ Uses an additional container component if `ListItemSecondaryAction` is the last 
 | <span class="prop-name">divider</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, a 1px light border is added to the bottom of the list item. |
 | <span class="prop-name">selected</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Use to apply selected styling. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -26,6 +26,8 @@ import ListSubheader from '@material-ui/core/ListSubheader';
 | <span class="prop-name">disableSticky</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the List Subheader will not stick to the top during scroll. |
 | <span class="prop-name">inset</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the List Subheader will be indented. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -25,6 +25,8 @@ import List from '@material-ui/core/List';
 | <span class="prop-name">disablePadding</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, vertical padding will be removed from the list. |
 | <span class="prop-name">subheader</span> | <span class="prop-type">node</span> |  | The content of the subheader, normally `ListSubheader`. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -23,6 +23,8 @@ import MenuItem from '@material-ui/core/MenuItem';
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'li'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">disableGutters</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the left and right padding is removed. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ListItem](/api/list-item/)).
 
 ## CSS

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -21,7 +21,7 @@ import MenuList from '@material-ui/core/MenuList';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | MenuList contents, normally `MenuItem`s. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([List](/api/list/)).
 

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -21,6 +21,8 @@ import MenuList from '@material-ui/core/MenuList';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | MenuList contents, normally `MenuItem`s. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([List](/api/list/)).
 
 ## Inheritance

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -34,6 +34,8 @@ import Menu from '@material-ui/core/Menu';
 | <span class="prop-name">PopoverClasses</span> | <span class="prop-type">object</span> |  | `classes` property applied to the [`Popover`](/api/popover/) element. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">'auto'</span> | The length of the transition in `ms`, or 'auto' |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Popover](/api/popover/)).
 
 ## CSS

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -34,7 +34,7 @@ import Menu from '@material-ui/core/Menu';
 | <span class="prop-name">PopoverClasses</span> | <span class="prop-type">object</span> |  | `classes` property applied to the [`Popover`](/api/popover/) element. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">'auto'</span> | The length of the transition in `ms`, or 'auto' |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([Popover](/api/popover/)).
 

--- a/pages/api/mobile-stepper.md
+++ b/pages/api/mobile-stepper.md
@@ -27,6 +27,8 @@ import MobileStepper from '@material-ui/core/MobileStepper';
 | <span class="prop-name required">steps&nbsp;*</span> | <span class="prop-type">number</span> |  | The total steps. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'text'&nbsp;&#124;<br>&nbsp;'dots'&nbsp;&#124;<br>&nbsp;'progress'<br></span> | <span class="prop-default">'dots'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -48,6 +48,8 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 | <span class="prop-name">onRendered</span> | <span class="prop-type">func</span> |  | Callback fired once the children has been mounted into the `container`. It signals that the `open={true}` property took effect. |
 | <span class="prop-name required">open&nbsp;*</span> | <span class="prop-type">bool</span> |  | If `true`, the modal is open. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -27,6 +27,8 @@ An alternative to `<Select native />` with a much smaller bundle size footprint.
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br></span> |  | The input value. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Input](/api/input/)).
 
 ## CSS

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -27,7 +27,7 @@ An alternative to `<Select native />` with a much smaller bundle size footprint.
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br></span> |  | The input value. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([Input](/api/input/)).
 

--- a/pages/api/no-ssr.md
+++ b/pages/api/no-ssr.md
@@ -28,6 +28,8 @@ This component can be useful in a variety of situations:
 | <span class="prop-name">defer</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will not only prevent server-side rendering. It will also defer the rendering of the children into a different screen frame. |
 | <span class="prop-name">fallback</span> | <span class="prop-type">node</span> | <span class="prop-default">null</span> | The fallback content to display. |
 
+The `ref` is **not** forwarded to the root element.
+
 
 ## Demos
 

--- a/pages/api/no-ssr.md
+++ b/pages/api/no-ssr.md
@@ -28,7 +28,7 @@ This component can be useful in a variety of situations:
 | <span class="prop-name">defer</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will not only prevent server-side rendering. It will also defer the rendering of the children into a different screen frame. |
 | <span class="prop-name">fallback</span> | <span class="prop-type">node</span> | <span class="prop-default">null</span> | The fallback content to display. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 
 ## Demos

--- a/pages/api/outlined-input.md
+++ b/pages/api/outlined-input.md
@@ -46,6 +46,8 @@ import OutlinedInput from '@material-ui/core/OutlinedInput';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value, required for a controlled component. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 
 ## CSS

--- a/pages/api/outlined-input.md
+++ b/pages/api/outlined-input.md
@@ -46,7 +46,7 @@ import OutlinedInput from '@material-ui/core/OutlinedInput';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the input element. It should be a valid HTML5 input type. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value, required for a controlled component. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([InputBase](/api/input-base/)).
 

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -24,6 +24,8 @@ import Paper from '@material-ui/core/Paper';
 | <span class="prop-name">elevation</span> | <span class="prop-type">number</span> | <span class="prop-default">2</span> | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |
 | <span class="prop-name">square</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, rounded corners are disabled. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -44,7 +44,7 @@ import Popover from '@material-ui/core/Popover';
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">'auto'</span> | Set to 'auto' to automatically calculate transition time based on height. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([Modal](/api/modal/)).
 

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -44,6 +44,8 @@ import Popover from '@material-ui/core/Popover';
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">'auto'</span> | Set to 'auto' to automatically calculate transition time based on height. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Modal](/api/modal/)).
 
 ## CSS

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -29,7 +29,7 @@ Poppers rely on the 3rd party library [Popper.js](https://github.com/FezVrasta/p
 | <span class="prop-name">popperOptions</span> | <span class="prop-type">object</span> |  | Options provided to the [`popper.js`](https://github.com/FezVrasta/popper.js) instance. |
 | <span class="prop-name">transition</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Help supporting a react-transition-group/Transition component. |
 
-The `ref` is attached to a component class.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -29,6 +29,8 @@ Poppers rely on the 3rd party library [Popper.js](https://github.com/FezVrasta/p
 | <span class="prop-name">popperOptions</span> | <span class="prop-type">object</span> |  | Options provided to the [`popper.js`](https://github.com/FezVrasta/popper.js) instance. |
 | <span class="prop-name">transition</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Help supporting a react-transition-group/Transition component. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## Demos

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -29,7 +29,7 @@ Poppers rely on the 3rd party library [Popper.js](https://github.com/FezVrasta/p
 | <span class="prop-name">popperOptions</span> | <span class="prop-type">object</span> |  | Options provided to the [`popper.js`](https://github.com/FezVrasta/popper.js) instance. |
 | <span class="prop-name">transition</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Help supporting a react-transition-group/Transition component. |
 
-The `ref` is forwarded to the root element.
+The `ref` is attached to a component class.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -29,7 +29,7 @@ Poppers rely on the 3rd party library [Popper.js](https://github.com/FezVrasta/p
 | <span class="prop-name">popperOptions</span> | <span class="prop-type">object</span> |  | Options provided to the [`popper.js`](https://github.com/FezVrasta/popper.js) instance. |
 | <span class="prop-name">transition</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Help supporting a react-transition-group/Transition component. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/portal.md
+++ b/pages/api/portal.md
@@ -24,6 +24,8 @@ that exists outside the DOM hierarchy of the parent component.
 | <span class="prop-name">disablePortal</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the portal behavior. The children stay within it's parent DOM hierarchy. |
 | <span class="prop-name">onRendered</span> | <span class="prop-type">func</span> |  | Callback fired once the children has been mounted into the `container`. |
 
+The `ref` is **not** forwarded to the root element.
+
 
 ## Demos
 

--- a/pages/api/portal.md
+++ b/pages/api/portal.md
@@ -24,7 +24,7 @@ that exists outside the DOM hierarchy of the parent component.
 | <span class="prop-name">disablePortal</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the portal behavior. The children stay within it's parent DOM hierarchy. |
 | <span class="prop-name">onRendered</span> | <span class="prop-type">func</span> |  | Callback fired once the children has been mounted into the `container`. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 
 ## Demos

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -24,7 +24,7 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when a radio button is selected.<br><br>**Signature:**<br>`function(event: object, value: string) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`.<br>*value:* The `value` of the selected radio button |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | Value of the selected radio button. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([FormGroup](/api/form-group/)).
 

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -24,6 +24,8 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when a radio button is selected.<br><br>**Signature:**<br>`function(event: object, value: string) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`.<br>*value:* The `value` of the selected radio button |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | Value of the selected radio button. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([FormGroup](/api/form-group/)).
 
 ## Inheritance

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -33,6 +33,8 @@ import Radio from '@material-ui/core/Radio';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([IconButton](/api/icon-button/)).
 
 ## CSS

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -48,6 +48,6 @@ class MyComponent extends React.Component {
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The wrapped element. |
 | <span class="prop-name required">rootRef&nbsp;*</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |  | Provide a way to access the DOM node of the wrapped element. You can provide a callback ref or a `React.createRef()` ref. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -48,4 +48,6 @@ class MyComponent extends React.Component {
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The wrapped element. |
 | <span class="prop-name required">rootRef&nbsp;*</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |  | Provide a way to access the DOM node of the wrapped element. You can provide a callback ref or a `React.createRef()` ref. |
 
+The `ref` is **not** forwarded to the root element.
+
 

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -37,6 +37,8 @@ import Select from '@material-ui/core/Select';
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value. This property is required when the `native` property is `false` (default). |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Input](/api/input/)).
 
 ## CSS

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -37,7 +37,7 @@ import Select from '@material-ui/core/Select';
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value. This property is required when the `native` property is `false` (default). |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([Input](/api/input/)).
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -24,7 +24,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-The `ref` is forwarded to the root element.
+The `ref` is attached to a component class.
 
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -24,7 +24,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -24,6 +24,8 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, show the component; triggers the enter or exit animation. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## Inheritance

--- a/pages/api/snackbar-content.md
+++ b/pages/api/snackbar-content.md
@@ -22,6 +22,8 @@ import SnackbarContent from '@material-ui/core/SnackbarContent';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">message</span> | <span class="prop-type">node</span> |  | The message to display. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -41,6 +41,8 @@ import Snackbar from '@material-ui/core/Snackbar';
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -23,6 +23,8 @@ import StepButton from '@material-ui/core/StepButton';
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> |  | The icon displayed by the step label. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node</span> |  | The optional node to display. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -20,6 +20,8 @@ import StepConnector from '@material-ui/core/StepConnector';
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -24,6 +24,8 @@ import StepContent from '@material-ui/core/StepContent';
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }&nbsp;&#124;<br>&nbsp;enum:&nbsp;'auto'<br><br></span> | <span class="prop-default">'auto'</span> | Adjust the duration of the content expand transition. Passed as a property to the transition component.<br>Set to 'auto' to automatically calculate transition time based on height. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -24,7 +24,7 @@ import StepIcon from '@material-ui/core/StepIcon';
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name required">icon&nbsp;*</span> | <span class="prop-type">node</span> |  | The icon displayed by the step label. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -24,6 +24,8 @@ import StepIcon from '@material-ui/core/StepIcon';
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as failed. |
 | <span class="prop-name required">icon&nbsp;*</span> | <span class="prop-type">node</span> |  | The icon displayed by the step label. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -27,6 +27,8 @@ import StepLabel from '@material-ui/core/StepLabel';
 | <span class="prop-name">StepIconComponent</span> | <span class="prop-type">elementType</span> |  | The component to render in place of the [`StepIcon`](/api/step-icon/). |
 | <span class="prop-name">StepIconProps</span> | <span class="prop-type">object</span> |  | Properties applied to the [`StepIcon`](/api/step-icon/) element. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -24,6 +24,8 @@ import Step from '@material-ui/core/Step';
 | <span class="prop-name">completed</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as completed. Is passed to child components. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as disabled, will also disable the button if `StepButton` is a child of `Step`. Is passed to child components. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -26,6 +26,8 @@ import Stepper from '@material-ui/core/Stepper';
 | <span class="prop-name">nonLinear</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If set the `Stepper` will not assist in controlling steps for linear flow. |
 | <span class="prop-name">orientation</span> | <span class="prop-type">enum:&nbsp;'horizontal'&nbsp;&#124;<br>&nbsp;'vertical'<br></span> | <span class="prop-default">'horizontal'</span> | The stepper orientation (layout flow direction). |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Paper](/api/paper/)).
 
 ## CSS

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -28,6 +28,8 @@ import SvgIcon from '@material-ui/core/SvgIcon';
 | <span class="prop-name">titleAccess</span> | <span class="prop-type">string</span> |  | Provides a human-readable title for the element that contains it. https://www.w3.org/TR/SVG-access/#Equivalent |
 | <span class="prop-name">viewBox</span> | <span class="prop-type">string</span> | <span class="prop-default">'0 0 24 24'</span> | Allows you to redefine what the coordinates without units mean inside an SVG element. For example, if the SVG element is 500 (width) by 200 (height), and you pass viewBox="0 0 50 20", this means that the coordinates inside the SVG will go from the top left corner (0,0) to bottom right (50,20) and each unit will be worth 10px. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -30,7 +30,7 @@ import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 | <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number</span> | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-The `ref` is attached to a component class.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([Drawer](/api/drawer/)).
 

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -30,7 +30,7 @@ import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 | <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number</span> | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-The `ref` is forwarded to the root element.
+The `ref` is attached to a component class.
 
 Any other properties supplied will be spread to the root element ([Drawer](/api/drawer/)).
 

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -30,6 +30,8 @@ import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 | <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number</span> | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Drawer](/api/drawer/)).
 
 ## Inheritance

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -30,7 +30,7 @@ import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 | <span class="prop-name">swipeAreaWidth</span> | <span class="prop-type">number</span> | <span class="prop-default">20</span> | The width of the left most (or right most) area in pixels where the drawer can be swiped open from. |
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([Drawer](/api/drawer/)).
 

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -32,6 +32,8 @@ import Switch from '@material-ui/core/Switch';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([IconButton](/api/icon-button/)).
 
 ## CSS

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -32,7 +32,7 @@ import Switch from '@material-ui/core/Switch';
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([IconButton](/api/icon-button/)).
 

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -26,6 +26,8 @@ import Tab from '@material-ui/core/Tab';
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | You can provide your own value. Otherwise, we fallback to the child position index. |
 | <span class="prop-name">wrapped</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Tab labels appear in a single row. They can use a second line if needed. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -22,6 +22,8 @@ import TableBody from '@material-ui/core/TableBody';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'tbody'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -28,6 +28,8 @@ import TableCell from '@material-ui/core/TableCell';
 | <span class="prop-name">sortDirection</span> | <span class="prop-type">enum:&nbsp;'asc'&nbsp;&#124;<br>&nbsp;'desc'&nbsp;&#124;<br>&nbsp;false<br></span> |  | Set aria-sort direction. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'head'&nbsp;&#124;<br>&nbsp;'body'&nbsp;&#124;<br>&nbsp;'footer'<br></span> |  | Specify the cell type. By default, the TableHead, TableBody or TableFooter parent component set the value. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -22,6 +22,8 @@ import TableFooter from '@material-ui/core/TableFooter';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'tfoot'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -22,6 +22,8 @@ import TableHead from '@material-ui/core/TableHead';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'thead'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -33,7 +33,7 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 | <span class="prop-name">rowsPerPageOptions</span> | <span class="prop-type">array</span> | <span class="prop-default">[10, 25, 50, 100]</span> | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |
 | <span class="prop-name">SelectProps</span> | <span class="prop-type">object</span> |  | Properties applied to the rows per page [`Select`](/api/select/) element. |
 
-The `ref` is **not** forwarded to the root element.
+The `ref` is forwarded to the root element.
 
 Any other properties supplied will be spread to the root element ([TableCell](/api/table-cell/)).
 

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -33,6 +33,8 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 | <span class="prop-name">rowsPerPageOptions</span> | <span class="prop-type">array</span> | <span class="prop-default">[10, 25, 50, 100]</span> | Customizes the options of the rows per page select field. If less than two options are available, no select field will be displayed. |
 | <span class="prop-name">SelectProps</span> | <span class="prop-type">object</span> |  | Properties applied to the rows per page [`Select`](/api/select/) element. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([TableCell](/api/table-cell/)).
 
 ## CSS

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -25,6 +25,8 @@ based on the material table element parent (head, body, etc).
 | <span class="prop-name">hover</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the table row will shade on hover. |
 | <span class="prop-name">selected</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the table row will have the selected shading. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -25,6 +25,8 @@ A button based label for placing inside `TableCell` for column sorting.
 | <span class="prop-name">hideSortIcon</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Hide sort icon when active is false. |
 | <span class="prop-name">IconComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">ArrowDownwardIcon</span> | Sort icon to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -24,6 +24,8 @@ import Table from '@material-ui/core/Table';
 | <span class="prop-name">padding</span> | <span class="prop-type">enum:&nbsp;'default'&nbsp;&#124;<br>&nbsp;'checkbox'&nbsp;&#124;<br>&nbsp;'none'<br></span> | <span class="prop-default">'default'</span> | Allows TableCells to inherit padding of the Table. |
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'<br></span> | <span class="prop-default">'medium'</span> | Allows TableCells to inherit size of the Table. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -34,6 +34,8 @@ import Tabs from '@material-ui/core/Tabs';
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the currently selected `Tab`. If you don't want any selected `Tab`, you can set this property to `false`. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'scrollable'&nbsp;&#124;<br>&nbsp;'fullWidth'<br></span> | <span class="prop-default">'standard'</span> | Determines additional display behavior of the tabs:  - `scrollable` will invoke scrolling properties and allow for horizontally  scrolling (or swiping) of the tab bar.  -`fullWidth` will make the tabs grow to use all the available space,  which should be used for small views, like on mobile.  - `standard` will render the default state. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -72,6 +72,8 @@ For advanced cases, please look at the source of TextField by clicking on the
 | <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br></span> |  | The value of the `Input` element, required for a controlled component. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> | <span class="prop-default">'standard'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([FormControl](/api/form-control/)).
 
 ## Inheritance

--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -24,6 +24,8 @@ import Toolbar from '@material-ui/core/Toolbar';
 | <span class="prop-name">disableGutters</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, disables gutter padding. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'regular'&nbsp;&#124;<br>&nbsp;'dense'<br></span> | <span class="prop-default">'regular'</span> | The variant to use. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -38,6 +38,8 @@ import Tooltip from '@material-ui/core/Tooltip';
 | <span class="prop-name">TransitionComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">Grow</span> | The component used for the transition. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -38,7 +38,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 | <span class="prop-name">TransitionComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">Grow</span> | The component used for the transition. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/touch-ripple.md
+++ b/pages/api/touch-ripple.md
@@ -21,7 +21,7 @@ import TouchRipple from '@material-ui/core/ButtonBase/TouchRipple';
 | <span class="prop-name">center</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple starts at the center of the component rather than at the point of interaction. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
-The component cannot hold a ref.
+The `ref` is attached to a component class.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/touch-ripple.md
+++ b/pages/api/touch-ripple.md
@@ -21,7 +21,7 @@ import TouchRipple from '@material-ui/core/ButtonBase/TouchRipple';
 | <span class="prop-name">center</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple starts at the center of the component rather than at the point of interaction. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/api/touch-ripple.md
+++ b/pages/api/touch-ripple.md
@@ -21,6 +21,8 @@ import TouchRipple from '@material-ui/core/ButtonBase/TouchRipple';
 | <span class="prop-name">center</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple starts at the center of the component rather than at the point of interaction. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -30,6 +30,8 @@ import Typography from '@material-ui/core/Typography';
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'subtitle2', 'body1', 'body2', 'caption', 'button', 'overline', 'srOnly', 'inherit'<br></span> | <span class="prop-default">'body1'</span> | Applies the theme typography styles. |
 | <span class="prop-name">variantMapping</span> | <span class="prop-type">object</span> | <span class="prop-default">{  h1: 'h1',  h2: 'h2',  h3: 'h3',  h4: 'h4',  h5: 'h5',  h6: 'h6',  subtitle1: 'h6',  subtitle2: 'h6',  body1: 'p',  body2: 'p',}</span> | We are empirically mapping the variant property to a range of different DOM element types. For instance, subtitle1 to `<h6>`. If you wish to change that mapping, you can provide your own. Alternatively, you can use the `component` property. |
 
+The `ref` is forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -24,7 +24,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -24,6 +24,8 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
 | <span class="prop-name">timeout</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
 
 ## Inheritance

--- a/pages/lab/api/slider.md
+++ b/pages/lab/api/slider.md
@@ -32,7 +32,7 @@ import Slider from '@material-ui/lab/Slider';
 | <span class="prop-name">valueReducer</span> | <span class="prop-type">func</span> | <span class="prop-default">function defaultValueReducer(rawValue, props) {  const { disabled, step } = props;  if (disabled) {    return null;  }  if (step) {    return roundToStep(rawValue, step);  }  return Number(rawValue.toFixed(3));}</span> | the reducer used to process the value emitted from the slider. If `null` or the same value is returned no change is emitted.<br><br>**Signature:**<br>`function(rawValue: number, props: SliderProps, event: Event) => void`<br>*rawValue:* value in [min, max]<br>*props:* current props of the Slider<br>*event:* the event the change was triggered from |
 | <span class="prop-name">vertical</span> | <span class="prop-type">bool</span> |  | If `true`, the slider will be vertical. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/lab/api/slider.md
+++ b/pages/lab/api/slider.md
@@ -32,6 +32,8 @@ import Slider from '@material-ui/lab/Slider';
 | <span class="prop-name">valueReducer</span> | <span class="prop-type">func</span> | <span class="prop-default">function defaultValueReducer(rawValue, props) {  const { disabled, step } = props;  if (disabled) {    return null;  }  if (step) {    return roundToStep(rawValue, step);  }  return Number(rawValue.toFixed(3));}</span> | the reducer used to process the value emitted from the slider. If `null` or the same value is returned no change is emitted.<br><br>**Signature:**<br>`function(rawValue: number, props: SliderProps, event: Event) => void`<br>*rawValue:* value in [min, max]<br>*props:* current props of the Slider<br>*event:* the event the change was triggered from |
 | <span class="prop-name">vertical</span> | <span class="prop-type">bool</span> |  | If `true`, the slider will be vertical. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/lab/api/speed-dial-action.md
+++ b/pages/lab/api/speed-dial-action.md
@@ -27,7 +27,7 @@ import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
 | <span class="prop-name">tooltipPlacement</span> | <span class="prop-type">enum:&nbsp;'bottom-end', 'bottom-start', 'bottom', 'left-end', 'left-start', 'left', 'right-end', 'right-start', 'right', 'top-end', 'top-start', 'top'<br></span> | <span class="prop-default">'left'</span> | Placement of the tooltip. |
 | <span class="prop-name required">tooltipTitle&nbsp;*</span> | <span class="prop-type">node</span> |  | Label to display in the tooltip. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element ([Tooltip](/api/tooltip/)).
 

--- a/pages/lab/api/speed-dial-action.md
+++ b/pages/lab/api/speed-dial-action.md
@@ -27,6 +27,8 @@ import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
 | <span class="prop-name">tooltipPlacement</span> | <span class="prop-type">enum:&nbsp;'bottom-end', 'bottom-start', 'bottom', 'left-end', 'left-start', 'left', 'right-end', 'right-start', 'right', 'top-end', 'top-start', 'top'<br></span> | <span class="prop-default">'left'</span> | Placement of the tooltip. |
 | <span class="prop-name required">tooltipTitle&nbsp;*</span> | <span class="prop-type">node</span> |  | Label to display in the tooltip. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([Tooltip](/api/tooltip/)).
 
 ## CSS

--- a/pages/lab/api/speed-dial-icon.md
+++ b/pages/lab/api/speed-dial-icon.md
@@ -22,7 +22,7 @@ import SpeedDialIcon from '@material-ui/lab/SpeedDialIcon';
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> |  | The icon to display in the SpeedDial Floating Action Button. |
 | <span class="prop-name">openIcon</span> | <span class="prop-type">node</span> |  | The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/lab/api/speed-dial-icon.md
+++ b/pages/lab/api/speed-dial-icon.md
@@ -22,6 +22,8 @@ import SpeedDialIcon from '@material-ui/lab/SpeedDialIcon';
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> |  | The icon to display in the SpeedDial Floating Action Button. |
 | <span class="prop-name">openIcon</span> | <span class="prop-type">node</span> |  | The icon to display in the SpeedDial Floating Action Button when the SpeedDial is open. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/lab/api/speed-dial.md
+++ b/pages/lab/api/speed-dial.md
@@ -32,7 +32,7 @@ import SpeedDial from '@material-ui/lab/SpeedDial';
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/lab/api/speed-dial.md
+++ b/pages/lab/api/speed-dial.md
@@ -32,6 +32,8 @@ import SpeedDial from '@material-ui/lab/SpeedDial';
 | <span class="prop-name">transitionDuration</span> | <span class="prop-type">union:&nbsp;number&nbsp;&#124;<br>&nbsp;{ enter?: number, exit?: number }<br></span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `Transition` element. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/lab/api/toggle-button-group.md
+++ b/pages/lab/api/toggle-button-group.md
@@ -24,7 +24,7 @@ import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: object) => void`<br>*event:* The event source of the callback<br>*value:* of the selected buttons. When `exclusive` is true this is a single value; when false an array of selected values. If no value is selected and `exclusive` is true the value is null; when false an empty array. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The currently selected value within the group or an array of selected values when `exclusive` is false. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/pages/lab/api/toggle-button-group.md
+++ b/pages/lab/api/toggle-button-group.md
@@ -24,6 +24,8 @@ import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: object) => void`<br>*event:* The event source of the callback<br>*value:* of the selected buttons. When `exclusive` is true this is a single value; when false an array of selected values. If no value is selected and `exclusive` is true the value is null; when false an empty array. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The currently selected value within the group or an array of selected values when `exclusive` is false. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element (native element).
 
 ## CSS

--- a/pages/lab/api/toggle-button.md
+++ b/pages/lab/api/toggle-button.md
@@ -26,7 +26,7 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 | <span class="prop-name">selected</span> | <span class="prop-type">bool</span> |  | If `true`, the button will be rendered in an active state. |
 | <span class="prop-name required">value&nbsp;*</span> | <span class="prop-type">any</span> |  | The value to associate with the button when selected in a ToggleButtonGroup. |
 
-The `ref` is **not** forwarded to the root element.
+The component cannot hold a ref.
 
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 

--- a/pages/lab/api/toggle-button.md
+++ b/pages/lab/api/toggle-button.md
@@ -26,6 +26,8 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 | <span class="prop-name">selected</span> | <span class="prop-type">bool</span> |  | If `true`, the button will be rendered in an active state. |
 | <span class="prop-name required">value&nbsp;*</span> | <span class="prop-type">any</span> |  | The value to associate with the button when selected in a ToggleButtonGroup. |
 
+The `ref` is **not** forwarded to the root element.
+
 Any other properties supplied will be spread to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS


### PR DESCRIPTION
Adds explicit documentation to `https://material-ui.com/api/*` about ref forwarding. Requires #15131 to not report false positives.

Finishes one point in #14415.