### PR TITLE
[types] Add @material-ui/types package

### DIFF
--- a/docs/src/pages/demos/breadcrumbs/RouterBreadcrumbs.tsx
+++ b/docs/src/pages/demos/breadcrumbs/RouterBreadcrumbs.tsx
@@ -14,7 +14,7 @@ import ExpandMore from '@material-ui/icons/ExpandMore';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
 import { Route, MemoryRouter } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
-import { Omit } from '@material-ui/core';
+import { Omit } from '@material-ui/types';
 
 interface RouterBreadcrumbsState {
   readonly open: boolean;

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.2.0",
     "@emotion/hash": "^0.7.1",
+    "@material-ui/types": "^1.0.0",
     "@material-ui/utils": "^4.0.0-beta.0",
     "clsx": "^1.0.2",
     "deepmerge": "^3.0.0",

--- a/packages/material-ui-styles/src/getThemeProps/getThemeProps.d.ts
+++ b/packages/material-ui-styles/src/getThemeProps/getThemeProps.d.ts
@@ -1,11 +1,15 @@
-import { ComponentsPropsList } from '@material-ui/core/styles';
-import { Theme as MuiTheme } from '@material-ui/core';
+export {};
 
-export interface NamedParams<K extends keyof ComponentsPropsList, Theme> {
-  name: K;
-  props: ComponentsPropsList[K];
-  theme?: Theme;
+interface ThemeWithProps<Components> {
+  props?: { [K in keyof Components]: Partial<Components[K]> };
 }
-export default function getThemeProps<Name extends keyof ComponentsPropsList, Theme = MuiTheme>(
-  params: NamedParams<Name, Theme>,
-): ComponentsPropsList[Name];
+
+type ThemedProps<Theme, Name extends keyof any> = Theme extends { props: Record<Name, infer Props> }
+  ? Props
+  : {};
+
+export default function getThemeProps<
+  Theme extends ThemeWithProps<any>,
+  Props,
+  Name extends keyof any
+>(params: { props: Props; name: Name; theme?: Theme }): Props & ThemedProps<Theme, Name>;

--- a/packages/material-ui-styles/src/getThemeProps/getThemeProps.spec.ts
+++ b/packages/material-ui-styles/src/getThemeProps/getThemeProps.spec.ts
@@ -1,0 +1,37 @@
+import { getThemeProps, useTheme } from '@material-ui/styles';
+
+interface ButtonProps {
+  color: 'blue' | 'red';
+  size: 'small' | 'big';
+}
+
+interface TextProps {
+  size: number;
+}
+
+interface Theme {
+  props: {
+    Button: Partial<ButtonProps> & { sigil: string };
+    Text: Partial<TextProps>;
+  };
+}
+
+function Text(props: TextProps) {
+  const { size } = getThemeProps({ name: 'Text', props });
+}
+
+function Button(props: ButtonProps) {
+  const { size } = getThemeProps({ name: 'Button', props });
+  // no theme provided
+  const { sigil } = getThemeProps({ name: 'Button', props }); // $ExpectError
+}
+
+function ThemedButton(props: ButtonProps) {
+  const theme = useTheme<Theme>();
+  // sigil comes from the theme
+  const { size, sigil } = getThemeProps({ name: 'Button', props, theme });
+}
+
+function Noop(props: {}) {
+  const {} = getThemeProps({ name: 'DoesntExist', props });
+}

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -1,4 +1,4 @@
-import { Omit } from '@material-ui/core';
+import { Omit } from '@material-ui/types';
 import {
   CSSProperties,
   StyledComponentProps,

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PropInjector } from '@material-ui/core';
+import { PropInjector } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ConsistentWith, Omit, PropInjector } from '@material-ui/core';
+import { ConsistentWith, Omit, PropInjector } from '@material-ui/types';
 
 export interface WithThemeCreatorOption<Theme> {
   defaultTheme?: Theme;

--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -1,20 +1,8 @@
 import * as React from 'react';
 import { Theme } from '@material-ui/core';
 import { AppBarProps } from '@material-ui/core/AppBar';
-import { createStyles, getThemeProps, makeStyles } from '@material-ui/styles';
+import { createStyles, makeStyles } from '@material-ui/styles';
 import styled, { StyledProps } from '@material-ui/styles/styled';
-
-function testGetThemeProps(theme: Theme, props: AppBarProps): void {
-  const overriddenProps: AppBarProps = getThemeProps({ name: 'MuiAppBar', props, theme });
-
-  // AvatarProps not assignable to AppBarProps
-  const wronglyNamedProps: AppBarProps = getThemeProps({
-    name: 'MuiAvatar',
-    // $ExpectError
-    props,
-    theme,
-  });
-}
 
 // makeStyles
 {

--- a/packages/material-ui-types/README.md
+++ b/packages/material-ui-types/README.md
@@ -1,0 +1,1 @@
+# @material-ui/types

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -1,0 +1,44 @@
+// disable automatic export
+export {};
+
+/**
+ * `T extends ConsistentWith<T, U>` means that where `T` has overlapping properties with
+ * `U`, their value types do not conflict.
+ *
+ * @internal
+ */
+export type ConsistentWith<DecorationTargetProps, InjectedProps> = {
+  [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
+    ? InjectedProps[P] extends DecorationTargetProps[P]
+      ? DecorationTargetProps[P]
+      : InjectedProps[P]
+    : DecorationTargetProps[P]
+};
+
+/**
+ * a function that takes {component} and returns a component that passes along
+ * all the props to {component} except the {InjectedProps} and will accept
+ * additional {AdditionalProps}
+ */
+export type PropInjector<InjectedProps, AdditionalProps = {}> = <
+  C extends React.ComponentType<ConsistentWith<React.ComponentProps<C>, InjectedProps>>
+>(
+  component: C,
+) => React.ComponentType<
+  Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
+    AdditionalProps
+>;
+
+/**
+ * Remove properties `K` from `T`.
+ *
+ * @internal
+ */
+export type Omit<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
+
+/**
+ * Like `T & U`, but using the value types from `U` where their properties overlap.
+ *
+ * @internal
+ */
+export type Overwrite<T, U> = Omit<T, keyof U> & U;

--- a/packages/material-ui-types/package.json
+++ b/packages/material-ui-types/package.json
@@ -5,6 +5,9 @@
   "author": "Material-UI Team",
   "description": "Material-UI Types - Utility types for Material-UI.",
   "types": "./index.d.ts",
+  "files": [
+    "./index.d.ts"
+  ],
   "keywords": [
     "react",
     "react-component",

--- a/packages/material-ui-types/package.json
+++ b/packages/material-ui-types/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@material-ui/types",
+  "version": "1.0.0",
+  "private": false,
+  "author": "Material-UI Team",
+  "description": "Material-UI Types - Utility types for Material-UI.",
+  "types": "./index.d.ts",
+  "keywords": [
+    "react",
+    "react-component",
+    "material design",
+    "material-ui",
+    "types"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui.git"
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mui-org/material-ui/issues"
+  },
+  "homepage": "https://github.com/mui-org/material-ui/tree/next/packages/material-ui-types",
+  "scripts": {
+    "release": "npm publish --tag next",
+    "test": "echo 'No runtime test. Type tests are run with the `typescript` script.'",
+    "typescript": "tslint -p tsconfig.json \"*.{ts,tsx}\""
+  },
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/material-ui-types/package.json
+++ b/packages/material-ui-types/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/next/packages/material-ui-types",
   "scripts": {
-    "release": "npm publish --tag next",
+    "release": "npm publish --tag latest",
     "test": "echo 'No runtime test. Type tests are run with the `typescript` script.'",
     "typescript": "tslint -p tsconfig.json \"*.{ts,tsx}\""
   },

--- a/packages/material-ui-types/tsconfig.json
+++ b/packages/material-ui-types/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig"
+}

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -39,6 +39,7 @@
     "@babel/runtime": "^7.2.0",
     "@material-ui/styles": "^4.0.0-beta.0",
     "@material-ui/system": "^4.0.0-beta.0",
+    "@material-ui/types": "^1.0.0",
     "@material-ui/utils": "^4.0.0-beta.0",
     "@types/react-transition-group": "^2.0.16",
     "clsx": "^1.0.2",

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { StandardProps, Omit } from '..';
+import { Omit } from '@material-ui/types';
+import { StandardProps } from '..';
 import { Breakpoint } from '../styles/createBreakpoints';
 
 export type GridItemsAlignment = 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline';

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Omit } from '..';
+import { Omit } from '@material-ui/types';
 import { Theme } from '../styles/createMuiTheme';
 import { TransitionProps } from '../transitions/transition';
 

--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
-import { Omit } from '..';
+import { Omit } from '@material-ui/types';
 import { TypographyProps } from '../Typography';
 
 declare const Link: OverridableComponent<{

--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Omit } from '.';
+import { Omit } from '@material-ui/types';
 import { StyledComponentProps } from './styles';
 
 /**

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.d.ts
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Omit } from '..';
+import { Omit } from '@material-ui/types';
 import { DrawerProps } from '../Drawer';
 
 export interface SwipeableDrawerProps extends Omit<DrawerProps, 'onClose' | 'open'> {

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
-import { Omit } from '..';
+import { Omit } from '@material-ui/types';
 import { TablePaginationActionsProps } from './TablePaginationActions';
 import { TableCellProps } from '../TableCell';
 import { IconButtonProps } from '../IconButton';

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -1,6 +1,13 @@
 import * as React from 'react';
+import { ConsistentWith, Omit } from '@material-ui/types';
 import { StyledComponentProps } from './styles';
 export { StyledComponentProps };
+
+/**
+ * @deprecated
+ * Import from `@material-ui/types` instead
+ */
+export { Omit };
 
 /**
  * All standard components exposed by `material-ui` are `StyledComponents` with
@@ -41,48 +48,6 @@ export interface Color {
   A400: string;
   A700: string;
 }
-
-/**
- * Remove properties `K` from `T`.
- *
- * @internal
- */
-export type Omit<T, K extends keyof any> = T extends any ? Pick<T, Exclude<keyof T, K>> : never;
-
-/**
- * `T extends ConsistentWith<T, U>` means that where `T` has overlapping properties with
- * `U`, their value types do not conflict.
- *
- * @internal
- */
-export type ConsistentWith<DecorationTargetProps, InjectedProps> = {
-  [P in keyof DecorationTargetProps]: P extends keyof InjectedProps
-    ? InjectedProps[P] extends DecorationTargetProps[P]
-      ? DecorationTargetProps[P]
-      : InjectedProps[P]
-    : DecorationTargetProps[P]
-};
-
-/**
- * a function that takes {component} and returns a component that passes along
- * all the props to {component} except the {InjectedProps} and will accept
- * additional {AdditionalProps}
- */
-export type PropInjector<InjectedProps, AdditionalProps = {}> = <
-  C extends React.ComponentType<ConsistentWith<React.ComponentProps<C>, InjectedProps>>
->(
-  component: C,
-) => React.ComponentType<
-  Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof InjectedProps> &
-    AdditionalProps
->;
-
-/**
- * Like `T & U`, but using the value types from `U` where their properties overlap.
- *
- * @internal
- */
-export type Overwrite<T, U> = Omit<T, keyof U> & U;
 
 export namespace PropTypes {
   type Alignment = 'inherit' | 'left' | 'center' | 'right' | 'justify';

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PropInjector } from '..';
+import { PropInjector } from '@material-ui/types';
 import { Theme } from './createMuiTheme';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -1,5 +1,5 @@
 import { Theme } from './createMuiTheme';
-import { PropInjector } from '..';
+import { PropInjector } from '@material-ui/types';
 
 export interface WithTheme {
   theme: Theme;

--- a/packages/material-ui/src/withMobileDialog/withMobileDialog.d.ts
+++ b/packages/material-ui/src/withMobileDialog/withMobileDialog.d.ts
@@ -1,6 +1,6 @@
 import { Breakpoint } from '../styles/createBreakpoints';
 import { WithWidth } from '../withWidth';
-import { PropInjector } from '..';
+import { PropInjector } from '@material-ui/types';
 
 export interface WithMobileDialogOptions {
   breakpoint: Breakpoint;

--- a/packages/material-ui/src/withWidth/withWidth.d.ts
+++ b/packages/material-ui/src/withWidth/withWidth.d.ts
@@ -1,5 +1,5 @@
 import { Breakpoint } from '../styles/createBreakpoints';
-import { PropInjector } from '..';
+import { PropInjector } from '@material-ui/types';
 
 export interface WithWidthOptions {
   withTheme?: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
       "@material-ui/lab/*": ["./material-ui-lab/src/*"],
       "@material-ui/styles": ["./material-ui-styles/src"],
       "@material-ui/styles/*": ["./material-ui-styles/src/*"],
-      "@material-ui/system": ["./material-ui-system/src"]
+      "@material-ui/system": ["./material-ui-system/src"],
+      "@material-ui/types": ["./material-ui-types"]
     }
   },
   "exclude": ["**/build/"]


### PR DESCRIPTION
Closes #15570

Publishes a new `@material-ui/types` package that holds utility types.

TODO:
- [x] How to type `getThemeProps`