### PR TITLE
[docs] Disable the table of content on a few pages

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -72,7 +72,7 @@ via [Patreon](https://www.patreon.com/oliviertassinari)
 | Kai Mit Pansen | Eric Nagy | Karens Grigorjancs | Mohamed Turco | Haroun Serang |
 | Antonio Seveso | Ali Akhavan | Bruno Winck | Alessandro Annini | Victor Irzak |
 | Manuel U Grullon | Skaronator | Peter James | Vincz | Micah Davidson |
-| Nelson Batalha |
+| Nelson Batalha | Daniel Woss | Michael Staub | Scott Fortmann-Roe |
 
 via [OpenCollective](https://opencollective.com/material-ui)
 

--- a/docs/src/modules/components/AppContent.js
+++ b/docs/src/modules/components/AppContent.js
@@ -20,13 +20,25 @@ const styles = theme => ({
       maxWidth: 'calc(100% - 240px - 175px)',
     },
   },
+  disableTocs: {
+    [theme.breakpoints.up('sm')]: {
+      maxWidth: 'calc(100%)',
+    },
+    [theme.breakpoints.up('lg')]: {
+      maxWidth: 'calc(100% - 240px)',
+    },
+  },
 });
 
 function AppContent(props) {
-  const { className, classes, children } = props;
+  const { className, classes, children, disableTocs } = props;
 
   return (
-    <main className={clsx(classes.root, className)}>
+    <main
+      className={clsx(classes.root, className, {
+        [classes.disableTocs]: disableTocs,
+      })}
+    >
       <Container>{children}</Container>
     </main>
   );
@@ -36,6 +48,7 @@ AppContent.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
   className: PropTypes.string,
+  disableTocs: PropTypes.bool.isRequired,
 };
 
 export default withStyles(styles)(AppContent);

--- a/docs/src/modules/components/AppContent.js
+++ b/docs/src/modules/components/AppContent.js
@@ -20,7 +20,7 @@ const styles = theme => ({
       maxWidth: 'calc(100% - 240px - 175px)',
     },
   },
