### PR TITLE
[docs] Improve CSS Grid documentation

### DIFF
--- a/docs/src/pages/layout/grid/grid.md
+++ b/docs/src/pages/layout/grid/grid.md
@@ -68,14 +68,6 @@ The following demo doesn't follow the Material Design specification, but illustr
 
 {{"demo": "pages/layout/grid/ComplexGrid.js"}}
 
-## CSS Grid Layout
-
-**CSS Grid Layout** excels at dividing a page into major regions, or defining the relationship in terms of size, position, and layer, between parts of a control built from HTML primitives.
-
-⚠️ Unfortunately, CSS grid is only supported by the most recent browsers.
-
-{{"demo": "pages/layout/grid/CSSGrid.js"}}
-
 ## Nested Grid
 
 The `container` and `item` properties are two independent booleans. They can be combined.
@@ -133,3 +125,11 @@ The properties which define the number of grids the component will use for a giv
 (`xs`, `sm`, `md`, `lg`, and `xl`) are focused on controlling width
 and do **not** have similar effects on height within `column` and `column-reverse` containers.
 If used within `column` or `column-reverse` containers, these properties may have undesirable effects on the width of the `Grid` elements.
+
+
+## CSS Grid Layout
+
+Material UI does not provide any CSS Grid functionality itself, but as seen below you can easily use CSS Grid to layout your pages.
+
+
+{{"demo": "pages/layout/grid/CSSGrid.js"}}

--- a/docs/src/pages/layout/grid/grid.md
+++ b/docs/src/pages/layout/grid/grid.md
@@ -126,10 +126,8 @@ The properties which define the number of grids the component will use for a giv
 and do **not** have similar effects on height within `column` and `column-reverse` containers.
 If used within `column` or `column-reverse` containers, these properties may have undesirable effects on the width of the `Grid` elements.
 
-
 ## CSS Grid Layout
 
-Material UI does not provide any CSS Grid functionality itself, but as seen below you can easily use CSS Grid to layout your pages.
-
+Material-UI doesn't provide any CSS Grid functionality itself, but as seen below you can easily use CSS Grid to layout your pages.
 
 {{"demo": "pages/layout/grid/CSSGrid.js"}}


### PR DESCRIPTION
As discussed in #9513 starting at https://github.com/mui-org/material-ui/issues/9513#issuecomment-486299939 the current documentation was a little confusing and not really located in a logical place.

I'm not sure there *is* a logical place for this information, but it seems like the end of the document is better than in the middle of information talking about grid stuff that MUI *does* support.

I made the fact that Material UI doesn't provide any CSS Grid functionality explicit.

I also took out the warning about CSS Grid only being supported in the latest browsers.  As of right now it has 90% browser coverage at https://caniuse.com/#feat=css-grid.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
