### PR TITLE
[TablePagination] Use OverridableComponent in TypeScript declarations

### DIFF
--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
 import { Omit } from '..';
 import { TablePaginationActionsProps } from './TablePaginationActions';
-import { StandardProps } from '..';
 import { TableCellProps } from '../TableCell';
 import { IconButtonProps } from '../IconButton';
 import { SelectProps } from '../Select';

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { OverridableComponent } from '../OverridableComponent';
 import { TablePaginationActionsProps } from './TablePaginationActions';
 import { StandardProps } from '..';
 import { TableCellProps } from '../TableCell';
@@ -16,7 +17,6 @@ export interface TablePaginationProps
   extends StandardProps<TablePaginationBaseProps, TablePaginationClassKey, 'component'> {
   ActionsComponent?: React.ElementType<TablePaginationActionsProps>;
   backIconButtonProps?: Partial<IconButtonProps>;
-  component?: React.ElementType<TablePaginationBaseProps>;
   count: number;
   labelDisplayedRows?: (paginationInfo: LabelDisplayedRowsArgs) => React.ReactNode;
   labelRowsPerPage?: React.ReactNode;
@@ -43,6 +43,10 @@ export type TablePaginationClassKey =
   | 'selectIcon'
   | 'actions';
 
-declare const TablePagination: React.ComponentType<TablePaginationProps>;
+declare const TablePagination: OverridableComponent<{
+  props: TablePaginationProps;
+  defaultComponent: React.ComponentType<TablePaginationBaseProps>,
+  classKey: TablePaginationClassKey;
+}>;
 
 export default TablePagination;

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -45,7 +45,7 @@ export type TablePaginationClassKey =
 
 declare const TablePagination: OverridableComponent<{
   props: TablePaginationProps;
-  defaultComponent: React.ComponentType<TablePaginationBaseProps>,
+  defaultComponent: React.ComponentType<TablePaginationBaseProps>;
   classKey: TablePaginationClassKey;
 }>;
 

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { OverridableComponent } from '../OverridableComponent';
+import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
+import { Omit } from '..';
 import { TablePaginationActionsProps } from './TablePaginationActions';
 import { StandardProps } from '..';
 import { TableCellProps } from '../TableCell';
@@ -13,23 +14,24 @@ export interface LabelDisplayedRowsArgs {
   page: number;
 }
 
-export interface TablePaginationProps
-  extends StandardProps<TablePaginationBaseProps, TablePaginationClassKey, 'component'> {
-  ActionsComponent?: React.ElementType<TablePaginationActionsProps>;
-  backIconButtonProps?: Partial<IconButtonProps>;
-  count: number;
-  labelDisplayedRows?: (paginationInfo: LabelDisplayedRowsArgs) => React.ReactNode;
-  labelRowsPerPage?: React.ReactNode;
-  nextIconButtonProps?: Partial<IconButtonProps>;
-  onChangePage: (event: React.MouseEvent<HTMLButtonElement> | null, page: number) => void;
-  onChangeRowsPerPage?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
-  page: number;
-  rowsPerPage: number;
-  rowsPerPageOptions?: number[];
-  SelectProps?: Partial<SelectProps>;
-}
-
-export type TablePaginationBaseProps = TableCellProps;
+declare const TablePagination: OverridableComponent<{
+  props: TablePaginationBaseProps & {
+    ActionsComponent?: React.ElementType<TablePaginationActionsProps>;
+    backIconButtonProps?: Partial<IconButtonProps>;
+    count: number;
+    labelDisplayedRows?: (paginationInfo: LabelDisplayedRowsArgs) => React.ReactNode;
+    labelRowsPerPage?: React.ReactNode;
+    nextIconButtonProps?: Partial<IconButtonProps>;
+    onChangePage: (event: React.MouseEvent<HTMLButtonElement> | null, page: number) => void;
+    onChangeRowsPerPage?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+    page: number;
+    rowsPerPage: number;
+    rowsPerPageOptions?: number[];
+    SelectProps?: Partial<SelectProps>;
+  };
+  defaultComponent: React.ComponentType<TablePaginationBaseProps>;
+  classKey: TablePaginationClassKey;
+}>;
 
 export type TablePaginationClassKey =
   | 'root'
@@ -43,10 +45,8 @@ export type TablePaginationClassKey =
   | 'selectIcon'
   | 'actions';
 
-declare const TablePagination: OverridableComponent<{
-  props: TablePaginationProps;
-  defaultComponent: React.ComponentType<TablePaginationBaseProps>;
-  classKey: TablePaginationClassKey;
-}>;
+export type TablePaginationBaseProps = Omit<TableCellProps, 'component'>;
+
+export type TablePaginationProps = SimplifiedPropsOf<typeof TablePagination>;
 
 export default TablePagination;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This makes it possible to set the `component` attribute of `TablePagination` to "div" or "span" etc. instead of only allowing custom components.