### PR TITLE
Fixed marginLeft

### DIFF
--- a/docs/src/pages/demos/drawers/PersistentDrawerLeft.js
+++ b/docs/src/pages/demos/drawers/PersistentDrawerLeft.js
@@ -67,14 +67,13 @@ const styles = theme => ({
       easing: theme.transitions.easing.sharp,
       duration: theme.transitions.duration.leavingScreen,
     }),
-    marginLeft: -drawerWidth,
   },
   contentShift: {
     transition: theme.transitions.create('margin', {
       easing: theme.transitions.easing.easeOut,
       duration: theme.transitions.duration.enteringScreen,
     }),
-    marginLeft: 0,
+    marginLeft: drawerWidth,
   },
 });
 


### PR DESCRIPTION
maginLeft was reversed. `contentShift.marginLeft` should be `drawerWidth` and `content.marginLeft` should be 0. With existing code the behaviour which happens is the contrary of which the user wants.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
