### PR TITLE
[docs] Adding Most Stepper Typescript Demos

### DIFF
--- a/docs/src/pages/demos/steppers/CustomizedStepper.tsx
+++ b/docs/src/pages/demos/steppers/CustomizedStepper.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import Stepper from '@material-ui/core/Stepper';
+import Step from '@material-ui/core/Step';
+import StepLabel from '@material-ui/core/StepLabel';
+import StepConnector from '@material-ui/core/StepConnector';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: '90%',
+  },
+  button: {
+    marginRight: theme.spacing(1),
+  },
+  instructions: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+  connectorActive: {
+    '& $connectorLine': {
+      borderColor: theme.palette.secondary.main,
+    },
+  },
+  connectorCompleted: {
+    '& $connectorLine': {
+      borderColor: theme.palette.primary.main,
+    },
+  },
+  connectorDisabled: {
+    '& $connectorLine': {
+      borderColor: theme.palette.grey[100],
+    },
+  },
+  connectorLine: {
+    transition: theme.transitions.create('border-color'),
+  },
+}));
+
+function getSteps() {
+  return ['Select campaign settings', 'Create an ad group', 'Create an ad'];
+}
+
+function getStepContent(step: number) {
+  switch (step) {
+    case 0:
+      return 'Select campaign settings...';
+    case 1:
+      return 'What is an ad group anyways?';
+    case 2:
+      return 'This is the bit I really care about!';
+    default:
+      return 'Unknown step';
+  }
+}
+
+function CustomizedStepper() {
+  const classes = useStyles();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const steps = getSteps();
+
+  function handleNext() {
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+  }
+
+  function handleBack() {
+    setActiveStep(prevActiveStep => prevActiveStep - 1);
+  }
+
+  function handleReset() {
+    setActiveStep(0);
+  }
+
+  const connector = (
+    <StepConnector
+      classes={{
+        active: classes.connectorActive,
+        completed: classes.connectorCompleted,
+        disabled: classes.connectorDisabled,
+        line: classes.connectorLine,
+      }}
+    />
+  );
+
+  return (
+    <div className={classes.root}>
+      <Stepper activeStep={activeStep} connector={connector}>
+        {steps.map(label => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+      <Stepper alternativeLabel activeStep={activeStep} connector={connector}>
+        {steps.map(label => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+      <div>
+        {activeStep === steps.length ? (
+          <div>
+            <Typography className={classes.instructions}>
+              All steps completed - you&apos;re finished
+            </Typography>
+            <Button onClick={handleReset} className={classes.button}>
+              Reset
+            </Button>
+          </div>
+        ) : (
+          <div>
+            <Typography className={classes.instructions}>{getStepContent(activeStep)}</Typography>
+            <div>
+              <Button disabled={activeStep === 0} onClick={handleBack} className={classes.button}>
+                Back
+              </Button>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleNext}
+                className={classes.button}
+              >
+                {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default CustomizedStepper;

--- a/docs/src/pages/demos/steppers/DotsMobileStepper.tsx
+++ b/docs/src/pages/demos/steppers/DotsMobileStepper.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+import MobileStepper from '@material-ui/core/MobileStepper';
+import Button from '@material-ui/core/Button';
+import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+
+const useStyles = makeStyles({
+  root: {
+    maxWidth: 400,
+    flexGrow: 1,
+  },
+});
+
+function DotsMobileStepper() {
+  const classes = useStyles();
+  const theme = useTheme();
+  const [activeStep, setActiveStep] = React.useState(0);
+
+  function handleNext() {
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+  }
+
+  function handleBack() {
+    setActiveStep(prevActiveStep => prevActiveStep - 1);
+  }
+
+  return (
+    <MobileStepper
+      variant="dots"
+      steps={6}
+      position="static"
+      activeStep={activeStep}
+      className={classes.root}
+      nextButton={
+        <Button size="small" onClick={handleNext} disabled={activeStep === 5}>
+          Next
+          {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+        </Button>
+      }
+      backButton={
+        <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+          {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+          Back
+        </Button>
+      }
+    />
+  );
+}
+
+export default DotsMobileStepper;

--- a/docs/src/pages/demos/steppers/HorizontalLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalLinearAlternativeLabelStepper.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import Stepper from '@material-ui/core/Stepper';
+import Step from '@material-ui/core/Step';
+import StepLabel from '@material-ui/core/StepLabel';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: '90%',
+  },
+  backButton: {
+    marginRight: theme.spacing(1),
+  },
+  instructions: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+function getSteps() {
+  return ['Select master blaster campaign settings', 'Create an ad group', 'Create an ad'];
+}
+
+function getStepContent(stepIndex: number) {
+  switch (stepIndex) {
+    case 0:
+      return 'Select campaign settings...';
+    case 1:
+      return 'What is an ad group anyways?';
+    case 2:
+      return 'This is the bit I really care about!';
+    default:
+      return 'Uknown stepIndex';
+  }
+}
+
+function HorizontalLabelPositionBelowStepper() {
+  const classes = useStyles();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const steps = getSteps();
+
+  function handleNext() {
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+  }
+
+  function handleBack() {
+    setActiveStep(prevActiveStep => prevActiveStep - 1);
+  }
+
+  function handleReset() {
+    setActiveStep(0);
+  }
+
+  return (
+    <div className={classes.root}>
+      <Stepper activeStep={activeStep} alternativeLabel>
+        {steps.map(label => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+          </Step>
+        ))}
+      </Stepper>
+      <div>
+        {activeStep === steps.length ? (
+          <div>
+            <Typography className={classes.instructions}>All steps completed</Typography>
+            <Button onClick={handleReset}>Reset</Button>
+          </div>
+        ) : (
+          <div>
+            <Typography className={classes.instructions}>{getStepContent(activeStep)}</Typography>
+            <div>
+              <Button
+                disabled={activeStep === 0}
+                onClick={handleBack}
+                className={classes.backButton}
+              >
+                Back
+              </Button>
+              <Button variant="contained" color="primary" onClick={handleNext}>
+                {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default HorizontalLabelPositionBelowStepper;

--- a/docs/src/pages/demos/steppers/HorizontalLinearStepper.js
+++ b/docs/src/pages/demos/steppers/HorizontalLinearStepper.js
@@ -130,6 +130,7 @@ function HorizontalLinearStepper() {
                   Skip
                 </Button>
               )}
+
               <Button
                 variant="contained"
                 color="primary"

--- a/docs/src/pages/demos/steppers/HorizontalLinearStepper.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalLinearStepper.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import Stepper from '@material-ui/core/Stepper';
+import Step from '@material-ui/core/Step';
+import StepLabel from '@material-ui/core/StepLabel';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: '90%',
+  },
+  button: {
+    marginRight: theme.spacing(1),
+  },
+  instructions: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+function getSteps() {
+  return ['Select campaign settings', 'Create an ad group', 'Create an ad'];
+}
+
+function getStepContent(step: number) {
+  switch (step) {
+    case 0:
+      return 'Select campaign settings...';
+    case 1:
+      return 'What is an ad group anyways?';
+    case 2:
+      return 'This is the bit I really care about!';
+    default:
+      return 'Unknown step';
+  }
+}
+
+function HorizontalLinearStepper() {
+  const classes = useStyles();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const [skipped, setSkipped] = React.useState(new Set<number>());
+  const steps = getSteps();
+
+  function isStepOptional(step: number) {
+    return step === 1;
+  }
+
+  function isStepSkipped(step: number) {
+    return skipped.has(step);
+  }
+
+  function handleNext() {
+    let newSkipped = skipped;
+    if (isStepSkipped(activeStep)) {
+      newSkipped = new Set(newSkipped.values());
+      newSkipped.delete(activeStep);
+    }
+
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+    setSkipped(newSkipped);
+  }
+
+  function handleBack() {
+    setActiveStep(prevActiveStep => prevActiveStep - 1);
+  }
+
+  function handleSkip() {
+    if (!isStepOptional(activeStep)) {
+      // You probably want to guard against something like this,
+      // it should never occur unless someone's actively trying to break something.
+      throw new Error("You can't skip a step that isn't optional.");
+    }
+
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+    setSkipped(prevSkipped => {
+      const newSkipped = new Set(prevSkipped.values());
+      newSkipped.add(activeStep);
+      return newSkipped;
+    });
+  }
+
+  function handleReset() {
+    setActiveStep(0);
+  }
+
+  return (
+    <div className={classes.root}>
+      <Stepper activeStep={activeStep}>
+        {steps.map((label, index) => {
+          const stepProps: { completed?: boolean } = {};
+          const labelProps: { optional?: React.ReactNode } = {};
+          if (isStepOptional(index)) {
+            labelProps.optional = <Typography variant="caption">Optional</Typography>;
+          }
+          if (isStepSkipped(index)) {
+            stepProps.completed = false;
+          }
+          return (
+            <Step key={label} {...stepProps}>
+              <StepLabel {...labelProps}>{label}</StepLabel>
+            </Step>
+          );
+        })}
+      </Stepper>
+      <div>
+        {activeStep === steps.length ? (
+          <div>
+            <Typography className={classes.instructions}>
+              All steps completed - you&apos;re finished
+            </Typography>
+            <Button onClick={handleReset} className={classes.button}>
+              Reset
+            </Button>
+          </div>
+        ) : (
+          <div>
+            <Typography className={classes.instructions}>{getStepContent(activeStep)}</Typography>
+            <div>
+              <Button disabled={activeStep === 0} onClick={handleBack} className={classes.button}>
+                Back
+              </Button>
+              {isStepOptional(activeStep) && (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleSkip}
+                  className={classes.button}
+                >
+                  Skip
+                </Button>
+              )}
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleNext}
+                className={classes.button}
+              >
+                {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default HorizontalLinearStepper;

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearAlternativeLabelStepper.js
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearAlternativeLabelStepper.js
@@ -89,9 +89,7 @@ function HorizontalNonLinearAlternativeLabelStepper() {
   }
 
   function handleNext() {
-    let newActiveStep;
-
-    newActiveStep =
+    const newActiveStep =
       isLastStep() && !allStepsCompleted()
         ? // It's the last step, but not all steps have been completed
           // find the first step that has been completed

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepButton from '@material-ui/core/StepButton';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     width: '90%',
   },
@@ -29,7 +29,7 @@ function getSteps() {
   return ['Select campaign settings', 'Create an ad group', 'Create an ad'];
 }
 
-function getStepContent(step) {
+function getStepContent(step: number) {
   switch (step) {
     case 0:
       return 'Step 1: Select campaign settings...';
@@ -45,15 +45,15 @@ function getStepContent(step) {
 function HorizontalNonLinearAlternativeLabelStepper() {
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
-  const [completed, setCompleted] = React.useState(new Set());
-  const [skipped, setSkipped] = React.useState(new Set());
+  const [completed, setCompleted] = React.useState(new Set<number>());
+  const [skipped, setSkipped] = React.useState(new Set<number>());
   const steps = getSteps();
 
   function totalSteps() {
     return getSteps().length;
   }
 
-  function isStepOptional(step) {
+  function isStepOptional(step: number) {
     return step === 1;
   }
 
@@ -91,12 +91,11 @@ function HorizontalNonLinearAlternativeLabelStepper() {
   function handleNext() {
     let newActiveStep;
 
-    newActiveStep =
-      isLastStep() && !allStepsCompleted()
-        ? // It's the last step, but not all steps have been completed
-          // find the first step that has been completed
-          steps.findIndex((step, i) => !completed.has(i))
-        : activeStep + 1;
+    newActiveStep = isLastStep() && !allStepsCompleted()
+      // It's the last step, but not all steps have been completed
+      // find the first step that has been completed
+      ? steps.findIndex((step, i) => !completed.has(i))
+      : activeStep + 1;
 
     setActiveStep(newActiveStep);
   }
@@ -105,7 +104,7 @@ function HorizontalNonLinearAlternativeLabelStepper() {
     setActiveStep(prevActiveStep => prevActiveStep - 1);
   }
 
-  const handleStep = step => () => {
+  const handleStep = (step: number) => () => {
     setActiveStep(step);
   };
 
@@ -126,15 +125,15 @@ function HorizontalNonLinearAlternativeLabelStepper() {
 
   function handleReset() {
     setActiveStep(0);
-    setCompleted(new Set());
-    setSkipped(new Set());
+    setCompleted(new Set<number>());
+    setSkipped(new Set<number>());
   }
 
-  function isStepSkipped(step) {
+  function isStepSkipped(step: number) {
     return skipped.has(step);
   }
 
-  function isStepComplete(step) {
+  function isStepComplete(step: number) {
     return completed.has(step);
   }
 
@@ -142,8 +141,8 @@ function HorizontalNonLinearAlternativeLabelStepper() {
     <div className={classes.root}>
       <Stepper alternativeLabel nonLinear activeStep={activeStep}>
         {steps.map((label, index) => {
-          const stepProps = {};
-          const buttonProps = {};
+          const stepProps: { completed?: boolean } = {};
+          const buttonProps: { optional?: React.ReactNode } = {};
           if (isStepOptional(index)) {
             buttonProps.optional = <Typography variant="caption">Optional</Typography>;
           }
@@ -196,7 +195,6 @@ function HorizontalNonLinearAlternativeLabelStepper() {
                   Skip
                 </Button>
               )}
-
               {activeStep !== steps.length &&
                 (completed.has(activeStep) ? (
                   <Typography variant="caption" className={classes.completed}>

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
@@ -91,11 +91,12 @@ function HorizontalNonLinearAlternativeLabelStepper() {
   function handleNext() {
     let newActiveStep;
 
-    newActiveStep = isLastStep() && !allStepsCompleted()
-      // It's the last step, but not all steps have been completed
-      // find the first step that has been completed
-      ? steps.findIndex((step, i) => !completed.has(i))
-      : activeStep + 1;
+    newActiveStep =
+      isLastStep() && !allStepsCompleted()
+        ? // It's the last step, but not all steps have been completed
+          // find the first step that has been completed
+          steps.findIndex((step, i) => !completed.has(i))
+        : activeStep + 1;
 
     setActiveStep(newActiveStep);
   }

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
@@ -89,9 +89,7 @@ function HorizontalNonLinearAlternativeLabelStepper() {
   }
 
   function handleNext() {
-    let newActiveStep;
-
-    newActiveStep =
+    const newActiveStep =
       isLastStep() && !allStepsCompleted()
         ? // It's the last step, but not all steps have been completed
           // find the first step that has been completed

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearStepper.js
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearStepper.js
@@ -62,9 +62,7 @@ function HorizontalNonLinearStepper() {
   }
 
   function handleNext() {
-    let newActiveStep;
-
-    newActiveStep =
+    const newActiveStep =
       isLastStep() && !allStepsCompleted()
         ? // It's the last step, but not all steps have been completed,
           // find the first step that has been completed

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearStepper.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepButton from '@material-ui/core/StepButton';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     width: '90%',
   },
@@ -26,7 +26,7 @@ function getSteps() {
   return ['Select campaign settings', 'Create an ad group', 'Create an ad'];
 }
 
-function getStepContent(step) {
+function getStepContent(step: number) {
   switch (step) {
     case 0:
       return 'Step 1: Select campaign settings...';
@@ -42,7 +42,7 @@ function getStepContent(step) {
 function HorizontalNonLinearStepper() {
   const classes = useStyles();
   const [activeStep, setActiveStep] = React.useState(0);
-  const [completed, setCompleted] = React.useState({});
+  const [completed, setCompleted] = React.useState<{ [k: number]: boolean }>({});
   const steps = getSteps();
 
   function totalSteps() {
@@ -64,12 +64,11 @@ function HorizontalNonLinearStepper() {
   function handleNext() {
     let newActiveStep;
 
-    newActiveStep =
-      isLastStep() && !allStepsCompleted()
-        ? // It's the last step, but not all steps have been completed,
-          // find the first step that has been completed
-          steps.findIndex((step, i) => !(i in completed))
-        : activeStep + 1;
+    newActiveStep = isLastStep() && !allStepsCompleted()
+      // It's the last step, but not all steps have been completed,
+      // find the first step that has been completed
+      ? steps.findIndex((step, i) => !(i in completed))
+      : activeStep + 1;
     setActiveStep(newActiveStep);
   }
 
@@ -77,7 +76,7 @@ function HorizontalNonLinearStepper() {
     setActiveStep(prevActiveStep => prevActiveStep - 1);
   }
 
-  const handleStep = step => () => {
+  const handleStep = (step: number) => () => {
     setActiveStep(step);
   };
 

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearStepper.tsx
@@ -64,11 +64,12 @@ function HorizontalNonLinearStepper() {
   function handleNext() {
     let newActiveStep;
 
-    newActiveStep = isLastStep() && !allStepsCompleted()
-      // It's the last step, but not all steps have been completed,
-      // find the first step that has been completed
-      ? steps.findIndex((step, i) => !(i in completed))
-      : activeStep + 1;
+    newActiveStep =
+      isLastStep() && !allStepsCompleted()
+        ? // It's the last step, but not all steps have been completed,
+          // find the first step that has been completed
+          steps.findIndex((step, i) => !(i in completed))
+        : activeStep + 1;
     setActiveStep(newActiveStep);
   }
 

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearStepper.tsx
@@ -62,9 +62,7 @@ function HorizontalNonLinearStepper() {
   }
 
   function handleNext() {
-    let newActiveStep;
-
-    newActiveStep =
+    const newActiveStep =
       isLastStep() && !allStepsCompleted()
         ? // It's the last step, but not all steps have been completed,
           // find the first step that has been completed

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearStepperWithError.js
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearStepperWithError.js
@@ -141,6 +141,7 @@ function HorizontalNonLinearStepperWithError() {
                   Skip
                 </Button>
               )}
+
               <Button
                 variant="contained"
                 color="primary"

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearStepperWithError.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearStepperWithError.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import Stepper from '@material-ui/core/Stepper';
+import Step from '@material-ui/core/Step';
+import StepLabel from '@material-ui/core/StepLabel';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: '90%',
+  },
+  button: {
+    marginRight: theme.spacing(1),
+  },
+  instructions: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+function getSteps() {
+  return ['Select campaign settings', 'Create an ad group', 'Create an ad'];
+}
+
+function getStepContent(step: number) {
+  switch (step) {
+    case 0:
+      return 'Select campaign settings...';
+    case 1:
+      return 'What is an ad group anyways?';
+    case 2:
+      return 'This is the bit I really care about!';
+    default:
+      return 'Unknown step';
+  }
+}
+
+function HorizontalNonLinearStepperWithError() {
+  const classes = useStyles();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const [skipped, setSkipped] = React.useState(new Set<number>());
+  const steps = getSteps();
+
+  function isStepOptional(step: number) {
+    return step === 1;
+  }
+
+  function isStepFailed(step: number) {
+    return step === 1;
+  }
+
+  function isStepSkipped(step: number) {
+    return skipped.has(step);
+  }
+
+  function handleNext() {
+    let newSkipped = skipped;
+    if (isStepSkipped(activeStep)) {
+      newSkipped = new Set(skipped.values());
+      newSkipped.delete(activeStep);
+    }
+
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+    setSkipped(newSkipped);
+  }
+
+  function handleBack() {
+    setActiveStep(prevActiveStep => prevActiveStep - 1);
+  }
+
+  function handleSkip() {
+    if (!isStepOptional(activeStep)) {
+      // You probably want to guard against something like this,
+      // it should never occur unless someone's actively trying to break something.
+      throw new Error("You can't skip a step that isn't optional.");
+    }
+
+    setSkipped(prevSkipped => {
+      const newSkipped = new Set(prevSkipped.values());
+      newSkipped.add(activeStep);
+      return newSkipped;
+    });
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+  }
+
+  function handleReset() {
+    setActiveStep(0);
+  }
+
+  return (
+    <div className={classes.root}>
+      <Stepper activeStep={activeStep}>
+        {steps.map((label, index) => {
+          const stepProps: { completed?: boolean } = {};
+          const labelProps: { optional?: React.ReactNode, error?: boolean } = {};
+          if (isStepOptional(index)) {
+            labelProps.optional = (
+              <Typography variant="caption" color="error">
+                Alert message
+              </Typography>
+            );
+          }
+          if (isStepFailed(index)) {
+            labelProps.error = true;
+          }
+          if (isStepSkipped(index)) {
+            stepProps.completed = false;
+          }
+          return (
+            <Step key={label} {...stepProps}>
+              <StepLabel {...labelProps}>{label}</StepLabel>
+            </Step>
+          );
+        })}
+      </Stepper>
+      <div>
+        {activeStep === steps.length ? (
+          <div>
+            <Typography className={classes.instructions}>
+              All steps completed - you&apos;re finished
+            </Typography>
+            <Button onClick={handleReset} className={classes.button}>
+              Reset
+            </Button>
+          </div>
+        ) : (
+          <div>
+            <Typography className={classes.instructions}>{getStepContent(activeStep)}</Typography>
+            <div>
+              <Button disabled={activeStep === 0} onClick={handleBack} className={classes.button}>
+                Back
+              </Button>
+              {isStepOptional(activeStep) && (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={handleSkip}
+                  className={classes.button}
+                >
+                  Skip
+                </Button>
+              )}
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={handleNext}
+                className={classes.button}
+              >
+                {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default HorizontalNonLinearStepperWithError;

--- a/docs/src/pages/demos/steppers/HorizontalNonLinearStepperWithError.tsx
+++ b/docs/src/pages/demos/steppers/HorizontalNonLinearStepperWithError.tsx
@@ -93,7 +93,7 @@ function HorizontalNonLinearStepperWithError() {
       <Stepper activeStep={activeStep}>
         {steps.map((label, index) => {
           const stepProps: { completed?: boolean } = {};
-          const labelProps: { optional?: React.ReactNode, error?: boolean } = {};
+          const labelProps: { optional?: React.ReactNode; error?: boolean } = {};
           if (isStepOptional(index)) {
             labelProps.optional = (
               <Typography variant="caption" color="error">

--- a/docs/src/pages/demos/steppers/ProgressMobileStepper.tsx
+++ b/docs/src/pages/demos/steppers/ProgressMobileStepper.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { makeStyles, useTheme } from '@material-ui/core/styles';
+import MobileStepper from '@material-ui/core/MobileStepper';
+import Button from '@material-ui/core/Button';
+import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+
+const useStyles = makeStyles({
+  root: {
+    maxWidth: 400,
+    flexGrow: 1,
+  },
+});
+
+function ProgressMobileStepper() {
+  const classes = useStyles();
+  const theme = useTheme();
+  const [activeStep, setActiveStep] = React.useState(0);
+
+  function handleNext() {
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+  }
+
+  function handleBack() {
+    setActiveStep(prevActiveStep => prevActiveStep - 1);
+  }
+
+  return (
+    <MobileStepper
+      variant="progress"
+      steps={6}
+      position="static"
+      activeStep={activeStep}
+      className={classes.root}
+      nextButton={
+        <Button size="small" onClick={handleNext} disabled={activeStep === 5}>
+          Next
+          {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+        </Button>
+      }
+      backButton={
+        <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+          {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+          Back
+        </Button>
+      }
+    />
+  );
+}
+
+export default ProgressMobileStepper;

--- a/docs/src/pages/demos/steppers/TextMobileStepper.tsx
+++ b/docs/src/pages/demos/steppers/TextMobileStepper.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
+import MobileStepper from '@material-ui/core/MobileStepper';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+
+const tutorialSteps = [
+  {
+    label: 'San Francisco – Oakland Bay Bridge, United States',
+    imgPath:
+      'https://images.unsplash.com/photo-1537944434965-cf4679d1a598?auto=format&fit=crop&w=400&h=250&q=60',
+  },
+  {
+    label: 'Bird',
+    imgPath:
+      'https://images.unsplash.com/photo-1538032746644-0212e812a9e7?auto=format&fit=crop&w=400&h=250&q=60',
+  },
+  {
+    label: 'Bali, Indonesia',
+    imgPath:
+      'https://images.unsplash.com/photo-1537996194471-e657df975ab4?auto=format&fit=crop&w=400&h=250&q=80',
+  },
+  {
+    label: 'NeONBRAND Digital Marketing, Las Vegas, United States',
+    imgPath:
+      'https://images.unsplash.com/photo-1518732714860-b62714ce0c59?auto=format&fit=crop&w=400&h=250&q=60',
+  },
+  {
+    label: 'Goč, Serbia',
+    imgPath:
+      'https://images.unsplash.com/photo-1512341689857-198e7e2f3ca8?auto=format&fit=crop&w=400&h=250&q=60',
+  },
+];
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    maxWidth: 400,
+    flexGrow: 1,
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    height: 50,
+    paddingLeft: theme.spacing(4),
+    backgroundColor: theme.palette.background.default,
+  },
+  img: {
+    height: 255,
+    maxWidth: 400,
+    overflow: 'hidden',
+    display: 'block',
+    width: '100%',
+  },
+}));
+
+function TextMobileStepper() {
+  const classes = useStyles();
+  const theme = useTheme();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const maxSteps = tutorialSteps.length;
+
+  function handleNext() {
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+  }
+
+  function handleBack() {
+    setActiveStep(prevActiveStep => prevActiveStep - 1);
+  }
+
+  return (
+    <div className={classes.root}>
+      <Paper square elevation={0} className={classes.header}>
+        <Typography>{tutorialSteps[activeStep].label}</Typography>
+      </Paper>
+      <img
+        className={classes.img}
+        src={tutorialSteps[activeStep].imgPath}
+        alt={tutorialSteps[activeStep].label}
+      />
+      <MobileStepper
+        steps={maxSteps}
+        position="static"
+        variant="text"
+        activeStep={activeStep}
+        nextButton={
+          <Button size="small" onClick={handleNext} disabled={activeStep === maxSteps - 1}>
+            Next
+            {theme.direction === 'rtl' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+          </Button>
+        }
+        backButton={
+          <Button size="small" onClick={handleBack} disabled={activeStep === 0}>
+            {theme.direction === 'rtl' ? <KeyboardArrowRight /> : <KeyboardArrowLeft />}
+            Back
+          </Button>
+        }
+      />
+    </div>
+  );
+}
+
+export default TextMobileStepper;

--- a/docs/src/pages/demos/steppers/VerticalLinearStepper.tsx
+++ b/docs/src/pages/demos/steppers/VerticalLinearStepper.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import Stepper from '@material-ui/core/Stepper';
+import Step from '@material-ui/core/Step';
+import StepLabel from '@material-ui/core/StepLabel';
+import StepContent from '@material-ui/core/StepContent';
+import Button from '@material-ui/core/Button';
+import Paper from '@material-ui/core/Paper';
+import Typography from '@material-ui/core/Typography';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: '90%',
+  },
+  button: {
+    marginTop: theme.spacing(1),
+    marginRight: theme.spacing(1),
+  },
+  actionsContainer: {
+    marginBottom: theme.spacing(2),
+  },
+  resetContainer: {
+    padding: theme.spacing(3),
+  },
+}));
+
+function getSteps() {
+  return ['Select campaign settings', 'Create an ad group', 'Create an ad'];
+}
+
+function getStepContent(step: number) {
+  switch (step) {
+    case 0:
+      return `For each ad campaign that you create, you can control how much
+              you're willing to spend on clicks and conversions, which networks
+              and geographical locations you want your ads to show on, and more.`;
+    case 1:
+      return 'An ad group contains one or more ads which target a shared set of keywords.';
+    case 2:
+      return `Try out different ad text to see what brings in the most customers,
+              and learn how to enhance your ads using features like ad extensions.
+              If you run into any problems with your ads, find out how to tell if
+              they're running and how to resolve approval issues.`;
+    default:
+      return 'Unknown step';
+  }
+}
+
+function VerticalLinearStepper() {
+  const classes = useStyles();
+  const [activeStep, setActiveStep] = React.useState(0);
+  const steps = getSteps();
+
+  function handleNext() {
+    setActiveStep(prevActiveStep => prevActiveStep + 1);
+  }
+
+  function handleBack() {
+    setActiveStep(prevActiveStep => prevActiveStep - 1);
+  }
+
+  function handleReset() {
+    setActiveStep(0);
+  }
+
+  return (
+    <div className={classes.root}>
+      <Stepper activeStep={activeStep} orientation="vertical">
+        {steps.map((label, index) => (
+          <Step key={label}>
+            <StepLabel>{label}</StepLabel>
+            <StepContent>
+              <Typography>{getStepContent(index)}</Typography>
+              <div className={classes.actionsContainer}>
+                <div>
+                  <Button
+                    disabled={activeStep === 0}
+                    onClick={handleBack}
+                    className={classes.button}
+                  >
+                    Back
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={handleNext}
+                    className={classes.button}
+                  >
+                    {activeStep === steps.length - 1 ? 'Finish' : 'Next'}
+                  </Button>
+                </div>
+              </div>
+            </StepContent>
+          </Step>
+        ))}
+      </Stepper>
+      {activeStep === steps.length && (
+        <Paper square elevation={0} className={classes.resetContainer}>
+          <Typography>All steps completed - you&apos;re finished</Typography>
+          <Button onClick={handleReset} className={classes.button}>
+            Reset
+          </Button>
+        </Paper>
+      )}
+    </div>
+  );
+}
+
+export default VerticalLinearStepper;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Adds most TS demos for Steppers.

One question: `SwipeableTextMobileStepper` has an import (`react-swipeable-views-utils`) that has no type definitions. I noticed that a TS demo for `VirtualizedList` also has an import (`react-window`) with no type definition. Should we make sure that there are types available for all imports before checking in that TS demo?