### PR TITLE
[test] Add undesired withStyles + generic props component behavior

### DIFF
--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -14,7 +14,7 @@ import {
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import { blue } from '@material-ui/core/colors';
-import { StandardProps } from '@material-ui/core';
+import { StandardProps, ButtonBase } from '@material-ui/core';
 
 // Shared types for examples
 interface ComponentProps extends WithStyles<typeof styles> {
@@ -462,4 +462,18 @@ withStyles(theme =>
   const CorrectUsage = () => <StyledMyButton nonDefaulted="2" />;
   // Property 'nonDefaulted' is missing in type '{}'
   const MissingPropUsage = () => <StyledMyButton />; // $ExpectError
+}
+
+// https://github.com/mui-org/material-ui/issues/14586
+{
+  const styles = createStyles({
+    root: {
+      color: 'red',
+    },
+  });
+
+  const StyledButton = withStyles(styles)(Button);
+
+  // undesired
+  <StyledButton component="a" />; // $ExpectError
 }


### PR DESCRIPTION
Minimal test for undesired behavior reported in #14586

Will need to investigate a solution without unions. Especially considering typescript 3.4.1 has a 20x perf regression with distributive unions.

Any other ideas @pelotom ?