### PR TITLE
[ToggleButton] fix typescript error

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import { PropTypes, StandardProps } from '@material-ui/core';
 import { ButtonBaseClassKey, ButtonBaseProps } from '@material-ui/core/ButtonBase';
+import { ButtonProps } from '@material-ui/core/Button';
 
 export interface ToggleButtonProps
   extends StandardProps<ButtonBaseProps, ToggleButtonClassKey, 'component'> {
@@ -10,7 +11,7 @@ export interface ToggleButtonProps
   disableFocusRipple?: boolean;
   disableRipple?: boolean;
   selected?: boolean;
-  type?: string;
+  type?: ButtonProps['type'];
   value?: any;
 }
 


### PR DESCRIPTION
fixing TypeScript error TS2430 by inheriting type from button.
Or would you rather have it hardcoded as `'button' | 'reset' | 'submit'` - like in Fab?
`node_modules/@material-ui/core/es/Fab/Fab.d.ts:13`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

```
node_modules/@material-ui/lab/ToggleButton/ToggleButton.d.ts:6:18 - error TS2430: Interface 'ToggleButtonProps' incorrectly extends interface 'Pick<ButtonBaseProps, "disabled" | "media" | "hidden" | "dir" | "form" | "slot" | "style" | "title" | "name" | "color" | "children" | "type" | "defaultChecked" | "defaultValue" | ... 268 more ... | "TouchRippleProps"> & StyledComponentProps<...> & { ...; }'.
  Type 'ToggleButtonProps' is not assignable to type 'Pick<ButtonBaseProps, "disabled" | "media" | "hidden" | "dir" | "form" | "slot" | "style" | "title" | "name" | "color" | "children" | "type" | "defaultChecked" | "defaultValue" | ... 268 more ... | "TouchRippleProps">'.
    Types of property 'type' are incompatible.
      Type 'string | undefined' is not assignable to type '"button" | "reset" | "submit" | undefined'.
        Type 'string' is not assignable to type '"button" | "reset" | "submit" | undefined'.
```