### PR TITLE
[InputBase] Fix onFilled/onEmpty being called during render

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -156,9 +156,6 @@ class InputBase extends React.Component {
   constructor(props) {
     super(props);
     this.isControlled = props.value != null;
-    if (this.isControlled) {
-      this.checkDirty(props);
-    }
   }
 
   state = {
@@ -166,9 +163,7 @@ class InputBase extends React.Component {
   };
 
   componentDidMount() {
-    if (!this.isControlled) {
-      this.checkDirty(this.inputRef);
-    }
+    this.checkDirty(this.isControlled ? this.props : this.inputRef);
   }
 
   componentDidUpdate(prevProps) {

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -396,51 +396,6 @@ describe('<InputBase />', () => {
     });
   });
 
-  describe('componentDidMount', () => {
-    let wrapper;
-    let instance;
-
-    before(() => {
-      wrapper = mount(<NakedInputBase classes={classes} />);
-      instance = wrapper.find('InputBase').instance();
-    });
-
-    beforeEach(() => {
-      instance.checkDirty = spy();
-    });
-
-    it('should not call checkDirty if controlled', () => {
-      instance.isControlled = true;
-      instance.componentDidMount();
-      assert.strictEqual(instance.checkDirty.callCount, 0);
-    });
-
-    it('should call checkDirty if controlled', () => {
-      instance.isControlled = false;
-      instance.componentDidMount();
-      assert.strictEqual(instance.checkDirty.callCount, 1);
-    });
-
-    it('should call checkDirty with input value', () => {
-      instance.isControlled = false;
-      instance.inputRef = 'woofinput';
-      instance.componentDidMount();
-      assert.strictEqual(instance.checkDirty.calledWith(instance.inputRef), true);
-    });
-
-    it('should call or not call checkDirty consistently', () => {
-      instance.isControlled = true;
-      instance.componentDidMount();
-      assert.strictEqual(instance.checkDirty.callCount, 0);
-      instance.isControlled = false;
-      instance.componentDidMount();
-      assert.strictEqual(instance.checkDirty.callCount, 1);
-      instance.isControlled = true;
-      instance.componentDidMount();
-      assert.strictEqual(instance.checkDirty.callCount, 1);
-    });
-  });
-
   describe('mount', () => {
     it('should be able to access the native input', () => {
       const handleRef = spy();


### PR DESCRIPTION
Caught with #15317 (see 2dd5cc09eb94c2afe02f135542fa1768a00fdb84 for observable fix)

The [constructor is called in the render phase](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects) which means it should be "side-effect free" (non-local).

I guess this also improves the API since it's now consistent when onEmpty/onFilled is called (it was different before between controlled/uncontrolled mode).