### PR TITLE
[Box] Test props to attributes forwarding

### DIFF
--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -33,20 +33,23 @@ describe('<Box />', () => {
     assert.strictEqual(wrapper.find('span').length, 1);
   });
 
-  it('forwards style props as DOM attributes', () => {
+  it('does not forward style props as DOM attributes', () => {
     const elementRef = React.createRef();
+    // need fragment so that enzyme doesn't add a wrapper component
     mount(
-      <Box
-        color="primary.main"
-        fontFamily="Comic Sans"
-        fontSize={{ xs: 'h6.fontSize', sm: 'h4.fontSize', md: 'h3.fontSize' }}
-        ref={elementRef}
-      />,
+      <React.Fragment>
+        <Box
+          color="primary.main"
+          fontFamily="Comic Sans"
+          fontSize={{ xs: 'h6.fontSize', sm: 'h4.fontSize', md: 'h3.fontSize' }}
+          ref={elementRef}
+        />
+      </React.Fragment>,
     );
 
     const { current: element } = elementRef;
-    assert.strictEqual(element.getAttribute('color'), 'primary.main');
-    assert.strictEqual(element.getAttribute('font-family'), 'Comic Sans');
-    assert.strictEqual(element.getAttribute('font-size'), '[object Object]');
+    assert.strictEqual(element.getAttribute('color'), null);
+    assert.strictEqual(element.getAttribute('font-family'), null);
+    assert.strictEqual(element.getAttribute('font-size'), null);
   });
 });

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -32,4 +32,21 @@ describe('<Box />', () => {
     assert.strictEqual(wrapper.contains(testChildren), true);
     assert.strictEqual(wrapper.find('span').length, 1);
   });
+
+  it('forwards style props as DOM attributes', () => {
+    const elementRef = React.createRef();
+    mount(
+      <Box
+        color="primary.main"
+        fontFamily="Comic Sans"
+        fontSize={{ xs: 'h6.fontSize', sm: 'h4.fontSize', md: 'h3.fontSize' }}
+        ref={elementRef}
+      />,
+    );
+
+    const { current: element } = elementRef;
+    assert.strictEqual(element.getAttribute('color'), 'primary.main');
+    assert.strictEqual(element.getAttribute('font-family'), 'Comic Sans');
+    assert.strictEqual(element.getAttribute('font-size'), '[object Object]');
+  });
 });


### PR DESCRIPTION
~This currently creates invalid HTML. Not sure if desired or not but the behavior should be documented in some form (e.g. a test).~

`Box` does not forward the props as DOM attributes.