### PR TITLE
[styles] Allow CSS properties to be functions

### DIFF
--- a/docs/src/pages/css-in-js/basics/AdaptingHook.js
+++ b/docs/src/pages/css-in-js/basics/AdaptingHook.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/styles';
+import Button from '@material-ui/core/Button';
+
+const useStyles = makeStyles({
+  root: {
+    background: props =>
+      props.color === 'red'
+        ? 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)'
+        : 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)',
+    border: 0,
+    borderRadius: 3,
+    boxShadow: props =>
+      props.color === 'red'
+        ? '0 3px 5px 2px rgba(255, 105, 135, .3)'
+        : '0 3px 5px 2px rgba(33, 203, 243, .3)',
+    color: 'white',
+    height: 48,
+    padding: '0 30px',
+    margin: 8,
+  },
+});
+
+function MyButton(props) {
+  const { color, ...other } = props;
+  const classes = useStyles(props);
+  return <Button className={classes.root} {...other} />;
+}
+
+MyButton.propTypes = {
+  color: PropTypes.oneOf(['red', 'blue']).isRequired,
+};
+
+function AdaptingHook() {
+  return (
+    <React.Fragment>
+      <MyButton color="red">Red</MyButton>
+      <MyButton color="blue">Blue</MyButton>
+    </React.Fragment>
+  );
+}
+
+export default AdaptingHook;

--- a/docs/src/pages/css-in-js/basics/AdaptingHook.tsx
+++ b/docs/src/pages/css-in-js/basics/AdaptingHook.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/styles';
+import Button, { ButtonProps } from '@material-ui/core/Button';
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+interface Props {
+  color: string;
+}
+
+const useStyles = makeStyles({
+  root: {
+    background: (props: Props) =>
+      props.color === 'red'
+        ? 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)'
+        : 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)',
+    border: 0,
+    borderRadius: 3,
+    boxShadow: (props: Props) =>
+      props.color === 'red'
+        ? '0 3px 5px 2px rgba(255, 105, 135, .3)'
+        : '0 3px 5px 2px rgba(33, 203, 243, .3)',
+    color: 'white',
+    height: 48,
+    padding: '0 30px',
+    margin: 8,
+  },
+});
+
+function MyButton(props: Props & Omit<ButtonProps, 'color'>) {
+  const { color, ...other } = props;
+  const classes = useStyles(props);
+  return <Button className={classes.root} {...other} />;
+}
+
+(MyButton as any).propTypes = {
+  color: PropTypes.string.isRequired,
+};
+
+function AdaptingHook() {
+  return (
+    <React.Fragment>
+      <MyButton color="red">Red</MyButton>
+      <MyButton color="blue">Blue</MyButton>
+    </React.Fragment>
+  );
+}
+
+export default AdaptingHook;

--- a/docs/src/pages/css-in-js/basics/AdaptingHook.tsx
+++ b/docs/src/pages/css-in-js/basics/AdaptingHook.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/styles';
-import Button, { ButtonProps } from '@material-ui/core/Button';
+import Button, { ButtonProps as MuiButtonProps } from '@material-ui/core/Button';
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
 interface Props {
-  color: string;
+  color: 'red' | 'blue';
 }
+
+type MyButtonProps = Props & Omit<MuiButtonProps, keyof Props>;
 
 const useStyles = makeStyles({
   root: {
@@ -27,14 +30,14 @@ const useStyles = makeStyles({
   },
 });
 
-function MyButton(props: Props & Omit<ButtonProps, 'color'>) {
+function MyButton(props: MyButtonProps) {
   const { color, ...other } = props;
   const classes = useStyles(props);
   return <Button className={classes.root} {...other} />;
 }
 
 (MyButton as any).propTypes = {
-  color: PropTypes.string.isRequired,
+  color: PropTypes.oneOf(['red', 'blue']).isRequired,
 };
 
 function AdaptingHook() {

--- a/docs/src/pages/css-in-js/basics/AdaptingStyledComponents.js
+++ b/docs/src/pages/css-in-js/basics/AdaptingStyledComponents.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { styled } from '@material-ui/styles';
+import Button from '@material-ui/core/Button';
+
+const MyButton = styled(({ color, ...other }) => <Button {...other} />)({
+  background: props =>
+    props.color === 'red'
+      ? 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)'
+      : 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)',
+  border: 0,
+  borderRadius: 3,
+  boxShadow: props =>
+    props.color === 'red'
+      ? '0 3px 5px 2px rgba(255, 105, 135, .3)'
+      : '0 3px 5px 2px rgba(33, 203, 243, .3)',
+  color: 'white',
+  height: 48,
+  padding: '0 30px',
+  margin: 8,
+});
+
+function AdaptingStyledComponents() {
+  return (
+    <React.Fragment>
+      <MyButton color="red">Red</MyButton>
+      <MyButton color="blue">Blue</MyButton>
+    </React.Fragment>
+  );
+}
+
+export default AdaptingStyledComponents;

--- a/docs/src/pages/css-in-js/basics/AdaptingStyledComponents.tsx
+++ b/docs/src/pages/css-in-js/basics/AdaptingStyledComponents.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { styled } from '@material-ui/styles';
+import Button, { ButtonProps as MuiButtonProps } from '@material-ui/core/Button';
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+interface Props {
+  color: 'red' | 'blue';
+}
+
+type MyButtonProps = Props & Omit<MuiButtonProps, keyof Props>;
+
+const MyButton = styled(({ color, ...other }: MyButtonProps) => <Button {...other} />)({
+  background: (props: Props) =>
+    props.color === 'red'
+      ? 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)'
+      : 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)',
+  border: 0,
+  borderRadius: 3,
+  boxShadow: (props: Props) =>
+    props.color === 'red'
+      ? '0 3px 5px 2px rgba(255, 105, 135, .3)'
+      : '0 3px 5px 2px rgba(33, 203, 243, .3)',
+  color: 'white',
+  height: 48,
+  padding: '0 30px',
+  margin: 8,
+});
+
+function AdaptingStyledComponents() {
+  return (
+    <React.Fragment>
+      <MyButton color="red">Red</MyButton>
+      <MyButton color="blue">Blue</MyButton>
+    </React.Fragment>
+  );
+}
+
+export default AdaptingStyledComponents;

