### PR TITLE
[Grid] Add root class

### DIFF
--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -93,6 +93,8 @@ function generateGutter(theme, breakpoint) {
 // flexWrap: 'nowrap',
 // justifyContent: 'flex-start',
 export const styles = theme => ({
+  /* Styles applied to the root element */
+  root: {},
   /* Styles applied to the root element if `container={true}`. */
   container: {
     boxSizing: 'border-box',
@@ -216,6 +218,7 @@ const Grid = React.forwardRef((props, ref) => {
   } = props;
 
   const className = clsx(
+    classes.root,
     {
       [classes.container]: container,
       [classes.item]: item,

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -20,9 +20,11 @@ describe('<Grid />', () => {
   });
 
   describeConformance(<Grid />, () => ({
+    classes,
+    inheritComponent: 'div',
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: 'span',
   }));
 
   it('should render', () => {

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -46,6 +46,7 @@ This property accepts the following keys:
 
 | Name | Description |
 |:-----|:------------|
+| <span class="prop-name">root</span> | Styles applied to the root element
 | <span class="prop-name">container</span> | Styles applied to the root element if `container={true}`.
 | <span class="prop-name">item</span> | Styles applied to the root element if `item={true}`.
 | <span class="prop-name">zeroMinWidth</span> | Styles applied to the root element if `zeroMinWidth={true}`.


### PR DESCRIPTION
Brings the CSS API in line with the other components. Allows for theme wide style customization of any `Grid` component.