### PR TITLE
[Modal] Fix to defer setting of exited state to Transition component

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -79,23 +79,6 @@ class Modal extends React.Component {
     }
   }
 
-  static getDerivedStateFromProps(nextProps) {
-    if (nextProps.open) {
-      return {
-        exited: false,
-      };
-    }
-
-    if (!getHasTransition(nextProps)) {
-      // Otherwise let handleExited take care of marking exited.
-      return {
-        exited: true,
-      };
-    }
-
-    return null;
-  }
-
   handleOpen = () => {
     const container = getContainer(this.props.container) || this.getDoc().body;
 
@@ -132,6 +115,10 @@ class Modal extends React.Component {
     if (!(hasTransition && this.props.closeAfterTransition) || reason === 'unmount') {
       this.props.manager.remove(this);
     }
+  };
+
+  handleEntered = () => {
+    this.setState({ exited: false });
   };
 
   handleExited = () => {
@@ -232,6 +219,7 @@ class Modal extends React.Component {
 
     // It's a Transition like component
     if (hasTransition) {
+      childProps.onEntered = createChainedFunction(this.handleEntered, children.props.onEntered);
       childProps.onExited = createChainedFunction(this.handleExited, children.props.onExited);
     }
 

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -375,6 +375,38 @@ describe('<Modal />', () => {
       const modalNode = modalRef.current;
       assert.strictEqual(modalNode.getAttribute('aria-hidden'), 'true');
     });
+
+    it('should remove the children in the DOM when closed on update frame immediately after mount', () => {
+      const wrapper = mount(
+        <Modal open={false} keepMounted={false}>
+          <span>Hello</span>
+        </Modal>,
+      );
+      wrapper.setProps({ open: true });
+      wrapper.setProps({ open: false });
+      wrapper.update();
+      assert.strictEqual(wrapper.find('span').length, 0);
+    });
+
+    /* Test case for https://github.com/mui-org/material-ui/issues/15180 */
+    it('should remove the transition children in the DOM when closed on update frame immediately after mount', () => {
+      const TestCase = props => (
+        <Modal open={props.open} keepMounted={false}>
+          <Fade in={props.open}>
+            <span>Hello</span>
+          </Fade>
+        </Modal>
+      );
+      TestCase.propTypes = {
+        open: PropTypes.bool,
+      };
+
+      const wrapper = mount(<TestCase open={false} />);
+      wrapper.setProps({ open: true });
+      wrapper.setProps({ open: false });
+      wrapper.update();
+      assert.strictEqual(wrapper.find('span').length, 0);
+    });
   });
 
   describe('focus', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Fixes https://github.com/mui-org/material-ui/issues/15180

- Added 2 additional `Modal` `keepMounted` prop behaviour tests, with failing test case for the fixed issue.
- Fixed by removing the `getDerivedStateFromProps` and deferring the `exited: false` state setting to the `Transition` component 