### PR TITLE
[docs] Migrate TextField demos to hooks

### DIFF
--- a/docs/src/pages/demos/text-fields/ComposedTextField.js
+++ b/docs/src/pages/demos/text-fields/ComposedTextField.js
@@ -20,11 +20,11 @@ const useStyles = makeStyles(theme => ({
 function ComposedTextField() {
   const [labelWidth, setLabelWidth] = React.useState(0);
   const [name, setName] = React.useState('Composed TextField');
-  const label = React.useRef(null);
+  const labelRef = React.useRef(null);
   const classes = useStyles();
 
   React.useEffect(() => {
-    setLabelWidth(label.current.offsetWidth);
+    setLabelWidth(labelRef.current.offsetWidth);
   }, []);
 
   function handleChange(event) {
@@ -63,7 +63,7 @@ function ComposedTextField() {
         <FormHelperText id="component-error-text">Error</FormHelperText>
       </FormControl>
       <FormControl className={classes.formControl} variant="outlined">
-        <InputLabel ref={label} htmlFor="component-outlined">
+        <InputLabel ref={labelRef} htmlFor="component-outlined">
           Name
         </InputLabel>
         <OutlinedInput

--- a/docs/src/pages/demos/text-fields/ComposedTextField.js
+++ b/docs/src/pages/demos/text-fields/ComposedTextField.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import FilledInput from '@material-ui/core/FilledInput';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -8,7 +7,7 @@ import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -16,81 +15,70 @@ const styles = theme => ({
   formControl: {
     margin: theme.spacing(1),
   },
-});
+}));
 
-class ComposedTextField extends React.Component {
-  label = React.createRef();
+function ComposedTextField() {
+  const [labelWidth, setLabelWidth] = React.useState(0);
+  const [name, setName] = React.useState('Composed TextField');
+  const label = React.useRef(null);
+  const classes = useStyles();
 
-  state = {
-    labelWidth: 0,
-    name: 'Composed TextField',
-  };
+  React.useEffect(() => {
+    setLabelWidth(label.current.offsetWidth);
+  }, []);
 
-  componentDidMount() {
-    this.setState({ labelWidth: this.label.current.offsetWidth });
+  function handleChange(event) {
+    setName(event.target.value);
   }
 
-  handleChange = event => {
-    this.setState({ name: event.target.value });
-  };
-
-  render() {
-    const { labelWidth, name } = this.state;
-    const { classes } = this.props;
-
-    return (
-      <div className={classes.container}>
-        <FormControl className={classes.formControl}>
-          <InputLabel htmlFor="component-simple">Name</InputLabel>
-          <Input id="component-simple" value={name} onChange={this.handleChange} />
-        </FormControl>
-        <FormControl className={classes.formControl}>
-          <InputLabel htmlFor="component-helper">Name</InputLabel>
-          <Input
-            id="component-helper"
-            value={name}
-            onChange={this.handleChange}
-            aria-describedby="component-helper-text"
-          />
-          <FormHelperText id="component-helper-text">Some important helper text</FormHelperText>
-        </FormControl>
-        <FormControl className={classes.formControl} disabled>
-          <InputLabel htmlFor="component-disabled">Name</InputLabel>
-          <Input id="component-disabled" value={name} onChange={this.handleChange} />
-          <FormHelperText>Disabled</FormHelperText>
-        </FormControl>
-        <FormControl className={classes.formControl} error>
-          <InputLabel htmlFor="component-error">Name</InputLabel>
-          <Input
-            id="component-error"
-            value={name}
-            onChange={this.handleChange}
-            aria-describedby="component-error-text"
-          />
-          <FormHelperText id="component-error-text">Error</FormHelperText>
-        </FormControl>
-        <FormControl className={classes.formControl} variant="outlined">
-          <InputLabel ref={this.label} htmlFor="component-outlined">
-            Name
-          </InputLabel>
-          <OutlinedInput
-            id="component-outlined"
-            value={name}
-            onChange={this.handleChange}
-            labelWidth={labelWidth}
-          />
-        </FormControl>
-        <FormControl className={classes.formControl} variant="filled">
-          <InputLabel htmlFor="component-filled">Name</InputLabel>
-          <FilledInput id="component-filled" value={name} onChange={this.handleChange} />
-        </FormControl>
-      </div>
-    );
-  }
+  return (
+    <div className={classes.container}>
+      <FormControl className={classes.formControl}>
+        <InputLabel htmlFor="component-simple">Name</InputLabel>
+        <Input id="component-simple" value={name} onChange={handleChange} />
+      </FormControl>
+      <FormControl className={classes.formControl}>
+        <InputLabel htmlFor="component-helper">Name</InputLabel>
+        <Input
+          id="component-helper"
+          value={name}
+          onChange={handleChange}
+          aria-describedby="component-helper-text"
+        />
+        <FormHelperText id="component-helper-text">Some important helper text</FormHelperText>
+      </FormControl>
+      <FormControl className={classes.formControl} disabled>
+        <InputLabel htmlFor="component-disabled">Name</InputLabel>
+        <Input id="component-disabled" value={name} onChange={handleChange} />
+        <FormHelperText>Disabled</FormHelperText>
+      </FormControl>
+      <FormControl className={classes.formControl} error>
+        <InputLabel htmlFor="component-error">Name</InputLabel>
+        <Input
+          id="component-error"
+          value={name}
+          onChange={handleChange}
+          aria-describedby="component-error-text"
+        />
+        <FormHelperText id="component-error-text">Error</FormHelperText>
+      </FormControl>
+      <FormControl className={classes.formControl} variant="outlined">
+        <InputLabel ref={label} htmlFor="component-outlined">
+          Name
+        </InputLabel>
+        <OutlinedInput
+          id="component-outlined"
+          value={name}
+          onChange={handleChange}
+          labelWidth={labelWidth}
+        />
+      </FormControl>
+      <FormControl className={classes.formControl} variant="filled">
+        <InputLabel htmlFor="component-filled">Name</InputLabel>
+        <FilledInput id="component-filled" value={name} onChange={handleChange} />
+      </FormControl>
+    </div>
+  );
 }
 
-ComposedTextField.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(ComposedTextField);
+export default ComposedTextField;

--- a/docs/src/pages/demos/text-fields/ComposedTextField.tsx
+++ b/docs/src/pages/demos/text-fields/ComposedTextField.tsx
@@ -22,11 +22,11 @@ const useStyles = makeStyles((theme: Theme) =>
 function ComposedTextField() {
   const [labelWidth, setLabelWidth] = React.useState(0);
   const [name, setName] = React.useState('Composed TextField');
-  const label = React.useRef<HTMLLabelElement>(null);
+  const labelRef = React.useRef<HTMLLabelElement>(null);
   const classes = useStyles();
 
   React.useEffect(() => {
-    setLabelWidth(label.current!.offsetWidth);
+    setLabelWidth(labelRef.current!.offsetWidth);
   }, []);
 
   function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -65,7 +65,7 @@ function ComposedTextField() {
         <FormHelperText id="component-error-text">Error</FormHelperText>
       </FormControl>
       <FormControl className={classes.formControl} variant="outlined">
-        <InputLabel ref={label} htmlFor="component-outlined">
+        <InputLabel ref={labelRef} htmlFor="component-outlined">
           Name
         </InputLabel>
         <OutlinedInput

--- a/docs/src/pages/demos/text-fields/ComposedTextField.tsx
+++ b/docs/src/pages/demos/text-fields/ComposedTextField.tsx
@@ -1,6 +1,5 @@
-import React, { ComponentClass } from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import React from 'react';
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
 import FilledInput from '@material-ui/core/FilledInput';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -8,7 +7,7 @@ import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
       display: 'flex',
@@ -17,88 +16,71 @@ const styles = (theme: Theme) =>
     formControl: {
       margin: theme.spacing(1),
     },
-  });
+  }),
+);
 
-export interface Props extends WithStyles<typeof styles> {}
+function ComposedTextField() {
+  const [labelWidth, setLabelWidth] = React.useState(0);
+  const [name, setName] = React.useState('Composed TextField');
+  const label = React.useRef<HTMLLabelElement>(null);
+  const classes = useStyles();
 
-interface State {
-  labelWidth: number;
-  name: string;
-}
+  React.useEffect(() => {
+    setLabelWidth(label.current!.offsetWidth);
+  }, []);
 
-class ComposedTextField extends React.Component<Props, State> {
-  label = React.createRef<HTMLLabelElement>();
-
-  state = {
-    labelWidth: 0,
-    name: 'Composed TextField',
-  };
-
-  componentDidMount() {
-    this.setState({ labelWidth: this.label.current!.offsetWidth });
+  function handleChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setName(event.target.value);
   }
 
-  handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ name: event.target.value });
-  };
-
-  render() {
-    const { labelWidth, name } = this.state;
-    const { classes } = this.props;
-
-    return (
-      <div className={classes.container}>
-        <FormControl className={classes.formControl}>
-          <InputLabel htmlFor="component-simple">Name</InputLabel>
-          <Input id="component-simple" value={name} onChange={this.handleChange} />
-        </FormControl>
-        <FormControl className={classes.formControl}>
-          <InputLabel htmlFor="component-helper">Name</InputLabel>
-          <Input
-            id="component-helper"
-            value={name}
-            onChange={this.handleChange}
-            aria-describedby="component-helper-text"
-          />
-          <FormHelperText id="component-helper-text">Some important helper text</FormHelperText>
-        </FormControl>
-        <FormControl className={classes.formControl} disabled>
-          <InputLabel htmlFor="component-disabled">Name</InputLabel>
-          <Input id="component-disabled" value={name} onChange={this.handleChange} />
-          <FormHelperText>Disabled</FormHelperText>
-        </FormControl>
-        <FormControl className={classes.formControl} error>
-          <InputLabel htmlFor="component-error">Name</InputLabel>
-          <Input
-            id="component-error"
-            value={name}
-            onChange={this.handleChange}
-            aria-describedby="component-error-text"
-          />
-          <FormHelperText id="component-error-text">Error</FormHelperText>
-        </FormControl>
-        <FormControl className={classes.formControl} variant="outlined">
-          <InputLabel ref={this.label} htmlFor="component-outlined">
-            Name
-          </InputLabel>
-          <OutlinedInput
-            id="component-outlined"
-            value={name}
-            onChange={this.handleChange}
-            labelWidth={labelWidth}
-          />
-        </FormControl>
-        <FormControl className={classes.formControl} variant="filled">
-          <InputLabel htmlFor="component-filled">Name</InputLabel>
-          <FilledInput id="component-filled" value={name} onChange={this.handleChange} />
-        </FormControl>
-      </div>
-    );
-  }
+  return (
+    <div className={classes.container}>
+      <FormControl className={classes.formControl}>
+        <InputLabel htmlFor="component-simple">Name</InputLabel>
+        <Input id="component-simple" value={name} onChange={handleChange} />
+      </FormControl>
+      <FormControl className={classes.formControl}>
+        <InputLabel htmlFor="component-helper">Name</InputLabel>
+        <Input
+          id="component-helper"
+          value={name}
+          onChange={handleChange}
+          aria-describedby="component-helper-text"
+        />
+        <FormHelperText id="component-helper-text">Some important helper text</FormHelperText>
+      </FormControl>
+      <FormControl className={classes.formControl} disabled>
+        <InputLabel htmlFor="component-disabled">Name</InputLabel>
+        <Input id="component-disabled" value={name} onChange={handleChange} />
+        <FormHelperText>Disabled</FormHelperText>
+      </FormControl>
+      <FormControl className={classes.formControl} error>
+        <InputLabel htmlFor="component-error">Name</InputLabel>
+        <Input
+          id="component-error"
+          value={name}
+          onChange={handleChange}
+          aria-describedby="component-error-text"
+        />
+        <FormHelperText id="component-error-text">Error</FormHelperText>
+      </FormControl>
+      <FormControl className={classes.formControl} variant="outlined">
+        <InputLabel ref={label} htmlFor="component-outlined">
+          Name
+        </InputLabel>
+        <OutlinedInput
+          id="component-outlined"
+          value={name}
+          onChange={handleChange}
+          labelWidth={labelWidth}
+        />
+      </FormControl>
+      <FormControl className={classes.formControl} variant="filled">
+        <InputLabel htmlFor="component-filled">Name</InputLabel>
+        <FilledInput id="component-filled" value={name} onChange={handleChange} />
+      </FormControl>
+    </div>
+  );
 }
 
-(ComposedTextField as ComponentClass<Props>).propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(ComposedTextField);
+export default ComposedTextField;

--- a/docs/src/pages/demos/text-fields/CustomizedInputBase.js
+++ b/docs/src/pages/demos/text-fields/CustomizedInputBase.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import InputBase from '@material-ui/core/InputBase';
 import Divider from '@material-ui/core/Divider';
@@ -9,7 +8,7 @@ import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import DirectionsIcon from '@material-ui/icons/Directions';
 
-const styles = {
+const useStyles = makeStyles({
   root: {
     padding: '2px 4px',
     display: 'flex',
@@ -28,10 +27,10 @@ const styles = {
     height: 28,
     margin: 4,
   },
-};
+});
 
-function CustomizedInputBase(props) {
-  const { classes } = props;
+function CustomizedInputBase() {
+  const classes = useStyles();
 
   return (
     <Paper className={classes.root}>
@@ -50,8 +49,4 @@ function CustomizedInputBase(props) {
   );
 }
 
-CustomizedInputBase.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(CustomizedInputBase);
+export default CustomizedInputBase;

--- a/docs/src/pages/demos/text-fields/CustomizedInputBase.tsx
+++ b/docs/src/pages/demos/text-fields/CustomizedInputBase.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, WithStyles, withStyles } from '@material-ui/core/styles';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import InputBase from '@material-ui/core/InputBase';
 import Divider from '@material-ui/core/Divider';
@@ -9,31 +8,31 @@ import MenuIcon from '@material-ui/icons/Menu';
 import SearchIcon from '@material-ui/icons/Search';
 import DirectionsIcon from '@material-ui/icons/Directions';
 
-const styles = createStyles({
-  root: {
-    padding: '2px 4px',
-    display: 'flex',
-    alignItems: 'center',
-    width: 400,
-  },
-  input: {
-    marginLeft: 8,
-    flex: 1,
-  },
-  iconButton: {
-    padding: 10,
-  },
-  divider: {
-    width: 1,
-    height: 28,
-    margin: 4,
-  },
-});
+const useStyles = makeStyles(
+  createStyles({
+    root: {
+      padding: '2px 4px',
+      display: 'flex',
+      alignItems: 'center',
+      width: 400,
+    },
+    input: {
+      marginLeft: 8,
+      flex: 1,
+    },
+    iconButton: {
+      padding: 10,
+    },
+    divider: {
+      width: 1,
+      height: 28,
+      margin: 4,
+    },
+  }),
+);
 
-export interface Props extends WithStyles<typeof styles> {}
-
-function CustomizedInputBase(props: Props) {
-  const { classes } = props;
+function CustomizedInputBase() {
+  const classes = useStyles();
 
   return (
     <Paper className={classes.root}>
@@ -52,8 +51,4 @@ function CustomizedInputBase(props: Props) {
   );
 }
 
-CustomizedInputBase.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(CustomizedInputBase);
+export default CustomizedInputBase;

--- a/docs/src/pages/demos/text-fields/CustomizedInputs.js
+++ b/docs/src/pages/demos/text-fields/CustomizedInputs.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles, createMuiTheme } from '@material-ui/core/styles';
+import { makeStyles, createMuiTheme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Input from '@material-ui/core/Input';
 import InputBase from '@material-ui/core/InputBase';
@@ -12,7 +11,7 @@ import FilledInput from '@material-ui/core/FilledInput';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -87,7 +86,7 @@ const styles = theme => ({
       borderColor: theme.palette.primary.main,
     },
   },
-});
+}));
 
 const theme = createMuiTheme({
   palette: {
@@ -95,8 +94,8 @@ const theme = createMuiTheme({
   },
 });
 
-function CustomizedInputs(props) {
-  const { classes } = props;
+function CustomizedInputs() {
+  const classes = useStyles();
 
   return (
     <div className={classes.root}>
@@ -179,8 +178,4 @@ function CustomizedInputs(props) {
   );
 }
 
-CustomizedInputs.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(CustomizedInputs);
+export default CustomizedInputs;

--- a/docs/src/pages/demos/text-fields/CustomizedInputs.tsx
+++ b/docs/src/pages/demos/text-fields/CustomizedInputs.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import {
-  createStyles,
-  Theme,
-  withStyles,
-  WithStyles,
-  createMuiTheme,
-} from '@material-ui/core/styles';
+import { createStyles, Theme, makeStyles, createMuiTheme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Input from '@material-ui/core/Input';
 import InputBase from '@material-ui/core/InputBase';
@@ -18,7 +11,7 @@ import FilledInput from '@material-ui/core/FilledInput';
 import purple from '@material-ui/core/colors/purple';
 import green from '@material-ui/core/colors/green';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       display: 'flex',
@@ -94,7 +87,8 @@ const styles = (theme: Theme) =>
         borderColor: theme.palette.primary.main,
       },
     },
-  });
+  }),
+);
 
 const theme = createMuiTheme({
   palette: {
@@ -102,10 +96,8 @@ const theme = createMuiTheme({
   },
 });
 
-export interface Props extends WithStyles<typeof styles> {}
-
-function CustomizedInputs(props: Props) {
-  const { classes } = props;
+function CustomizedInputs() {
+  const classes = useStyles();
 
   return (
     <div className={classes.root}>
@@ -188,8 +180,4 @@ function CustomizedInputs(props: Props) {
   );
 }
 
-CustomizedInputs.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(CustomizedInputs);
+export default CustomizedInputs;

--- a/docs/src/pages/demos/text-fields/FilledInputAdornments.tsx
+++ b/docs/src/pages/demos/text-fields/FilledInputAdornments.tsx
@@ -48,7 +48,7 @@ interface State {
 
 function FilledInputAdornments() {
   const classes = useStyles();
-  const [values, setValues] = React.useState({
+  const [values, setValues] = React.useState<State>({
     amount: '',
     password: '',
     weight: '',
@@ -56,9 +56,7 @@ function FilledInputAdornments() {
     showPassword: false,
   });
 
-  const handleChange = (prop: 'amount' | 'password' | 'weight' | 'weightRange') => (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleChange = (prop: keyof State) => (event: React.ChangeEvent<HTMLInputElement>) => {
     setValues({ ...values, [prop]: event.target.value });
   };
 

--- a/docs/src/pages/demos/text-fields/FilledTextFields.tsx
+++ b/docs/src/pages/demos/text-fields/FilledTextFields.tsx
@@ -51,7 +51,7 @@ interface State {
 
 function FilledTextFields() {
   const classes = useStyles();
-  const [values, setValues] = React.useState({
+  const [values, setValues] = React.useState<State>({
     name: 'Cat in the Hat',
     age: '',
     multiline: 'Controlled',

--- a/docs/src/pages/demos/text-fields/FormattedInputs.tsx
+++ b/docs/src/pages/demos/text-fields/FormattedInputs.tsx
@@ -81,7 +81,7 @@ interface State {
 
 function FormattedInputs() {
   const classes = useStyles();
-  const [values, setValues] = React.useState({
+  const [values, setValues] = React.useState<State>({
     textmask: '(1  )    -    ',
     numberformat: '1320',
   });

--- a/docs/src/pages/demos/text-fields/InputAdornments.tsx
+++ b/docs/src/pages/demos/text-fields/InputAdornments.tsx
@@ -45,9 +45,17 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
+interface State {
+  amount: string;
+  password: string;
+  weight: string;
+  weightRange: string;
+  showPassword: boolean;
+}
+
 function InputAdornments() {
   const classes = useStyles();
-  const [values, setValues] = React.useState({
+  const [values, setValues] = React.useState<State>({
     amount: '',
     password: '',
     weight: '',
@@ -55,9 +63,7 @@ function InputAdornments() {
     showPassword: false,
   });
 
-  const handleChange = (prop: 'amount' | 'password' | 'weight' | 'weightRange') => (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleChange = (prop: keyof State) => (event: React.ChangeEvent<HTMLInputElement>) => {
     setValues({ ...values, [prop]: event.target.value });
   };
 

--- a/docs/src/pages/demos/text-fields/InputWithIcon.js
+++ b/docs/src/pages/demos/text-fields/InputWithIcon.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import InputAdornment from '@material-ui/core/InputAdornment';
@@ -9,14 +8,14 @@ import TextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
 import AccountCircle from '@material-ui/icons/AccountCircle';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   margin: {
     margin: theme.spacing(1),
   },
-});
+}));
 
-function InputWithIcon(props) {
-  const { classes } = props;
+function InputWithIcon() {
+  const classes = useStyles();
 
   return (
     <div>
@@ -57,8 +56,4 @@ function InputWithIcon(props) {
   );
 }
 
-InputWithIcon.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(InputWithIcon);
+export default InputWithIcon;

--- a/docs/src/pages/demos/text-fields/InputWithIcon.tsx
+++ b/docs/src/pages/demos/text-fields/InputWithIcon.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
 import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import InputAdornment from '@material-ui/core/InputAdornment';
@@ -9,17 +8,16 @@ import TextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
 import AccountCircle from '@material-ui/icons/AccountCircle';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     margin: {
       margin: theme.spacing(1),
     },
-  });
+  }),
+);
 
-export interface Props extends WithStyles<typeof styles> {}
-
-function InputWithIcon(props: Props) {
-  const { classes } = props;
+function InputWithIcon() {
+  const classes = useStyles();
 
   return (
     <div>
@@ -60,8 +58,4 @@ function InputWithIcon(props: Props) {
   );
 }
 
-InputWithIcon.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(InputWithIcon);
+export default InputWithIcon;

--- a/docs/src/pages/demos/text-fields/Inputs.js
+++ b/docs/src/pages/demos/text-fields/Inputs.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Input from '@material-ui/core/Input';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -11,10 +10,11 @@ const styles = theme => ({
   input: {
     margin: theme.spacing(1),
   },
-});
+}));
 
-function Inputs(props) {
-  const { classes } = props;
+function Inputs() {
+  const classes = useStyles();
+
   return (
     <div className={classes.container}>
       <Input
@@ -51,8 +51,4 @@ function Inputs(props) {
   );
 }
 
-Inputs.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(Inputs);
+export default Inputs;

--- a/docs/src/pages/demos/text-fields/Inputs.tsx
+++ b/docs/src/pages/demos/text-fields/Inputs.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
 import Input from '@material-ui/core/Input';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
       display: 'flex',
@@ -12,12 +11,12 @@ const styles = (theme: Theme) =>
     input: {
       margin: theme.spacing(1),
     },
-  });
+  }),
+);
 
-export interface Props extends WithStyles<typeof styles> {}
+function Inputs() {
+  const classes = useStyles();
 
-function Inputs(props: Props) {
-  const { classes } = props;
   return (
     <div className={classes.container}>
       <Input
@@ -54,8 +53,4 @@ function Inputs(props: Props) {
   );
 }
 
-Inputs.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(Inputs);
+export default Inputs;

--- a/docs/src/pages/demos/text-fields/OutlinedInputAdornments.tsx
+++ b/docs/src/pages/demos/text-fields/OutlinedInputAdornments.tsx
@@ -38,9 +38,17 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
+interface State {
+  amount: string;
+  password: string;
+  weight: string;
+  weightRange: string;
+  showPassword: boolean;
+}
+
 function OutlinedInputAdornments() {
   const classes = useStyles();
-  const [values, setValues] = React.useState({
+  const [values, setValues] = React.useState<State>({
     amount: '',
     password: '',
     weight: '',
@@ -48,9 +56,7 @@ function OutlinedInputAdornments() {
     showPassword: false,
   });
 
-  const handleChange = (prop: 'amount' | 'password' | 'weight' | 'weightRange') => (
-    event: React.ChangeEvent<HTMLInputElement>,
-  ) => {
+  const handleChange = (prop: keyof State) => (event: React.ChangeEvent<HTMLInputElement>) => {
     setValues({ ...values, [prop]: event.target.value });
   };
 

--- a/docs/src/pages/demos/text-fields/OutlinedTextFields.tsx
+++ b/docs/src/pages/demos/text-fields/OutlinedTextFields.tsx
@@ -51,7 +51,7 @@ interface State {
 
 function OutlinedTextFields() {
   const classes = useStyles();
-  const [values, setValues] = React.useState({
+  const [values, setValues] = React.useState<State>({
     name: 'Cat in the Hat',
     age: '',
     multiline: 'Controlled',

--- a/docs/src/pages/demos/text-fields/TextFieldMargins.js
+++ b/docs/src/pages/demos/text-fields/TextFieldMargins.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   container: {
     display: 'flex',
     flexWrap: 'wrap',
@@ -13,10 +12,10 @@ const styles = theme => ({
     marginRight: theme.spacing(1),
     width: 200,
   },
-});
+}));
 
-const TextFieldMargins = props => {
-  const { classes } = props;
+function TextFieldMargins() {
+  const classes = useStyles();
 
   return (
     <div className={classes.container}>
@@ -45,10 +44,6 @@ const TextFieldMargins = props => {
       />
     </div>
   );
-};
+}
 
-TextFieldMargins.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(TextFieldMargins);
+export default TextFieldMargins;

--- a/docs/src/pages/demos/text-fields/TextFieldMargins.tsx
+++ b/docs/src/pages/demos/text-fields/TextFieldMargins.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
 import TextField from '@material-ui/core/TextField';
 
-const styles = (theme: Theme) =>
+const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     container: {
       display: 'flex',
@@ -14,12 +13,11 @@ const styles = (theme: Theme) =>
       marginRight: theme.spacing(1),
       width: 200,
     },
-  });
+  }),
+);
 
-export interface Props extends WithStyles<typeof styles> {}
-
-const TextFieldMargins = (props: Props) => {
-  const { classes } = props;
+function TextFieldMargins() {
+  const classes = useStyles();
 
   return (
     <div className={classes.container}>
@@ -48,10 +46,6 @@ const TextFieldMargins = (props: Props) => {
       />
     </div>
   );
-};
+}
 
-TextFieldMargins.propTypes = {
-  classes: PropTypes.object.isRequired,
-} as any;
-
-export default withStyles(styles)(TextFieldMargins);
+export default TextFieldMargins;

--- a/docs/src/pages/demos/text-fields/TextFields.tsx
+++ b/docs/src/pages/demos/text-fields/TextFields.tsx
@@ -52,7 +52,7 @@ interface State {
 
 function TextFields() {
   const classes = useStyles();
-  const [values, setValues] = React.useState({
+  const [values, setValues] = React.useState<State>({
     name: 'Cat in the Hat',
     age: '',
     multiline: 'Controlled',


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Migrated the TextField demos to hooks and converted `ComposedTextField` demo to a functional component. Minor improvements to some of the typescript demos