### PR TITLE
[test] Conform components forward ref to root component

### DIFF
--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -109,9 +109,16 @@ function describeRef(element, getOptions) {
   describe('ref', () => {
     it(`attaches the ref`, () => {
       // type def in ConformanceOptions
-      const { mount, refInstanceof } = getOptions();
+      const { inheritComponent, mount, refInstanceof } = getOptions();
 
-      testRef(element, mount, current => assert.instanceOf(current, refInstanceof));
+      testRef(element, mount, (instance, wrapper) => {
+        assert.instanceOf(instance, refInstanceof);
+
+        if (inheritComponent && instance instanceof window.Element) {
+          const rootHost = findOutermostIntrinsic(wrapper);
+          assert.strictEqual(instance, rootHost.instance());
+        }
+      });
     });
   });
 }

--- a/packages/material-ui/src/test-utils/testRef.js
+++ b/packages/material-ui/src/test-utils/testRef.js
@@ -16,6 +16,6 @@ function assertDOMNode(node) {
  */
 export default function testRef(element, mount, onRef = assertDOMNode) {
   const ref = React.createRef();
-  mount(<React.Fragment>{React.cloneElement(element, { ref })}</React.Fragment>);
-  onRef(ref.current);
+  const wrapper = mount(<React.Fragment>{React.cloneElement(element, { ref })}</React.Fragment>);
+  onRef(ref.current, wrapper);
 }


### PR DESCRIPTION
Cherry-pick improved ref testing from #15387

