### PR TITLE
[DialogContent] Add divider prop type for TypeScript

### DIFF
--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.js
@@ -30,51 +30,41 @@ const options = [
   'Umbriel',
 ];
 
-const useConfirmationDialogRawStyles = makeStyles({
-  paper: {
-    width: '80%',
-    maxHeight: 435,
-  },
-});
-
 function ConfirmationDialogRaw(props) {
-  const classes = useConfirmationDialogRawStyles();
-  const [value, setValue] = React.useState(props.value);
+  const { onClose, value: valueProp, ...other } = props;
+  const [value, setValue] = React.useState(valueProp);
   const radioGroupRef = React.useRef(null);
 
-  React.useEffect(() => {
-    setValue(props.value);
-  }, [props.value]);
+  if (valueProp !== value) {
+    setValue(valueProp);
+  }
 
   function handleEntering() {
-    if (radioGroupRef.current) {
+    if (radioGroupRef.current != null) {
       radioGroupRef.current.focus();
     }
   }
 
   function handleCancel() {
-    props.onClose(props.value);
+    onClose(value);
   }
 
   function handleOk() {
-    props.onClose(value);
+    onClose(value);
   }
 
   function handleChange(event, newValue) {
     setValue(newValue);
   }
 
-  const { value: valueProps, onClose, ...otherProps } = props;
-
   return (
     <Dialog
-      classes={classes}
       disableBackdropClick
       disableEscapeKeyDown
       maxWidth="xs"
       onEntering={handleEntering}
       aria-labelledby="confirmation-dialog-title"
-      {...otherProps}
+      {...other}
     >
       <DialogTitle id="confirmation-dialog-title">Phone Ringtone</DialogTitle>
       <DialogContent dividers>
@@ -104,20 +94,23 @@ function ConfirmationDialogRaw(props) {
 
 ConfirmationDialogRaw.propTypes = {
   onClose: PropTypes.func,
-  open: PropTypes.bool,
   value: PropTypes.string,
 };
 
-const useConfirmationDialogStyles = makeStyles(theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
     maxWidth: 360,
     backgroundColor: theme.palette.background.paper,
   },
+  paper: {
+    width: '80%',
+    maxHeight: 435,
+  },
 }));
 
 function ConfirmationDialog() {
-  const classes = useConfirmationDialogStyles();
+  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const [value, setValue] = React.useState('Dione');
 
@@ -149,7 +142,14 @@ function ConfirmationDialog() {
         <ListItem button divider disabled>
           <ListItemText primary="Default notification ringtone" secondary="Tethys" />
         </ListItem>
-        <ConfirmationDialogRaw open={open} onClose={handleClose} value={value} />
+        <ConfirmationDialogRaw
+          classes={{
+            paper: classes.paper,
+          }}
+          open={open}
+          onClose={handleClose}
+          value={value}
+        />
       </List>
     </div>
   );

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.js
@@ -103,8 +103,8 @@ function ConfirmationDialogRaw(props) {
 }
 
 ConfirmationDialogRaw.propTypes = {
-  open: PropTypes.bool,
   onClose: PropTypes.func,
+  open: PropTypes.bool,
   value: PropTypes.string,
 };
 

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.tsx
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.tsx
@@ -109,8 +109,8 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
 }
 
 ConfirmationDialogRaw.propTypes = {
-  open: PropTypes.bool,
   onClose: PropTypes.func,
+  open: PropTypes.bool,
   value: PropTypes.string,
 };
 

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.tsx
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.tsx
@@ -31,56 +31,47 @@ const options = [
 ];
 
 export interface ConfirmationDialogRawProps {
+  classes: Record<'paper', 'string'>;
   value: string;
   open: boolean;
   onClose: (value: string) => void;
 }
 
-const useConfirmationDialogRawStyles = makeStyles({
-  paper: {
-    width: '80%',
-    maxHeight: 435,
-  },
-});
-
 function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
-  const classes = useConfirmationDialogRawStyles();
-  const [value, setValue] = React.useState(props.value);
+  const { onClose, value: valueProp, ...other } = props;
+  const [value, setValue] = React.useState(valueProp);
   const radioGroupRef = React.useRef<HTMLElement>(null);
 
-  React.useEffect(() => {
-    setValue(props.value);
-  }, [props.value]);
+  if (valueProp !== value) {
+    setValue(valueProp);
+  }
 
   function handleEntering() {
-    if (radioGroupRef.current) {
+    if (radioGroupRef.current != null) {
       radioGroupRef.current.focus();
     }
   }
 
   function handleCancel() {
-    props.onClose(props.value);
+    onClose(value);
   }
 
   function handleOk() {
-    props.onClose(value);
+    onClose(value);
   }
 
   function handleChange(event: React.ChangeEvent<{}>, newValue: string) {
     setValue(newValue);
   }
 
-  const { value: valueProps, onClose, ...otherProps } = props;
-
   return (
     <Dialog
-      classes={classes}
       disableBackdropClick
       disableEscapeKeyDown
       maxWidth="xs"
       onEntering={handleEntering}
       aria-labelledby="confirmation-dialog-title"
-      {...otherProps}
+      {...other}
     >
       <DialogTitle id="confirmation-dialog-title">Phone Ringtone</DialogTitle>
       <DialogContent dividers>
@@ -110,20 +101,23 @@ function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
 
 ConfirmationDialogRaw.propTypes = {
   onClose: PropTypes.func,
-  open: PropTypes.bool,
   value: PropTypes.string,
 };
 
-const useConfirmationDialogStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles((theme: Theme) => ({
   root: {
     width: '100%',
     maxWidth: 360,
     backgroundColor: theme.palette.background.paper,
   },
+  paper: {
+    width: '80%',
+    maxHeight: 435,
+  },
 }));
 
 function ConfirmationDialog() {
-  const classes = useConfirmationDialogStyles();
+  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const [value, setValue] = React.useState('Dione');
 
@@ -155,7 +149,14 @@ function ConfirmationDialog() {
         <ListItem button divider disabled>
           <ListItemText primary="Default notification ringtone" secondary="Tethys" />
         </ListItem>
-        <ConfirmationDialogRaw open={open} onClose={handleClose} value={value} />
+        <ConfirmationDialogRaw
+          classes={{
+            paper: classes.paper,
+          }}
+          open={open}
+          onClose={handleClose}
+          value={value}
+        />
       </List>
     </div>
   );

--- a/docs/src/pages/demos/dialogs/ConfirmationDialog.tsx
+++ b/docs/src/pages/demos/dialogs/ConfirmationDialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -30,6 +30,12 @@ const options = [
   'Umbriel',
 ];
 
+export interface ConfirmationDialogRawProps {
+  value: string;
+  open: boolean;
+  onClose: (value: string) => void;
+}
+
 const useConfirmationDialogRawStyles = makeStyles({
   paper: {
     width: '80%',
@@ -37,10 +43,10 @@ const useConfirmationDialogRawStyles = makeStyles({
   },
 });
 
-function ConfirmationDialogRaw(props) {
+function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
   const classes = useConfirmationDialogRawStyles();
   const [value, setValue] = React.useState(props.value);
-  const radioGroupRef = React.useRef(null);
+  const radioGroupRef = React.useRef<HTMLElement>(null);
 
   React.useEffect(() => {
     setValue(props.value);
@@ -60,7 +66,7 @@ function ConfirmationDialogRaw(props) {
     props.onClose(value);
   }
 
-  function handleChange(event, newValue) {
+  function handleChange(event: React.ChangeEvent<{}>, newValue: string) {
     setValue(newValue);
   }
 
@@ -108,7 +114,7 @@ ConfirmationDialogRaw.propTypes = {
   value: PropTypes.string,
 };
 
-const useConfirmationDialogStyles = makeStyles(theme => ({
+const useConfirmationDialogStyles = makeStyles((theme: Theme) => ({
   root: {
     width: '100%',
     maxWidth: 360,
@@ -125,7 +131,7 @@ function ConfirmationDialog() {
     setOpen(true);
   }
 
-  function handleClose(newValue) {
+  function handleClose(newValue: string) {
     setOpen(false);
     setValue(newValue);
   }

--- a/packages/material-ui/src/DialogContent/DialogContent.d.ts
+++ b/packages/material-ui/src/DialogContent/DialogContent.d.ts
@@ -2,7 +2,9 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface DialogContentProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, DialogContentClassKey> {}
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, DialogContentClassKey> {
+  dividers?: boolean;
+}
 
 export type DialogContentClassKey = 'root';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This PR adds the TS demo for ConfirmationDialog. This was separated from the main PR (#15271) because more changes were required for this demo.