### PR TITLE
[Paper] Reduce the default elevation

### DIFF
--- a/docs/src/pages/demos/paper/PaperSheet.js
+++ b/docs/src/pages/demos/paper/PaperSheet.js
@@ -15,7 +15,7 @@ function PaperSheet(props) {
 
   return (
     <div>
-      <Paper className={classes.root} elevation={1}>
+      <Paper className={classes.root}>
         <Typography variant="h5" component="h3">
           This is a sheet of paper.
         </Typography>

--- a/docs/src/pages/demos/paper/PaperSheet.tsx
+++ b/docs/src/pages/demos/paper/PaperSheet.tsx
@@ -16,7 +16,7 @@ function PaperSheet(props: WithStyles<typeof styles>) {
 
   return (
     <div>
-      <Paper className={classes.root} elevation={1}>
+      <Paper className={classes.root}>
         <Typography variant="h5" component="h3">
           This is a sheet of paper.
         </Typography>

--- a/docs/src/pages/demos/text-fields/CustomizedInputBase.js
+++ b/docs/src/pages/demos/text-fields/CustomizedInputBase.js
@@ -34,7 +34,7 @@ function CustomizedInputBase(props) {
   const { classes } = props;
 
   return (
-    <Paper className={classes.root} elevation={1}>
+    <Paper className={classes.root}>
       <IconButton className={classes.iconButton} aria-label="Menu">
         <MenuIcon />
       </IconButton>

--- a/docs/src/pages/demos/text-fields/CustomizedInputBase.tsx
+++ b/docs/src/pages/demos/text-fields/CustomizedInputBase.tsx
@@ -36,7 +36,7 @@ function CustomizedInputBase(props: Props) {
   const { classes } = props;
 
   return (
-    <Paper className={classes.root} elevation={1}>
+    <Paper className={classes.root}>
       <IconButton className={classes.iconButton} aria-label="Menu">
         <MenuIcon />
       </IconButton>

--- a/docs/src/pages/demos/transfer-list/TransferList.js
+++ b/docs/src/pages/demos/transfer-list/TransferList.js
@@ -79,7 +79,7 @@ function TransferList() {
   };
 
   const customList = items => (
-    <Paper elevation={1} className={classes.paper}>
+    <Paper className={classes.paper}>
       <List dense>
         {items.map(value => (
           <ListItem

--- a/docs/src/pages/premium-themes/tweeper/components/tweeper/Header.js
+++ b/docs/src/pages/premium-themes/tweeper/components/tweeper/Header.js
@@ -10,7 +10,7 @@ const { AppBar, Avatar, Badge, Icon, Toolbar } = atoms;
 const { Tabs, Tab, ListItem, InputAdornment } = molecules;
 
 const Header = () => (
-  <AppBar position="sticky" elevation={1}>
+  <AppBar position="sticky">
     <Toolbar>
       <Grid container alignItems="center" spacing={2}>
         <Grid item xs={6} sm={4}>

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -119,7 +119,6 @@ const ExpansionPanel = React.forwardRef(function ExpansionPanel(props, ref) {
         },
         className,
       )}
-
       ref={ref}
       square={square}
       {...other}

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -119,7 +119,7 @@ const ExpansionPanel = React.forwardRef(function ExpansionPanel(props, ref) {
         },
         className,
       )}
-      elevation={1}
+
       ref={ref}
       square={square}
       {...other}

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -39,7 +39,6 @@ describe('<ExpansionPanel />', () => {
     const wrapper = mount(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
     const root = wrapper.find(`.${classes.root}`).first();
     assert.strictEqual(root.type(), Paper);
-    assert.strictEqual(root.props().elevation, 1);
     assert.strictEqual(root.props().square, false);
     wrapper.setProps({ expanded: true });
     assert.strictEqual(root.hasClass(classes.expanded), false, 'uncontrolled');

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -73,7 +73,7 @@ Paper.propTypes = {
   component: PropTypes.elementType,
   /**
    * Shadow depth, corresponds to `dp` in the spec.
-   * It's accepting values between 0 and 24 inclusive.
+   * It accepts values between 0 and 24 inclusive.
    */
   elevation: PropTypes.number,
   /**

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -84,7 +84,7 @@ Paper.propTypes = {
 
 Paper.defaultProps = {
   component: 'div',
-  elevation: 2,
+  elevation: 1,
   square: false,
 };
 

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -21,7 +21,7 @@ import Paper from '@material-ui/core/Paper';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">elevation</span> | <span class="prop-type">number</span> | <span class="prop-default">1</span> | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |
+| <span class="prop-name">elevation</span> | <span class="prop-type">number</span> | <span class="prop-default">1</span> | Shadow depth, corresponds to `dp` in the spec. It accepts values between 0 and 24 inclusive. |
 | <span class="prop-name">square</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, rounded corners are disabled. |
 
 The `ref` is forwarded to the root element.

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -21,7 +21,7 @@ import Paper from '@material-ui/core/Paper';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">elevation</span> | <span class="prop-type">number</span> | <span class="prop-default">2</span> | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |
+| <span class="prop-name">elevation</span> | <span class="prop-type">number</span> | <span class="prop-default">1</span> | Shadow depth, corresponds to `dp` in the spec. It's accepting values between 0 and 24 inclusive. |
 | <span class="prop-name">square</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, rounded corners are disabled. |
 
 The `ref` is forwarded to the root element.


### PR DESCRIPTION
This is a proposal. Google seems to use fewer and fewer elevation with its product design. I think that we can reflect this trend by decreasing the default elevation of the Paper from 2 to 1. Please review!

### Breaking change

Change the default Paper elevation to match the Card and the Expansion Panel:
```diff
-<Paper />
+<Paper elevation={2} />
```