### PR TITLE
[Modal] -74% bundle size reduction

### DIFF
--- a/docs/src/pages/utils/modal/modal.md
+++ b/docs/src/pages/utils/modal/modal.md
@@ -17,6 +17,7 @@ component and some styles:
 - ♿️ It properly manages focus; moving to the modal content,
   and keeping it there until the modal is closed.
 - ♿️ Adds the appropriate ARIA roles automatically.
+- 📦 [6.5 kB gzipped](/size-snapshot).
 
 > **Terminology note**. The term "modal" is sometimes used to mean "dialog", but this is a misnomer.
 A Modal window describes parts of a UI.

--- a/docs/src/pages/utils/popper/popper.md
+++ b/docs/src/pages/utils/popper/popper.md
@@ -11,12 +11,12 @@ Some important features of the `Popper` component:
 
 - 🕷 Popper relies on the 3rd party library ([Popper.js](https://github.com/FezVrasta/popper.js)) for perfect positioning.
 - 💄 It's an alternative API to react-popper. It aims for simplicity.
-- 📦 Less than [10 KB gzipped](/size-snapshot).
+- 📦 [10 kB gzipped](/size-snapshot).
 - The children is [`Portal`](/utils/portal/) to the body of the document to avoid rendering problems.
 You can disable this behavior with `disablePortal`.
 - The scroll isn't blocked like with the [`Popover`](/utils/popover/) component.
 The placement of the popper updates with the available area in the viewport.
-- Clicking away does not hide the `Popper` component. 
+- Clicking away does not hide the `Popper` component.
   If you need this behavior, you can use [`ClickAwayListener`](utils/click-away-listener/) - see the example in the [menu documentation section](/demos/menus/#menulist-composition).
 - The `anchorEl` is passed as the reference object to create a new `Popper.js` instance.
 

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import { capitalize } from '../utils/helpers';
 import Modal from '../Modal';
+import Backdrop from '../Backdrop';
 import Fade from '../Fade';
 import { duration } from '../styles/transitions';
 import Paper from '../Paper';
@@ -195,6 +196,7 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
   return (
     <Modal
       className={clsx(classes.root, className)}
+      BackdropComponent={Backdrop}
       BackdropProps={{
         transitionDuration,
         ...BackdropProps,

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Modal from '../Modal';
+import Backdrop from '../Backdrop';
 import withStyles from '../styles/withStyles';
 import Slide from '../Slide';
 import Paper from '../Paper';
@@ -178,6 +179,7 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
         ...BackdropPropsProp,
         transitionDuration,
       }}
+      BackdropComponent={Backdrop}
       className={clsx(classes.root, classes.modal, className)}
       open={open}
       onClose={onClose}

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import ownerDocument from '../utils/ownerDocument';
 import Portal from '../Portal';
 import { createChainedFunction } from '../utils/helpers';
 import { setRef } from '../utils/reactHelpers';
 import withForwardedRef from '../utils/withForwardedRef';
-import withStyles from '../styles/withStyles';
+import { withTheme } from '@material-ui/styles';
+import zIndex from '../styles/zIndex';
 import ModalManager from './ModalManager';
 import TrapFocus from './TrapFocus';
-import Backdrop from '../Backdrop';
+import SimpleBackdrop from './SimpleBackdrop';
 import { ariaHidden } from './manageAriaHidden';
 
 function getContainer(container) {
@@ -187,8 +187,6 @@ class Modal extends React.Component {
       BackdropComponent,
       BackdropProps,
       children,
-      classes,
-      className,
       closeAfterTransition,
       container,
       disableAutoFocus,
@@ -206,6 +204,7 @@ class Modal extends React.Component {
       onEscapeKeyDown,
       onRendered,
       open,
+      theme,
       ...other
     } = this.props;
     const { exited } = this.state;
@@ -231,6 +230,8 @@ class Modal extends React.Component {
       childProps.tabIndex = children.props.tabIndex || '-1';
     }
 
+    const stylesRender = styles(theme || { zIndex });
+
     return (
       <Portal
         ref={this.handlePortalRef}
@@ -249,10 +250,12 @@ class Modal extends React.Component {
           ref={this.handleModalRef}
           onKeyDown={this.handleKeyDown}
           role="presentation"
-          className={clsx(classes.root, className, {
-            [classes.hidden]: !open && exited,
-          })}
           {...other}
+          style={{
+            ...stylesRender.root,
+            ...(!open && exited ? stylesRender.hidden : {}),
+            ...other.style,
+          }}
         >
           {hideBackdrop ? null : (
             <BackdropComponent open={open} onClick={this.handleBackdropClick} {...BackdropProps} />
@@ -286,15 +289,6 @@ Modal.propTypes = {
    * A single child content element.
    */
   children: PropTypes.element.isRequired,
-  /**
-   * Override or extend the styles applied to the component.
-   * See [CSS API](#css) below for more details.
-   */
-  classes: PropTypes.object.isRequired,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
   /**
    * When set to true the Modal waits until a nested Transition is completed before closing.
    */
@@ -386,10 +380,14 @@ Modal.propTypes = {
    * If `true`, the modal is open.
    */
   open: PropTypes.bool.isRequired,
+  /**
+   * @ignore
+   */
+  theme: PropTypes.object,
 };
 
 Modal.defaultProps = {
-  BackdropComponent: Backdrop,
+  BackdropComponent: SimpleBackdrop,
   closeAfterTransition: false,
   disableAutoFocus: false,
   disableBackdropClick: false,
@@ -403,4 +401,4 @@ Modal.defaultProps = {
   manager: new ModalManager(),
 };
 
-export default withStyles(styles, { flip: false, name: 'MuiModal' })(withForwardedRef(Modal));
+export default withTheme(withForwardedRef(Modal));

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -7,7 +7,6 @@ import {
   createMount,
   findOutermostIntrinsic,
   describeConformance,
-  getClasses,
 } from '@material-ui/core/test-utils';
 import Fade from '../Fade';
 import Portal from '../Portal';
@@ -16,15 +15,9 @@ import Modal from './Modal';
 
 describe('<Modal />', () => {
   let mount;
-  let classes;
   let savedBodyStyle;
 
   before(() => {
-    classes = getClasses(
-      <Modal open={false}>
-        <div />
-      </Modal>,
-    );
     // StrictModeViolation: uses Backdrop
     mount = createMount({ strict: false });
     savedBodyStyle = document.body.style;
@@ -43,11 +36,10 @@ describe('<Modal />', () => {
       <div />
     </Modal>,
     () => ({
-      classes,
       inheritComponent: 'div',
       mount,
       refInstanceof: window.HTMLDivElement,
-      skip: ['componentProp'],
+      skip: ['rootClass', 'componentProp'],
     }),
   );
 
@@ -72,13 +64,12 @@ describe('<Modal />', () => {
       const modal = findOutermostIntrinsic(portal);
 
       assert.strictEqual(modal.type(), 'div');
-      assert.strictEqual(modal.hasClass(classes.root), true);
     });
   });
 
   describe('backdrop', () => {
     const modal = (
-      <Modal open id="modal">
+      <Modal open id="modal" BackdropComponent={Backdrop}>
         <div id="container">
           <h1 id="heading">Hello</h1>
         </div>
@@ -95,7 +86,7 @@ describe('<Modal />', () => {
       assert.strictEqual(transition.props().in, true);
     });
 
-    it('should pass a transitionDuration prop to the transition component', () => {
+    it('should pass prop to the transition component', () => {
       const wrapper = mount(modal);
       wrapper.setProps({ BackdropProps: { transitionDuration: 200 } });
 
@@ -369,7 +360,7 @@ describe('<Modal />', () => {
     it('does not include the children in the a11y tree', () => {
       const modalRef = React.createRef();
       mount(
-        <Modal keepMounted open={false} innerRef={modalRef}>
+        <Modal keepMounted open={false} ref={modalRef}>
           <div />
         </Modal>,
       );

--- a/packages/material-ui/src/Modal/SimpleBackdrop.js
+++ b/packages/material-ui/src/Modal/SimpleBackdrop.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const styles = {
+  /* Styles applied to the root element. */
+  root: {
+    zIndex: -1,
+    position: 'fixed',
+    right: 0,
+    bottom: 0,
+    top: 0,
+    left: 0,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    // Remove grey highlight
+    WebkitTapHighlightColor: 'transparent',
+    // Disable scroll capabilities.
+    touchAction: 'none',
+  },
+  /* Styles applied to the root element if `invisible={true}`. */
+  invisible: {
+    backgroundColor: 'transparent',
+  },
+};
+
+/**
+ * @ignore - internal component.
+ */
+const SimpleBackdrop = React.forwardRef(function SimpleBackdrop(props, ref) {
+  const { invisible, open, ...other } = props;
+
+  return open ? (
+    <div
+      data-mui-test="Backdrop"
+      aria-hidden="true"
+      ref={ref}
+      {...other}
+      style={{
+        ...styles.root,
+        ...(invisible ? styles.invisible : {}),
+        ...other.style,
+      }}
+    />
+  ) : null;
+});
+
+SimpleBackdrop.propTypes = {
+  /**
+   * If `true`, the backdrop is invisible.
+   * It can be used when rendering a popover or a custom select component.
+   */
+  invisible: PropTypes.bool,
+  /**
+   * If `true`, the backdrop is open.
+   */
+  open: PropTypes.bool.isRequired,
+};
+
+SimpleBackdrop.defaultProps = {
+  invisible: false,
+};
+
+export default SimpleBackdrop;

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -385,7 +385,7 @@ describe('<Menu> integration', () => {
       });
       assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: true');
       const backdrop = portalLayer.querySelector('[data-mui-test="Backdrop"]');
-      assert.strictEqual(typeof backdrop !== 'undefined', true);
+      assert.strictEqual(backdrop != null, true);
       backdrop.click();
       assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: false');
     });

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -28,10 +28,9 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">BackdropComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">Backdrop</span> | A backdrop component. This property enables custom backdrop rendering. |
+| <span class="prop-name">BackdropComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">SimpleBackdrop</span> | A backdrop component. This property enables custom backdrop rendering. |
 | <span class="prop-name">BackdropProps</span> | <span class="prop-type">object</span> |  | Properties applied to the [`Backdrop`](/api/backdrop/) element. |
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | A single child content element. |
-| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">closeAfterTransition</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | When set to true the Modal waits until a nested Transition is completed before closing. |
 | <span class="prop-name">container</span> | <span class="prop-type">union:&nbsp;object&nbsp;&#124;<br>&nbsp;func<br></span> |  | A node, component instance, or function that returns either. The `container` will have the portal children appended to it. |
 | <span class="prop-name">disableAutoFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the modal will not automatically shift focus to itself when it opens, and replace it to the last focused element when it closes. This also works correctly with any modal children that have the `disableAutoFocus` prop.<br>Generally this should never be set to `true` as it makes the modal less accessible to assistive technologies, like screen readers. |
@@ -51,24 +50,6 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 The `ref` is forwarded to the root element.
 
 Any other properties supplied will be provided to the root element (native element).
-
-## CSS
-
-You can override all the class names injected by Material-UI thanks to the `classes` property.
-This property accepts the following keys:
-
-
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">hidden</span> | Styles applied to the root element if the `Modal` has exited.
-
-Have a look at [overriding with classes](/customization/overrides/#overriding-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/Modal/Modal.js)
-for more detail.
-
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiModal`.
 
 ## Demos
 

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -65,6 +65,7 @@ async function getSizeLimitBundles() {
     },
     {
       // vs https://bundlephobia.com/result?p=react-modal
+      // vs https://bundlephobia.com/result?p=@reach/dialog
       name: 'Modal',
       webpack: true,
       path: 'packages/material-ui/build/esm/Modal/index.js',


### PR DESCRIPTION
I wanted to try this change for months! #5750 gave me enough energy to start. The core idea behind this change is that we market the Modal component as a perfect starting point to build a Modal (outside of Material Design). This vision can only be achieved with an outstanding small bundle size.

*This change doesn't help people already using @material-ui/styles and our theme. But it reduces the entry cost for new developers. A developer can progressively add our generic components, with only paying for what he needs.*

> Modal | -74.06% | -72.43% | 79,337 | 20,578 | 23,972 | 6,609

From 23.4 kB gzipped to 6.5 kB gzipped. We can still do better. The react hooks migration will help. We should be able to go down to 5.5 kB.

- vs https://bundlephobia.com/result?p=react-modal
- vs https://bundlephobia.com/result?p=@reach/dialog

### Breaking change

Remove the classes customization API for the Modal component.