--- a/docs/src/pages/styles/basics/AdaptingHook.js
+++ b/docs/src/pages/styles/basics/AdaptingHook.js
@@ -29,7 +29,7 @@ function MyButton(props) {
 }
 
 MyButton.propTypes = {
-  color: PropTypes.string.isRequired,
+  color: PropTypes.oneOf(['red', 'blue']).isRequired,
 };
 
 function AdaptingHook() {

--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -8,9 +8,9 @@ import { StyleRules } from '@material-ui/styles/withStyles';
  * @param styles a set of style mappings
  * @returns the same styles that were passed in
  */
-// For TypeScript v3.5 P has to extend {} instead of object
+// For TypeScript v3.5 Props has to extend {} instead of object
 // See https://github.com/mui-org/material-ui/issues/15942
 // and https://github.com/microsoft/TypeScript/issues/31735
-export default function createStyles<C extends string, P extends {}>(
-  styles: StyleRules<C, P>,
-): StyleRules<C, P>;
+export default function createStyles<ClassKey extends string, Props extends {}>(
+  styles: StyleRules<ClassKey, Props>,
+): StyleRules<ClassKey, Props>;

--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -12,5 +12,5 @@ import { StyleRules } from '@material-ui/styles/withStyles';
 // See https://github.com/mui-org/material-ui/issues/15942
 // and https://github.com/microsoft/TypeScript/issues/31735
 export default function createStyles<ClassKey extends string, Props extends {}>(
-  styles: StyleRules<ClassKey, Props>,
-): StyleRules<ClassKey, Props>;
+  styles: StyleRules<Props, ClassKey>,
+): StyleRules<Props, ClassKey>;

--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -12,5 +12,5 @@ import { StyleRules } from '@material-ui/styles/withStyles';
 // See https://github.com/mui-org/material-ui/issues/15942
 // and https://github.com/microsoft/TypeScript/issues/31735
 export default function createStyles<C extends string, P extends {}>(
-  styles: StyleRules<P, C>,
-): StyleRules<P, C>;
+  styles: StyleRules<C, P>,
+): StyleRules<C, P>;

--- a/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.d.ts
+++ b/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.d.ts
@@ -1,7 +1,7 @@
 import { StyleRules, Styles } from '@material-ui/styles/withStyles';
 
 export interface StylesCreator<Theme, Props extends object, ClassKey extends string = string> {
-  create: (theme: Theme, name: string) => StyleRules<Props, ClassKey>;
+  create: (theme: Theme, name: string) => StyleRules<ClassKey, Props>;
   options: {};
   themingEnabled: boolean;
 }

