### PR TITLE
[docs] Improve installation instructions for running the docs locally

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,12 @@ To start the docs site in development mode, from the project root, run:
 ```sh
 yarn && yarn start
 ```
+If you do not have yarn installed, select your OS and follow the instructions on the [Yarn website](https://yarnpkg.com/lang/en/docs/install/#mac-stable).
+
+*Mac users: note that you must have version 10.10.3 or higher for the Yarn installation to work as of 2019*
+
+*Also note: DO NOT USE NPM, use Yarn to install dependencies and everything else*
+
 
 ## How can I add a new demo to the documentation?
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,10 @@ To start the docs site in development mode, from the project root, run:
 ```sh
 yarn && yarn start
 ```
+
 If you do not have yarn installed, select your OS and follow the instructions on the [Yarn website](https://yarnpkg.com/lang/en/docs/install/#mac-stable).
 
-*Mac users: note that you must have version 10.10.3 or higher for the Yarn installation to work as of 2019*
-
-*Also note: DO NOT USE NPM, use Yarn to install dependencies and everything else*
-
+*DO NOT USE NPM, use Yarn to install the dependencies.*
 
 ## How can I add a new demo to the documentation?
 
@@ -21,5 +19,5 @@ on how to get started contributing to Material-UI.
 
 ## How do I help improve to the translations?
 
-Please visit https://translate.material-ui.com/ where you will be able to select a language 
-and edit the translations. Please don't submit pull requests directly.
+Please visit https://translate.material-ui.com/ where you will be able to select a language and edit the translations.
+Please don't submit pull requests directly.


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

I updated the installation instructions on the README file to clarify some things after:
1. Trying and failing to install the Yarn dependencies due to my outdated OS.
2. When testing to add a feature request, my colleague who is also working on this project, ran into issues when using NPM on Mac, therefore I clarified that one should only use Yarn for installation and testing for things to run smoothly.

