### PR TITLE
[test] Decouple root class from root component

### DIFF
--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -7,6 +7,7 @@ import {
   getClasses,
 } from '@material-ui/core/test-utils';
 import Backdrop from './Backdrop';
+import Fade from '../Fade';
 
 describe('<Backdrop />', () => {
   let mount;
@@ -24,9 +25,11 @@ describe('<Backdrop />', () => {
   });
 
   describeConformance(<Backdrop open />, () => ({
+    classes,
+    inheritComponent: Fade,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: false,
   }));
 
   it('should render a backdrop div', () => {

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -9,7 +9,6 @@ import {
   getClasses,
   unwrap,
 } from '@material-ui/core/test-utils';
-import { Transition } from 'react-transition-group';
 import Collapse from './Collapse';
 
 describe('<Collapse />', () => {
@@ -33,7 +32,7 @@ describe('<Collapse />', () => {
 
   describeConformance(<Collapse {...props} />, () => ({
     classes,
-    inheritComponent: Transition,
+    inheritComponent: 'Transition',
     mount,
     skip: ['refForwarding'],
     testComponentPropWith: false,

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -2,10 +2,18 @@ import React from 'react';
 import { ReactWrapper } from 'enzyme';
 import { assert } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { createShallow, createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
+import {
+  createShallow,
+  createMount,
+  describeConformance,
+  getClasses,
+  unwrap,
+} from '@material-ui/core/test-utils';
+import { Transition } from 'react-transition-group';
 import Collapse from './Collapse';
 
 describe('<Collapse />', () => {
+  let mount;
   let shallow;
   let classes;
   const props = {
@@ -14,14 +22,22 @@ describe('<Collapse />', () => {
   };
 
   before(() => {
+    mount = createMount();
     shallow = createShallow({ dive: true });
     classes = getClasses(<Collapse {...props} />);
   });
 
-  it('should render a Transition', () => {
-    const wrapper = shallow(<Collapse {...props} />);
-    assert.strictEqual(wrapper.name(), 'Transition');
+  after(() => {
+    mount.cleanUp();
   });
+
+  describeConformance(<Collapse {...props} />, () => ({
+    classes,
+    inheritComponent: Transition,
+    mount,
+    skip: ['refForwarding'],
+    testComponentPropWith: false,
+  }));
 
   it('should render a container around the wrapper', () => {
     const wrapper = shallow(<Collapse {...props} classes={{ container: 'woofCollapse1' }} />);
@@ -364,17 +380,11 @@ describe('<Collapse />', () => {
   });
 
   describe('mount', () => {
-    let mount;
     let mountInstance;
 
     before(() => {
-      mount = createMount();
       const CollapseNaked = unwrap(Collapse);
       mountInstance = mount(<CollapseNaked classes={{}} theme={{}} />).instance();
-    });
-
-    after(() => {
-      mount.cleanUp();
     });
 
     it('instance should have a wrapper property', () => {

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createMount, describeConformance } from '@material-ui/core/test-utils';
-import { Transition } from 'react-transition-group';
 import Fade from './Fade';
 
 describe('<Fade />', () => {
@@ -23,7 +22,7 @@ describe('<Fade />', () => {
 
   describeConformance(<Fade {...defaultProps} />, () => ({
     classes: {},
-    inheritComponent: Transition,
+    inheritComponent: 'Transition',
     mount,
     skip: ['refForwarding'],
     testComponentPropWith: false,

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import { createMount, describeConformance } from '@material-ui/core/test-utils';
+import { Transition } from 'react-transition-group';
 import Fade from './Fade';
 
 describe('<Fade />', () => {
@@ -20,10 +21,13 @@ describe('<Fade />', () => {
     mount.cleanUp();
   });
 
-  it('should render a Transition', () => {
-    const wrapper = mount(<Fade {...defaultProps} />);
-    assert.strictEqual(wrapper.find('Transition').exists(), true);
-  });
+  describeConformance(<Fade {...defaultProps} />, () => ({
+    classes: {},
+    inheritComponent: Transition,
+    mount,
+    skip: ['refForwarding'],
+    testComponentPropWith: false,
+  }));
 
   describe('event callbacks', () => {
     describe('entering', () => {

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -7,6 +7,7 @@ import {
   getClasses,
 } from '@material-ui/core/test-utils';
 import FilledInput from './FilledInput';
+import InputBase from '../InputBase';
 
 describe('<FilledInput />', () => {
   let classes;
@@ -21,24 +22,23 @@ describe('<FilledInput />', () => {
     mount.cleanUp();
   });
 
-  describeConformance(<FilledInput />, () => ({
+  describeConformance(<FilledInput open />, () => ({
+    classes,
+    inheritComponent: InputBase,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: false,
   }));
 
-  it('should render a <div />', () => {
+  it('should have the underline class', () => {
     const wrapper = mount(<FilledInput />);
     const root = findOutermostIntrinsic(wrapper);
-    assert.strictEqual(root.type(), 'div');
-    assert.strictEqual(root.hasClass(classes.root), true);
     assert.strictEqual(root.hasClass(classes.underline), true);
   });
 
-  it('should disable the underline', () => {
+  it('can disable the underline', () => {
     const wrapper = mount(<FilledInput disableUnderline />);
     const root = findOutermostIntrinsic(wrapper);
-    assert.strictEqual(root.hasClass(classes.root), true);
     assert.strictEqual(root.hasClass(classes.underline), false);
   });
 });

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -19,6 +19,10 @@ describe('<Grid />', () => {
     classes = getClasses(<Grid />);
   });
 
+  after(() => {
+    mount.cleanUp();
+  });
+
   describeConformance(<Grid />, () => ({
     classes,
     inheritComponent: 'div',
@@ -26,12 +30,6 @@ describe('<Grid />', () => {
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
   }));
-
-  it('should render', () => {
-    const wrapper = shallow(<Grid className="woofGrid" />);
-    assert.strictEqual(wrapper.name(), 'div');
-    assert.strictEqual(wrapper.hasClass('woofGrid'), true);
-  });
 
   describe('prop: container', () => {
     it('should apply the container class', () => {
@@ -44,13 +42,6 @@ describe('<Grid />', () => {
     it('should apply the item class', () => {
       const wrapper = shallow(<Grid item />);
       assert.strictEqual(wrapper.hasClass(classes.item), true);
-    });
-  });
-
-  describe('prop: component', () => {
-    it('should change the component', () => {
-      const wrapper = shallow(<Grid component="span" />);
-      assert.strictEqual(wrapper.name(), 'span');
     });
   });
 

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import { createMount, describeConformance } from '@material-ui/core/test-utils';
 import Grow from './Grow';
 import { createMuiTheme } from '@material-ui/core/styles';
+import { Transition } from 'react-transition-group';
 
 describe('<Grow />', () => {
   let mount;
@@ -20,10 +21,18 @@ describe('<Grow />', () => {
     mount.cleanUp();
   });
 
-  it('should render a Transition', () => {
-    const wrapper = mount(<Grow {...defaultProps} />);
-    assert.strictEqual(wrapper.find('Transition').exists(), true);
-  });
+  describeConformance(
+    <Grow in>
+      <div />
+    </Grow>,
+    () => ({
+      classes: {},
+      inheritComponent: Transition,
+      mount,
+      skip: ['refForwarding'],
+      testComponentPropWith: false,
+    }),
+  );
 
   describe('event callbacks', () => {
     describe('entering', () => {

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -4,7 +4,6 @@ import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, describeConformance } from '@material-ui/core/test-utils';
 import Grow from './Grow';
 import { createMuiTheme } from '@material-ui/core/styles';
-import { Transition } from 'react-transition-group';
 
 describe('<Grow />', () => {
   let mount;
@@ -27,7 +26,7 @@ describe('<Grow />', () => {
     </Grow>,
     () => ({
       classes: {},
-      inheritComponent: Transition,
+      inheritComponent: 'Transition',
       mount,
       skip: ['refForwarding'],
       testComponentPropWith: false,

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -1,16 +1,14 @@
 import React from 'react';
-import { assert } from 'chai';
-import {
-  createMount,
-  describeConformance,
-  findOutermostIntrinsic,
-} from '@material-ui/core/test-utils';
+import { createMount, describeConformance, getClasses } from '@material-ui/core/test-utils';
 import Input from './Input';
+import InputBase from '../InputBase';
 
 describe('<Input />', () => {
+  let classes;
   let mount;
 
   before(() => {
+    classes = getClasses(<Input />);
     mount = createMount();
   });
 
@@ -19,13 +17,10 @@ describe('<Input />', () => {
   });
 
   describeConformance(<Input />, () => ({
+    classes,
+    inheritComponent: InputBase,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: false,
   }));
-
-  it('should render a <div />', () => {
-    const wrapper = mount(<Input />);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).type(), 'div');
-  });
 });

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -26,15 +26,12 @@ describe('<Menu />', () => {
   });
 
   describeConformance(<Menu {...defaultProps} open />, () => ({
+    classes,
+    inheritComponent: Popover,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: false,
   }));
-
-  it('should render a Popover', () => {
-    const wrapper = mount(<Menu {...defaultProps} />);
-    assert.strictEqual(wrapper.find(Popover).exists(), true);
-  });
 
   describe('event callbacks', () => {
     describe('entering', () => {
@@ -143,14 +140,6 @@ describe('<Menu />', () => {
           .exists(),
         true,
       );
-    });
-
-    it('should spread other props on the Popover', () => {
-      assert.strictEqual(wrapper.find(Popover).props()['data-test'], 'hi');
-    });
-
-    it('should have the user classes', () => {
-      assert.strictEqual(wrapper.find(Popover).hasClass('test-class'), true);
     });
   });
 

--- a/packages/material-ui/src/MenuList/MenuList.test.js
+++ b/packages/material-ui/src/MenuList/MenuList.test.js
@@ -4,6 +4,7 @@ import { stub } from 'sinon';
 import { createMount, describeConformance } from '@material-ui/core/test-utils';
 import MenuList from './MenuList';
 import getScrollbarSize from '../utils/getScrollbarSize';
+import List from '../List';
 
 function setStyleWidthForJsdomOrBrowser(style, width) {
   style.width = '';
@@ -27,23 +28,12 @@ describe('<MenuList />', () => {
   });
 
   describeConformance(<MenuList />, () => ({
+    classes: {},
+    inheritComponent: List,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLUListElement,
+    testComponentPropWith: false,
   }));
-
-  describe('list node', () => {
-    let wrapper;
-
-    before(() => {
-      wrapper = mount(<MenuList className="test-class" data-test="hi" />);
-    });
-
-    it('should render a List', () => {
-      assert.strictEqual(wrapper.props()['data-test'], 'hi');
-      assert.strictEqual(wrapper.hasClass('test-class'), true);
-    });
-  });
 
   describe('prop: children', () => {
     it('should support invalid children', () => {

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
-import { getClasses, createMount } from '@material-ui/core/test-utils';
+import { getClasses, createMount, describeConformance } from '@material-ui/core/test-utils';
 import Input from '../Input';
 import NativeSelect from './NativeSelect';
 
@@ -28,10 +28,14 @@ describe('<NativeSelect />', () => {
     mount.cleanUp();
   });
 
-  it('should render a correct top element', () => {
-    const wrapper = mount(<NativeSelect {...props} />);
-    assert.strictEqual(wrapper.find(Input).exists(), true);
-  });
+  describeConformance(<NativeSelect {...props} />, () => ({
+    classes,
+    inheritComponent: Input,
+    mount,
+    refInstanceof: window.HTMLDivElement,
+    skip: ['rootClass'],
+    testComponentPropWith: false,
+  }));
 
   it('should provide the classes to the input component', () => {
     const wrapper = mount(<NativeSelect {...props} />);

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -1,17 +1,16 @@
 import React from 'react';
 import { assert } from 'chai';
-import {
-  createMount,
-  describeConformance,
-  findOutermostIntrinsic,
-} from '@material-ui/core/test-utils';
+import { createMount, describeConformance, getClasses } from '@material-ui/core/test-utils';
 import OutlinedInput from './OutlinedInput';
 import NotchedOutline from './NotchedOutline';
+import InputBase from '../InputBase';
 
 describe('<OutlinedInput />', () => {
+  let classes;
   let mount;
 
   before(() => {
+    classes = getClasses(<OutlinedInput />);
     mount = createMount();
   });
 
@@ -20,17 +19,14 @@ describe('<OutlinedInput />', () => {
   });
 
   describeConformance(<OutlinedInput labelWidth={0} />, () => ({
+    classes,
+    inheritComponent: InputBase,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: false,
   }));
 
-  it('should render a <div />', () => {
-    const wrapper = mount(<OutlinedInput labelWidth={0} />);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).type(), 'div');
-  });
-
-  it('should mount', () => {
+  it('should render a NotchedOutline', () => {
     const wrapper = mount(<OutlinedInput labelWidth={0} />);
     assert.strictEqual(wrapper.find(NotchedOutline).length, 1);
   });

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -39,9 +39,11 @@ describe('<Popover />', () => {
   });
 
   describeConformance(<Popover {...defaultProps} open />, () => ({
+    classes,
+    inheritComponent: Modal,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: false,
   }));
 
   describe('root node', () => {

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
-import { createShallow, createMount } from '@material-ui/core/test-utils';
+import { createShallow, createMount, describeConformance } from '@material-ui/core/test-utils';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Grow from '../Grow';
 import Popper from './Popper';
@@ -10,31 +10,28 @@ import Popper from './Popper';
 describe('<Popper />', () => {
   let shallow;
   let mount;
-  let anchorEl;
-  let defaultProps;
+  const defaultProps = {
+    anchorEl: () => window.document.createElement('div'),
+    children: <span>Hello World</span>,
+    open: true,
+  };
 
   before(() => {
-    anchorEl = window.document.createElement('div');
-    window.document.body.appendChild(anchorEl);
     shallow = createShallow();
     mount = createMount();
-    defaultProps = {
-      anchorEl,
-      children: <span>Hello World</span>,
-      open: true,
-    };
   });
 
   after(() => {
     mount.cleanUp();
-    window.document.body.removeChild(anchorEl);
   });
 
-  it('should render the correct structure', () => {
-    const wrapper = shallow(<Popper {...defaultProps} />);
-    assert.strictEqual(wrapper.name(), 'Portal');
-    assert.strictEqual(wrapper.childAt(0).name(), 'div');
-  });
+  describeConformance(<Popper {...defaultProps} />, () => ({
+    classes: {},
+    inheritComponent: 'div',
+    mount,
+    refInstanceof: React.Component,
+    testComponentPropWith: false,
+  }));
 
   describe('prop: placement', () => {
     before(() => {

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -27,14 +27,15 @@ describe('<RadioGroup />', () => {
   }
 
   describeConformance(<RadioGroup value="" />, () => ({
+    classes: {},
+    inheritComponent: FormGroup,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    testComponentPropWith: false,
   }));
 
-  it('should render a FormGroup with the radiogroup role', () => {
+  it('the root component has the radiogroup role', () => {
     const wrapper = mount(<RadioGroup value="" />);
-    assert.strictEqual(wrapper.childAt(0).type(), FormGroup);
     assert.strictEqual(findOutermostIntrinsic(wrapper).props().role, 'radiogroup');
   });
 

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -32,15 +32,13 @@ describe('<Select />', () => {
   });
 
   describeConformance(<Select {...defaultProps} />, () => ({
+    classes,
+    inheritComponent: Input,
     mount,
-    only: ['refForwarding'],
     refInstanceof: window.HTMLDivElement,
+    skip: ['rootClass'],
+    testComponentPropWith: false,
   }));
-
-  it('should render a correct top element', () => {
-    const wrapper = mount(<Select {...defaultProps} />);
-    assert.strictEqual(wrapper.find(Input).exists(), true);
-  });
 
   it('should provide the classes to the input component', () => {
     const wrapper = mount(<Select {...defaultProps} />);

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -10,7 +10,6 @@ import {
 import Slide, { setTranslateValue } from './Slide';
 import transitions, { easing } from '../styles/transitions';
 import createMuiTheme from '../styles/createMuiTheme';
-import { Transition } from 'react-transition-group';
 
 describe('<Slide />', () => {
   let shallow;
@@ -37,7 +36,7 @@ describe('<Slide />', () => {
     </Slide>,
     () => ({
       classes: {},
-      inheritComponent: Transition,
+      inheritComponent: 'Transition',
       mount,
       refInstanceof: React.Component,
       testComponentPropWith: false,

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -1,10 +1,16 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import { createShallow, createMount, unwrap } from '@material-ui/core/test-utils';
+import {
+  createShallow,
+  createMount,
+  describeConformance,
+  unwrap,
+} from '@material-ui/core/test-utils';
 import Slide, { setTranslateValue } from './Slide';
 import transitions, { easing } from '../styles/transitions';
 import createMuiTheme from '../styles/createMuiTheme';
+import { Transition } from 'react-transition-group';
 
 describe('<Slide />', () => {
   let shallow;
@@ -25,11 +31,18 @@ describe('<Slide />', () => {
     mount.cleanUp();
   });
 
-  it('should render a Transition', () => {
-    const wrapper = shallow(<Slide {...defaultProps} />);
-    assert.strictEqual(wrapper.name(), 'EventListener');
-    assert.strictEqual(wrapper.childAt(0).name(), 'Transition');
-  });
+  describeConformance(
+    <Slide in>
+      <div />
+    </Slide>,
+    () => ({
+      classes: {},
+      inheritComponent: Transition,
+      mount,
+      refInstanceof: React.Component,
+      testComponentPropWith: false,
+    }),
+  );
 
   it('should not override children styles', () => {
     const wrapper = mount(

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, stub } from 'sinon';
-import { createMount, unwrap } from '@material-ui/core/test-utils';
+import { createMount, describeConformance, unwrap } from '@material-ui/core/test-utils';
 import Drawer from '../Drawer';
 import SwipeableDrawer, { reset } from './SwipeableDrawer';
 import SwipeArea from './SwipeArea';
@@ -57,6 +57,14 @@ describe('<SwipeableDrawer />', () => {
   after(() => {
     mount.cleanUp();
   });
+
+  describeConformance(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open />, () => ({
+    classes: {},
+    inheritComponent: Drawer,
+    mount,
+    refInstanceof: React.Component,
+    testComponentPropWith: false,
+  }));
 
   it('should render a Drawer and a SwipeArea', () => {
     const wrapper = mount(

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -31,6 +31,15 @@ describe('<Switch />', () => {
     refInstanceof: window.HTMLSpanElement,
   }));
 
+  /* TODO Switch violates root component
+  describeConformance(<Switch />, () => ({
+    classes,
+    inheritComponent: IconButton,
+    mount,
+    refInstanceof: window.HTMLSpanElement,
+    testComponentPropWith: false,
+  })); */
+
   describe('styleSheet', () => {
     it('should have the classes required for SwitchBase', () => {
       assert.strictEqual(typeof classes.root, 'string');
@@ -44,12 +53,6 @@ describe('<Switch />', () => {
 
     beforeEach(() => {
       wrapper = shallow(<Switch className="foo" />);
-    });
-
-    it('should render a span with the root and user classes', () => {
-      assert.strictEqual(wrapper.name(), 'span');
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass('foo'), true);
     });
 
     it('should render SwitchBase with a custom span icon with the thumb class', () => {

--- a/packages/material-ui/src/TableHead/TableHead.test.js
+++ b/packages/material-ui/src/TableHead/TableHead.test.js
@@ -9,7 +9,7 @@ describe('<TableHead />', () => {
   let classes;
   function mountInTable(node) {
     const wrapper = mount(<table>{node}</table>);
-    return wrapper.find('table');
+    return wrapper.find('table').childAt(0);
   }
 
   before(() => {

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -1,13 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import PropTypes from 'prop-types';
-import {
-  createShallow,
-  createMount,
-  describeConformance,
-  findOutermostIntrinsic,
-  getClasses,
-} from '@material-ui/core/test-utils';
+import { createMount, describeConformance, getClasses } from '@material-ui/core/test-utils';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Select from '../Select';
 import IconButton from '../IconButton';
@@ -20,7 +14,6 @@ import TablePagination from './TablePagination';
 describe('<TablePagination />', () => {
   const noop = () => {};
   let classes;
-  let shallow;
   let mount;
 
   function mountInTable(node) {
@@ -38,7 +31,6 @@ describe('<TablePagination />', () => {
     classes = getClasses(
       <TablePagination count={1} onChangePage={() => {}} page={0} rowsPerPage={1} />,
     );
-    shallow = createShallow({ dive: true });
     mount = createMount();
   });
 
@@ -49,85 +41,14 @@ describe('<TablePagination />', () => {
   describeConformance(
     <TablePagination count={1} onChangePage={() => {}} page={0} rowsPerPage={1} />,
     () => ({
+      classes,
+      inheritComponent: TableCell,
       mount: mountInTable,
-      only: ['refForwarding'],
       refInstanceof: window.HTMLTableCellElement,
+      // can only use `td` in a tr so we just fake a different component
+      testComponentPropWith: props => <td {...props} />,
     }),
   );
-
-  it('should render a TableCell', () => {
-    const wrapper = mount(
-      <table>
-        <tbody>
-          <tr>
-            <TablePagination
-              count={1}
-              page={0}
-              onChangePage={noop}
-              onChangeRowsPerPage={noop}
-              rowsPerPage={5}
-            />
-          </tr>
-        </tbody>
-      </table>,
-    );
-    assert.strictEqual(wrapper.find(TableCell).hasClass(classes.root), true);
-  });
-
-  it('should spread custom props on the root node', () => {
-    const wrapper = shallow(
-      <TablePagination
-        count={1}
-        page={0}
-        onChangePage={noop}
-        onChangeRowsPerPage={noop}
-        rowsPerPage={5}
-        data-my-prop="woofTablePagination"
-      />,
-    );
-    assert.strictEqual(
-      wrapper.props()['data-my-prop'],
-      'woofTablePagination',
-      'custom prop should be woofTablePagination',
-    );
-  });
-
-  describe('prop: component', () => {
-    it('should render a TableCell by default', () => {
-      const wrapper = mount(
-        <table>
-          <tbody>
-            <tr>
-              <TablePagination
-                count={1}
-                page={0}
-                onChangePage={noop}
-                onChangeRowsPerPage={noop}
-                rowsPerPage={5}
-              />
-            </tr>
-          </tbody>
-        </table>,
-      );
-      assert.strictEqual(wrapper.find(TableCell).hasClass(classes.root), true);
-      assert.notStrictEqual(wrapper.find('td').props().colSpan, undefined);
-    });
-
-    it('should be able to use outside of the table', () => {
-      const wrapper = mount(
-        <TablePagination
-          component="div"
-          count={1}
-          page={0}
-          onChangePage={noop}
-          onChangeRowsPerPage={noop}
-          rowsPerPage={5}
-        />,
-      );
-      assert.strictEqual(findOutermostIntrinsic(wrapper).name(), 'div');
-      assert.strictEqual(wrapper.props().colSpan, undefined);
-    });
-  });
 
   describe('mount', () => {
     it('should use the labelDisplayedRows callback', () => {

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
-import { createMount } from '@material-ui/core/test-utils';
+import { createMount, describeConformance } from '@material-ui/core/test-utils';
 import Zoom from './Zoom';
+import { Transition } from 'react-transition-group';
 
 describe('<Zoom />', () => {
   let mount;
@@ -19,10 +20,18 @@ describe('<Zoom />', () => {
     mount.cleanUp();
   });
 
-  it('should render a Transition', () => {
-    const wrapper = mount(<Zoom {...defaultProps} />);
-    assert.strictEqual(wrapper.find('Transition').exists(), true);
-  });
+  describeConformance(
+    <Zoom in>
+      <div />
+    </Zoom>,
+    () => ({
+      classes: {},
+      inheritComponent: Transition,
+      mount,
+      skip: ['refForwarding'],
+      testComponentPropWith: false,
+    }),
+  );
 
   describe('event callbacks', () => {
     describe('entering', () => {

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -3,7 +3,6 @@ import { assert } from 'chai';
 import { spy } from 'sinon';
 import { createMount, describeConformance } from '@material-ui/core/test-utils';
 import Zoom from './Zoom';
-import { Transition } from 'react-transition-group';
 
 describe('<Zoom />', () => {
   let mount;
@@ -26,7 +25,7 @@ describe('<Zoom />', () => {
     </Zoom>,
     () => ({
       classes: {},
-      inheritComponent: Transition,
+      inheritComponent: 'Transition',
       mount,
       skip: ['refForwarding'],
       testComponentPropWith: false,

--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -7,7 +7,7 @@ import testRef from './testRef';
  * Glossary
  * - root component:
  *   - renders the outermost host component
- *   - has the `root` class
+ *   - has the `root` class if the component has one
  *   - excess props are spread to this component
  *   - has the type of `inheritComponent`
  */
@@ -135,7 +135,7 @@ function testRootClass(element, getOptions) {
 
     const wrapper = mount(element);
 
-    // we established that the root component the outermost previously. We immediately
+    // we established that the root component renders the outermost host previously. We immediately
     // jump to the host component because some components pass the `root` class
     // to the `classes` prop of the root component.
     // https://github.com/mui-org/material-ui/blob/f9896bcd129a1209153106296b3d2487547ba205/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L101

--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -1,10 +1,12 @@
 import { assert } from 'chai';
 import React from 'react';
+import findOutermostIntrinsic from './findOutermostIntrinsic';
 import testRef from './testRef';
 
 /**
  * Glossary
  * - root component:
+ *   - renders the outermost host component
  *   - has the `root` class
  *   - excess props are spread to this component
  *   - has the type of `inheritComponent`
@@ -107,11 +109,30 @@ function describeRef(element, getOptions) {
   });
 }
 
+/**
+ * Tests that the root component renders the outermost host
+ *
+ * @param {React.ReactElement} element
+ * @param {() => ConformanceOptions} getOptions
+ */
+function testOutermostHost(element, getOptions) {
+  it("it's root component renders the outermost host component", () => {
+    const { classes, inheritComponent, mount } = getOptions();
+    const wrapper = mount(element);
+
+    const rootComponent = findRootComponent(wrapper, { classes, component: inheritComponent });
+    const outermostIntrinsic = findOutermostIntrinsic(wrapper);
+
+    assert.strictEqual(rootComponent.contains(outermostIntrinsic.getElement()), true);
+  });
+}
+
 const fullSuite = {
-  class: testClassName,
   componentProp: testComponentProp,
+  mergeClassName: testClassName,
   propsSpread: testPropsSpread,
   refForwarding: describeRef,
+  rendersOutermostHost: testOutermostHost,
 };
 
 /**

--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -43,13 +43,16 @@ function randomStringValue() {
  */
 function testClassName(element, getOptions) {
   it('applies the className to the root component', () => {
-    const { classes, inheritComponent, mount } = getOptions();
+    const { mount } = getOptions();
     const className = randomStringValue();
 
     const wrapper = mount(React.cloneElement(element, { className }));
-    const root = findRootComponent(wrapper, { classes, component: inheritComponent });
 
-    assert.strictEqual(root.hasClass(className), true, 'does have a custom `className`');
+    assert.strictEqual(
+      findOutermostIntrinsic(wrapper).hasClass(className),
+      true,
+      'does have a custom `className`',
+    );
   });
 }
 

--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -124,16 +124,19 @@ function describeRef(element, getOptions) {
  * @param {() => ConformanceOptions} getOptions
  */
 function testRootClass(element, getOptions) {
-  it("applies to root class to the root component if it has this class", () => {
-    const { classes, inheritComponent, mount } = getOptions();
+  it('applies to root class to the root component if it has this class', () => {
+    const { classes, mount } = getOptions();
     if (classes.root == null) {
-      return
+      return;
     }
 
     const wrapper = mount(element);
-    const rootComponent = findRootComponent(wrapper, { component: inheritComponent });
 
-    assert.strictEqual(rootComponent.hasClass(classes.root), true);
+    // we established that the root component the outermost previously. We immediately
+    // jump to the host component because some components pass the `root` class
+    // to the `classes` prop of the root component.
+    // https://github.com/mui-org/material-ui/blob/f9896bcd129a1209153106296b3d2487547ba205/packages/material-ui/src/OutlinedInput/OutlinedInput.js#L101
+    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.root), true);
   });
 }
 


### PR DESCRIPTION
Continues #15131. Using "root component = component that renders the outermost host" covers more components while also being testable.

The `root` class is now (following the docs text) an afterthought. "The `root` class is applied to the root component." Not "The root component has the root class". The distinction is important since not every component has a root class. Since the description for the `root` class can be different for each component we allow `describeConformance` to signal that its `root` class doesn't follow the usual definition.