### PR TITLE
[docs] Use tsx syntax highlighting

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -87,7 +87,7 @@ const markedOptions = {
 
       case 'ts':
       case 'tsx':
-        language = prism.languages.typescript;
+        language = prism.languages.tsx;
         break;
 
       case 'js':

--- a/docs/src/modules/components/prism.js
+++ b/docs/src/modules/components/prism.js
@@ -6,7 +6,7 @@ import 'prismjs/components/prism-diff';
 import 'prismjs/components/prism-javascript';
 import 'prismjs/components/prism-jsx';
 import 'prismjs/components/prism-markup';
-import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-tsx';
 
 let styleNode;
 let lightTheme;


### PR DESCRIPTION
We use jsx highlighting for all our JS code so we should use tsx highlighting for all our TS code.