### PR TITLE
[core] Fix createStyles not being defined

### DIFF
--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -3,6 +3,7 @@ import * as colors from './colors';
 export { colors };
 export {
   createMuiTheme,
+  createStyles,
   makeStyles,
   MuiThemeProvider,
   styled,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Resolves #15532 by re-adding the `createStyles` method. The function still exists in the source code (and corresponding TypeScript definitions). It performs a simple forward, but the function is not exported.

This change exports the function again, which should make (a setup similar to) [the demo in the linked issue](https://codesandbox.io/s/wqqzkjvyx5) not crash anymore.