### PR TITLE
[Select] Display 0 as a valid value, fix a propType warning

### DIFF
--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -166,9 +166,9 @@ OutlinedInput.propTypes = {
    */
   inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   /**
-   * The width of the legend.
+   * The width of the label.
    */
-  labelWidth: PropTypes.number.isRequired,
+  labelWidth: PropTypes.number,
   /**
    * If `dense`, will adjust vertical spacing. This is normally obtained via context from
    * FormControl.
@@ -231,6 +231,7 @@ OutlinedInput.propTypes = {
 InputBase.defaultProps = {
   fullWidth: false,
   inputComponent: 'input',
+  labelWidth: 0,
   multiline: false,
   type: 'text',
 };

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -276,7 +276,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       >
         {/* So the vertical align positioning algorithm kicks in. */}
         {/* eslint-disable-next-line react/no-danger */}
-        {display || <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />}
+        {display != null ? display : <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />}
       </div>
       <input
         value={Array.isArray(value) ? value.join(',') : value}


### PR DESCRIPTION
Basically what this allows is to select 0 (number value) as an option on the Select component, it also allows to set 0 as a default value.

[Discussion](https://spectrum.chat/material-ui/help/select-doesnt-work-with-0-as-default-value~fa39ca72-1c82-45b9-8ac9-df64711b1297)

[Example](https://codesandbox.io/s/328j5lr8oq)