### PR TITLE
[docs] Enable react profiling in production

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,9 @@ module.exports = withTypescript({
       );
     }
 
+    config.resolve.alias['react-dom$'] = 'react-dom/profiling';
+    config.resolve.alias['scheduler/tracing'] = 'scheduler/tracing-profiling';
+
     return Object.assign({}, config, {
       plugins,
       node: {


### PR DESCRIPTION
This will add runtime overhead and bundle size. 94.5% of our traffic is coming from desktop which allows this IMO. We should probably add a little hint to the docs for people that are interested that this is enabled. For now it only enables the profiler tab in `react-devtools`.

Following https://gist.github.com/bvaughn/25e6233aeb1b4f0cdb8d8366e54a3977 and https://github.com/zeit/next.js/blob/master/examples/with-absolute-imports/next.config.js

> docs.main | +0.99% | +0.91% | 644,591 | 650,971 | 200,685 | 202,502

1% or 2kB gzipped for the whole bundle isn't that bad I guess.


