### PR TITLE
[Example] Added styled-components as dependency in gatsby example

### DIFF
--- a/examples/gatsby-next/package.json
+++ b/examples/gatsby-next/package.json
@@ -9,7 +9,8 @@
     "gatsby-plugin-react-helmet": "latest",
     "react": "latest",
     "react-dom": "latest",
-    "react-helmet": "latest"
+    "react-helmet": "latest",
+    "styled-components": "latest"
   },
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
`styled-components` is used in `index.js` file but missing in dependencies.

Not sure though about the `latest` version range.
