### PR TITLE
[docs] Shadows - fix minor typo

### DIFF
--- a/docs/src/pages/system/shadows/Demo.js
+++ b/docs/src/pages/system/shadows/Demo.js
@@ -21,7 +21,7 @@ function Height() {
         p={1}
         style={{ width: '8rem', height: '5rem' }}
       >
-        boxShadow={2}
+        boxShadow={1}
       </Box>
       <Box
         boxShadow={2}


### PR DESCRIPTION
There is a typo / copy & pasta error. 🍝

It says two times `2` (0,2,2,3) - but it's 0,1,2,3

![Screenshot 2019-04-23 at 15 57 00](https://user-images.githubusercontent.com/1742115/56586726-80d47e00-65e0-11e9-9ae5-bd09c6954847.png)


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
