### PR TITLE
[docs] Improve the @material-ui/styles documentation

### DIFF
--- a/docs/src/modules/utils/getDemoConfig.js
+++ b/docs/src/modules/utils/getDemoConfig.js
@@ -68,9 +68,9 @@ export default function getDemo(demoData) {
       'index.html': `
 <body>
   <!-- Fonts to support Material Design -->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
   <!-- Icons to support Material Design -->
-  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <div id="root"></div>
 </body>
       `,

--- a/docs/src/modules/utils/helpers.js
+++ b/docs/src/modules/utils/helpers.js
@@ -94,6 +94,8 @@ export function getDependencies(raw, options = {}) {
     '@material-ui/system': 'next',
     '@material-ui/utils': 'next',
     'date-fns': 'next',
+    jss: 'next',
+    'jss-plugin-template': 'next',
   };
   const re = /^import\s.*\sfrom\s+'([^']+)|import\s'([^']+)'/gm;
   let m;

--- a/docs/src/pages/css-in-js/advanced/StringTemplates.js
+++ b/docs/src/pages/css-in-js/advanced/StringTemplates.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { jssPreset, StylesProvider, makeStyles } from '@material-ui/styles';
 import { create } from 'jss';
 import jssTemplate from 'jss-plugin-template';
-import Button from '@material-ui/core/Button';
 
 const jss = create({
   plugins: [jssTemplate(), ...jssPreset().plugins],
@@ -11,7 +10,8 @@ const jss = create({
 const useStyles = makeStyles({
   root: `
     background: linear-gradient(45deg, #fe6b8b 30%, #ff8e53 90%);
-    border-radius: 3;
+    border-radius: 3px;
+    font-size: 16px;
     border: 0;
     color: white;
     height: 48px;
@@ -22,7 +22,11 @@ const useStyles = makeStyles({
 
 function Child() {
   const classes = useStyles();
-  return <Button className={classes.root}>String templates</Button>;
+  return (
+    <button type="button" className={classes.root}>
+      String templates
+    </button>
+  );
 }
 
 function StringTemplates() {

--- a/docs/src/pages/css-in-js/advanced/ThemeNesting.js
+++ b/docs/src/pages/css-in-js/advanced/ThemeNesting.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { ThemeProvider, makeStyles } from '@material-ui/styles';
-import Button from '@material-ui/core/Button';
 
 const useStyles = makeStyles(theme => ({
   root: {
     background: theme.background,
     border: 0,
+    fontSize: 16,
     borderRadius: 3,
     boxShadow: theme.boxShadow,
     color: 'white',
@@ -17,7 +17,11 @@ const useStyles = makeStyles(theme => ({
 function DeepChild() {
   const classes = useStyles();
 
-  return <Button className={classes.root}>Theme nesting</Button>;
+  return (
+    <button type="button" className={classes.root}>
+      Theme nesting
+    </button>
+  );
 }
 
 function Theme() {

--- a/docs/src/pages/css-in-js/advanced/Theming.js
+++ b/docs/src/pages/css-in-js/advanced/Theming.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { ThemeProvider, makeStyles } from '@material-ui/styles';
-import Button from '@material-ui/core/Button';
 
 const useStyles = makeStyles(theme => ({
   root: {
     background: theme.background,
     border: 0,
+    fontSize: 16,
     borderRadius: 3,
     boxShadow: '0 3px 5px 2px rgba(255, 105, 135, .3)',
     color: 'white',
@@ -17,7 +17,11 @@ const useStyles = makeStyles(theme => ({
 function DeepChild() {
   const classes = useStyles();
 
-  return <Button className={classes.root}>Theming</Button>;
+  return (
+    <button type="button" className={classes.root}>
+      Theming
+    </button>
+  );
 }
 
 const theme = {

--- a/docs/src/pages/css-in-js/advanced/advanced.md
+++ b/docs/src/pages/css-in-js/advanced/advanced.md
@@ -128,7 +128,8 @@ If you prefer using the CSS syntax, you can use the [jss-plugin-template](https:
 const useStyles = makeStyles({
   root: `
     background: linear-gradient(45deg, #fe6b8b 30%, #ff8e53 90%);
-    border-radius: 3;
+    border-radius: 3px;
+    font-size: 16px;
     border: 0;
     color: white;
     height: 48px;

--- a/docs/src/pages/css-in-js/basics/StressTest.js
+++ b/docs/src/pages/css-in-js/basics/StressTest.js
@@ -47,7 +47,7 @@ function StressTest() {
   const theme = React.useMemo(() => ({ color }), [color]);
 
   return (
-    <ThemeProvider theme={() => theme}>
+    <ThemeProvider theme={theme}>
       <div>
         <fieldset>
           <div>

--- a/examples/create-react-app-next/README.md
+++ b/examples/create-react-app-next/README.md
@@ -19,22 +19,3 @@ npm start
 ## The idea behind the example
 
 This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app).
-
-## Folder Structure
-
-```
-/src
-    /components
-```
-
-- `src:` Contains the minimum number of files necessary to bootstrap the application.
-
-  - `index.js` wraps the `App` with `ThemeProvider`. This allows us to access our
-    theme anywhere in our component tree (using `makeStyles()`). `index.js` also
-    provides the `CssBaseline`.
-  - `App.js` is the root of our component tree. In this simple example, it contains
-    the layout of our landing page. In a more complex applications, you might want to
-    place your router here along with other providers.
-
-- `components:` This is where we keep the components that are used in the app - one
-  folder per component or a set of tightly related components.

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -68,6 +68,9 @@ const blacklistFilename = [
   'docs-getting-started-page-layout-examples-dashboard/Deposits.png',
   'docs-getting-started-page-layout-examples-dashboard/Orders.png',
   'docs-getting-started-page-layout-examples-dashboard/Title.png',
+  'docs-getting-started-page-layout-examples-checkout/AddressForm.png',
+  'docs-getting-started-page-layout-examples-checkout/PaymentForm.png',
+  'docs-getting-started-page-layout-examples-checkout/Review.png',
 
   // Flaky
   'docs-demos-grid-list/ImageGridList.png',
@@ -97,7 +100,7 @@ const demos = requireDemos.keys().reduce((res, path) => {
     return res;
   }
 
-  if (/^docs-premium-themes(.*)/.test(suite) || /\.hooks$/.test(name)) {
+  if (/^docs-premium-themes(.*)/.test(suite)) {
     return res;
   }
 


### PR DESCRIPTION
I have removed all the imports from `@material-ui/core` in the advanced section of the documentation of the styles package. It fixes the codesandboxes.

Closes #15153.