### PR TITLE
[docs] Add DelayingApperance TypeScript demo

### DIFF
--- a/docs/src/pages/demos/progress/DelayingAppearance.tsx
+++ b/docs/src/pages/demos/progress/DelayingAppearance.tsx
@@ -1,29 +1,31 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import Fade from '@material-ui/core/Fade';
 import Button from '@material-ui/core/Button';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-  },
-  button: {
-    margin: theme.spacing(2),
-  },
-  placeholder: {
-    height: 40,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+    },
+    button: {
+      margin: theme.spacing(2),
+    },
+    placeholder: {
+      height: 40,
+    },
+  }),
+);
 
 function DelayingAppearance() {
   const classes = useStyles();
   const [loading, setLoading] = React.useState(false);
   const [query, setQuery] = React.useState('idle');
-  const timerRef = React.useRef();
+  const timerRef = React.useRef<number>();
 
   React.useEffect(
     () => () => {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

- Added typescript demo for `demos\progress\DelayingApperance`.
- Store `timer` as a ref with `React.useRef`

Part of #14897