### PR TITLE
[core] Generic props for FormControl, FormLabel, List

### DIFF
--- a/docs/src/pages/demos/breadcrumbs/RouterBreadcrumbs.js
+++ b/docs/src/pages/demos/breadcrumbs/RouterBreadcrumbs.js
@@ -108,7 +108,7 @@ class RouterBreadcrumbs extends React.Component {
               <List component="nav">
                 <ListItemLink to="/inbox" open={this.state.open} onClick={this.handleClick} />
                 <Collapse in={this.state.open} timeout="auto" unmountOnExit>
-                  <List component={'div'} disablePadding>
+                  <List component="div" disablePadding>
                     <ListItemLink to="/inbox/important" className={classes.nested} />
                   </List>
                 </Collapse>

--- a/docs/src/pages/demos/breadcrumbs/RouterBreadcrumbs.tsx
+++ b/docs/src/pages/demos/breadcrumbs/RouterBreadcrumbs.tsx
@@ -126,7 +126,7 @@ class RouterBreadcrumbs extends React.Component<RouterBreadcrumbsProp, RouterBre
               <List component="nav">
                 <ListItemLink to="/inbox" open={this.state.open} onClick={this.handleClick} />
                 <Collapse in={this.state.open} timeout="auto" unmountOnExit>
-                  <List component={'div' as 'ul'} disablePadding>
+                  <List component="div" disablePadding>
                     <ListItemLink to="/inbox/important" className={classes.nested} />
                   </List>
                 </Collapse>

--- a/docs/src/pages/demos/selection-controls/CheckboxesGroup.js
+++ b/docs/src/pages/demos/selection-controls/CheckboxesGroup.js
@@ -33,8 +33,8 @@ function CheckboxesGroup() {
 
   return (
     <div className={classes.root}>
-      <FormControl component={'fieldset'} className={classes.formControl}>
-        <FormLabel component={'legend'}>Assign responsibility</FormLabel>
+      <FormControl component="fieldset" className={classes.formControl}>
+        <FormLabel component="legend">Assign responsibility</FormLabel>
         <FormGroup>
           <FormControlLabel
             control={<Checkbox checked={gilad} onChange={handleChange('gilad')} value="gilad" />}
@@ -53,8 +53,8 @@ function CheckboxesGroup() {
         </FormGroup>
         <FormHelperText>Be careful</FormHelperText>
       </FormControl>
-      <FormControl required error={error} component={'fieldset'} className={classes.formControl}>
-        <FormLabel component={'legend'}>Pick two</FormLabel>
+      <FormControl required error={error} component="fieldset" className={classes.formControl}>
+        <FormLabel component="legend">Pick two</FormLabel>
         <FormGroup>
           <FormControlLabel
             control={<Checkbox checked={gilad} onChange={handleChange('gilad')} value="gilad" />}

--- a/docs/src/pages/demos/selection-controls/CheckboxesGroup.tsx
+++ b/docs/src/pages/demos/selection-controls/CheckboxesGroup.tsx
@@ -33,8 +33,8 @@ function CheckboxesGroup() {
 
   return (
     <div className={classes.root}>
-      <FormControl component={'fieldset' as 'div'} className={classes.formControl}>
-        <FormLabel component={'legend' as 'label'}>Assign responsibility</FormLabel>
+      <FormControl component="fieldset" className={classes.formControl}>
+        <FormLabel component="legend">Assign responsibility</FormLabel>
         <FormGroup>
           <FormControlLabel
             control={<Checkbox checked={gilad} onChange={handleChange('gilad')} value="gilad" />}
@@ -53,13 +53,8 @@ function CheckboxesGroup() {
         </FormGroup>
         <FormHelperText>Be careful</FormHelperText>
       </FormControl>
-      <FormControl
-        required
-        error={error}
-        component={'fieldset' as 'div'}
-        className={classes.formControl}
-      >
-        <FormLabel component={'legend' as 'label'}>Pick two</FormLabel>
+      <FormControl required error={error} component="fieldset" className={classes.formControl}>
+        <FormLabel component="legend">Pick two</FormLabel>
         <FormGroup>
           <FormControlLabel
             control={<Checkbox checked={gilad} onChange={handleChange('gilad')} value="gilad" />}

--- a/docs/src/pages/demos/text-fields/ComposedTextField.tsx
+++ b/docs/src/pages/demos/text-fields/ComposedTextField.tsx
@@ -27,7 +27,7 @@ interface State {
 }
 
 class ComposedTextField extends React.Component<Props, State> {
-  label = React.createRef<HTMLElement>();
+  label = React.createRef<HTMLLabelElement>();
 
   state = {
     labelWidth: 0,

--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -1,21 +1,24 @@
 import * as React from 'react';
-import { StandardProps, PropTypes } from '..';
+import { PropTypes } from '..';
+import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
 
-export interface FormControlProps
-  extends StandardProps<React.HtmlHTMLAttributes<HTMLDivElement>, FormControlClassKey> {
-  component?: React.ElementType<React.HtmlHTMLAttributes<HTMLDivElement>>;
-  disabled?: boolean;
-  error?: boolean;
-  fullWidth?: boolean;
-  margin?: PropTypes.Margin;
-  onBlur?: React.EventHandler<any>;
-  onFocus?: React.EventHandler<any>;
-  required?: boolean;
-  variant?: 'standard' | 'outlined' | 'filled';
-}
+declare const FormControl: OverridableComponent<{
+  props: {
+    disabled?: boolean;
+    error?: boolean;
+    fullWidth?: boolean;
+    margin?: PropTypes.Margin;
+    onBlur?: React.EventHandler<any>;
+    onFocus?: React.EventHandler<any>;
+    required?: boolean;
+    variant?: 'standard' | 'outlined' | 'filled';
+  };
+  defaultComponent: 'div';
+  classKey: FormControlClassKey;
+}>;
 
 export type FormControlClassKey = 'root' | 'marginNormal' | 'marginDense' | 'fullWidth';
 
-declare const FormControl: React.ComponentType<FormControlProps>;
+export type FormControlProps = SimplifiedPropsOf<typeof FormControl>;
 
 export default FormControl;

--- a/packages/material-ui/src/FormControl/FormControl.spec.tsx
+++ b/packages/material-ui/src/FormControl/FormControl.spec.tsx
@@ -1,8 +1,0 @@
-import * as React from 'react';
-import FormControl from '@material-ui/core/FormControl';
-
-// custom host
-// https://github.com/mui-org/material-ui/issues/13744
-{
-  <FormControl component="fieldset" className="hello-world" />;
-}

--- a/packages/material-ui/src/FormControl/FormControl.spec.tsx
+++ b/packages/material-ui/src/FormControl/FormControl.spec.tsx
@@ -1,12 +1,6 @@
 import * as React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 
-// custom intrinsic
-// https://github.com/mui-org/material-ui/issues/13744
 {
-  // we only accept DivAttributes since we don't have generic props
-  // however once v4 typings are available this should be accepted #v4-typings
-  <FormControl component="fieldset" className="hello-world" />; // $ExpectError
-  // Defeat device
-  <FormControl component={'fieldset' as 'div'} className="hello-world" />;
+  <FormControl component="fieldset" className="hello-world" />;
 }

--- a/packages/material-ui/src/FormControl/FormControl.spec.tsx
+++ b/packages/material-ui/src/FormControl/FormControl.spec.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import FormControl from '@material-ui/core/FormControl';
 
+// custom host
+// https://github.com/mui-org/material-ui/issues/13744
 {
   <FormControl component="fieldset" className="hello-world" />;
 }

--- a/packages/material-ui/src/FormLabel/FormLabel.d.ts
+++ b/packages/material-ui/src/FormLabel/FormLabel.d.ts
@@ -7,11 +7,6 @@ declare const FormLabel: OverridableComponent<{
     error?: boolean;
     filled?: boolean;
     focused?: boolean;
-    /**
-     * Should only be used if ref forwarding `component` is used.
-     * This is imprecise if `<FormLabel component={SomeComponent} />` is used.
-     */
-    ref?: React.Ref<HTMLElement>;
     required?: boolean;
   };
   defaultComponent: 'label';

--- a/packages/material-ui/src/FormLabel/FormLabel.d.ts
+++ b/packages/material-ui/src/FormLabel/FormLabel.d.ts
@@ -1,21 +1,22 @@
 import * as React from 'react';
-import { StandardProps } from '..';
+import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
 
-export interface FormLabelProps extends StandardProps<FormLabelBaseProps, FormLabelClassKey> {
-  component?: React.ElementType<FormLabelBaseProps>;
-  disabled?: boolean;
-  error?: boolean;
-  filled?: boolean;
-  focused?: boolean;
-  /**
-   * Should only be used if ref forwarding `component` is used.
-   * This is imprecise if `<FormLabel component={SomeComponent} />` is used.
-   */
-  ref?: React.Ref<HTMLElement>;
-  required?: boolean;
-}
-
-export type FormLabelBaseProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+declare const FormLabel: OverridableComponent<{
+  props: FormLabelBaseProps & {
+    disabled?: boolean;
+    error?: boolean;
+    filled?: boolean;
+    focused?: boolean;
+    /**
+     * Should only be used if ref forwarding `component` is used.
+     * This is imprecise if `<FormLabel component={SomeComponent} />` is used.
+     */
+    ref?: React.Ref<HTMLElement>;
+    required?: boolean;
+  };
+  defaultComponent: 'label';
+  classKey: FormLabelClassKey;
+}>;
 
 export type FormLabelClassKey =
   | 'root'
@@ -26,6 +27,8 @@ export type FormLabelClassKey =
   | 'required'
   | 'asterisk';
 
-declare const FormLabel: React.ComponentType<FormLabelProps>;
+export type FormLabelBaseProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+export type FormLabelProps = SimplifiedPropsOf<typeof FormLabel>;
 
 export default FormLabel;

--- a/packages/material-ui/src/FormLabel/FormLabel.spec.tsx
+++ b/packages/material-ui/src/FormLabel/FormLabel.spec.tsx
@@ -1,6 +1,0 @@
-import * as React from 'react';
-import FormLabel from '@material-ui/core/FormLabel';
-
-{
-  <FormLabel component="legend" />;
-}

--- a/packages/material-ui/src/FormLabel/FormLabel.spec.tsx
+++ b/packages/material-ui/src/FormLabel/FormLabel.spec.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import FormLabel from '@material-ui/core/FormLabel';
+
+{
+  <FormLabel component="legend" />;
+}

--- a/packages/material-ui/src/List/List.d.ts
+++ b/packages/material-ui/src/List/List.d.ts
@@ -1,16 +1,18 @@
 import * as React from 'react';
-import { StandardProps } from '..';
+import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
 
-export interface ListProps
-  extends StandardProps<React.HTMLAttributes<HTMLUListElement>, ListClassKey> {
-  component?: React.ElementType<React.HTMLAttributes<HTMLUListElement>>;
-  dense?: boolean;
-  disablePadding?: boolean;
-  subheader?: React.ReactElement;
-}
+declare const List: OverridableComponent<{
+  props: {
+    dense?: boolean;
+    disablePadding?: boolean;
+    subheader?: React.ReactElement;
+  };
+  defaultComponent: 'ul';
+  classKey: ListClassKey;
+}>;
 
 export type ListClassKey = 'root' | 'padding' | 'dense' | 'subheader';
 
-declare const List: React.ComponentType<ListProps>;
+export type ListProps = SimplifiedPropsOf<typeof List>;
 
 export default List;

--- a/packages/material-ui/src/List/List.spec.tsx
+++ b/packages/material-ui/src/List/List.spec.tsx
@@ -5,8 +5,8 @@ import List from '@material-ui/core/List';
   <List component="div" />;
   <List
     component="div"
-    onChange={e => {
-      e.currentTarget; // $ExpectType EventTarget & HTMLUListElement
+    onChange={(e: React.FormEvent<HTMLDivElement>) => {
+      e.currentTarget;
     }}
   />;
 }

--- a/packages/material-ui/src/List/List.spec.tsx
+++ b/packages/material-ui/src/List/List.spec.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import List from '@material-ui/core/List';
 
+// custom host
+// https://github.com/mui-org/material-ui/issues/13746
 {
   <List component="div" />;
   <List

--- a/packages/material-ui/src/List/List.spec.tsx
+++ b/packages/material-ui/src/List/List.spec.tsx
@@ -1,13 +1,10 @@
 import * as React from 'react';
 import List from '@material-ui/core/List';
 
-// use other components
-// https://github.com/mui-org/material-ui/issues/13746
 {
-  // HTMLDivElement is not assignable to HTMLUlElement #v4-typings
-  <List component="div" />; // $ExpectError
+  <List component="div" />;
   <List
-    component={'div' as 'ul'}
+    component="div"
     onChange={e => {
       e.currentTarget; // $ExpectType EventTarget & HTMLUListElement
     }}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This PR adds v4 typings for FormControl, FormLabel, and List components. It also includes some small changes to clean up the TS demos for this components.

Edit @eps1lon:
Closes #13744 (completely), #13746