### PR TITLE
[test] Add hoc + overrideable component workaround

### DIFF
--- a/packages/material-ui/test/typescript/hoc-interop.spec.tsx
+++ b/packages/material-ui/test/typescript/hoc-interop.spec.tsx
@@ -8,7 +8,8 @@
  *
  * See https://github.com/Microsoft/TypeScript/issues/28339 for in-depth discussion
  */
-
+import { createStyles, ThemeProvider } from '@material-ui/styles';
+import { Button, withStyles } from '@material-ui/core';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import emotionStyled from '@emotion/styled';
 import * as React from 'react';
@@ -49,4 +50,22 @@ const filledProps = {
   <TextFieldWithRouter variant="filled" {...filledProps} />;
   // $ExpectError
   <TextFieldWithRouter {...filledProps} />; // desired
+}
+
+// https://github.com/mui-org/material-ui/issues/14586
+{
+  const styles = createStyles({
+    root: {
+      color: 'red',
+    },
+  });
+
+  const StyledButton = withStyles(styles)(Button);
+
+  // undesired; caused by https://github.com/Microsoft/TypeScript/issues/26591
+  <StyledButton component="a" />; // $ExpectError
+
+  // workaround
+  const UnsafeStyledButton = withStyles({ root: { color: 'ref' } })(Button) as typeof Button;
+  <UnsafeStyledButton component="a" />;
 }

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -474,6 +474,10 @@ withStyles(theme =>
 
   const StyledButton = withStyles(styles)(Button);
 
-  // undesired
+  // undesired; caused by https://github.com/Microsoft/TypeScript/issues/26591
   <StyledButton component="a" />; // $ExpectError
+
+  // workaround
+  const UnsafeStyledButton = withStyles({ root: { color: 'ref' } })(Button) as typeof Button;
+  <UnsafeStyledButton component="a" />;
 }

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -14,7 +14,7 @@ import {
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import { blue } from '@material-ui/core/colors';
-import { StandardProps, ButtonBase } from '@material-ui/core';
+import { StandardProps } from '@material-ui/core';
 
 // Shared types for examples
 interface ComponentProps extends WithStyles<typeof styles> {
@@ -462,22 +462,4 @@ withStyles(theme =>
   const CorrectUsage = () => <StyledMyButton nonDefaulted="2" />;
   // Property 'nonDefaulted' is missing in type '{}'
   const MissingPropUsage = () => <StyledMyButton />; // $ExpectError
-}
-
-// https://github.com/mui-org/material-ui/issues/14586
-{
-  const styles = createStyles({
-    root: {
-      color: 'red',
-    },
-  });
-
-  const StyledButton = withStyles(styles)(Button);
-
-  // undesired; caused by https://github.com/Microsoft/TypeScript/issues/26591
-  <StyledButton component="a" />; // $ExpectError
-
-  // workaround
-  const UnsafeStyledButton = withStyles({ root: { color: 'ref' } })(Button) as typeof Button;
-  <UnsafeStyledButton component="a" />;
 }


### PR DESCRIPTION
Closes #14586 

This is a TypeScript design limitation. We can fall back to `as typeof WrappedComponent` cast if the HOC only changed prop values but not types.