### PR TITLE
[MenuList] Ignore disableListWrap for text focus navigation

### DIFF
--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -155,7 +155,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
         currentFocus && !criteria.repeating && textCriteriaMatches(currentFocus, criteria);
       if (
         criteria.previousKeyMatched &&
-        (keepFocusOnCurrent || moveFocus(list, currentFocus, disableListWrap, nextItem, criteria))
+        (keepFocusOnCurrent || moveFocus(list, currentFocus, false, nextItem, criteria))
       ) {
         event.preventDefault();
       } else {


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Addresses issues noted [here](https://github.com/mui-org/material-ui/pull/15484#issuecomment-487600068).

* Native `select` behavior wraps the navigation when doing text matching but not for arrow keys, so the text matching now ignores the `disableListWrap` property.

* This makes an attempt to regression test focus-visible logic for `MenuList`, however it is difficult to do this robustly since the `simulate` function does not bubble events up the same way as dispatchEvent, so events never reach the document event listeners set up by `focusVisible.js`. I added a couple usages of `dispatchEvent` to cause changes to `hadKeyboardEvent` in `focusVisible.js` and verified that the focus visible class gets added or not appropriately after focus change.