### PR TITLE
[core] Add `strict` option to createMount

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -423,7 +423,7 @@ class Slider extends React.Component {
   handleRef = ref => {
     setRef(this.props.innerRef, ref);
 
-    // StrictMode ready
+    // #StrictMode ready
     const nextContainer = ReactDOM.findDOMNode(ref);
     const prevContainer = this.container;
 

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -20,7 +20,8 @@ describe('<Slider />', () => {
 
   before(() => {
     classes = getClasses(<Slider value={0} />);
-    mount = createMount();
+    // StrictMode violation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -32,7 +32,8 @@ describe('<SpeedDial />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     shallow = createShallow({ dive: true });
     classes = getClasses(
       <SpeedDial {...defaultProps} icon={icon}>
@@ -296,7 +297,7 @@ describe('<SpeedDial />', () => {
 
     it('displays the actions on focus gain', () => {
       resetDialToOpen();
-      assert.strictEqual(wrapper.props().open, true);
+      assert.strictEqual(wrapper.find('SpeedDial').props().open, true);
     });
 
     describe('first item selection', () => {

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -17,7 +17,8 @@ describe('<SpeedDialAction />', () => {
   };
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<SpeedDialAction {...defaultProps} />);
   });
 

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -13,7 +13,7 @@ describe('<SpeedDialIcon />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<SpeedDialIcon />);
   });
 

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
@@ -17,7 +17,8 @@ describe('<ToggleButton />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     render = createRender();
     classes = getClasses(<ToggleButton value="classes">Hello World</ToggleButton>);
   });

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -15,7 +15,8 @@ describe('<ToggleButtonGroup />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(
       <ToggleButtonGroup>
         <ToggleButton value="hello" />

--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
@@ -21,7 +21,7 @@ describe('StylesProvider', () => {
   let generateClassName;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   beforeEach(() => {

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -9,7 +9,7 @@ describe('ThemeProvider', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {
@@ -17,51 +17,57 @@ describe('ThemeProvider', () => {
   });
 
   it('should provide the theme', () => {
+    const ref = React.createRef();
+    const text = () => ref.current.textContent;
     function Test() {
       const theme = useTheme();
 
-      return <span>{theme.foo}</span>;
+      return <span ref={ref}>{theme.foo}</span>;
     }
 
-    const wrapper = mount(
+    mount(
       <ThemeProvider theme={{ foo: 'foo' }}>
         <Test />
       </ThemeProvider>,
     );
-    assert.strictEqual(wrapper.text(), 'foo');
+    assert.strictEqual(text(), 'foo');
   });
 
   it('should merge the themes', () => {
+    const ref = React.createRef();
+    const text = () => ref.current.textContent;
     function Test() {
       const theme = useTheme();
 
       return (
-        <span>
+        <span ref={ref}>
           {theme.foo}
           {theme.bar}
         </span>
       );
     }
 
-    const wrapper = mount(
+    mount(
       <ThemeProvider theme={{ bar: 'bar' }}>
         <ThemeProvider theme={{ foo: 'foo' }}>
           <Test />
         </ThemeProvider>
       </ThemeProvider>,
     );
-    assert.strictEqual(wrapper.text(), 'foobar');
+    assert.strictEqual(text(), 'foobar');
   });
 
   it('should memoize the merged output', () => {
     const themes = [];
 
+    const ref = React.createRef();
+    const text = () => ref.current.textContent;
     function Test() {
       const theme = useTheme();
       themes.push(theme);
 
       return (
-        <span>
+        <span ref={ref}>
           {theme.foo}
           {theme.bar}
         </span>
@@ -83,9 +89,9 @@ describe('ThemeProvider', () => {
     }
 
     const wrapper = mount(<Container />);
-    assert.strictEqual(wrapper.text(), 'foobar');
+    assert.strictEqual(text(), 'foobar');
     wrapper.setProps({});
-    assert.strictEqual(wrapper.text(), 'foobar');
+    assert.strictEqual(text(), 'foobar');
     assert.strictEqual(themes.length, 1);
   });
 
@@ -104,7 +110,7 @@ describe('ThemeProvider', () => {
           <div />
         </ThemeProvider>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.strictEqual(consoleErrorMock.callCount(), 2); // twice in strict mode
       assert.include(consoleErrorMock.args()[0][0], 'However, no outer theme is present.');
     });
 
@@ -117,7 +123,7 @@ describe('ThemeProvider', () => {
           ,
         </ThemeProvider>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.strictEqual(consoleErrorMock.callCount(), 2);
       assert.include(
         consoleErrorMock.args()[0][0],
         'you should return an object from your theme function',

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -39,7 +39,7 @@ describe('makeStyles', () => {
   let generateClassName;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: undefined });
   });
 
   beforeEach(() => {

--- a/packages/material-ui-styles/src/styled/styled.test.js
+++ b/packages/material-ui-styles/src/styled/styled.test.js
@@ -13,7 +13,8 @@ describe('styled', () => {
   let StyledButton;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses makeStyles
+    mount = createMount({ strict: false });
     StyledButton = styled('button')({
       background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
       borderRadius: 3,

--- a/packages/material-ui-styles/src/useTheme/useTheme.test.js
+++ b/packages/material-ui-styles/src/useTheme/useTheme.test.js
@@ -8,7 +8,7 @@ describe('useTheme', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {
@@ -16,17 +16,19 @@ describe('useTheme', () => {
   });
 
   it('should use the theme', () => {
+    const ref = React.createRef();
+    const text = () => ref.current.textContent;
     function Test() {
       const theme = useTheme();
 
-      return <span>{theme.foo}</span>;
+      return <span ref={ref}>{theme.foo}</span>;
     }
 
-    const wrapper = mount(
+    mount(
       <ThemeProvider theme={{ foo: 'foo' }}>
         <Test />
       </ThemeProvider>,
     );
-    assert.strictEqual(wrapper.text(), 'foo');
+    assert.strictEqual(text(), 'foo');
   });
 });

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -17,7 +17,8 @@ describe('withStyles', () => {
   let generateClassName;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses makeStyles
+    mount = createMount({ strict: false });
   });
 
   beforeEach(() => {

--- a/packages/material-ui-styles/src/withTheme/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme/withTheme.test.js
@@ -12,7 +12,7 @@ describe('withTheme', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {
@@ -20,8 +20,10 @@ describe('withTheme', () => {
   });
 
   it('should inject the theme', () => {
+    const ref = React.createRef();
+    const text = () => ref.current.textContent;
     function Test(props) {
-      return <span>{props.theme.foo}</span>;
+      return <span ref={ref}>{props.theme.foo}</span>;
     }
 
     Test.propTypes = {
@@ -30,12 +32,12 @@ describe('withTheme', () => {
 
     const TestWithTheme = withTheme(Test);
 
-    const wrapper = mount(
+    mount(
       <ThemeProvider theme={{ foo: 'foo' }}>
         <TestWithTheme />
       </ThemeProvider>,
     );
-    assert.strictEqual(wrapper.text(), 'foo');
+    assert.strictEqual(text(), 'foo');
   });
 
   it('hoist statics', () => {

--- a/packages/material-ui/src/AppBar/AppBar.test.js
+++ b/packages/material-ui/src/AppBar/AppBar.test.js
@@ -15,7 +15,7 @@ describe('<AppBar />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<AppBar>Hello World</AppBar>);
   });

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -15,7 +15,8 @@ describe('<Backdrop />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses Fade
+    mount = createMount({ strict: false });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Backdrop open />);
   });

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -24,7 +24,8 @@ describe('<BottomNavigation />', () => {
         <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
-    mount = createMount();
+    // StrictModeViolation: uses BottomNavigationAction
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -17,7 +17,8 @@ describe('<BottomNavigationAction />', () => {
   const icon = <Icon>restore</Icon>;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<BottomNavigationAction />);
   });
 

--- a/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.test.js
+++ b/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.test.js
@@ -11,7 +11,7 @@ describe('<BreadcrumbCollapsed />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<BreadcrumbCollapsed />);
   });
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -22,7 +22,8 @@ describe('<ButtonBase />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true, disableLifecycleMethods: true });
-    mount = createMount();
+    // StrictModeViolation: uses TouchRipple
+    mount = createMount({ strict: false });
     classes = getClasses(<ButtonBase />);
   });
 
@@ -43,7 +44,7 @@ describe('<ButtonBase />', () => {
       const wrapper = mount(<ButtonBase type="submit">Hello</ButtonBase>);
       const button = wrapper.find('button');
       assert.strictEqual(button.exists(), true);
-      assert.strictEqual(wrapper.props().type, 'submit');
+      assert.strictEqual(button.props().type, 'submit');
     });
 
     it('should change the button component and add accessibility requirements', () => {
@@ -679,9 +680,10 @@ describe('<ButtonBase />', () => {
       wrapper.setProps({
         children: 'bar',
       });
+
       assert.strictEqual(
         rerender.updates.filter(update => update.displayName !== 'NoSsr').length,
-        1,
+        2,
       );
     });
   });

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -13,7 +13,7 @@ describe('<Ripple />', () => {
   before(() => {
     shallow = createShallow();
     classes = getClasses(<TouchRipple />);
-    mount = createMount();
+    mount = createMount({ strict: undefined });
   });
 
   after(() => {

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -21,7 +21,7 @@ describe('<TouchRipple />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    mount = createMount({ strict: undefined });
     classes = getClasses(<TouchRipple />);
   });
 

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -10,7 +10,8 @@ describe('<Checkbox />', () => {
 
   before(() => {
     classes = getClasses(<Checkbox />);
-    mount = createMount();
+    // StrictModeViolation: uses IconButton
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -13,7 +13,7 @@ describe('<Chip />', () => {
 
   before(() => {
     classes = getClasses(<Chip />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -19,7 +19,7 @@ describe('<ClickAwayListener />', () => {
   let wrapper;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   afterEach(() => {

--- a/packages/material-ui/src/Container/Container.test.js
+++ b/packages/material-ui/src/Container/Container.test.js
@@ -16,7 +16,7 @@ describe('<Container />', () => {
   };
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<Container {...defaultProps} />);
   });
 

--- a/packages/material-ui/src/CssBaseline/CssBaseline.test.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.test.js
@@ -1,30 +1,25 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import { createMount } from '@material-ui/core/test-utils';
 import CssBaseline from './CssBaseline';
 
 describe('<CssBaseline />', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {
     mount.cleanUp();
   });
 
-  it('should render nothing', () => {
-    const wrapper = mount(<CssBaseline />);
-    assert.strictEqual(wrapper.childAt(0).children().length, 0, 'should have no children');
-  });
-
-  it('should render a div with the root class', () => {
+  it('renders its children', () => {
     const wrapper = mount(
       <CssBaseline>
-        <div />
+        <div id="child" />
       </CssBaseline>,
     );
-    assert.strictEqual(findOutermostIntrinsic(wrapper).name(), 'div');
+    assert.strictEqual(wrapper.find('#child').type(), 'div');
   });
 });

--- a/packages/material-ui/src/CssBaseline/CssBaseline.test.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.test.js
@@ -7,7 +7,9 @@ describe('<CssBaseline />', () => {
   let mount;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: makeStyles will retain the styles in the head in strict mode
+    // which becomes an issue for global styles
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -25,7 +25,8 @@ describe('<Dialog />', () => {
   };
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses Fade
+    mount = createMount({ strict: false });
     classes = getClasses(<Dialog {...defaultProps}>foo</Dialog>);
   });
 

--- a/packages/material-ui/src/DialogActions/DialogActions.test.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.test.js
@@ -7,7 +7,7 @@ describe('<DialogActions />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<DialogActions />);
   });
 

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -17,7 +17,8 @@ describe('<Drawer />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses Slide
+    mount = createMount({ strict: false });
     classes = getClasses(
       <Drawer>
         <div />

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -20,7 +20,8 @@ describe('<ExpansionPanel />', () => {
   const minimalChildren = [<ExpansionPanelSummary key="header" />];
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses Collapse
+    mount = createMount({ strict: false });
     classes = getClasses(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
   });
 
@@ -87,7 +88,6 @@ describe('<ExpansionPanel />', () => {
     const wrapper = mount(
       <ExpansionPanel onChange={handleChange}>{minimalChildren}</ExpansionPanel>,
     );
-    assert.strictEqual(wrapper.type(), ExpansionPanel);
     wrapper.find(ExpansionPanelSummary).simulate('click');
     assert.strictEqual(handleChange.callCount, 1);
   });

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -19,7 +19,8 @@ describe('<ExpansionPanelSummary />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<ExpansionPanelSummary />);
   });
 

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -13,7 +13,8 @@ describe('<Fade />', () => {
   };
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -14,7 +14,7 @@ describe('<FilledInput />', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<FilledInput />);
   });
 

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -25,7 +25,7 @@ describe('<FormControl />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<FormControl />);
   });
 
@@ -52,14 +52,12 @@ describe('<FormControl />', () => {
     it('should have the margin normal class', () => {
       const wrapper = mount(<FormControl margin="normal" />);
 
-      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginNormal), true);
     });
 
     it('should have the margin dense class', () => {
       const wrapper = mount(<FormControl margin="dense" />);
 
-      assert.strictEqual(findOutermostIntrinsic(wrapper).name(), 'div');
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginDense), true);
       assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.marginNormal), false);
     });

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -16,7 +16,8 @@ describe('<FormControlLabel />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses Checkbox in test
+    mount = createMount({ strict: false });
     classes = getClasses(<FormControlLabel label="Pizza" control={<div />} />);
   });
 

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -15,7 +15,7 @@ describe('<FormHelperText />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<FormHelperText />);
   });
 

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -15,7 +15,7 @@ describe('<FormLabel />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<FormLabel />);
   });
 
@@ -33,16 +33,19 @@ describe('<FormLabel />', () => {
 
   describe('prop: required', () => {
     it('should show an asterisk if required is set', () => {
-      const wrapper = mount(<FormLabel required />);
-      const text = wrapper.text();
+      const labelRef = React.createRef();
+      const wrapper = mount(<FormLabel ref={labelRef} required />);
+      const text = labelRef.current.textContent;
       assert.strictEqual(text.slice(-1), '*');
       assert.strictEqual(wrapper.find('[data-mui-test="FormLabelAsterisk"]').length, 1);
     });
 
     it('should not show an asterisk by default', () => {
-      const wrapper = mount(<FormLabel />);
+      const labelRef = React.createRef();
+      const wrapper = mount(<FormLabel ref={labelRef} />);
+
       assert.strictEqual(wrapper.find('[data-mui-test="FormLabelAsterisk"]').length, 0);
-      assert.strictEqual(wrapper.text().includes('*'), false);
+      assert.strictEqual(labelRef.current.textContent.indexOf('*'), -1);
     });
   });
 

--- a/packages/material-ui/src/GridListTile/GridListTile.test.js
+++ b/packages/material-ui/src/GridListTile/GridListTile.test.js
@@ -10,7 +10,7 @@ describe('<GridListTile />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<GridListTile />);
   });
 

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -20,7 +20,8 @@ describe('<IconButton />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<IconButton />);
   });
 

--- a/packages/material-ui/src/Input/Input.test.js
+++ b/packages/material-ui/src/Input/Input.test.js
@@ -9,7 +9,7 @@ describe('<Input />', () => {
 
   before(() => {
     classes = getClasses(<Input />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -18,7 +18,7 @@ describe('<InputAdornment />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<InputAdornment position="start">foo</InputAdornment>);
   });
 

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -147,8 +147,7 @@ describe('<InputBase />', () => {
         // don't test number because zero is a empty state, whereas '' is not
         if (typeof value !== 'number') {
           it('should have called the handleEmpty callback', () => {
-            // Strict mode doubles it TODO should this actually happen
-            assert.strictEqual(handleEmpty.callCount, 2);
+            assert.strictEqual(handleEmpty.callCount, 1);
           });
 
           it('should fire the onFilled callback when dirtied', () => {
@@ -158,9 +157,9 @@ describe('<InputBase />', () => {
           });
 
           it('should fire the onEmpty callback when dirtied', () => {
-            assert.strictEqual(handleEmpty.callCount, 2);
+            assert.strictEqual(handleEmpty.callCount, 1);
             wrapper.setProps({ value });
-            assert.strictEqual(handleEmpty.callCount, 3);
+            assert.strictEqual(handleEmpty.callCount, 2);
           });
         }
       });

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -26,7 +26,7 @@ describe('<InputBase />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<InputBase />);
   });
 
@@ -147,7 +147,8 @@ describe('<InputBase />', () => {
         // don't test number because zero is a empty state, whereas '' is not
         if (typeof value !== 'number') {
           it('should have called the handleEmpty callback', () => {
-            assert.strictEqual(handleEmpty.callCount, 1);
+            // Strict mode doubles it TODO should this actually happen
+            assert.strictEqual(handleEmpty.callCount, 2);
           });
 
           it('should fire the onFilled callback when dirtied', () => {
@@ -157,9 +158,9 @@ describe('<InputBase />', () => {
           });
 
           it('should fire the onEmpty callback when dirtied', () => {
-            assert.strictEqual(handleEmpty.callCount, 1);
-            wrapper.setProps({ value });
             assert.strictEqual(handleEmpty.callCount, 2);
+            wrapper.setProps({ value });
+            assert.strictEqual(handleEmpty.callCount, 3);
           });
         }
       });

--- a/packages/material-ui/src/InputBase/Textarea.test.js
+++ b/packages/material-ui/src/InputBase/Textarea.test.js
@@ -29,7 +29,7 @@ describe('<Textarea />', () => {
 
   before(() => {
     shallow = createShallow();
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {
@@ -62,10 +62,12 @@ describe('<Textarea />', () => {
   });
 
   describe('height behavior', () => {
+    let instanceWrapper;
     let wrapper;
 
     beforeEach(() => {
-      wrapper = mount(<TextareaNaked classes={{}} value="f" />);
+      wrapper = mount(<Textarea value="f" />);
+      instanceWrapper = wrapper.find('Textarea');
     });
 
     afterEach(() => {
@@ -73,24 +75,24 @@ describe('<Textarea />', () => {
     });
 
     it('should update the height when the value change', () => {
-      const instance = wrapper.instance();
+      const instance = instanceWrapper.instance();
       instance.singlelineShadowRef = { scrollHeight: 19 };
       instance.shadowRef = { scrollHeight: 19 };
       wrapper.setProps({ value: 'fo' });
-      assert.strictEqual(wrapper.state().height, 19);
+      assert.strictEqual(instanceWrapper.state().height, 19);
       instance.shadowRef = { scrollHeight: 48 };
       wrapper.setProps({ value: 'foooooo' });
-      assert.strictEqual(wrapper.state().height, 48);
+      assert.strictEqual(instanceWrapper.state().height, 48);
     });
 
     it('should respect the rowsMax property', () => {
-      const instance = wrapper.instance();
+      const instance = instanceWrapper.instance();
       const rowsMax = 4;
       const lineHeight = 19;
       instance.singlelineShadowRef = { scrollHeight: lineHeight };
       instance.shadowRef = { scrollHeight: lineHeight * 5 };
       wrapper.setProps({ rowsMax });
-      assert.strictEqual(wrapper.state().height, lineHeight * rowsMax);
+      assert.strictEqual(instanceWrapper.state().height, lineHeight * rowsMax);
     });
   });
 

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -16,7 +16,7 @@ describe('<InputLabel />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<InputLabel />);
   });
 

--- a/packages/material-ui/src/List/List.test.js
+++ b/packages/material-ui/src/List/List.test.js
@@ -15,7 +15,7 @@ describe('<List />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<List />);
   });
 

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -22,7 +22,8 @@ describe('<ListItem />', () => {
 
   before(() => {
     classes = getClasses(<ListItem />);
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {
@@ -69,9 +70,9 @@ describe('<ListItem />', () => {
   });
 
   describe('prop: button', () => {
-    it('should render a div', () => {
+    it('renders a div', () => {
       const wrapper = mount(<ListItem button />);
-      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
+      assert.strictEqual(findOutermostIntrinsic(wrapper).type(), 'div');
     });
   });
 

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.test.js
@@ -10,7 +10,7 @@ describe('<ListItemAvatar />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(
       <ListItemAvatar className="foo">
         <Avatar className="bar" />
@@ -34,18 +34,5 @@ describe('<ListItemAvatar />', () => {
     assert.strictEqual(avatar.hasClass('foo'), true);
     assert.strictEqual(avatar.hasClass('bar'), true);
     assert.strictEqual(avatar.hasClass(classes.root), true);
-  });
-
-  describe('List', () => {
-    it('should render an Avatar', () => {
-      const wrapper = mount(
-        <ListContext.Provider value={{ dense: true }}>
-          <ListItemAvatar>
-            <Avatar />
-          </ListItemAvatar>
-        </ListContext.Provider>,
-      );
-      assert.strictEqual(wrapper.type(), ListItemAvatar);
-    });
   });
 });

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -14,7 +14,7 @@ describe('<ListItemText />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<ListItemText />);
   });
 
@@ -47,12 +47,14 @@ describe('<ListItemText />', () => {
 
   describe('prop: primary', () => {
     it('should render primary text', () => {
-      const wrapper = mount(<ListItemText primary="This is the primary text" />);
+      const ref = React.createRef();
+      const text = () => ref.current.textContent;
+      const wrapper = mount(<ListItemText primary="This is the primary text" ref={ref} />);
       const listItemText = findOutermostIntrinsic(wrapper);
       const typography = listItemText.find(Typography);
       assert.strictEqual(typography.exists(), true);
       assert.strictEqual(typography.props().variant, 'body1');
-      assert.strictEqual(wrapper.text(), 'This is the primary text');
+      assert.strictEqual(text(), 'This is the primary text');
     });
 
     it('should use the primary node', () => {

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -18,7 +18,8 @@ describe('<Menu />', () => {
 
   before(() => {
     classes = getClasses(<Menu {...defaultProps} />);
-    mount = createMount();
+    // StrictModeViolation: uses Popover
+    mount = createMount({ strict: false });
   });
 
   after(() => {
@@ -109,20 +110,20 @@ describe('<Menu />', () => {
   it('should pass onClose prop to Popover', () => {
     const fn = () => {};
     const wrapper = mount(<Menu {...defaultProps} onClose={fn} />);
-    assert.strictEqual(wrapper.props().onClose, fn);
+    assert.strictEqual(wrapper.find(Popover).props().onClose, fn);
   });
 
   it('should pass anchorEl prop to Popover', () => {
     const el = document.createElement('div');
     const wrapper = mount(<Menu {...defaultProps} anchorEl={el} />);
-    assert.strictEqual(wrapper.props().anchorEl, el);
+    assert.strictEqual(wrapper.find(Popover).props().anchorEl, el);
   });
 
   it('should pass through the `open` prop to Popover', () => {
     const wrapper = mount(<Menu {...defaultProps} />);
-    assert.strictEqual(wrapper.props().open, false);
+    assert.strictEqual(wrapper.find(Popover).props().open, false);
     wrapper.setProps({ open: true });
-    assert.strictEqual(wrapper.props().open, true);
+    assert.strictEqual(wrapper.find(Popover).props().open, true);
   });
 
   describe('list node', () => {

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -19,7 +19,8 @@ describe('<MenuItem />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<MenuItem />);
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/MenuList/MenuList.test.js
+++ b/packages/material-ui/src/MenuList/MenuList.test.js
@@ -20,7 +20,7 @@ describe('<MenuList />', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -25,7 +25,8 @@ describe('<Modal />', () => {
         <div />
       </Modal>,
     );
-    mount = createMount();
+    // StrictModeViolation: uses Backdrop
+    mount = createMount({ strict: false });
     savedBodyStyle = document.body.style;
   });
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -21,7 +21,7 @@ describe('<NativeSelect />', () => {
 
   before(() => {
     classes = getClasses(<NativeSelect {...props} />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -26,7 +26,7 @@ describe('<NativeSelectInput />', () => {
 
   before(() => {
     shallow = createShallow();
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/NoSsr/NoSsr.test.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.test.js
@@ -8,7 +8,7 @@ describe('<NoSsr />', () => {
   let render;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     render = createRender();
   });
 
@@ -31,11 +31,10 @@ describe('<NoSsr />', () => {
     it('should render the children', () => {
       const wrapper = mount(
         <NoSsr>
-          <span>Hello</span>
+          <span id="client-only" />
         </NoSsr>,
       );
-      assert.strictEqual(wrapper.find('span').length, 1);
-      assert.strictEqual(wrapper.text(), 'Hello');
+      assert.strictEqual(wrapper.find('#client-only').exists(), true);
     });
   });
 
@@ -56,10 +55,10 @@ describe('<NoSsr />', () => {
     it('should defer the rendering', () => {
       const wrapper = mount(
         <NoSsr defer>
-          <span>Hello</span>
+          <span id="client-only">Hello</span>
         </NoSsr>,
       );
-      assert.strictEqual(wrapper.find('span').length, 1);
+      assert.strictEqual(wrapper.find('#client-only').exists(), true);
     });
   });
 });

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -11,7 +11,7 @@ describe('<OutlinedInput />', () => {
 
   before(() => {
     classes = getClasses(<OutlinedInput />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -14,7 +14,7 @@ describe('<Paper />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Paper />);
   });

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -26,7 +26,8 @@ describe('<Popover />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    // StrictModeViolation: uses Grow
+    mount = createMount({ strict: false });
     classes = getClasses(
       <Popover {...defaultProps}>
         <div />

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -18,7 +18,8 @@ describe('<Popper />', () => {
 
   before(() => {
     shallow = createShallow();
-    mount = createMount();
+    // StrictModeViolation: uses Portal
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Portal/Portal.test.js
+++ b/packages/material-ui/src/Portal/Portal.test.js
@@ -14,7 +14,8 @@ describe('<Portal />', () => {
   const reactDomMock = {};
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses findDOMNode
+    mount = createMount({ strict: false });
     render = createRender();
   });
 
@@ -104,7 +105,7 @@ describe('<Portal />', () => {
           <h1 className="woofPortal">Foo</h1>
         </Portal>,
       );
-      assert.strictEqual(wrapper.children().length, 0, 'should have no children');
+      assert.strictEqual(wrapper.find('Portal').children().length, 0, 'should have no children');
     });
 
     it('should have access to the mountNode', () => {
@@ -113,7 +114,7 @@ describe('<Portal />', () => {
           <h1>Foo</h1>
         </Portal>,
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.find('Portal').instance();
       assert.strictEqual(instance.getMountNode(), instance.mountNode);
     });
 
@@ -123,7 +124,7 @@ describe('<Portal />', () => {
           <h1 className="woofPortal">Foo</h1>
         </Portal>,
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.find('Portal').instance();
       assert.notStrictEqual(instance.mountNode, null, 'should have a mountNode');
       assert.strictEqual(document.querySelectorAll('.woofPortal').length, 1);
     });
@@ -158,7 +159,7 @@ describe('<Portal />', () => {
 
       const wrapper = mount(<Parent />);
       assert.strictEqual(document.querySelectorAll('#test1').length, 1);
-      wrapper.setState({ show: false });
+      wrapper.find('Parent').setState({ show: false });
       assert.strictEqual(document.querySelectorAll('#test1').length, 0);
     });
 
@@ -192,12 +193,11 @@ describe('<Portal />', () => {
 
         render() {
           return (
-            <div>
-              <div
-                ref={ref => {
-                  this.containerRef = ref;
-                }}
-              />
+            <div
+              ref={ref => {
+                this.containerRef = ref;
+              }}
+            >
               <Portal container={this.state.container}>
                 <div id="test3" />
               </Portal>
@@ -207,9 +207,10 @@ describe('<Portal />', () => {
       }
 
       const wrapper = mount(<ContainerTest />);
+      const instanceWrapper = wrapper.find('ContainerTest');
 
       assert.strictEqual(document.querySelector('#test3').parentNode.nodeName, 'BODY');
-      wrapper.setState({ container: wrapper.instance().containerRef });
+      instanceWrapper.setState({ container: instanceWrapper.instance().containerRef });
       setTimeout(() => {
         assert.strictEqual(document.querySelector('#test3').parentNode.nodeName, 'DIV');
         done();

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -11,7 +11,8 @@ describe('<Radio />', () => {
 
   before(() => {
     classes = getClasses(<Radio />);
-    mount = createMount();
+    // StrictModeViolation: uses Switchbase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -16,7 +16,8 @@ describe('<RadioGroup />', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses #simulate
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/RootRef/RootRef.test.js
+++ b/packages/material-ui/src/RootRef/RootRef.test.js
@@ -11,7 +11,8 @@ describe('<RootRef />', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses findDOMNode
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -24,7 +24,8 @@ describe('<Select />', () => {
 
   before(() => {
     classes = getClasses(<Select {...defaultProps} />);
-    mount = createMount();
+    // StrictModeViolation: test uses MenuItem
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -32,7 +32,8 @@ describe('<SelectInput />', () => {
 
   before(() => {
     shallow = createShallow();
-    mount = createMount();
+    // StrictModeViolation: test uses MenuItem
+    mount = createMount({ strict: false });
   });
 
   after(() => {
@@ -175,18 +176,18 @@ describe('<SelectInput />', () => {
           MenuProps={{ transitionDuration: 0 }}
         />,
       );
-      instance = wrapper.instance();
+      instance = wrapper.find('SelectInput').instance();
     });
 
     it('should call onChange when clicking an item', () => {
       wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.state().open, true);
+      assert.strictEqual(wrapper.find('SelectInput').state().open, true);
       const portalLayer = wrapper
         .find(Portal)
         .instance()
         .getMountNode();
       portalLayer.querySelectorAll('li')[1].click();
-      assert.strictEqual(wrapper.state().open, false);
+      assert.strictEqual(wrapper.find('SelectInput').state().open, false);
       assert.strictEqual(handleChange.callCount, 1);
       assert.strictEqual(handleChange.args[0][0].target.value, 20);
     });
@@ -196,7 +197,7 @@ describe('<SelectInput />', () => {
       wrapper.setProps({ onBlur: handleBlur });
 
       wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.state().open, true);
+      assert.strictEqual(wrapper.find('SelectInput').state().open, true);
       assert.strictEqual(instance.ignoreNextBlur, true);
       wrapper.find(`.${defaultProps.classes.select}`).simulate('blur');
       assert.strictEqual(handleBlur.callCount, 0);
@@ -210,7 +211,7 @@ describe('<SelectInput />', () => {
       wrapper.setProps({ onBlur: handleBlur, name: 'blur-testing' });
 
       wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.state().open, true);
+      assert.strictEqual(wrapper.find('SelectInput').state().open, true);
       assert.strictEqual(instance.ignoreNextBlur, true);
       wrapper.find(`.${defaultProps.classes.select}`).simulate('blur');
       assert.strictEqual(handleBlur.callCount, 0);
@@ -223,14 +224,14 @@ describe('<SelectInput />', () => {
     [' ', 'ArrowUp', 'ArrowDown', 'Enter'].forEach(key => {
       it(`'should open menu when pressed ${key} key on select`, () => {
         wrapper.find(`.${defaultProps.classes.select}`).simulate('keyDown', { key });
-        assert.strictEqual(wrapper.state().open, true);
+        assert.strictEqual(wrapper.find('SelectInput').state().open, true);
         assert.strictEqual(instance.ignoreNextBlur, true);
       });
     });
 
     it('should call handleClose', () => {
       wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.state().open, true);
+      assert.strictEqual(wrapper.find('SelectInput').state().open, true);
 
       const portalLayer = wrapper
         .find(Portal)
@@ -238,7 +239,7 @@ describe('<SelectInput />', () => {
         .getMountNode();
       const backdrop = portalLayer.querySelector('[data-mui-test="Backdrop"]');
       backdrop.click();
-      assert.strictEqual(wrapper.state().open, false);
+      assert.strictEqual(wrapper.find('SelectInput').state().open, false);
     });
   });
 
@@ -265,9 +266,9 @@ describe('<SelectInput />', () => {
     it('should allow to control closing by passing onClose props', () => {
       const wrapper = mount(<ControlledWrapper />);
       wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.state().open, true);
+      assert.strictEqual(wrapper.find('ControlledWrapper').state().open, true);
       wrapper.find(MenuItem).simulate('click');
-      assert.strictEqual(wrapper.state().open, false);
+      assert.strictEqual(wrapper.find('ControlledWrapper').state().open, false);
     });
 
     it('should work when open is initially true', () => {
@@ -385,21 +386,21 @@ describe('<SelectInput />', () => {
 
       it('should call onChange when clicking an item', () => {
         wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-        assert.strictEqual(wrapper.state().open, true);
+        assert.strictEqual(wrapper.find('SelectInput').state().open, true);
         const portalLayer = wrapper
           .find(Portal)
           .instance()
           .getMountNode();
 
         portalLayer.querySelectorAll('li')[1].click();
-        assert.strictEqual(wrapper.state().open, true);
+        assert.strictEqual(wrapper.find('SelectInput').state().open, true);
         assert.strictEqual(handleChange.callCount, 1);
         assert.deepEqual(handleChange.args[0][0].target.value, [30]);
         assert.deepEqual(handleChange.args[0][0].target.name, 'age');
         wrapper.setProps({ value: [30] });
 
         portalLayer.querySelectorAll('li')[0].click();
-        assert.strictEqual(wrapper.state().open, true);
+        assert.strictEqual(wrapper.find('SelectInput').state().open, true);
         assert.strictEqual(handleChange.callCount, 2);
         assert.deepEqual(handleChange.args[1][0].target.value, [30, 10]);
       });

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -1,12 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
-import {
-  createShallow,
-  createMount,
-  describeConformance,
-  unwrap,
-} from '@material-ui/core/test-utils';
+import { createShallow, createMount, describeConformance } from '@material-ui/core/test-utils';
 import Slide, { setTranslateValue } from './Slide';
 import transitions, { easing } from '../styles/transitions';
 import createMuiTheme from '../styles/createMuiTheme';
@@ -14,7 +9,6 @@ import createMuiTheme from '../styles/createMuiTheme';
 describe('<Slide />', () => {
   let shallow;
   let mount;
-  const SlideNaked = unwrap(Slide);
   const defaultProps = {
     in: true,
     children: <div />,
@@ -23,7 +17,8 @@ describe('<Slide />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
   });
 
   after(() => {
@@ -45,13 +40,13 @@ describe('<Slide />', () => {
 
   it('should not override children styles', () => {
     const wrapper = mount(
-      <SlideNaked
+      <Slide
         {...defaultProps}
         style={{ color: 'red', backgroundColor: 'yellow' }}
         theme={createMuiTheme()}
       >
         <div id="with-slide" style={{ color: 'blue' }} />
-      </SlideNaked>,
+      </Slide>,
     );
     assert.deepEqual(wrapper.find('#with-slide').props().style, {
       backgroundColor: 'yellow',
@@ -125,10 +120,8 @@ describe('<Slide />', () => {
 
   describe('prop: direction', () => {
     it('should update the position', () => {
-      const wrapper = mount(
-        <SlideNaked {...defaultProps} theme={createMuiTheme()} in={false} direction="left" />,
-      );
-      const transition = wrapper.instance().childDOMNode;
+      const wrapper = mount(<Slide {...defaultProps} in={false} direction="left" />);
+      const transition = wrapper.find('Slide').instance().childDOMNode;
 
       const transition1 = transition.style.transform;
       wrapper.setProps({
@@ -241,11 +234,11 @@ describe('<Slide />', () => {
   describe('mount', () => {
     it('should work when initially hidden', () => {
       const wrapper = mount(
-        <SlideNaked theme={createMuiTheme()} in={false}>
+        <Slide in={false}>
           <div>Foo</div>
-        </SlideNaked>,
+        </Slide>,
       );
-      const transition = wrapper.instance().childDOMNode;
+      const transition = wrapper.find('Slide').instance().childDOMNode;
 
       assert.strictEqual(transition.style.visibility, 'hidden');
       assert.notStrictEqual(transition.style.transform, undefined);
@@ -265,11 +258,11 @@ describe('<Slide />', () => {
 
     it('should recompute the correct position', () => {
       const wrapper = mount(
-        <SlideNaked theme={createMuiTheme()} direction="up" in={false}>
+        <Slide direction="up" in={false}>
           <div>Foo</div>
-        </SlideNaked>,
+        </Slide>,
       );
-      const instance = wrapper.instance();
+      const instance = wrapper.find('Slide').instance();
       instance.handleResize();
       clock.tick(166);
       const transition = instance.childDOMNode;

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -11,7 +11,8 @@ describe('<Snackbar />', () => {
 
   before(() => {
     classes = getClasses(<Snackbar open />);
-    mount = createMount();
+    // StrictModeViolation: uses Slide
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -16,7 +16,7 @@ describe('<Step />', () => {
   before(() => {
     classes = getClasses(<Step />);
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -20,7 +20,8 @@ describe('<StepButton />', () => {
   before(() => {
     classes = getClasses(<StepButton />);
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -16,7 +16,7 @@ describe('<StepConnector />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<StepConnector />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -20,7 +20,8 @@ describe('<StepContent />', () => {
   before(() => {
     classes = getClasses(<StepContent />);
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    // StrictModeViolation: uses Collapse
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -12,7 +12,7 @@ describe('<StepIcon />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -18,7 +18,7 @@ describe('<StepLabel />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<StepLabel />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -22,7 +22,8 @@ describe('<Stepper />', () => {
   before(() => {
     classes = getClasses(<Stepper />);
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    // StrictModeViolation: test uses StepContent
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -16,7 +16,7 @@ describe('<SvgIcon />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<SvgIcon>foo</SvgIcon>);
     path = <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />;
   });

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -53,7 +53,8 @@ describe('<SwipeableDrawer />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    // test are mostly asserting on implementation details
+    mount = createMount({ strict: undefined });
   });
 
   after(() => {

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -142,10 +142,10 @@ describe('<SwipeableDrawer />', () => {
       }
     });
 
-    const bodyWidth = () => document.body.offsetWidth;
-    const windowHeight = () => window.innerHeight;
+    const bodyWidth = document.body.offsetWidth;
+    const windowHeight = window.innerHeight;
     const tests = [
-      () => ({
+      {
         anchor: 'left',
         openTouches: [
           { pageX: 0, clientY: 0 },
@@ -159,23 +159,23 @@ describe('<SwipeableDrawer />', () => {
         ],
         edgeTouch: { pageX: 10, clientY: 50 },
         ignoreTouch: { pageX: 100, clientY: 0 },
-      }),
-      () => ({
+      },
+      {
         anchor: 'right',
         openTouches: [
-          { pageX: bodyWidth(), clientY: 0 },
-          { pageX: bodyWidth() - 20, clientY: 0 },
-          { pageX: bodyWidth() - 180, clientY: 0 },
+          { pageX: bodyWidth, clientY: 0 },
+          { pageX: bodyWidth - 20, clientY: 0 },
+          { pageX: bodyWidth - 180, clientY: 0 },
         ],
         closeTouches: [
-          { pageX: bodyWidth() - 200, clientY: 0 },
-          { pageX: bodyWidth() - 180, clientY: 0 },
-          { pageX: bodyWidth() - 10, clientY: 0 },
+          { pageX: bodyWidth - 200, clientY: 0 },
+          { pageX: bodyWidth - 180, clientY: 0 },
+          { pageX: bodyWidth - 10, clientY: 0 },
         ],
-        edgeTouch: { pageX: bodyWidth() - 10, clientY: 50 },
-        ignoreTouch: { pageX: bodyWidth() - 100, clientY: 0 },
-      }),
-      () => ({
+        edgeTouch: { pageX: bodyWidth - 10, clientY: 50 },
+        ignoreTouch: { pageX: bodyWidth - 100, clientY: 0 },
+      },
+      {
         anchor: 'top',
         openTouches: [
           { pageX: 0, clientY: 0 },
@@ -189,29 +189,27 @@ describe('<SwipeableDrawer />', () => {
         ],
         edgeTouch: { pageX: 50, clientY: 10 },
         ignoreTouch: { pageX: 0, clientY: 100 },
-      }),
-      () => ({
+      },
+      {
         anchor: 'bottom',
         openTouches: [
-          { pageX: 0, clientY: windowHeight() },
-          { pageX: 0, clientY: windowHeight() - 20 },
-          { pageX: 0, clientY: windowHeight() - 180 },
+          { pageX: 0, clientY: windowHeight },
+          { pageX: 0, clientY: windowHeight - 20 },
+          { pageX: 0, clientY: windowHeight - 180 },
         ],
         closeTouches: [
-          { pageX: 0, clientY: windowHeight() - 200 },
-          { pageX: 0, clientY: windowHeight() - 180 },
-          { pageX: 0, clientY: windowHeight() - 10 },
+          { pageX: 0, clientY: windowHeight - 200 },
+          { pageX: 0, clientY: windowHeight - 180 },
+          { pageX: 0, clientY: windowHeight - 10 },
         ],
-        edgeTouch: { pageX: 50, clientY: windowHeight() - 10 },
-        ignoreTouch: { pageX: 0, clientY: windowHeight() - 100 },
-      }),
+        edgeTouch: { pageX: 50, clientY: windowHeight - 10 },
+        ignoreTouch: { pageX: 0, clientY: windowHeight - 100 },
+      },
     ];
 
-    tests.forEach(getParams => {
-      describe(`anchor=${getParams().anchor}`, () => {
-        let params;
+    tests.forEach(params => {
+      describe(`anchor=${params.anchor}`, () => {
         beforeEach(() => {
-          params = getParams();
           wrapper.setProps({ anchor: params.anchor });
         });
 

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -142,10 +142,10 @@ describe('<SwipeableDrawer />', () => {
       }
     });
 
-    const bodyWidth = document.body.offsetWidth;
-    const windowHeight = window.innerHeight;
+    const bodyWidth = () => document.body.offsetWidth;
+    const windowHeight = () => window.innerHeight;
     const tests = [
-      {
+      () => ({
         anchor: 'left',
         openTouches: [
           { pageX: 0, clientY: 0 },
@@ -159,23 +159,23 @@ describe('<SwipeableDrawer />', () => {
         ],
         edgeTouch: { pageX: 10, clientY: 50 },
         ignoreTouch: { pageX: 100, clientY: 0 },
-      },
-      {
+      }),
+      () => ({
         anchor: 'right',
         openTouches: [
-          { pageX: bodyWidth, clientY: 0 },
-          { pageX: bodyWidth - 20, clientY: 0 },
-          { pageX: bodyWidth - 180, clientY: 0 },
+          { pageX: bodyWidth(), clientY: 0 },
+          { pageX: bodyWidth() - 20, clientY: 0 },
+          { pageX: bodyWidth() - 180, clientY: 0 },
         ],
         closeTouches: [
-          { pageX: bodyWidth - 200, clientY: 0 },
-          { pageX: bodyWidth - 180, clientY: 0 },
-          { pageX: bodyWidth - 10, clientY: 0 },
+          { pageX: bodyWidth() - 200, clientY: 0 },
+          { pageX: bodyWidth() - 180, clientY: 0 },
+          { pageX: bodyWidth() - 10, clientY: 0 },
         ],
-        edgeTouch: { pageX: bodyWidth - 10, clientY: 50 },
-        ignoreTouch: { pageX: bodyWidth - 100, clientY: 0 },
-      },
-      {
+        edgeTouch: { pageX: bodyWidth() - 10, clientY: 50 },
+        ignoreTouch: { pageX: bodyWidth() - 100, clientY: 0 },
+      }),
+      () => ({
         anchor: 'top',
         openTouches: [
           { pageX: 0, clientY: 0 },
@@ -189,27 +189,29 @@ describe('<SwipeableDrawer />', () => {
         ],
         edgeTouch: { pageX: 50, clientY: 10 },
         ignoreTouch: { pageX: 0, clientY: 100 },
-      },
-      {
+      }),
+      () => ({
         anchor: 'bottom',
         openTouches: [
-          { pageX: 0, clientY: windowHeight },
-          { pageX: 0, clientY: windowHeight - 20 },
-          { pageX: 0, clientY: windowHeight - 180 },
+          { pageX: 0, clientY: windowHeight() },
+          { pageX: 0, clientY: windowHeight() - 20 },
+          { pageX: 0, clientY: windowHeight() - 180 },
         ],
         closeTouches: [
-          { pageX: 0, clientY: windowHeight - 200 },
-          { pageX: 0, clientY: windowHeight - 180 },
-          { pageX: 0, clientY: windowHeight - 10 },
+          { pageX: 0, clientY: windowHeight() - 200 },
+          { pageX: 0, clientY: windowHeight() - 180 },
+          { pageX: 0, clientY: windowHeight() - 10 },
         ],
-        edgeTouch: { pageX: 50, clientY: windowHeight - 10 },
-        ignoreTouch: { pageX: 0, clientY: windowHeight - 100 },
-      },
+        edgeTouch: { pageX: 50, clientY: windowHeight() - 10 },
+        ignoreTouch: { pageX: 0, clientY: windowHeight() - 100 },
+      }),
     ];
 
-    tests.forEach(params => {
-      describe(`anchor=${params.anchor}`, () => {
+    tests.forEach(getParams => {
+      describe(`anchor=${getParams().anchor}`, () => {
+        let params;
         beforeEach(() => {
+          params = getParams();
           wrapper.setProps({ anchor: params.anchor });
         });
 

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -20,7 +20,8 @@ describe('<Tab />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<Tab textColor="inherit" />);
   });
 

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -10,7 +10,7 @@ describe('<Table />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<Table>foo</Table>);
   });
 

--- a/packages/material-ui/src/TableBody/TableBody.test.js
+++ b/packages/material-ui/src/TableBody/TableBody.test.js
@@ -14,7 +14,8 @@ describe('<TableBody />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
+
     classes = getClasses(<TableBody />);
   });
 

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -23,7 +23,7 @@ describe('<TableCell />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<TableCell />);
   });
 

--- a/packages/material-ui/src/TableFooter/TableFooter.test.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.test.js
@@ -14,7 +14,7 @@ describe('<TableFooter />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<TableFooter />);
   });
 

--- a/packages/material-ui/src/TableHead/TableHead.test.js
+++ b/packages/material-ui/src/TableHead/TableHead.test.js
@@ -13,7 +13,7 @@ describe('<TableHead />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<TableHead>foo</TableHead>);
   });
 

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -31,7 +31,8 @@ describe('<TablePagination />', () => {
     classes = getClasses(
       <TablePagination count={1} onChangePage={() => {}} page={0} rowsPerPage={1} />,
     );
-    mount = createMount();
+    // StrictModeViolation: uses  ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/TableRow/TableRow.test.js
+++ b/packages/material-ui/src/TableRow/TableRow.test.js
@@ -16,7 +16,7 @@ describe('<TableRow />', () => {
   }
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<TableRow />);
   });
 

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -17,7 +17,8 @@ describe('<TableSortLabel />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<TableSortLabel />);
   });
 
@@ -75,8 +76,13 @@ describe('<TableSortLabel />', () => {
 
     it('should accept a custom icon for the sort icon', () => {
       const wrapper = mount(<TableSortLabel IconComponent={Sort} />);
-      assert.strictEqual(wrapper.props().IconComponent, Sort);
-      assert.strictEqual(wrapper.find(Sort).length, 1);
+      assert.strictEqual(
+        wrapper
+          .find(`.${classes.icon}`)
+          .first()
+          .type(),
+        Sort,
+      );
     });
   });
 

--- a/packages/material-ui/src/Tabs/TabScrollButton.test.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.test.js
@@ -17,7 +17,8 @@ describe('<TabScrollButton />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<TabScrollButton {...props} />);
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -53,7 +53,8 @@ describe('<Tabs />', () => {
 
   before(() => {
     classes = getClasses(<Tabs onChange={noop} value={0} />);
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     render = createRender();
   });
 

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -96,7 +96,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
   const labelRef = React.useRef();
   React.useEffect(() => {
     if (variant === 'outlined') {
-      // StrictMode ready
+      // #StrictMode ready
       const labelNode = ReactDOM.findDOMNode(labelRef.current);
       setLabelWidth(labelNode != null ? labelNode.offsetWidth : 0);
     }

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -12,7 +12,7 @@ describe('<TextField />', () => {
 
   before(() => {
     classes = getClasses(<TextField />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {
@@ -98,9 +98,7 @@ describe('<TextField />', () => {
     describe('with an outline', () => {
       it('should set outline props', () => {
         wrapper = mount(<TextField variant="outlined" />);
-
-        assert.strictEqual(wrapper.props().variant, 'outlined');
-        assert.strictEqual(typeof wrapper.find(OutlinedInput).props().labelWidth, 'number');
+        assert.strictEqual(wrapper.find(OutlinedInput).props().labelWidth, 0);
       });
 
       it('should set shrink prop on outline from label', () => {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -28,7 +28,8 @@ describe('<Tooltip />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true, disableLifecycleMethods: true });
-    mount = createMount();
+    // StrictModeViolation: uses RootRef, Grow and tests a lot of impl details
+    mount = createMount({ strict: undefined });
     classes = getClasses(<Tooltip {...defaultProps} />);
     clock = useFakeTimers();
   });

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -8,7 +8,8 @@ describe('<Zoom />', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -76,7 +76,8 @@ describe('<SwitchBase />', () => {
 
   before(() => {
     SwitchBaseNaked = unwrap(SwitchBase);
-    mount = createMount();
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<SwitchBase {...defaultProps} />);
   });
 
@@ -122,7 +123,7 @@ describe('<SwitchBase />', () => {
   it('should spread custom props on the root node', () => {
     const wrapper = mount(<SwitchBase {...defaultProps} data-my-prop="woofSwitchBase" />);
     assert.strictEqual(
-      wrapper.props()['data-my-prop'],
+      findOutermostIntrinsic(wrapper).props()['data-my-prop'],
       'woofSwitchBase',
       'custom prop should be woofSwitchBase',
     );

--- a/packages/material-ui/src/test-utils/createMount.js
+++ b/packages/material-ui/src/test-utils/createMount.js
@@ -3,48 +3,54 @@ import ReactDOM from 'react-dom';
 import * as PropTypes from 'prop-types';
 import { mount as enzymeMount } from 'enzyme';
 
+/**
+ * Can't just mount <React.Fragment>{node}</React.Fragment>
+ * because that swallows wrapper.setProps
+ *
+ * why class component:
+ * https://github.com/airbnb/enzyme/issues/2043
+ */
+// eslint-disable-next-line react/prefer-stateless-function
+class Mode extends React.Component {
+  static propTypes = {
+    /**
+     * this is essentially children. However we can't use children because then
+     * using `wrapper.setProps({ children })` would work differently if this component
+     * would be the root.
+     */
+    __element: PropTypes.element.isRequired,
+    __strict: PropTypes.bool.isRequired,
+  };
+
+  render() {
+    const { __element, __strict, ...other } = this.props;
+    const Component = __strict ? React.StrictMode : React.Fragment;
+
+    return <Component>{React.cloneElement(__element, other)}</Component>;
+  }
+}
+
+Mode.propTypes = {
+  /**
+   * this is essentially children. However we can't use children because then
+   * using `wrapper.setProps({ children })` would work differently if this component
+   * would be the root.
+   */
+  __element: PropTypes.element.isRequired,
+  __strict: PropTypes.bool.isRequired,
+};
+
 // Generate an enhanced mount function.
 export default function createMount(options = {}) {
-  const { mount = enzymeMount, strict: strictOption, ...enzymeOptions } = options;
+  const { mount = enzymeMount, strict: globalStrict, ...globalEnzymeOptions } = options;
 
   const attachTo = window.document.createElement('div');
   attachTo.className = 'app';
   attachTo.setAttribute('id', 'app');
   window.document.body.insertBefore(attachTo, window.document.body.firstChild);
 
-  /**
-   * Can't just mount <React.Fragment>{node}</React.Fragment>
-   * because that swallows wrapper.setProps
-   *
-   * why class component:
-   * https://github.com/airbnb/enzyme/issues/2043
-   */
-
-  class Mode extends React.PureComponent {
-    static propTypes = {
-      /**
-       * this is essentially children. However we can't use children because then
-       * using `wrapper.setProps({ children })` would work differently if this component
-       * would be the root.
-       */
-      __element: PropTypes.element.isRequired,
-      __strict: PropTypes.bool.isRequired,
-    };
-
-    render() {
-      const { __element, __strict, ...other } = this.props;
-      const Component = __strict ? React.StrictMode : React.Fragment;
-
-      return <Component>{React.cloneElement(__element, other)}</Component>;
-    }
-  }
-
   const mountWithContext = function mountWithContext(node, localOptions = {}) {
-    const {
-      disableUnnmount = false,
-      strict: localStrictOption = strictOption,
-      ...localEnzymeOptions
-    } = localOptions;
+    const { disableUnnmount = false, strict = globalStrict, ...localEnzymeOptions } = localOptions;
 
     if (!disableUnnmount) {
       ReactDOM.unmountComponentAtNode(attachTo);
@@ -52,18 +58,11 @@ export default function createMount(options = {}) {
 
     // some tests require that no other components are in the tree
     // e.g. when doing .instance(), .state() etc.
-    return mount(
-      localStrictOption == null ? (
-        node
-      ) : (
-        <Mode __element={node} __strict={Boolean(localStrictOption)} />
-      ),
-      {
-        attachTo,
-        ...enzymeOptions,
-        ...localEnzymeOptions,
-      },
-    );
+    return mount(strict == null ? node : <Mode __element={node} __strict={Boolean(strict)} />, {
+      attachTo,
+      ...globalEnzymeOptions,
+      ...localEnzymeOptions,
+    });
   };
 
   mountWithContext.attachTo = attachTo;

--- a/packages/material-ui/src/test-utils/createMount.js
+++ b/packages/material-ui/src/test-utils/createMount.js
@@ -1,27 +1,69 @@
+import React from 'react';
 import ReactDOM from 'react-dom';
+import * as PropTypes from 'prop-types';
 import { mount as enzymeMount } from 'enzyme';
 
 // Generate an enhanced mount function.
-export default function createMount(options1 = {}) {
-  const { mount = enzymeMount, ...other1 } = options1;
+export default function createMount(options = {}) {
+  const { mount = enzymeMount, strict: strictOption, ...enzymeOptions } = options;
 
   const attachTo = window.document.createElement('div');
   attachTo.className = 'app';
   attachTo.setAttribute('id', 'app');
   window.document.body.insertBefore(attachTo, window.document.body.firstChild);
 
-  const mountWithContext = function mountWithContext(node, options2 = {}) {
-    const { disableUnnmount = false, ...other2 } = options2;
+  /**
+   * Can't just mount <React.Fragment>{node}</React.Fragment>
+   * because that swallows wrapper.setProps
+   *
+   * why class component:
+   * https://github.com/airbnb/enzyme/issues/2043
+   */
+
+  class Mode extends React.PureComponent {
+    static propTypes = {
+      /**
+       * this is essentially children. However we can't use children because then
+       * using `wrapper.setProps({ children })` would work differently if this component
+       * would be the root.
+       */
+      __element: PropTypes.element.isRequired,
+      __strict: PropTypes.bool.isRequired,
+    };
+
+    render() {
+      const { __element, __strict, ...other } = this.props;
+      const Component = __strict ? React.StrictMode : React.Fragment;
+
+      return <Component>{React.cloneElement(__element, other)}</Component>;
+    }
+  }
+
+  const mountWithContext = function mountWithContext(node, localOptions = {}) {
+    const {
+      disableUnnmount = false,
+      strict: localStrictOption = strictOption,
+      ...localEnzymeOptions
+    } = localOptions;
 
     if (!disableUnnmount) {
       ReactDOM.unmountComponentAtNode(attachTo);
     }
 
-    return mount(node, {
-      attachTo,
-      ...other1,
-      ...other2,
-    });
+    // some tests require that no other components are in the tree
+    // e.g. when doing .instance(), .state() etc.
+    return mount(
+      localStrictOption == null ? (
+        node
+      ) : (
+        <Mode __element={node} __strict={Boolean(localStrictOption)} />
+      ),
+      {
+        attachTo,
+        ...enzymeOptions,
+        ...localEnzymeOptions,
+      },
+    );
   };
 
   mountWithContext.attachTo = attachTo;

--- a/packages/material-ui/src/test-utils/createMount.js
+++ b/packages/material-ui/src/test-utils/createMount.js
@@ -23,22 +23,13 @@ class Mode extends React.Component {
   };
 
   render() {
+    // Excess props will come from e.g. enzyme setProps
     const { __element, __strict, ...other } = this.props;
     const Component = __strict ? React.StrictMode : React.Fragment;
 
     return <Component>{React.cloneElement(__element, other)}</Component>;
   }
 }
-
-Mode.propTypes = {
-  /**
-   * this is essentially children. However we can't use children because then
-   * using `wrapper.setProps({ children })` would work differently if this component
-   * would be the root.
-   */
-  __element: PropTypes.element.isRequired,
-  __strict: PropTypes.bool.isRequired,
-};
 
 // Generate an enhanced mount function.
 export default function createMount(options = {}) {

--- a/packages/material-ui/src/test-utils/findOutermostIntrinsic.test.js
+++ b/packages/material-ui/src/test-utils/findOutermostIntrinsic.test.js
@@ -22,7 +22,7 @@ describe('findOutermostIntrinsic', () => {
   const Headless = ({ children }) => children;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: undefined });
   });
 
   after(() => {

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -72,7 +72,7 @@ describe('useMediaQuery', () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
         });
-        React.useEffect(() => values(matches), [matches]);
+        React.useEffect(() => values(matches));
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
@@ -90,7 +90,7 @@ describe('useMediaQuery', () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: false,
         });
-        React.useEffect(() => values(matches), [matches]);
+        React.useEffect(() => values(matches));
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
@@ -106,7 +106,7 @@ describe('useMediaQuery', () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
         });
-        React.useEffect(() => values(matches), [matches]);
+        React.useEffect(() => values(matches));
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
@@ -123,7 +123,7 @@ describe('useMediaQuery', () => {
           defaultMatches: true,
           noSsr: true,
         });
-        React.useEffect(() => values(matches), [matches]);
+        React.useEffect(() => values(matches));
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
@@ -140,7 +140,7 @@ describe('useMediaQuery', () => {
       const matches = useMediaQuery('(min-width:2000px)', {
         defaultMatches: true,
       });
-      React.useEffect(() => values(matches), [matches]);
+      React.useEffect(() => values(matches));
       return <span ref={ref}>{`${matches}`}</span>;
     };
 
@@ -162,7 +162,7 @@ describe('useMediaQuery', () => {
       const matches = useMediaQuery(props.query, {
         defaultMatches: true,
       });
-      React.useEffect(() => values(matches), [matches]);
+      React.useEffect(() => values(matches));
       return <span ref={ref}>{`${matches}`}</span>;
     };
     Test.propTypes = {
@@ -174,7 +174,7 @@ describe('useMediaQuery', () => {
     assert.strictEqual(values.callCount, 2);
     wrapper.setProps({ query: '(min-width:100px)' });
     assert.strictEqual(text(), 'true');
-    assert.strictEqual(values.callCount, 3);
+    assert.strictEqual(values.callCount, 4);
   });
 
   it('should observe the media query', () => {
@@ -182,7 +182,7 @@ describe('useMediaQuery', () => {
     const text = () => ref.current.textContent;
     const Test = props => {
       const matches = useMediaQuery(props.query);
-      React.useEffect(() => values(matches), [matches]);
+      React.useEffect(() => values(matches));
       return <span ref={ref}>{`${matches}`}</span>;
     };
     Test.propTypes = {

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { act } from 'react-dom/test-utils';
 import PropTypes from 'prop-types';
 import { createMount } from '@material-ui/core/test-utils';
 import mediaQuery from 'css-mediaquery';
@@ -176,7 +177,7 @@ describe('useMediaQuery', () => {
     assert.strictEqual(values.callCount, 3);
   });
 
-  it.skip('should observe the media query', () => {
+  it('should observe the media query', () => {
     const ref = React.createRef();
     const text = () => ref.current.textContent;
     const Test = props => {
@@ -193,8 +194,10 @@ describe('useMediaQuery', () => {
     assert.strictEqual(text(), 'false');
 
     window.matchMedia = createMatchMedia(30000, listeners);
-    listeners[0]({
-      matches: true,
+    act(() => {
+      listeners[0]({
+        matches: true,
+      });
     });
     assert.strictEqual(text(), 'true');
     assert.strictEqual(values.callCount, 2);

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -55,13 +55,13 @@ describe('useMediaQuery', () => {
       const text = () => ref.current.textContent;
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)');
-        values(matches);
+        React.useEffect(() => values(matches), [matches]);
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
       mount(<Test />);
       assert.strictEqual(text(), 'false');
-      assert.strictEqual(values.callCount, 2);
+      assert.strictEqual(values.callCount, 1);
     });
 
     it('should take the option into account', () => {
@@ -71,13 +71,13 @@ describe('useMediaQuery', () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
         });
-        values(matches);
+        React.useEffect(() => values(matches), [matches]);
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
       mount(<Test />);
       assert.strictEqual(text(), 'false');
-      assert.strictEqual(values.callCount, 4);
+      assert.strictEqual(values.callCount, 2);
     });
   });
 
@@ -89,13 +89,13 @@ describe('useMediaQuery', () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: false,
         });
-        values(matches);
+        React.useEffect(() => values(matches), [matches]);
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
       mount(<Test />);
       assert.strictEqual(text(), 'false');
-      assert.strictEqual(values.callCount, 2);
+      assert.strictEqual(values.callCount, 1);
     });
 
     it('should render twice if the default value does not match the expectation', () => {
@@ -105,13 +105,13 @@ describe('useMediaQuery', () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
         });
-        values(matches);
+        React.useEffect(() => values(matches), [matches]);
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
       mount(<Test />);
       assert.strictEqual(text(), 'false');
-      assert.strictEqual(values.callCount, 4);
+      assert.strictEqual(values.callCount, 2);
     });
 
     it('should render once if the default value does not match the expectation', () => {
@@ -122,42 +122,36 @@ describe('useMediaQuery', () => {
           defaultMatches: true,
           noSsr: true,
         });
-        values(matches);
+        React.useEffect(() => values(matches), [matches]);
         return <span ref={ref}>{`${matches}`}</span>;
       };
 
       mount(<Test />);
       assert.strictEqual(text(), 'false');
-      assert.strictEqual(values.callCount, 2);
+      assert.strictEqual(values.callCount, 1);
     });
   });
 
-  it('should try to reconcile only the first time', done => {
+  it('should try to reconcile only the first time', () => {
     const ref = React.createRef();
     const text = () => ref.current.textContent;
     const Test = () => {
       const matches = useMediaQuery('(min-width:2000px)', {
         defaultMatches: true,
       });
-      values(matches);
+      React.useEffect(() => values(matches), [matches]);
       return <span ref={ref}>{`${matches}`}</span>;
     };
 
     mount(<Test />);
     assert.strictEqual(text(), 'false');
-    assert.strictEqual(values.callCount, 4);
-    setTimeout(() => {
-      ReactDOM.unmountComponentAtNode(mount.attachTo);
-      mount(<Test />);
-      assert.strictEqual(text(), 'false');
-      assert.strictEqual(values.callCount, 6);
+    assert.strictEqual(values.callCount, 2);
 
-      setTimeout(() => {
-        assert.strictEqual(text(), 'false');
-        assert.strictEqual(values.callCount, 6);
-        done();
-      });
-    });
+    ReactDOM.unmountComponentAtNode(mount.attachTo);
+
+    mount(<Test />);
+    assert.strictEqual(text(), 'false');
+    assert.strictEqual(values.callCount, 3);
   });
 
   it('should be able to change the query dynamically', () => {
@@ -167,7 +161,7 @@ describe('useMediaQuery', () => {
       const matches = useMediaQuery(props.query, {
         defaultMatches: true,
       });
-      values(matches);
+      React.useEffect(() => values(matches), [matches]);
       return <span ref={ref}>{`${matches}`}</span>;
     };
     Test.propTypes = {
@@ -176,18 +170,18 @@ describe('useMediaQuery', () => {
 
     const wrapper = mount(<Test query="(min-width:2000px)" />);
     assert.strictEqual(text(), 'false');
-    assert.strictEqual(values.callCount, 4);
+    assert.strictEqual(values.callCount, 2);
     wrapper.setProps({ query: '(min-width:100px)' });
     assert.strictEqual(text(), 'true');
-    assert.strictEqual(values.callCount, 8);
+    assert.strictEqual(values.callCount, 3);
   });
 
-  it('should observe the media query', () => {
+  it.skip('should observe the media query', () => {
     const ref = React.createRef();
     const text = () => ref.current.textContent;
     const Test = props => {
       const matches = useMediaQuery(props.query);
-      values(matches);
+      React.useEffect(() => values(matches), [matches]);
       return <span ref={ref}>{`${matches}`}</span>;
     };
     Test.propTypes = {
@@ -195,7 +189,7 @@ describe('useMediaQuery', () => {
     };
 
     mount(<Test query="(min-width:2000px)" />);
-    assert.strictEqual(values.callCount, 2);
+    assert.strictEqual(values.callCount, 1);
     assert.strictEqual(text(), 'false');
 
     window.matchMedia = createMatchMedia(30000, listeners);
@@ -203,6 +197,6 @@ describe('useMediaQuery', () => {
       matches: true,
     });
     assert.strictEqual(text(), 'true');
-    assert.strictEqual(values.callCount, 4);
+    assert.strictEqual(values.callCount, 2);
   });
 });

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -36,7 +36,7 @@ describe('useMediaQuery', () => {
   }
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   beforeEach(() => {
@@ -51,142 +51,158 @@ describe('useMediaQuery', () => {
 
   describe('option: defaultMatches', () => {
     it('should be false by default', () => {
+      const ref = React.createRef();
+      const text = () => ref.current.textContent;
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)');
         values(matches);
-        return <span>{`${matches}`}</span>;
+        return <span ref={ref}>{`${matches}`}</span>;
       };
 
-      const wrapper = mount(<Test />);
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 1);
+      mount(<Test />);
+      assert.strictEqual(text(), 'false');
+      assert.strictEqual(values.callCount, 2);
     });
 
     it('should take the option into account', () => {
+      const ref = React.createRef();
+      const text = () => ref.current.textContent;
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
         });
         values(matches);
-        return <span>{`${matches}`}</span>;
+        return <span ref={ref}>{`${matches}`}</span>;
       };
 
-      const wrapper = mount(<Test />);
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 2);
+      mount(<Test />);
+      assert.strictEqual(text(), 'false');
+      assert.strictEqual(values.callCount, 4);
     });
   });
 
   describe('option: noSsr', () => {
     it('should render once if the default value match the expectation', () => {
+      const ref = React.createRef();
+      const text = () => ref.current.textContent;
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: false,
         });
         values(matches);
-        return <span>{`${matches}`}</span>;
+        return <span ref={ref}>{`${matches}`}</span>;
       };
 
-      const wrapper = mount(<Test />);
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 1);
+      mount(<Test />);
+      assert.strictEqual(text(), 'false');
+      assert.strictEqual(values.callCount, 2);
     });
 
     it('should render twice if the default value does not match the expectation', () => {
+      const ref = React.createRef();
+      const text = () => ref.current.textContent;
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
         });
         values(matches);
-        return <span>{`${matches}`}</span>;
+        return <span ref={ref}>{`${matches}`}</span>;
       };
 
-      const wrapper = mount(<Test />);
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 2);
+      mount(<Test />);
+      assert.strictEqual(text(), 'false');
+      assert.strictEqual(values.callCount, 4);
     });
 
     it('should render once if the default value does not match the expectation', () => {
+      const ref = React.createRef();
+      const text = () => ref.current.textContent;
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)', {
           defaultMatches: true,
           noSsr: true,
         });
         values(matches);
-        return <span>{`${matches}`}</span>;
+        return <span ref={ref}>{`${matches}`}</span>;
       };
 
-      const wrapper = mount(<Test />);
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 1);
+      mount(<Test />);
+      assert.strictEqual(text(), 'false');
+      assert.strictEqual(values.callCount, 2);
     });
   });
 
   it('should try to reconcile only the first time', done => {
+    const ref = React.createRef();
+    const text = () => ref.current.textContent;
     const Test = () => {
       const matches = useMediaQuery('(min-width:2000px)', {
         defaultMatches: true,
       });
       values(matches);
-      return <span>{`${matches}`}</span>;
+      return <span ref={ref}>{`${matches}`}</span>;
     };
 
-    let wrapper = mount(<Test />);
-    assert.strictEqual(wrapper.text(), 'false');
-    assert.strictEqual(values.callCount, 2);
+    mount(<Test />);
+    assert.strictEqual(text(), 'false');
+    assert.strictEqual(values.callCount, 4);
     setTimeout(() => {
       ReactDOM.unmountComponentAtNode(mount.attachTo);
-      wrapper = mount(<Test />);
-      assert.strictEqual(wrapper.text(), 'false');
-      assert.strictEqual(values.callCount, 3);
+      mount(<Test />);
+      assert.strictEqual(text(), 'false');
+      assert.strictEqual(values.callCount, 6);
 
       setTimeout(() => {
-        assert.strictEqual(wrapper.text(), 'false');
-        assert.strictEqual(values.callCount, 3);
+        assert.strictEqual(text(), 'false');
+        assert.strictEqual(values.callCount, 6);
         done();
       });
     });
   });
 
   it('should be able to change the query dynamically', () => {
+    const ref = React.createRef();
+    const text = () => ref.current.textContent;
     const Test = props => {
       const matches = useMediaQuery(props.query, {
         defaultMatches: true,
       });
       values(matches);
-      return <span>{`${matches}`}</span>;
+      return <span ref={ref}>{`${matches}`}</span>;
     };
     Test.propTypes = {
       query: PropTypes.string.isRequired,
     };
 
     const wrapper = mount(<Test query="(min-width:2000px)" />);
-    assert.strictEqual(wrapper.text(), 'false');
-    assert.strictEqual(values.callCount, 2);
-    wrapper.setProps({ query: '(min-width:100px)' });
-    assert.strictEqual(wrapper.text(), 'true');
+    assert.strictEqual(text(), 'false');
     assert.strictEqual(values.callCount, 4);
+    wrapper.setProps({ query: '(min-width:100px)' });
+    assert.strictEqual(text(), 'true');
+    assert.strictEqual(values.callCount, 8);
   });
 
   it('should observe the media query', () => {
+    const ref = React.createRef();
+    const text = () => ref.current.textContent;
     const Test = props => {
       const matches = useMediaQuery(props.query);
       values(matches);
-      return <span>{`${matches}`}</span>;
+      return <span ref={ref}>{`${matches}`}</span>;
     };
     Test.propTypes = {
       query: PropTypes.string.isRequired,
     };
 
-    const wrapper = mount(<Test query="(min-width:2000px)" />);
-    assert.strictEqual(values.callCount, 1);
-    assert.strictEqual(wrapper.text(), 'false');
+    mount(<Test query="(min-width:2000px)" />);
+    assert.strictEqual(values.callCount, 2);
+    assert.strictEqual(text(), 'false');
 
     window.matchMedia = createMatchMedia(30000, listeners);
     listeners[0]({
       matches: true,
     });
-    assert.strictEqual(wrapper.text(), 'true');
-    assert.strictEqual(values.callCount, 2);
+    assert.strictEqual(text(), 'true');
+    assert.strictEqual(values.callCount, 4);
   });
 });

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -56,7 +56,7 @@ describe('useMediaQuery', () => {
       const text = () => ref.current.textContent;
       const Test = () => {
         const matches = useMediaQuery('(min-width:2000px)');
-        React.useEffect(() => values(matches), [matches]);
+        React.useEffect(() => values(matches));
         return <span ref={ref}>{`${matches}`}</span>;
       };
 

--- a/packages/material-ui/src/useMediaQuery/useMediaQueryTheme.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQueryTheme.test.js
@@ -36,10 +36,11 @@ describe('useMediaQueryTheme', () => {
   });
 
   it('should use the ssr match media ponyfill', () => {
+    const containerRef = React.createRef();
     function MyComponent() {
       const matches = useMediaQueryTheme('(min-width:2000px)');
       values(matches);
-      return <span>{`${matches}`}</span>;
+      return <span ref={containerRef}>{`${matches}`}</span>;
     }
 
     const Test = () => {

--- a/packages/material-ui/src/withWidth/withWidth.test.js
+++ b/packages/material-ui/src/withWidth/withWidth.test.js
@@ -19,7 +19,7 @@ describe('withWidth', () => {
 
   before(() => {
     shallow = createShallow({ dive: true, disableLifecycleMethods: true });
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -10,7 +10,8 @@ describe('<Menu> integration', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: test uses Portal
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -50,7 +50,8 @@ describe('<MenuList> integration', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses RootRef
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/test/integration/NestedMenu.test.js
+++ b/packages/material-ui/test/integration/NestedMenu.test.js
@@ -8,7 +8,8 @@ describe('<NestedMenu> integration', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: test uses Portal
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -8,7 +8,8 @@ describe('<Select> integration', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    // StrictModeViolation: uses Portal
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createMount, getClasses } from 'packages/material-ui/src/test-utils';
+import {
+  createMount,
+  findOutermostIntrinsic,
+  getClasses,
+} from 'packages/material-ui/src/test-utils';
 import TableCell from 'packages/material-ui/src/TableCell';
 import TableFooter from 'packages/material-ui/src/TableFooter';
 import TableHead from 'packages/material-ui/src/TableHead';
@@ -21,7 +25,7 @@ describe('<TableRow> integration', () => {
 
   before(() => {
     classes = getClasses(<TableCell />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {
@@ -30,10 +34,11 @@ describe('<TableRow> integration', () => {
 
   it('should render a th with the head class when in the context of a table head', () => {
     const wrapper = mountInTable(<TableCell />, TableHead);
-    assert.strictEqual(wrapper.getDOMNode().nodeName, 'TH');
-    assert.strictEqual(wrapper.find('th').hasClass(classes.root), true);
-    assert.strictEqual(wrapper.find('th').hasClass(classes.head), true);
-    assert.strictEqual(wrapper.find('th').props().scope, 'col');
+    const root = findOutermostIntrinsic(wrapper);
+    assert.strictEqual(root.type(), 'th');
+    assert.strictEqual(root.hasClass(classes.root), true);
+    assert.strictEqual(root.hasClass(classes.head), true);
+    assert.strictEqual(root.props().scope, 'col');
   });
 
   it('should render specified scope attribute even when in the context of a table head', () => {
@@ -43,9 +48,10 @@ describe('<TableRow> integration', () => {
 
   it('should render a th with the footer class when in the context of a table footer', () => {
     const wrapper = mountInTable(<TableCell />, TableFooter);
-    assert.strictEqual(wrapper.getDOMNode().nodeName, 'TD');
-    assert.strictEqual(wrapper.find('td').hasClass(classes.root), true);
-    assert.strictEqual(wrapper.find('td').hasClass(classes.footer), true);
+    const root = findOutermostIntrinsic(wrapper);
+    assert.strictEqual(root.type(), 'td');
+    assert.strictEqual(root.hasClass(classes.root), true);
+    assert.strictEqual(root.hasClass(classes.footer), true);
   });
 
   it('should render with the footer class when in the context of a table footer', () => {

--- a/packages/material-ui/test/integration/TableRow.test.js
+++ b/packages/material-ui/test/integration/TableRow.test.js
@@ -11,7 +11,7 @@ describe('<TableRow> integration', () => {
 
   before(() => {
     classes = getClasses(<TableRow />);
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {


### PR DESCRIPTION
Adds an option to `createMount` that allows mount tests to run in strict mode.

```jsx
const strictMount = createMount({ strict: true });
strictMount(<div />); // <React.StrictMode><div /></React.StrictMode>

const looseMount = createMount({ strict: false });
looseMount(<div />); // <React.Fragment><div /></React.Fragment>

const mount = createMount();
mount(<div />); // <div />
```

### Why is `strict: false` different than `strict: undefined`?

If you still rely on `childAt(0)`, `dive` etc. consistently adding an additional level to the component tree allows toggling strict mode without changing your test assertions. 
 
## own test suite changes

Runs every test that uses `createMount` either in strict mode or not.

## Implementation
https://github.com/mui-org/material-ui/pull/15317/files#diff-b24ed23497b02191114acc4c33e82796