### PR TITLE
[core] Set default theme type for makeStyles

### DIFF
--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -1,3 +1,12 @@
-import { makeStyles } from '@material-ui/styles';
+import { Theme as DefaultTheme } from './createMuiTheme';
+import { Styles, WithStylesOptions } from '@material-ui/styles/withStyles';
+import { StylesHook } from '@material-ui/styles/makeStyles';
 
-export default makeStyles;
+export default function makeStyles<
+  Theme = DefaultTheme,
+  Props extends {} = {},
+  ClassKey extends string = string
+>(
+  styles: Styles<Theme, Props, ClassKey>,
+  options?: WithStylesOptions<Theme>,
+): StylesHook<Styles<Theme, Props, ClassKey>>;

--- a/packages/material-ui/test/typescript/hoc-interop.spec.tsx
+++ b/packages/material-ui/test/typescript/hoc-interop.spec.tsx
@@ -8,8 +8,7 @@
  *
  * See https://github.com/Microsoft/TypeScript/issues/28339 for in-depth discussion
  */
-import { createStyles, ThemeProvider } from '@material-ui/styles';
-import { Button, withStyles } from '@material-ui/core';
+import { Button, withStyles, createStyles } from '@material-ui/core';
 import TextField, { TextFieldProps } from '@material-ui/core/TextField';
 import emotionStyled from '@emotion/styled';
 import * as React from 'react';

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -10,6 +10,7 @@ import {
   StyledComponentProps,
   WithStyles,
   WithTheme,
+  makeStyles,
 } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
@@ -462,4 +463,17 @@ withStyles(theme =>
   const CorrectUsage = () => <StyledMyButton nonDefaulted="2" />;
   // Property 'nonDefaulted' is missing in type '{}'
   const MissingPropUsage = () => <StyledMyButton />; // $ExpectError
+}
+
+{
+  // theme is defaulted to type of Theme
+  const useStyles = makeStyles(theme => {
+    // $ExpectType Theme
+    const t = theme;
+    return {
+      root: {
+        margin: t.spacing(1),
+      },
+    };
+  });
 }

--- a/packages/material-ui/tsconfig.json
+++ b/packages/material-ui/tsconfig.json
@@ -7,6 +7,8 @@
       "@material-ui/core/*": ["packages/material-ui/src/*"],
       "@material-ui/lab": ["packages/material-ui-lab/src"],
       "@material-ui/lab/*": ["packages/material-ui-lab/src/*"],
+      "@material-ui/styles": ["packages/material-ui-styles/src"],
+      "@material-ui/styles/*": ["packages/material-ui-styles/src/*"],
       "jss": ["node_modules/@types/jss"]
     }
   },


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Sets the default theme for `makeStyles`

Extracted from https://github.com/mui-org/material-ui/pull/15402

Helps with #15542 