### PR TITLE
[Box] Add to core index TypeScript definitions

### DIFF
--- a/docs/src/pages/utils/box/box.md
+++ b/docs/src/pages/utils/box/box.md
@@ -66,7 +66,7 @@ import Box from '@material-ui/core/Box';
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">union:&nbsp;node&nbsp;&#124;<br>&nbsp;func<br></span> | | Box render function or node. |
-| <span class="prop-name">clone</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the box will recycle it's children DOM element. It's using `React.cloneElement` internally. |
+| <span class="prop-name">clone</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the box will recycle its children DOM element. It's using `React.cloneElement` internally. |
 | <span class="prop-name">component</span> | <span class="prop-type">union:&nbsp;string&nbsp;&#124;<br>&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 
 Any other properties supplied will be used by [the style functions](/system/basics/#all-inclusive) or spread to the root element.

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -113,6 +113,7 @@ export { default as Backdrop } from './Backdrop';
 export { default as Badge } from './Badge';
 export { default as BottomNavigation } from './BottomNavigation';
 export { default as BottomNavigationAction } from './BottomNavigationAction';
+export { default as Box } from './Box';
 export { default as Breadcrumbs } from './Breadcrumbs';
 export { default as Button } from './Button';
 export { default as ButtonBase } from './ButtonBase';


### PR DESCRIPTION
Adds the `Box` component export to `src/index.d.ts`. This allows importing it along with other components like:

```ts
import { Box, Button, List } from '@material-ui/core';
``` 

instead of 

```ts
import { Button, List } from '@material-ui/core';
import Box from '@material-ui/core/Box';
```
