### PR TITLE
[docs] Extract inherited component from test

### DIFF
--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -45,26 +45,33 @@ const theme = createMuiTheme();
 const inheritedComponentRegexp = /\/\/ @inheritedComponent (.*)/;
 
 function getInheritance(testInfo, src) {
-  const inheritedComponent = testInfo.inheritComponent; // src.match(inheritedComponentRegexp);
+  let inheritedComponentName = testInfo.inheritComponent;
 
-  if (inheritedComponent == null) {
+  if (inheritedComponentName == null) {
+    const match = src.match(inheritedComponentRegexp);
+    if (match !== null) {
+      inheritedComponentName = match[1];
+    }
+  }
+
+  if (inheritedComponentName == null) {
     return null;
   }
 
   let pathname;
 
-  switch (inheritedComponent) {
+  switch (inheritedComponentName) {
     case 'Transition':
       pathname = 'https://reactcommunity.org/react-transition-group/#Transition';
       break;
 
     default:
-      pathname = `/api/${kebabCase(inheritedComponent)}`;
+      pathname = `/api/${kebabCase(inheritedComponentName)}`;
       break;
   }
 
   return {
-    component: inheritedComponent,
+    component: inheritedComponentName,
     pathname,
   };
 }

--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -44,28 +44,27 @@ const theme = createMuiTheme();
 
 const inheritedComponentRegexp = /\/\/ @inheritedComponent (.*)/;
 
-function getInheritance(src) {
-  const inheritedComponent = src.match(inheritedComponentRegexp);
+function getInheritance(testInfo, src) {
+  const inheritedComponent = testInfo.inheritComponent; // src.match(inheritedComponentRegexp);
 
-  if (!inheritedComponent) {
+  if (inheritedComponent == null) {
     return null;
   }
 
-  const component = inheritedComponent[1];
   let pathname;
 
-  switch (component) {
+  switch (inheritedComponent) {
     case 'Transition':
       pathname = 'https://reactcommunity.org/react-transition-group/#Transition';
       break;
 
     default:
-      pathname = `/api/${kebabCase(component)}`;
+      pathname = `/api/${kebabCase(inheritedComponent)}`;
       break;
   }
 
   return {
-    component,
+    component: inheritedComponent,
     pathname,
   };
 }
@@ -150,7 +149,7 @@ async function buildDocs(options) {
 
   // Relative location in the file system.
   reactAPI.filename = componentObject.filename.replace(rootDirectory, '');
-  reactAPI.inheritance = getInheritance(src);
+  reactAPI.inheritance = getInheritance(testInfo, src);
 
   let markdown;
   try {

--- a/docs/src/modules/utils/parseTest.js
+++ b/docs/src/modules/utils/parseTest.js
@@ -67,6 +67,14 @@ function getRefInstance(valueNode) {
 }
 
 /**
+ *
+ * @param {import('@babel/core').Node} valueNode - An Identifier
+ */
+function getInheritComponentName(valueNode) {
+  return valueNode.name;
+}
+
+/**
  * @typedef {Object} ParseResult
  * @property {string?} forwardsRefTo
  */
@@ -83,6 +91,7 @@ export default async function parseTest(componentFilename) {
 
   const result = {
     forwardsRefTo: undefined,
+    inheritComponent: undefined,
   };
 
   const { properties = [] } = descriptor;
@@ -92,6 +101,9 @@ export default async function parseTest(componentFilename) {
     switch (key) {
       case 'refInstanceof':
         result.forwardsRefTo = getRefInstance(property.value);
+        break;
+      case 'inheritComponent':
+        result.inheritComponent = getInheritComponentName(property.value);
         break;
       default:
         break;

--- a/packages/material-ui/src/AppBar/AppBar.js
+++ b/packages/material-ui/src/AppBar/AppBar.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Paper
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -7,7 +7,6 @@ import {
   getClasses,
 } from '@material-ui/core/test-utils';
 import Backdrop from './Backdrop';
-import Fade from '../Fade';
 
 describe('<Backdrop />', () => {
   let mount;
@@ -27,7 +26,7 @@ describe('<Backdrop />', () => {
 
   describeConformance(<Backdrop open />, () => ({
     classes,
-    inheritComponent: Fade,
+    inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Card/Card.js
+++ b/packages/material-ui/src/Card/Card.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Paper
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -1,5 +1,3 @@
-// @inheritedComponent IconButton
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import IndeterminateCheckBoxIcon from '../internal/svg-icons/IndeterminateCheckBox';
 import { describeConformance, getClasses, createMount } from '@material-ui/core/test-utils';
 import Checkbox from './Checkbox';
+import IconButton from '../IconButton';
 
 describe('<Checkbox />', () => {
   let classes;
@@ -20,7 +21,7 @@ describe('<Checkbox />', () => {
 
   describeConformance(<Checkbox checked />, () => ({
     classes,
-    inheritComponent: 'span',
+    inheritComponent: IconButton,
     mount,
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp'],

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Transition
-
 import React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -4,6 +4,7 @@ import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, describeConformance, getClasses } from '@material-ui/core/test-utils';
 import Collapse from './Collapse';
 import { createMuiTheme } from '@material-ui/core/styles';
+import { Transition } from 'react-transition-group';
 
 describe('<Collapse />', () => {
   let mount;
@@ -24,7 +25,7 @@ describe('<Collapse />', () => {
 
   describeConformance(<Collapse {...defaultProps} />, () => ({
     classes,
-    inheritComponent: 'Transition',
+    inheritComponent: Transition,
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -1,6 +1,5 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
 /* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
-// @inheritedComponent Modal
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/material-ui/src/DialogContentText/DialogContentText.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Typography
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import withStyles from '../styles/withStyles';

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -36,7 +36,7 @@ describe('<Drawer />', () => {
     </Drawer>,
     () => ({
       classes,
-      inheritComponent: Modal,
+      inheritComponent: 'div',
       mount,
       refInstanceof: window.HTMLDivElement,
       skip: ['componentProp'],

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Paper
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Transition
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount, describeConformance } from '@material-ui/core/test-utils';
 import Fade from './Fade';
+import { Transition } from 'react-transition-group';
 
 describe('<Fade />', () => {
   let mount;
@@ -23,7 +24,7 @@ describe('<Fade />', () => {
 
   describeConformance(<Fade {...defaultProps} />, () => ({
     classes: {},
-    inheritComponent: 'Transition',
+    inheritComponent: Transition,
     mount,
     skip: ['componentProp', 'refForwarding'],
   }));

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -1,5 +1,3 @@
-// @inheritedComponent InputBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Transition
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -4,6 +4,7 @@ import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, describeConformance } from '@material-ui/core/test-utils';
 import Grow from './Grow';
 import { createMuiTheme } from '@material-ui/core/styles';
+import { Transition } from 'react-transition-group';
 
 describe('<Grow />', () => {
   let mount;
@@ -26,7 +27,7 @@ describe('<Grow />', () => {
     </Grow>,
     () => ({
       classes: {},
-      inheritComponent: 'Transition',
+      inheritComponent: Transition,
       mount,
       skip: ['componentProp', 'refForwarding'],
     }),

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -1,5 +1,3 @@
-// @inheritedComponent InputBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -1,5 +1,3 @@
-// @inheritedComponent FormLabel
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Typography
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Popover
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ListItem
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -1,5 +1,3 @@
-// @inheritedComponent List
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';

--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Paper
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Input
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import NativeSelectInput from './NativeSelectInput';

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -1,5 +1,3 @@
-// @inheritedComponent InputBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Modal
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -1,5 +1,3 @@
-// @inheritedComponent IconButton
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -4,6 +4,7 @@ import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
 import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
 import { getClasses, createMount, describeConformance } from '@material-ui/core/test-utils';
 import Radio from './Radio';
+import IconButton from '../IconButton';
 
 describe('<Radio />', () => {
   let classes;
@@ -21,7 +22,7 @@ describe('<Radio />', () => {
 
   describeConformance(<Radio />, () => ({
     classes,
-    inheritComponent: 'span',
+    inheritComponent: IconButton,
     mount,
     refInstanceof: window.HTMLSpanElement,
     skip: ['componentProp'],

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -1,5 +1,3 @@
-// @inheritedComponent FormGroup
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Input
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { mergeClasses } from '@material-ui/styles';

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Transition
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -4,6 +4,7 @@ import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, describeConformance } from '@material-ui/core/test-utils';
 import Slide, { setTranslateValue } from './Slide';
 import createMuiTheme from '../styles/createMuiTheme';
+import { Transition } from 'react-transition-group';
 
 describe('<Slide />', () => {
   let mount;
@@ -28,7 +29,7 @@ describe('<Slide />', () => {
     </Slide>,
     () => ({
       classes: {},
-      inheritComponent: 'Transition',
+      inheritComponent: Transition,
       mount,
       refInstanceof: React.Component,
       skip: ['componentProp', 'refForwarding'],

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Paper
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Paper
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -1,5 +1,4 @@
 /* eslint-disable consistent-this */
-// @inheritedComponent Drawer
 
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -1,5 +1,3 @@
-// @inheritedComponent IconButton
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -1,3 +1,5 @@
+// @inheritedComponent IconButton
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -1,5 +1,3 @@
-// @inheritedComponent TableCell
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { chainPropTypes } from '@material-ui/utils';

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -1,5 +1,3 @@
-// @inheritedComponent ButtonBase
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -1,5 +1,3 @@
-// @inheritedComponent FormControl
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import warning from 'warning';

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -1,5 +1,3 @@
-// @inheritedComponent Transition
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Transition } from 'react-transition-group';

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount, describeConformance } from '@material-ui/core/test-utils';
+import { Transition } from 'react-transition-group';
 import Zoom from './Zoom';
 
 describe('<Zoom />', () => {
@@ -22,7 +23,7 @@ describe('<Zoom />', () => {
     </Zoom>,
     () => ({
       classes: {},
-      inheritComponent: 'Transition',
+      inheritComponent: Transition,
       mount,
       skip: ['componentProp', 'refForwarding'],
     }),

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -1,5 +1,3 @@
-// @inheritedComponent IconButton
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -35,7 +35,7 @@ import Switch from '@material-ui/core/Switch';
 
 The `ref` is forwarded to the root element.
 
-Any other properties supplied will be provided to the root element (native element).
+Any other properties supplied will be provided to the root element ([IconButton](/api/icon-button/)).
 
 ## CSS
 
@@ -63,6 +63,11 @@ for more detail.
 
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSwitch`.
+
+## Inheritance
+
+The properties of the [IconButton](/api/icon-button/) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -35,7 +35,7 @@ import Switch from '@material-ui/core/Switch';
 
 The `ref` is forwarded to the root element.
 
-Any other properties supplied will be provided to the root element ([IconButton](/api/icon-button/)).
+Any other properties supplied will be provided to the root element (native element).
 
 ## CSS
 
@@ -63,11 +63,6 @@ for more detail.
 
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSwitch`.
-
-## Inheritance
-
-The properties of the [IconButton](/api/icon-button/) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 

--- a/pages/lab/api/speed-dial-action.md
+++ b/pages/lab/api/speed-dial-action.md
@@ -29,7 +29,7 @@ import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element (native element).
+Any other properties supplied will be provided to the root element ([Tooltip](/api/tooltip/)).
 
 ## CSS
 
@@ -48,6 +48,11 @@ for more detail.
 
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSpeedDialAction`.
+
+## Inheritance
+
+The properties of the [Tooltip](/api/tooltip/) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 

--- a/pages/lab/api/speed-dial-action.md
+++ b/pages/lab/api/speed-dial-action.md
@@ -29,7 +29,7 @@ import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element ([Tooltip](/api/tooltip/)).
+Any other properties supplied will be provided to the root element (native element).
 
 ## CSS
 
@@ -48,11 +48,6 @@ for more detail.
 
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSpeedDialAction`.
-
-## Inheritance
-
-The properties of the [Tooltip](/api/tooltip/) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 

--- a/pages/lab/api/toggle-button.md
+++ b/pages/lab/api/toggle-button.md
@@ -28,7 +28,7 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
+Any other properties supplied will be provided to the root element (native element).
 
 ## CSS
 
@@ -49,11 +49,6 @@ for more detail.
 
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiToggleButton`.
-
-## Inheritance
-
-The properties of the [ButtonBase](/api/button-base/) component are also available.
-You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 

--- a/pages/lab/api/toggle-button.md
+++ b/pages/lab/api/toggle-button.md
@@ -28,7 +28,7 @@ import ToggleButton from '@material-ui/lab/ToggleButton';
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element (native element).
+Any other properties supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
 
@@ -49,6 +49,11 @@ for more detail.
 
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiToggleButton`.
+
+## Inheritance
+
+The properties of the [ButtonBase](/api/button-base/) component are also available.
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Demos
 


### PR DESCRIPTION
- `@inheritedComponent` code annotation is used as fallback only if it is not actually tested or doesn't conform (like `Switch`)
- improves some tests regarding `inheritComponent`