### PR TITLE
[Popper] Fix popperOptions prop

### DIFF
--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -98,7 +98,7 @@ class Popper extends React.Component {
       // We could have been using a custom modifier like react-popper is doing.
       // But it seems this is the best public API for this use case.
       onCreate: createChainedFunction(this.handlePopperUpdate, popperOptions.onCreate),
-      onUpdate: createChainedFunction(this.handlePopperUpdate, popperOptions.onUpdate)
+      onUpdate: createChainedFunction(this.handlePopperUpdate, popperOptions.onUpdate),
     });
   };
 

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -4,6 +4,7 @@ import PopperJS from 'popper.js';
 import { chainPropTypes } from '@material-ui/utils';
 import Portal from '../Portal';
 import { setRef, withForwardedRef } from '../utils';
+import { createChainedFunction } from '../utils/helpers';
 
 function flipPlacement(placement) {
   const direction = (typeof window !== 'undefined' && document.body.getAttribute('dir')) || 'ltr';
@@ -96,8 +97,8 @@ class Popper extends React.Component {
       },
       // We could have been using a custom modifier like react-popper is doing.
       // But it seems this is the best public API for this use case.
-      onCreate: this.handlePopperUpdate,
-      onUpdate: this.handlePopperUpdate,
+      onCreate: createChainedFunction(this.handlePopperUpdate, popperOptions.onCreate),
+      onUpdate: createChainedFunction(this.handlePopperUpdate, popperOptions.onUpdate)
     });
   };
 

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -126,7 +126,7 @@ describe('<Popper />', () => {
   describe('prop: popperOptions', () => {
     const popperProps = {
       onCreate: spy(),
-      onUpdate: spy()
+      onUpdate: spy(),
     };
 
     it('should correctly pass down lifecycle callbacks to popperjs', () => {

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -123,6 +123,22 @@ describe('<Popper />', () => {
     });
   });
 
+  describe('prop: popperOptions', () => {
+    const popperProps = {
+      onCreate: spy(),
+      onUpdate: spy()
+    };
+
+    it('should correctly pass down lifecycle callbacks to popperjs', () => {
+      const wrapper = mount(<Popper {...defaultProps} popperOptions={popperProps} />);
+      const instance = wrapper.find('Popper').instance();
+      instance.popper.options.onCreate({ placement: '' });
+      instance.popper.options.onUpdate({ placement: '' });
+      assert.strictEqual(popperProps.onCreate.callCount, 1);
+      assert.strictEqual(popperProps.onUpdate.callCount, 1);
+    });
+  });
+
   describe('prop: keepMounted', () => {
     describe('by default', () => {
       // Test case for https://github.com/mui-org/material-ui/issues/15180

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -124,18 +124,16 @@ describe('<Popper />', () => {
   });
 
   describe('prop: popperOptions', () => {
-    const popperProps = {
-      onCreate: spy(),
-      onUpdate: spy(),
-    };
-
-    it('should correctly pass down lifecycle callbacks to popperjs', () => {
-      const wrapper = mount(<Popper {...defaultProps} popperOptions={popperProps} />);
-      const instance = wrapper.find('Popper').instance();
-      instance.popper.options.onCreate({ placement: '' });
-      instance.popper.options.onUpdate({ placement: '' });
-      assert.strictEqual(popperProps.onCreate.callCount, 1);
-      assert.strictEqual(popperProps.onUpdate.callCount, 1);
+    it('should pass all popperOptions to popperjs', done => {
+      const popperOptions = {
+        onCreate: data => {
+          data.instance.update({ placement: 'left' });
+        },
+        onUpdate: () => {
+          done();
+        },
+      };
+      mount(<Popper {...defaultProps} popperOptions={popperOptions} placement="top" open />);
     });
   });
 


### PR DESCRIPTION
Fixes popperjs options for onUpdate and onCreate that were being spread over in Popper component

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #15262