### PR TITLE
[Transition] Fix false-positive ref warning

### DIFF
--- a/packages/material-ui/src/utils/reactHelpers.js
+++ b/packages/material-ui/src/utils/reactHelpers.js
@@ -14,15 +14,17 @@ export function setRef(ref, value) {
 
 export function useForkRef(refA, refB) {
   /**
-   * This will create a new function if the ref props change.
+   * This will create a new function if the ref props change and are defined.
    * This means react will call the old forkRef with `null` and the new forkRef
    * with the ref. Cleanup naturally emerges from this behavior
    */
-  return React.useCallback(
-    refValue => {
+  return React.useMemo(() => {
+    if (refA == null && refB == null) {
+      return null;
+    }
+    return refValue => {
       setRef(refA, refValue);
       setRef(refB, refValue);
-    },
-    [refA, refB],
-  );
+    };
+  }, [refA, refB]);
 }

--- a/packages/material-ui/src/utils/reactHelpers.test.js
+++ b/packages/material-ui/src/utils/reactHelpers.test.js
@@ -161,8 +161,8 @@ describe('utils/reactHelpers.js', () => {
 
       it('cleans up detached refs', () => {
         const firstLeftRef = React.createRef();
-        const firstRightRef = { current: null, _id: 'first-inner' };
-        const secondRightRef = { current: null, _id: 'second-inner' };
+        const firstRightRef = React.createRef();
+        const secondRightRef = React.createRef();
 
         const wrapper = mount(<Div leftRef={firstLeftRef} rightRef={firstRightRef} id="test" />);
 


### PR DESCRIPTION
Fix false-positive ref warning with suggestion from @oliviertassinari 
Closes #15515 

`useForkRef` always created a callback even if none of the branches required a ref leading to false positives when the component didn't need the ref but just forwarded the ref to a clones child.

Used this opportunity to improve tests for useForkRef. Especially ref cleanup was never actually tested.