### PR TITLE
[MenuItem]: add prop for ListItem classes

### DIFF
--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -28,7 +28,16 @@ export const styles = theme => ({
 });
 
 const MenuItem = React.forwardRef(function MenuItem(props, ref) {
-  const { classes, className, component, disableGutters, role, selected, ...other } = props;
+  const {
+    classes,
+    className,
+    component,
+    disableGutters,
+    role,
+    selected,
+    ListItemClasses,
+    ...other
+  } = props;
 
   return (
     <ListItem
@@ -37,6 +46,7 @@ const MenuItem = React.forwardRef(function MenuItem(props, ref) {
       tabIndex={-1}
       component={component}
       selected={selected}
+      classes={ListItemClasses}
       disableGutters={disableGutters}
       className={clsx(
         classes.root,
@@ -75,6 +85,10 @@ MenuItem.propTypes = {
    * If `true`, the left and right padding is removed.
    */
   disableGutters: PropTypes.bool,
+  /**
+   * `classes` property applied to the [`ListItem`](/api/list-item/) element.
+   */
+  ListItemClasses: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -34,6 +34,13 @@ describe('<MenuItem />', () => {
     testComponentPropWith: 'a',
   }));
 
+  describe('prop: ListItemClasses', () => {
+    it('should be able to change the ListItem style', () => {
+      const wrapper = shallow(<MenuItem ListItemClasses={{ root: 'bar' }} />);
+      assert.strictEqual(wrapper.find(ListItem).props().classes.root, 'bar');
+    });
+  });
+
   it('should render a button ListItem with with ripple', () => {
     const wrapper = shallow(<MenuItem />);
     assert.strictEqual(wrapper.type(), ListItem);

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -22,6 +22,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |   | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'li'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">disableGutters</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the left and right padding is removed. |
+| <span class="prop-name">ListItemClasses</span> | <span class="prop-type">object</span> |   | `classes` property applied to the [`ListItem`](/api/list-item/) element. |
 
 Any other properties supplied will be spread to the root element ([ListItem](/api/list-item/)).
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

As far as I could tell, there was no way to modify the `ListItem` classes. I used the same methodology as the `Menu` does for changing the child `Popover` classes.