### PR TITLE
[List] Add keyboard navigation

### DIFF
--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import warning from 'warning';
 import ownerDocument from '../utils/ownerDocument';
+import handleListKeyDown from '../utils/handleListKeyDown';
 import List from '../List';
 import getScrollbarSize from '../utils/getScrollbarSize';
 import { useForkRef } from '../utils/reactHelpers';
@@ -92,46 +93,8 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
     }
   };
 
-  const handleKeyDown = event => {
-    const list = listRef.current;
-    const key = event.key;
-    const currentFocus = ownerDocument(list).activeElement;
-
-    if (
-      (key === 'ArrowUp' || key === 'ArrowDown') &&
-      (!currentFocus || (currentFocus && !list.contains(currentFocus)))
-    ) {
-      if (selectedItemRef.current) {
-        selectedItemRef.current.focus();
-      } else {
-        list.firstChild.focus();
-      }
-    } else if (key === 'ArrowDown') {
-      event.preventDefault();
-      if (currentFocus.nextElementSibling) {
-        currentFocus.nextElementSibling.focus();
-      } else if (!disableListWrap) {
-        list.firstChild.focus();
-      }
-    } else if (key === 'ArrowUp') {
-      event.preventDefault();
-      if (currentFocus.previousElementSibling) {
-        currentFocus.previousElementSibling.focus();
-      } else if (!disableListWrap) {
-        list.lastChild.focus();
-      }
-    } else if (key === 'Home') {
-      event.preventDefault();
-      list.firstChild.focus();
-    } else if (key === 'End') {
-      event.preventDefault();
-      list.lastChild.focus();
-    }
-
-    if (onKeyDown) {
-      onKeyDown(event);
-    }
-  };
+  const handleKeyDown = event =>
+    handleListKeyDown(event, listRef, selectedItemRef, disableListWrap, onKeyDown);
 
   const handleItemFocus = event => {
     const list = listRef.current;

--- a/packages/material-ui/src/utils/handleListKeyDown.js
+++ b/packages/material-ui/src/utils/handleListKeyDown.js
@@ -1,0 +1,48 @@
+import ownerDocument from './ownerDocument';
+
+export default function handleListKeyDown(
+  event,
+  listRef,
+  selectedItemRef,
+  disableListWrap,
+  onKeyDown,
+) {
+  const list = listRef.current;
+  const key = event.key;
+  const currentFocus = ownerDocument(list).activeElement;
+
+  if (
+    (key === 'ArrowUp' || key === 'ArrowDown') &&
+    (!currentFocus || (currentFocus && !list.contains(currentFocus)))
+  ) {
+    if (selectedItemRef.current) {
+      selectedItemRef.current.focus();
+    } else {
+      list.firstChild.focus();
+    }
+  } else if (key === 'ArrowDown') {
+    event.preventDefault();
+    if (currentFocus.nextElementSibling) {
+      currentFocus.nextElementSibling.focus();
+    } else if (!disableListWrap) {
+      list.firstChild.focus();
+    }
+  } else if (key === 'ArrowUp') {
+    event.preventDefault();
+    if (currentFocus.previousElementSibling) {
+      currentFocus.previousElementSibling.focus();
+    } else if (!disableListWrap) {
+      list.lastChild.focus();
+    }
+  } else if (key === 'Home') {
+    event.preventDefault();
+    list.firstChild.focus();
+  } else if (key === 'End') {
+    event.preventDefault();
+    list.lastChild.focus();
+  }
+
+  if (onKeyDown) {
+    onKeyDown(event);
+  }
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Discussion draft - applies the same logic to `List` as currently used in `MenuList`.

**Not resolved**:

- Sublist navigation
- Sibling list navigation

(Not that MenuList currently supports these either.)
