### PR TITLE
[docs] Updated v3 Migration guide

### DIFF
--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -29,7 +29,7 @@ You need to update your `package.json` to use the latest version of Material-UI.
 
 ```json
 "dependencies": {
-  "@material-ui/core": "^4.0.0-alpha.0"
+  "@material-ui/core": "^4.0.0-beta.0"
 }
 ```
 
@@ -41,6 +41,26 @@ npm install @material-ui/core@next
 or
 
 yarn add @material-ui/core@next
+```
+
+# Update Material-UI Styles version
+
+If you are previously using `@material-ui/styles` with v3 you need to update your `package.json` to use the latest version of Material-UI Styles
+
+```json
+"dependencies": {
+  "@material-ui/styles": "^4.0.0-beta.0"
+}
+```
+
+Or run
+
+```sh
+npm install @material-ui/styles@next
+
+or
+
+yarn add @material-ui/styles@next
 ```
 
 ### Update React version

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -43,7 +43,12 @@ or
 yarn add @material-ui/core@next
 ```
 
-# Update Material-UI Styles version
+### Update React version
+
+The minimum required version of React was increased from `react@^16.3.0` to `react@^16.8.0`.
+This allows us to rely on [Hooks](https://reactjs.org/docs/hooks-intro.html) (we no longer use the class API).
+
+### Update Material-UI Styles version
 
 If you are previously using `@material-ui/styles` with v3 you need to update your `package.json` to use the latest version of Material-UI Styles
 
@@ -62,11 +67,6 @@ or
 
 yarn add @material-ui/styles@next
 ```
-
-### Update React version
-
-The minimum required version of React was increased from `react@^16.3.0` to `react@^16.8.0`.
-This allows us to rely on [Hooks](https://reactjs.org/docs/hooks-intro.html) (we no longer use the class API).
 
 ## Handling breaking changes
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Updated the v3 migration guide for latest  `@material/core@next` and `@material/styles@next`