### PR TITLE
[docs] Migrate docs' Tooltips page to hooks

### DIFF
--- a/docs/src/pages/demos/tooltips/InteractiveTooltips.js
+++ b/docs/src/pages/demos/tooltips/InteractiveTooltips.js
@@ -1,17 +1,16 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(1),
   },
-});
+}));
 
-function InteractiveTooltips(props) {
-  const { classes } = props;
+function InteractiveTooltips() {
+  const classes = useStyles();
 
   return (
     <div>
@@ -25,8 +24,4 @@ function InteractiveTooltips(props) {
   );
 }
 
-InteractiveTooltips.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(InteractiveTooltips);
+export default InteractiveTooltips;

--- a/docs/src/pages/demos/tooltips/InteractiveTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/InteractiveTooltips.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, createStyles, Theme, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     button: {
       margin: theme.spacing(1),
     },
-  });
+  }),
+);
 
-function InteractiveTooltips(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function InteractiveTooltips() {
+  const classes = useStyles();
 
   return (
     <div>
@@ -26,8 +26,4 @@ function InteractiveTooltips(props: WithStyles<typeof styles>) {
   );
 }
 
-InteractiveTooltips.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(InteractiveTooltips);
+export default InteractiveTooltips;

--- a/docs/src/pages/demos/tooltips/PositionedTooltips.js
+++ b/docs/src/pages/demos/tooltips/PositionedTooltips.js
@@ -1,18 +1,17 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = {
+const useStyles = makeStyles({
   root: {
     width: 500,
   },
-};
+});
 
-function PositionedTooltips(props) {
-  const { classes } = props;
+function PositionedTooltips() {
+  const classes = useStyles();
   return (
     <div className={classes.root}>
       <Grid container justify="center">
@@ -77,8 +76,4 @@ function PositionedTooltips(props) {
   );
 }
 
-PositionedTooltips.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(PositionedTooltips);
+export default PositionedTooltips;

--- a/docs/src/pages/demos/tooltips/PositionedTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/PositionedTooltips.tsx
@@ -1,18 +1,19 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, createStyles, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = createStyles({
-  root: {
-    width: 500,
-  },
-});
+const useStyles = makeStyles(
+  createStyles({
+    root: {
+      width: 500,
+    },
+  }),
+);
 
-function PositionedTooltips(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function PositionedTooltips() {
+  const classes = useStyles();
   return (
     <div className={classes.root}>
       <Grid container justify="center">
@@ -77,8 +78,4 @@ function PositionedTooltips(props: WithStyles<typeof styles>) {
   );
 }
 
-PositionedTooltips.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(PositionedTooltips);
+export default PositionedTooltips;

--- a/docs/src/pages/demos/tooltips/SimpleTooltips.js
+++ b/docs/src/pages/demos/tooltips/SimpleTooltips.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
 import Fab from '@material-ui/core/Fab';
 import DeleteIcon from '@material-ui/icons/Delete';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   fab: {
     margin: theme.spacing(2),
   },
@@ -16,10 +15,10 @@ const styles = theme => ({
     bottom: theme.spacing(2),
     right: theme.spacing(3),
   },
-});
+}));
 
-function SimpleTooltips(props) {
-  const { classes } = props;
+function SimpleTooltips() {
+  const classes = useStyles();
   return (
     <div>
       <Tooltip title="Delete">
@@ -41,8 +40,4 @@ function SimpleTooltips(props) {
   );
 }
 
-SimpleTooltips.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(SimpleTooltips);
+export default SimpleTooltips;

--- a/docs/src/pages/demos/tooltips/SimpleTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/SimpleTooltips.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, Theme, WithStyles, createStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
 import Fab from '@material-ui/core/Fab';
 import DeleteIcon from '@material-ui/icons/Delete';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     fab: {
       margin: theme.spacing(2),
@@ -17,10 +16,11 @@ const styles = (theme: Theme) =>
       bottom: theme.spacing(2),
       right: theme.spacing(3),
     },
-  });
+  }),
+);
 
-function SimpleTooltips(props: WithStyles<typeof styles>) {
-  const { classes } = props;
+function SimpleTooltips() {
+  const classes = useStyles();
   return (
     <div>
       <Tooltip title="Delete">
@@ -42,8 +42,4 @@ function SimpleTooltips(props: WithStyles<typeof styles>) {
   );
 }
 
-SimpleTooltips.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(SimpleTooltips);
+export default SimpleTooltips;

--- a/docs/src/pages/demos/tooltips/VariableWidth.js
+++ b/docs/src/pages/demos/tooltips/VariableWidth.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(1),
   },
@@ -14,7 +13,7 @@ const styles = theme => ({
   noMaxWidth: {
     maxWidth: 'none',
   },
-});
+}));
 
 const longText = `
 Aliquam eget finibus ante, non facilisis lectus. Sed vitae dignissim est, vel aliquam tellus.
@@ -22,7 +21,8 @@ Praesent non nunc mollis, fermentum neque at, semper arcu.
 Nullam eget est sed sem iaculis gravida eget vitae justo.
 `;
 
-function VariableWidth({ classes }) {
+function VariableWidth() {
+  const classes = useStyles();
   return (
     <div>
       <Tooltip title={longText}>
@@ -38,8 +38,4 @@ function VariableWidth({ classes }) {
   );
 }
 
-VariableWidth.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(VariableWidth);
+export default VariableWidth;

--- a/docs/src/pages/demos/tooltips/VariableWidth.tsx
+++ b/docs/src/pages/demos/tooltips/VariableWidth.tsx
@@ -1,10 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, Theme, createStyles, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     button: {
       margin: theme.spacing(1),
@@ -15,7 +14,8 @@ const styles = (theme: Theme) =>
     noMaxWidth: {
       maxWidth: 'none',
     },
-  });
+  }),
+);
 
 const longText = `
 Aliquam eget finibus ante, non facilisis lectus. Sed vitae dignissim est, vel aliquam tellus.
@@ -23,7 +23,8 @@ Praesent non nunc mollis, fermentum neque at, semper arcu.
 Nullam eget est sed sem iaculis gravida eget vitae justo.
 `;
 
-function VariableWidth({ classes }: WithStyles<typeof styles>) {
+function VariableWidth() {
+  const classes = useStyles();
   return (
     <div>
       <Tooltip title={longText}>
@@ -39,8 +40,4 @@ function VariableWidth({ classes }: WithStyles<typeof styles>) {
   );
 }
 
-VariableWidth.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(VariableWidth);
+export default VariableWidth;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Description
This PR migrates the doc's tooltips page to hooks. Relates to #15032.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).