### PR TITLE
[NProgressBar] Add types

### DIFF
--- a/packages/material-ui-docs/src/NProgressBar/NProgressBar.d.ts
+++ b/packages/material-ui-docs/src/NProgressBar/NProgressBar.d.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export interface NProgressBarProps {
+  children?: React.ReactNode;
+}
+
+declare const NProgressBar: React.FunctionComponent<NProgressBarProps>;
+export default NProgressBar;

--- a/packages/material-ui-docs/src/NProgressBar/index.d.ts
+++ b/packages/material-ui-docs/src/NProgressBar/index.d.ts
@@ -1,0 +1,1 @@
+export { default, NProgressBarProps } from './NProgressBar';


### PR DESCRIPTION
Makes it consistent with our other packages. The build for this package would fail otherwise (copy-files insists on existing types for sub-packages) i.e. `yarn lerna run build` works now. 