### PR TITLE
[MenuList] Add text keyboard focus navigation

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -30,7 +30,6 @@ export const styles = theme => ({
   container: {
     position: 'relative',
   },
-  // To remove in v4
   /* Styles applied to the `component`'s `focusVisibleClassName` property if `button={true}`. */
   focusVisible: {
     backgroundColor: theme.palette.action.selected,

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -34,20 +34,14 @@ function textCriteriaMatches(nextFocus, textCriteria) {
   if (text === undefined) {
     return false;
   }
-  text = text.trim();
+  text = text.trim().toLowerCase();
   if (text.length === 0) {
     return false;
   }
-  text = text.toLowerCase();
   if (textCriteria.repeating) {
-    return text.charAt(0) === textCriteria.keys[0];
+    return text[0] === textCriteria.keys[0];
   }
-  for (let charIndex = 0; charIndex < textCriteria.keys.length; charIndex += 1) {
-    if (charIndex >= text.length || text.charAt(charIndex) !== textCriteria.keys[charIndex]) {
-      return false;
-    }
-  }
-  return true;
+  return text.indexOf(textCriteria.keys.join('')) === 0;
 }
 
 function moveFocus(list, currentFocus, disableListWrap, traversalFunction, textCriteria) {
@@ -55,12 +49,14 @@ function moveFocus(list, currentFocus, disableListWrap, traversalFunction, textC
   let nextFocus = traversalFunction(list, currentFocus, currentFocus ? disableListWrap : false);
 
   while (nextFocus) {
+    // Prevent infinite loop.
     if (nextFocus === list.firstChild) {
       if (wrappedOnce) {
         return false;
       }
       wrappedOnce = true;
     }
+    // Move to the next element.
     if (
       !nextFocus.hasAttribute('tabindex') ||
       nextFocus.disabled ||
@@ -144,6 +140,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
       const lowerKey = key.toLowerCase();
       const currTime = performance.now();
       if (criteria.keys.length > 0) {
+        // Reset
         if (currTime - criteria.lastTime > 500) {
           criteria.keys = [];
           criteria.repeating = true;

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -51,15 +51,15 @@ function textCriteriaMatches(nextFocus, textCriteria) {
 }
 
 function moveFocus(list, currentFocus, disableListWrap, traversalFunction, textCriteria) {
-  let startingPoint = currentFocus;
+  let wrappedOnce = false;
   let nextFocus = traversalFunction(list, currentFocus, currentFocus ? disableListWrap : false);
 
   while (nextFocus) {
-    if (nextFocus === startingPoint) {
-      return false;
-    }
-    if (startingPoint === null) {
-      startingPoint = nextFocus;
+    if (nextFocus === list.firstChild) {
+      if (wrappedOnce) {
+        return false;
+      }
+      wrappedOnce = true;
     }
     if (
       !nextFocus.hasAttribute('tabindex') ||

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -192,6 +192,7 @@ MenuList.propTypes = {
   actions: PropTypes.shape({ current: PropTypes.object }),
   /**
    * If `true`, the list will be focused during the first mount.
+   * Focus will also be triggered if the value changes from false to true.
    */
   autoFocus: PropTypes.bool,
   /**

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -31,7 +31,11 @@ function textCriteriaMatches(nextFocus, textCriteria) {
     // jsdom doesn't support innerText
     text = nextFocus.textContent;
   }
-  if (text === undefined || text.length === 0) {
+  if (text === undefined) {
+    return false;
+  }
+  text = text.trim();
+  if (text.length === 0) {
     return false;
   }
   text = text.toLowerCase();

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -102,6 +102,10 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
     } else if (key === 'End') {
       event.preventDefault();
       moveFocus(list, null, disableListWrap, previousItem);
+    } else if (key.length === 1) {
+      event.preventDefault();
+      // TODO here's where the new logic goes
+      moveFocus(list, currentFocus, disableListWrap, nextItem);
     }
 
     if (onKeyDown) {

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -472,7 +472,12 @@ describe('<MenuList> integration', () => {
           <MenuItem>aardvark</MenuItem>
           <MenuItem>Colorado</MenuItem>
           <MenuItem>Argentina</MenuItem>
-          <MenuItem>color</MenuItem>
+          <MenuItem>
+            color{' '}
+            <a href="/" id="focusableDescendant">
+              Focusable Descendant
+            </a>
+          </MenuItem>
           <MenuItem />
           <MenuItem>Hello Worm</MenuItem>
           <MenuItem>
@@ -515,6 +520,13 @@ describe('<MenuList> integration', () => {
       assertFocused(2, 'Colorado');
       wrapper.simulate('keyDown', { key: 'l' });
       assertFocused(2, 'Colorado');
+    });
+
+    it('should avoid infinite loop if focus starts on descendant', () => {
+      const link = document.getElementById('focusableDescendant');
+      link.focus();
+      wrapper.simulate('keyDown', { key: 'z' });
+      assert.strictEqual(link, document.activeElement);
     });
 
     it('should reset matching after wait', done => {

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -51,17 +51,32 @@ function assertMenuItemTabIndexed(wrapper, tabIndexed) {
   });
 }
 
-function assertMenuItemFocused(wrapper, focusedIndex) {
+function assertMenuItemFocused(wrapper, focusedIndex, expectedNumMenuItems = 4, expectedInnerText) {
   const items = wrapper.find('li[role="menuitem"]');
-  assert.strictEqual(items.length, 4);
+  assert.strictEqual(items.length, expectedNumMenuItems);
 
   items.forEach((item, index) => {
+    const instance = item.find('li').instance();
     if (index === focusedIndex) {
-      assert.strictEqual(item.find('li').instance(), document.activeElement);
+      assert.strictEqual(instance, document.activeElement);
+      if (expectedInnerText) {
+        let innerText = instance.innerText;
+        if (innerText === undefined) {
+          // jsdom doesn't support innerText
+          innerText = instance.textContent;
+        }
+        assert.strictEqual(expectedInnerText, innerText);
+      }
     } else {
-      assert.notStrictEqual(item.find('li').instance(), document.activeElement);
+      assert.notStrictEqual(instance, document.activeElement);
     }
   });
+}
+
+function getAssertMenuItemFocused(wrapper, expectedNumMenuItems) {
+  return (focusedIndex, expectedInnerText) => {
+    return assertMenuItemFocused(wrapper, focusedIndex, expectedNumMenuItems, expectedInnerText);
+  }
 }
 
 describe('<MenuList> integration', () => {
@@ -443,6 +458,82 @@ describe('<MenuList> integration', () => {
       assertMenuItemFocused(wrapper, -1);
       wrapper.simulate('keyDown', { key: 'ArrowUp' });
       assertMenuItemFocused(wrapper, -1);
+    });
+  });
+
+  describe('MenuList text-based keyboard controls', () => {
+    let wrapper;
+    let assertFocused;
+    let innerTextSupported;
+    const resetWrapper = () => {
+      wrapper = mount(
+        <MenuList>
+          <MenuItem>Arizona</MenuItem>
+          <MenuItem>aardvark</MenuItem>
+          <MenuItem>Colorado</MenuItem>
+          <MenuItem>Argentina</MenuItem>
+          <MenuItem>color</MenuItem>
+          <MenuItem>Hello <span style={{display: 'none'}}>Test innerText</span> World</MenuItem>
+        </MenuList>,
+      );
+      innerTextSupported = wrapper.find('ul').instance().innerText !== undefined;
+      assertFocused = getAssertMenuItemFocused(wrapper, 6);
+    };
+
+    before(resetWrapper);
+
+    it('should support repeating initial character', () => {
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
+      assertFocused(0, 'Arizona');
+      wrapper.simulate('keyDown', { key: 'a' });
+      assertFocused(1, 'aardvark');
+      wrapper.simulate('keyDown', { key: 'a' });
+      assertFocused(3, 'Argentina');
+      wrapper.simulate('keyDown', { key: 'r' });
+      assertFocused(1, 'aardvark');
+    });
+
+    it('should not move focus when no match', () => {
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
+      assertFocused(0, 'Arizona');
+      wrapper.simulate('keyDown', { key: 'c' });
+      assertFocused(2, 'Colorado');
+      wrapper.simulate('keyDown', { key: 'z' });
+      assertFocused(2, 'Colorado');
+      wrapper.simulate('keyDown', { key: 'a' });
+      assertFocused(2, 'Colorado');
+    });
+
+    it('should reset matching after wait', (done) => {
+      wrapper.simulate('keyDown', { key: 'ArrowDown' });
+      assertFocused(0, 'Arizona');
+      wrapper.simulate('keyDown', { key: 'c' });
+      assertFocused(2, 'Colorado');
+      wrapper.simulate('keyDown', { key: 'z' });
+      assertFocused(2, 'Colorado');
+      setTimeout(()=> {
+        wrapper.simulate('keyDown', { key: 'a' });
+        assertFocused(3, 'Argentina');
+        done();
+      }, 700);
+    });
+
+    it('should match ignoring hidden text', () => {
+      if (innerTextSupported) {
+        // Will only be executed in Karma tests, since jsdom doesn't support innerText
+        wrapper.simulate('keyDown', { key: 'h' });
+        wrapper.simulate('keyDown', { key: 'e' });
+        wrapper.simulate('keyDown', { key: 'l' });
+        wrapper.simulate('keyDown', { key: 'l' });
+        wrapper.simulate('keyDown', { key: 'o' });
+        wrapper.simulate('keyDown', { key: ' ' });
+        wrapper.simulate('keyDown', { key: 'w' });
+        wrapper.simulate('keyDown', { key: 'o' });
+        wrapper.simulate('keyDown', { key: 'r' });
+        wrapper.simulate('keyDown', { key: 'l' });
+        wrapper.simulate('keyDown', { key: 'd' });
+        assertFocused(0, 'Hello World');
+      }
     });
   });
 });

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -65,7 +65,7 @@ function assertMenuItemFocused(wrapper, focusedIndex, expectedNumMenuItems = 4, 
           // jsdom doesn't support innerText
           innerText = instance.textContent;
         }
-        assert.strictEqual(expectedInnerText, innerText);
+        assert.strictEqual(expectedInnerText, innerText.trim());
       }
     } else {
       assert.notStrictEqual(instance, document.activeElement);
@@ -474,13 +474,14 @@ describe('<MenuList> integration', () => {
           <MenuItem>Argentina</MenuItem>
           <MenuItem>color</MenuItem>
           <MenuItem />
+          <MenuItem>Hello Worm</MenuItem>
           <MenuItem>
             Hello <span style={{ display: 'none' }}>Test innerText</span> World
           </MenuItem>
         </MenuList>,
       );
       innerTextSupported = wrapper.find('ul').instance().innerText !== undefined;
-      assertFocused = getAssertMenuItemFocused(wrapper, 7);
+      assertFocused = getAssertMenuItemFocused(wrapper, 8);
     };
 
     beforeEach(resetWrapper);
@@ -542,9 +543,10 @@ describe('<MenuList> integration', () => {
         wrapper.simulate('keyDown', { key: 'w' });
         wrapper.simulate('keyDown', { key: 'o' });
         wrapper.simulate('keyDown', { key: 'r' });
+        assertFocused(6, 'Hello Worm');
         wrapper.simulate('keyDown', { key: 'l' });
         wrapper.simulate('keyDown', { key: 'd' });
-        assertFocused(6, 'Hello World');
+        assertFocused(7, 'Hello World');
       }
     });
   });

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -76,7 +76,7 @@ function assertMenuItemFocused(wrapper, focusedIndex, expectedNumMenuItems = 4, 
 function getAssertMenuItemFocused(wrapper, expectedNumMenuItems) {
   return (focusedIndex, expectedInnerText) => {
     return assertMenuItemFocused(wrapper, focusedIndex, expectedNumMenuItems, expectedInnerText);
-  }
+  };
 }
 
 describe('<MenuList> integration', () => {
@@ -473,14 +473,17 @@ describe('<MenuList> integration', () => {
           <MenuItem>Colorado</MenuItem>
           <MenuItem>Argentina</MenuItem>
           <MenuItem>color</MenuItem>
-          <MenuItem>Hello <span style={{display: 'none'}}>Test innerText</span> World</MenuItem>
+          <MenuItem />
+          <MenuItem>
+            Hello <span style={{ display: 'none' }}>Test innerText</span> World
+          </MenuItem>
         </MenuList>,
       );
       innerTextSupported = wrapper.find('ul').instance().innerText !== undefined;
-      assertFocused = getAssertMenuItemFocused(wrapper, 6);
+      assertFocused = getAssertMenuItemFocused(wrapper, 7);
     };
 
-    before(resetWrapper);
+    beforeEach(resetWrapper);
 
     it('should support repeating initial character', () => {
       wrapper.simulate('keyDown', { key: 'ArrowDown' });
@@ -504,14 +507,23 @@ describe('<MenuList> integration', () => {
       assertFocused(2, 'Colorado');
     });
 
-    it('should reset matching after wait', (done) => {
+    it('should not move focus when additional keys match current focus', () => {
+      wrapper.simulate('keyDown', { key: 'c' });
+      assertFocused(2, 'Colorado');
+      wrapper.simulate('keyDown', { key: 'o' });
+      assertFocused(2, 'Colorado');
+      wrapper.simulate('keyDown', { key: 'l' });
+      assertFocused(2, 'Colorado');
+    });
+
+    it('should reset matching after wait', done => {
       wrapper.simulate('keyDown', { key: 'ArrowDown' });
       assertFocused(0, 'Arizona');
       wrapper.simulate('keyDown', { key: 'c' });
       assertFocused(2, 'Colorado');
       wrapper.simulate('keyDown', { key: 'z' });
       assertFocused(2, 'Colorado');
-      setTimeout(()=> {
+      setTimeout(() => {
         wrapper.simulate('keyDown', { key: 'a' });
         assertFocused(3, 'Argentina');
         done();
@@ -532,7 +544,7 @@ describe('<MenuList> integration', () => {
         wrapper.simulate('keyDown', { key: 'r' });
         wrapper.simulate('keyDown', { key: 'l' });
         wrapper.simulate('keyDown', { key: 'd' });
-        assertFocused(0, 'Hello World');
+        assertFocused(6, 'Hello World');
       }
     });
   });

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -18,7 +18,7 @@ import MenuList from '@material-ui/core/MenuList';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | If `true`, the list will be focused during the first mount. |
+| <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> |  | If `true`, the list will be focused during the first mount. Focus will also be triggered if the value changes from false to true. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | MenuList contents, normally `MenuItem`s. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #8191
Dependent on #15484 before it will work properly.

There are two aspects in my implementation that I consider optional that could be removed if they aren't considered worth the additional code:

1. The `previousKeyMatched` portion of the text criteria. The user-observable behavior is unchanged if this is removed. The purpose is to avoid cycling through all the menu items checking for a match when we already know a match isn't possible because the previously accumulated keys didn't match anything and now the user is adding another key to that unmatched sequence.
2. The use of `innerText` when available (otherwise falls back to `textContent`). If `innerText` and `textContent` are different, `innerText` would be the better one to use; however `innerText` isn't supported by jsdom (thus the fallback to `textContent`). In practice, I wouldn't expect these to hardly ever be different in real-world menu item scenarios, so it would likely be fine to just always use `textContent`.

Neither of these two aspects adds much code, but they only add a very small amount of (mostly hypothetical) value.

I based the behavior on what I observed in Chrome on Windows for native `select` elements (a [state list](https://codepen.io/carlnunes/pen/yhiEo) is a convenient case to test out the browser behavior). The 500ms threshold for reset of the key sequence is based on the 0.x implementation mentioned in @kgregory's [comment](https://github.com/mui-org/material-ui/issues/8191#issuecomment-331964402) and seems to at least be close to what browsers use, but I didn't go looking for a more official source for what the timing of the reset should be.

The gist of the behavior is:

- Always search forward from the current focus point for text matches (wrapping if wrapping is not disabled)
- A repeated character at the beginning of the key sequence (prior to a reset) always advances to the next element starting with that character regardless of whether there is a match for the full sequence (e.g. if you have "Arizona", "cat", "aaaah", "dog", and "Argentina", typing "aaaa" will cycle through "Arizona", "aaaah", "Argentina", and back to "Arizona" rather than stopping on "aaaah" which matches the full sequence)
- Once a second distinct character exists within the sequence, then matching occurs on the full sequence
- A pause of 500ms or more causes a reset in the key sequence used for matching
