### PR TITLE
[docs] Migrate picker demos to hooks

### DIFF
--- a/docs/src/pages/demos/pickers/DateAndTimePickers.js
+++ b/docs/src/pages/demos/pickers/DateAndTimePickers.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -13,10 +12,10 @@ const styles = theme => ({
     marginRight: theme.spacing(1),
     width: 200,
   },
-});
+}));
 
-function DateAndTimePickers(props) {
-  const { classes } = props;
+function DateAndTimePickers() {
+  const classes = useStyles();
 
   return (
     <form className={classes.container} noValidate>
@@ -34,8 +33,4 @@ function DateAndTimePickers(props) {
   );
 }
 
-DateAndTimePickers.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(DateAndTimePickers);
+export default DateAndTimePickers;

--- a/docs/src/pages/demos/pickers/DateAndTimePickers.tsx
+++ b/docs/src/pages/demos/pickers/DateAndTimePickers.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
       display: 'flex',
@@ -14,12 +13,11 @@ const styles = (theme: Theme) =>
       marginRight: theme.spacing(1),
       width: 200,
     },
-  });
+  }),
+);
 
-export type Props = WithStyles<typeof styles>;
-
-function DateAndTimePickers(props: Props) {
-  const { classes } = props;
+function DateAndTimePickers() {
+  const classes = useStyles();
 
   return (
     <form className={classes.container} noValidate>
@@ -37,8 +35,4 @@ function DateAndTimePickers(props: Props) {
   );
 }
 
-DateAndTimePickers.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(DateAndTimePickers);
+export default DateAndTimePickers;

--- a/docs/src/pages/demos/pickers/DatePickers.js
+++ b/docs/src/pages/demos/pickers/DatePickers.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -13,10 +12,10 @@ const styles = theme => ({
     marginRight: theme.spacing(1),
     width: 200,
   },
-});
+}));
 
-function DatePickers(props) {
-  const { classes } = props;
+function DatePickers() {
+  const classes = useStyles();
 
   return (
     <form className={classes.container} noValidate>
@@ -34,8 +33,4 @@ function DatePickers(props) {
   );
 }
 
-DatePickers.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(DatePickers);
+export default DatePickers;

--- a/docs/src/pages/demos/pickers/DatePickers.tsx
+++ b/docs/src/pages/demos/pickers/DatePickers.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
       display: 'flex',
@@ -14,12 +13,11 @@ const styles = (theme: Theme) =>
       marginRight: theme.spacing(1),
       width: 200,
     },
-  });
+  }),
+);
 
