### PR TITLE
[docs] Run the TypeScript demos

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -87,6 +87,7 @@ module.exports = {
       ],
     },
     'docs-development': {
+      presets: ['@zeit/next-typescript/babel'],
       plugins: [
         'babel-plugin-preval',
         [
@@ -106,7 +107,7 @@ module.exports = {
       ],
     },
     'docs-production': {
-      presets: ['next/babel'],
+      presets: ['next/babel', '@zeit/next-typescript/babel'],
       plugins: [
         'babel-plugin-preval',
         [

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -211,7 +211,8 @@ class Demo extends React.Component {
         codeVariant: CODE_VARIANTS.TS,
         githubLocation: githubLocation.replace(/\.js$/, '.tsx'),
         raw: demo.rawTS,
-        js: demo.js,
+        Component: demo.tsx,
+        sourceLanguage: 'tsx',
       };
     }
 
@@ -219,7 +220,8 @@ class Demo extends React.Component {
       codeVariant: CODE_VARIANTS.JS,
       githubLocation,
       raw: demo.raw,
-      js: demo.js,
+      Component: demo.js,
+      sourceLanguage: 'jsx',
     };
   };
 
@@ -227,11 +229,10 @@ class Demo extends React.Component {
     const { classes, codeVariant, demo, demoOptions, t } = this.props;
     const { anchorEl, codeOpen, demoHovered, sourceHintSeen } = this.state;
     const showSourceHint = demoHovered && !sourceHintSeen;
-    const category = demoOptions.demo;
+
     const demoData = this.getDemoData();
-    const DemoComponent = demoData.js;
-    const sourceLanguage = demoData.codeVariant === CODE_VARIANTS.TS ? 'tsx' : 'jsx';
-    const Frame = demoOptions.iframe ? DemoFrame : React.Fragment;
+    const DemoComponent = demoData.Component;
+    const Sandbox = demoOptions.iframe ? DemoFrame : React.Fragment;
 
     return (
       <div className={classes.root}>
@@ -242,7 +243,7 @@ class Demo extends React.Component {
                 demo={demo}
                 codeOpen={codeOpen}
                 codeVariant={codeVariant}
-                gaEventCategory={category}
+                gaEventCategory={demoOptions.demo}
                 onLanguageClick={this.handleCodeLanguageClick}
               />
               <div>
@@ -255,7 +256,7 @@ class Demo extends React.Component {
                   placement="top"
                 >
                   <IconButton
-                    data-ga-event-category={category}
+                    data-ga-event-category={demoOptions.demo}
                     data-ga-event-action="expand"
                     onClick={this.handleClickCodeOpen}
                     color={demoHovered ? 'primary' : 'default'}
@@ -269,7 +270,7 @@ class Demo extends React.Component {
                   placement="top"
                 >
                   <IconButton
-                    data-ga-event-category={category}
+                    data-ga-event-category={demoOptions.demo}
                     data-ga-event-action="github"
                     href={demoData.githubLocation}
                     target="_blank"
@@ -284,7 +285,7 @@ class Demo extends React.Component {
                     placement="top"
                   >
                     <IconButton
-                      data-ga-event-category={category}
+                      data-ga-event-category={demoOptions.demo}
                       data-ga-event-action="codesandbox"
                       onClick={this.handleClickCodeSandbox}
                     >
@@ -316,7 +317,7 @@ class Demo extends React.Component {
                   }}
                 >
                   <MenuItem
-                    data-ga-event-category={category}
+                    data-ga-event-category={demoOptions.demo}
                     data-ga-event-action="copy"
                     onClick={this.handleClickCopy}
                   >
@@ -324,7 +325,7 @@ class Demo extends React.Component {
                   </MenuItem>
                   {demoOptions.hideEditButton ? null : (
                     <MenuItem
-                      data-ga-event-category={category}
+                      data-ga-event-category={demoOptions.demo}
                       data-ga-event-action="stackblitz"
                       onClick={this.handleClickStackBlitz}
                     >
@@ -338,7 +339,7 @@ class Demo extends React.Component {
               <MarkdownElement
                 dir="ltr"
                 className={classes.code}
-                text={`\`\`\`${sourceLanguage}\n${demoData.raw}\n\`\`\``}
+                text={`\`\`\`${demoData.sourceLanguage}\n${demoData.raw}\n\`\`\``}
               />
             </Collapse>
           </div>
@@ -350,9 +351,9 @@ class Demo extends React.Component {
           onMouseEnter={this.handleDemoHover}
           onMouseLeave={this.handleDemoHover}
         >
-          <Frame>
+          <Sandbox>
             <DemoComponent />
-          </Frame>
+          </Sandbox>
         </div>
       </div>
     );

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -233,6 +233,7 @@ class Demo extends React.Component {
     const demoData = this.getDemoData();
     const DemoComponent = demoData.Component;
     const Sandbox = demoOptions.iframe ? DemoFrame : React.Fragment;
+    const gaCategory = demoOptions.demo;
 
     return (
       <div className={classes.root}>
@@ -243,7 +244,7 @@ class Demo extends React.Component {
                 demo={demo}
                 codeOpen={codeOpen}
                 codeVariant={codeVariant}
-                gaEventCategory={demoOptions.demo}
+                gaEventCategory={gaCategory}
                 onLanguageClick={this.handleCodeLanguageClick}
               />
               <div>
@@ -256,7 +257,7 @@ class Demo extends React.Component {
                   placement="top"
                 >
                   <IconButton
-                    data-ga-event-category={demoOptions.demo}
+                    data-ga-event-category={gaCategory}
                     data-ga-event-action="expand"
                     onClick={this.handleClickCodeOpen}
                     color={demoHovered ? 'primary' : 'default'}
@@ -270,7 +271,7 @@ class Demo extends React.Component {
                   placement="top"
                 >
                   <IconButton
-                    data-ga-event-category={demoOptions.demo}
+                    data-ga-event-category={gaCategory}
                     data-ga-event-action="github"
                     href={demoData.githubLocation}
                     target="_blank"
@@ -285,7 +286,7 @@ class Demo extends React.Component {
                     placement="top"
                   >
                     <IconButton
-                      data-ga-event-category={demoOptions.demo}
+                      data-ga-event-category={gaCategory}
                       data-ga-event-action="codesandbox"
                       onClick={this.handleClickCodeSandbox}
                     >
@@ -317,7 +318,7 @@ class Demo extends React.Component {
                   }}
                 >
                   <MenuItem
-                    data-ga-event-category={demoOptions.demo}
+                    data-ga-event-category={gaCategory}
                     data-ga-event-action="copy"
                     onClick={this.handleClickCopy}
                   >
@@ -325,7 +326,7 @@ class Demo extends React.Component {
                   </MenuItem>
                   {demoOptions.hideEditButton ? null : (
                     <MenuItem
-                      data-ga-event-category={demoOptions.demo}
+                      data-ga-event-category={gaCategory}
                       data-ga-event-action="stackblitz"
                       onClick={this.handleClickStackBlitz}
                     >

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -58,7 +58,6 @@ function MarkdownDocs(props) {
   if (req) {
     demos = {};
     const markdowns = {};
-    const sourceFiles = reqSource.keys();
     req.keys().forEach(filename => {
       if (filename.indexOf('.md') !== -1) {
         const match = filename.match(/-([a-z]{2})\.md$/);
@@ -68,16 +67,21 @@ function MarkdownDocs(props) {
         } else {
           markdowns.en = req(filename);
         }
+      } else if (filename.indexOf('.tsx') !== -1) {
+        const demoName = `${reqPrefix}/${filename.replace(/\.\//g, '').replace(/\.tsx/g, '.js')}`;
+
+        demos[demoName] = {
+          ...demos[demoName],
+          tsx: req(filename).default,
+          rawTS: reqSource(filename),
+        };
       } else {
-        const demoName = `${reqPrefix}/${filename.replace(/.\//g, '')}`;
-        const tsFilename = filename.replace(/\.js$/, '.tsx');
-        const hasTSVersion = sourceFiles.indexOf(tsFilename) !== -1;
+        const demoName = `${reqPrefix}/${filename.replace(/\.\//g, '')}`;
 
         demos[demoName] = {
           ...demos[demoName],
           js: req(filename).default,
           raw: reqSource(filename),
-          rawTS: hasTSVersion ? reqSource(tsFilename) : undefined,
         };
       }
     });

--- a/docs/src/pages/premium-themes/instapaper/components/atoms/index.js
+++ b/docs/src/pages/premium-themes/instapaper/components/atoms/index.js
@@ -1,5 +1,5 @@
 const cache = {};
-const req = require.context('./', false, /\.js$/);
+const req = require.context('./', false, /\.(js|tsx)$/);
 
 req.keys().forEach(filename => {
   cache[filename.replace(/\.\/|\.js/g, '')] = req(filename).default;

--- a/docs/src/pages/premium-themes/instapaper/components/molecules/index.js
+++ b/docs/src/pages/premium-themes/instapaper/components/molecules/index.js
@@ -1,5 +1,5 @@
 const cache = {};
-const req = require.context('./', false, /\.js$/);
+const req = require.context('./', false, /\.(js|tsx)$/);
 
 req.keys().forEach(filename => {
   cache[filename.replace(/\.\/|\.js/g, '')] = req(filename).default;

--- a/docs/src/pages/premium-themes/tweeper/components/atoms/index.js
+++ b/docs/src/pages/premium-themes/tweeper/components/atoms/index.js
@@ -1,5 +1,5 @@
 const cache = {};
-const req = require.context('./', false, /\.js$/);
+const req = require.context('./', false, /\.(js|tsx)$/);
 
 req.keys().forEach(filename => {
   cache[filename.replace(/\.\/|\.js/g, '')] = req(filename).default;

--- a/docs/src/pages/premium-themes/tweeper/components/molecules/index.js
+++ b/docs/src/pages/premium-themes/tweeper/components/molecules/index.js
@@ -1,5 +1,5 @@
 const cache = {};
-const req = require.context('./', false, /\.js$/);
+const req = require.context('./', false, /\.(js|tsx)$/);
 
 req.keys().forEach(filename => {
   cache[filename.replace(/\.\/|\.js/g, '')] = req(filename).default;

--- a/next.config.js
+++ b/next.config.js
@@ -3,10 +3,11 @@ const pkg = require('./package.json');
 const withTM = require('next-plugin-transpile-modules');
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
 const { findPages } = require('./docs/src/modules/utils/find');
+const withTypescript = require('@zeit/next-typescript');
 
 const LANGUAGES = ['en', 'zh', 'ru', 'pt', 'fr', 'es', 'de'];
 
-module.exports = {
+module.exports = withTypescript({
   webpack: (config, options) => {
     // Alias @material-ui/core peer dependency imports form the following modules to our sources.
     config = withTM({
@@ -97,4 +98,4 @@ module.exports = {
     // Number of pages that should be kept simultaneously without being disposed
     pagesBufferLength: 3, // default 2
   },
-};
+});

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@types/react-swipeable-views": "^0.13.0",
     "@types/react-text-mask": "^5.4.2",
     "@types/styled-components": "^4.1.11",
+    "@zeit/next-typescript": "^1.1.1",
     "argos-cli": "^0.1.1",
     "autoprefixer": "^9.0.0",
     "autosuggest-highlight": "^3.1.1",

--- a/pages/css-in-js/advanced.js
+++ b/pages/css-in-js/advanced.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/css-in-js/advanced', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/css-in-js/advanced', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/css-in-js/advanced',
   false,

--- a/pages/css-in-js/advanced.js
+++ b/pages/css-in-js/advanced.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/css-in-js/advanced', false, /\.(md|j
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/css-in-js/advanced',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/css-in-js/advanced';
 

--- a/pages/css-in-js/api.js
+++ b/pages/css-in-js/api.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/css-in-js/api', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/css-in-js/api', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/css-in-js/api', false, /\.js$/);
 const reqPrefix = 'pages/css-in-js/api';
 

--- a/pages/css-in-js/api.js
+++ b/pages/css-in-js/api.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/css-in-js/api', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/css-in-js/api', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/css-in-js/api',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/css-in-js/api';
 
 function Page() {

--- a/pages/css-in-js/basics.js
+++ b/pages/css-in-js/basics.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/css-in-js/basics', false, /\.(md|js|
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/css-in-js/basics',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/css-in-js/basics';
 

--- a/pages/css-in-js/basics.js
+++ b/pages/css-in-js/basics.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/css-in-js/basics', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/css-in-js/basics', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/css-in-js/basics',
   false,

--- a/pages/customization/default-theme.js
+++ b/pages/customization/default-theme.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/customization/default-theme', false,
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/customization/default-theme',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/customization/default-theme';
 

--- a/pages/customization/default-theme.js
+++ b/pages/customization/default-theme.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/customization/default-theme', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/customization/default-theme', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/customization/default-theme',
   false,

--- a/pages/customization/overrides.js
+++ b/pages/customization/overrides.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/customization/overrides', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/customization/overrides', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/customization/overrides',
   false,

--- a/pages/customization/overrides.js
+++ b/pages/customization/overrides.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/customization/overrides', false, /\.
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/customization/overrides',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/customization/overrides';
 

--- a/pages/customization/themes.js
+++ b/pages/customization/themes.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/customization/themes', false, /\.(md
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/customization/themes',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/customization/themes';
 

--- a/pages/customization/themes.js
+++ b/pages/customization/themes.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/customization/themes', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/customization/themes', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/customization/themes',
   false,

--- a/pages/demos/app-bar.js
+++ b/pages/demos/app-bar.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/app-bar', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/app-bar', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/app-bar',
   false,

--- a/pages/demos/autocomplete.js
+++ b/pages/demos/autocomplete.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/autocomplete', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/autocomplete', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/autocomplete',
   false,

--- a/pages/demos/avatars.js
+++ b/pages/demos/avatars.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/avatars', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/avatars', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/avatars',
   false,

--- a/pages/demos/badges.js
+++ b/pages/demos/badges.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/badges', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/badges', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/badges',
   false,

--- a/pages/demos/bottom-navigation.js
+++ b/pages/demos/bottom-navigation.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/bottom-navigation', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/bottom-navigation', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/bottom-navigation',
   false,

--- a/pages/demos/breadcrumbs.js
+++ b/pages/demos/breadcrumbs.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/breadcrumbs', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/breadcrumbs', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/breadcrumbs',
   false,

--- a/pages/demos/buttons.js
+++ b/pages/demos/buttons.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/buttons', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/buttons', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/buttons',
   false,

--- a/pages/demos/cards.js
+++ b/pages/demos/cards.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/cards', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/cards', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/cards',
   false,

--- a/pages/demos/chips.js
+++ b/pages/demos/chips.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/chips', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/chips', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/chips',
   false,

--- a/pages/demos/dialogs.js
+++ b/pages/demos/dialogs.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/dialogs', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/dialogs', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/dialogs',
   false,

--- a/pages/demos/dividers.js
+++ b/pages/demos/dividers.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/dividers', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/dividers', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/dividers',
   false,

--- a/pages/demos/drawers.js
+++ b/pages/demos/drawers.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/drawers', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/drawers', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/drawers',
   false,

--- a/pages/demos/expansion-panels.js
+++ b/pages/demos/expansion-panels.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/expansion-panels', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/expansion-panels', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/expansion-panels',
   false,

--- a/pages/demos/grid-list.js
+++ b/pages/demos/grid-list.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/grid-list', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/grid-list', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/grid-list',
   false,

--- a/pages/demos/lists.js
+++ b/pages/demos/lists.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/lists', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/lists', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/lists',
   false,

--- a/pages/demos/menus.js
+++ b/pages/demos/menus.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/menus', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/menus', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/menus',
   false,

--- a/pages/demos/paper.js
+++ b/pages/demos/paper.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/paper', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/paper', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/paper',
   false,

--- a/pages/demos/pickers.js
+++ b/pages/demos/pickers.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/pickers', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/pickers', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/pickers',
   false,

--- a/pages/demos/progress.js
+++ b/pages/demos/progress.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/progress', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/progress', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/progress',
   false,

--- a/pages/demos/selection-controls.js
+++ b/pages/demos/selection-controls.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/selection-controls', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/selection-controls', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/selection-controls',
   false,

--- a/pages/demos/selects.js
+++ b/pages/demos/selects.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/selects', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/selects', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/selects',
   false,

--- a/pages/demos/snackbars.js
+++ b/pages/demos/snackbars.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/snackbars', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/snackbars', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/snackbars',
   false,

--- a/pages/demos/steppers.js
+++ b/pages/demos/steppers.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/steppers', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/steppers', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/steppers',
   false,

--- a/pages/demos/tables.js
+++ b/pages/demos/tables.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/tables', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/tables', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/tables',
   false,

--- a/pages/demos/tabs.js
+++ b/pages/demos/tabs.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/tabs', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/tabs', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/tabs',
   false,

--- a/pages/demos/text-fields.js
+++ b/pages/demos/text-fields.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/text-fields', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/text-fields', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/text-fields',
   false,

--- a/pages/demos/tooltips.js
+++ b/pages/demos/tooltips.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/demos/tooltips', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/demos/tooltips', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/demos/tooltips',
   false,

--- a/pages/discover-more/changelog.js
+++ b/pages/discover-more/changelog.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/discover-more/changelog', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/discover-more/changelog', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/changelog',
   false,

--- a/pages/discover-more/changelog.js
+++ b/pages/discover-more/changelog.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/discover-more/changelog', false, /\.
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/changelog',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/discover-more/changelog';
 

--- a/pages/discover-more/community.js
+++ b/pages/discover-more/community.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/discover-more/community', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/discover-more/community', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/community',
   false,

--- a/pages/discover-more/community.js
+++ b/pages/discover-more/community.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/discover-more/community', false, /\.
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/community',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/discover-more/community';
 

--- a/pages/discover-more/languages.js
+++ b/pages/discover-more/languages.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/discover-more/languages', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/discover-more/languages', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/languages',
   false,

--- a/pages/discover-more/languages.js
+++ b/pages/discover-more/languages.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/discover-more/languages', false, /\.
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/languages',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/discover-more/languages';
 

--- a/pages/discover-more/related-projects.js
+++ b/pages/discover-more/related-projects.js
@@ -11,7 +11,7 @@ const req = require.context(
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/related-projects',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/discover-more/related-projects';
 

--- a/pages/discover-more/related-projects.js
+++ b/pages/discover-more/related-projects.js
@@ -3,7 +3,11 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/discover-more/related-projects', false, /\.md|\.js$/);
+const req = require.context(
+  'docs/src/pages/discover-more/related-projects',
+  false,
+  /\.(md|js|tsx)$/,
+);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/related-projects',
   false,

--- a/pages/discover-more/showcase.js
+++ b/pages/discover-more/showcase.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/discover-more/showcase', false, /\.(
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/showcase',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/discover-more/showcase';
 

--- a/pages/discover-more/showcase.js
+++ b/pages/discover-more/showcase.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/discover-more/showcase', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/discover-more/showcase', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/showcase',
   false,

--- a/pages/discover-more/team.js
+++ b/pages/discover-more/team.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/discover-more/team', false, /\.(md|j
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/team',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/discover-more/team';
 

--- a/pages/discover-more/team.js
+++ b/pages/discover-more/team.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/discover-more/team', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/discover-more/team', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/team',
   false,

--- a/pages/discover-more/vision.js
+++ b/pages/discover-more/vision.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/discover-more/vision', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/discover-more/vision', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/vision',
   false,

--- a/pages/discover-more/vision.js
+++ b/pages/discover-more/vision.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/discover-more/vision', false, /\.(md
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/discover-more/vision',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/discover-more/vision';
 

--- a/pages/getting-started/example-projects.js
+++ b/pages/getting-started/example-projects.js
@@ -3,7 +3,11 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/getting-started/example-projects', false, /\.md|\.js$/);
+const req = require.context(
+  'docs/src/pages/getting-started/example-projects',
+  false,
+  /\.(md|js|tsx)$/,
+);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/example-projects',
   false,

--- a/pages/getting-started/example-projects.js
+++ b/pages/getting-started/example-projects.js
@@ -11,7 +11,7 @@ const req = require.context(
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/example-projects',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/getting-started/example-projects';
 

--- a/pages/getting-started/faq.js
+++ b/pages/getting-started/faq.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/getting-started/faq', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/getting-started/faq', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/faq',
   false,

--- a/pages/getting-started/faq.js
+++ b/pages/getting-started/faq.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/getting-started/faq', false, /\.(md|
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/faq',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/getting-started/faq';
 

--- a/pages/getting-started/installation.js
+++ b/pages/getting-started/installation.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/getting-started/installation', false
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/installation',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/getting-started/installation';
 

--- a/pages/getting-started/installation.js
+++ b/pages/getting-started/installation.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/getting-started/installation', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/getting-started/installation', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/installation',
   false,

--- a/pages/getting-started/learn.js
+++ b/pages/getting-started/learn.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/getting-started/learn', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/getting-started/learn', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/learn',
   false,

--- a/pages/getting-started/learn.js
+++ b/pages/getting-started/learn.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/getting-started/learn', false, /\.(m
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/learn',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/getting-started/learn';
 

--- a/pages/getting-started/page-layout-examples.js
+++ b/pages/getting-started/page-layout-examples.js
@@ -11,7 +11,7 @@ const req = require.context(
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/page-layout-examples',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/getting-started/page-layout-examples';
 

--- a/pages/getting-started/supported-components.js
+++ b/pages/getting-started/supported-components.js
@@ -11,7 +11,7 @@ const req = require.context(
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/supported-components',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/getting-started/supported-components';
 

--- a/pages/getting-started/supported-platforms.js
+++ b/pages/getting-started/supported-platforms.js
@@ -11,7 +11,7 @@ const req = require.context(
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/supported-platforms',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/getting-started/supported-platforms';
 

--- a/pages/getting-started/usage.js
+++ b/pages/getting-started/usage.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/getting-started/usage', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/getting-started/usage', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/usage',
   false,

--- a/pages/getting-started/usage.js
+++ b/pages/getting-started/usage.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/getting-started/usage', false, /\.(m
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/getting-started/usage',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/getting-started/usage';
 

--- a/pages/guides/api.js
+++ b/pages/guides/api.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/guides/api', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/guides/api', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/guides/api',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/guides/api';
 
 function Page() {

--- a/pages/guides/api.js
+++ b/pages/guides/api.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/api', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/api', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/guides/api', false, /\.js$/);
 const reqPrefix = 'pages/guides/api';
 

--- a/pages/guides/composition.js
+++ b/pages/guides/composition.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/guides/composition', false, /\.(md|j
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/composition',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/composition';
 

--- a/pages/guides/composition.js
+++ b/pages/guides/composition.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/composition', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/composition', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/composition',
   false,

--- a/pages/guides/flow.js
+++ b/pages/guides/flow.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/guides/flow', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/guides/flow', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/guides/flow',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/guides/flow';
 
 function Page() {

--- a/pages/guides/flow.js
+++ b/pages/guides/flow.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/flow', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/flow', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/guides/flow', false, /\.js$/);
 const reqPrefix = 'pages/guides/flow';
 

--- a/pages/guides/interoperability.js
+++ b/pages/guides/interoperability.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/guides/interoperability', false, /\.
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/interoperability',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/interoperability';
 

--- a/pages/guides/interoperability.js
+++ b/pages/guides/interoperability.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/interoperability', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/interoperability', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/interoperability',
   false,

--- a/pages/guides/migration-v0x.js
+++ b/pages/guides/migration-v0x.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/migration-v0x', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/migration-v0x', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/migration-v0x',
   false,

--- a/pages/guides/migration-v0x.js
+++ b/pages/guides/migration-v0x.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/guides/migration-v0x', false, /\.(md
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/migration-v0x',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/migration-v0x';
 

--- a/pages/guides/migration-v3.js
+++ b/pages/guides/migration-v3.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/migration-v3', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/migration-v3', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/migration-v3',
   false,

--- a/pages/guides/migration-v3.js
+++ b/pages/guides/migration-v3.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/guides/migration-v3', false, /\.(md|
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/migration-v3',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/migration-v3';
 

--- a/pages/guides/minimizing-bundle-size.js
+++ b/pages/guides/minimizing-bundle-size.js
@@ -11,7 +11,7 @@ const req = require.context(
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/minimizing-bundle-size',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/minimizing-bundle-size';
 

--- a/pages/guides/minimizing-bundle-size.js
+++ b/pages/guides/minimizing-bundle-size.js
@@ -3,7 +3,11 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/minimizing-bundle-size', false, /\.md|\.js$/);
+const req = require.context(
+  'docs/src/pages/guides/minimizing-bundle-size',
+  false,
+  /\.(md|js|tsx)$/,
+);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/minimizing-bundle-size',
   false,

--- a/pages/guides/right-to-left.js
+++ b/pages/guides/right-to-left.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/guides/right-to-left', false, /\.(md
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/right-to-left',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/right-to-left';
 

--- a/pages/guides/right-to-left.js
+++ b/pages/guides/right-to-left.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/right-to-left', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/right-to-left', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/right-to-left',
   false,

--- a/pages/guides/server-rendering.js
+++ b/pages/guides/server-rendering.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/server-rendering', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/server-rendering', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/server-rendering',
   false,

--- a/pages/guides/server-rendering.js
+++ b/pages/guides/server-rendering.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/guides/server-rendering', false, /\.
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/server-rendering',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/server-rendering';
 

--- a/pages/guides/testing.js
+++ b/pages/guides/testing.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/guides/testing', false, /\.(md|js|ts
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/testing',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/testing';
 

--- a/pages/guides/testing.js
+++ b/pages/guides/testing.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/testing', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/testing', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/testing',
   false,

--- a/pages/guides/typescript.js
+++ b/pages/guides/typescript.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/guides/typescript', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/guides/typescript', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/typescript',
   false,

--- a/pages/guides/typescript.js
+++ b/pages/guides/typescript.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/guides/typescript', false, /\.(md|js
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/guides/typescript',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/guides/typescript';
 

--- a/pages/lab/about.js
+++ b/pages/lab/about.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/lab/about', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/lab/about', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/lab/about',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/lab/about';
 
 function Page() {

--- a/pages/lab/about.js
+++ b/pages/lab/about.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/lab/about', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/lab/about', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/lab/about', false, /\.js$/);
 const reqPrefix = 'pages/lab/about';
 

--- a/pages/lab/slider.js
+++ b/pages/lab/slider.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/lab/slider', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/lab/slider', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/lab/slider', false, /\.js$/);
 const reqPrefix = 'pages/lab/slider';
 

--- a/pages/lab/slider.js
+++ b/pages/lab/slider.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/lab/slider', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/lab/slider', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/lab/slider',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/lab/slider';
 
 function Page() {

--- a/pages/lab/speed-dial.js
+++ b/pages/lab/speed-dial.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/lab/speed-dial', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/lab/speed-dial', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/lab/speed-dial',
   false,

--- a/pages/lab/speed-dial.js
+++ b/pages/lab/speed-dial.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/lab/speed-dial', false, /\.(md|js|ts
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/lab/speed-dial',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/lab/speed-dial';
 

--- a/pages/lab/toggle-button.js
+++ b/pages/lab/toggle-button.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/lab/toggle-button', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/lab/toggle-button', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/lab/toggle-button',
   false,

--- a/pages/lab/toggle-button.js
+++ b/pages/lab/toggle-button.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/lab/toggle-button', false, /\.(md|js
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/lab/toggle-button',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/lab/toggle-button';
 

--- a/pages/layout/basics.js
+++ b/pages/layout/basics.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/layout/basics', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/layout/basics', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/layout/basics', false, /\.js$/);
 const reqPrefix = 'pages/layout/basics';
 

--- a/pages/layout/basics.js
+++ b/pages/layout/basics.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/layout/basics', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/layout/basics', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/layout/basics',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/layout/basics';
 
 function Page() {

--- a/pages/layout/breakpoints.js
+++ b/pages/layout/breakpoints.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/layout/breakpoints', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/layout/breakpoints', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/layout/breakpoints',
   false,

--- a/pages/layout/breakpoints.js
+++ b/pages/layout/breakpoints.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/layout/breakpoints', false, /\.(md|j
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/layout/breakpoints',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/layout/breakpoints';
 

--- a/pages/layout/container.js
+++ b/pages/layout/container.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/layout/container', false, /\.(md|js|
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/layout/container',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/layout/container';
 

--- a/pages/layout/container.js
+++ b/pages/layout/container.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/layout/container', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/layout/container', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/layout/container',
   false,

--- a/pages/layout/grid.js
+++ b/pages/layout/grid.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/layout/grid', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/layout/grid', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/layout/grid', false, /\.js$/);
 const reqPrefix = 'pages/layout/grid';
 

--- a/pages/layout/grid.js
+++ b/pages/layout/grid.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/layout/grid', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/layout/grid', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/layout/grid',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/layout/grid';
 
 function Page() {

--- a/pages/layout/hidden.js
+++ b/pages/layout/hidden.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/layout/hidden', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/layout/hidden', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/layout/hidden', false, /\.js$/);
 const reqPrefix = 'pages/layout/hidden';
 

--- a/pages/layout/hidden.js
+++ b/pages/layout/hidden.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/layout/hidden', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/layout/hidden', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/layout/hidden',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/layout/hidden';
 
 function Page() {

--- a/pages/layout/use-media-query.js
+++ b/pages/layout/use-media-query.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/layout/use-media-query', false, /\.(
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/layout/use-media-query',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/layout/use-media-query';
 

--- a/pages/layout/use-media-query.js
+++ b/pages/layout/use-media-query.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/layout/use-media-query', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/layout/use-media-query', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/layout/use-media-query',
   false,

--- a/pages/premium-themes.js
+++ b/pages/premium-themes.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/premium-themes', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../docs/src/pages/premium-themes', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../docs/src/pages/premium-themes',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/premium-themes';
 
 function Page() {

--- a/pages/premium-themes.js
+++ b/pages/premium-themes.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/premium-themes', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/premium-themes', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../docs/src/pages/premium-themes', false, /\.js$/);
 const reqPrefix = 'pages/premium-themes';
 

--- a/pages/style/color.js
+++ b/pages/style/color.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/style/color', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/style/color', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/style/color',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/style/color';
 
 function Page() {

--- a/pages/style/color.js
+++ b/pages/style/color.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/style/color', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/style/color', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/style/color', false, /\.js$/);
 const reqPrefix = 'pages/style/color';
 

--- a/pages/style/css-baseline.js
+++ b/pages/style/css-baseline.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/style/css-baseline', false, /\.(md|j
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/style/css-baseline',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/style/css-baseline';
 

--- a/pages/style/css-baseline.js
+++ b/pages/style/css-baseline.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/style/css-baseline', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/style/css-baseline', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/style/css-baseline',
   false,

--- a/pages/style/icons.js
+++ b/pages/style/icons.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/style/icons', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/style/icons', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/style/icons',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/style/icons';
 
 function Page() {

--- a/pages/style/icons.js
+++ b/pages/style/icons.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/style/icons', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/style/icons', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/style/icons', false, /\.js$/);
 const reqPrefix = 'pages/style/icons';
 

--- a/pages/style/links.js
+++ b/pages/style/links.js
@@ -3,7 +3,7 @@ import '../../docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/style/links', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/style/links', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/style/links', false, /\.js$/);
 const reqPrefix = 'pages/style/links';
 

--- a/pages/style/links.js
+++ b/pages/style/links.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/style/links', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/style/links', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/style/links',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/style/links';
 
 function Page() {

--- a/pages/style/typography.js
+++ b/pages/style/typography.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/style/typography', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/style/typography', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/style/typography',
   false,

--- a/pages/system/api.js
+++ b/pages/system/api.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/api', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/api', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/system/api', false, /\.js$/);
 const reqPrefix = 'pages/system/api';
 

--- a/pages/system/api.js
+++ b/pages/system/api.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/system/api', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/system/api', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/system/api',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/system/api';
 
 function Page() {

--- a/pages/system/basics.js
+++ b/pages/system/basics.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/basics', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/basics', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/system/basics', false, /\.js$/);
 const reqPrefix = 'pages/system/basics';
 

--- a/pages/system/basics.js
+++ b/pages/system/basics.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/system/basics', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/system/basics', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/system/basics',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/system/basics';
 
 function Page() {

--- a/pages/system/borders.js
+++ b/pages/system/borders.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/system/borders', false, /\.(md|js|ts
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/borders',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/system/borders';
 

--- a/pages/system/borders.js
+++ b/pages/system/borders.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/borders', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/borders', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/borders',
   false,

--- a/pages/system/display.js
+++ b/pages/system/display.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/system/display', false, /\.(md|js|ts
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/display',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/system/display';
 

--- a/pages/system/display.js
+++ b/pages/system/display.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/display', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/display', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/display',
   false,

--- a/pages/system/flexbox.js
+++ b/pages/system/flexbox.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/system/flexbox', false, /\.(md|js|ts
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/flexbox',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/system/flexbox';
 

--- a/pages/system/flexbox.js
+++ b/pages/system/flexbox.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/flexbox', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/flexbox', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/flexbox',
   false,

--- a/pages/system/palette.js
+++ b/pages/system/palette.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/palette', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/palette', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/palette',
   false,

--- a/pages/system/palette.js
+++ b/pages/system/palette.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/system/palette', false, /\.(md|js|ts
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/palette',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/system/palette';
 

--- a/pages/system/positions.js
+++ b/pages/system/positions.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/positions', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/positions', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/positions',
   false,

--- a/pages/system/positions.js
+++ b/pages/system/positions.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/system/positions', false, /\.(md|js|
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/positions',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/system/positions';
 

--- a/pages/system/shadows.js
+++ b/pages/system/shadows.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/system/shadows', false, /\.(md|js|ts
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/shadows',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/system/shadows';
 

--- a/pages/system/shadows.js
+++ b/pages/system/shadows.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/shadows', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/shadows', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/shadows',
   false,

--- a/pages/system/sizing.js
+++ b/pages/system/sizing.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/system/sizing', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/system/sizing', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/system/sizing',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/system/sizing';
 
 function Page() {

--- a/pages/system/sizing.js
+++ b/pages/system/sizing.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/sizing', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/sizing', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/system/sizing', false, /\.js$/);
 const reqPrefix = 'pages/system/sizing';
 

--- a/pages/system/spacing.js
+++ b/pages/system/spacing.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/spacing', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/spacing', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/spacing',
   false,

--- a/pages/system/spacing.js
+++ b/pages/system/spacing.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/system/spacing', false, /\.(md|js|ts
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/spacing',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/system/spacing';
 

--- a/pages/system/typography.js
+++ b/pages/system/typography.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/system/typography', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/system/typography', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/typography',
   false,

--- a/pages/system/typography.js
+++ b/pages/system/typography.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/system/typography', false, /\.(md|js
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/system/typography',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/system/typography';
 

--- a/pages/utils/box.js
+++ b/pages/utils/box.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/utils/box', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/box', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/utils/box',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/utils/box';
 
 function Page() {

--- a/pages/utils/box.js
+++ b/pages/utils/box.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/utils/box', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/utils/box', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/box', false, /\.js$/);
 const reqPrefix = 'pages/utils/box';
 

--- a/pages/utils/click-away-listener.js
+++ b/pages/utils/click-away-listener.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/utils/click-away-listener', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/utils/click-away-listener', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/utils/click-away-listener',
   false,

--- a/pages/utils/click-away-listener.js
+++ b/pages/utils/click-away-listener.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/utils/click-away-listener', false, /
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/utils/click-away-listener',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/utils/click-away-listener';
 

--- a/pages/utils/modal.js
+++ b/pages/utils/modal.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/utils/modal', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/utils/modal', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/modal', false, /\.js$/);
 const reqPrefix = 'pages/utils/modal';
 

--- a/pages/utils/modal.js
+++ b/pages/utils/modal.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/utils/modal', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/modal', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/utils/modal',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/utils/modal';
 
 function Page() {

--- a/pages/utils/no-ssr.js
+++ b/pages/utils/no-ssr.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/utils/no-ssr', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/no-ssr', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/utils/no-ssr',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/utils/no-ssr';
 
 function Page() {

--- a/pages/utils/no-ssr.js
+++ b/pages/utils/no-ssr.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/utils/no-ssr', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/utils/no-ssr', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/no-ssr', false, /\.js$/);
 const reqPrefix = 'pages/utils/no-ssr';
 

--- a/pages/utils/popover.js
+++ b/pages/utils/popover.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/utils/popover', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/popover', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/utils/popover',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/utils/popover';
 
 function Page() {

--- a/pages/utils/popover.js
+++ b/pages/utils/popover.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/utils/popover', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/utils/popover', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/popover', false, /\.js$/);
 const reqPrefix = 'pages/utils/popover';
 

--- a/pages/utils/popper.js
+++ b/pages/utils/popper.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/utils/popper', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/utils/popper', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/popper', false, /\.js$/);
 const reqPrefix = 'pages/utils/popper';
 

--- a/pages/utils/popper.js
+++ b/pages/utils/popper.js
@@ -4,7 +4,11 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/utils/popper', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../../docs/src/pages/utils/popper', false, /\.js$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/utils/popper',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/utils/popper';
 
 function Page() {

--- a/pages/utils/portal.js
+++ b/pages/utils/portal.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/utils/portal', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/utils/portal', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/utils/portal',
   false,

--- a/pages/utils/transitions.js
+++ b/pages/utils/transitions.js
@@ -7,7 +7,7 @@ const req = require.context('docs/src/pages/utils/transitions', false, /\.(md|js
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/utils/transitions',
   false,
-  /\.js$/,
+  /\.(js|tsx)$/,
 );
 const reqPrefix = 'pages/utils/transitions';
 

--- a/pages/utils/transitions.js
+++ b/pages/utils/transitions.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/utils/transitions', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/utils/transitions', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
   '!raw-loader!../../docs/src/pages/utils/transitions',
   false,

--- a/pages/versions.js
+++ b/pages/versions.js
@@ -4,7 +4,7 @@ import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
 const req = require.context('docs/src/pages/versions', false, /\.(md|js|tsx)$/);
-const reqSource = require.context('!raw-loader!../docs/src/pages/versions', false, /\.js$/);
+const reqSource = require.context('!raw-loader!../docs/src/pages/versions', false, /\.(js|tsx)$/);
 const reqPrefix = 'pages/versions';
 
 function Page() {

--- a/pages/versions.js
+++ b/pages/versions.js
@@ -3,7 +3,7 @@ import 'docs/src/modules/components/bootstrap';
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-const req = require.context('docs/src/pages/versions', false, /\.md|\.js$/);
+const req = require.context('docs/src/pages/versions', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../docs/src/pages/versions', false, /\.js$/);
 const reqPrefix = 'pages/versions';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1055,7 +1055,7 @@
     "@babel/plugin-transform-react-jsx-self" "^7.0.0"
     "@babel/plugin-transform-react-jsx-source" "^7.0.0"
 
-"@babel/preset-typescript@^7.1.0":
+"@babel/preset-typescript@^7.0.0", "@babel/preset-typescript@^7.1.0":
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.3.3.tgz#88669911053fa16b2b276ea2ede2ca603b3f307a"
   integrity sha512-mzMVuIP4lqtn4du2ynEfdO0+RYcslwrZiJHXu4MGaC1ctJiW2fyaeDrtjJGs7R/KebZ1sgowcIoWf4uRpEfKEg==
@@ -2530,6 +2530,13 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
+
+"@zeit/next-typescript@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@zeit/next-typescript/-/next-typescript-1.1.1.tgz#0b0ddfbb13ca04cde52ac2718473f1b9c40ba0ee"
+  integrity sha512-EUcHCASftz1Bc80djkf3cKJrFgvFQyODOH1kty7ShVLLdXMaZpRLj+z7RxrCoNo1bP06w0vtXEDU0cKa0HmGgg==
+  dependencies:
+    "@babel/preset-typescript" "^7.0.0"
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
This change is running the TypeScript demos when the code variant is selected. It will significantly improve my workflow. Now, I can iterate on the TypeScript demo variants, then run `docs:typescript:formatted`. I do no longer have to worry about the JavaScript demos.

*I have only migrated the snackbar*