### PR TITLE
[TableCell] Allow setting a number for padding

### DIFF
--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -69,6 +69,7 @@ export const styles = theme => ({
       padding: 0,
     },
   },
+  paddingNumber: ({ padding }) => ({ padding }),
   /* Styles applied to the root element if `align="left"`. */
   alignLeft: {
     textAlign: 'left',
@@ -136,6 +137,7 @@ function TableCell(props) {
                 [classes[`align${capitalize(align)}`]]: align !== 'inherit',
                 [classes.numeric]: numeric,
                 [classes[`padding${capitalize(padding)}`]]: padding !== 'default',
+                [classes['paddingNumber']]: typeof padding === 'number',
               },
               classNameProp,
             );
@@ -191,7 +193,7 @@ TableCell.propTypes = {
    * Sets the padding applied to the cell.
    * By default, the Table parent component set the value.
    */
-  padding: PropTypes.oneOf(['default', 'checkbox', 'dense', 'none']),
+  padding: PropTypes.oneOfType(PropTypes.number, [PropTypes.oneOf(['default', 'checkbox', 'dense', 'none'])]),
   /**
    * Set scope attribute.
    */


### PR DESCRIPTION
I find that the options allowed for table padding are very limiting, and require a ton of extra work to get the right layout if you need to stray away from `none`, `dense`, or `default`.

I'm wondering if a change like this that allows passing a number to padding is an acceptable one?

TODO:
* [ ] Change `Table` propTypes