### PR TITLE
[blog] Add /march-2019-update

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -343,10 +343,10 @@ const pages = [
     pathname: '/blog',
     children: [
       {
-        pathname: '/blog/2019-developer-survey-results',
+        pathname: '/blog/march-2019-update',
       },
       {
-        pathname: '/blog/march-2019-update',
+        pathname: '/blog/2019-developer-survey-results',
       },
     ],
   },

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -345,6 +345,9 @@ const pages = [
       {
         pathname: '/blog/2019-developer-survey-results',
       },
+      {
+        pathname: '/blog/march-2019-update',
+      },
     ],
   },
   {

--- a/pages/blog/2019-developer-survey-results.md
+++ b/pages/blog/2019-developer-survey-results.md
@@ -256,7 +256,7 @@ Multiple options were allowed.
 
 Dashboards are at the top of the heap, and we've long known that many of you are building internal
 systems that can't feature in [the showcase](/discover-more/showcase/). Let us know by opening a PR
-if you're bucking that tend, and have something sparkly to share! And if you're in the 40% building UI
+if you're bucking that trend, and have something sparkly to share! And if you're in the 40% building UI
 components, we'd be happy to give you a shout out in the [related projects](/discover-more/related-projects/)
 section.
 

--- a/pages/blog/2019-developer-survey-results.md
+++ b/pages/blog/2019-developer-survey-results.md
@@ -1,11 +1,12 @@
 ---
 description: 2019 Material-UI Developer Survey results
 ---
+
 # 2019 Material-UI Developer Survey results
 
 **Olivier Tassinari, Matt Brookes**
 
-_March 16, 2019_
+*March 16, 2019*
 
 While we are currently working on the upcoming release of Material-UI v4, we need to prioritize our
 roadmap for the coming year. To refine our focus, we launched a developer survey last month,
@@ -254,8 +255,8 @@ Multiple options were allowed.
 - Blog: 8%
 
 Dashboards are at the top of the heap, and we've long known that many of you are building internal
-systems that can't feature in [the showcase](/discover-more/showcase/). Let us know by opening a PR 
-if you're bucking that tend, and have something sparkly to share! And if you're in the 40% building UI 
+systems that can't feature in [the showcase](/discover-more/showcase/). Let us know by opening a PR
+if you're bucking that tend, and have something sparkly to share! And if you're in the 40% building UI
 components, we'd be happy to give you a shout out in the [related projects](/discover-more/related-projects/)
 section.
 

--- a/pages/blog/march-2019-update.js
+++ b/pages/blog/march-2019-update.js
@@ -1,0 +1,11 @@
+import 'docs/src/modules/components/bootstrap';
+// --- Post bootstrap -----
+import React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './march-2019-update.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} disableAd disableEdit />;
+}
+
+export default Page;

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -12,7 +12,7 @@ Here are the most significant changes in March:
 
 - We have removed the old styles modules 💅.
 Be aware [of the difference](https://next.material-ui.com/customization/default-theme/#material-ui-core-styles-vs-material-ui-styles) between `@material-ui/core/styles` and `@material-ui/styles`.
-- The community has helped us to add many TypeScript demo variants. In order to minimize the overhead of handling two variants per demo (JavaScript & TypeScript). We are generating the JavaScript variant using the TypeScript variant. If you are using TypeScript, you can ignore the `.propTypes =` assignations.
+- The community has helped us to add many TypeScript demo variants. In order to minimize the overhead of handling two variants per demo (JavaScript & TypeScript), the JavaScript variant is generated from the TypeScript variant. If you are using TypeScript, you can ignore the `.propTypes =` assignations.
 - We have migrated a few demos from the `withStyles()` API to the `makeStyles()` API.
 People are wondering what they should use. We are encouraging the usage of `makeStyles()` where possible. `withStyles()` is interesting for overriding our components or for handling legacy class logics.
 - We have made the [Box API](https://next.material-ui.com/system/basics/) stable 🥳.

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -20,7 +20,7 @@ People are wondering what they should use. We are encouraging the usage of `make
   -import { unstable_Box as Box } from '@material-ui/core/Box';
   +import Box from '@material-ui/core/Box';
   ```
-- We have commited to [a new Roadmap](https://next.material-ui.com/discover-more/roadmap/)  (prioritized) for the next 6 months.
+- We have commited to [a new Roadmap](https://next.material-ui.com/discover-more/roadmap/) (prioritized) for the next 6 months.
 - We have migrated 50% of the codebase from the Classes API to the Hooks API. Once we are done with this task, we can remove the internal usage of higher-order components.
 - We have introduced [a simplified server-side rendering API](https://next.material-ui.com/css-in-js/advanced/#server-side-rendering), inspired by styled-components.
 

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -30,7 +30,7 @@ People are wondering what they should use. We are encouraging the usage of `make
 
 - We are almost done with [the v4.0.0-alpha breaking changes](https://github.com/mui-org/material-ui/issues/13663). You can already find [the upgrade path](https://next.material-ui.com/guides/migration-v3/) from v3 to v4 in the documentation. Next, we will release the first beta version (no more breaking changes).
 The results of the Material-UI developer survey suggested that there are too many breaking changes.
-Don't worry. It's almost over! We can focus on providing more components once we have released v4 stable.
+Don't worry, it's almost over! We will focus on providing more components once we have released v4 stable.
 - We will continue and hopefully complete the tasks we undertook:
   - TypeScript demo variants.
   - Migration from Classes to Hooks, removal of unnecessary internal components.

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -26,7 +26,7 @@ People are wondering what they should use. We are encouraging the usage of `make
 
 ## Our roadmap intent for April
 
-*we will do our best, no guarantee*
+*(We'll do our best, no guarantee!)*
 
 - We are almost done with [the v4.0.0-alpha breaking changes](https://github.com/mui-org/material-ui/issues/13663). You can already find [the upgrade path](https://next.material-ui.com/guides/migration-v3/) from v3 to v4 in the documentation. We will release or first beta version (no more breaking changes in beta).
 We have heard your feedback. You find that we introduce too many breaking changes.

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -21,7 +21,7 @@ People are wondering what they should use. We are encouraging the usage of `make
   +import Box from '@material-ui/core/Box';
   ```
 - We have commited to [a new Roadmap](https://next.material-ui.com/discover-more/roadmap/) (prioritized) for the next 6 months.
-- We have migrated 50% of the codebase from the Classes API to the Hooks API. Once we are done with this task, we can remove the internal usage of higher-order components.
+- We have migrated 50% of the codebase from the Classes API to the Hooks API. Once we are done with this task we can remove the internal usage of higher-order components.
 - We have introduced [a simplified server-side rendering API](https://next.material-ui.com/css-in-js/advanced/#server-side-rendering), inspired by styled-components.
 
 ## Our roadmap intent for April

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -28,7 +28,7 @@ People are wondering what they should use. We are encouraging the usage of `make
 
 *(We'll do our best, no guarantee!)*
 
-- We are almost done with [the v4.0.0-alpha breaking changes](https://github.com/mui-org/material-ui/issues/13663). You can already find [the upgrade path](https://next.material-ui.com/guides/migration-v3/) from v3 to v4 in the documentation. We will release or first beta version (no more breaking changes in beta).
+- We are almost done with [the v4.0.0-alpha breaking changes](https://github.com/mui-org/material-ui/issues/13663). You can already find [the upgrade path](https://next.material-ui.com/guides/migration-v3/) from v3 to v4 in the documentation. Next, we will release the first beta version (no more breaking changes).
 We have heard your feedback. You find that we introduce too many breaking changes.
 Don't worry. It's almost over! We can focus on providing more components once we have released v4 stable.
 - We will continue and hopefully complete the tasks we undertook:

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -1,0 +1,44 @@
+---
+description: Here are the most significant changes in March.
+---
+
+# March 2019 Update
+
+**Olivier Tassinari**
+
+*April 5, 2019*
+
+Here are the most significant changes in March:
+
+- We have removed the old styles modules 💅.
+Be aware [of the difference](https://next.material-ui.com/customization/default-theme/#material-ui-core-styles-vs-material-ui-styles) between `@material-ui/core/styles` and `@material-ui/styles`.
+- The community has helped us to add many TypeScript demo variants. In order to minimize the overhead of handling two variants per demo (JavaScript & TypeScript). We are generating the JavaScript variant using the TypeScript variant. If you are using TypeScript, you can ignore the `.propTypes =` assignations.
+- We have migrated a few demos from the `withStyles()` API to the `makeStyles()` API.
+People are wondering what they should use. We are encouraging the usage of `makeStyles()` where possible. `withStyles()` is interesting for overriding our components or for handling legacy class logics.
+- We have made the [Box API](https://next.material-ui.com/system/basics/) stable 🥳.
+  ```diff
+  -import { unstable_Box as Box } from '@material-ui/core/Box';
+  +import Box from '@material-ui/core/Box';
+  ```
+- We have commited to [a new Roadmap](https://next.material-ui.com/discover-more/roadmap/)  (prioritized) for the next 6 months.
+- We have migrated 50% of the codebase from the Classes API to the Hooks API. Once we are done with this task, we can remove the internal usage of higher-order components.
+- We have introduced [a simplified server-side rendering API](https://next.material-ui.com/css-in-js/advanced/#server-side-rendering), inspired by styled-components.
+
+## Our roadmap intent for April
+
+*we will do our best, no guarantee*
+
+- We are almost done with [the v4.0.0-alpha breaking changes](https://github.com/mui-org/material-ui/issues/13663). You can already find [the upgrade path](https://next.material-ui.com/guides/migration-v3/) from v3 to v4 in the documentation. We will release or first beta version (no more breaking changes in beta).
+We have heard your feedback. You find that we introduce too many breaking changes.
+Don't worry. It's almost over! We can focus on providing more components once we have released v4 stable.
+- We will continue and hopefully complete the tasks we undertook:
+  - TypeScript demo variants.
+  - Migration from Classes to Hooks, removal of unnecessary internal components.
+  - Removal of `findDOMNode()`, support of `StrictMode`, forward of references.
+
+<hr />
+
+Material-UI is an MIT-licensed open source project. It’s an independent project with ongoing development made possible thanks to the support of these awesome [backers](https://github.com/mui-org/material-ui/blob/master/BACKERS.md). If you’d like to join them, please consider:
+
+- [Become a backer or sponsor on OpenCollective.](https://opencollective.com/material-ui)
+- [Become a backer or sponsor on my Patreon.](https://www.patreon.com/oliviertassinari)

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -29,7 +29,7 @@ People are wondering what they should use. We are encouraging the usage of `make
 *(We'll do our best, no guarantee!)*
 
 - We are almost done with [the v4.0.0-alpha breaking changes](https://github.com/mui-org/material-ui/issues/13663). You can already find [the upgrade path](https://next.material-ui.com/guides/migration-v3/) from v3 to v4 in the documentation. Next, we will release the first beta version (no more breaking changes).
-We have heard your feedback. You find that we introduce too many breaking changes.
+The results of the Material-UI developer survey suggested that there are too many breaking changes.
 Don't worry. It's almost over! We can focus on providing more components once we have released v4 stable.
 - We will continue and hopefully complete the tasks we undertook:
   - TypeScript demo variants.

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -31,7 +31,7 @@ People are wondering what they should use. We are encouraging the usage of `make
 - We are almost done with [the v4.0.0-alpha breaking changes](https://github.com/mui-org/material-ui/issues/13663). You can already find [the upgrade path](https://next.material-ui.com/guides/migration-v3/) from v3 to v4 in the documentation. Next, we will release the first beta version (no more breaking changes).
 The results of the Material-UI developer survey suggested that there are too many breaking changes.
 Don't worry, it's almost over! We will focus on providing more components once we have released v4 stable.
-- We will continue and hopefully complete the tasks we undertook:
+- We will continue, and hopefully complete, the tasks we undertook:
   - TypeScript demo variants.
   - Migration from Classes to Hooks, removal of unnecessary internal components.
   - Removal of `findDOMNode()`, support of `StrictMode`, forward of references.

--- a/pages/blog/march-2019-update.md
+++ b/pages/blog/march-2019-update.md
@@ -14,7 +14,7 @@ Here are the most significant changes in March:
 Be aware [of the difference](https://next.material-ui.com/customization/default-theme/#material-ui-core-styles-vs-material-ui-styles) between `@material-ui/core/styles` and `@material-ui/styles`.
 - The community has helped us to add many TypeScript demo variants. In order to minimize the overhead of handling two variants per demo (JavaScript & TypeScript), the JavaScript variant is generated from the TypeScript variant. If you are using TypeScript, you can ignore the `.propTypes =` assignations.
 - We have migrated a few demos from the `withStyles()` API to the `makeStyles()` API.
-People are wondering what they should use. We are encouraging the usage of `makeStyles()` where possible. `withStyles()` is interesting for overriding our components or for handling legacy class logics.
+If you are wondering which you should use, we would encourage the use of `makeStyles()` where possible. `withStyles()` is interesting for overriding component styles or for handling legacy class logics.
 - We have made the [Box API](https://next.material-ui.com/system/basics/) stable 🥳.
   ```diff
   -import { unstable_Box as Box } from '@material-ui/core/Box';


### PR DESCRIPTION
We publish under material-ui.com now to take advantage of the SEO potential. The articles are imported in Medium.