### PR TITLE
[TextField] Update labelWidth for outline variant if required is updated

### DIFF
--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -100,7 +100,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
       const labelNode = ReactDOM.findDOMNode(labelRef.current);
       setLabelWidth(labelNode != null ? labelNode.offsetWidth : 0);
     }
-  }, [variant]);
+  }, [variant, required]);
 
   warning(
     !select || Boolean(children),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Currently, if a TextField using `outlined` for the variant has the required prop update to true the asterisk will overlap with the outline a little bit. This will update the width if required changes to accommodate for the additional spacing.

As a note, I did originally go through to write tests for this, but the offsetWidth was always reporting 0 no matter the label or changes. I assume this is a JSDOM limitation. If anyone has any ideas the best way to test this I am open to adding one.