### PR TITLE
[core] Allow docs:dev access over local network

### DIFF
--- a/docs/src/server.js
+++ b/docs/src/server.js
@@ -1,3 +1,4 @@
+import address from 'address';
 import http from 'http';
 import express from 'express';
 import url from 'url';
@@ -46,15 +47,16 @@ async function run() {
 
   const server = http.createServer(app);
   const port = parseInt(process.env.PORT, 10) || 3000;
-  const host = process.env.HOST || 'localhost';
 
-  server.listen(port, host, err => {
+  server.listen(port, err => {
     if (err) {
       throw err;
     }
+
+    const lanHost = address.ip();
     log.info({
       name: 'http',
-      msg: `ready on http://${host}:${port}`,
+      msg: `ready on http://localhost:${port} and http://${lanHost}:${port}`,
     });
   });
 

--- a/docs/src/server.js
+++ b/docs/src/server.js
@@ -46,7 +46,7 @@ async function run() {
 
   const server = http.createServer(app);
   const port = parseInt(process.env.PORT, 10) || 3000;
-  const host = 'localhost';
+  const host = process.env.HOST || 'localhost';
 
   server.listen(port, host, err => {
     if (err) {
@@ -54,7 +54,7 @@ async function run() {
     }
     log.info({
       name: 'http',
-      msg: `ready on http://${server.address().address}:${server.address().port}`,
+      msg: `ready on http://${host}:${port}`,
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@types/react-window": "^1.7.0",
     "@types/styled-components": "^4.1.11",
     "@zeit/next-typescript": "^1.1.1",
+    "address": "^1.0.3",
     "argos-cli": "^0.1.1",
     "autoprefixer": "^9.0.0",
     "autosuggest-highlight": "^3.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2600,6 +2600,11 @@ acorn@^6.0.1, acorn@^6.0.4, acorn@^6.0.5, acorn@^6.0.7, acorn@^6.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
+address@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
+  integrity sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==
+
 adm-zip@^0.4.7:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.13.tgz#597e2f8cc3672151e1307d3e95cddbc75672314a"


### PR DESCRIPTION
This is helpful for debugging via browserstack or other devices. `address` is used by `create-react-app` as well.