### PR TITLE
[docs] Add Button + react-router TypeScript demo

### DIFF
--- a/docs/src/pages/demos/buttons/ButtonRouter.js
+++ b/docs/src/pages/demos/buttons/ButtonRouter.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { MemoryRouter as Router } from 'react-router';
+import { Link } from 'react-router-dom';
+import Button from '@material-ui/core/Button';
+
+// required for react-router-dom < 6.0.0
+// see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
+const AdapterLink = React.forwardRef((props, ref) => <Link innerRef={ref} {...props} />);
+
+const HomeLink = React.forwardRef((props, ref) => <Link innerRef={ref} to="/home" {...props} />);
+
+function App() {
+  return (
+    <Router>
+      <Button color="primary" component={AdapterLink} to="/">
+        Root
+      </Button>
+      {/* Avoids property collision */}
+      <Button component={HomeLink}>Home</Button>
+    </Router>
+  );
+}
+
+export default App;

--- a/docs/src/pages/demos/buttons/ButtonRouter.tsx
+++ b/docs/src/pages/demos/buttons/ButtonRouter.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { MemoryRouter as Router } from 'react-router';
+import { Link, LinkProps } from 'react-router-dom';
+import Button from '@material-ui/core/Button';
+
+// required for react-router-dom < 6.0.0
+// see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
+const AdapterLink = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => (
+  <Link innerRef={ref as any} {...props} />
+));
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+const HomeLink = React.forwardRef<HTMLAnchorElement, Omit<LinkProps, 'innerRef' | 'to'>>(
+  (props, ref) => <Link innerRef={ref as any} to="/home" {...props} />,
+);
+
+function App() {
+  return (
+    <Router>
+      <Button color="primary" component={AdapterLink} to="/">
+        Root
+      </Button>
+      {/* Avoids property collision */}
+      <Button component={HomeLink}>Home</Button>
+    </Router>
+  );
+}
+
+export default App;

--- a/docs/src/pages/demos/buttons/buttons.md
+++ b/docs/src/pages/demos/buttons/buttons.md
@@ -123,32 +123,7 @@ component forwards this ref to the underlying DOM node.
 Given that a lot of our interactive components rely on `ButtonBase`, you should be
 able to take advantage of it everywhere:
 
-```jsx
-import React from 'react';
-import { Link as RouterLink } from 'react-router-dom'
-import Button from '@material-ui/core/Button';
+{{"demo": "pages/demos/buttons/ButtonRouter.js", "defaultCodeOpen": true}}
 
-// required for react-router-dom < 5.0.0 
-// see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
-const Link = React.forwardRef((props, ref) => <RouterLink {...props} innerRef={ref} />)
-
-<Button component={Link} to="/open-collective">
-  Link
-</Button>
-```
-
-or if you want to avoid properties collision:
-
-```jsx
-import { Link } from 'react-router-dom'
-import Button from '@material-ui/core/Button';
-
-// use `ref` instead of `innerRef` with react-router-dom@^5.0.0
-const MyLink = React.forwardRef((props, ref) => <Link to="/open-collective" {...props} innerRef={ref} />);
-
-<Button component={MyLink}>
-  Link
-</Button>
-```
-
-*Note: Creating `MyLink` is necessary to prevent unexpected unmounting. You can read more about it in our [component property guide](/guides/composition/#component-property).*
+_Note: Creating the Button components is necessary to prevent unexpected unmounting.
+You can read more about it in our [component property guide](/guides/composition/#component-property)._

--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -249,63 +249,10 @@ const theme = createMyTheme({ appDrawer: { breakpoint: 'md' }});
 ```
 
 ## Usage of `component` property
-
 Material-UI allows you to replace a component's root node via a `component` property.
-For example, a `Button`'s root node can be replaced with a React Router `Link`, and any additional props that are passed to `Button`, such as `to`, will be spread to the `Link` component, meaning you can do this:
-```jsx
-import { Link } from 'react-router-dom';
+For example, a `Button`'s root node can be replaced with a React Router `Link`, and any additional props that are passed to `Button`, such as `to`, will be spread to the `Link` component. For a code
+example concerning `Button` and `react-router-dom` checkout [this Button demo](/demos/buttons/#third-party-routing-library)
 
-<Button component={Link} to="/">Go Home</Button>
-```
-
-However, TypeScript will complain about it, because `to` is not part of the `ButtonProps` interface, and with the current type declarations it has no way of inferring what props can be passed to `component`.
-
-The current workaround is to cast Link to `any`:
-
-```tsx
-import { Link } from 'react-router-dom';
-import Button, { ButtonProps } from '@material-ui/core/Button';
-
-interface LinkButtonProps extends ButtonProps {
-  to: string;
-  replace?: boolean;
-}
-
-const LinkButton = (props: LinkButtonProps) => (
-  <Button {...props} component={Link as any} />
-)
-
-// usage:
-<LinkButton color="primary" to="/">Go Home</LinkButton>
-```
-
-Material-UI components pass some basic event handler props (`onClick`, `onDoubleClick`, etc.) to their root nodes.
-These handlers have a signature of:
-```ts
-(event: MouseEvent<HTMLElement, MouseEvent>) => void
-```
-
-which is incompatible with the event handler signatures that `Link` expects, which are:
-```ts
-(event: MouseEvent<AnchorElement>) => void
-```
-
-Any element or component that you pass into `component` will have this problem if the signatures of their event handler props don't match.
-
+Not every component fully supports any component type you pass in. If you encounter a
+component that rejects its `component` props in TypeScript please open an issue.
 There is an ongoing effort to fix this by making component props generic.
-
-### Avoiding properties collision
-
-The previous strategy suffers from a little limitation: properties collision.
-The component providing the `component` property might not forward all its properties to the root element.
-To workaround this issue, you can create a custom component:
-
-```tsx
-import { Link } from 'react-router-dom';
-import Button from '@material-ui/core/Button';
-
-const MyLink = (props: any) => <Link to="/" {...props} />;
-
-// usage:
-<Button color="primary" component={MyLink}>Go Home</Button>
-```

--- a/packages/material-ui/src/Button/Button.spec.tsx
+++ b/packages/material-ui/src/Button/Button.spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Button, { ButtonProps } from '@material-ui/core/Button';
 import { Link as ReactRouterLink, LinkProps } from 'react-router-dom';
-import { type } from 'os';
 
 const log = console.log;
 


### PR DESCRIPTION
Component prop example was mainly concerned with react-router + button so we just added a proper demo for it.

Closes #13218