### PR TITLE
[docs] Improve v3 migration guide

### DIFF
--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -100,7 +100,7 @@ yarn add @material-ui/styles@next
   -const DeepChild = withTheme()(DeepChildRaw);
   +const DeepChild = withTheme(DeepChildRaw);
   ```
-- Scope the keyframes API. You should apply the following changes in your codebase.
+- Scope the [keyframes API](https://cssinjs.org/jss-syntax/#keyframes-animation). You should apply the following changes in your codebase.
   It helps isolating the animation logic:
 
   ```diff

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -107,7 +107,7 @@ yarn add @material-ui/styles@next
     rippleVisible: {
       opacity: 0.3,
   -   animation: 'mui-ripple-enter 100ms cubic-bezier(0.4, 0, 0.2, 1)',
-  +   animation: `${mui-ripple-enter 100ms cubic-bezier(0.4, 0, 0.2, 1)}`,
+  +   animation: '$mui-ripple-enter 100ms cubic-bezier(0.4, 0, 0.2, 1)',
     },
     '@keyframes mui-ripple-enter': {
       '0%': {

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -107,7 +107,7 @@ yarn add @material-ui/styles@next
     rippleVisible: {
       opacity: 0.3,
   -   animation: 'mui-ripple-enter 100ms cubic-bezier(0.4, 0, 0.2, 1)',
-  +   animation: `$mui-ripple-enter 100ms cubic-bezier(0.4, 0, 0.2, 1)`,
+  +   animation: `${mui-ripple-enter 100ms cubic-bezier(0.4, 0, 0.2, 1)}`,
     },
     '@keyframes mui-ripple-enter': {
       '0%': {


### PR DESCRIPTION
I think there was a type in the keyframes API example 🤔

Because why would you have to change animation from a regular string to a string literal, when you are not using the `${}` syntax? I might be wrong though...

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
