### PR TITLE
[core] Synchronise value and checked prop typing

### DIFF
--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -136,7 +136,7 @@ Checkbox.propTypes = {
    */
   type: PropTypes.string,
   /**
-   * The value of the component.
+   * The value of the component. The DOM API casts this to a string.
    */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
 };

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -138,7 +138,7 @@ Checkbox.propTypes = {
   /**
    * The value of the component.
    */
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
 };
 
 Checkbox.defaultProps = {

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -138,7 +138,7 @@ Checkbox.propTypes = {
   /**
    * The value of the component. The DOM API casts this to a string.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  value: PropTypes.any,
 };
 
 Checkbox.defaultProps = {

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -70,7 +70,7 @@ Checkbox.propTypes = {
   /**
    * If `true`, the component is checked.
    */
-  checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  checked: PropTypes.bool,
   /**
    * The icon to display when the component is checked.
    */

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -163,15 +163,7 @@ FilledInput.propTypes = {
   /**
    * The default `input` element value, useful when not controlling the component.
    */
-  defaultValue: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  defaultValue: PropTypes.any,
   /**
    * If `true`, the `input` element will be disabled.
    */
@@ -262,15 +254,7 @@ FilledInput.propTypes = {
   /**
    * The value of the `input` element, required for a controlled component.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  value: PropTypes.any,
 };
 
 InputBase.defaultProps = {

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
@@ -15,7 +15,7 @@ export interface FormControlLabelProps
   name?: string;
   onChange?: (event: React.ChangeEvent<{}>, checked: boolean) => void;
   labelPlacement?: 'end' | 'start' | 'top' | 'bottom';
-  value?: any;
+  value?: unknown;
 }
 
 export type FormControlLabelClassKey = 'root' | 'start' | 'disabled' | 'label';

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
@@ -7,7 +7,7 @@ export interface FormControlLabelProps
     FormControlLabelClassKey,
     'onChange'
   > {
-  checked?: boolean | string;
+  checked?: boolean;
   control: React.ReactElement;
   disabled?: boolean;
   inputRef?: React.Ref<any>;
@@ -15,7 +15,7 @@ export interface FormControlLabelProps
   name?: string;
   onChange?: (event: React.ChangeEvent<{}>, checked: boolean) => void;
   labelPlacement?: 'end' | 'start' | 'top' | 'bottom';
-  value?: string;
+  value?: any;
 }
 
 export type FormControlLabelClassKey = 'root' | 'start' | 'disabled' | 'label';

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -114,7 +114,7 @@ FormControlLabel.propTypes = {
   /**
    * If `true`, the component appears selected.
    */
-  checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  checked: PropTypes.bool,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
@@ -163,7 +163,7 @@ FormControlLabel.propTypes = {
   /**
    * The value of the component.
    */
-  value: PropTypes.string,
+  value: PropTypes.any,
 };
 
 FormControlLabel.defaultProps = {

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -131,15 +131,7 @@ Input.propTypes = {
   /**
    * The default `input` element value, useful when not controlling the component.
    */
-  defaultValue: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  defaultValue: PropTypes.any,
   /**
    * If `true`, the `input` element will be disabled.
    */
@@ -230,15 +222,7 @@ Input.propTypes = {
   /**
    * The value of the `input` element, required for a controlled component.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  value: PropTypes.any,
 };
 
 InputBase.defaultProps = {

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -9,7 +9,7 @@ export interface InputBaseProps
   > {
   autoComplete?: string;
   autoFocus?: boolean;
-  defaultValue?: Array<string | number | boolean | object> | string | number | boolean | object;
+  defaultValue?: any;
   disabled?: boolean;
   endAdornment?: React.ReactNode;
   error?: boolean;
@@ -37,7 +37,7 @@ export interface InputBaseProps
   rowsMax?: string | number;
   startAdornment?: React.ReactNode;
   type?: string;
-  value?: Array<string | number | boolean | object> | string | number | boolean | object;
+  value?: any;
   onFilled?: () => void;
   /**
    * `onChange`, `onKeyUp` + `onKeyDown` are applied to the inner `InputComponent`,

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -9,7 +9,7 @@ export interface InputBaseProps
   > {
   autoComplete?: string;
   autoFocus?: boolean;
-  defaultValue?: any;
+  defaultValue?: unknown;
   disabled?: boolean;
   endAdornment?: React.ReactNode;
   error?: boolean;
@@ -37,7 +37,7 @@ export interface InputBaseProps
   rowsMax?: string | number;
   startAdornment?: React.ReactNode;
   type?: string;
-  value?: any;
+  value?: unknown;
   onFilled?: () => void;
   /**
    * `onChange`, `onKeyUp` + `onKeyDown` are applied to the inner `InputComponent`,

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -456,15 +456,7 @@ InputBase.propTypes = {
   /**
    * The default `input` element value, useful when not controlling the component.
    */
-  defaultValue: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  defaultValue: PropTypes.any,
   /**
    * If `true`, the `input` element will be disabled.
    */
@@ -592,15 +584,7 @@ InputBase.propTypes = {
   /**
    * The value of the `input` element, required for a controlled component.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  value: PropTypes.any,
 };
 
 InputBase.defaultProps = {

--- a/packages/material-ui/src/InputBase/Textarea.d.ts
+++ b/packages/material-ui/src/InputBase/Textarea.d.ts
@@ -12,7 +12,7 @@ export interface TextareaProps
   rows?: string | number;
   rowsMax?: string | number;
   textareaRef?: React.Ref<any> | React.RefObject<any>;
-  value?: string;
+  value?: any;
 }
 
 export type TextareaClassKey = 'root' | 'shadow' | 'textarea';

--- a/packages/material-ui/src/InputBase/Textarea.d.ts
+++ b/packages/material-ui/src/InputBase/Textarea.d.ts
@@ -5,14 +5,14 @@ export interface TextareaProps
   extends StandardProps<
     React.TextareaHTMLAttributes<HTMLTextAreaElement>,
     TextareaClassKey,
-    'rows'
+    'defaultValue' | 'rows' | 'value'
   > {
-  defaultValue?: any;
+  defaultValue?: unknown;
   disabled?: boolean;
   rows?: string | number;
   rowsMax?: string | number;
   textareaRef?: React.Ref<any> | React.RefObject<any>;
-  value?: any;
+  value?: unknown;
 }
 
 export type TextareaClassKey = 'root' | 'shadow' | 'textarea';

--- a/packages/material-ui/src/InputBase/Textarea.js
+++ b/packages/material-ui/src/InputBase/Textarea.js
@@ -207,7 +207,7 @@ Textarea.propTypes = {
   /**
    * @ignore
    */
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  defaultValue: PropTypes.any,
   /**
    * @ignore
    */
@@ -236,7 +236,7 @@ Textarea.propTypes = {
   /**
    * @ignore
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  value: PropTypes.any,
 };
 
 Textarea.defaultProps = {

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -8,7 +8,7 @@ export interface NativeSelectProps
     Pick<NativeSelectInputProps, 'onChange'> {
   IconComponent?: React.ElementType;
   input?: React.ReactNode;
-  value?: Array<string | number | boolean> | string | number | boolean;
+  value?: any;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -8,7 +8,7 @@ export interface NativeSelectProps
     Pick<NativeSelectInputProps, 'onChange'> {
   IconComponent?: React.ElementType;
   input?: React.ReactNode;
-  value?: any;
+  value?: unknown;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -153,12 +153,7 @@ NativeSelect.propTypes = {
   /**
    * The input value.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])),
-  ]),
+  value: PropTypes.any,
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
@@ -8,7 +8,7 @@ export interface NativeSelectInputProps {
   ) => void;
   name?: string;
   onChange?: (event: React.ChangeEvent<HTMLSelectElement>, child: React.ReactNode) => void;
-  value?: any;
+  value?: unknown;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
@@ -8,7 +8,7 @@ export interface NativeSelectInputProps {
   ) => void;
   name?: string;
   onChange?: (event: React.ChangeEvent<HTMLSelectElement>, child: React.ReactNode) => void;
-  value?: Array<string | number | boolean> | string | number | boolean;
+  value?: any;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -88,12 +88,7 @@ NativeSelectInput.propTypes = {
   /**
    * The input value.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])),
-  ]),
+  value: PropTypes.any,
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -130,15 +130,7 @@ OutlinedInput.propTypes = {
   /**
    * The default `input` element value, useful when not controlling the component.
    */
-  defaultValue: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  defaultValue: PropTypes.any,
   /**
    * If `true`, the `input` element will be disabled.
    */
@@ -233,15 +225,7 @@ OutlinedInput.propTypes = {
   /**
    * The value of the `input` element, required for a controlled component.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  value: PropTypes.any,
 };
 
 InputBase.defaultProps = {

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -66,7 +66,7 @@ Radio.propTypes = {
   /**
    * If `true`, the component is checked.
    */
-  checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  checked: PropTypes.bool,
   /**
    * The icon to display when the component is checked.
    */
@@ -123,7 +123,7 @@ Radio.propTypes = {
   /**
    * The value of the component.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  value: PropTypes.any,
 };
 
 Radio.defaultProps = {

--- a/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
@@ -5,8 +5,8 @@ import { FormGroupProps, FormGroupClassKey } from '../FormGroup';
 export interface RadioGroupProps
   extends StandardProps<FormGroupProps, RadioGroupClassKey, 'onChange'> {
   name?: string;
-  onChange?: (event: React.ChangeEvent<{}>, value: any) => void;
-  value?: any;
+  onChange?: (event: React.ChangeEvent<{}>, value: string) => void;
+  value?: string;
 }
 
 export type RadioGroupClassKey = FormGroupClassKey;

--- a/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
@@ -5,8 +5,8 @@ import { FormGroupProps, FormGroupClassKey } from '../FormGroup';
 export interface RadioGroupProps
   extends StandardProps<FormGroupProps, RadioGroupClassKey, 'onChange'> {
   name?: string;
-  onChange?: (event: React.ChangeEvent<{}>, value: string) => void;
-  value?: string;
+  onChange?: (event: React.ChangeEvent<{}>, value: any) => void;
+  value?: any;
 }
 
 export type RadioGroupClassKey = FormGroupClassKey;

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -86,7 +86,7 @@ RadioGroup.propTypes = {
   /**
    * The default `input` element value, useful when not controlling the component.
    */
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  defaultValue: PropTypes.any,
   /**
    * The name used to reference the value of the control.
    */
@@ -110,7 +110,7 @@ RadioGroup.propTypes = {
   /**
    * Value of the selected radio button.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  value: PropTypes.any,
 };
 
 export default RadioGroup;

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -110,7 +110,7 @@ RadioGroup.propTypes = {
   /**
    * Value of the selected radio button.
    */
-  value: PropTypes.any,
+  value: PropTypes.string,
 };
 
 export default RadioGroup;

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -204,47 +204,58 @@ describe('<RadioGroup />', () => {
       assert.strictEqual(handleChange2.callCount, 1);
     });
 
-    it('passes the value of the selected Radio as a string', () => {
-      function selectNth(wrapper, n) {
-        return wrapper
-          .find('input[type="radio"]')
-          .at(n)
-          .simulate('change');
-      }
-      function isNthChecked(wrapper, n) {
-        return wrapper
-          .find('input[type="radio"]')
-          .at(n)
-          .is('[checked=true]');
-      }
-      function Test(props) {
-        const { values, ...other } = props;
-        return (
-          <RadioGroup {...other}>
-            {values.map(value => {
-              return <Radio key={value.id} value={value} />;
-            })}
-          </RadioGroup>
-        );
-      }
-      Test.propTypes = {
-        values: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.number.isRequired })),
-      };
+    describe('with non-string values', () => {
+      before(() => {
+        // swallow prop-types warnings
+        consoleErrorMock.spy();
+      });
 
-      const values = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
-      const handleChange = spy();
+      after(() => {
+        consoleErrorMock.reset();
+      });
 
-      const wrapper = mount(<Test onChange={handleChange} value={values[1]} values={values} />);
-      // on the initial mount it works because we compare to the `value` prop
-      assert.strictEqual(isNthChecked(wrapper, 0), false);
-      assert.strictEqual(isNthChecked(wrapper, 1), true);
+      it('passes the value of the selected Radio as a string', () => {
+        function selectNth(wrapper, n) {
+          return wrapper
+            .find('input[type="radio"]')
+            .at(n)
+            .simulate('change');
+        }
+        function isNthChecked(wrapper, n) {
+          return wrapper
+            .find('input[type="radio"]')
+            .at(n)
+            .is('[checked=true]');
+        }
+        function Test(props) {
+          const { values, ...other } = props;
+          return (
+            <RadioGroup {...other}>
+              {values.map(value => {
+                return <Radio key={value.id} value={value} />;
+              })}
+            </RadioGroup>
+          );
+        }
+        Test.propTypes = {
+          values: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.number.isRequired })),
+        };
 
-      selectNth(wrapper, 0);
-      // on updates, however, we compare against event.target.value
-      // object information is lost on stringification.
-      assert.strictEqual(isNthChecked(wrapper, 0), false);
-      assert.strictEqual(isNthChecked(wrapper, 1), true);
-      assert.strictEqual(handleChange.firstCall.args[1], '[object Object]');
+        const values = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+        const handleChange = spy();
+
+        const wrapper = mount(<Test onChange={handleChange} value={values[1]} values={values} />);
+        // on the initial mount it works because we compare to the `value` prop
+        assert.strictEqual(isNthChecked(wrapper, 0), false);
+        assert.strictEqual(isNthChecked(wrapper, 1), true);
+
+        selectNth(wrapper, 0);
+        // on updates, however, we compare against event.target.value
+        // object information is lost on stringification.
+        assert.strictEqual(isNthChecked(wrapper, 0), false);
+        assert.strictEqual(isNthChecked(wrapper, 1), true);
+        assert.strictEqual(handleChange.firstCall.args[1], '[object Object]');
+      });
     });
   });
 

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
+import * as PropTypes from 'prop-types';
 import {
   createMount,
   describeConformance,
@@ -201,6 +202,49 @@ describe('<RadioGroup />', () => {
       findRadio(wrapper, 'woofRadioGroup').simulate('change');
       assert.strictEqual(handleChange1.callCount, 1);
       assert.strictEqual(handleChange2.callCount, 1);
+    });
+
+    it('passes the value of the selected Radio as a string', () => {
+      function selectNth(wrapper, n) {
+        return wrapper
+          .find('input[type="radio"]')
+          .at(n)
+          .simulate('change');
+      }
+      function isNthChecked(wrapper, n) {
+        return wrapper
+          .find('input[type="radio"]')
+          .at(n)
+          .is('[checked=true]');
+      }
+      function Test(props) {
+        const { values, ...other } = props;
+        return (
+          <RadioGroup {...other}>
+            {values.map(value => {
+              return <Radio key={value.id} value={value} />;
+            })}
+          </RadioGroup>
+        );
+      }
+      Test.propTypes = {
+        values: PropTypes.arrayOf(PropTypes.shape({ id: PropTypes.number.isRequired })),
+      };
+
+      const values = [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }];
+      const handleChange = spy();
+
+      const wrapper = mount(<Test onChange={handleChange} value={values[1]} values={values} />);
+      // on the initial mount it works because we compare to the `value` prop
+      assert.strictEqual(isNthChecked(wrapper, 0), false);
+      assert.strictEqual(isNthChecked(wrapper, 1), true);
+
+      selectNth(wrapper, 0);
+      // on updates, however, we compare against event.target.value
+      // object information is lost on stringification.
+      assert.strictEqual(isNthChecked(wrapper, 0), false);
+      assert.strictEqual(isNthChecked(wrapper, 1), true);
+      assert.strictEqual(handleChange.firstCall.args[1], '[object Object]');
     });
   });
 

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -19,7 +19,7 @@ export interface SelectProps
   open?: boolean;
   renderValue?: (value: SelectProps['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
-  value?: Array<string | number | boolean | object> | string | number | boolean | object;
+  value?: any;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -19,7 +19,7 @@ export interface SelectProps
   open?: boolean;
   renderValue?: (value: SelectProps['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
-  value?: any;
+  value?: unknown;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -175,15 +175,7 @@ Select.propTypes = {
    * The input value.
    * This property is required when the `native` property is `false` (default).
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]),
+  value: PropTypes.any,
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -23,7 +23,7 @@ export interface SelectInputProps {
   renderValue?: (value: SelectInputProps['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
   tabIndex?: number;
-  value: string | number | boolean | Array<string | number | boolean>;
+  value: any;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -23,7 +23,7 @@ export interface SelectInputProps {
   renderValue?: (value: SelectInputProps['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
   tabIndex?: number;
-  value: any;
+  value: unknown;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -464,15 +464,7 @@ SelectInput.propTypes = {
   /**
    * The input value.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.object,
-    PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool, PropTypes.object]),
-    ),
-  ]).isRequired,
+  value: PropTypes.any.isRequired,
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -143,7 +143,7 @@ Switch.propTypes = {
   /**
    * If `true`, the component is checked.
    */
-  checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  checked: PropTypes.bool,
   /**
    * The icon to display when the component is checked.
    */
@@ -204,7 +204,7 @@ Switch.propTypes = {
   /**
    * The value of the component.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  value: PropTypes.any,
 };
 
 Switch.defaultProps = {

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -13,7 +13,7 @@ export interface BaseTextFieldProps
   autoComplete?: string;
   autoFocus?: boolean;
   children?: React.ReactNode;
-  defaultValue?: any;
+  defaultValue?: unknown;
   disabled?: boolean;
   error?: boolean;
   FormHelperTextProps?: Partial<FormHelperTextProps>;
@@ -34,7 +34,7 @@ export interface BaseTextFieldProps
   select?: boolean;
   SelectProps?: Partial<SelectProps>;
   type?: string;
-  value?: any;
+  value?: unknown;
 }
 
 export interface StandardTextFieldProps extends BaseTextFieldProps {

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -13,7 +13,7 @@ export interface BaseTextFieldProps
   autoComplete?: string;
   autoFocus?: boolean;
   children?: React.ReactNode;
-  defaultValue?: string | number;
+  defaultValue?: any;
   disabled?: boolean;
   error?: boolean;
   FormHelperTextProps?: Partial<FormHelperTextProps>;
@@ -34,7 +34,7 @@ export interface BaseTextFieldProps
   select?: boolean;
   SelectProps?: Partial<SelectProps>;
   type?: string;
-  value?: Array<string | number | boolean> | string | number | boolean;
+  value?: any;
 }
 
 export interface StandardTextFieldProps extends BaseTextFieldProps {

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -202,7 +202,7 @@ TextField.propTypes = {
   /**
    * The default value of the `input` element.
    */
-  defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  defaultValue: PropTypes.any,
   /**
    * If `true`, the `input` element will be disabled.
    */
@@ -310,12 +310,7 @@ TextField.propTypes = {
   /**
    * The value of the `input` element, required for a controlled component.
    */
-  value: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-    PropTypes.bool,
-    PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool])),
-  ]),
+  value: PropTypes.any,
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -18,7 +18,7 @@ export interface SwitchBaseProps
   readOnly?: boolean;
   required?: boolean;
   tabIndex?: number;
-  value?: any;
+  value?: unknown;
 }
 
 export type SwitchBaseClassKey = 'root' | 'checked' | 'disabled' | 'input';

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -18,7 +18,7 @@ export interface SwitchBaseProps
   readOnly?: boolean;
   required?: boolean;
   tabIndex?: number;
-  value?: string | number | boolean;
+  value?: any;
 }
 
 export type SwitchBaseClassKey = 'root' | 'checked' | 'disabled' | 'input';

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -5,7 +5,7 @@ import { IconButtonProps } from '../IconButton';
 export interface SwitchBaseProps
   extends StandardProps<IconButtonProps, SwitchBaseClassKey, 'onChange' | 'value'> {
   autoFocus?: boolean;
-  checked?: boolean | string;
+  checked?: boolean;
   checkedIcon: React.ReactNode;
   defaultChecked?: boolean;
   disabled?: boolean;

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -151,7 +151,7 @@ SwitchBase.propTypes = {
   /**
    * If `true`, the component is checked.
    */
-  checked: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  checked: PropTypes.bool,
   /**
    * The icon to display when the component is checked.
    */
@@ -233,7 +233,7 @@ SwitchBase.propTypes = {
   /**
    * The value of the component.
    */
-  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.bool]),
+  value: PropTypes.any,
 };
 
 export default withStyles(styles, { name: 'MuiPrivateSwitchBase' })(

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -32,7 +32,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 | <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |  | This property can be used to pass a ref callback to the `input` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. |
+| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. The DOM API casts this to a string. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -32,7 +32,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 | <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |  | This property can be used to pass a ref callback to the `input` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
-| <span class="prop-name">value</span> | <span class="prop-type">string</span> |  | The value of the component. |
+| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -32,7 +32,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 | <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |  | This property can be used to pass a ref callback to the `input` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. The DOM API casts this to a string. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the component. The DOM API casts this to a string. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -18,7 +18,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">checked</span> | <span class="prop-type">union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br></span> |  | If `true`, the component is checked. |
+| <span class="prop-name">checked</span> | <span class="prop-type">bool</span> |  | If `true`, the component is checked. |
 | <span class="prop-name">checkedIcon</span> | <span class="prop-type">node</span> | <span class="prop-default">&lt;CheckBoxIcon /></span> | The icon to display when the component is checked. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br></span> | <span class="prop-default">'secondary'</span> | The color of the component. It supports those theme colors that make sense for this component. |

--- a/pages/api/filled-input.md
+++ b/pages/api/filled-input.md
@@ -22,7 +22,7 @@ import FilledInput from '@material-ui/core/FilledInput';
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be focused during the first mount. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |  | The CSS class name of the wrapper element. |
-| <span class="prop-name">defaultValue</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The default `input` element value, useful when not controlling the component. |
+| <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default `input` element value, useful when not controlling the component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be disabled. |
 | <span class="prop-name">disableUnderline</span> | <span class="prop-type">bool</span> |  | If `true`, the input will not have an underline. |
 | <span class="prop-name">endAdornment</span> | <span class="prop-type">node</span> |  | End `InputAdornment` for this component. |
@@ -43,7 +43,7 @@ import FilledInput from '@material-ui/core/FilledInput';
 | <span class="prop-name">rowsMax</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br></span> |  | Maximum number of rows to display when multiline option is set to true. |
 | <span class="prop-name">startAdornment</span> | <span class="prop-type">node</span> |  | Start `InputAdornment` for this component. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The value of the `input` element, required for a controlled component. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -19,7 +19,7 @@ Use this component if you want to display an extra label.
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">checked</span> | <span class="prop-type">union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br></span> |  | If `true`, the component appears selected. |
+| <span class="prop-name">checked</span> | <span class="prop-type">bool</span> |  | If `true`, the component appears selected. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">control</span> | <span class="prop-type">element</span> |  | A control element. For instance, it can be be a `Radio`, a `Switch` or a `Checkbox`. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |  | If `true`, the control will be disabled. |
@@ -28,7 +28,7 @@ Use this component if you want to display an extra label.
 | <span class="prop-name">labelPlacement</span> | <span class="prop-type">enum:&nbsp;'end'&nbsp;&#124;<br>&nbsp;'start'&nbsp;&#124;<br>&nbsp;'top'&nbsp;&#124;<br>&nbsp;'bottom'<br></span> | <span class="prop-default">'end'</span> | The position of the label. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  |  |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
-| <span class="prop-name">value</span> | <span class="prop-type">string</span> |  | The value of the component. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the component. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/input-base.md
+++ b/pages/api/input-base.md
@@ -24,7 +24,7 @@ It contains a load of style reset and some state logic.
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be focused during the first mount. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |  | The CSS class name of the wrapper element. |
-| <span class="prop-name">defaultValue</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The default `input` element value, useful when not controlling the component. |
+| <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default `input` element value, useful when not controlling the component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be disabled. |
 | <span class="prop-name">endAdornment</span> | <span class="prop-type">node</span> |  | End `InputAdornment` for this component. |
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> |  | If `true`, the input will indicate an error. This is normally obtained via context from FormControl. |
@@ -44,7 +44,7 @@ It contains a load of style reset and some state logic.
 | <span class="prop-name">rowsMax</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br></span> |  | Maximum number of rows to display when multiline option is set to true. |
 | <span class="prop-name">startAdornment</span> | <span class="prop-type">node</span> |  | Start `InputAdornment` for this component. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> | <span class="prop-default">'text'</span> | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The value of the `input` element, required for a controlled component. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -22,7 +22,7 @@ import Input from '@material-ui/core/Input';
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be focused during the first mount. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |  | The CSS class name of the wrapper element. |
-| <span class="prop-name">defaultValue</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The default `input` element value, useful when not controlling the component. |
+| <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default `input` element value, useful when not controlling the component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be disabled. |
 | <span class="prop-name">disableUnderline</span> | <span class="prop-type">bool</span> |  | If `true`, the input will not have an underline. |
 | <span class="prop-name">endAdornment</span> | <span class="prop-type">node</span> |  | End `InputAdornment` for this component. |
@@ -43,7 +43,7 @@ import Input from '@material-ui/core/Input';
 | <span class="prop-name">rowsMax</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br></span> |  | Maximum number of rows to display when multiline option is set to true. |
 | <span class="prop-name">startAdornment</span> | <span class="prop-type">node</span> |  | Start `InputAdornment` for this component. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The value of the `input` element, required for a controlled component. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -24,7 +24,7 @@ An alternative to `<Select native />` with a much smaller bundle size footprint.
 | <span class="prop-name">input</span> | <span class="prop-type">element</span> | <span class="prop-default">&lt;Input /></span> | An `Input` element; does not have to be a material-ui specific `Input`. |
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object</span> |  | Attributes applied to the `select` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback function fired when a menu item is selected.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`. |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br></span> |  | The input value. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The input value. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. |
 
 The `ref` is forwarded to the root element.

--- a/pages/api/outlined-input.md
+++ b/pages/api/outlined-input.md
@@ -22,7 +22,7 @@ import OutlinedInput from '@material-ui/core/OutlinedInput';
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be focused during the first mount. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |  | The CSS class name of the wrapper element. |
-| <span class="prop-name">defaultValue</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The default `input` element value, useful when not controlling the component. |
+| <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default `input` element value, useful when not controlling the component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be disabled. |
 | <span class="prop-name">endAdornment</span> | <span class="prop-type">node</span> |  | End `InputAdornment` for this component. |
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> |  | If `true`, the input will indicate an error. This is normally obtained via context from FormControl. |
@@ -44,7 +44,7 @@ import OutlinedInput from '@material-ui/core/OutlinedInput';
 | <span class="prop-name">rowsMax</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br></span> |  | Maximum number of rows to display when multiline option is set to true. |
 | <span class="prop-name">startAdornment</span> | <span class="prop-type">node</span> |  | Start `InputAdornment` for this component. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The value of the `input` element, required for a controlled component. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -19,10 +19,10 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
-| <span class="prop-name">defaultValue</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The default `input` element value, useful when not controlling the component. |
+| <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default `input` element value, useful when not controlling the component. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | The name used to reference the value of the control. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when a radio button is selected.<br><br>**Signature:**<br>`function(event: object, value: string) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`.<br>*value:* The `value` of the selected radio button |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | Value of the selected radio button. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | Value of the selected radio button. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -22,7 +22,7 @@ import RadioGroup from '@material-ui/core/RadioGroup';
 | <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default `input` element value, useful when not controlling the component. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | The name used to reference the value of the control. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when a radio button is selected.<br><br>**Signature:**<br>`function(event: object, value: string) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`.<br>*value:* The `value` of the selected radio button |
-| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | Value of the selected radio button. |
+| <span class="prop-name">value</span> | <span class="prop-type">string</span> |  | Value of the selected radio button. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -18,7 +18,7 @@ import Radio from '@material-ui/core/Radio';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">checked</span> | <span class="prop-type">union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br></span> |  | If `true`, the component is checked. |
+| <span class="prop-name">checked</span> | <span class="prop-type">bool</span> |  | If `true`, the component is checked. |
 | <span class="prop-name">checkedIcon</span> | <span class="prop-type">node</span> |  | The icon to display when the component is checked. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br></span> | <span class="prop-default">'secondary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
@@ -31,7 +31,7 @@ import Radio from '@material-ui/core/Radio';
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | Name attribute of the `input` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the component. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -34,7 +34,7 @@ import Select from '@material-ui/core/Select';
 | <span class="prop-name">open</span> | <span class="prop-type">bool</span> |  | Control `select` open state. You can only use it when the `native` property is `false` (default). |
 | <span class="prop-name">renderValue</span> | <span class="prop-type">func</span> |  | Render the selected value. You can only use it when the `native` property is `false` (default).<br><br>**Signature:**<br>`function(value: any) => ReactElement`<br>*value:* The `value` provided to the component. |
 | <span class="prop-name">SelectDisplayProps</span> | <span class="prop-type">object</span> |  | Properties applied to the clickable div element. |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string, number, bool, object, arrayOf<br></span> |  | The input value. This property is required when the `native` property is `false` (default). |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The input value. This property is required when the `native` property is `false` (default). |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> |  | The variant to use. |
 
 The `ref` is forwarded to the root element.

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -18,7 +18,7 @@ import Switch from '@material-ui/core/Switch';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">checked</span> | <span class="prop-type">union:&nbsp;bool&nbsp;&#124;<br>&nbsp;string<br></span> |  | If `true`, the component is checked. |
+| <span class="prop-name">checked</span> | <span class="prop-type">bool</span> |  | If `true`, the component is checked. |
 | <span class="prop-name">checkedIcon</span> | <span class="prop-type">node</span> |  | The icon to display when the component is checked. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">enum:&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'default'<br></span> | <span class="prop-default">'secondary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
@@ -30,7 +30,7 @@ import Switch from '@material-ui/core/Switch';
 | <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |  | This property can be used to pass a ref callback to the `input` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component property `type`. |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool<br></span> |  | The value of the component. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the component. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -50,7 +50,7 @@ For advanced cases, please look at the source of TextField by clicking on the
 | <span class="prop-name">autoComplete</span> | <span class="prop-type">string</span> |  | This property helps users to fill forms faster, especially on mobile devices. The name can be confusing, as it's more like an autofill. You can learn more about it [following the specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#autofill). |
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be focused during the first mount. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">defaultValue</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number<br></span> |  | The default value of the `input` element. |
+| <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default value of the `input` element. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be disabled. |
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> |  | If `true`, the label will be displayed in an error state. |
 | <span class="prop-name">FormHelperTextProps</span> | <span class="prop-type">object</span> |  | Properties applied to the [`FormHelperText`](/api/form-helper-text/) element. |
@@ -73,7 +73,7 @@ For advanced cases, please look at the source of TextField by clicking on the
 | <span class="prop-name">select</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Render a [`Select`](/api/select/) element while passing the Input element to `Select` as `input` parameter. If this option is set you must pass the options of the select as children. |
 | <span class="prop-name">SelectProps</span> | <span class="prop-type">object</span> |  | Properties applied to the [`Select`](/api/select/) element. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | Type of the `input` element. It should be [a valid HTML5 input type](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Form_%3Cinput%3E_types). |
-| <span class="prop-name">value</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;number&nbsp;&#124;<br>&nbsp;bool&nbsp;&#124;<br>&nbsp;arrayOf<br></span> |  | The value of the `input` element, required for a controlled component. |
+| <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the `input` element, required for a controlled component. |
 | <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'outlined'&nbsp;&#124;<br>&nbsp;'filled'<br></span> | <span class="prop-default">'standard'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This allows for easier integration with redux-form without warning in the console.

```
const renderCheckBox = field => {
  return <Checkbox {...field.input} />;
};
```
instead of
```
const renderCheckBox = field => {
  const { input: { value, ...props} } = field;
  return <Checkbox value={String(value)} {...props} />;
};
```

Edit @eps1lon: 
Closes #14286, #13782