-export type Props = WithStyles<typeof styles>;
-
-function DatePickers(props: Props) {
-  const { classes } = props;
+function DatePickers() {
+  const classes = useStyles();
 
   return (
     <form className={classes.container} noValidate>
@@ -37,8 +35,4 @@ function DatePickers(props: Props) {
   );
 }
 
-DatePickers.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(DatePickers);
+export default DatePickers;

--- a/docs/src/pages/demos/pickers/MaterialUIPickers.js
+++ b/docs/src/pages/demos/pickers/MaterialUIPickers.js
@@ -1,54 +1,43 @@
 import 'date-fns';
 import React from 'react';
-import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider, TimePicker, DatePicker } from 'material-ui-pickers';
 
-const styles = {
+const useStyles = makeStyles({
   grid: {
     width: '60%',
   },
-};
+});
 
-class MaterialUIPickers extends React.Component {
-  state = {
-    // The first commit of Material-UI
-    selectedDate: new Date('2014-08-18T21:11:54'),
-  };
+function MaterialUIPickers() {
+  // The first commit of Material-UI
+  const [selectedDate, setSelectedDate] = React.useState(new Date('2014-08-18T21:11:54'));
+  const classes = useStyles();
 
-  handleDateChange = date => {
-    this.setState({ selectedDate: date });
-  };
-
-  render() {
-    const { classes } = this.props;
-    const { selectedDate } = this.state;
-
-    return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
-        <Grid container className={classes.grid} justify="space-around">
-          <DatePicker
-            margin="normal"
-            label="Date picker"
-            value={selectedDate}
-            onChange={this.handleDateChange}
-          />
-          <TimePicker
-            margin="normal"
-            label="Time picker"
-            value={selectedDate}
-            onChange={this.handleDateChange}
-          />
-        </Grid>
-      </MuiPickersUtilsProvider>
-    );
+  function handleDateChange(date) {
+    setSelectedDate(date);
   }
+
+  return (
+    <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <Grid container className={classes.grid} justify="space-around">
+        <DatePicker
+          margin="normal"
+          label="Date picker"
+          value={selectedDate}
+          onChange={handleDateChange}
+        />
+        <TimePicker
+          margin="normal"
+          label="Time picker"
+          value={selectedDate}
+          onChange={handleDateChange}
+        />
+      </Grid>
+    </MuiPickersUtilsProvider>
+  );
 }
 
-MaterialUIPickers.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(MaterialUIPickers);
+export default MaterialUIPickers;

--- a/docs/src/pages/demos/pickers/MaterialUIPickers.tsx
+++ b/docs/src/pages/demos/pickers/MaterialUIPickers.tsx
@@ -1,60 +1,45 @@
 import 'date-fns';
 import React from 'react';
-import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
-import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
 import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider, TimePicker, DatePicker } from 'material-ui-pickers';
 
-const styles = createStyles({
-  grid: {
-    width: '60%',
-  },
-});
+const useStyles = makeStyles(
+  createStyles({
+    grid: {
+      width: '60%',
+    },
+  }),
+);
 
-export type Props = WithStyles<typeof styles>;
+function MaterialUIPickers() {
+  // The first commit of Material-UI
+  const [selectedDate, setSelectedDate] = React.useState(new Date('2014-08-18T21:11:54'));
+  const classes = useStyles();
 
-export interface State {
-  selectedDate: Date;
-}
-
-class MaterialUIPickers extends React.Component<Props, State> {
-  state = {
-    // The first commit of Material-UI
-    selectedDate: new Date('2014-08-18T21:11:54'),
-  };
-
-  handleDateChange = (date: Date) => {
-    this.setState({ selectedDate: date });
-  };
-
-  render() {
-    const { classes } = this.props;
-    const { selectedDate } = this.state;
-
-    return (
-      <MuiPickersUtilsProvider utils={DateFnsUtils}>
-        <Grid container className={classes.grid} justify="space-around">
-          <DatePicker
-            margin="normal"
-            label="Date picker"
-            value={selectedDate}
-            onChange={this.handleDateChange}
-          />
-          <TimePicker
-            margin="normal"
-            label="Time picker"
-            value={selectedDate}
-            onChange={this.handleDateChange}
-          />
-        </Grid>
-      </MuiPickersUtilsProvider>
-    );
+  function handleDateChange(date: Date) {
+    setSelectedDate(date);
   }
+
+  return (
+    <MuiPickersUtilsProvider utils={DateFnsUtils}>
+      <Grid container className={classes.grid} justify="space-around">
+        <DatePicker
+          margin="normal"
+          label="Date picker"
+          value={selectedDate}
+          onChange={handleDateChange}
+        />
+        <TimePicker
+          margin="normal"
+          label="Time picker"
+          value={selectedDate}
+          onChange={handleDateChange}
+        />
+      </Grid>
+    </MuiPickersUtilsProvider>
+  );
 }
 
-(MaterialUIPickers as React.ComponentClass<Props, State>).propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(MaterialUIPickers);
+export default MaterialUIPickers;

--- a/docs/src/pages/demos/pickers/TimePickers.js
+++ b/docs/src/pages/demos/pickers/TimePickers.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -13,10 +12,10 @@ const styles = theme => ({
     marginRight: theme.spacing(1),
     width: 200,
   },
-});
+}));
 
-function TimePickers(props) {
-  const { classes } = props;
+function TimePickers() {
+  const classes = useStyles();
 
   return (
     <form className={classes.container} noValidate>
@@ -37,8 +36,4 @@ function TimePickers(props) {
   );
 }
 
-TimePickers.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(TimePickers);
+export default TimePickers;

--- a/docs/src/pages/demos/pickers/TimePickers.tsx
+++ b/docs/src/pages/demos/pickers/TimePickers.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, withStyles, WithStyles, Theme } from '@material-ui/core/styles';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
       display: 'flex',
@@ -14,12 +13,11 @@ const styles = (theme: Theme) =>
       marginRight: theme.spacing(1),
       width: 200,
     },
-  });
+  }),
+);
 
-export type Props = WithStyles<typeof styles>;
-
-function TimePickers(props: Props) {
-  const { classes } = props;
+function TimePickers() {
+  const classes = useStyles();
 
   return (
     <form className={classes.container} noValidate>
@@ -40,8 +38,4 @@ function TimePickers(props: Props) {
   );
 }
 
-TimePickers.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(TimePickers);
+export default TimePickers;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Migrated the picker demos to use hooks and converted the `MaterialUIPickers` demo to a functional component