### PR TITLE
[InputBase] Fix placeholder bug in Edge

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -23,7 +23,7 @@ export const styles = theme => {
     }),
   };
   const placeholderHidden = {
-    opacity: 0,
+    opacity: '0 !important',
   };
   const placeholderVisible = {
     opacity: light ? 0.42 : 0.5,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

---
Fixes #15183

This PR fixes a bug related to the Placeholder and Label. They are being overlapped when a Input is focused and then unfocused by clicking at the address bar.

This bug is only happening in Edge.

FYI @oliviertassinari :)