### PR TITLE
[docs] Fix line ending issue on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
+* text=auto eol=lf

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -24,9 +24,7 @@ async function getUnstagedGitFiles() {
 }
 
 function fixBabelGeneratorIssues(source) {
-  return source
-    .replace(/\/>(\r\n|\r|\n)(\r\n|\r|\n)/g, '/>\n')
-    .replace(/,(\r\n|\r|\n)(\r\n|\r|\n)/g, ',\n');
+  return source.replace(/\/>\n\n/g, '/>\n').replace(/,\n\n/g, ',\n');
 }
 
 exec('yarn docs:typescript')

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -25,8 +25,8 @@ async function getUnstagedGitFiles() {
 
 function fixBabelGeneratorIssues(source) {
   return source
-    .replace(/\/>(\r\n|\r|\n)(\r\n|\r|\n)/g, '/>\r\n')
-    .replace(/,(\r\n|\r|\n)(\r\n|\r|\n)/g, ',\r\n');
+    .replace(/\/>(\r\n|\r|\n)(\r\n|\r|\n)/g, '/>\n')
+    .replace(/,(\r\n|\r|\n)(\r\n|\r|\n)/g, ',\n');
 }
 
 exec('yarn docs:typescript')

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -24,7 +24,9 @@ async function getUnstagedGitFiles() {
 }
 
 function fixBabelGeneratorIssues(source) {
-  return source.replace(/\/>\n\n/g, '/>\n').replace(/,\n\n/g, ',\n');
+  return source
+    .replace(/\/>(\r\n|\r|\n)(\r\n|\r|\n)/g, '/>\r\n')
+    .replace(/,(\r\n|\r|\n)(\r\n|\r|\n)/g, ',\r\n');
 }
 
 exec('yarn docs:typescript')

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,4 +5,5 @@ module.exports = {
   semi: true,
   singleQuote: true,
   trailingComma: 'all',
+  endOfLine: 'lf',
 };


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

When running `yarn docs:typescript:formatted` on Windows it leaves empty lines in files because `git checkout` saves them with `\r\n`.
Solution to this is to set `endOfLine: 'lf',` in `prettier.config.js` and `eol=lf` in `.gitattributes`

See https://prettier.io/docs/en/options.html#end-of-line for more