### PR TITLE
[styles] Add injectFirst to StylesOptions interface

### DIFF
--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.d.ts
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.d.ts
@@ -3,6 +3,7 @@ import { GenerateId, Jss } from 'jss';
 export interface StylesOptions {
   disableGeneration?: boolean;
   generateClassName?: GenerateId;
+  injectFirst?: boolean;
   jss?: Jss;
   // TODO need info @oliviertassinari
   sheetsCache?: {};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

I noticed the new injectFirst prop was missing in the StylesOptions interface, so this adds it.