### PR TITLE
[docs] Add ref vs dom node prop explanation

### DIFF
--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -359,7 +359,7 @@ function App() {
 ```
 
 where `Portal` would only mount the children into the container when `container.current` is available.
-With a simple heuristic Portal would re-render after it mounts because refs are up-to-date before any effects run.
+Here is a naive implementation of Portal: 
 
 ```jsx
 function Portal({ children, container }) {
@@ -376,6 +376,7 @@ function Portal({ children, container }) {
 }
 ```
 
+With this simple heuristic Portal would re-render after it mounts because refs are up-to-date before any effects run. 
 This assumption can introduce subtle bugs the farther away the actual host component with the container ref is.
 If the ref is attached to a ref forwarding component it is not clear when the DOM node will be available. This is
 especially apparent for React.lazy components in Suspense. The above implementation could also not account for a change in the DOM node.

--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -336,3 +336,65 @@ If you use Material-UI in a commercial project and would like to support its con
 or in a side or hobby project and would like to become a backer, you can do so through [OpenCollective](https://opencollective.com/material-ui).
 
 All funds raised are managed transparently, and Sponsors receive recognition in the README and on the Material-UI home page.
+
+## Why does component X require a DOM node in a prop instead of a ref object?
+
+Components like the [Portal](/api/Portal/#props) or [Popper](/api/Popper/#props) require a DOM node in the `container` or `anchorEl` prop respectively.
+It seems convenient to simply pass a ref object in those props and let Material-UI access the current value.
+This works in a simple scenario:
+
+```jsx
+function App() {
+  const container = React.useRef(null);
+
+  return (
+    <div className="App">
+      <Portal container={container}>
+        <span>portaled children</span>
+      </Portal>
+      <div ref={container} />
+    </div>
+  );
+}
+```
+
+where `Portal` would only mount the children into the container when `container.current` is available.
+With a simple heuristic Portal would re-render after it mounts because refs are up-to-date before any effects run.
+
+```jsx
+function Portal({ children, container }) {
+  const [node, setNode] = React.useState(null);
+
+  React.useEffect(() => {
+    setNode(container.current);
+  }, [container]);
+
+  if (node === null) {
+    return null;
+  }
+  return ReactDOM.createPortal(children, node);
+}
+```
+
+This assumption can introduce subtle bugs the farther away the actual host component with the container ref is.
+If the ref is attached to a ref forwarding component it is not clear when the DOM node will be available. This is
+especially apparent for React.lazy components in Suspense. The above implementation could also not account for a change in the DOM node.
+
+This is why we require a prop with the actual DOM node so that React can take care of determining
+when the `Portal` should re-render:
+
+```jsx
+function App() {
+  const [container, setContainer] = React.useState(null);
+  const handleRef = React.useCallback(instance => setContainer(instance), [setContainer])
+
+  return (
+    <div className="App">
+      <Portal container={container}>
+        <span>Portaled</span>
+      </Portal>
+      <div ref={handleRef} />
+    </div>
+  );
+}
+```

--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -376,9 +376,10 @@ function Portal({ children, container }) {
 }
 ```
 
-With this simple heuristic Portal would re-render after it mounts because refs are up-to-date before any effects run. 
-This assumption can introduce subtle bugs the farther away the actual host component with the container ref is.
-If the ref is attached to a ref forwarding component it is not clear when the DOM node will be available. This is
+With this simple heuristic `Portal` might re-render after it mounts because refs are up-to-date before any effects run.
+However, just because a ref is up-to-date doesn't mean it points to a defined instance.
+If the ref is attached to a ref forwarding component it is not clear when the DOM node will be available.
+In the above example the `Portal` would run run an effect once but might not re-render because `ref.current` is still `null`. This is
 especially apparent for React.lazy components in Suspense. The above implementation could also not account for a change in the DOM node.
 
 This is why we require a prop with the actual DOM node so that React can take care of determining


### PR DESCRIPTION
Closes #15456

https://deploy-preview-15458--material-ui.netlify.com/getting-started/faq/#why-does-component-x-require-a-dom-node-in-a-prop-instead-of-a-ref-object