### PR TITLE
[core] Type ref for components

### DIFF
--- a/docs/src/pages/demos/breadcrumbs/RouterBreadcrumbs.tsx
+++ b/docs/src/pages/demos/breadcrumbs/RouterBreadcrumbs.tsx
@@ -14,7 +14,8 @@ import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
 import { Route, MemoryRouter } from 'react-router';
-import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router-dom';
+import { Omit } from '@material-ui/core';
 
 interface RouterBreadcrumbsState {
   readonly open: boolean;
@@ -35,7 +36,7 @@ const breadcrumbNameMap: { [key: string]: string } = {
   '/drafts': 'Drafts',
 };
 
-function ListItemLink(props: ListItemLinkProps) {
+function ListItemLink(props: Omit<ListItemLinkProps, 'ref'>) {
   const { to, open, ...other } = props;
   const primary = breadcrumbNameMap[to];
 

--- a/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.tsx
+++ b/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.tsx
@@ -39,9 +39,9 @@ const ExpansionPanelSummary = withStyles({
     },
   },
   expanded: {},
-})(props => <MuiExpansionPanelSummary {...props} />) as any;
+})((props: ExpansionPanelSummaryProps) => <MuiExpansionPanelSummary {...props} />);
 
-ExpansionPanelSummary.muiName = 'ExpansionPanelSummary';
+(ExpansionPanelSummary as any).muiName = 'ExpansionPanelSummary';
 
 const ExpansionPanelDetails = withStyles(theme => ({
   root: {
@@ -53,7 +53,7 @@ interface CustomizedExpansionPanelStates {
   expanded: string | boolean;
 }
 
-class CustomizedExpansionPanel extends React.Component<any, CustomizedExpansionPanelStates> {
+class CustomizedExpansionPanel extends React.Component<{}, CustomizedExpansionPanelStates> {
   state = {
     expanded: 'panel1',
   };

--- a/packages/material-ui-lab/src/Slider/Slider.d.ts
+++ b/packages/material-ui-lab/src/Slider/Slider.d.ts
@@ -13,7 +13,7 @@ export type ValueReducer = (
 export const defaultValueReducer: ValueReducer;
 
 export interface SliderProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, SliderClassKey, 'onChange'> {
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, SliderClassKey, 'onChange', false> {
   disabled?: boolean;
   vertical?: boolean;
   max?: number;

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
@@ -7,7 +7,9 @@ import { TransitionHandlerProps } from '@material-ui/core/transitions';
 export interface SpeedDialProps
   extends StandardProps<
     React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>,
-    SpeedDialClassKey
+    SpeedDialClassKey,
+    never,
+    false
   > {
   ariaLabel: string;
   ButtonProps?: Partial<ButtonProps>;

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -4,7 +4,7 @@ import { ButtonProps } from '@material-ui/core/Button';
 import { TooltipProps } from '@material-ui/core/Tooltip';
 
 export interface SpeedDialActionProps
-  extends StandardProps<Partial<TooltipProps>, SpeedDialActionClassKey> {
+  extends StandardProps<Partial<TooltipProps>, SpeedDialActionClassKey, never, false> {
   ButtonProps?: Partial<ButtonProps>;
   delay?: number;
   icon: React.ReactNode;

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { StandardProps } from '@material-ui/core';
 
 export interface SpeedDialIconProps
-  extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, SpeedDialIconClassKey> {
+  extends StandardProps<
+    React.HTMLAttributes<HTMLSpanElement>,
+    SpeedDialIconClassKey,
+    never,
+    false
+  > {
   icon?: React.ReactNode;
   openIcon?: React.ReactNode;
 }

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -6,7 +6,8 @@ export interface ToggleButtonGroupProps
   extends StandardProps<
     React.HTMLAttributes<HTMLDivElement>,
     ToggleButtonGroupClassKey,
-    'onChange'
+    'onChange',
+    false
   > {
   selected?: boolean;
   exclusive?: boolean;

--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -8,9 +8,9 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
   const overriddenProps: AppBarProps = getThemeProps({ name: 'MuiAppBar', props, theme });
 
   // AvatarProps not assignable to AppBarProps
-  // $ExpectError
   const wronglyNamedProps: AppBarProps = getThemeProps({
     name: 'MuiAvatar',
+    // $ExpectError
     props,
     theme,
   });

--- a/packages/material-ui/src/Badge/Badge.d.ts
+++ b/packages/material-ui/src/Badge/Badge.d.ts
@@ -6,7 +6,7 @@ export interface BadgeProps
   children: React.ReactNode;
   badgeContent?: React.ReactNode;
   color?: PropTypes.Color | 'error';
-  component?: React.ElementType<BadgeProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   invisible?: boolean;
   max?: number;
   showZero?: boolean;

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.d.ts
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.d.ts
@@ -8,7 +8,7 @@ export interface BottomNavigationProps
     'onChange'
   > {
   children: React.ReactNode;
-  component?: React.ElementType<BottomNavigationProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   onChange?: (event: React.ChangeEvent<{}>, value: any) => void;
   showLabels?: boolean;
   value?: any;

--- a/packages/material-ui/src/CardContent/CardContent.d.ts
+++ b/packages/material-ui/src/CardContent/CardContent.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface CardContentProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, CardContentClassKey> {
-  component?: React.ElementType<CardContentProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
 }
 
 export type CardContentClassKey = 'root';

--- a/packages/material-ui/src/CardHeader/CardHeader.d.ts
+++ b/packages/material-ui/src/CardHeader/CardHeader.d.ts
@@ -6,7 +6,7 @@ export interface CardHeaderProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, CardHeaderClassKey, 'title'> {
   action?: React.ReactNode;
   avatar?: React.ReactNode;
-  component?: React.ElementType<CardHeaderProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   disableTypography?: boolean;
   subheader?: React.ReactNode;
   subheaderTypographyProps?: Partial<TypographyProps>;

--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -6,7 +6,7 @@ import { TransitionProps } from '../transitions/transition';
 export interface CollapseProps extends StandardProps<TransitionProps, CollapseClassKey, 'timeout'> {
   children?: React.ReactNode;
   collapsedHeight?: string;
-  component?: React.ElementType<CollapseProps>;
+  component?: React.ElementType<TransitionProps>;
   theme?: Theme;
   timeout?: TransitionProps['timeout'] | 'auto';
 }

--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -3,7 +3,7 @@ import { StandardProps, PropTypes } from '..';
 
 export interface FormControlProps
   extends StandardProps<React.HtmlHTMLAttributes<HTMLDivElement>, FormControlClassKey> {
-  component?: React.ElementType<FormControlProps>;
+  component?: React.ElementType<React.HtmlHTMLAttributes<HTMLDivElement>>;
   disabled?: boolean;
   error?: boolean;
   fullWidth?: boolean;

--- a/packages/material-ui/src/FormHelperText/FormHelperText.d.ts
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.d.ts
@@ -7,7 +7,7 @@ export interface FormHelperTextProps
   error?: boolean;
   filled?: boolean;
   focused?: boolean;
-  component?: React.ElementType<FormHelperTextProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLParagraphElement>>;
   margin?: 'dense';
   required?: boolean;
   variant?: 'standard' | 'outlined' | 'filled';

--- a/packages/material-ui/src/GridList/GridList.d.ts
+++ b/packages/material-ui/src/GridList/GridList.d.ts
@@ -5,7 +5,7 @@ export interface GridListProps
   extends StandardProps<React.HTMLAttributes<HTMLUListElement>, GridListClassKey> {
   cellHeight?: number | 'auto';
   cols?: number;
-  component?: React.ElementType<GridListProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLUListElement>>;
   spacing?: number;
 }
 

--- a/packages/material-ui/src/GridListTile/GridListTile.d.ts
+++ b/packages/material-ui/src/GridListTile/GridListTile.d.ts
@@ -4,7 +4,7 @@ import { StandardProps } from '..';
 export interface GridListTileProps
   extends StandardProps<React.HTMLAttributes<HTMLLIElement>, GridListTileClassKey> {
   cols?: number;
-  component?: React.ElementType<GridListTileProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLLIElement>>;
   rows?: number;
 }
 

--- a/packages/material-ui/src/Hidden/Hidden.d.ts
+++ b/packages/material-ui/src/Hidden/Hidden.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { Breakpoint } from '../styles/createBreakpoints';
 
-export interface HiddenProps extends StandardProps<{}, never> {
+export interface HiddenProps {
   implementation?: 'js' | 'css';
   initialWidth?: Breakpoint;
   lgDown?: boolean;

--- a/packages/material-ui/src/Icon/Icon.d.ts
+++ b/packages/material-ui/src/Icon/Icon.d.ts
@@ -4,7 +4,7 @@ import { StandardProps, PropTypes } from '..';
 export interface IconProps
   extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, IconClassKey> {
   color?: PropTypes.Color | 'action' | 'disabled' | 'error';
-  component?: React.ElementType<IconProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLSpanElement>>;
   fontSize?: 'inherit' | 'default' | 'small' | 'large';
 }
 

--- a/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface InputAdornmentProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, InputAdornmentClassKey> {
-  component?: React.ElementType<InputAdornmentProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   disablePointerEvents?: boolean;
   disableTypography?: boolean;
   position: 'start' | 'end';

--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -8,7 +8,11 @@ export interface LinkProps
     LinkClassKey,
     'component'
   > {
-  component?: React.ElementType<LinkProps>;
+  /**
+   * we only document this here since we use an anchor element instead of the
+   * default component in typography.
+   */
+  component?: React.ElementType<React.AnchorHTMLAttributes<HTMLAnchorElement> & TypographyProps>;
   TypographyClasses?: TypographyProps['classes'];
   underline?: 'none' | 'hover' | 'always';
 }

--- a/packages/material-ui/src/List/List.d.ts
+++ b/packages/material-ui/src/List/List.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface ListProps
   extends StandardProps<React.HTMLAttributes<HTMLUListElement>, ListClassKey> {
-  component?: React.ElementType<ListProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLUListElement>>;
   dense?: boolean;
   disablePadding?: boolean;
   subheader?: React.ReactElement;

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
@@ -1,6 +1,7 @@
 import { StandardProps } from '..';
 
-export interface ListItemAvatarProps extends StandardProps<{}, ListItemAvatarClassKey> {}
+export interface ListItemAvatarProps
+  extends StandardProps<{}, ListItemAvatarClassKey, never, false> {}
 
 export type ListItemAvatarClassKey = 'root' | 'icon';
 

--- a/packages/material-ui/src/ListSubheader/ListSubheader.d.ts
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.d.ts
@@ -4,7 +4,7 @@ import { StandardProps } from '..';
 export interface ListSubheaderProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ListSubheaderClassKey> {
   color?: 'default' | 'primary' | 'inherit';
-  component?: React.ElementType<ListSubheaderProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   disableGutters?: boolean;
   disableSticky?: boolean;
   inset?: boolean;

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface PaperProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, PaperClassKey> {
-  component?: React.ElementType<PaperProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   elevation?: number;
   square?: boolean;
 }

--- a/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
@@ -4,7 +4,7 @@ import { StandardProps, PropTypes } from '..';
 export interface SvgIconProps
   extends StandardProps<React.SVGProps<SVGSVGElement>, SvgIconClassKey> {
   color?: PropTypes.Color | 'action' | 'disabled' | 'error';
-  component?: React.ElementType<SvgIconProps>;
+  component?: React.ElementType<React.SVGProps<SVGSVGElement>>;
   fontSize?: 'inherit' | 'default' | 'small' | 'large';
   htmlColor?: string;
   shapeRendering?: string;

--- a/packages/material-ui/src/Toolbar/Toolbar.d.ts
+++ b/packages/material-ui/src/Toolbar/Toolbar.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface ToolbarProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ToolbarClassKey> {
-  component?: React.ElementType<ToolbarProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   disableGutters?: boolean;
   variant?: 'regular' | 'dense';
 }

--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { TransitionProps } from '../transitions/transition';
 
 export interface TooltipProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title'> {
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title', false> {
   children: React.ReactElement;
   disableFocusListener?: boolean;
   disableHoverListener?: boolean;

--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -15,7 +15,7 @@ export interface TypographyProps
     | 'textPrimary'
     | 'textSecondary'
     | 'error';
-  component?: React.ElementType<TypographyProps>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
   display?: 'initial' | 'block' | 'inline';
   gutterBottom?: boolean;
   noWrap?: boolean;

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -13,6 +13,7 @@ export type StandardProps<C, ClassKey extends string, Removals extends keyof C =
 > &
   StyledComponentProps<ClassKey> & {
     className?: string;
+    ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
     style?: React.CSSProperties;
   };
 

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -7,14 +7,21 @@ export { StyledComponentProps };
  * certain `classes`, on which one can also set a top-level `className` and inline
  * `style`.
  */
-export type StandardProps<C, ClassKey extends string, Removals extends keyof C = never> = Omit<
+export type StandardProps<
   C,
-  'classes' | Removals
-> &
+  ClassKey extends string,
+  Removals extends keyof C = never,
+  AcceptsRef = true
+> = Omit<C, 'classes' | Removals> &
   StyledComponentProps<ClassKey> & {
     className?: string;
-    ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
     style?: React.CSSProperties;
+  } & {
+    ref?: AcceptsRef extends true
+      ? C extends { ref?: infer RefType }
+        ? RefType
+        : React.Ref<unknown>
+      : never;
   };
 
 export type PaletteType = 'light' | 'dark';

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -1124,3 +1124,32 @@ const LinkTest = () => {
     </Typography>
   );
 };
+
+const refTest = () => {
+  // for a detailed explanation of refs in react see https://github.com/mui-org/material-ui/pull/15199
+  const genericRef = React.createRef<Element>();
+  const divRef = React.createRef<HTMLDivElement>();
+  const inputRef = React.createRef<HTMLInputElement>();
+
+  <Paper ref={genericRef} />;
+  <Paper ref={divRef} />;
+  // undesired: throws when assuming inputRef.current.value !== undefined
+  <Paper ref={inputRef} />;
+  // recommended: soundness is the responsibility of the dev
+  // alternatively use React.useRef<unknown>()  or React.createRef<unknown>()
+  <Paper
+    ref={ref => {
+      // with runtime overhead, sound usage
+      if (ref instanceof HTMLInputElement) {
+        const i: number = ref.valueAsNumber;
+      }
+      // unsafe casts, sound usage, no runtime overhead
+      const j: number = (ref as HTMLInputElement).valueAsNumber;
+      // unsafe casts, unsound usage, no runtime overhead
+      const k: number = (ref as any).valueAsNumber;
+      // tslint:disable-next-line ban-ts-ignore
+      // @ts-ignore unsound usage, no runtime overhead, least syntax
+      const n: number = ref.valueAsNumber;
+    }}
+  />;
+};


### PR DESCRIPTION
Types ref for all components not using generic props as `unknown`
Finishes on point in #14415

## rationale
See https://github.com/eps1lon/typescript-react-ref-issue/blob/626f5197601c35a13e1207a8f4ab7e029454ecb6/index.tsx for current state of `ref` in React.

### Options
We have three options when declaring the type for the ref attribute:
1. Type it as `unknown`
2. Type it exact
3. Type it less specific e.g. `HTMLElement` instead of `HTMLInputElement`

### evaluation
1. has the drawback of assigning refs that don't extend the actual ref.
It allows reading as `HTMLInputElement` while it's actually assigned to `HTMLDivElement`
2.
- Is dangerous if we allow the rendered component to be overridden e.g.
`<Paper component="span" ref={divRef} />` would pass but might throw.
It's most likely very rare since the usual suspects for DOM escape hatches
are focus, measuring and `input.value` read/write.
The bigger issue would be passing a class component which is definitely wrong
WRT to types.
- rejects more abstract types
3.
- same issue as 2. WRT to soundness
- would also reject more abstract types unless we use to to `EventTarget` but that type doesn't offer any value WRT measuring

Given that 1, 2 and 3 allow assigning wrong refs with `component` override
but only 1 allows full type safety at compile time with type narrowing we use
`unknown` until we can infer the ref type from the `component` override.

There's not much the compiler can do for DX at the moment. Type safety comes
from how you declare the type. We just make sure you can.

## Why not just use the generic props approach?

Given that unions props won't work very good with hocs (require distributive Pick/Omit which have extremely bad perf in ts 3.4.1) it's not certain we can stick with that approach. That's why I rather not immediately apply it to the whole codebase until necessary.

It might also be better to rethink ref inference in those components given that too specific refs reject more abstract refs.

## props spreading between material-ui components

Spreading props from one component to the other works flawlessly only if both are from the same "generation". One generation includes components using non-generic components (which have `Ref<unknown>`) the other includes components using generic props which infer their ref type. It might also cause some issues for components with generic props if the refs mismatch or are more abstract.

https://github.com/mui-org/material-ui/pull/15199/files#diff-e5a9e405d750f736e98750ee9c4a8eabR39 showcases this issue.


## TODO
- [x] apply to all components

/cc @pelotom 