### PR TITLE
[withMobileDialog] Improve types

### DIFF
--- a/packages/material-ui/src/withMobileDialog/withMobileDialog.d.ts
+++ b/packages/material-ui/src/withMobileDialog/withMobileDialog.d.ts
@@ -1,16 +1,20 @@
 import { Breakpoint } from '../styles/createBreakpoints';
 import { WithWidth } from '../withWidth';
+import { PropInjector } from '..';
 
 export interface WithMobileDialogOptions {
   breakpoint: Breakpoint;
 }
 
-export interface InjectedProps {
-  fullScreen?: boolean;
+export interface WithMobileDialog extends WithWidth {
+  fullScreen: boolean;
 }
+
+/**
+ * @deprecated
+ */
+export interface InjectedProps extends WithMobileDialog {}
 
 export default function withMobileDialog<P = {}>(
   options?: WithMobileDialogOptions,
-): (
-  component: React.ComponentType<P & InjectedProps & Partial<WithWidth>>,
-) => React.ComponentType<P & Partial<WithWidth>>;
+): PropInjector<WithMobileDialog, Partial<WithMobileDialog>>;

--- a/packages/material-ui/src/withMobileDialog/withMobileDialog.spec.tsx
+++ b/packages/material-ui/src/withMobileDialog/withMobileDialog.spec.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import withMobileDialog, { WithMobileDialog } from '@material-ui/core/withMobileDialog';
+
+interface SimpleProps extends WithMobileDialog {
+  note: string;
+  title: string;
+}
+
+function Component(props: SimpleProps) {
+  const { fullScreen, note, title } = props;
+  return (
+    <div>
+      {title} is fullscreen? {fullScreen}
+      <br />
+      {note}
+    </div>
+  );
+}
+
+Component.defaultProps = {
+  note: 'nothing special',
+};
+
+// Missing fullscreen, width
+<Component title="Not responsive yet!" />; // $ExpectError
+
+const ResponsiveComponent = withMobileDialog()(Component);
+
+<ResponsiveComponent title="Not responsive yet!" />;

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -69,7 +69,6 @@ import {
   Toolbar,
   Tooltip,
   Typography,
-  withMobileDialog,
 } from '@material-ui/core';
 import {
   withStyles,
@@ -951,17 +950,6 @@ const SelectTest = () => (
 );
 
 const InputAdornmentTest = () => <InputAdornment position="end" onClick={() => alert('Hello')} />;
-
-const ResponsiveComponentTest = () => {
-  const ResponsiveComponent = withMobileDialog({
-    breakpoint: 'sm',
-  })(({ children, width, fullScreen }) => (
-    <div style={{ width, position: fullScreen ? 'fixed' : 'static' }}>{children}</div>
-  ));
-  <ResponsiveComponent />;
-
-  const ResponsiveDialogComponent = withMobileDialog<DialogProps>()(Dialog);
-};
 
 const TooltipComponentTest = () => (
   <div>

--- a/tslint.json
+++ b/tslint.json
@@ -5,6 +5,7 @@
     "rules": {
         "deprecation": true,
         "file-name-casing": false,
+        "no-empty-interface": false,
         "no-unnecessary-callback-wrapper": false,
         "no-unnecessary-generics": false,
         "semicolon": [true, "always", "ignore-bound-class-methods"]


### PR DESCRIPTION
Motivated by https://stackoverflow.com/q/55547408/3406963.

Brings `withMobileDialog` in line with the other higher-order components.

This PR also disables the `no-empty-interface` rule. The rationale for this rule is incorrect. `interface` is not  equivalent to `type`.