### PR TITLE
[Link] Improve TypeScript integration with react-router 

### DIFF
--- a/docs/src/pages/demos/buttons/ButtonRouter.js
+++ b/docs/src/pages/demos/buttons/ButtonRouter.js
@@ -7,18 +7,19 @@ import Button from '@material-ui/core/Button';
 // see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
 const AdapterLink = React.forwardRef((props, ref) => <Link innerRef={ref} {...props} />);
 
-const HomeLink = React.forwardRef((props, ref) => <Link innerRef={ref} to="/home" {...props} />);
+const CollisionLink = React.forwardRef((props, ref) => (
+  <Link innerRef={ref} to="/getting-started/installation/" {...props} />
+));
 
-function App() {
+function ButtonRouter() {
   return (
     <Router>
       <Button color="primary" component={AdapterLink} to="/">
-        Root
+        Simple case
       </Button>
-      {/* Avoids property collision */}
-      <Button component={HomeLink}>Home</Button>
+      <Button component={CollisionLink}>Avoids props collision</Button>
     </Router>
   );
 }
 
-export default App;
+export default ButtonRouter;

--- a/docs/src/pages/demos/buttons/ButtonRouter.tsx
+++ b/docs/src/pages/demos/buttons/ButtonRouter.tsx
@@ -10,20 +10,19 @@ const AdapterLink = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) 
 ));
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-const HomeLink = React.forwardRef<HTMLAnchorElement, Omit<LinkProps, 'innerRef' | 'to'>>(
-  (props, ref) => <Link innerRef={ref as any} to="/home" {...props} />,
+const CollisionLink = React.forwardRef<HTMLAnchorElement, Omit<LinkProps, 'innerRef' | 'to'>>(
+  (props, ref) => <Link innerRef={ref as any} to="/getting-started/installation/" {...props} />,
 );
 
-function App() {
+function ButtonRouter() {
   return (
     <Router>
       <Button color="primary" component={AdapterLink} to="/">
-        Root
+        Simple case
       </Button>
-      {/* Avoids property collision */}
-      <Button component={HomeLink}>Home</Button>
+      <Button component={CollisionLink}>Avoids props collision</Button>
     </Router>
   );
 }
 
-export default App;
+export default ButtonRouter;

--- a/docs/src/pages/style/links/LinkRouter.js
+++ b/docs/src/pages/style/links/LinkRouter.js
@@ -1,0 +1,33 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React from 'react';
+import { MemoryRouter as Router } from 'react-router';
+import { Link as RouterLink } from 'react-router-dom';
+import Link from '@material-ui/core/Link';
+
+// required for react-router-dom < 6.0.0
+// see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
+const AdapterLink = React.forwardRef((props, ref) => <RouterLink innerRef={ref} {...props} />);
+
+const CollisionLink = React.forwardRef((props, ref) => (
+  <RouterLink innerRef={ref} to="/getting-started/installation/" {...props} />
+));
+
+function LinkRouter() {
+  return (
+    <Router>
+      <div>
+        <Link component={RouterLink} to="/">
+          Simple case
+        </Link>
+        <br />
+        <Link component={AdapterLink} to="/">
+          Ref forwarding
+        </Link>
+        <br />
+        <Link component={CollisionLink}>Avoids props collision</Link>
+      </div>
+    </Router>
+  );
+}
+
+export default LinkRouter;

--- a/docs/src/pages/style/links/LinkRouter.tsx
+++ b/docs/src/pages/style/links/LinkRouter.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
+import React from 'react';
+import { MemoryRouter as Router } from 'react-router';
+import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-dom';
+import Link from '@material-ui/core/Link';
+
+// required for react-router-dom < 6.0.0
+// see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
+const AdapterLink = React.forwardRef<HTMLAnchorElement, RouterLinkProps>((props, ref) => (
+  <RouterLink innerRef={ref as any} {...props} />
+));
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+const CollisionLink = React.forwardRef<HTMLAnchorElement, Omit<RouterLinkProps, 'innerRef' | 'to'>>(
+  (props, ref) => (
+    <RouterLink innerRef={ref as any} to="/getting-started/installation/" {...props} />
+  ),
+);
+
+function LinkRouter() {
+  return (
+    <Router>
+      <div>
+        <Link component={RouterLink} to="/">
+          Simple case
+        </Link>
+        <br />
+        <Link component={AdapterLink} to="/">
+          Ref forwarding
+        </Link>
+        <br />
+        <Link component={CollisionLink}>Avoids props collision</Link>
+      </div>
+    </Router>
+  );
+}
+
+export default LinkRouter;

--- a/docs/src/pages/style/links/links.md
+++ b/docs/src/pages/style/links/links.md
@@ -14,13 +14,14 @@ You can leverage its properties.
 {{"demo": "pages/style/links/Links.js"}}
 
 However, the Link has different default properties than the Typography:
+
 - `color="primary"` as the link needs to stand out.
 - `variant="inherit"` as the link will, most of the time, be used as a child of a Typograpy component.
 
 ## Accessibility
 
 - When providing the content for the link, avoid generic descriptions like "click here" or "go to".
-Instead, use [specific descriptions](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text).
+  Instead, use [specific descriptions](https://developers.google.com/web/tools/lighthouse/audits/descriptive-link-text).
 - For the best user experience links should stand out from the text on the page.
 - If a link doesn't have a meaningful href, [it should be rendered using a `<button>` element](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md).
 
@@ -31,34 +32,15 @@ Instead, use [specific descriptions](https://developers.google.com/web/tools/lig
 When you use `target="_blank"` with Links it is [recommended](https://developers.google.com/web/tools/lighthouse/audits/noopener) to always set `rel="noopener"` or `rel="noreferrer"` when linking to third party content.
 
 - `rel="noopener"` prevents the new page from being able to access the window.opener property and ensures it runs in a separate process.
-Without this the target page can potentially redirect your page to a malicious URL.
-- `rel="noreferrer""` has the same effect, but also prevents the *Referer* header from being sent to the new page.
-⚠️ Removing the referrer header will affect analytics.
+  Without this the target page can potentially redirect your page to a malicious URL.
+- `rel="noreferrer""` has the same effect, but also prevents the _Referer_ header from being sent to the new page.
+  ⚠️ Removing the referrer header will affect analytics.
 
 ## Third-party routing library
 
 One common use case is to perform the navigation on the client only, without doing a .html round-trip with the server. The `Link` component provides a property to handle this use case: `component`.
 
-```jsx
-import { Link as RouterLink } from 'react-router-dom'
-import Link from '@material-ui/core/Link';
+{{"demo": "pages/style/links/LinkRouter.js", "defaultCodeOpen": true}}
 
-<Link component={RouterLink} to="/open-collective">
-  Link
-</Link>
-```
-
-or if you want to avoid properties collision:
-
-```jsx
-import { Link as RouterLink } from 'react-router-dom'
-import Link from '@material-ui/core/Link';
-
-const MyLink = props => <RouterLink to="/open-collective" {...props} />
-
-<Link component={MyLink}>
-  Link
-</Link>
-```
-
-*Note: Creating `MyLink` is necessary to prevent unexpected unmounting. You can read more about it in our [component property guide](/guides/composition/#component-property).*
+_Note: Creating the Link components is necessary to prevent unexpected unmounting.
+You can read more about it in our [component property guide](/guides/composition/#component-property)._

--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -1,21 +1,16 @@
 import * as React from 'react';
-import { StandardProps } from '..';
+import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
+import { Omit } from '..';
 import { TypographyProps } from '../Typography';
 
-export interface LinkProps
-  extends StandardProps<
-    React.AnchorHTMLAttributes<HTMLAnchorElement> & TypographyProps,
-    LinkClassKey,
-    'component'
-  > {
-  /**
-   * we only document this here since we use an anchor element instead of the
-   * default component in typography.
-   */
-  component?: React.ElementType<React.AnchorHTMLAttributes<HTMLAnchorElement> & TypographyProps>;
-  TypographyClasses?: TypographyProps['classes'];
-  underline?: 'none' | 'hover' | 'always';
-}
+declare const Link: OverridableComponent<{
+  props: LinkBaseProps & {
+    TypographyClasses?: TypographyProps['classes'];
+    underline?: 'none' | 'hover' | 'always';
+  };
+  defaultComponent: 'a';
+  classKey: LinkClassKey;
+}>;
 
 export type LinkClassKey =
   | 'root'
@@ -24,6 +19,9 @@ export type LinkClassKey =
   | 'underlineAlways'
   | 'button';
 
-declare const Link: React.ComponentType<LinkProps>;
+export type LinkBaseProps = React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  Omit<TypographyProps, 'component'>;
+
+export type LinkProps = SimplifiedPropsOf<typeof Link>;
 
 export default Link;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #15105, closes #15299, based on 3rd suggestion in https://github.com/mui-org/material-ui/issues/15299#issuecomment-481726292

Since TypographyProps is currently not using OverridableComponent yet, I omitted the 'Component' prop for now to avoid conflicting types.