### PR TITLE
[docs] Fix placeholder position in react-select demo

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.js
@@ -88,6 +88,7 @@ const useStyles = makeStyles(theme => ({
   placeholder: {
     position: 'absolute',
     left: 2,
+    bottom: 6,
     fontSize: 16,
   },
   paper: {

--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.tsx
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.tsx
@@ -102,6 +102,7 @@ const useStyles = makeStyles((theme: Theme) =>
     placeholder: {
       position: 'absolute',
       left: 2,
+      bottom: 6,
       fontSize: 16,
     },
     paper: {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

The placeholder in the `react-select` demo isn't placed correctly in Internet Explorer, this PR fixes that by adding a `bottom: 6` to the placeholder