### PR TITLE
[docs] Fix types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,8 @@
       "@material-ui/core/*": ["./material-ui/src/*"],
       "@material-ui/lab": ["./material-ui-lab/src"],
       "@material-ui/lab/*": ["./material-ui-lab/src/*"],
+      "@material-ui/styles": ["./material-ui-styles/src"],
+      "@material-ui/styles/*": ["./material-ui-styles/src/*"],
       "@material-ui/system": ["./material-ui-system/src"]
     }
   },


### PR DESCRIPTION
Alternate to #15501

I have no idea:
- what declarations typescript used thus far for `@material-ui/styles`
- why it never reported implicit any
