### PR TITLE
[core] Set default theme type for useTheme

### DIFF
--- a/docs/src/pages/demos/autocomplete/IntegrationReactSelect.tsx
+++ b/docs/src/pages/demos/autocomplete/IntegrationReactSelect.tsx
@@ -229,7 +229,7 @@ const components = {
 
 function IntegrationReactSelect() {
   const classes = useStyles();
-  const theme = useTheme<Theme>();
+  const theme = useTheme();
   const [single, setSingle] = React.useState<ValueType<OptionType>>(null);
   const [multi, setMulti] = React.useState<ValueType<OptionType>>(null);
 

--- a/docs/src/pages/demos/cards/MediaControlCard.tsx
+++ b/docs/src/pages/demos/cards/MediaControlCard.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 function MediaControlCard() {
   const classes = useStyles();
-  const theme = useTheme<Theme>();
+  const theme = useTheme();
 
   return (
     <Card className={classes.card}>

--- a/docs/src/pages/demos/drawers/MiniDrawer.tsx
+++ b/docs/src/pages/demos/drawers/MiniDrawer.tsx
@@ -83,7 +83,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 function MiniDrawer() {
   const classes = useStyles();
-  const theme: Theme = useTheme();
+  const theme = useTheme();
   const [open, setOpen] = React.useState(false);
 
   function handleDrawerOpen() {

--- a/docs/src/pages/demos/drawers/PersistentDrawerLeft.tsx
+++ b/docs/src/pages/demos/drawers/PersistentDrawerLeft.tsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 function PersistentDrawerLeft() {
   const classes = useStyles();
-  const theme: Theme = useTheme();
+  const theme = useTheme();
   const [open, setOpen] = React.useState(false);
 
   function handleDrawerOpen() {

--- a/docs/src/pages/demos/drawers/PersistentDrawerRight.tsx
+++ b/docs/src/pages/demos/drawers/PersistentDrawerRight.tsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 
 function PersistentDrawerRight() {
   const classes = useStyles();
-  const theme: Theme = useTheme();
+  const theme = useTheme();
   const [open, setOpen] = React.useState(false);
 
   function handleDrawerOpen() {

--- a/docs/src/pages/demos/drawers/ResponsiveDrawer.tsx
+++ b/docs/src/pages/demos/drawers/ResponsiveDrawer.tsx
@@ -60,7 +60,7 @@ interface ResponsiveDrawerProps {
 function ResponsiveDrawer(props: ResponsiveDrawerProps) {
   const { container } = props;
   const classes = useStyles();
-  const theme: Theme = useTheme();
+  const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
 
   function handleDrawerToggle() {

--- a/packages/material-ui/src/styles/useTheme.d.ts
+++ b/packages/material-ui/src/styles/useTheme.d.ts
@@ -1,3 +1,3 @@
-import { useTheme } from '@material-ui/styles';
+import { Theme } from './createMuiTheme';
 
-export default useTheme;
+export default function useTheme<T = Theme>(): T;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Set the default theme type for `useTheme`

Extracted from https://github.com/mui-org/material-ui/pull/15402