### PR TITLE
[Tab] Remove internal indicator prop from Tab types

### DIFF
--- a/packages/material-ui/src/Tab/Tab.d.ts
+++ b/packages/material-ui/src/Tab/Tab.d.ts
@@ -7,7 +7,6 @@ declare const Tab: ExtendButtonBase<{
     disabled?: boolean;
     fullWidth?: boolean;
     icon?: string | React.ReactElement;
-    indicator?: React.ReactNode;
     value?: any;
     label?: React.ReactNode;
     onChange?: (event: React.ChangeEvent<{ checked: boolean }>, value: any) => void;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This PR removes the `indicator` prop from the exported Tab types, as it is an internal-only prop
