### PR TITLE
[ListItem] Make semantically correct

### DIFF
--- a/docs/src/pages/demos/lists/NestedList.js
+++ b/docs/src/pages/demos/lists/NestedList.js
@@ -34,7 +34,6 @@ function NestedList() {
 
   return (
     <List
-      component="nav"
       subheader={<ListSubheader component="div">Nested List Items</ListSubheader>}
       className={classes.root}
     >

--- a/docs/src/pages/demos/lists/PinnedSubheaderList.js
+++ b/docs/src/pages/demos/lists/PinnedSubheaderList.js
@@ -31,8 +31,8 @@ function PinnedSubheaderList(props) {
     <List className={classes.root} subheader={<li />}>
       {[0, 1, 2, 3, 4].map(sectionId => (
         <li key={`section-${sectionId}`} className={classes.listSection}>
+          <ListSubheader component="span">{`I'm sticky ${sectionId}`}</ListSubheader>
           <ul className={classes.ul}>
-            <ListSubheader>{`I'm sticky ${sectionId}`}</ListSubheader>
             {[0, 1, 2].map(item => (
               <ListItem key={`item-${sectionId}-${item}`}>
                 <ListItemText primary={`Item ${item}`} />

--- a/docs/src/pages/demos/lists/PinnedSubheaderList.tsx
+++ b/docs/src/pages/demos/lists/PinnedSubheaderList.tsx
@@ -34,8 +34,8 @@ function PinnedSubheaderList(props: PinnedSubheaderListProps) {
     <List className={classes.root} subheader={<li />}>
       {[0, 1, 2, 3, 4].map(sectionId => (
         <li key={`section-${sectionId}`} className={classes.listSection}>
+          <ListSubheader component="span">{`I'm sticky ${sectionId}`}</ListSubheader>
           <ul className={classes.ul}>
-            <ListSubheader>{`I'm sticky ${sectionId}`}</ListSubheader>
             {[0, 1, 2].map(item => (
               <ListItem key={`item-${sectionId}-${item}`}>
                 <ListItemText primary={`Item ${item}`} />

--- a/docs/src/pages/demos/lists/SelectedListItem.js
+++ b/docs/src/pages/demos/lists/SelectedListItem.js
@@ -25,8 +25,8 @@ function SelectedListItem() {
   }
 
   return (
-    <div className={classes.root}>
-      <List component="nav">
+    <nav className={classes.root}>
+      <List>
         <ListItem
           button
           selected={selectedIndex === 0}
@@ -47,9 +47,7 @@ function SelectedListItem() {
           </ListItemIcon>
           <ListItemText primary="Drafts" />
         </ListItem>
-      </List>
-      <Divider />
-      <List component="nav">
+        <Divider component="li" />
         <ListItem
           button
           selected={selectedIndex === 2}
@@ -65,7 +63,7 @@ function SelectedListItem() {
           <ListItemText primary="Spam" />
         </ListItem>
       </List>
-    </div>
+    </nav>
   );
 }
 

--- a/docs/src/pages/demos/lists/SelectedListItem.tsx
+++ b/docs/src/pages/demos/lists/SelectedListItem.tsx
@@ -28,8 +28,8 @@ function SelectedListItem() {
   }
 
   return (
-    <div className={classes.root}>
-      <List component="nav">
+    <nav className={classes.root}>
+      <List>
         <ListItem
           button
           selected={selectedIndex === 0}
@@ -50,9 +50,7 @@ function SelectedListItem() {
           </ListItemIcon>
           <ListItemText primary="Drafts" />
         </ListItem>
-      </List>
-      <Divider />
-      <List component="nav">
+        <Divider component="li" />
         <ListItem
           button
           selected={selectedIndex === 2}
@@ -68,7 +66,7 @@ function SelectedListItem() {
           <ListItemText primary="Spam" />
         </ListItem>
       </List>
-    </div>
+    </nav>
   );
 }
 

--- a/docs/src/pages/demos/lists/SimpleList.js
+++ b/docs/src/pages/demos/lists/SimpleList.js
@@ -18,7 +18,8 @@ const styles = theme => ({
 });
 
 function ListItemLink(props) {
-  return <ListItem button component="a" {...props} />;
+  const { href, ...other } = props;
+  return <ListItem button buttonBaseProps={{ component: 'a', href }} {...other} />;
 }
 
 function SimpleList(props) {
@@ -38,7 +39,7 @@ function SimpleList(props) {
           </ListItemIcon>
           <ListItemText primary="Drafts" />
         </ListItem>
-        <Divider component="li" role="separator" />
+        <Divider component="li" />
         <ListItem button>
           <ListItemText primary="Trash" />
         </ListItem>

--- a/docs/src/pages/demos/lists/SimpleList.js
+++ b/docs/src/pages/demos/lists/SimpleList.js
@@ -24,7 +24,7 @@ function ListItemLink(props) {
 function SimpleList(props) {
   const { classes } = props;
   return (
-    <nav className={classes.root} role="navigation">
+    <nav className={classes.root} role="navigation" aria-label="Demo">
       <List>
         <ListItem button>
           <ListItemIcon>
@@ -38,9 +38,7 @@ function SimpleList(props) {
           </ListItemIcon>
           <ListItemText primary="Drafts" />
         </ListItem>
-      </List>
-      <Divider />
-      <List>
+        <Divider component="li" role="separator" />
         <ListItem button>
           <ListItemText primary="Trash" />
         </ListItem>

--- a/docs/src/pages/demos/lists/SimpleList.js
+++ b/docs/src/pages/demos/lists/SimpleList.js
@@ -24,7 +24,7 @@ function ListItemLink(props) {
 function SimpleList(props) {
   const { classes } = props;
   return (
-    <nav className={classes.root} role="navigation" aria-label="Demo">
+    <nav className={classes.root} aria-label="Demo">
       <List>
         <ListItem button>
           <ListItemIcon>

--- a/docs/src/pages/demos/lists/SimpleList.js
+++ b/docs/src/pages/demos/lists/SimpleList.js
@@ -24,8 +24,8 @@ function ListItemLink(props) {
 function SimpleList(props) {
   const { classes } = props;
   return (
-    <div className={classes.root}>
-      <List component="nav">
+    <nav className={classes.root} role="navigation">
+      <List>
         <ListItem button>
           <ListItemIcon>
             <InboxIcon />
@@ -40,7 +40,7 @@ function SimpleList(props) {
         </ListItem>
       </List>
       <Divider />
-      <List component="nav">
+      <List>
         <ListItem button>
           <ListItemText primary="Trash" />
         </ListItem>
@@ -48,7 +48,7 @@ function SimpleList(props) {
           <ListItemText primary="Spam" />
         </ListItemLink>
       </List>
-    </div>
+    </nav>
   );
 }
 

--- a/docs/src/pages/demos/lists/SimpleList.tsx
+++ b/docs/src/pages/demos/lists/SimpleList.tsx
@@ -27,7 +27,7 @@ export interface SimpleListProps extends WithStyles<typeof styles> {}
 function SimpleList(props: SimpleListProps) {
   const { classes } = props;
   return (
-    <nav className={classes.root} role="navigation" aria-label="Demo">
+    <nav className={classes.root} aria-label="Demo">
       <List>
         <ListItem button>
           <ListItemIcon>

--- a/docs/src/pages/demos/lists/SimpleList.tsx
+++ b/docs/src/pages/demos/lists/SimpleList.tsx
@@ -27,8 +27,8 @@ export interface SimpleListProps extends WithStyles<typeof styles> {}
 function SimpleList(props: SimpleListProps) {
   const { classes } = props;
   return (
-    <div className={classes.root}>
-      <List component="nav">
+    <nav className={classes.root} role="navigation" aria-label="Demo">
+      <List>
         <ListItem button>
           <ListItemIcon>
             <InboxIcon />
@@ -41,9 +41,7 @@ function SimpleList(props: SimpleListProps) {
           </ListItemIcon>
           <ListItemText primary="Drafts" />
         </ListItem>
-      </List>
-      <Divider />
-      <List component="nav">
+        <Divider component="li" role="separator" />
         <ListItem button>
           <ListItemText primary="Trash" />
         </ListItem>
@@ -51,7 +49,7 @@ function SimpleList(props: SimpleListProps) {
           <ListItemText primary="Spam" />
         </ListItemLink>
       </List>
-    </div>
+    </nav>
   );
 }
 

--- a/docs/src/pages/demos/lists/SimpleList.tsx
+++ b/docs/src/pages/demos/lists/SimpleList.tsx
@@ -18,8 +18,9 @@ const styles = (theme: Theme) =>
     },
   });
 
-function ListItemLink(props: ListItemProps<'a', { button?: true }>) {
-  return <ListItem button component="a" {...props} />;
+function ListItemLink(props: any) {
+  const { href, ...other } = props;
+  return <ListItem button buttonBaseProps={{ component: 'a', href }} {...other} />;
 }
 
 export interface SimpleListProps extends WithStyles<typeof styles> {}
@@ -41,7 +42,7 @@ function SimpleList(props: SimpleListProps) {
           </ListItemIcon>
           <ListItemText primary="Drafts" />
         </ListItem>
-        <Divider component="li" role="separator" />
+        <Divider component="li" />
         <ListItem button>
           <ListItemText primary="Trash" />
         </ListItem>

--- a/docs/src/pages/demos/lists/VirtualizedList.js
+++ b/docs/src/pages/demos/lists/VirtualizedList.js
@@ -34,7 +34,7 @@ function VirtualizedList() {
 
   return (
     <div className={classes.root}>
-      <FixedSizeList height={400} width={360} itemSize={46} itemCount={200}>
+      <FixedSizeList innerElementType="ul" height={400} width={360} itemSize={46} itemCount={200}>
         {Row}
       </FixedSizeList>
     </div>

--- a/docs/src/pages/demos/lists/VirtualizedList.tsx
+++ b/docs/src/pages/demos/lists/VirtualizedList.tsx
@@ -36,7 +36,7 @@ function VirtualizedList() {
 
   return (
     <div className={classes.root}>
-      <FixedSizeList height={400} width={360} itemSize={46} itemCount={200}>
+      <FixedSizeList innerElementType="ul" height={400} width={360} itemSize={46} itemCount={200}>
         {Row}
       </FixedSizeList>
     </div>

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -130,12 +130,12 @@ const ListItem = React.forwardRef(function ListItem(props, ref) {
     disabled,
     ...other,
   };
-  let Component = componentProp || 'li';
+  let Component = componentProp;
 
   if (button) {
-    componentProps.component = componentProp || 'div';
-    componentProps.focusVisibleClassName = clsx(classes.focusVisible, focusVisibleClassName);
     Component = ButtonBase;
+    componentProps.component = 'button';
+    componentProps.focusVisibleClassName = clsx(classes.focusVisible, focusVisibleClassName);
   }
 
   // Avoid nesting of li > li.
@@ -250,7 +250,7 @@ ListItem.propTypes = {
 ListItem.defaultProps = {
   alignItems: 'center',
   button: false,
-  component: 'li',
+  component: 'div',
   ContainerComponent: 'li',
   disabled: false,
   disableGutters: false,

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -138,38 +138,25 @@ const ListItem = React.forwardRef(function ListItem(props, ref) {
     Component = ButtonBase;
   }
 
-  if (hasSecondaryAction) {
-    // Use div by default.
-    Component = !componentProps.component && !componentProp ? 'div' : Component;
-
-    // Avoid nesting of li > li.
-    if (ContainerComponent === 'li') {
-      if (Component === 'li') {
-        Component = 'div';
-      } else if (componentProps.component === 'li') {
-        componentProps.component = 'div';
-      }
+  // Avoid nesting of li > li.
+  if (ContainerComponent === 'li') {
+    if (Component === 'li') {
+      Component = 'div';
+    } else if (componentProps.component === 'li') {
+      componentProps.component = 'div';
     }
-
-    return (
-      <ListContext.Provider value={childContext}>
-        <ContainerComponent
-          className={clsx(classes.container, ContainerClassName)}
-          ref={ref}
-          {...ContainerProps}
-        >
-          <Component {...componentProps}>{children}</Component>
-          {children.pop()}
-        </ContainerComponent>
-      </ListContext.Provider>
-    );
   }
 
   return (
     <ListContext.Provider value={childContext}>
-      <Component ref={ref} {...componentProps}>
-        {children}
-      </Component>
+      <ContainerComponent
+        className={clsx(classes.container, ContainerClassName)}
+        ref={ref}
+        {...ContainerProps}
+      >
+        <Component {...componentProps}>{children}</Component>
+        {hasSecondaryAction ? children.pop() : null}
+      </ContainerComponent>
     </ListContext.Provider>
   );
 });

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -263,6 +263,7 @@ ListItem.propTypes = {
 ListItem.defaultProps = {
   alignItems: 'center',
   button: false,
+  component: 'li',
   ContainerComponent: 'li',
   disabled: false,
   disableGutters: false,

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -12,24 +12,21 @@ filename: /packages/material-ui/src/ListItem/ListItem.js
 import ListItem from '@material-ui/core/ListItem';
 ```
 
-Uses an additional container component if `ListItemSecondaryAction` is the last child.
-
 ## Props
 
-| Name | Type | Default | Description |
-|:-----|:-----|:--------|:------------|
-| <span class="prop-name">alignItems</span> | <span class="prop-type">enum:&nbsp;'flex-start'&nbsp;&#124;<br>&nbsp;'center'<br></span> | <span class="prop-default">'center'</span> | Defines the `align-items` style property. |
-| <span class="prop-name">button</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the list item will be a button (using `ButtonBase`). |
-| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. If a `ListItemSecondaryAction` is used it must be the last child. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> |  | The component used for the root node. Either a string to use a DOM element or a component. By default, it's a `li` when `button` is `false` and a `div` when `button` is `true`. |
-| <span class="prop-name">ContainerComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'li'</span> | The container component used when a `ListItemSecondaryAction` is the last child. |
-| <span class="prop-name">ContainerProps</span> | <span class="prop-type">object</span> |  | Properties applied to the container component if used. |
-| <span class="prop-name">dense</span> | <span class="prop-type">bool</span> |  | If `true`, compact vertical padding designed for keyboard and mouse input will be used. |
-| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the list item will be disabled. |
-| <span class="prop-name">disableGutters</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the left and right padding is removed. |
-| <span class="prop-name">divider</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, a 1px light border is added to the bottom of the list item. |
-| <span class="prop-name">selected</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Use to apply selected styling. |
+| Name                                           | Type                                                                                     | Default                                    | Description                                                                                         |
+| :--------------------------------------------- | :--------------------------------------------------------------------------------------- | :----------------------------------------- | :-------------------------------------------------------------------------------------------------- |
+| <span class="prop-name">alignItems</span>      | <span class="prop-type">enum:&nbsp;'flex-start'&nbsp;&#124;<br>&nbsp;'center'<br></span> | <span class="prop-default">'center'</span> | Defines the `align-items` style property.                                                           |
+| <span class="prop-name">button</span>          | <span class="prop-type">bool</span>                                                      | <span class="prop-default">false</span>    | If `true`, the list item will be a button (using `ButtonBase`).                                     |
+| <span class="prop-name">children</span>        | <span class="prop-type">node</span>                                                      |                                            | The content of the component. If a `ListItemSecondaryAction` is used it must be the last child.     |
+| <span class="prop-name">classes</span>         | <span class="prop-type">object</span>                                                    |                                            | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">buttonBaseProps</span> | <span class="prop-type">object</span>                                                    |                                            | Properties applied to the ButtonBase component.                                                     |
+| <span class="prop-name">component</span>       | <span class="prop-type">elementType</span>                                               | <span class="prop-default">'li'</span>     | The component used for the root node. Either a string to use a DOM element or a component.          |
+| <span class="prop-name">dense</span>           | <span class="prop-type">bool</span>                                                      |                                            | If `true`, compact vertical padding designed for keyboard and mouse input will be used.             |
+| <span class="prop-name">disabled</span>        | <span class="prop-type">bool</span>                                                      | <span class="prop-default">false</span>    | If `true`, the list item will be disabled.                                                          |
+| <span class="prop-name">disableGutters</span>  | <span class="prop-type">bool</span>                                                      | <span class="prop-default">false</span>    | If `true`, the left and right padding is removed.                                                   |
+| <span class="prop-name">divider</span>         | <span class="prop-type">bool</span>                                                      | <span class="prop-default">false</span>    | If `true`, a 1px light border is added to the bottom of the list item.                              |
+| <span class="prop-name">selected</span>        | <span class="prop-type">bool</span>                                                      | <span class="prop-default">false</span>    | Use to apply selected styling.                                                                      |
 
 The `ref` is forwarded to the root element.
 
@@ -40,20 +37,18 @@ Any other properties supplied will be provided to the root element (native eleme
 You can override all the class names injected by Material-UI thanks to the `classes` property.
 This property accepts the following keys:
 
-
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the (normally root) `component` element. May be wrapped by a `container`.
-| <span class="prop-name">container</span> | Styles applied to the `container` element if `children` includes `ListItemSecondaryAction`.
-| <span class="prop-name">focusVisible</span> | Styles applied to the `component`'s `focusVisibleClassName` property if `button={true}`.
-| <span class="prop-name">dense</span> | Styles applied to the `component` element if dense.
-| <span class="prop-name">alignItemsFlexStart</span> | Styles applied to the `component` element if `alignItems="flex-start"`.
-| <span class="prop-name">disabled</span> | Styles applied to the inner `component` element if `disabled={true}`.
-| <span class="prop-name">divider</span> | Styles applied to the inner `component` element if `divider={true}`.
-| <span class="prop-name">gutters</span> | Styles applied to the inner `component` element if `disableGutters={false}`.
-| <span class="prop-name">button</span> | Styles applied to the inner `component` element if `button={true}`.
-| <span class="prop-name">secondaryAction</span> | Styles applied to the `component` element if `children` includes `ListItemSecondaryAction`.
-| <span class="prop-name">selected</span> | Styles applied to the root element if `selected={true}`.
+| Name                                               | Description                                                                                 |
+| :------------------------------------------------- | :------------------------------------------------------------------------------------------ |
+| <span class="prop-name">root</span>                | Styles applied to the root `component` element.                                             |
+| <span class="prop-name">li</span>                  | Styles applied to the `container` element if `children` includes `ListItemSecondaryAction`. |
+| <span class="prop-name">dense</span>               | Styles applied to the `component` element if dense.                                         |
+| <span class="prop-name">alignItemsFlexStart</span> | Styles applied to the `component` element if `alignItems="flex-start"`.                     |
+| <span class="prop-name">disabled</span>            | Styles applied to the inner `component` element if `disabled={true}`.                       |
+| <span class="prop-name">divider</span>             | Styles applied to the inner `component` element if `divider={true}`.                        |
+| <span class="prop-name">gutters</span>             | Styles applied to the inner `component` element if `disableGutters={false}`.                |
+| <span class="prop-name">button</span>              | Styles applied to the inner `component` element if `button={true}`.                         |
+| <span class="prop-name">secondaryAction</span>     | Styles applied to the `component` element if `children` includes `ListItemSecondaryAction`. |
+| <span class="prop-name">selected</span>            | Styles applied to the root element if `selected={true}`.                                    |
 
 Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/ListItem/ListItem.js)
@@ -66,4 +61,3 @@ you need to use the following style sheet name: `MuiListItem`.
 
 - [Lists](/demos/lists/)
 - [Transfer List](/demos/transfer-list/)
-


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This is a discussion draft. I have only changed one demo so far, and it's still not perfect. The changes are:

- Significantly simplify ListItem internals.

- Use semantically correct lists to allow screen readers to enumerate the items.

- ~~Use `role="navigation"` on the `nav`:
https://www.w3.org/WAI/tutorials/page-structure/regions/#accessupport~~

- ~~Use `<li role="separator">` for the Divider.~~ (Divider already adds this when `component="li"`. Updated demos to be compliant.)

Also, closes #15482