### PR TITLE
[Tooltip] Suppress disabled button warning when controlled

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -91,6 +91,7 @@ class Tooltip extends React.Component {
   componentDidMount() {
     warning(
       !this.childrenRef.disabled ||
+        (this.childrenRef.disabled && this.isControlled) ||
         (this.childrenRef.disabled && this.props.title === '') ||
         this.childrenRef.tagName.toLowerCase() !== 'button',
       [

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -296,7 +296,7 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 1, 'should not call console.error');
+      assert.strictEqual(consoleErrorMock.callCount(), 0);
     });
   });
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -273,7 +273,7 @@ describe('<Tooltip />', () => {
       assert.strictEqual(consoleErrorMock.callCount(), 0, 'should not call console.error');
     });
 
-    it('should raise a warning when we can listen to events', () => {
+    it('should raise a warning when we are uncontrolled and can not listen to events', () => {
       mount(
         <Tooltip title="Hello World">
           <button type="submit" disabled>
@@ -286,6 +286,17 @@ describe('<Tooltip />', () => {
         consoleErrorMock.args()[0][0],
         /Material-UI: you are providing a disabled `button` child to the Tooltip component/,
       );
+    });
+
+    it('should not raise a warning when we are controlled', () => {
+      mount(
+        <Tooltip title="Hello World" open={true}>
+          <button type="submit" disabled>
+            Hello World
+          </button>
+        </Tooltip>,
+      );
+      assert.strictEqual(consoleErrorMock.callCount(), 1, 'should not call console.error');
     });
   });
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -254,11 +254,11 @@ describe('<Tooltip />', () => {
   });
 
   describe('disabled button warning', () => {
-    before(() => {
+    beforeEach(() => {
       consoleErrorMock.spy();
     });
 
-    after(() => {
+    afterEach(() => {
       consoleErrorMock.reset();
     });
 
@@ -290,7 +290,7 @@ describe('<Tooltip />', () => {
 
     it('should not raise a warning when we are controlled', () => {
       mount(
-        <Tooltip title="Hello World" open={true}>
+        <Tooltip title="Hello World" open>
           <button type="submit" disabled>
             Hello World
           </button>


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This suppresses the warning as described in #15303. Includes unit test.

Also: wording fix in existing test title - should probably be "can not" listen to events

Closes #15303.