### PR TITLE
[Tooltip] Convert to function component

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -100,19 +100,19 @@ function Tooltip(props) {
 
   const [openState, setOpenState] = React.useState(false);
   const [, forceUpdate] = React.useState(0);
+  const [childNode, setChildNode] = React.useState();
   const ignoreNonTouchEvents = React.useRef(false);
   const { current: isControlled } = React.useRef(props.open != null);
-  const [childNode, setChildNode] = React.useState();
-  // can be removed once we drop support for non ref forwarding class components
-  const handleOwnRef = React.useCallback(ref => {
-    setChildNode(ReactDOM.findDOMNode(ref));
-  }, []);
-  const handleRef = useForkRef(children.ref, handleOwnRef);
   const defaultId = React.useRef();
   const closeTimer = React.useRef();
   const enterTimer = React.useRef();
   const leaveTimer = React.useRef();
   const touchTimer = React.useRef();
+  // can be removed once we drop support for non ref forwarding class components
+  const handleOwnRef = React.useCallback(ref => {
+    setChildNode(ReactDOM.findDOMNode(ref));
+  }, []);
+  const handleRef = useForkRef(children.ref, handleOwnRef);
 
   React.useEffect(() => {
     if (childNode) {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -107,7 +107,7 @@ function Tooltip(props) {
   const handleOwnRef = React.useCallback(ref => {
     setChildNode(ReactDOM.findDOMNode(ref));
   }, []);
-  const handleRef = useForkRef(childNode, handleOwnRef);
+  const handleRef = useForkRef(children.ref, handleOwnRef);
   const defaultId = React.useRef();
   const closeTimer = React.useRef();
   const enterTimer = React.useRef();

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -115,21 +115,22 @@ function Tooltip(props) {
   const handleRef = useForkRef(children.ref, handleOwnRef);
 
   React.useEffect(() => {
-    if (childNode) {
-      warning(
-        !childNode.disabled ||
-          (childNode.disabled && isControlled) ||
-          (childNode.disabled && title === '') ||
-          childNode.tagName.toLowerCase() !== 'button',
-        [
-          'Material-UI: you are providing a disabled `button` child to the Tooltip component.',
-          'A disabled element does not fire events.',
-          "Tooltip needs to listen to the child element's events to display the title.",
-          '',
-          'Place a `div` container on top of the element.',
-        ].join('\n'),
-      );
-    }
+    warning(
+      !(
+        childNode &&
+        childNode.disabled &&
+        !isControlled &&
+        title !== '' &&
+        childNode.tagName.toLowerCase() === 'button'
+      ),
+      [
+        'Material-UI: you are providing a disabled `button` child to the Tooltip component.',
+        'A disabled element does not fire events.',
+        "Tooltip needs to listen to the child element's events to display the title.",
+        '',
+        'Place a `div` container on top of the element.',
+      ].join('\n'),
+    );
   }, [isControlled, title, childNode]);
 
   React.useEffect(() => {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -145,10 +145,6 @@ function Tooltip(props) {
     };
   });
 
-  const onRootRef = ref => {
-    childrenRef.current = ref;
-  };
-
   const handleOpen = event => {
     // The mouseover event will trigger for every nested element in the tooltip.
     // We can skip rerendering when the tooltip is already open.
@@ -329,7 +325,7 @@ function Tooltip(props) {
 
   return (
     <React.Fragment>
-      <RootRef rootRef={onRootRef}>{React.cloneElement(children, childrenProps)}</RootRef>
+      <RootRef rootRef={childrenRef}>{React.cloneElement(children, childrenProps)}</RootRef>
       <Popper
         className={clsx(classes.popper, {
           [classes.popperInteractive]: interactive,

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -149,13 +149,15 @@ function Tooltip(props) {
     // Fallback to this default id when possible.
     // Use the random value for client side rendering only.
     // We can't use it server-side.
-    defaultId.current = `mui-tooltip-${Math.round(Math.random() * 1e5)}`;
+    if (!defaultId.current) {
+      defaultId.current = `mui-tooltip-${Math.round(Math.random() * 1e5)}`;
+    }
 
     // Rerender with defaultId and childNode.
-    if (openProp && !mountedRef.current) {
+    if (openProp) {
       forceUpdate(n => !n);
     }
-  }, [mountedRef, openProp]);
+  }, [openProp]);
 
   React.useEffect(() => {
     return () => {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -73,18 +73,6 @@ export const styles = theme => ({
   },
 });
 
-function useMountedRef() {
-  const mountedRef = React.useRef(false);
-  React.useEffect(() => {
-    mountedRef.current = true;
-    return () => {
-      mountedRef.current = false;
-    };
-  }, []);
-
-  return mountedRef;
-}
-
 function Tooltip(props) {
   const {
     children,
@@ -121,7 +109,6 @@ function Tooltip(props) {
   }, []);
   const handleRef = useForkRef(childNode, handleOwnRef);
   const defaultId = React.useRef();
-  const mountedRef = useMountedRef();
   const closeTimer = React.useRef();
   const enterTimer = React.useRef();
   const leaveTimer = React.useRef();
@@ -131,7 +118,7 @@ function Tooltip(props) {
     if (childNode) {
       warning(
         !childNode.disabled ||
-        (childNode.disabled && isControlled) ||
+          (childNode.disabled && isControlled) ||
           (childNode.disabled && title === '') ||
           childNode.tagName.toLowerCase() !== 'button',
         [

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -110,12 +110,15 @@ function Tooltip(props) {
     ...other
   } = props;
 
+  const [openState, setOpenState] = React.useState(false);
+  const [, forceUpdate] = React.useState(0);
   const ignoreNonTouchEvents = React.useRef(false);
   const { current: isControlled } = React.useRef(props.open != null);
   const childrenRef = React.useRef();
   // can be removed once we drop support for non ref forwarding class components
   const handleOwnRef = React.useCallback(ref => {
     childrenRef.current = ReactDOM.findDOMNode(ref);
+    forceUpdate(n => !n);
   }, []);
   const handleRef = useForkRef(children.ref, handleOwnRef);
   const defaultId = React.useRef();
@@ -124,8 +127,6 @@ function Tooltip(props) {
   const enterTimer = React.useRef();
   const leaveTimer = React.useRef();
   const touchTimer = React.useRef();
-  const [, forceUpdate] = React.useState();
-  const [openState, setOpenState] = React.useState(false);
 
   React.useEffect(() => {
     warning(
@@ -149,9 +150,8 @@ function Tooltip(props) {
 
     // Rerender with defaultId and childrenRef.
     if (openProp && !mountedRef.current) {
-      forceUpdate();
+      forceUpdate(n => !n);
     }
-    mountedRef.current = true;
   }, [isControlled, title, openProp, mountedRef]);
 
   React.useEffect(() => {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -3,20 +3,17 @@ import { assert } from 'chai';
 import PropTypes from 'prop-types';
 import { spy, useFakeTimers } from 'sinon';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createShallow, createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
+import { createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
 import Popper from '../Popper';
 import Tooltip from './Tooltip';
 import Input from '../Input';
 import createMuiTheme from '../styles/createMuiTheme';
 import RootRef from '../RootRef';
 
-function persist() {}
-
 const TooltipNaked = unwrap(Tooltip);
 const theme = createMuiTheme();
 
 describe('<Tooltip />', () => {
-  let shallow;
   let mount;
   let classes;
   let clock;
@@ -27,7 +24,6 @@ describe('<Tooltip />', () => {
   };
 
   before(() => {
-    shallow = createShallow({ dive: true, disableLifecycleMethods: true });
     mount = createMount();
     classes = getClasses(<Tooltip {...defaultProps} />);
     clock = useFakeTimers();
@@ -39,16 +35,16 @@ describe('<Tooltip />', () => {
   });
 
   it('should render the correct structure', () => {
-    const wrapper = shallow(<Tooltip {...defaultProps} />);
-    assert.strictEqual(wrapper.type(), React.Fragment);
-    assert.strictEqual(wrapper.childAt(0).type(), RootRef);
-    assert.strictEqual(wrapper.childAt(1).type(), Popper);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.popper), true);
+    const wrapper = mount(<Tooltip {...defaultProps} />);
+    const children = wrapper.childAt(0);
+    assert.strictEqual(children.childAt(0).type(), RootRef);
+    assert.strictEqual(children.childAt(1).type(), Popper);
+    assert.strictEqual(children.childAt(1).hasClass(classes.popper), true);
   });
 
   describe('prop: disableHoverListener', () => {
     it('should hide the native title', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <Tooltip {...defaultProps} title="Hello World" disableHoverListener>
           <button type="submit">Hello World</button>
         </Tooltip>,
@@ -66,12 +62,12 @@ describe('<Tooltip />', () => {
     });
 
     it('should not display if the title is an empty string', () => {
-      const wrapper = shallow(<Tooltip {...defaultProps} title="" open />);
+      const wrapper = mount(<Tooltip {...defaultProps} title="" open />);
       assert.strictEqual(wrapper.find(Popper).props().open, false);
     });
 
     it('should be passed down to the child as a native title', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <Tooltip {...defaultProps} title="Hello World">
           <button type="submit">Hello World</button>
         </Tooltip>,
@@ -84,88 +80,74 @@ describe('<Tooltip />', () => {
 
   describe('prop: placement', () => {
     it('should have top placement', () => {
-      const wrapper = shallow(<Tooltip {...defaultProps} placement="top" />);
+      const wrapper = mount(<Tooltip {...defaultProps} placement="top" />);
       assert.strictEqual(wrapper.find(Popper).props().placement, 'top');
     });
   });
 
   it('should respond to external events', () => {
-    const wrapper = shallow(<Tooltip {...defaultProps} />);
-    wrapper.instance().childrenRef = document.createElement('div');
+    const wrapper = mount(<Tooltip {...defaultProps} />);
     const children = wrapper.childAt(0).childAt(0);
-    assert.strictEqual(wrapper.instance().state.open, false);
-    children.simulate('mouseOver', { type: 'mouseover' });
-    assert.strictEqual(wrapper.instance().state.open, true);
-    children.simulate('mouseLeave', { type: 'mouseleave' });
-    assert.strictEqual(wrapper.instance().state.open, false);
+    assert.strictEqual(wrapper.find(Popper).props().open, false);
+    children.simulate('mouseOver');
+    assert.strictEqual(wrapper.find(Popper).props().open, true);
+    children.simulate('mouseLeave');
+    assert.strictEqual(wrapper.find(Popper).props().open, false);
   });
 
   it('should be controllable', () => {
     const handleRequestOpen = spy();
     const handleClose = spy();
 
-    const wrapper = shallow(
+    const wrapper = mount(
       <Tooltip {...defaultProps} open onOpen={handleRequestOpen} onClose={handleClose} />,
     );
-    wrapper.instance().childrenRef = document.createElement('div');
     const children = wrapper.childAt(0).childAt(0);
     assert.strictEqual(handleRequestOpen.callCount, 0);
     assert.strictEqual(handleClose.callCount, 0);
-    children.simulate('mouseOver', { type: 'mouseover' });
+    children.simulate('mouseOver');
     assert.strictEqual(handleRequestOpen.callCount, 1);
     assert.strictEqual(handleClose.callCount, 0);
-    children.simulate('mouseLeave', { type: 'mouseleave' });
+    children.simulate('mouseLeave');
     assert.strictEqual(handleRequestOpen.callCount, 1);
     assert.strictEqual(handleClose.callCount, 1);
   });
 
   it('should close when the interaction is over', () => {
-    const wrapper = shallow(<Tooltip {...defaultProps} />);
-    const childrenRef = document.createElement('div');
-    childrenRef.tabIndex = 0;
-    wrapper.instance().childrenRef = childrenRef;
+    const wrapper = mount(<Tooltip {...defaultProps} />);
     const children = wrapper.childAt(0).childAt(0);
-    assert.strictEqual(wrapper.instance().state.open, false);
-    children.simulate('mouseOver', { type: 'mouseover' });
-    childrenRef.focus();
-    children.simulate('focus', { type: 'focus', persist });
-    clock.tick(0);
-    assert.strictEqual(wrapper.instance().state.open, true);
-    children.simulate('mouseLeave', { type: 'mouseleave' });
-    assert.strictEqual(wrapper.instance().state.open, false);
-    children.simulate('blur', { type: 'blur' });
-    assert.strictEqual(wrapper.instance().state.open, false);
+    assert.strictEqual(wrapper.find(Popper).props().open, false);
+    children.simulate('mouseOver');
+    children.simulate('focus');
+    assert.strictEqual(wrapper.find(Popper).props().open, true);
+    children.simulate('mouseLeave');
+    assert.strictEqual(wrapper.find(Popper).props().open, false);
+    children.simulate('blur');
+    assert.strictEqual(wrapper.find(Popper).props().open, false);
   });
 
   describe('touch screen', () => {
     it('should not respond to quick events', () => {
-      const wrapper = shallow(<Tooltip {...defaultProps} />);
-      const childrenRef = document.createElement('div');
-      childrenRef.tabIndex = 0;
-      wrapper.instance().childrenRef = childrenRef;
+      const wrapper = mount(<Tooltip {...defaultProps} />);
       const children = wrapper.childAt(0).childAt(0);
-      children.simulate('touchStart', { type: 'touchstart', persist });
-      children.simulate('touchEnd', { type: 'touchend', persist });
-      childrenRef.focus();
-      children.simulate('focus', { type: 'focus', persist });
-      assert.strictEqual(wrapper.instance().state.open, false);
+      children.simulate('touchStart');
+      children.simulate('touchEnd');
+      children.simulate('focus');
+      assert.strictEqual(wrapper.find(Popper).props().open, false);
     });
 
     it('should open on long press', () => {
-      const wrapper = shallow(<Tooltip {...defaultProps} />);
-      const childrenRef = document.createElement('div');
-      childrenRef.tabIndex = 0;
-      wrapper.instance().childrenRef = childrenRef;
+      const wrapper = mount(<Tooltip {...defaultProps} />);
       const children = wrapper.childAt(0).childAt(0);
-      children.simulate('touchStart', { type: 'touchstart', persist });
-      childrenRef.focus();
-      children.simulate('focus', { type: 'focus', persist });
-      clock.tick(1e3);
-      assert.strictEqual(wrapper.instance().state.open, true);
-      children.simulate('touchEnd', { type: 'touchend', persist });
-      children.simulate('blur', { type: 'blur' });
+      children.simulate('touchStart');
+      children.simulate('focus');
+      clock.tick(1000);
+      wrapper.update();
+      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      children.simulate('touchEnd');
+      children.simulate('blur');
       clock.tick(1500);
-      assert.strictEqual(wrapper.instance().state.open, false);
+      assert.strictEqual(wrapper.find(Popper).props().open, false);
     });
   });
 
@@ -200,27 +182,25 @@ describe('<Tooltip />', () => {
   describe('prop: delay', () => {
     it('should take the enterDelay into account', () => {
       const wrapper = mount(<TooltipNaked classes={{}} enterDelay={111} {...defaultProps} />);
-      const childrenRef = wrapper.instance().childrenRef;
-      childrenRef.tabIndex = 0;
-      childrenRef.focus();
-      assert.strictEqual(document.activeElement, childrenRef);
-      assert.strictEqual(wrapper.instance().state.open, false);
+      const children = wrapper.childAt(0).childAt(0);
+      children.simulate('focus');
+      assert.strictEqual(wrapper.find(Popper).props().open, false);
       clock.tick(111);
-      assert.strictEqual(wrapper.instance().state.open, true);
+      wrapper.update();
+      assert.strictEqual(wrapper.find(Popper).props().open, true);
     });
 
     it('should take the leaveDelay into account', () => {
       const wrapper = mount(<TooltipNaked classes={{}} leaveDelay={111} {...defaultProps} />);
-      const childrenRef = wrapper.instance().childrenRef;
-      childrenRef.tabIndex = 0;
-      childrenRef.focus();
-      assert.strictEqual(document.activeElement, childrenRef);
+      const children = wrapper.childAt(0).childAt(0);
+      children.simulate('focus');
       clock.tick(0);
-      assert.strictEqual(wrapper.instance().state.open, true);
-      childrenRef.blur();
-      assert.strictEqual(wrapper.instance().state.open, true);
+      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      children.simulate('blur');
+      assert.strictEqual(wrapper.find(Popper).props().open, true);
       clock.tick(111);
-      assert.strictEqual(wrapper.instance().state.open, false);
+      wrapper.update();
+      assert.strictEqual(wrapper.find(Popper).props().open, false);
     });
   });
 
@@ -236,17 +216,16 @@ describe('<Tooltip />', () => {
     ].forEach(name => {
       it(`should be transparent for the ${name} event`, () => {
         const handler = spy();
-        const wrapper = shallow(
+        const wrapper = mount(
           <Tooltip {...defaultProps} title="Hello World">
             <button type="submit" {...{ [name]: handler }}>
               Hello World
             </button>
           </Tooltip>,
         );
-        wrapper.instance().childrenRef = document.createElement('div');
         const children = wrapper.childAt(0).childAt(0);
         const type = name.slice(2).toLowerCase();
-        children.simulate(type, { type, persist });
+        children.simulate(type);
         clock.tick(0);
         assert.strictEqual(handler.callCount, 1);
       });
@@ -311,19 +290,19 @@ describe('<Tooltip />', () => {
       const children = wrapper.childAt(0).childAt(0);
       children.simulate('mouseOver', { type: 'mouseOver' });
       clock.tick(0);
-      assert.strictEqual(tooltipNaked.instance().state.open, true);
+      assert.strictEqual(wrapper.find(Popper).props().open, true);
       const popper = wrapper.find(Popper);
       children.simulate('mouseLeave', { type: 'mouseleave' });
-      assert.strictEqual(tooltipNaked.instance().state.open, true);
+      assert.strictEqual(wrapper.find(Popper).props().open, true);
       popper.simulate('mouseOver', { type: 'mouseover' });
       clock.tick(111);
-      assert.strictEqual(tooltipNaked.instance().state.open, true);
+      assert.strictEqual(wrapper.find(Popper).props().open, true);
     });
   });
 
   describe('forward', () => {
     it('should forward properties to the child element', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <Tooltip className="foo" {...defaultProps}>
           <h1 className="bar">H1</h1>
         </Tooltip>,
@@ -332,7 +311,7 @@ describe('<Tooltip />', () => {
     });
 
     it('should respect the properties priority', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <Tooltip hidden {...defaultProps}>
           <h1 hidden={false}>H1</h1>
         </Tooltip>,

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -8,7 +8,6 @@ import Popper from '../Popper';
 import Tooltip from './Tooltip';
 import Input from '../Input';
 import createMuiTheme from '../styles/createMuiTheme';
-import RootRef from '../RootRef';
 
 const theme = createMuiTheme();
 
@@ -17,7 +16,7 @@ describe('<Tooltip />', () => {
   let classes;
   let clock;
   const defaultProps = {
-    children: <span>Hello World</span>,
+    children: <span id="testChild">Hello World</span>,
     theme,
     title: 'Hello World',
   };
@@ -36,7 +35,6 @@ describe('<Tooltip />', () => {
   it('should render the correct structure', () => {
     const wrapper = mount(<Tooltip {...defaultProps} />);
     const children = wrapper.childAt(0);
-    assert.strictEqual(children.childAt(0).type(), RootRef);
     assert.strictEqual(children.childAt(1).type(), Popper);
     assert.strictEqual(children.childAt(1).hasClass(classes.popper), true);
   });
@@ -86,7 +84,7 @@ describe('<Tooltip />', () => {
 
   it('should respond to external events', () => {
     const wrapper = mount(<Tooltip {...defaultProps} />);
-    const children = wrapper.childAt(0).childAt(0);
+    const children = wrapper.find('#testChild');
     assert.strictEqual(wrapper.find(Popper).props().open, false);
     children.simulate('mouseOver');
     assert.strictEqual(wrapper.find(Popper).props().open, true);
@@ -101,7 +99,7 @@ describe('<Tooltip />', () => {
     const wrapper = mount(
       <Tooltip {...defaultProps} open onOpen={handleRequestOpen} onClose={handleClose} />,
     );
-    const children = wrapper.childAt(0).childAt(0);
+    const children = wrapper.find('#testChild');
     assert.strictEqual(handleRequestOpen.callCount, 0);
     assert.strictEqual(handleClose.callCount, 0);
     children.simulate('mouseOver');
@@ -114,7 +112,7 @@ describe('<Tooltip />', () => {
 
   it('should close when the interaction is over', () => {
     const wrapper = mount(<Tooltip {...defaultProps} />);
-    const children = wrapper.childAt(0).childAt(0);
+    const children = wrapper.find('#testChild');
     assert.strictEqual(wrapper.find(Popper).props().open, false);
     children.simulate('mouseOver');
     children.simulate('focus');
@@ -128,7 +126,7 @@ describe('<Tooltip />', () => {
   describe('touch screen', () => {
     it('should not respond to quick events', () => {
       const wrapper = mount(<Tooltip {...defaultProps} />);
-      const children = wrapper.childAt(0).childAt(0);
+      const children = wrapper.find('#testChild');
       children.simulate('touchStart');
       children.simulate('touchEnd');
       children.simulate('focus');
@@ -137,7 +135,7 @@ describe('<Tooltip />', () => {
 
     it('should open on long press', () => {
       const wrapper = mount(<Tooltip {...defaultProps} />);
-      const children = wrapper.childAt(0).childAt(0);
+      const children = wrapper.find('#testChild');
       children.simulate('touchStart');
       children.simulate('focus');
       clock.tick(1000);
@@ -181,7 +179,7 @@ describe('<Tooltip />', () => {
   describe('prop: delay', () => {
     it('should take the enterDelay into account', () => {
       const wrapper = mount(<Tooltip enterDelay={111} {...defaultProps} />);
-      const children = wrapper.childAt(0).childAt(0);
+      const children = wrapper.find('#testChild');
       children.simulate('focus');
       assert.strictEqual(wrapper.find(Popper).props().open, false);
       clock.tick(111);
@@ -191,7 +189,7 @@ describe('<Tooltip />', () => {
 
     it('should take the leaveDelay into account', () => {
       const wrapper = mount(<Tooltip leaveDelay={111} {...defaultProps} />);
-      const children = wrapper.childAt(0).childAt(0);
+      const children = wrapper.find('#testChild');
       children.simulate('focus');
       clock.tick(0);
       assert.strictEqual(wrapper.find(Popper).props().open, true);
@@ -217,12 +215,12 @@ describe('<Tooltip />', () => {
         const handler = spy();
         const wrapper = mount(
           <Tooltip {...defaultProps} title="Hello World">
-            <button type="submit" {...{ [name]: handler }}>
+            <button id="testChild" type="submit" {...{ [name]: handler }}>
               Hello World
             </button>
           </Tooltip>,
         );
-        const children = wrapper.childAt(0).childAt(0);
+        const children = wrapper.find('#testChild');
         const type = name.slice(2).toLowerCase();
         children.simulate(type);
         clock.tick(0);
@@ -282,11 +280,13 @@ describe('<Tooltip />', () => {
     it('should keep the overlay open if the popper element is hovered', () => {
       const wrapper = mount(
         <Tooltip title="Hello World" interactive leaveDelay={111}>
-          <button type="submit">Hello World</button>
+          <button id="testChild" type="submit">
+            Hello World
+          </button>
         </Tooltip>,
       );
 
-      const children = wrapper.childAt(0).childAt(0);
+      const children = wrapper.find('#testChild');
       children.simulate('mouseOver', { type: 'mouseOver' });
       clock.tick(0);
       assert.strictEqual(wrapper.find(Popper).props().open, true);

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -3,14 +3,13 @@ import { assert } from 'chai';
 import PropTypes from 'prop-types';
 import { spy, useFakeTimers } from 'sinon';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
+import { createMount, getClasses } from '@material-ui/core/test-utils';
 import Popper from '../Popper';
 import Tooltip from './Tooltip';
 import Input from '../Input';
 import createMuiTheme from '../styles/createMuiTheme';
 import RootRef from '../RootRef';
 
-const TooltipNaked = unwrap(Tooltip);
 const theme = createMuiTheme();
 
 describe('<Tooltip />', () => {
@@ -181,7 +180,7 @@ describe('<Tooltip />', () => {
 
   describe('prop: delay', () => {
     it('should take the enterDelay into account', () => {
-      const wrapper = mount(<TooltipNaked classes={{}} enterDelay={111} {...defaultProps} />);
+      const wrapper = mount(<Tooltip enterDelay={111} {...defaultProps} />);
       const children = wrapper.childAt(0).childAt(0);
       children.simulate('focus');
       assert.strictEqual(wrapper.find(Popper).props().open, false);
@@ -191,7 +190,7 @@ describe('<Tooltip />', () => {
     });
 
     it('should take the leaveDelay into account', () => {
-      const wrapper = mount(<TooltipNaked classes={{}} leaveDelay={111} {...defaultProps} />);
+      const wrapper = mount(<Tooltip leaveDelay={111} {...defaultProps} />);
       const children = wrapper.childAt(0).childAt(0);
       children.simulate('focus');
       clock.tick(0);
@@ -286,7 +285,7 @@ describe('<Tooltip />', () => {
           <button type="submit">Hello World</button>
         </Tooltip>,
       );
-      const tooltipNaked = wrapper.find(TooltipNaked);
+
       const children = wrapper.childAt(0).childAt(0);
       children.simulate('mouseOver', { type: 'mouseOver' });
       clock.tick(0);

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -55,12 +55,12 @@ describe('<Tooltip />', () => {
   describe('prop: title', () => {
     it('should display if the title is present', () => {
       const wrapper = mount(<Tooltip {...defaultProps} open />);
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
     });
 
     it('should not display if the title is an empty string', () => {
       const wrapper = mount(<Tooltip {...defaultProps} title="" open />);
-      assert.strictEqual(wrapper.find(Popper).props().open, false);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
     });
 
     it('should be passed down to the child as a native title', () => {
@@ -85,10 +85,13 @@ describe('<Tooltip />', () => {
   it('should respond to external events', () => {
     const wrapper = mount(<Tooltip {...defaultProps} />);
     const children = wrapper.find('#testChild');
-    assert.strictEqual(wrapper.find(Popper).props().open, false);
+    assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
     children.simulate('mouseOver');
-    assert.strictEqual(wrapper.find(Popper).props().open, true);
+    children.simulate('focus');
+    assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
     children.simulate('mouseLeave');
+    assert.strictEqual(wrapper.find(Popper).props().open, false);
+    children.simulate('blur');
     assert.strictEqual(wrapper.find(Popper).props().open, false);
   });
 
@@ -110,19 +113,6 @@ describe('<Tooltip />', () => {
     assert.strictEqual(handleClose.callCount, 1);
   });
 
-  it('should close when the interaction is over', () => {
-    const wrapper = mount(<Tooltip {...defaultProps} />);
-    const children = wrapper.find('#testChild');
-    assert.strictEqual(wrapper.find(Popper).props().open, false);
-    children.simulate('mouseOver');
-    children.simulate('focus');
-    assert.strictEqual(wrapper.find(Popper).props().open, true);
-    children.simulate('mouseLeave');
-    assert.strictEqual(wrapper.find(Popper).props().open, false);
-    children.simulate('blur');
-    assert.strictEqual(wrapper.find(Popper).props().open, false);
-  });
-
   describe('touch screen', () => {
     it('should not respond to quick events', () => {
       const wrapper = mount(<Tooltip {...defaultProps} />);
@@ -130,7 +120,7 @@ describe('<Tooltip />', () => {
       children.simulate('touchStart');
       children.simulate('touchEnd');
       children.simulate('focus');
-      assert.strictEqual(wrapper.find(Popper).props().open, false);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
     });
 
     it('should open on long press', () => {
@@ -140,7 +130,7 @@ describe('<Tooltip />', () => {
       children.simulate('focus');
       clock.tick(1000);
       wrapper.update();
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
       children.simulate('touchEnd');
       children.simulate('blur');
       clock.tick(1500);
@@ -169,10 +159,10 @@ describe('<Tooltip />', () => {
 
       const wrapper = mount(<AutoFocus />);
       wrapper.setProps({ open: true });
-      assert.strictEqual(wrapper.find(Popper).props().open, false);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
       clock.tick(0);
       wrapper.update();
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
     });
   });
 
@@ -181,10 +171,10 @@ describe('<Tooltip />', () => {
       const wrapper = mount(<Tooltip enterDelay={111} {...defaultProps} />);
       const children = wrapper.find('#testChild');
       children.simulate('focus');
-      assert.strictEqual(wrapper.find(Popper).props().open, false);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
       clock.tick(111);
       wrapper.update();
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
     });
 
     it('should take the leaveDelay into account', () => {
@@ -192,9 +182,9 @@ describe('<Tooltip />', () => {
       const children = wrapper.find('#testChild');
       children.simulate('focus');
       clock.tick(0);
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
       children.simulate('blur');
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
       clock.tick(111);
       wrapper.update();
       assert.strictEqual(wrapper.find(Popper).props().open, false);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #15283  *(edit @eps1lon)*

## Breaking Change

The child of the `Tooltip` needs to be able to hold a ref:
```diff
class Component extends React.Component {
  render() {
    return <div />
  }
}
-const MyComponent = props => <div {...props} />
+const MyComponent = React.forwardRef((props, ref) => <div ref={ref} {...props} />);
<Tooltip><Component /></Tooltip>
<Tooltip><MyComponent /></Tooltip>
<Tooltip><div /></Tooltip>
```