--- a/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.d.ts
+++ b/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.d.ts
@@ -1,7 +1,7 @@
 import { StyleRules, Styles } from '@material-ui/styles/withStyles';
 
 export interface StylesCreator<Theme, Props extends object, ClassKey extends string = string> {
-  create: (theme: Theme, name: string) => StyleRules<ClassKey, Props>;
+  create: (theme: Theme, name: string) => StyleRules<Props, ClassKey>;
   options: {};
   themingEnabled: boolean;
 }

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -10,7 +10,9 @@ import * as React from 'react';
  * @internal
  */
 export type ComponentCreator<C extends React.ElementType> = <Theme, Props extends {} = any>(
-  styles: CSSProperties | (({ theme, ...props }: { theme: Theme } & Props) => CSSProperties),
+  styles:
+    | CSSProperties<Props>
+    | (({ theme, ...props }: { theme: Theme } & Props) => CSSProperties<Props>),
   options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
   Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, 'classes' | 'className'> &

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -1,6 +1,6 @@
 import { Omit } from '@material-ui/types';
 import {
-  CSSProperties,
+  CreateCSSProperties,
   StyledComponentProps,
   WithStylesOptions,
 } from '@material-ui/styles/withStyles';
@@ -11,8 +11,8 @@ import * as React from 'react';
  */
 export type ComponentCreator<C extends React.ElementType> = <Theme, Props extends {} = any>(
   styles:
-    | CSSProperties<Props>
-    | (({ theme, ...props }: { theme: Theme } & Props) => CSSProperties<Props>),
+    | CreateCSSProperties<Props>
+    | (({ theme, ...props }: { theme: Theme } & Props) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
   Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, 'classes' | 'className'> &

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -9,13 +9,16 @@ import * as React from 'react';
 /**
  * @internal
  */
-export type ComponentCreator<C extends React.ElementType> = <Theme, Props extends {} = any>(
+export type ComponentCreator<Component extends React.ElementType> = <Theme, Props extends {} = any>(
   styles:
     | CreateCSSProperties<Props>
     | (({ theme, ...props }: { theme: Theme } & Props) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
-  Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, 'classes' | 'className'> &
+  Omit<
+    JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
+    'classes' | 'className'
+  > &
     StyledComponentProps<'root'> & { className?: string }
 >;
 
@@ -23,4 +26,6 @@ export interface StyledProps {
   className: string;
 }
 
-export default function styled<C extends React.ElementType>(Component: C): ComponentCreator<C>;
+export default function styled<Component extends React.ElementType>(
+  Component: Component,
+): ComponentCreator<Component>;

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -3,15 +3,22 @@ import { PropInjector } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 
+export interface CSSProperties extends CSS.Properties<number | string> {
+  // Allow pseudo selectors and media queries
+  [k: string]: CSS.Properties<number | string>[keyof CSS.Properties] | CSSProperties;
+}
+
 export type BaseCSSProperties<Props extends object = {}> = {
   [P in keyof CSS.Properties<number | string>]:
     | CSS.Properties<number | string>[P]
     | ((props: Props) => CSS.Properties<number | string>[P])
 };
 
-export interface CSSProperties<Props extends object = {}> extends BaseCSSProperties<Props> {
+export interface CreateCSSProperties<Props extends object = {}> extends BaseCSSProperties<Props> {
   // Allow pseudo selectors and media queries
-  [k: string]: BaseCSSProperties<Props>[keyof BaseCSSProperties<Props>] | CSSProperties<Props>;
+  [k: string]:
+    | BaseCSSProperties<Props>[keyof BaseCSSProperties<Props>]
+    | CreateCSSProperties<Props>;
 }
 
 /**
@@ -24,7 +31,7 @@ export interface CSSProperties<Props extends object = {}> extends BaseCSSPropert
  */
 export type StyleRules<Props extends object, ClassKey extends string = string> = Record<
   ClassKey,
-  CSSProperties<Props> | ((props: Props) => CSSProperties<Props>)
+  CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
 >;
 
 /**

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -3,13 +3,13 @@ import { PropInjector } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 
-export type BaseCSSProperties<Props extends {} = {}> = {
+export type BaseCSSProperties<Props extends object = {}> = {
   [P in keyof CSS.Properties<number | string>]:
     | CSS.Properties<number | string>[P]
     | ((props: Props) => CSS.Properties<number | string>[P])
 };
 
-export interface CSSProperties<Props extends {} = {}> extends BaseCSSProperties<Props> {
+export interface CSSProperties<Props extends object = {}> extends BaseCSSProperties<Props> {
   // Allow pseudo selectors and media queries
   [k: string]: BaseCSSProperties<Props>[keyof BaseCSSProperties<Props>] | CSSProperties<Props>;
 }
@@ -34,7 +34,7 @@ export type StyleRulesCallback<Theme, Props extends object, ClassKey extends str
   theme: Theme,
 ) => StyleRules<Props, ClassKey>;
 
-export type Styles<Theme, Props extends {}, ClassKey extends string = string> =
+export type Styles<Theme, Props extends object, ClassKey extends string = string> =
   | StyleRules<Props, ClassKey>
   | StyleRulesCallback<Theme, Props, ClassKey>;
 
@@ -50,7 +50,7 @@ export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, st
 /**
  * @internal
  */
-export type ClassKeyInferable<Theme, Props extends {}> = string | Styles<Theme, Props>;
+export type ClassKeyInferable<Theme, Props extends object> = string | Styles<Theme, Props>;
 export type ClassKeyOfStyles<S> = S extends string
   ? S
   : S extends StyleRulesCallback<any, any, infer K>

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -3,9 +3,15 @@ import { PropInjector } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 
-export interface CSSProperties extends CSS.Properties<number | string> {
+export type BaseCSSProperties<Props extends {} = {}> = {
+  [P in keyof CSS.Properties<number | string>]:
+    | CSS.Properties<number | string>[P]
+    | ((props: Props) => CSS.Properties<number | string>[P])
+};
+
+export interface CSSProperties<Props extends {} = {}> extends BaseCSSProperties<Props> {
   // Allow pseudo selectors and media queries
-  [k: string]: CSS.Properties<number | string>[keyof CSS.Properties] | CSSProperties;
+  [k: string]: BaseCSSProperties<Props>[keyof BaseCSSProperties<Props>] | CSSProperties<Props>;
 }
 
 /**
@@ -18,7 +24,7 @@ export interface CSSProperties extends CSS.Properties<number | string> {
  */
 export type StyleRules<Props extends object, ClassKey extends string = string> = Record<
   ClassKey,
-  CSSProperties | ((props: Props) => CSSProperties)
+  CSSProperties<Props> | ((props: Props) => CSSProperties<Props>)
 >;
 
 /**

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -59,30 +59,30 @@ export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, st
  * @internal
  */
 export type ClassKeyInferable<Theme, Props extends object> = string | Styles<Theme, Props>;
-export type ClassKeyOfStyles<S> = S extends string
-  ? S
-  : S extends StyleRulesCallback<any, any, infer K>
-  ? K
-  : S extends StyleRules<infer K>
-  ? K
+export type ClassKeyOfStyles<StylesOrClassKey> = StylesOrClassKey extends string
+  ? StylesOrClassKey
+  : StylesOrClassKey extends StyleRulesCallback<any, any, infer ClassKey>
+  ? ClassKey
+  : StylesOrClassKey extends StyleRules<infer ClassKey>
+  ? ClassKey
   : never;
 
 /**
  * infers the type of the theme used in the styles
  */
-export type PropsOfStyles<S> = S extends Styles<any, infer Props> ? Props : {};
+export type PropsOfStyles<StylesType> = StylesType extends Styles<any, infer Props> ? Props : {};
 /**
  * infers the type of the props used in the styles
  */
-export type ThemeOfStyles<S> = S extends Styles<infer Theme, any> ? Theme : {};
+export type ThemeOfStyles<StylesType> = StylesType extends Styles<infer Theme, any> ? Theme : {};
 
 export type WithStyles<
-  S extends ClassKeyInferable<any, any>,
+  StylesType extends ClassKeyInferable<any, any>,
   IncludeTheme extends boolean | undefined = false
-> = (IncludeTheme extends true ? { theme: ThemeOfStyles<S> } : {}) & {
-  classes: ClassNameMap<ClassKeyOfStyles<S>>;
+> = (IncludeTheme extends true ? { theme: ThemeOfStyles<StylesType> } : {}) & {
+  classes: ClassNameMap<ClassKeyOfStyles<StylesType>>;
   innerRef?: React.Ref<any> | React.RefObject<any>;
-} & PropsOfStyles<S>;
+} & PropsOfStyles<StylesType>;
 
 export interface StyledComponentProps<ClassKey extends string = string> {
   classes?: Partial<ClassNameMap<ClassKey>>;
@@ -90,9 +90,12 @@ export interface StyledComponentProps<ClassKey extends string = string> {
 }
 
 export default function withStyles<
-  S extends Styles<any, any>,
-  Options extends WithStylesOptions<ThemeOfStyles<S>> = {}
+  StylesType extends Styles<any, any>,
+  Options extends WithStylesOptions<ThemeOfStyles<StylesType>> = {}
 >(
-  style: S,
+  style: StylesType,
   options?: Options,
-): PropInjector<WithStyles<S, Options['withTheme']>, StyledComponentProps<ClassKeyOfStyles<S>>>;
+): PropInjector<
+  WithStyles<StylesType, Options['withTheme']>,
+  StyledComponentProps<ClassKeyOfStyles<StylesType>>
+>;

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -29,7 +29,7 @@ export interface CreateCSSProperties<Props extends object = {}> extends BaseCSSP
  *
  * if only `CSSProperties` are matched `Props` are inferred to `any`
  */
-export type StyleRules<Props extends object, ClassKey extends string = string> = Record<
+export type StyleRules<ClassKey extends string = string, Props extends object = {}> = Record<
   ClassKey,
   CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
 >;
@@ -39,10 +39,10 @@ export type StyleRules<Props extends object, ClassKey extends string = string> =
  */
 export type StyleRulesCallback<Theme, Props extends object, ClassKey extends string = string> = (
   theme: Theme,
-) => StyleRules<Props, ClassKey>;
+) => StyleRules<ClassKey, Props>;
 
 export type Styles<Theme, Props extends object, ClassKey extends string = string> =
-  | StyleRules<Props, ClassKey>
+  | StyleRules<ClassKey, Props>
   | StyleRulesCallback<Theme, Props, ClassKey>;
 
 export interface WithStylesOptions<Theme> extends JSS.StyleSheetFactoryOptions {
@@ -62,7 +62,7 @@ export type ClassKeyOfStyles<S> = S extends string
   ? S
   : S extends StyleRulesCallback<any, any, infer K>
   ? K
-  : S extends StyleRules<any, infer K>
+  : S extends StyleRules<infer K>
   ? K
   : never;
 

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -8,16 +8,17 @@ export interface CSSProperties extends CSS.Properties<number | string> {
   [k: string]: CSS.Properties<number | string>[keyof CSS.Properties] | CSSProperties;
 }
 
-export type BaseCSSProperties<Props extends object = {}> = {
+export type BaseCreateCSSProperties<Props extends object = {}> = {
   [P in keyof CSS.Properties<number | string>]:
     | CSS.Properties<number | string>[P]
     | ((props: Props) => CSS.Properties<number | string>[P])
 };
 
-export interface CreateCSSProperties<Props extends object = {}> extends BaseCSSProperties<Props> {
+export interface CreateCSSProperties<Props extends object = {}>
+  extends BaseCreateCSSProperties<Props> {
   // Allow pseudo selectors and media queries
   [k: string]:
-    | BaseCSSProperties<Props>[keyof BaseCSSProperties<Props>]
+    | BaseCreateCSSProperties<Props>[keyof BaseCreateCSSProperties<Props>]
     | CreateCSSProperties<Props>;
 }
 

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -30,7 +30,7 @@ export interface CreateCSSProperties<Props extends object = {}>
  *
  * if only `CSSProperties` are matched `Props` are inferred to `any`
  */
-export type StyleRules<ClassKey extends string = string, Props extends object = {}> = Record<
+export type StyleRules<Props extends object = {}, ClassKey extends string = string> = Record<
   ClassKey,
   CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
 >;
@@ -40,10 +40,10 @@ export type StyleRules<ClassKey extends string = string, Props extends object = 
  */
 export type StyleRulesCallback<Theme, Props extends object, ClassKey extends string = string> = (
   theme: Theme,
-) => StyleRules<ClassKey, Props>;
+) => StyleRules<Props, ClassKey>;
 
 export type Styles<Theme, Props extends object, ClassKey extends string = string> =
-  | StyleRules<ClassKey, Props>
+  | StyleRules<Props, ClassKey>
   | StyleRulesCallback<Theme, Props, ClassKey>;
 
 export interface WithStylesOptions<Theme> extends JSS.StyleSheetFactoryOptions {
@@ -63,7 +63,7 @@ export type ClassKeyOfStyles<StylesOrClassKey> = StylesOrClassKey extends string
   ? StylesOrClassKey
   : StylesOrClassKey extends StyleRulesCallback<any, any, infer ClassKey>
   ? ClassKey
-  : StylesOrClassKey extends StyleRules<infer ClassKey>
+  : StylesOrClassKey extends StyleRules<any, infer ClassKey>
   ? ClassKey
   : never;
 

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { createStyles, withStyles, withTheme, WithTheme, WithStyles } from '@material-ui/styles';
+import {
+  createStyles,
+  withStyles,
+  withTheme,
+  WithTheme,
+  WithStyles,
+  makeStyles,
+} from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import { Theme } from '@material-ui/core/styles';
 
@@ -418,4 +425,27 @@ function forwardRefTest() {
   // undesired: `innerRef` is currently typed as any but for backwards compat we're keeping it
   // especially since `innerRef` will be removed in v5 and is equivalent to `ref`
   <StyledRefableAnchor innerRef={buttonRef} />;
+}
+
+{
+  // https://github.com/mui-org/material-ui/pull/15546
+  // Update type definition to let CSS properties be functions
+  interface testProps {
+    foo: boolean;
+  }
+  const useStyles = makeStyles((theme: Theme) => ({
+    root: {
+      width: (prop: testProps) => (prop.foo ? 100 : 0),
+    },
+    root2: (prop2: testProps) => ({
+      width: (prop: testProps) => (prop.foo && prop2.foo ? 100 : 0),
+      height: 100,
+    }),
+  }));
+
+  const styles = useStyles({ foo: true });
+  // $ExpectType string
+  const root = styles.root;
+  // $ExpectType string
+  const root2 = styles.root2;
 }

--- a/packages/material-ui/src/styles/createStyles.d.ts
+++ b/packages/material-ui/src/styles/createStyles.d.ts
@@ -1,11 +1,3 @@
-import { StyleRules } from './withStyles';
+import createStyles from '@material-ui/styles/createStyles';
 
-/**
- * This function doesn't really "do anything" at runtime, it's just the identity
- * function. Its only purpose is to defeat TypeScript's type widening when providing
- * style rules to `withStyles` which are a function of the `Theme`.
- *
- * @param styles a set of style mappings
- * @returns the same styles that were passed in
- */
-export default function createStyles<C extends string>(styles: StyleRules<C>): StyleRules<C>;
+export default createStyles;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -11,6 +11,8 @@ import {
   WithStylesOptions as DefaultWithStylesOptions,
   StyleRules,
   StyleRulesCallback as DefaultStyleRulesCallback,
+  Styles as DefaultStyles,
+  ClassKeyOfStyles,
 } from '@material-ui/styles/withStyles';
 
 export { CreateCSSProperties, CSSProperties, ClassNameMap, StyledComponentProps, StyleRules };
@@ -23,21 +25,19 @@ export type StyleRulesCallback<
   Props extends object = {}
 > = DefaultStyleRulesCallback<Theme, Props, ClassKey>;
 
+export type Styles<ClassKey extends string = string, Props extends object = {}> = DefaultStyles<
+  Theme,
+  Props,
+  ClassKey
+>;
+
 export type WithStylesOptions = Omit<DefaultWithStylesOptions<Theme>, 'defaultTheme'>;
 
 export type WithStyles<
-  T extends string | StyleRules | StyleRulesCallback = string,
+  T extends string | Styles = string,
   IncludeTheme extends boolean | undefined = false
 > = (IncludeTheme extends true ? { theme: Theme } : {}) & {
-  classes: ClassNameMap<
-    T extends string
-      ? T
-      : T extends StyleRulesCallback<infer K>
-      ? K
-      : T extends StyleRules<infer K>
-      ? K
-      : never
-  >;
+  classes: ClassNameMap<ClassKeyOfStyles<T>>;
 };
 
 export default function withStyles<
@@ -45,6 +45,6 @@ export default function withStyles<
   Options extends WithStylesOptions = {},
   Props extends object = {}
 >(
-  style: StyleRulesCallback<ClassKey, Props> | StyleRules<ClassKey, Props>,
+  style: Styles<ClassKey, Props>,
   options?: Options,
 ): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey>>;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,11 +1,17 @@
 import * as React from 'react';
-import { PropInjector } from '@material-ui/types';
+import { PropInjector, Omit } from '@material-ui/types';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
-import { CreateCSSProperties, CSSProperties } from '@material-ui/styles/withStyles';
+import {
+  CreateCSSProperties,
+  CSSProperties,
+  ClassNameMap,
+  StyledComponentProps,
+  WithStylesOptions as DefaultWithStylesOptions,
+} from '@material-ui/styles/withStyles';
 
-export { CSSProperties };
+export { CreateCSSProperties, CSSProperties, ClassNameMap, StyledComponentProps };
 
 /**
  * This is basically the API of JSS. It defines a Map<string, CSS>,
@@ -29,13 +35,7 @@ export interface StylesCreator {
   themingEnabled: boolean;
 }
 
-export interface WithStylesOptions extends JSS.StyleSheetFactoryOptions {
-  flip?: boolean;
-  withTheme?: boolean;
-  name?: string;
-}
-
-export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
+export type WithStylesOptions = Omit<DefaultWithStylesOptions<Theme>, 'defaultTheme'>;
 
 export type WithStyles<
   T extends string | StyleRules | StyleRulesCallback = string,
@@ -51,11 +51,6 @@ export type WithStyles<
       : never
   >;
 };
-
-export interface StyledComponentProps<ClassKey extends string = string> {
-  classes?: Partial<ClassNameMap<ClassKey>>;
-  innerRef?: React.Ref<any> | React.RefObject<any>;
-}
 
 export default function withStyles<
   ClassKey extends string,

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -10,13 +10,18 @@ import {
   StyledComponentProps,
   WithStylesOptions as DefaultWithStylesOptions,
   StyleRules,
+  StyleRulesCallback as DefaultStyleRulesCallback,
 } from '@material-ui/styles/withStyles';
 
 export { CreateCSSProperties, CSSProperties, ClassNameMap, StyledComponentProps, StyleRules };
 
-export type StyleRulesCallback<ClassKey extends string = string, Props extends object = {}> = (
-  theme: Theme,
-) => StyleRules<ClassKey, Props>;
+/**
+ * @internal
+ */
+export type StyleRulesCallback<
+  ClassKey extends string = string,
+  Props extends object = {}
+> = DefaultStyleRulesCallback<Theme, Props, ClassKey>;
 
 export type WithStylesOptions = Omit<DefaultWithStylesOptions<Theme>, 'defaultTheme'>;
 

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -6,7 +6,7 @@ import {
   ClassNameMap,
   StyledComponentProps,
   WithStylesOptions,
-  StyleRules,
+  StyleRules as ActualStyleRules,
   StyleRulesCallback,
   Styles,
   ClassKeyOfStyles,
@@ -17,11 +17,19 @@ export {
   CSSProperties,
   ClassNameMap,
   StyledComponentProps,
-  StyleRules,
   Styles,
   WithStylesOptions,
   StyleRulesCallback,
 };
+
+/**
+ * Adapter for `StyleRules` from `@material-ui/styles` for backwards compatibility.
+ * Order of generic arguments is just reversed.
+ */
+export type StyleRules<
+  ClassKey extends string = string,
+  Props extends object = {}
+> = ActualStyleRules<Props, ClassKey>;
 
 export type WithStyles<
   StylesOrClassKey extends string | Styles<any, any, any> = string,

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -24,10 +24,10 @@ export {
 };
 
 export type WithStyles<
-  T extends string | Styles<any, any, any> = string,
+  StylesOrClassKey extends string | Styles<any, any, any> = string,
   IncludeTheme extends boolean | undefined = false
 > = (IncludeTheme extends true ? { theme: Theme } : {}) & {
-  classes: ClassNameMap<ClassKeyOfStyles<T>>;
+  classes: ClassNameMap<ClassKeyOfStyles<StylesOrClassKey>>;
 };
 
 export default function withStyles<

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { PropInjector } from '@material-ui/types';
 import { Theme } from './createMuiTheme';
 import {
@@ -8,8 +7,8 @@ import {
   StyledComponentProps,
   WithStylesOptions,
   StyleRules,
-  StyleRulesCallback as DefaultStyleRulesCallback,
-  Styles as DefaultStyles,
+  StyleRulesCallback,
+  Styles,
   ClassKeyOfStyles,
 } from '@material-ui/styles/withStyles';
 
@@ -19,25 +18,13 @@ export {
   ClassNameMap,
   StyledComponentProps,
   StyleRules,
+  Styles,
   WithStylesOptions,
+  StyleRulesCallback,
 };
 
-/**
- * @internal
- */
-export type StyleRulesCallback<
-  ClassKey extends string = string,
-  Props extends object = {}
-> = DefaultStyleRulesCallback<Theme, Props, ClassKey>;
-
-export type Styles<ClassKey extends string = string, Props extends object = {}> = DefaultStyles<
-  Theme,
-  Props,
-  ClassKey
->;
-
 export type WithStyles<
-  T extends string | Styles = string,
+  T extends string | Styles<any, any, any> = string,
   IncludeTheme extends boolean | undefined = false
 > = (IncludeTheme extends true ? { theme: Theme } : {}) & {
   classes: ClassNameMap<ClassKeyOfStyles<T>>;
@@ -48,6 +35,6 @@ export default function withStyles<
   Options extends WithStylesOptions<Theme> = {},
   Props extends object = {}
 >(
-  style: Styles<ClassKey, Props>,
+  style: Styles<Theme, Props, ClassKey>,
   options?: Options,
 ): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey>>;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -3,11 +3,9 @@ import { PropInjector } from '@material-ui/types';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
+import { CreateCSSProperties, CSSProperties } from '@material-ui/styles/withStyles';
 
-export interface CSSProperties extends CSS.Properties<number | string> {
-  // Allow pseudo selectors and media queries
-  [k: string]: CSS.Properties<number | string>[keyof CSS.Properties] | CSSProperties;
-}
+export { CSSProperties };
 
 /**
  * This is basically the API of JSS. It defines a Map<string, CSS>,
@@ -16,11 +14,14 @@ export interface CSSProperties extends CSS.Properties<number | string> {
  * - the `keys` are the class (names) that will be created
  * - the `values` are objects that represent CSS rules (`React.CSSProperties`).
  */
-export type StyleRules<ClassKey extends string = string> = Record<ClassKey, CSSProperties>;
+export type StyleRules<ClassKey extends string = string, Props extends object = {}> = Record<
+  ClassKey,
+  CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
+>;
 
-export type StyleRulesCallback<ClassKey extends string = string> = (
+export type StyleRulesCallback<ClassKey extends string = string, Props extends object = {}> = (
   theme: Theme,
-) => StyleRules<ClassKey>;
+) => StyleRules<ClassKey, Props>;
 
 export interface StylesCreator {
   create(theme: Theme, name: string): StyleRules;
@@ -56,7 +57,11 @@ export interface StyledComponentProps<ClassKey extends string = string> {
   innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
-export default function withStyles<ClassKey extends string, Options extends WithStylesOptions = {}>(
-  style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
+export default function withStyles<
+  ClassKey extends string,
+  Options extends WithStylesOptions = {},
+  Props extends object = {}
+>(
+  style: StyleRulesCallback<ClassKey, Props> | StyleRules<ClassKey, Props>,
   options?: Options,
 ): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey>>;

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -29,12 +29,6 @@ export type StyleRulesCallback<ClassKey extends string = string, Props extends o
   theme: Theme,
 ) => StyleRules<ClassKey, Props>;
 
-export interface StylesCreator {
-  create(theme: Theme, name: string): StyleRules;
-  options: { index: number };
-  themingEnabled: boolean;
-}
-
 export type WithStylesOptions = Omit<DefaultWithStylesOptions<Theme>, 'defaultTheme'>;
 
 export type WithStyles<

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -9,21 +9,10 @@ import {
   ClassNameMap,
   StyledComponentProps,
   WithStylesOptions as DefaultWithStylesOptions,
+  StyleRules,
 } from '@material-ui/styles/withStyles';
 
-export { CreateCSSProperties, CSSProperties, ClassNameMap, StyledComponentProps };
-
-/**
- * This is basically the API of JSS. It defines a Map<string, CSS>,
- * where
- *
- * - the `keys` are the class (names) that will be created
- * - the `values` are objects that represent CSS rules (`React.CSSProperties`).
- */
-export type StyleRules<ClassKey extends string = string, Props extends object = {}> = Record<
-  ClassKey,
-  CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
->;
+export { CreateCSSProperties, CSSProperties, ClassNameMap, StyledComponentProps, StyleRules };
 
 export type StyleRulesCallback<ClassKey extends string = string, Props extends object = {}> = (
   theme: Theme,

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -872,7 +872,7 @@ const TabsTest = () => {
 
   type ClassKey = 'root' | 'button';
 
-  const styles: StyleRulesCallback<ClassKey> = theme => ({
+  const styles: StyleRulesCallback<Theme, any, ClassKey> = theme => ({
     root: {
       flexGrow: 1,
       marginTop: theme.spacing(3),

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -264,8 +264,8 @@ withStyles(theme =>
     content: {
       minHeight: '100vh',
     },
+    // $ExpectError
     '@media (min-width: 960px)': {
-      // $ExpectError
       content: {
         display: 'flex',
       },
@@ -476,4 +476,90 @@ withStyles(theme =>
       },
     };
   });
+}
+
+{
+  // https://github.com/mui-org/material-ui/pull/15546
+  // Update type definition to let CSS properties be functions
+  interface testProps {
+    foo: boolean;
+  }
+
+  // makeStyles accepts properties as functions
+  {
+    const useStyles = makeStyles({
+      root: {
+        width: (prop: testProps) => (prop.foo ? 100 : 0),
+      },
+      root2: (prop2: testProps) => ({
+        width: (prop: testProps) => (prop.foo && prop2.foo ? 100 : 0),
+      }),
+    });
+
+    const styles = useStyles({ foo: true });
+    // $ExpectType string
+    const root = styles.root;
+    // $ExpectType string
+    const root2 = styles.root2;
+  }
+
+  // makeStyles accepts properties as functions using a callback
+  {
+    const useStyles = makeStyles(theme => ({
+      root: {
+        width: (prop: testProps) => (prop.foo ? 100 : 0),
+      },
+      root2: (prop2: testProps) => ({
+        width: (prop: testProps) => (prop.foo && prop2.foo ? 100 : 0),
+        margin: theme.spacing(1),
+      }),
+    }));
+
+    const styles = useStyles({ foo: true });
+    // $ExpectType string
+    const root = styles.root;
+    // $ExpectType string
+    const root2 = styles.root2;
+  }
+
+  // createStyles accepts properties as functions
+  {
+    const styles = createStyles({
+      root: {
+        width: (prop: testProps) => (prop.foo ? 100 : 0),
+      },
+      root2: (prop2: testProps) => ({
+        width: (prop: testProps) => (prop.foo && prop2.foo ? 100 : 0),
+      }),
+    });
+
+    // $ExpectType string
+    const root = makeStyles(styles)({ foo: true }).root;
+  }
+
+  // withStyles accepts properties as functions
+  {
+    withStyles({
+      root: {
+        width: (prop: testProps) => (prop.foo ? 100 : 0),
+      },
+      root2: (prop2: testProps) => ({
+        width: (prop: testProps) => (prop.foo && prop2.foo ? 100 : 0),
+        margin: 8,
+      }),
+    });
+  }
+
+  // withStyles accepts properties as functions using a callback
+  {
+    withStyles(theme => ({
+      root: {
+        width: (prop: testProps) => (prop.foo ? 100 : 0),
+      },
+      root2: (prop2: testProps) => ({
+        width: (prop: testProps) => (prop.foo && prop2.foo ? 100 : 0),
+        height: theme.spacing(1),
+      }),
+    }));
+  }
 }

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -396,7 +396,7 @@ withStyles(theme =>
 
 {
   // https://github.com/mui-org/material-ui/issues/11164
-  const style: StyleRulesCallback = theme => ({
+  const style: StyleRulesCallback<Theme, any, any> = theme => ({
     text: theme.typography.body2,
   });
 }


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

* Updated type definition to let CSS properties be functions that returns a value

Fixes #14814
Fixes #16007