### PR TITLE
 [system] Fix css typings

### DIFF
--- a/docs/src/pages/system/basics/CssProp.tsx
+++ b/docs/src/pages/system/basics/CssProp.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styled, { ThemeProvider } from 'styled-components';
+import NoSsr from '@material-ui/core/NoSsr';
+import { createMuiTheme } from '@material-ui/core/styles';
+import { compose, spacing, palette, css } from '@material-ui/system';
+
+const Box = styled.div`
+  ${css(
+    compose(
+      spacing,
+      palette,
+    ),
+  )}
+`;
+
+const theme = createMuiTheme();
+
+function CssProp() {
+  return (
+    <NoSsr>
+      <ThemeProvider theme={theme}>
+        <Box color="white" css={{ bgcolor: 'palevioletred', p: 1, textTransform: 'uppercase' }}>
+          CssProp
+        </Box>
+      </ThemeProvider>
+    </NoSsr>
+  );
+}
+
+export default CssProp;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Fixed css typings and restored CssProp.tsx which was removed in #15501 