### PR TITLE
[docs] Document v4 theme.spacing.unit deprecation

### DIFF
--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -139,6 +139,17 @@ yarn add @material-ui/styles@next
   },
   ```
 
+- `theme.spacing.unit` usage is deprecated, you can use the new API:
+  
+  ```diff    
+  [theme.breakpoints.up('sm')]: {     
+  - paddingTop: theme.spacing.unit * 12,  
+  + paddingTop: theme.spacing(12),
+  },
+  ```
+
+  *Tip: you can provide more than 1 argument: theme.spacing(1, 2) // = '8px 16px'*
+
 ### Typography
 
 - [Typography] Remove the deprecated typography variants. You can upgrade by performing the following replacements:


### PR DESCRIPTION
Should this be documented? https://github.com/mui-org/material-ui/pull/14099
