### PR TITLE
[ToggleButton] align ToggleButton `type` prop with @types/react@latest

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -10,7 +10,7 @@ export interface ToggleButtonProps
   disableFocusRipple?: boolean;
   disableRipple?: boolean;
   selected?: boolean;
-  type?: string;
+  type?: 'reset' | 'button' | 'submit' | undefined;
   value?: any;
 }
 


### PR DESCRIPTION
* `@types/react` recently narrowed the type on the `button` element
  * this started causing issues with `ToggleButton` attempting to assign a looser type, `string`, to it

Fixes #15200
