### PR TITLE
fix rtl plugin documentation

### DIFF
--- a/docs/src/pages/guides/right-to-left/right-to-left.md
+++ b/docs/src/pages/guides/right-to-left/right-to-left.md
@@ -43,7 +43,7 @@ import JssProvider from 'react-jss/lib/JssProvider';
 import { createGenerateClassName, jssPreset } from '@material-ui/core/styles';
 
 // Configure JSS
-const jss = create({ plugins: [...jssPreset().plugins, rtl()] });
+const jss = create({ plugins: [...jssPreset().plugins, { rtl: rtl() }] });
 
 // Custom Material-UI class name generator.
 const generateClassName = createGenerateClassName();


### PR DESCRIPTION
Just using rtl() directly appears to throw a type error.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
