### PR TITLE
[core] Polish `type` type of button related components

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@emotion/styled": "^10.0.0",
     "@trendmicro/react-interpolate": "0.5.5",
     "@types/enzyme": "^3.1.4",
-    "@types/react": "^16.7.10",
+    "@types/react": "^16.8.10",
     "@types/react-dom": "^16.0.9",
     "@types/react-router-dom": "^4.3.1",
     "@types/react-select": "^2.0.14",

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -7,7 +7,6 @@ declare const ToggleButton: ExtendButtonBase<{
     disableFocusRipple?: boolean;
     disableRipple?: boolean;
     selected?: boolean;
-    type?: string;
     value?: any;
   };
   defaultComponent: 'button';

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -11,7 +11,6 @@ declare const Button: ExtendButtonBase<{
     fullWidth?: boolean;
     href?: string;
     size?: 'small' | 'medium' | 'large';
-    type?: 'submit' | 'reset' | 'button';
     variant?: 'text' | 'outlined' | 'contained';
   };
   defaultComponent: 'button';

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -458,9 +458,8 @@ ButtonBase.propTypes = {
   /**
    * Used to control the button's purpose.
    * This property passes the value to the `type` attribute of the native button component.
-   * Valid property values include `button`, `submit`, and `reset`.
    */
-  type: PropTypes.string,
+  type: PropTypes.oneOf(['submit', 'reset', 'button']),
 };
 
 ButtonBase.defaultProps = {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -284,7 +284,7 @@ class ButtonBase extends React.Component {
 
     const buttonProps = {};
     if (ComponentProp === 'button') {
-      buttonProps.type = type || 'button';
+      buttonProps.type = type;
       buttonProps.disabled = disabled;
     } else {
       buttonProps.role = 'button';

--- a/packages/material-ui/src/Fab/Fab.d.ts
+++ b/packages/material-ui/src/Fab/Fab.d.ts
@@ -10,7 +10,6 @@ declare const Fab: ExtendButtonBase<{
     disableRipple?: boolean;
     href?: string;
     size?: 'small' | 'medium' | 'large';
-    type?: 'submit' | 'reset' | 'button';
     variant?: 'round' | 'extended';
   };
   defaultComponent: 'button';

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -33,7 +33,7 @@ It contains a load of style reset and some focus/ripple logic.
 | <span class="prop-name">focusVisibleClassName</span> | <span class="prop-type">string</span> |  | This property can help a person know which element has the keyboard focus. The class name will be applied when the element gain the focus through a keyboard interaction. It's a polyfill for the [CSS :focus-visible selector](https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo). The rationale for using this feature [is explained here](https://github.com/WICG/focus-visible/blob/master/explainer.md). A [polyfill can be used](https://github.com/WICG/focus-visible) to apply a `focus-visible` class to other components if needed. |
 | <span class="prop-name">onFocusVisible</span> | <span class="prop-type">func</span> |  | Callback fired when the component is focused with a keyboard. We trigger a `onFocus` callback too. |
 | <span class="prop-name">TouchRippleProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `TouchRipple` element. |
-| <span class="prop-name">type</span> | <span class="prop-type">string</span> | <span class="prop-default">'button'</span> | Used to control the button's purpose. This property passes the value to the `type` attribute of the native button component. Valid property values include `button`, `submit`, and `reset`. |
+| <span class="prop-name">type</span> | <span class="prop-type">enum:&nbsp;'submit'&nbsp;&#124;<br>&nbsp;'reset'&nbsp;&#124;<br>&nbsp;'button'<br></span> | <span class="prop-default">'button'</span> | Used to control the button's purpose. This property passes the value to the `type` attribute of the native button component. |
 
 Any other properties supplied will be spread to the root element (native element).
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2217,10 +2217,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.7.10":
-  version "16.8.8"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.8.tgz#4b60a469fd2469f7aa6eaa0f8cfbc51f6d76e662"
-  integrity sha512-xwEvyet96u7WnB96kqY0yY7qxx/pEpU51QeACkKFtrgjjXITQn0oO1iwPEraXVgh10ZFPix7gs1R4OJXF7P5sg==
+"@types/react@*", "@types/react@^16.8.10":
+  version "16.8.10"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.10.tgz#1ccb6fde17f71a62ef055382ec68bdc379d4d8d9"
+  integrity sha512-7bUQeZKP4XZH/aB4i7k1i5yuwymDu/hnLMhD9NjVZvQQH7ZUgRN3d6iu8YXzx4sN/tNr0bj8jgguk8hhObzGvA==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"


### PR DESCRIPTION
Closes #15157 

Button related typings now work with any version of `@types/react` with regard to the `type` attribute.

## Possible side-effects
`<Button component="a" type="reset" />` will throw when building a TypeScript project.