### PR TITLE
[Popover] Fix the warning when anchorReference="anchorPosition"

### DIFF
--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -378,6 +378,11 @@ Popover.propTypes = {
    */
   anchorEl: chainPropTypes(PropTypes.oneOfType([PropTypes.object, PropTypes.func]), props => {
     if (props.open) {
+      const anchorReference = props.anchorReference || Popover.defaultProps.anchorReference;
+      if (anchorReference !== 'anchorEl') {
+        return null;
+      }
+
       const resolvedAnchorEl = getAnchorEl(props.anchorEl);
 
       if (resolvedAnchorEl instanceof HTMLElement) {
@@ -398,11 +403,6 @@ Popover.propTypes = {
           );
         }
       } else {
-        const anchorReference = props.anchorReference || "anchorEl";
-        if (anchorReference !== "anchorEl" && (props.anchorEl === undefined || props.anchorEl === null)) {
-          return null;
-        }
- 
         return new Error(
           [
             'Material-UI: the `anchorEl` prop provided to the component is invalid.',

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -377,7 +377,10 @@ Popover.propTypes = {
    * that may be used to set the position of the popover.
    */
   anchorEl: chainPropTypes(PropTypes.oneOfType([PropTypes.object, PropTypes.func]), props => {
-    if (props.open) {
+    if (props.anchorEl === undefined || props.anchorEl === null) {
+      return null;
+    }
+    else if (props.open) {
       const resolvedAnchorEl = getAnchorEl(props.anchorEl);
 
       if (resolvedAnchorEl instanceof HTMLElement) {

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -377,10 +377,7 @@ Popover.propTypes = {
    * that may be used to set the position of the popover.
    */
   anchorEl: chainPropTypes(PropTypes.oneOfType([PropTypes.object, PropTypes.func]), props => {
-    if (props.anchorEl === undefined || props.anchorEl === null) {
-      return null;
-    }
-    else if (props.open) {
+    if (props.open) {
       const resolvedAnchorEl = getAnchorEl(props.anchorEl);
 
       if (resolvedAnchorEl instanceof HTMLElement) {
@@ -401,6 +398,11 @@ Popover.propTypes = {
           );
         }
       } else {
+        const anchorReference = props.anchorReference || "anchorEl";
+        if (anchorReference !== "anchorEl" && (props.anchorEl === undefined || props.anchorEl === null)) {
+          return null;
+        }
+ 
         return new Error(
           [
             'Material-UI: the `anchorEl` prop provided to the component is invalid.',

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -377,12 +377,7 @@ Popover.propTypes = {
    * that may be used to set the position of the popover.
    */
   anchorEl: chainPropTypes(PropTypes.oneOfType([PropTypes.object, PropTypes.func]), props => {
-    if (props.open) {
-      const anchorReference = props.anchorReference || Popover.defaultProps.anchorReference;
-      if (anchorReference !== 'anchorEl') {
-        return null;
-      }
-
+    if (props.open && props.anchorReference === 'anchorEl') {
       const resolvedAnchorEl = getAnchorEl(props.anchorEl);
 
       if (resolvedAnchorEl instanceof HTMLElement) {


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This is a fix for a warning when passing undefined to anchorEl explicitly rather than not including it in the props object:

```
<Popover anchorEl={undefined} .../>
Triggers:
Warning: Failed prop type: Material-UI: the `anchorEl` prop provided to the component is invalid.
It should be a HTMLElement instance but it's `undefined` instead.
    in Popover (created by ForwardRef(Popover))

<Popover ... />
doesn't trigger the warning

this is specially annoying when the logic is like
<Popover anchorEl={someCondition ? someElement : undefined} ... />
```