### PR TITLE
[Modal] Add reason parameter to onClose function signature

### DIFF
--- a/docs/src/pages/demos/drawers/TemporaryDrawer.tsx
+++ b/docs/src/pages/demos/drawers/TemporaryDrawer.tsx
@@ -29,7 +29,9 @@ function TemporaryDrawer() {
   });
 
   type DrawerSide = 'top' | 'left' | 'bottom' | 'right';
-  const toggleDrawer = (side: DrawerSide, open: boolean) => (event: React.SyntheticEvent<any>) => {
+  const toggleDrawer = (side: DrawerSide, open: boolean) => (
+    event: React.KeyboardEvent | React.MouseEvent,
+  ) => {
     if (
       event.type === 'keydown' &&
       ((event as React.KeyboardEvent).key === 'Tab' ||

--- a/docs/src/pages/demos/drawers/TemporaryDrawer.tsx
+++ b/docs/src/pages/demos/drawers/TemporaryDrawer.tsx
@@ -29,9 +29,7 @@ function TemporaryDrawer() {
   });
 
   type DrawerSide = 'top' | 'left' | 'bottom' | 'right';
-  const toggleDrawer = (side: DrawerSide, open: boolean) => (
-    event: React.KeyboardEvent | React.MouseEvent,
-  ) => {
+  const toggleDrawer = (side: DrawerSide, open: boolean) => (event: React.SyntheticEvent<any>) => {
     if (
       event.type === 'keydown' &&
       ((event as React.KeyboardEvent).key === 'Tab' ||

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -20,10 +20,7 @@ export interface ModalProps
   keepMounted?: boolean;
   manager?: ModalManager;
   onBackdropClick?: React.ReactEventHandler<{}>;
-  onClose?: (
-    event: React.SyntheticEvent<unknown>,
-    reason: 'backdropClick' | 'escapeKeyDown',
-  ) => void;
+  onClose?: (event: React.ReactEventHandler<{}>, reason: 'backdropClick' | 'escapeKeyDown') => void;
   onEscapeKeyDown?: React.ReactEventHandler<{}>;
   onRendered?: PortalProps['onRendered'];
   open: boolean;

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -20,7 +20,7 @@ export interface ModalProps
   keepMounted?: boolean;
   manager?: ModalManager;
   onBackdropClick?: React.ReactEventHandler<{}>;
-  onClose?: React.ReactEventHandler<{}>;
+  onClose?: (event: React.SyntheticEvent<any>, reason: string) => void;
   onEscapeKeyDown?: React.ReactEventHandler<{}>;
   onRendered?: PortalProps['onRendered'];
   open: boolean;

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -20,7 +20,7 @@ export interface ModalProps
   keepMounted?: boolean;
   manager?: ModalManager;
   onBackdropClick?: React.ReactEventHandler<{}>;
-  onClose?: (event: React.ReactEventHandler<{}>, reason: 'backdropClick' | 'escapeKeyDown') => void;
+  onClose?: (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => void;
   onEscapeKeyDown?: React.ReactEventHandler<{}>;
   onRendered?: PortalProps['onRendered'];
   open: boolean;

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -20,7 +20,10 @@ export interface ModalProps
   keepMounted?: boolean;
   manager?: ModalManager;
   onBackdropClick?: React.ReactEventHandler<{}>;
-  onClose?: (event: React.SyntheticEvent<any>, reason: string) => void;
+  onClose?: (
+    event: React.SyntheticEvent<unknown>,
+    reason: 'backdropClick' | 'escapeKeyDown',
+  ) => void;
   onEscapeKeyDown?: React.ReactEventHandler<{}>;
   onRendered?: PortalProps['onRendered'];
   open: boolean;

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -20,7 +20,9 @@ export interface ModalProps
   keepMounted?: boolean;
   manager?: ModalManager;
   onBackdropClick?: React.ReactEventHandler<{}>;
-  onClose?: (event: {}, reason: 'backdropClick' | 'escapeKeyDown') => void;
+  onClose?: {
+    bivarianceHack(event: {}, reason: 'backdropClick' | 'escapeKeyDown'): void;
+  }['bivarianceHack'];
   onEscapeKeyDown?: React.ReactEventHandler<{}>;
   onRendered?: PortalProps['onRendered'];
   open: boolean;

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -328,7 +328,7 @@ describe('<Modal />', () => {
       assert.strictEqual(onEscapeKeyDownSpy.callCount, 1);
       assert.strictEqual(onEscapeKeyDownSpy.calledWith(event), true);
       assert.strictEqual(onCloseSpy.callCount, 1);
-      assert.strictEqual(onCloseSpy.calledWith(event), true);
+      assert.strictEqual(onCloseSpy.calledWith(event, 'escapeKeyDown'), true);
     });
 
     it('when disableEscapeKeyDown should call only onClose', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #15358.

I have also updated an existing test which now ensures that the onClose callback is called with the correct reason as well as the event. 
