### PR TITLE
[Button] Use fixed outlined stroke color

### DIFF
--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -75,9 +75,6 @@ export const styles = theme => ({
     border: `1px solid ${
       theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.12)' : 'rgba(255, 255, 255, 0.12)'
     }`,
-    '&$disabled': {
-      border: `1px solid ${theme.palette.action.disabled}`,
-    },
   },
   /* Styles applied to the root element if `variant="outlined"` and `color="primary"`. */
   outlinedPrimary: {

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -73,7 +73,7 @@ export const styles = theme => ({
   outlined: {
     padding: '5px 16px',
     border: `1px solid ${
-      theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.23)' : 'rgba(255, 255, 255, 0.23)'
+      theme.palette.type === 'light' ? 'rgba(0, 0, 0, 0.12)' : 'rgba(255, 255, 255, 0.12)'
     }`,
     '&$disabled': {
       border: `1px solid ${theme.palette.action.disabled}`,
@@ -82,9 +82,7 @@ export const styles = theme => ({
   /* Styles applied to the root element if `variant="outlined"` and `color="primary"`. */
   outlinedPrimary: {
     color: theme.palette.primary.main,
-    border: `1px solid ${fade(theme.palette.primary.main, 0.5)}`,
     '&:hover': {
-      border: `1px solid ${theme.palette.primary.main}`,
       backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
       '@media (hover: none)': {
@@ -95,17 +93,12 @@ export const styles = theme => ({
   /* Styles applied to the root element if `variant="outlined"` and `color="secondary"`. */
   outlinedSecondary: {
     color: theme.palette.secondary.main,
-    border: `1px solid ${fade(theme.palette.secondary.main, 0.5)}`,
     '&:hover': {
-      border: `1px solid ${theme.palette.secondary.main}`,
       backgroundColor: fade(theme.palette.secondary.main, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
       '@media (hover: none)': {
         backgroundColor: 'transparent',
       },
-    },
-    '&$disabled': {
-      border: `1px solid ${theme.palette.action.disabled}`,
     },
   },
   /* Styles applied to the root element if `variant="contained"`. */


### PR DESCRIPTION
Closes #9526 

- [material.io: Outlined buttons](https://material.io/design/components/buttons.html#outlined-button)
- [material.io: Outlined buttons spec](https://material.io/design/components/buttons.html#specs)


## Breaking
Outlined buttons use a fixed border color for the containers independent of color variant or state.

## Get the old look

```js
import React from 'react';
import { fade, makeStyles } from '@material-ui/core/styles';
import Button from '@material-ui/core/Button';

const useOldStyles = makeStyles(theme => {
  return {
    outlined: {
      '&$disabled': {
        border: `1px solid ${theme.palette.action.disabled}`,
      },
    },
    outlinedPrimary: {
      border: `1px solid ${fade(theme.palette.primary.main, 0.5)}`,
      '&:hover': {
        border: `1px solid ${theme.palette.primary.main}`,
      },
    },
    outlinedSecondary: {
      border: `1px solid ${fade(theme.palette.secondary.main, 0.5)}`,
      '&:hover': {
        border: `1px solid ${theme.palette.secondary.main}`,
      },
    },
  };
});

function OldButton(props) {
  const classes = useOldStyles(props);
  return <Button {...props} classes={classes} />;
}
```

## Visual diff
[docs: next](https://5ca9d09cf8d7770007fc2997--material-ui.netlify.com/demos/buttons/#outlined-buttons) vs. [docs: PR](https://deploy-preview-15242--material-ui.netlify.com/demos/buttons/#outlined-buttons)

[argos: next](https://argos-screenshots-us.s3.amazonaws.com/7fef543f8c6bea23a500b5d9fefa3da2) vs. [argos: PR](https://argos-screenshots-us.s3.amazonaws.com/afe780941b97567c5909a9eea3124ce6)
