### PR TITLE
[docs] Use Date type instead of any for MUI pickers demo

### DIFF
--- a/docs/src/pages/demos/pickers/MaterialUIPickers.tsx
+++ b/docs/src/pages/demos/pickers/MaterialUIPickers.tsx
@@ -15,7 +15,7 @@ const styles = createStyles({
 export type Props = WithStyles<typeof styles>;
 
 export interface State {
-  selectedDate: any;
+  selectedDate: Date;
 }
 
 class MaterialUIPickers extends React.Component<Props, State> {
@@ -24,7 +24,7 @@ class MaterialUIPickers extends React.Component<Props, State> {
     selectedDate: new Date('2014-08-18T21:11:54'),
   };
 
-  handleDateChange = (date: any) => {
+  handleDateChange = (date: Date) => {
     this.setState({ selectedDate: date });
   };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This PR replaces the `any` type with `Date` type, this will definitely be the return type as per the conversation in #15103