### PR TITLE
[docs] Expand demo by default instead of duplicating the code

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -99,7 +99,7 @@ const styles = theme => ({
 class Demo extends React.Component {
   state = {
     anchorEl: null,
-    codeOpen: false,
+    codeOpen: Boolean(this.props.demoOptions.defaultCodeOpen),
     demoHovered: false,
     sourceHintSeen: false,
   };

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -21,25 +21,7 @@ It's important to understand that this package exposes pure (side-effect free) s
 In the rest of this *Getting Started* section we are using **styled-components** as the reference example (to emphasize the universality of this package). Alternatively, you can [use JSS](#interoperability).
 The demos are also based on the **default** Material-UI [theme object](/customization/default-theme/).
 
-```jsx
-import { palette, spacing, typography } from '@material-ui/system';
-import styled from 'styled-components';
-
-const Box = styled.div`${palette}${spacing}${typography}`;
-// or import Box from '@material-ui/core/Box';
-
-<Box
-  color="primary.main"
-  bgcolor="background.paper"
-  fontFamily="h6.fontFamily"
-  fontSize={{ xs: 'h6.fontSize', sm: 'h4.fontSize', md: 'h3.fontSize' } }
-  p={{ xs: 2, sm: 3, md: 4} }
->
-  @material-ui/system
-</Box>
-```
-
-{{"demo": "pages/system/basics/Demo.js"}}
+{{"demo": "pages/system/basics/Demo.js", "defaultCodeOpen": true}}
 
 ### Installation
 
@@ -142,36 +124,15 @@ If you are already using `@material-ui/core`, we encourage you to start with the
 
 ### JSS
 
-```jsx
-import { palette, spacing, compose } from '@material-ui/system';
-import { styled } from '@material-ui/styles';
-
-const Box = styled(compose(spacing, palette));
-```
-
-{{"demo": "pages/system/basics/JSS.js"}}
+{{"demo": "pages/system/basics/JSS.js", "defaultCodeOpen": true}}
 
 ### Styled components
 
-```jsx
-import { palette, spacing } from '@material-ui/system';
-import styled from 'styled-components';
-
-const Box = styled.div`${palette}${spacing}`;
-```
-
-{{"demo": "pages/system/basics/StyledComponents.js"}}
+{{"demo": "pages/system/basics/StyledComponents.js", "defaultCodeOpen": true}}
 
 ### Emotion
 
-```jsx
-import { spacing, palette } from '@material-ui/system';
-import styled from '@emotion/styled';
-
-const Box = styled.div`${palette}${spacing}`;
-```
-
-{{"demo": "pages/system/basics/Emotion.js"}}
+{{"demo": "pages/system/basics/Emotion.js", "defaultCodeOpen": true}}
 
 ## Responsive
 
@@ -335,68 +296,14 @@ const palette = compose(textColor, bgcolor);
 The `style()` helper can also be used to maps properties to style objects in a theme.
 In this example, the `variant` property supports all the keys present in `theme.typography`.
 
-```jsx
-import React from 'react';
-import styled, { ThemeProvider } from 'styled-components';
-import { style, typography } from '@material-ui/system';
-
-const variant = style({
-  prop: 'variant',
-  cssProperty: false,
-  themeKey: 'typography',
-});
-
-// ⚠ Text is already defined in the global context:
-// https://developer.mozilla.org/en-US/docs/Web/API/Text/Text.
-const Text = styled.span`
-  font-family: Helvetica;
-  ${variant}
-  ${typography}
-`;
-
-const theme = {
-  typography: {
-    h1: {
-      fontSize: 30,
-      lineHeight: 1.5,
-    },
-    h2: {
-      fontSize: 25,
-      lineHeight: 1.5,
-    },
-  },
-};
-
-// Renders the theme.typography.h1 style object.
-<Text variant="h1">variant=h1</Text>
-```
-
-{{"demo": "pages/system/basics/Variant.js"}}
+{{"demo": "pages/system/basics/Variant.js", "defaultCodeOpen": true}}
 
 ## CSS property
 
 If you want to support custom CSS values, you can use our `css()` helper.
 It will process the `css` property.
 
-```jsx
-import { compose, spacing, palette, css } from '@material-ui/system';
-import styled from 'styled-components';
-
-const Box = styled.div`
-  ${css(
-    compose(
-      spacing,
-      palette,
-    ),
-  )}
-`;
-
-<Box color="white" css={{ bgcolor: 'palevioletred', p: 1, textTransform: 'uppercase' }}>
-  CssProp
-</Box>
-```
-
-{{"demo": "pages/system/basics/CssProp.js"}}
+{{"demo": "pages/system/basics/CssProp.js", "defaultCodeOpen": true}}
 
 ## How it works
 


### PR DESCRIPTION
This was mainly an issue with https://next.material-ui.com/system/basics/ where demo code became out-of-sync with the code in the markdown. When demo code is expanded we would end up with duplicate code.

I added a `defaultCodeOpen` demo option that can be used like any other demo option:
```diff
-{{"demo": "pages/system/basics/Demo.js"}}
+{{"demo": "pages/system/basics/Demo.js", "defaultCodeOpen": true}}
```

This exposes `NoSsr` usage in the demo code that was hidden in the usage example. @oliviertassinari Why do we need this and if so why did we not include this requirement? 