### PR TITLE
[styles] Improve typings for makeStyles

### DIFF
--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -3,7 +3,6 @@ import {
   ClassNameMap,
   PropsOfStyles,
   Styles,
-  ThemeOfStyles,
   WithStylesOptions,
 } from '@material-ui/styles/withStyles';
 
@@ -70,7 +69,7 @@ export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> exten
   ? (props?: any) => ClassNameMap<ClassKeyOfStyles<S>>
   : (props: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
 
-export default function makeStyles<S extends Styles<any, any>>(
-  styles: S,
-  options?: WithStylesOptions<ThemeOfStyles<S>>,
-): StylesHook<S>;
+export default function makeStyles<C extends string, P extends {}, T = unknown>(
+  styles: Styles<T, P, C>,
+  options?: WithStylesOptions<T>,
+): StylesHook<Styles<T, P, C>>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -69,7 +69,11 @@ export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> exten
   ? (props?: any) => ClassNameMap<ClassKeyOfStyles<S>>
   : (props: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
 
-export default function makeStyles<C extends string, P extends {}, T = unknown>(
-  styles: Styles<T, P, C>,
-  options?: WithStylesOptions<T>,
-): StylesHook<Styles<T, P, C>>;
+export default function makeStyles<
+  Theme = unknown,
+  Props extends {} = {},
+  ClassKey extends string = string
+>(
+  styles: Styles<Theme, Props, ClassKey>,
+  options?: WithStylesOptions<Theme>,
+): StylesHook<Styles<Theme, Props, ClassKey>>;

--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -132,6 +132,21 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
       color: theme.palette.primary.main,
     }),
   }));
+
+  {
+    // If any generic is provided, inferrence breaks.
+    // If the proposal https://github.com/Microsoft/TypeScript/issues/26242 goes through, we can fix this.
+    const useStyles = makeStyles<Theme>(theme => ({
+      root: {
+        background: 'blue',
+      },
+    }));
+
+    const classes = useStyles();
+
+    // This doesn't fail, because inferrence is broken
+    classes.other;
+  }
 }
 
 // styled

--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -116,10 +116,6 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
       },
     });
 
-  makeStyles<typeof style>(style, {
-    defaultTheme: validCustomTheme,
-  });
-
   makeStyles(style, {
     defaultTheme: validCustomTheme,
   });
@@ -129,10 +125,13 @@ function testGetThemeProps(theme: Theme, props: AppBarProps): void {
     defaultTheme: invalidCustomTheme,
   });
 
-  // $ExpectError
-  makeStyles<typeof style>(style, {
-    defaultTheme: invalidCustomTheme,
-  });
+  // Use styles with props and theme without createStyles
+  makeStyles((theme: Theme) => ({
+    root: (props: StyleProps) => ({
+      background: props.color,
+      color: theme.palette.primary.main,
+    }),
+  }));
 }
 
 // styled


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This PR makes typings smarter for `makeStyles`, so you get autocompletion of CSS properties as requested in #14872.

A slight breaking changes is that you can no longer pass in `typeof styles` as a generic, though not sure why/if this was needed. 

Since TypeScript currently does not support partial inferrence of generics, all generics must be unspecified to get full strong typing of both props and classkeys.

Both Props and Theme can be specified in their respective lambdas:

```typescript
const useStyles = makeStyles((theme: CustomTheme) => ({
  root: (props: CustomProps) => ({
    background: props.background,
    color: theme.palette.primary.main
  })
})
```