-  disableTocs: {
+  disableToc: {
     [theme.breakpoints.up('sm')]: {
       maxWidth: 'calc(100%)',
     },
@@ -31,12 +31,12 @@ const styles = theme => ({
 });
 
 function AppContent(props) {
-  const { className, classes, children, disableTocs } = props;
+  const { className, classes, children, disableToc } = props;
 
   return (
     <main
       className={clsx(classes.root, className, {
-        [classes.disableTocs]: disableTocs,
+        [classes.disableToc]: disableToc,
       })}
     >
       <Container>{children}</Container>
@@ -48,7 +48,7 @@ AppContent.propTypes = {
   children: PropTypes.node.isRequired,
   classes: PropTypes.object.isRequired,
   className: PropTypes.string,
-  disableTocs: PropTypes.bool.isRequired,
+  disableToc: PropTypes.bool.isRequired,
 };
 
 export default withStyles(styles)(AppContent);

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -46,7 +46,7 @@ function MarkdownDocs(props) {
   const {
     classes,
     disableAd,
-    disableTocs,
+    disableToc,
     markdown: markdownProp,
     markdownLocation: markdownLocationProp,
     req,
@@ -103,13 +103,13 @@ function MarkdownDocs(props) {
             title={`${headers.title || getTitle(markdown)} - Material-UI`}
             description={headers.description || getDescription(markdown)}
           />
-          {disableTocs ? null : <AppTableOfContents contents={contents} />}
+          {disableToc ? null : <AppTableOfContents contents={contents} />}
           {disableAd ? null : (
             <Portal container={() => document.querySelector('.description')}>
               <Ad />
             </Portal>
           )}
-          <AppContent disableTocs={disableTocs} className={classes.root}>
+          <AppContent disableToc={disableToc} className={classes.root}>
             <div className={classes.header}>
               <EditPage
                 markdownLocation={markdownLocation}
@@ -175,7 +175,7 @@ function MarkdownDocs(props) {
 MarkdownDocs.propTypes = {
   classes: PropTypes.object.isRequired,
   disableAd: PropTypes.bool,
-  disableTocs: PropTypes.bool,
+  disableToc: PropTypes.bool,
   markdown: PropTypes.string,
   // You can define the direction location of the markdown file.
   // Otherwise, we try to determine it with an heuristic.
@@ -188,7 +188,7 @@ MarkdownDocs.propTypes = {
 
 MarkdownDocs.defaultProps = {
   disableAd: false,
-  disableTocs: false,
+  disableToc: false,
 };
 
 export default compose(

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -46,6 +46,7 @@ function MarkdownDocs(props) {
   const {
     classes,
     disableAd,
+    disableTocs,
     markdown: markdownProp,
     markdownLocation: markdownLocationProp,
     req,
@@ -102,13 +103,13 @@ function MarkdownDocs(props) {
             title={`${headers.title || getTitle(markdown)} - Material-UI`}
             description={headers.description || getDescription(markdown)}
           />
-          <AppTableOfContents contents={contents} />
+          {disableTocs ? null : <AppTableOfContents contents={contents} />}
           {disableAd ? null : (
             <Portal container={() => document.querySelector('.description')}>
               <Ad />
             </Portal>
           )}
-          <AppContent className={classes.root}>
+          <AppContent disableTocs={disableTocs} className={classes.root}>
             <div className={classes.header}>
               <EditPage
                 markdownLocation={markdownLocation}
@@ -174,6 +175,7 @@ function MarkdownDocs(props) {
 MarkdownDocs.propTypes = {
   classes: PropTypes.object.isRequired,
   disableAd: PropTypes.bool,
+  disableTocs: PropTypes.bool,
   markdown: PropTypes.string,
   // You can define the direction location of the markdown file.
   // Otherwise, we try to determine it with an heuristic.
@@ -186,6 +188,7 @@ MarkdownDocs.propTypes = {
 
 MarkdownDocs.defaultProps = {
   disableAd: false,
+  disableTocs: false,
 };
 
 export default compose(

--- a/docs/src/pages/customization/themes/themes.md
+++ b/docs/src/pages/customization/themes/themes.md
@@ -354,7 +354,7 @@ Material-UI uses [a recommended 8px scaling factor by default](https://material.
 const styles = theme => ({
   root: {
     // JSS uses px as the default units for this CSS property.
-    padding: theme.spacing(2), // Outputs 8 * 2
+    padding: theme.spacing(2), // = 8 * 2
   },
 });
 ```
@@ -371,14 +371,24 @@ const theme = createMuiTheme({
 theme.spacing(2) // = 4 * 2
 ```
 
-- or a function
+- a function
 
 ```js
 const theme = createMuiTheme({
   spacing: factor => `${0.25 * factor}rem`, // (Bootstrap strategy)
 });
 
-theme.spacing(2) // = 0.5rem = 8px
+theme.spacing(2); // = 0.25 * 2rem = 0.5rem = 8px
+```
+
+- an array
+
+```js
+const theme = createMuiTheme({
+  spacing: factor => [0, 4, 8, 16, 32, 64][factor],
+});
+
+theme.spacing(2); // = 8
 ```
 
 ### Multiple arity

--- a/docs/src/pages/demos/tables/tables.md
+++ b/docs/src/pages/demos/tables/tables.md
@@ -83,5 +83,3 @@ For more advanced use cases you might be able to take advantage of:
 - [dx-react-grid-material-ui](https://devexpress.github.io/devextreme-reactive/react/grid/) A data grid for Material-UI with paging, sorting, filtering, grouping and editing features ([custom license](https://js.devexpress.com/licensing/)).
 - [mui-datatables](https://github.com/gregnb/mui-datatables) Responsive data tables for Material-UI with filtering, sorting, search and more.
 - [material-table](https://github.com/mbrn/material-table) DataTable based on table component with additional features like search, filtering, sorting and much more.
-- [mui-virtualized-table](https://github.com/techniq/mui-virtualized-table) Virtualized Material-UI table.
-- [mui-tables](https://parkerself.gitbook.io/mui-table/) Customizable table for managing complex data. Features a summary row, de-duplication & merging, as well as filtering, search, etc.

--- a/pages/discover-more/showcase.js
+++ b/pages/discover-more/showcase.js
@@ -12,7 +12,7 @@ const reqSource = require.context(
 const reqPrefix = 'pages/discover-more/showcase';
 
 function Page() {
-  return <MarkdownDocs disableTocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+  return <MarkdownDocs disableToc req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
 }
 
 export default Page;

--- a/pages/discover-more/showcase.js
+++ b/pages/discover-more/showcase.js
@@ -12,7 +12,7 @@ const reqSource = require.context(
 const reqPrefix = 'pages/discover-more/showcase';
 
 function Page() {
-  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+  return <MarkdownDocs disableTocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
 }
 
 export default Page;

--- a/pages/getting-started/page-layout-examples.js
+++ b/pages/getting-started/page-layout-examples.js
@@ -16,7 +16,9 @@ const reqSource = require.context(
 const reqPrefix = 'pages/getting-started/page-layout-examples';
 
 function Page() {
-  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+  return (
+    <MarkdownDocs disableTocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />
+  );
 }
 
 export default Page;

--- a/pages/getting-started/page-layout-examples.js
+++ b/pages/getting-started/page-layout-examples.js
@@ -16,9 +16,7 @@ const reqSource = require.context(
 const reqPrefix = 'pages/getting-started/page-layout-examples';
 
 function Page() {
-  return (
-    <MarkdownDocs disableTocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />
-  );
+  return <MarkdownDocs disableTocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
 }
 
 export default Page;

--- a/pages/getting-started/page-layout-examples.js
+++ b/pages/getting-started/page-layout-examples.js
@@ -16,7 +16,7 @@ const reqSource = require.context(
 const reqPrefix = 'pages/getting-started/page-layout-examples';
 
 function Page() {
-  return <MarkdownDocs disableTocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+  return <MarkdownDocs disableToc req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
 }
 
 export default Page;

--- a/pages/premium-themes.js
+++ b/pages/premium-themes.js
@@ -12,7 +12,9 @@ const reqSource = require.context(
 const reqPrefix = 'pages/premium-themes';
 
 function Page() {
-  return <MarkdownDocs disableAd req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+  return (
+    <MarkdownDocs disableTocs disableAd req={req} reqSource={reqSource} reqPrefix={reqPrefix} />
+  );
 }
 
 export default Page;

--- a/pages/premium-themes.js
+++ b/pages/premium-themes.js
@@ -13,7 +13,7 @@ const reqPrefix = 'pages/premium-themes';
 
 function Page() {
   return (
-    <MarkdownDocs disableTocs disableAd req={req} reqSource={reqSource} reqPrefix={reqPrefix} />
+    <MarkdownDocs disableToc disableAd req={req} reqSource={reqSource} reqPrefix={reqPrefix} />
   );
 }
 

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -30,32 +30,32 @@ async function getSizeLimitBundles() {
     {
       name: '@material-ui/core',
       webpack: true,
-      path: 'packages/material-ui/build/index.js',
+      path: 'packages/material-ui/build/esm/index.js',
     },
     {
       name: '@material-ui/core/styles/createMuiTheme',
       webpack: true,
-      path: 'packages/material-ui/build/styles/createMuiTheme.js',
+      path: 'packages/material-ui/build/esm/styles/createMuiTheme.js',
     },
     {
       name: '@material-ui/lab',
       webpack: true,
-      path: 'packages/material-ui-lab/build/index.js',
+      path: 'packages/material-ui-lab/build/esm/index.js',
     },
     {
       name: '@material-ui/styles',
       webpack: true,
-      path: 'packages/material-ui-styles/build/index.js',
+      path: 'packages/material-ui-styles/build/esm/index.js',
     },
     {
       name: '@material-ui/system',
       webpack: true,
-      path: 'packages/material-ui-system/build/index.js',
+      path: 'packages/material-ui-system/build/esm/index.js',
     },
     {
       name: 'colorManipulator',
       webpack: true,
-      path: 'packages/material-ui/build/styles/colorManipulator.js',
+      path: 'packages/material-ui/build/esm/styles/colorManipulator.js',
     },
     {
       // why we use esm here: https://github.com/mui-org/material-ui/pull/13391#issuecomment-459692816


### PR DESCRIPTION
I have batched a few other small changes:

- [Table] Less project is better quality
- Optimize for esm
- Add 3 x $2/month backers
- [docs] Illustrate how to use a spacing array