### PR TITLE
[docs] Improve the customization demos

### DIFF
--- a/docs/src/pages/demos/badges/CustomizedBadge.js
+++ b/docs/src/pages/demos/badges/CustomizedBadge.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
-import { makeStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 
-const useStyles = makeStyles(theme => ({
+const StyledBadge = withStyles(theme => ({
   badge: {
     top: '50%',
     right: -3,
@@ -13,16 +13,14 @@ const useStyles = makeStyles(theme => ({
       theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
     }`,
   },
-}));
+}))(Badge);
 
 function CustomizedBadge() {
-  const classes = useStyles();
-
   return (
     <IconButton aria-label="Cart">
-      <Badge badgeContent={4} color="primary" classes={{ badge: classes.badge }}>
+      <StyledBadge badgeContent={4} color="primary">
         <ShoppingCartIcon />
-      </Badge>
+      </StyledBadge>
     </IconButton>
   );
 }

--- a/docs/src/pages/demos/badges/CustomizedBadge.tsx
+++ b/docs/src/pages/demos/badges/CustomizedBadge.tsx
@@ -1,30 +1,26 @@
 import React from 'react';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { withStyles, Theme } from '@material-ui/core/styles';
 import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    badge: {
-      top: '50%',
-      right: -3,
-      // The border color match the background color.
-      border: `2px solid ${
-        theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
-      }`,
-    },
-  }),
-);
+const StyledBadge = withStyles((theme: Theme) => ({
+  badge: {
+    top: '50%',
+    right: -3,
+    // The border color match the background color.
+    border: `2px solid ${
+      theme.palette.type === 'light' ? theme.palette.grey[200] : theme.palette.grey[900]
+    }`,
+  },
+}))(Badge);
 
 function CustomizedBadge() {
-  const classes = useStyles();
-
   return (
     <IconButton aria-label="Cart">
-      <Badge badgeContent={4} color="primary" classes={{ badge: classes.badge }}>
+      <StyledBadge badgeContent={4} color="primary">
         <ShoppingCartIcon />
-      </Badge>
+      </StyledBadge>
     </IconButton>
   );
 }

--- a/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.js
+++ b/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.js
@@ -22,7 +22,7 @@ const StyledBreadcrumb = withStyles(theme => ({
       backgroundColor: emphasize(theme.palette.grey[300], 0.12),
     },
   },
-}))(props => <Chip {...props} />);
+}))(Chip); // TypeScript only: need a type cast here because https://github.com/Microsoft/TypeScript/issues/26591
 
 function handleClick(event) {
   event.preventDefault();
@@ -45,7 +45,7 @@ function CustomizedBreadcrumbs() {
   return (
     <Paper elevation={0} className={classes.root}>
       <Breadcrumbs aria-label="Breadcrumb">
-        <StyledBreadcrumb
+        <Chip
           component="a"
           href="#"
           label="Home"

--- a/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.js
+++ b/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, makeStyles } from '@material-ui/core/styles';
 import { emphasize } from '@material-ui/core/styles/colorManipulator';
 import Paper from '@material-ui/core/Paper';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
@@ -9,11 +8,8 @@ import Avatar from '@material-ui/core/Avatar';
 import HomeIcon from '@material-ui/icons/Home';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
-const styles = theme => ({
+const StyledBreadcrumb = withStyles(theme => ({
   root: {
-    padding: theme.spacing(1),
-  },
-  chip: {
     backgroundColor: theme.palette.grey[100],
     height: 24,
     color: theme.palette.grey[800],
@@ -26,30 +22,25 @@ const styles = theme => ({
       backgroundColor: emphasize(theme.palette.grey[300], 0.12),
     },
   },
-  avatar: {
-    background: 'none',
-    marginRight: -theme.spacing(1.5),
-  },
-});
+}))(props => <Chip {...props} />);
 
 function handleClick(event) {
   event.preventDefault();
   alert('You clicked a breadcrumb.'); // eslint-disable-line no-alert
 }
 
-function CustomBreadcrumb(props) {
-  const { classes, ...rest } = props;
-  return <Chip className={classes.chip} {...rest} />;
-}
+const useStyles = makeStyles(theme => ({
+  root: {
+    padding: theme.spacing(1),
+  },
+  avatar: {
+    background: 'none',
+    marginRight: -theme.spacing(1.5),
+  },
+}));
 
-CustomBreadcrumb.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-const StyledBreadcrumb = withStyles(styles)(CustomBreadcrumb);
-
-function CustomizedBreadcrumbs(props) {
-  const { classes } = props;
+function CustomizedBreadcrumbs() {
+  const classes = useStyles();
 
   return (
     <Paper elevation={0} className={classes.root}>
@@ -77,8 +68,4 @@ function CustomizedBreadcrumbs(props) {
   );
 }
 
-CustomizedBreadcrumbs.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(CustomizedBreadcrumbs);
+export default CustomizedBreadcrumbs;

--- a/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.js
+++ b/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.js
@@ -45,7 +45,7 @@ function CustomizedBreadcrumbs() {
   return (
     <Paper elevation={0} className={classes.root}>
       <Breadcrumbs aria-label="Breadcrumb">
-        <Chip
+        <StyledBreadcrumb
           component="a"
           href="#"
           label="Home"

--- a/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.tsx
+++ b/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, Theme, createStyles, WithStyles } from '@material-ui/core/styles';
+import { withStyles, makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import { emphasize } from '@material-ui/core/styles/colorManipulator';
 import Paper from '@material-ui/core/Paper';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
@@ -9,52 +8,41 @@ import Avatar from '@material-ui/core/Avatar';
 import HomeIcon from '@material-ui/icons/Home';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
-interface CustomBreadcrumbProps extends WithStyles<typeof styles> {}
+const StyledBreadcrumb = withStyles((theme: Theme) => ({
+  root: {
+    backgroundColor: theme.palette.grey[100],
+    height: 24,
+    color: theme.palette.grey[800],
+    fontWeight: theme.typography.fontWeightRegular,
+    '&:hover, &:focus': {
+      backgroundColor: theme.palette.grey[300],
+    },
+    '&:active': {
+      boxShadow: theme.shadows[1],
+      backgroundColor: emphasize(theme.palette.grey[300], 0.12),
+    },
+  },
+}))((props: any) => <Chip {...props} />);
 
-interface CustomizedBreadcrumbsProps extends WithStyles<typeof styles> {}
+function handleClick(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+  event.preventDefault();
+  alert('You clicked a breadcrumb.'); // eslint-disable-line no-alert
+}
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       padding: theme.spacing(1),
-    },
-    chip: {
-      backgroundColor: theme.palette.grey[100],
-      height: 24,
-      color: theme.palette.grey[800],
-      fontWeight: theme.typography.fontWeightRegular,
-      '&:hover, &:focus': {
-        backgroundColor: theme.palette.grey[300],
-      },
-      '&:active': {
-        boxShadow: theme.shadows[1],
-        backgroundColor: emphasize(theme.palette.grey[300], 0.12),
-      },
     },
     avatar: {
       background: 'none',
       marginRight: -theme.spacing(1.5),
     },
-  });
+  }),
+);
 
-function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
-  event.preventDefault();
-  alert('You clicked a breadcrumb.'); // eslint-disable-line no-alert
-}
-
-function CustomBreadcrumb(props: CustomBreadcrumbProps) {
-  const { classes, ...rest } = props;
-  return <Chip className={classes.chip} {...rest} />;
-}
-
-CustomBreadcrumb.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-const StyledBreadcrumb = withStyles(styles)(CustomBreadcrumb);
-
-function CustomizedBreadcrumbs(props: CustomizedBreadcrumbsProps) {
-  const { classes } = props;
+function CustomizedBreadcrumbs() {
+  const classes = useStyles();
 
   return (
     <Paper elevation={0} className={classes.root}>
@@ -82,8 +70,4 @@ function CustomizedBreadcrumbs(props: CustomizedBreadcrumbsProps) {
   );
 }
 
-CustomizedBreadcrumbs.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(CustomizedBreadcrumbs);
+export default CustomizedBreadcrumbs;

--- a/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.tsx
+++ b/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.tsx
@@ -47,7 +47,7 @@ function CustomizedBreadcrumbs() {
   return (
     <Paper elevation={0} className={classes.root}>
       <Breadcrumbs aria-label="Breadcrumb">
-        <Chip
+        <StyledBreadcrumb
           component="a"
           href="#"
           label="Home"

--- a/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.tsx
+++ b/docs/src/pages/demos/breadcrumbs/CustomizedBreadcrumbs.tsx
@@ -22,9 +22,9 @@ const StyledBreadcrumb = withStyles((theme: Theme) => ({
       backgroundColor: emphasize(theme.palette.grey[300], 0.12),
     },
   },
-}))((props: any) => <Chip {...props} />);
+}))(Chip) as typeof Chip; // TypeScript only: need a type cast here because https://github.com/Microsoft/TypeScript/issues/26591
 
-function handleClick(event: React.MouseEvent<HTMLDivElement, MouseEvent>) {
+function handleClick(event: React.MouseEvent<Element, MouseEvent>) {
   event.preventDefault();
   alert('You clicked a breadcrumb.'); // eslint-disable-line no-alert
 }
@@ -47,7 +47,7 @@ function CustomizedBreadcrumbs() {
   return (
     <Paper elevation={0} className={classes.root}>
       <Breadcrumbs aria-label="Breadcrumb">
-        <StyledBreadcrumb
+        <Chip
           component="a"
           href="#"
           label="Home"

--- a/docs/src/pages/demos/buttons/CustomizedButtons.js
+++ b/docs/src/pages/demos/buttons/CustomizedButtons.js
@@ -1,23 +1,12 @@
 import React from 'react';
-import clsx from 'clsx';
-import { createMuiTheme, makeStyles } from '@material-ui/core/styles';
+import { createMuiTheme, withStyles, makeStyles } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const useStyles = makeStyles(theme => ({
-  margin: {
-    margin: theme.spacing(1),
-  },
-  cssRoot: {
-    color: theme.palette.getContrastText(purple[500]),
-    backgroundColor: purple[500],
-    '&:hover': {
-      backgroundColor: purple[700],
-    },
-  },
-  bootstrapRoot: {
+const BootstrapButton = withStyles({
+  root: {
     boxShadow: 'none',
     textTransform: 'none',
     fontSize: 16,
@@ -51,6 +40,22 @@ const useStyles = makeStyles(theme => ({
       boxShadow: '0 0 0 0.2rem rgba(0,123,255,.5)',
     },
   },
+})(Button);
+
+const ColorButton = withStyles(theme => ({
+  root: {
+    color: theme.palette.getContrastText(purple[500]),
+    backgroundColor: purple[500],
+    '&:hover': {
+      backgroundColor: purple[700],
+    },
+  },
+}))(Button);
+
+const useStyles = makeStyles(theme => ({
+  margin: {
+    margin: theme.spacing(1),
+  },
 }));
 
 const theme = createMuiTheme({
@@ -64,22 +69,17 @@ function CustomizedButtons() {
 
   return (
     <div>
-      <Button variant="contained" color="primary" className={clsx(classes.margin, classes.cssRoot)}>
+      <ColorButton variant="contained" color="primary" className={classes.margin}>
         Custom CSS
-      </Button>
+      </ColorButton>
       <ThemeProvider theme={theme}>
         <Button variant="contained" color="primary" className={classes.margin}>
-          ThemeProvider
+          Theme Provider
         </Button>
       </ThemeProvider>
-      <Button
-        variant="contained"
-        color="primary"
-        disableRipple
-        className={clsx(classes.margin, classes.bootstrapRoot)}
-      >
+      <BootstrapButton variant="contained" color="primary" disableRipple className={classes.margin}>
         Bootstrap
-      </Button>
+      </BootstrapButton>
     </div>
   );
 }

--- a/docs/src/pages/demos/buttons/CustomizedButtons.tsx
+++ b/docs/src/pages/demos/buttons/CustomizedButtons.tsx
@@ -1,56 +1,67 @@
 import React from 'react';
-import clsx from 'clsx';
-import { createMuiTheme, createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import {
+  createMuiTheme,
+  createStyles,
+  withStyles,
+  makeStyles,
+  Theme,
+} from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
+const BootstrapButton = withStyles({
+  root: {
+    boxShadow: 'none',
+    textTransform: 'none',
+    fontSize: 16,
+    padding: '6px 12px',
+    border: '1px solid',
+    lineHeight: 1.5,
+    backgroundColor: '#007bff',
+    borderColor: '#007bff',
+    fontFamily: [
+      '-apple-system',
+      'BlinkMacSystemFont',
+      '"Segoe UI"',
+      'Roboto',
+      '"Helvetica Neue"',
+      'Arial',
+      'sans-serif',
+      '"Apple Color Emoji"',
+      '"Segoe UI Emoji"',
+      '"Segoe UI Symbol"',
+    ].join(','),
+    '&:hover': {
+      backgroundColor: '#0069d9',
+      borderColor: '#0062cc',
+    },
+    '&:active': {
+      boxShadow: 'none',
+      backgroundColor: '#0062cc',
+      borderColor: '#005cbf',
+    },
+    '&:focus': {
+      boxShadow: '0 0 0 0.2rem rgba(0,123,255,.5)',
+    },
+  },
+})(Button);
+
+const ColorButton = withStyles((theme: Theme) => ({
+  root: {
+    color: theme.palette.getContrastText(purple[500]),
+    backgroundColor: purple[500],
+    '&:hover': {
+      backgroundColor: purple[700],
+    },
+  },
+}))(Button);
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     margin: {
       margin: theme.spacing(1),
-    },
-    cssRoot: {
-      color: theme.palette.getContrastText(purple[500]),
-      backgroundColor: purple[500],
-      '&:hover': {
-        backgroundColor: purple[700],
-      },
-    },
-    bootstrapRoot: {
-      boxShadow: 'none',
-      textTransform: 'none',
-      fontSize: 16,
-      padding: '6px 12px',
-      border: '1px solid',
-      lineHeight: 1.5,
-      backgroundColor: '#007bff',
-      borderColor: '#007bff',
-      fontFamily: [
-        '-apple-system',
-        'BlinkMacSystemFont',
-        '"Segoe UI"',
-        'Roboto',
-        '"Helvetica Neue"',
-        'Arial',
-        'sans-serif',
-        '"Apple Color Emoji"',
-        '"Segoe UI Emoji"',
-        '"Segoe UI Symbol"',
-      ].join(','),
-      '&:hover': {
-        backgroundColor: '#0069d9',
-        borderColor: '#0062cc',
-      },
-      '&:active': {
-        boxShadow: 'none',
-        backgroundColor: '#0062cc',
-        borderColor: '#005cbf',
-      },
-      '&:focus': {
-        boxShadow: '0 0 0 0.2rem rgba(0,123,255,.5)',
-      },
     },
   }),
 );
@@ -66,22 +77,17 @@ function CustomizedButtons() {
 
   return (
     <div>
-      <Button variant="contained" color="primary" className={clsx(classes.margin, classes.cssRoot)}>
+      <ColorButton variant="contained" color="primary" className={classes.margin}>
         Custom CSS
-      </Button>
+      </ColorButton>
       <ThemeProvider theme={theme}>
         <Button variant="contained" color="primary" className={classes.margin}>
-          ThemeProvider
+          Theme Provider
         </Button>
       </ThemeProvider>
-      <Button
-        variant="contained"
-        color="primary"
-        disableRipple
-        className={clsx(classes.margin, classes.bootstrapRoot)}
-      >
+      <BootstrapButton variant="contained" color="primary" disableRipple className={classes.margin}>
         Bootstrap
-      </Button>
+      </BootstrapButton>
     </div>
   );
 }

--- a/docs/src/pages/demos/dialogs/CustomizedDialog.tsx
+++ b/docs/src/pages/demos/dialogs/CustomizedDialog.tsx
@@ -43,13 +43,13 @@ const DialogTitle = withStyles(styles)((props: DialogTitleProps) => {
   );
 });
 
-const DialogContent = withStyles(theme => ({
+const DialogContent = withStyles((theme: Theme) => ({
   root: {
     padding: theme.spacing(2),
   },
 }))(MuiDialogContent);
 
-const DialogActions = withStyles(theme => ({
+const DialogActions = withStyles((theme: Theme) => ({
   root: {
     margin: 0,
     padding: theme.spacing(1),

--- a/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.js
+++ b/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.js
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography';
 
 const ExpansionPanel = withStyles({
   root: {
-    border: '1px solid rgba(0,0,0,.125)',
+    border: '1px solid rgba(0, 0, 0, .125)',
     boxShadow: 'none',
     '&:not(:last-child)': {
       borderBottom: 0,
@@ -15,16 +15,17 @@ const ExpansionPanel = withStyles({
     '&:before': {
       display: 'none',
     },
+    '&$expanded': {
+      margin: 'auto',
+    },
   },
-  expanded: {
-    margin: 'auto',
-  },
+  expanded: {},
 })(MuiExpansionPanel);
 
 const ExpansionPanelSummary = withStyles({
   root: {
-    backgroundColor: 'rgba(0,0,0,.03)',
-    borderBottom: '1px solid rgba(0,0,0,.125)',
+    backgroundColor: 'rgba(0, 0, 0, .03)',
+    borderBottom: '1px solid rgba(0, 0, 0, .125)',
     marginBottom: -1,
     minHeight: 56,
     '&$expanded': {
@@ -45,72 +46,53 @@ const ExpansionPanelDetails = withStyles(theme => ({
   },
 }))(MuiExpansionPanelDetails);
 
-class CustomizedExpansionPanel extends React.Component {
-  state = {
-    expanded: 'panel1',
+function CustomizedExpansionPanel() {
+  const [expanded, setExpanded] = React.useState('panel1');
+
+  const handleChange = panel => (event, newExpanded) => {
+    setExpanded(newExpanded ? panel : false);
   };
 
-  handleChange = panel => (event, expanded) => {
-    this.setState({
-      expanded: expanded ? panel : false,
-    });
-  };
-
-  render() {
-    const { expanded } = this.state;
-    return (
-      <div>
-        <ExpansionPanel
-          square
-          expanded={expanded === 'panel1'}
-          onChange={this.handleChange('panel1')}
-        >
-          <ExpansionPanelSummary aria-controls="panel1d-content" id="panel1d-header">
-            <Typography>Collapsible Group Item #1</Typography>
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus
-              ex, sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur
-              adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
-            </Typography>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
-        <ExpansionPanel
-          square
-          expanded={expanded === 'panel2'}
-          onChange={this.handleChange('panel2')}
-        >
-          <ExpansionPanelSummary aria-controls="panel2d-content" id="panel2d-header">
-            <Typography>Collapsible Group Item #2</Typography>
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus
-              ex, sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur
-              adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
-            </Typography>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
-        <ExpansionPanel
-          square
-          expanded={expanded === 'panel3'}
-          onChange={this.handleChange('panel3')}
-        >
-          <ExpansionPanelSummary aria-controls="panel3d-content" id="panel3d-header">
-            <Typography>Collapsible Group Item #3</Typography>
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus
-              ex, sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur
-              adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
-            </Typography>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
-      </div>
-    );
-  }
+  return (
+    <div>
+      <ExpansionPanel square expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>
+        <ExpansionPanelSummary aria-controls="panel1d-content" id="panel1d-header">
+          <Typography>Collapsible Group Item #1</Typography>
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+      <ExpansionPanel square expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
+        <ExpansionPanelSummary aria-controls="panel2d-content" id="panel2d-header">
+          <Typography>Collapsible Group Item #2</Typography>
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+      <ExpansionPanel square expanded={expanded === 'panel3'} onChange={handleChange('panel3')}>
+        <ExpansionPanelSummary aria-controls="panel3d-content" id="panel3d-header">
+          <Typography>Collapsible Group Item #3</Typography>
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+    </div>
+  );
 }
 
 export default CustomizedExpansionPanel;

--- a/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.tsx
+++ b/docs/src/pages/demos/expansion-panels/CustomizedExpansionPanel.tsx
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography';
 
 const ExpansionPanel = withStyles({
   root: {
-    border: '1px solid rgba(0,0,0,.125)',
+    border: '1px solid rgba(0, 0, 0, .125)',
     boxShadow: 'none',
     '&:not(:last-child)': {
       borderBottom: 0,
@@ -15,16 +15,17 @@ const ExpansionPanel = withStyles({
     '&:before': {
       display: 'none',
     },
+    '&$expanded': {
+      margin: 'auto',
+    },
   },
-  expanded: {
-    margin: 'auto',
-  },
+  expanded: {},
 })(MuiExpansionPanel);
 
 const ExpansionPanelSummary = withStyles({
   root: {
-    backgroundColor: 'rgba(0,0,0,.03)',
-    borderBottom: '1px solid rgba(0,0,0,.125)',
+    backgroundColor: 'rgba(0, 0, 0, .03)',
+    borderBottom: '1px solid rgba(0, 0, 0, .125)',
     marginBottom: -1,
     minHeight: 56,
     '&$expanded': {
@@ -49,72 +50,53 @@ interface CustomizedExpansionPanelStates {
   expanded: string | boolean;
 }
 
-class CustomizedExpansionPanel extends React.Component<{}, CustomizedExpansionPanelStates> {
-  state = {
-    expanded: 'panel1',
+function CustomizedExpansionPanel() {
+  const [expanded, setExpanded] = React.useState<string | false>('panel1');
+
+  const handleChange = (panel: string) => (event: React.ChangeEvent<{}>, newExpanded: boolean) => {
+    setExpanded(newExpanded ? panel : false);
   };
 
-  handleChange = (panel: string) => (event: React.ChangeEvent<{}>, expanded: boolean) => {
-    this.setState({
-      expanded: expanded ? panel : false,
-    });
-  };
-
-  render() {
-    const { expanded } = this.state;
-    return (
-      <div>
-        <ExpansionPanel
-          square
-          expanded={expanded === 'panel1'}
-          onChange={this.handleChange('panel1')}
-        >
-          <ExpansionPanelSummary aria-controls="panel1d-content" id="panel1d-header">
-            <Typography>Collapsible Group Item #1</Typography>
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus
-              ex, sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur
-              adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
-            </Typography>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
-        <ExpansionPanel
-          square
-          expanded={expanded === 'panel2'}
-          onChange={this.handleChange('panel2')}
-        >
-          <ExpansionPanelSummary aria-controls="panel2d-content" id="panel2d-header">
-            <Typography>Collapsible Group Item #2</Typography>
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus
-              ex, sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur
-              adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
-            </Typography>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
-        <ExpansionPanel
-          square
-          expanded={expanded === 'panel3'}
-          onChange={this.handleChange('panel3')}
-        >
-          <ExpansionPanelSummary aria-controls="panel3d-content" id="panel3d-header">
-            <Typography>Collapsible Group Item #3</Typography>
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            <Typography>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus
-              ex, sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur
-              adipiscing elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
-            </Typography>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
-      </div>
-    );
-  }
+  return (
+    <div>
+      <ExpansionPanel square expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>
+        <ExpansionPanelSummary aria-controls="panel1d-content" id="panel1d-header">
+          <Typography>Collapsible Group Item #1</Typography>
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+      <ExpansionPanel square expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
+        <ExpansionPanelSummary aria-controls="panel2d-content" id="panel2d-header">
+          <Typography>Collapsible Group Item #2</Typography>
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+      <ExpansionPanel square expanded={expanded === 'panel3'} onChange={handleChange('panel3')}>
+        <ExpansionPanelSummary aria-controls="panel3d-content" id="panel3d-header">
+          <Typography>Collapsible Group Item #3</Typography>
+        </ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <Typography>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse malesuada lacus ex,
+            sit amet blandit leo lobortis eget. Lorem ipsum dolor sit amet, consectetur adipiscing
+            elit. Suspendisse malesuada lacus ex, sit amet blandit leo lobortis eget.
+          </Typography>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+    </div>
+  );
 }
 
 export default CustomizedExpansionPanel;

--- a/docs/src/pages/demos/progress/CustomizedProgress.js
+++ b/docs/src/pages/demos/progress/CustomizedProgress.js
@@ -1,93 +1,93 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { lighten } from '@material-ui/core/styles/colorManipulator';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import Paper from '@material-ui/core/Paper';
 import LinearProgress from '@material-ui/core/LinearProgress';
 
-const styles = theme => ({
+const ColorCircularProgress = withStyles({
   root: {
-    flexGrow: 1,
-  },
-  progress: {
-    margin: theme.spacing(2),
     color: '#00695c',
   },
-  linearColorPrimary: {
+})(CircularProgress);
+
+const ColorLinearProgress = withStyles({
+  colorPrimary: {
     backgroundColor: '#b2dfdb',
   },
-  linearBarColorPrimary: {
+  barColorPrimary: {
     backgroundColor: '#00695c',
   },
-  linearProgressDeterminate: {
-    margin: `${theme.spacing(1)}px auto 0`,
+})(LinearProgress);
+
+const BorderLinearProgress = withStyles({
+  root: {
     height: 10,
     backgroundColor: lighten('#ff6c5c', 0.5),
   },
-  linearProgressDeterminateBar: {
+  bar: {
     borderRadius: 20,
     backgroundColor: '#ff6c5c',
   },
-  // Reproduce the Facebook spinners.
-  facebook: {
-    margin: theme.spacing(2),
+})(LinearProgress);
+
+// Inspired by the Facebook spinners.
+const FacebookProgress = withStyles({
+  root: {
     position: 'relative',
   },
-  facebook1: {
+  top: {
     color: '#eef3fd',
   },
-  facebook2: {
+  bottom: {
     color: '#6798e5',
     animationDuration: '550ms',
     position: 'absolute',
     left: 0,
   },
-});
+})(({ classes, ...props }) => (
+  <div className={classes.root} {...props}>
+    <CircularProgress
+      variant="determinate"
+      value={100}
+      className={classes.top}
+      size={24}
+      thickness={4}
+    />
+    <CircularProgress
+      variant="indeterminate"
+      disableShrink
+      className={classes.bottom}
+      size={24}
+      thickness={4}
+    />
+  </div>
+));
 
-function CustomizedProgress(props) {
-  const { classes } = props;
+const useStyles = makeStyles(theme => ({
+  root: {
+    flexGrow: 1,
+  },
+  margin: {
+    margin: theme.spacing(1),
+  },
+}));
+
+function CustomizedProgress() {
+  const classes = useStyles();
 
   return (
-    <Paper className={classes.root}>
-      <CircularProgress className={classes.progress} size={30} thickness={5} />
-      <LinearProgress
-        classes={{
-          colorPrimary: classes.linearColorPrimary,
-          barColorPrimary: classes.linearBarColorPrimary,
-        }}
-      />
-      <LinearProgress
+    <div className={classes.root}>
+      <ColorCircularProgress size={30} thickness={5} />
+      <ColorLinearProgress className={classes.margin} />
+      <BorderLinearProgress
+        className={classes.margin}
         variant="determinate"
         color="secondary"
         value={50}
-        classes={{
-          root: classes.linearProgressDeterminate,
-          bar: classes.linearProgressDeterminateBar,
-        }}
       />
-      <div className={classes.facebook}>
-        <CircularProgress
-          variant="determinate"
-          value={100}
-          className={classes.facebook1}
-          size={24}
-          thickness={4}
-        />
-        <CircularProgress
-          variant="indeterminate"
-          disableShrink
-          className={classes.facebook2}
-          size={24}
-          thickness={4}
-        />
-      </div>
-    </Paper>
+      <FacebookProgress />
+    </div>
   );
 }
 
-CustomizedProgress.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(CustomizedProgress);
+export default CustomizedProgress;

--- a/docs/src/pages/demos/progress/CustomizedProgress.js
+++ b/docs/src/pages/demos/progress/CustomizedProgress.js
@@ -31,7 +31,7 @@ const BorderLinearProgress = withStyles({
 })(LinearProgress);
 
 // Inspired by the Facebook spinners.
-const FacebookProgress = withStyles({
+const useStylesFacebook = makeStyles({
   root: {
     position: 'relative',
   },
@@ -44,24 +44,32 @@ const FacebookProgress = withStyles({
     position: 'absolute',
     left: 0,
   },
-})(({ classes, ...props }) => (
-  <div className={classes.root} {...props}>
-    <CircularProgress
-      variant="determinate"
-      value={100}
-      className={classes.top}
-      size={24}
-      thickness={4}
-    />
-    <CircularProgress
-      variant="indeterminate"
-      disableShrink
-      className={classes.bottom}
-      size={24}
-      thickness={4}
-    />
-  </div>
-));
+});
+
+function FacebookProgress(props) {
+  const classes = useStylesFacebook();
+
+  return (
+    <div className={classes.root}>
+      <CircularProgress
+        variant="determinate"
+        value={100}
+        className={classes.top}
+        size={24}
+        thickness={4}
+        {...props}
+      />
+      <CircularProgress
+        variant="indeterminate"
+        disableShrink
+        className={classes.bottom}
+        size={24}
+        thickness={4}
+        {...props}
+      />
+    </div>
+  );
+}
 
 const useStyles = makeStyles(theme => ({
   root: {

--- a/docs/src/pages/demos/progress/CustomizedProgress.tsx
+++ b/docs/src/pages/demos/progress/CustomizedProgress.tsx
@@ -1,96 +1,95 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
 import { lighten } from '@material-ui/core/styles/colorManipulator';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import Paper from '@material-ui/core/Paper';
 import LinearProgress from '@material-ui/core/LinearProgress';
 
-const styles = (theme: Theme) =>
+const ColorCircularProgress = withStyles({
+  root: {
+    color: '#00695c',
+  },
+})(CircularProgress);
+
+const ColorLinearProgress = withStyles({
+  colorPrimary: {
+    backgroundColor: '#b2dfdb',
+  },
+  barColorPrimary: {
+    backgroundColor: '#00695c',
+  },
+})(LinearProgress);
+
+const BorderLinearProgress = withStyles({
+  root: {
+    height: 10,
+    backgroundColor: lighten('#ff6c5c', 0.5),
+  },
+  bar: {
+    borderRadius: 20,
+    backgroundColor: '#ff6c5c',
+  },
+})(LinearProgress);
+
+// Inspired by the Facebook spinners.
+const FacebookProgress = withStyles({
+  root: {
+    position: 'relative',
+  },
+  top: {
+    color: '#eef3fd',
+  },
+  bottom: {
+    color: '#6798e5',
+    animationDuration: '550ms',
+    position: 'absolute',
+    left: 0,
+  },
+})(({ classes, ...props }: any) => (
+  <div className={classes.root} {...props}>
+    <CircularProgress
+      variant="determinate"
+      value={100}
+      className={classes.top}
+      size={24}
+      thickness={4}
+    />
+    <CircularProgress
+      variant="indeterminate"
+      disableShrink
+      className={classes.bottom}
+      size={24}
+      thickness={4}
+    />
+  </div>
+));
+
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexGrow: 1,
     },
-    progress: {
-      margin: theme.spacing(2),
-      color: '#00695c',
+    margin: {
+      margin: theme.spacing(1),
     },
-    linearColorPrimary: {
-      backgroundColor: '#b2dfdb',
-    },
-    linearBarColorPrimary: {
-      backgroundColor: '#00695c',
-    },
-    linearProgressDeterminate: {
-      margin: `${theme.spacing(1)}px auto 0`,
-      height: 10,
-      backgroundColor: lighten('#ff6c5c', 0.5),
-    },
-    linearProgressDeterminateBar: {
-      borderRadius: 20,
-      backgroundColor: '#ff6c5c',
-    },
-    // Reproduce the Facebook spinners.
-    facebook: {
-      margin: theme.spacing(2),
-      position: 'relative',
-    },
-    facebook1: {
-      color: '#eef3fd',
-    },
-    facebook2: {
-      color: '#6798e5',
-      animationDuration: '550ms',
-      position: 'absolute',
-      left: 0,
-    },
-  });
+  }),
+);
 
-export type Props = WithStyles<typeof styles>;
-
-function CustomizedProgress(props: Props) {
-  const { classes } = props;
+function CustomizedProgress() {
+  const classes = useStyles();
 
   return (
-    <Paper className={classes.root}>
-      <CircularProgress className={classes.progress} size={30} thickness={5} />
-      <LinearProgress
-        classes={{
-          colorPrimary: classes.linearColorPrimary,
-          barColorPrimary: classes.linearBarColorPrimary,
-        }}
-      />
-      <LinearProgress
+    <div className={classes.root}>
+      <ColorCircularProgress size={30} thickness={5} />
+      <ColorLinearProgress className={classes.margin} />
+      <BorderLinearProgress
+        className={classes.margin}
         variant="determinate"
         color="secondary"
         value={50}
-        classes={{
-          root: classes.linearProgressDeterminate,
-          bar: classes.linearProgressDeterminateBar,
-        }}
       />
-      <div className={classes.facebook}>
-        <CircularProgress
-          variant="determinate"
-          value={100}
-          className={classes.facebook1}
-          size={24}
-          thickness={4}
-        />
-        <CircularProgress
-          variant="indeterminate"
-          disableShrink
-          className={classes.facebook2}
-          size={24}
-          thickness={4}
-        />
-      </div>
-    </Paper>
+      <FacebookProgress />
+    </div>
   );
 }
 
-CustomizedProgress.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(CustomizedProgress);
+export default CustomizedProgress;

--- a/docs/src/pages/demos/progress/CustomizedProgress.tsx
+++ b/docs/src/pages/demos/progress/CustomizedProgress.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles, createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
 import { lighten } from '@material-ui/core/styles/colorManipulator';
-import CircularProgress from '@material-ui/core/CircularProgress';
+import CircularProgress, { CircularProgressProps } from '@material-ui/core/CircularProgress';
 import LinearProgress from '@material-ui/core/LinearProgress';
 
 const ColorCircularProgress = withStyles({
@@ -31,7 +31,7 @@ const BorderLinearProgress = withStyles({
 })(LinearProgress);
 
 // Inspired by the Facebook spinners.
-const FacebookProgress = withStyles({
+const useStylesFacebook = makeStyles({
   root: {
     position: 'relative',
   },
@@ -44,24 +44,32 @@ const FacebookProgress = withStyles({
     position: 'absolute',
     left: 0,
   },
-})(({ classes, ...props }: any) => (
-  <div className={classes.root} {...props}>
-    <CircularProgress
-      variant="determinate"
-      value={100}
-      className={classes.top}
-      size={24}
-      thickness={4}
-    />
-    <CircularProgress
-      variant="indeterminate"
-      disableShrink
-      className={classes.bottom}
-      size={24}
-      thickness={4}
-    />
-  </div>
-));
+});
+
+function FacebookProgress(props: CircularProgressProps) {
+  const classes = useStylesFacebook();
+
+  return (
+    <div className={classes.root}>
+      <CircularProgress
+        variant="determinate"
+        value={100}
+        className={classes.top}
+        size={24}
+        thickness={4}
+        {...props}
+      />
+      <CircularProgress
+        variant="indeterminate"
+        disableShrink
+        className={classes.bottom}
+        size={24}
+        thickness={4}
+        {...props}
+      />
+    </div>
+  );
+}
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/docs/src/pages/demos/selects/CustomizedSelects.js
+++ b/docs/src/pages/demos/selects/CustomizedSelects.js
@@ -51,9 +51,6 @@ const useStyles = makeStyles(theme => ({
   margin: {
     margin: theme.spacing(1),
   },
-  bootstrapFormLabel: {
-    fontSize: 18,
-  },
 }));
 
 function CustomizedSelects() {
@@ -65,15 +62,11 @@ function CustomizedSelects() {
   return (
     <form className={classes.root} autoComplete="off">
       <FormControl className={classes.margin}>
-        <InputLabel htmlFor="age-customized-select" className={classes.bootstrapFormLabel}>
-          Age
-        </InputLabel>
+        <InputLabel htmlFor="age-customized-select">Age</InputLabel>
         <BootstrapInput />
       </FormControl>
       <FormControl className={classes.margin}>
-        <InputLabel htmlFor="age-customized-select" className={classes.bootstrapFormLabel}>
-          Age
-        </InputLabel>
+        <InputLabel htmlFor="age-customized-select">Age</InputLabel>
         <Select
           value={age}
           onChange={handleChange}
@@ -88,9 +81,7 @@ function CustomizedSelects() {
         </Select>
       </FormControl>
       <FormControl className={classes.margin}>
-        <InputLabel htmlFor="age-customized-native-simple" className={classes.bootstrapFormLabel}>
-          Age
-        </InputLabel>
+        <InputLabel htmlFor="age-customized-native-simple">Age</InputLabel>
         <NativeSelect
           value={age}
           onChange={handleChange}

--- a/docs/src/pages/demos/selects/CustomizedSelects.tsx
+++ b/docs/src/pages/demos/selects/CustomizedSelects.tsx
@@ -52,9 +52,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   margin: {
     margin: theme.spacing(1),
   },
-  bootstrapFormLabel: {
-    fontSize: 18,
-  },
 }));
 
 function CustomizedSelects() {
@@ -66,15 +63,11 @@ function CustomizedSelects() {
   return (
     <form className={classes.root} autoComplete="off">
       <FormControl className={classes.margin}>
-        <InputLabel htmlFor="age-customized-select" className={classes.bootstrapFormLabel}>
-          Age
-        </InputLabel>
+        <InputLabel htmlFor="age-customized-select">Age</InputLabel>
         <BootstrapInput />
       </FormControl>
       <FormControl className={classes.margin}>
-        <InputLabel htmlFor="age-customized-select" className={classes.bootstrapFormLabel}>
-          Age
-        </InputLabel>
+        <InputLabel htmlFor="age-customized-select">Age</InputLabel>
         <Select
           value={age}
           onChange={handleChange}
@@ -89,9 +82,7 @@ function CustomizedSelects() {
         </Select>
       </FormControl>
       <FormControl className={classes.margin}>
-        <InputLabel htmlFor="age-customized-native-simple" className={classes.bootstrapFormLabel}>
-          Age
-        </InputLabel>
+        <InputLabel htmlFor="age-customized-native-simple">Age</InputLabel>
         <NativeSelect
           value={age}
           onChange={handleChange}

--- a/docs/src/pages/demos/tables/CustomizedTable.js
+++ b/docs/src/pages/demos/tables/CustomizedTable.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -8,7 +7,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 
-const CustomTableCell = withStyles(theme => ({
+const StyledTableCell = withStyles(theme => ({
   head: {
     backgroundColor: theme.palette.common.black,
     color: theme.palette.common.white,
@@ -18,21 +17,13 @@ const CustomTableCell = withStyles(theme => ({
   },
 }))(TableCell);
 
-const styles = theme => ({
+const StyledTableRow = withStyles(theme => ({
   root: {
-    width: '100%',
-    marginTop: theme.spacing(3),
-    overflowX: 'auto',
-  },
-  table: {
-    minWidth: 700,
-  },
-  row: {
     '&:nth-of-type(odd)': {
       backgroundColor: theme.palette.background.default,
     },
   },
-});
+}))(TableRow);
 
 function createData(name, calories, fat, carbs, protein) {
   return { name, calories, fat, carbs, protein };
@@ -46,32 +37,43 @@ const rows = [
   createData('Gingerbread', 356, 16.0, 49, 3.9),
 ];
 
-function CustomizedTable(props) {
-  const { classes } = props;
+const useStyles = makeStyles(theme => ({
+  root: {
+    width: '100%',
+    marginTop: theme.spacing(3),
+    overflowX: 'auto',
+  },
+  table: {
+    minWidth: 700,
+  },
+}));
+
+function CustomizedTable() {
+  const classes = useStyles();
 
   return (
     <Paper className={classes.root}>
       <Table className={classes.table}>
         <TableHead>
           <TableRow>
-            <CustomTableCell>Dessert (100g serving)</CustomTableCell>
-            <CustomTableCell align="right">Calories</CustomTableCell>
-            <CustomTableCell align="right">Fat&nbsp;(g)</CustomTableCell>
-            <CustomTableCell align="right">Carbs&nbsp;(g)</CustomTableCell>
-            <CustomTableCell align="right">Protein&nbsp;(g)</CustomTableCell>
+            <StyledTableCell>Dessert (100g serving)</StyledTableCell>
+            <StyledTableCell align="right">Calories</StyledTableCell>
+            <StyledTableCell align="right">Fat&nbsp;(g)</StyledTableCell>
+            <StyledTableCell align="right">Carbs&nbsp;(g)</StyledTableCell>
+            <StyledTableCell align="right">Protein&nbsp;(g)</StyledTableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {rows.map(row => (
-            <TableRow className={classes.row} key={row.name}>
-              <CustomTableCell component="th" scope="row">
+            <StyledTableRow key={row.name}>
+              <StyledTableCell component="th" scope="row">
                 {row.name}
-              </CustomTableCell>
-              <CustomTableCell align="right">{row.calories}</CustomTableCell>
-              <CustomTableCell align="right">{row.fat}</CustomTableCell>
-              <CustomTableCell align="right">{row.carbs}</CustomTableCell>
-              <CustomTableCell align="right">{row.protein}</CustomTableCell>
-            </TableRow>
+              </StyledTableCell>
+              <StyledTableCell align="right">{row.calories}</StyledTableCell>
+              <StyledTableCell align="right">{row.fat}</StyledTableCell>
+              <StyledTableCell align="right">{row.carbs}</StyledTableCell>
+              <StyledTableCell align="right">{row.protein}</StyledTableCell>
+            </StyledTableRow>
           ))}
         </TableBody>
       </Table>
@@ -79,8 +81,4 @@ function CustomizedTable(props) {
   );
 }
 
-CustomizedTable.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(CustomizedTable);
+export default CustomizedTable;

--- a/docs/src/pages/demos/tables/CustomizedTable.tsx
+++ b/docs/src/pages/demos/tables/CustomizedTable.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, Theme, createStyles, WithStyles } from '@material-ui/core/styles';
+import { withStyles, Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -8,7 +7,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import Paper from '@material-ui/core/Paper';
 
-const CustomTableCell = withStyles((theme: Theme) =>
+const StyledTableCell = withStyles((theme: Theme) =>
   createStyles({
     head: {
       backgroundColor: theme.palette.common.black,
@@ -20,22 +19,15 @@ const CustomTableCell = withStyles((theme: Theme) =>
   }),
 )(TableCell);
 
-const styles = (theme: Theme) =>
+const StyledTableRow = withStyles((theme: Theme) =>
   createStyles({
     root: {
-      width: '100%',
-      marginTop: theme.spacing(3),
-      overflowX: 'auto',
-    },
-    table: {
-      minWidth: 700,
-    },
-    row: {
       '&:nth-of-type(odd)': {
         backgroundColor: theme.palette.background.default,
       },
     },
-  });
+  }),
+)(TableRow);
 
 function createData(name: string, calories: number, fat: number, carbs: number, protein: number) {
   return { name, calories, fat, carbs, protein };
@@ -49,34 +41,45 @@ const rows = [
   createData('Gingerbread', 356, 16.0, 49, 3.9),
 ];
 
-export interface CustomizedTableProps extends WithStyles<typeof styles> {}
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      marginTop: theme.spacing(3),
+      overflowX: 'auto',
+    },
+    table: {
+      minWidth: 700,
+    },
+  }),
+);
 
-function CustomizedTable(props: CustomizedTableProps) {
-  const { classes } = props;
+function CustomizedTable() {
+  const classes = useStyles();
 
   return (
     <Paper className={classes.root}>
       <Table className={classes.table}>
         <TableHead>
           <TableRow>
-            <CustomTableCell>Dessert (100g serving)</CustomTableCell>
-            <CustomTableCell align="right">Calories</CustomTableCell>
-            <CustomTableCell align="right">Fat&nbsp;(g)</CustomTableCell>
-            <CustomTableCell align="right">Carbs&nbsp;(g)</CustomTableCell>
-            <CustomTableCell align="right">Protein&nbsp;(g)</CustomTableCell>
+            <StyledTableCell>Dessert (100g serving)</StyledTableCell>
+            <StyledTableCell align="right">Calories</StyledTableCell>
+            <StyledTableCell align="right">Fat&nbsp;(g)</StyledTableCell>
+            <StyledTableCell align="right">Carbs&nbsp;(g)</StyledTableCell>
+            <StyledTableCell align="right">Protein&nbsp;(g)</StyledTableCell>
           </TableRow>
         </TableHead>
         <TableBody>
           {rows.map(row => (
-            <TableRow className={classes.row} key={row.name}>
-              <CustomTableCell component="th" scope="row">
+            <StyledTableRow key={row.name}>
+              <StyledTableCell component="th" scope="row">
                 {row.name}
-              </CustomTableCell>
-              <CustomTableCell align="right">{row.calories}</CustomTableCell>
-              <CustomTableCell align="right">{row.fat}</CustomTableCell>
-              <CustomTableCell align="right">{row.carbs}</CustomTableCell>
-              <CustomTableCell align="right">{row.protein}</CustomTableCell>
-            </TableRow>
+              </StyledTableCell>
+              <StyledTableCell align="right">{row.calories}</StyledTableCell>
+              <StyledTableCell align="right">{row.fat}</StyledTableCell>
+              <StyledTableCell align="right">{row.carbs}</StyledTableCell>
+              <StyledTableCell align="right">{row.protein}</StyledTableCell>
+            </StyledTableRow>
           ))}
         </TableBody>
       </Table>
@@ -84,8 +87,4 @@ function CustomizedTable(props: CustomizedTableProps) {
   );
 }
 
-CustomizedTable.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(CustomizedTable);
+export default CustomizedTable;

--- a/docs/src/pages/demos/tabs/CustomizedTabs.js
+++ b/docs/src/pages/demos/tabs/CustomizedTabs.js
@@ -27,18 +27,17 @@ const StyledTab = withStyles(theme => ({
   },
 }))(props => <Tab disableRipple {...props} />);
 
-const useStyles = makeStyles(theme => ({
+const AntTabs = withStyles({
   root: {
-    flexGrow: 1,
-    backgroundColor: theme.palette.background.paper,
-  },
-  tabsRoot: {
     borderBottom: '1px solid #e8e8e8',
   },
-  tabsIndicator: {
+  indicator: {
     backgroundColor: '#1890ff',
   },
-  tabRoot: {
+})(Tabs);
+
+const AntTab = withStyles(theme => ({
+  root: {
     textTransform: 'none',
     minWidth: 72,
     fontWeight: theme.typography.fontWeightRegular,
@@ -59,7 +58,7 @@ const useStyles = makeStyles(theme => ({
       color: '#40a9ff',
       opacity: 1,
     },
-    '&$tabSelected': {
+    '&$selected': {
       color: '#1890ff',
       fontWeight: theme.typography.fontWeightMedium,
     },
@@ -67,9 +66,18 @@ const useStyles = makeStyles(theme => ({
       color: '#40a9ff',
     },
   },
-  tabSelected: {},
+  selected: {},
+}))(props => <Tab disableRipple {...props} />);
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    flexGrow: 1,
+  },
   typography: {
     padding: theme.spacing(3),
+  },
+  demo1: {
+    backgroundColor: theme.palette.background.paper,
   },
   demo2: {
     backgroundColor: '#2e1534',
@@ -86,28 +94,14 @@ function CustomizedTabs() {
 
   return (
     <div className={classes.root}>
-      <Tabs
-        value={value}
-        onChange={handleChange}
-        classes={{ root: classes.tabsRoot, indicator: classes.tabsIndicator }}
-      >
-        <Tab
-          disableRipple
-          classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
-          label="Tab 1"
-        />
-        <Tab
-          disableRipple
-          classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
-          label="Tab 2"
-        />
-        <Tab
-          disableRipple
-          classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
-          label="Tab 3"
-        />
-      </Tabs>
-      <Typography className={classes.typography}>Ant Design UI powered by Material-UI</Typography>
+      <div className={classes.demo1}>
+        <AntTabs value={value} onChange={handleChange}>
+          <AntTab label="Tab 1" />
+          <AntTab label="Tab 2" />
+          <AntTab label="Tab 3" />
+        </AntTabs>
+        <Typography className={classes.typography} />
+      </div>
       <div className={classes.demo2}>
         <StyledTabs value={value} onChange={handleChange}>
           <StyledTab label="Workflows" />

--- a/docs/src/pages/demos/tabs/CustomizedTabs.tsx
+++ b/docs/src/pages/demos/tabs/CustomizedTabs.tsx
@@ -38,54 +38,66 @@ const StyledTab = withStyles((theme: Theme) =>
   }),
 )((props: StyledTabProps) => <Tab disableRipple {...props} />);
 
-const useStyles = makeStyles((theme: Theme) => ({
+const AntTabs = withStyles({
   root: {
-    flexGrow: 1,
-    backgroundColor: theme.palette.background.paper,
-  },
-  tabsRoot: {
     borderBottom: '1px solid #e8e8e8',
   },
-  tabsIndicator: {
+  indicator: {
     backgroundColor: '#1890ff',
   },
-  tabRoot: {
-    textTransform: 'none',
-    minWidth: 72,
-    fontWeight: theme.typography.fontWeightRegular,
-    marginRight: theme.spacing(4),
-    fontFamily: [
-      '-apple-system',
-      'BlinkMacSystemFont',
-      '"Segoe UI"',
-      'Roboto',
-      '"Helvetica Neue"',
-      'Arial',
-      'sans-serif',
-      '"Apple Color Emoji"',
-      '"Segoe UI Emoji"',
-      '"Segoe UI Symbol"',
-    ].join(','),
-    '&:hover': {
-      color: '#40a9ff',
-      opacity: 1,
+})(Tabs);
+
+const AntTab = withStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      textTransform: 'none',
+      minWidth: 72,
+      fontWeight: theme.typography.fontWeightRegular,
+      marginRight: theme.spacing(4),
+      fontFamily: [
+        '-apple-system',
+        'BlinkMacSystemFont',
+        '"Segoe UI"',
+        'Roboto',
+        '"Helvetica Neue"',
+        'Arial',
+        'sans-serif',
+        '"Apple Color Emoji"',
+        '"Segoe UI Emoji"',
+        '"Segoe UI Symbol"',
+      ].join(','),
+      '&:hover': {
+        color: '#40a9ff',
+        opacity: 1,
+      },
+      '&$selected': {
+        color: '#1890ff',
+        fontWeight: theme.typography.fontWeightMedium,
+      },
+      '&:focus': {
+        color: '#40a9ff',
+      },
     },
-    '&$tabSelected': {
-      color: '#1890ff',
-      fontWeight: theme.typography.fontWeightMedium,
+    selected: {},
+  }),
+)((props: StyledTabProps) => <Tab disableRipple {...props} />);
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
     },
-    '&:focus': {
-      color: '#40a9ff',
+    typography: {
+      padding: theme.spacing(3),
     },
-  },
-  tabSelected: {},
-  typography: {
-    padding: theme.spacing(3),
-  },
-  demo2: {
-    backgroundColor: '#2e1534',
-  },
-}));
+    demo1: {
+      backgroundColor: theme.palette.background.paper,
+    },
+    demo2: {
+      backgroundColor: '#2e1534',
+    },
+  }),
+);
 
 function CustomizedTabs() {
   const classes = useStyles();
@@ -97,28 +109,14 @@ function CustomizedTabs() {
 
   return (
     <div className={classes.root}>
-      <Tabs
-        value={value}
-        onChange={handleChange}
-        classes={{ root: classes.tabsRoot, indicator: classes.tabsIndicator }}
-      >
-        <Tab
-          disableRipple
-          classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
-          label="Tab 1"
-        />
-        <Tab
-          disableRipple
-          classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
-          label="Tab 2"
-        />
-        <Tab
-          disableRipple
-          classes={{ root: classes.tabRoot, selected: classes.tabSelected }}
-          label="Tab 3"
-        />
-      </Tabs>
-      <Typography className={classes.typography}>Ant Design UI powered by Material-UI</Typography>
+      <div className={classes.demo1}>
+        <AntTabs value={value} onChange={handleChange}>
+          <AntTab label="Tab 1" />
+          <AntTab label="Tab 2" />
+          <AntTab label="Tab 3" />
+        </AntTabs>
+        <Typography className={classes.typography} />
+      </div>
       <div className={classes.demo2}>
         <StyledTabs value={value} onChange={handleChange}>
           <StyledTab label="Workflows" />

--- a/docs/src/pages/demos/tooltips/CustomizedTooltips.js
+++ b/docs/src/pages/demos/tooltips/CustomizedTooltips.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { withStyles, makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
@@ -51,49 +51,122 @@ function arrowGenerator(color) {
   };
 }
 
-const useStyles = makeStyles(theme => ({
-  button: {
-    margin: theme.spacing(1),
-  },
-  lightTooltip: {
+const LightTooltip = withStyles(theme => ({
+  tooltip: {
     backgroundColor: theme.palette.common.white,
     color: 'rgba(0, 0, 0, 0.87)',
     boxShadow: theme.shadows[1],
     fontSize: 11,
   },
-  arrowPopper: arrowGenerator(theme.palette.grey[700]),
-  arrow: {
-    position: 'absolute',
-    fontSize: 6,
-    width: '3em',
-    height: '3em',
-    '&::before': {
-      content: '""',
-      margin: 'auto',
-      display: 'block',
-      width: 0,
-      height: 0,
-      borderStyle: 'solid',
+}))(Tooltip);
+
+const ArrowTooltip = withStyles(theme =>
+  makeStyles({
+    arrow: {
+      position: 'absolute',
+      fontSize: 6,
+      width: '3em',
+      height: '3em',
+      '&::before': {
+        content: '""',
+        margin: 'auto',
+        display: 'block',
+        width: 0,
+        height: 0,
+        borderStyle: 'solid',
+      },
     },
-  },
-  bootstrapPopper: arrowGenerator(theme.palette.common.black),
-  bootstrapTooltip: {
-    backgroundColor: theme.palette.common.black,
-  },
-  bootstrapPlacementLeft: {
-    margin: '0 8px',
-  },
-  bootstrapPlacementRight: {
-    margin: '0 8px',
-  },
-  bootstrapPlacementTop: {
-    margin: '8px 0',
-  },
-  bootstrapPlacementBottom: {
-    margin: '8px 0',
-  },
-  htmlPopper: arrowGenerator('#dadde9'),
-  htmlTooltip: {
+    popper: arrowGenerator(theme.palette.grey[700]),
+  }),
+)(({ classes: { arrow, ...classes }, title, ...props }) => {
+  const [arrowRef, setArrowRef] = React.useState(null);
+
+  return (
+    <Tooltip
+      title={
+        <React.Fragment>
+          {title}
+          <span className={arrow} ref={setArrowRef} />
+        </React.Fragment>
+      }
+      classes={classes}
+      PopperProps={{
+        popperOptions: {
+          modifiers: {
+            arrow: {
+              enabled: Boolean(arrowRef),
+              element: arrowRef,
+            },
+          },
+        },
+      }}
+      {...props}
+    />
+  );
+});
+
+const BootstrapTooltip = withStyles(theme =>
+  makeStyles({
+    arrow: {
+      position: 'absolute',
+      fontSize: 6,
+      width: '3em',
+      height: '3em',
+      '&::before': {
+        content: '""',
+        margin: 'auto',
+        display: 'block',
+        width: 0,
+        height: 0,
+        borderStyle: 'solid',
+      },
+    },
+    popper: arrowGenerator(theme.palette.common.black),
+    tooltip: {
+      backgroundColor: theme.palette.common.black,
+    },
+    tooltipPlacementLeft: {
+      margin: '0 8px',
+    },
+    tooltipPlacementRight: {
+      margin: '0 8px',
+    },
+    tooltipPlacementTop: {
+      margin: '8px 0',
+    },
+    tooltipPlacementBottom: {
+      margin: '8px 0',
+    },
+  }),
+)(({ classes: { arrow, ...classes }, title, ...props }) => {
+  const [arrowRef, setArrowRef] = React.useState(null);
+
+  return (
+    <Tooltip
+      title={
+        <React.Fragment>
+          {title}
+          <span className={arrow} ref={setArrowRef} />
+        </React.Fragment>
+      }
+      classes={classes}
+      PopperProps={{
+        popperOptions: {
+          modifiers: {
+            arrow: {
+              enabled: Boolean(arrowRef),
+              element: arrowRef,
+            },
+          },
+        },
+      }}
+      {...props}
+    />
+  );
+});
+
+const HtmlTooltip = withStyles(theme => ({
+  tooltip: {
     backgroundColor: '#f5f5f9',
     color: 'rgba(0, 0, 0, 0.87)',
     maxWidth: 220,
@@ -103,92 +176,31 @@ const useStyles = makeStyles(theme => ({
       fontWeight: theme.typography.fontWeightMedium,
     },
   },
-}));
+}))(Tooltip);
 
 function CustomizedTooltips() {
-  const classes = useStyles();
-  const [arrowRef, setArrowRef] = React.useState(null);
-
   return (
     <div>
-      <Tooltip title="Add" classes={{ tooltip: classes.lightTooltip }}>
-        <Button className={classes.button}>Light</Button>
-      </Tooltip>
-      <Tooltip
-        title={
-          <React.Fragment>
-            Add
-            <span className={classes.arrow} ref={setArrowRef} />
-          </React.Fragment>
-        }
-        classes={{ popper: classes.arrowPopper }}
-        PopperProps={{
-          popperOptions: {
-            modifiers: {
-              arrow: {
-                enabled: Boolean(arrowRef),
-                element: arrowRef,
-              },
-            },
-          },
-        }}
-      >
-        <Button className={classes.button}>Arrow</Button>
-      </Tooltip>
-      <Tooltip
-        title={
-          <React.Fragment>
-            Add
-            <span className={classes.arrow} ref={setArrowRef} />
-          </React.Fragment>
-        }
-        classes={{
-          tooltip: classes.bootstrapTooltip,
-          popper: classes.bootstrapPopper,
-          tooltipPlacementLeft: classes.bootstrapPlacementLeft,
-          tooltipPlacementRight: classes.bootstrapPlacementRight,
-          tooltipPlacementTop: classes.bootstrapPlacementTop,
-          tooltipPlacementBottom: classes.bootstrapPlacementBottom,
-        }}
-        PopperProps={{
-          popperOptions: {
-            modifiers: {
-              arrow: {
-                enabled: Boolean(arrowRef),
-                element: arrowRef,
-              },
-            },
-          },
-        }}
-      >
-        <Button className={classes.button}>Bootstrap</Button>
-      </Tooltip>
-      <Tooltip
-        classes={{
-          popper: classes.htmlPopper,
-          tooltip: classes.htmlTooltip,
-        }}
-        PopperProps={{
-          popperOptions: {
-            modifiers: {
-              arrow: {
-                enabled: Boolean(arrowRef),
-                element: arrowRef,
-              },
-            },
-          },
-        }}
+      <LightTooltip title="Add">
+        <Button>Light</Button>
+      </LightTooltip>
+      <ArrowTooltip title="Add">
+        <Button>Arrow</Button>
+      </ArrowTooltip>
+      <BootstrapTooltip title="Add">
+        <Button>Bootstrap</Button>
+      </BootstrapTooltip>
+      <HtmlTooltip
         title={
           <React.Fragment>
             <Typography color="inherit">Tooltip with HTML</Typography>
             <em>{"And here's"}</em> <b>{'some'}</b> <u>{'amazing content'}</u>.{' '}
             {"It's very engaging. Right?"}
-            <span className={classes.arrow} ref={setArrowRef} />
           </React.Fragment>
         }
       >
-        <Button className={classes.button}>HTML</Button>
-      </Tooltip>
+        <Button>HTML</Button>
+      </HtmlTooltip>
     </div>
   );
 }

--- a/docs/src/pages/demos/tooltips/CustomizedTooltips.js
+++ b/docs/src/pages/demos/tooltips/CustomizedTooltips.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
 import { withStyles, makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
@@ -60,35 +61,30 @@ const LightTooltip = withStyles(theme => ({
   },
 }))(Tooltip);
 
-const ArrowTooltip = withStyles(theme =>
-  makeStyles({
-    arrow: {
-      position: 'absolute',
-      fontSize: 6,
-      width: '3em',
-      height: '3em',
-      '&::before': {
-        content: '""',
-        margin: 'auto',
-        display: 'block',
-        width: 0,
-        height: 0,
-        borderStyle: 'solid',
-      },
+const useStylesArrow = makeStyles(theme => ({
+  arrow: {
+    position: 'absolute',
+    fontSize: 6,
+    width: '3em',
+    height: '3em',
+    '&::before': {
+      content: '""',
+      margin: 'auto',
+      display: 'block',
+      width: 0,
+      height: 0,
+      borderStyle: 'solid',
     },
-    popper: arrowGenerator(theme.palette.grey[700]),
-  }),
-)(({ classes: { arrow, ...classes }, title, ...props }) => {
+  },
+  popper: arrowGenerator(theme.palette.grey[700]),
+}));
+
+function ArrowTooltip(props) {
+  const { arrow, ...classes } = useStylesArrow();
   const [arrowRef, setArrowRef] = React.useState(null);
 
   return (
     <Tooltip
-      title={
-        <React.Fragment>
-          {title}
-          <span className={arrow} ref={setArrowRef} />
-        </React.Fragment>
-      }
       classes={classes}
       PopperProps={{
         popperOptions: {
@@ -101,54 +97,55 @@ const ArrowTooltip = withStyles(theme =>
         },
       }}
       {...props}
+      title={
+        <React.Fragment>
+          {props.title}
+          <span className={arrow} ref={setArrowRef} />
+        </React.Fragment>
+      }
     />
   );
-});
+}
 
-const BootstrapTooltip = withStyles(theme =>
-  makeStyles({
-    arrow: {
-      position: 'absolute',
-      fontSize: 6,
-      width: '3em',
-      height: '3em',
-      '&::before': {
-        content: '""',
-        margin: 'auto',
-        display: 'block',
-        width: 0,
-        height: 0,
-        borderStyle: 'solid',
-      },
+const useStylesBootstrap = makeStyles(theme => ({
+  arrow: {
+    position: 'absolute',
+    fontSize: 6,
+    width: '3em',
+    height: '3em',
+    '&::before': {
+      content: '""',
+      margin: 'auto',
+      display: 'block',
+      width: 0,
+      height: 0,
+      borderStyle: 'solid',
     },
-    popper: arrowGenerator(theme.palette.common.black),
-    tooltip: {
-      backgroundColor: theme.palette.common.black,
-    },
-    tooltipPlacementLeft: {
-      margin: '0 8px',
-    },
-    tooltipPlacementRight: {
-      margin: '0 8px',
-    },
-    tooltipPlacementTop: {
-      margin: '8px 0',
-    },
-    tooltipPlacementBottom: {
-      margin: '8px 0',
-    },
-  }),
-)(({ classes: { arrow, ...classes }, title, ...props }) => {
+  },
+  popper: arrowGenerator(theme.palette.common.black),
+  tooltip: {
+    backgroundColor: theme.palette.common.black,
+  },
+  tooltipPlacementLeft: {
+    margin: '0 8px',
+  },
+  tooltipPlacementRight: {
+    margin: '0 8px',
+  },
+  tooltipPlacementTop: {
+    margin: '8px 0',
+  },
+  tooltipPlacementBottom: {
+    margin: '8px 0',
+  },
+}));
+
+function BootstrapTooltip(props) {
+  const { arrow, ...classes } = useStylesBootstrap();
   const [arrowRef, setArrowRef] = React.useState(null);
 
   return (
     <Tooltip
-      title={
-        <React.Fragment>
-          {title}
-          <span className={arrow} ref={setArrowRef} />
-        </React.Fragment>
-      }
       classes={classes}
       PopperProps={{
         popperOptions: {
@@ -161,9 +158,15 @@ const BootstrapTooltip = withStyles(theme =>
         },
       }}
       {...props}
+      title={
+        <React.Fragment>
+          {props.title}
+          <span className={arrow} ref={setArrowRef} />
+        </React.Fragment>
+      }
     />
   );
-});
+}
 
 const HtmlTooltip = withStyles(theme => ({
   tooltip: {

--- a/docs/src/pages/demos/tooltips/CustomizedTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/CustomizedTooltips.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+import { withStyles, Theme, makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
@@ -51,18 +51,17 @@ function arrowGenerator(color: string) {
   };
 }
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    button: {
-      margin: theme.spacing(1),
-    },
-    lightTooltip: {
-      backgroundColor: theme.palette.common.white,
-      color: 'rgba(0, 0, 0, 0.87)',
-      boxShadow: theme.shadows[1],
-      fontSize: 11,
-    },
-    arrowPopper: arrowGenerator(theme.palette.grey[700]),
+const LightTooltip = withStyles((theme: Theme) => ({
+  tooltip: {
+    backgroundColor: theme.palette.common.white,
+    color: 'rgba(0, 0, 0, 0.87)',
+    boxShadow: theme.shadows[1],
+    fontSize: 11,
+  },
+}))(Tooltip);
+
+const ArrowTooltip = withStyles((theme: Theme) =>
+  makeStyles({
     arrow: {
       position: 'absolute',
       fontSize: 6,
@@ -77,120 +76,131 @@ const useStyles = makeStyles((theme: Theme) =>
         borderStyle: 'solid',
       },
     },
-    bootstrapPopper: arrowGenerator(theme.palette.common.black),
-    bootstrapTooltip: {
-      backgroundColor: theme.palette.common.black,
-    },
-    bootstrapPlacementLeft: {
-      margin: '0 8px',
-    },
-    bootstrapPlacementRight: {
-      margin: '0 8px',
-    },
-    bootstrapPlacementTop: {
-      margin: '8px 0',
-    },
-    bootstrapPlacementBottom: {
-      margin: '8px 0',
-    },
-    htmlPopper: arrowGenerator('#dadde9'),
-    htmlTooltip: {
-      backgroundColor: '#f5f5f9',
-      color: 'rgba(0, 0, 0, 0.87)',
-      maxWidth: 220,
-      fontSize: theme.typography.pxToRem(12),
-      border: '1px solid #dadde9',
-      '& b': {
-        fontWeight: theme.typography.fontWeightMedium,
-      },
-    },
+    popper: arrowGenerator(theme.palette.grey[700]),
   }),
-);
-
-function CustomizedTooltips() {
-  const classes = useStyles();
+)(({ classes: { arrow, ...classes }, title, ...props }: any) => {
   const [arrowRef, setArrowRef] = React.useState<HTMLSpanElement | null>(null);
 
   return (
+    <Tooltip
+      title={
+        <React.Fragment>
+          {title}
+          <span className={arrow} ref={setArrowRef} />
+        </React.Fragment>
+      }
+      classes={classes}
+      PopperProps={{
+        popperOptions: {
+          modifiers: {
+            arrow: {
+              enabled: Boolean(arrowRef),
+              element: arrowRef,
+            },
+          },
+        },
+      }}
+      {...props}
+    />
+  );
+});
+
+const BootstrapTooltip = withStyles((theme: Theme) =>
+  makeStyles({
+    arrow: {
+      position: 'absolute',
+      fontSize: 6,
+      width: '3em',
+      height: '3em',
+      '&::before': {
+        content: '""',
+        margin: 'auto',
+        display: 'block',
+        width: 0,
+        height: 0,
+        borderStyle: 'solid',
+      },
+    },
+    popper: arrowGenerator(theme.palette.common.black),
+    tooltip: {
+      backgroundColor: theme.palette.common.black,
+    },
+    tooltipPlacementLeft: {
+      margin: '0 8px',
+    },
+    tooltipPlacementRight: {
+      margin: '0 8px',
+    },
+    tooltipPlacementTop: {
+      margin: '8px 0',
+    },
+    tooltipPlacementBottom: {
+      margin: '8px 0',
+    },
+  }),
+)(({ classes: { arrow, ...classes }, title, ...props }: any) => {
+  const [arrowRef, setArrowRef] = React.useState<HTMLSpanElement | null>(null);
+
+  return (
+    <Tooltip
+      title={
+        <React.Fragment>
+          {title}
+          <span className={arrow} ref={setArrowRef} />
+        </React.Fragment>
+      }
+      classes={classes}
+      PopperProps={{
+        popperOptions: {
+          modifiers: {
+            arrow: {
+              enabled: Boolean(arrowRef),
+              element: arrowRef,
+            },
+          },
+        },
+      }}
+      {...props}
+    />
+  );
+});
+
+const HtmlTooltip = withStyles((theme: Theme) => ({
+  tooltip: {
+    backgroundColor: '#f5f5f9',
+    color: 'rgba(0, 0, 0, 0.87)',
+    maxWidth: 220,
+    fontSize: theme.typography.pxToRem(12),
+    border: '1px solid #dadde9',
+    '& b': {
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+  },
+}))(Tooltip);
+
+function CustomizedTooltips() {
+  return (
     <div>
-      <Tooltip title="Add" classes={{ tooltip: classes.lightTooltip }}>
-        <Button className={classes.button}>Light</Button>
-      </Tooltip>
-      <Tooltip
-        title={
-          <React.Fragment>
-            Add
-            <span className={classes.arrow} ref={setArrowRef} />
-          </React.Fragment>
-        }
-        classes={{ popper: classes.arrowPopper }}
-        PopperProps={{
-          popperOptions: {
-            modifiers: {
-              arrow: {
-                enabled: Boolean(arrowRef),
-                element: arrowRef,
-              },
-            },
-          },
-        }}
-      >
-        <Button className={classes.button}>Arrow</Button>
-      </Tooltip>
-      <Tooltip
-        title={
-          <React.Fragment>
-            Add
-            <span className={classes.arrow} ref={setArrowRef} />
-          </React.Fragment>
-        }
-        classes={{
-          tooltip: classes.bootstrapTooltip,
-          popper: classes.bootstrapPopper,
-          tooltipPlacementLeft: classes.bootstrapPlacementLeft,
-          tooltipPlacementRight: classes.bootstrapPlacementRight,
-          tooltipPlacementTop: classes.bootstrapPlacementTop,
-          tooltipPlacementBottom: classes.bootstrapPlacementBottom,
-        }}
-        PopperProps={{
-          popperOptions: {
-            modifiers: {
-              arrow: {
-                enabled: Boolean(arrowRef),
-                element: arrowRef,
-              },
-            },
-          },
-        }}
-      >
-        <Button className={classes.button}>Bootstrap</Button>
-      </Tooltip>
-      <Tooltip
-        classes={{
-          popper: classes.htmlPopper,
-          tooltip: classes.htmlTooltip,
-        }}
-        PopperProps={{
-          popperOptions: {
-            modifiers: {
-              arrow: {
-                enabled: Boolean(arrowRef),
-                element: arrowRef,
-              },
-            },
-          },
-        }}
+      <LightTooltip title="Add">
+        <Button>Light</Button>
+      </LightTooltip>
+      <ArrowTooltip title="Add">
+        <Button>Arrow</Button>
+      </ArrowTooltip>
+      <BootstrapTooltip title="Add">
+        <Button>Bootstrap</Button>
+      </BootstrapTooltip>
+      <HtmlTooltip
         title={
           <React.Fragment>
             <Typography color="inherit">Tooltip with HTML</Typography>
             <em>{"And here's"}</em> <b>{'some'}</b> <u>{'amazing content'}</u>.{' '}
             {"It's very engaging. Right?"}
-            <span className={classes.arrow} ref={setArrowRef} />
           </React.Fragment>
         }
       >
-        <Button className={classes.button}>HTML</Button>
-      </Tooltip>
+        <Button>HTML</Button>
+      </HtmlTooltip>
     </div>
   );
 }

--- a/docs/src/pages/demos/tooltips/CustomizedTooltips.tsx
+++ b/docs/src/pages/demos/tooltips/CustomizedTooltips.tsx
@@ -1,7 +1,8 @@
+/* eslint-disable react/prop-types */
 import React from 'react';
-import { withStyles, Theme, makeStyles } from '@material-ui/core/styles';
+import { withStyles, Theme, makeStyles, createStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
-import Tooltip from '@material-ui/core/Tooltip';
+import Tooltip, { TooltipProps } from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 
 function arrowGenerator(color: string) {
@@ -60,8 +61,8 @@ const LightTooltip = withStyles((theme: Theme) => ({
   },
 }))(Tooltip);
 
-const ArrowTooltip = withStyles((theme: Theme) =>
-  makeStyles({
+const useStylesArrow = makeStyles((theme: Theme) =>
+  createStyles({
     arrow: {
       position: 'absolute',
       fontSize: 6,
@@ -78,17 +79,14 @@ const ArrowTooltip = withStyles((theme: Theme) =>
     },
     popper: arrowGenerator(theme.palette.grey[700]),
   }),
-)(({ classes: { arrow, ...classes }, title, ...props }: any) => {
+);
+
+function ArrowTooltip(props: TooltipProps) {
+  const { arrow, ...classes } = useStylesArrow();
   const [arrowRef, setArrowRef] = React.useState<HTMLSpanElement | null>(null);
 
   return (
     <Tooltip
-      title={
-        <React.Fragment>
-          {title}
-          <span className={arrow} ref={setArrowRef} />
-        </React.Fragment>
-      }
       classes={classes}
       PopperProps={{
         popperOptions: {
@@ -101,12 +99,18 @@ const ArrowTooltip = withStyles((theme: Theme) =>
         },
       }}
       {...props}
+      title={
+        <React.Fragment>
+          {props.title}
+          <span className={arrow} ref={setArrowRef} />
+        </React.Fragment>
+      }
     />
   );
-});
+}
 
-const BootstrapTooltip = withStyles((theme: Theme) =>
-  makeStyles({
+const useStylesBootstrap = makeStyles((theme: Theme) =>
+  createStyles({
     arrow: {
       position: 'absolute',
       fontSize: 6,
@@ -138,17 +142,14 @@ const BootstrapTooltip = withStyles((theme: Theme) =>
       margin: '8px 0',
     },
   }),
-)(({ classes: { arrow, ...classes }, title, ...props }: any) => {
+);
+
+function BootstrapTooltip(props: TooltipProps) {
+  const { arrow, ...classes } = useStylesBootstrap();
   const [arrowRef, setArrowRef] = React.useState<HTMLSpanElement | null>(null);
 
   return (
     <Tooltip
-      title={
-        <React.Fragment>
-          {title}
-          <span className={arrow} ref={setArrowRef} />
-        </React.Fragment>
-      }
       classes={classes}
       PopperProps={{
         popperOptions: {
@@ -161,9 +162,15 @@ const BootstrapTooltip = withStyles((theme: Theme) =>
         },
       }}
       {...props}
+      title={
+        <React.Fragment>
+          {props.title}
+          <span className={arrow} ref={setArrowRef} />
+        </React.Fragment>
+      }
     />
   );
-});
+}
 
 const HtmlTooltip = withStyles((theme: Theme) => ({
   tooltip: {

--- a/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.js
+++ b/packages/material-ui/src/Breadcrumbs/BreadcrumbCollapsed.js
@@ -46,4 +46,4 @@ BreadcrumbCollapsed.propTypes = {
   classes: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles, { name: 'MuiPrivateBreadcrumbCollapsed' })(BreadcrumbCollapsed);
+export default withStyles(styles, { name: 'PrivateBreadcrumbCollapsed' })(BreadcrumbCollapsed);

--- a/packages/material-ui/src/Breadcrumbs/BreadcrumbSeparator.js
+++ b/packages/material-ui/src/Breadcrumbs/BreadcrumbSeparator.js
@@ -27,4 +27,4 @@ BreadcrumbSeparator.propTypes = {
   className: PropTypes.string,
 };
 
-export default withStyles(styles, { name: 'MuiPrivateBreadcrumbSeparator' })(BreadcrumbSeparator);
+export default withStyles(styles, { name: 'PrivateBreadcrumbSeparator' })(BreadcrumbSeparator);

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -34,6 +34,18 @@ export const styles = theme => {
           display: 'none',
         },
       },
+      '&$expanded': {
+        margin: '16px 0',
+        '&:first-child': {
+          marginTop: 0,
+        },
+        '&:last-child': {
+          marginBottom: 0,
+        },
+        '&:before': {
+          opacity: 0,
+        },
+      },
       '&$expanded + &': {
         '&:before': {
           display: 'none',
@@ -58,18 +70,7 @@ export const styles = theme => {
       },
     },
     /* Styles applied to the root element if `expanded={true}`. */
-    expanded: {
-      margin: '16px 0',
-      '&:first-child': {
-        marginTop: 0,
-      },
-      '&:last-child': {
-        marginBottom: 0,
-      },
-      '&:before': {
-        opacity: 0,
-      },
-    },
+    expanded: {},
     /* Styles applied to the root element if `disabled={true}`. */
     disabled: {
       backgroundColor: theme.palette.action.disabledBackground,

--- a/packages/material-ui/src/Hidden/HiddenCss.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.js
@@ -152,4 +152,4 @@ HiddenCss.propTypes = {
   xsUp: PropTypes.bool,
 };
 
-export default withStyles(styles, { name: 'MuiPrivateHiddenCss' })(HiddenCss);
+export default withStyles(styles, { name: 'PrivateHiddenCss' })(HiddenCss);

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -118,6 +118,6 @@ NotchedOutline.propTypes = {
   theme: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'MuiPrivateNotchedOutline', withTheme: true })(
+export default withStyles(styles, { name: 'PrivateNotchedOutline', withTheme: true })(
   NotchedOutline,
 );

--- a/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeArea.js
@@ -70,4 +70,4 @@ SwipeArea.propTypes = {
   width: PropTypes.number.isRequired,
 };
 
-export default withStyles(styles, { name: 'MuiPrivateSwipeArea' })(SwipeArea);
+export default withStyles(styles, { name: 'PrivateSwipeArea' })(SwipeArea);

--- a/packages/material-ui/src/Tabs/TabIndicator.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.js
@@ -55,4 +55,4 @@ TabIndicator.propTypes = {
   color: PropTypes.oneOf(['primary', 'secondary']),
 };
 
-export default withStyles(styles, { name: 'MuiPrivateTabIndicator' })(TabIndicator);
+export default withStyles(styles, { name: 'PrivateTabIndicator' })(TabIndicator);

--- a/packages/material-ui/src/Tabs/TabScrollButton.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.js
@@ -62,4 +62,4 @@ TabScrollButton.defaultProps = {
   visible: true,
 };
 
-export default withStyles(styles, { name: 'MuiPrivateTabScrollButton' })(TabScrollButton);
+export default withStyles(styles, { name: 'PrivateTabScrollButton' })(TabScrollButton);

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -236,6 +236,6 @@ SwitchBase.propTypes = {
   value: PropTypes.any,
 };
 
-export default withStyles(styles, { name: 'MuiPrivateSwitchBase' })(
+export default withStyles(styles, { name: 'PrivateSwitchBase' })(
   withFormControlContext(SwitchBase),
 );


### PR DESCRIPTION
The changes are extracted from #15140. It isolates each customization example. Each customization demo is **a component on its own**. I'm using `withStyles` most of the time as it minimizes boilerplate.