### PR TITLE
[core] Add cli tool to collect affect components by a prop change

### DIFF
--- a/docs/scripts/componentsAffected.js
+++ b/docs/scripts/componentsAffected.js
@@ -1,9 +1,18 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, no-restricted-syntax */
 import * as inquirer from 'inquirer';
 import * as path from 'path';
 import { findComponents } from '../src/modules/utils/find';
 import getDependencyGraph from '../src/modules/utils/getDependencyGraph';
 import getApparentProps from '../src/modules/utils/getApparentProps';
+
+function* readAnswers() {
+  while (true) {
+    yield inquirer.prompt([
+      { message: 'What component changed (name):', name: 'component' },
+      { message: 'What prop changed (name):', name: 'prop' },
+    ]);
+  }
+}
 
 async function run() {
   console.log('Building meta data. This might take a while.');
@@ -20,26 +29,27 @@ async function run() {
   // input feels unresponsive
   const componentsApparentProps = await getApparentProps(components, dependencyGraph);
 
-  const { component: changedComponentName, prop: changedPropName } = await inquirer.prompt([
-    { message: 'What component changed (name):', name: 'component' },
-    { message: 'What prop changed (name):', name: 'prop' },
-  ]);
+  for await (const answer of readAnswers()) {
+    const { component: changedComponentName, prop: changedPropName } = answer;
 
-  const affectedComponents = Array.from(componentsApparentProps.entries())
-    .filter(([, apparentProps]) => {
-      return Object.entries(apparentProps).some(
-        ([propName, prop]) =>
-          propName === changedPropName && prop.implementedBy === changedComponentName,
-      );
-    })
-    .map(([componentName]) => componentName)
-    .sort((a, b) => a.localeCompare(b));
+    const affectedComponents = Array.from(componentsApparentProps.entries())
+      .filter(([, apparentProps]) => {
+        return Object.entries(apparentProps).some(
+          ([propName, prop]) =>
+            propName === changedPropName && prop.implementedBy === changedComponentName,
+        );
+      })
+      .map(([componentName]) => componentName)
+      .sort((a, b) => a.localeCompare(b));
 
-  console.log(
-    `Changing the prop '${changedPropName}' in '${changedComponentName}' affects the following components:\n${affectedComponents
-      .map(name => `  - ${name}`)
-      .join('\n')}`,
-  );
+    console.log(
+      `Changing the prop '${changedPropName}' in '${changedComponentName}' affects the following components:\n${affectedComponents
+        .map(name => `  - ${name}`)
+        .join('\n')}`,
+    );
+
+    console.log('\nCTRL+C to stop program\n');
+  }
 }
 
 run().catch(error => {

--- a/docs/scripts/componentsAffected.js
+++ b/docs/scripts/componentsAffected.js
@@ -1,0 +1,48 @@
+/* eslint-disable no-console */
+import * as inquirer from 'inquirer';
+import * as path from 'path';
+import { findComponents } from '../src/modules/utils/find';
+import getDependencyGraph from '../src/modules/utils/getDependencyGraph';
+import getApparentProps from '../src/modules/utils/getApparentProps';
+
+async function run() {
+  console.log('Building meta data. This might take a while.');
+
+  const workspaceRoot = path.join(__dirname, '../../');
+
+  const coreComponents = findComponents(path.join(workspaceRoot, 'packages/material-ui/src'));
+  const labComponents = findComponents(path.join(workspaceRoot, 'packages/material-ui-lab/src'));
+  const components = [...coreComponents, ...labComponents];
+
+  const dependencyGraph = await getDependencyGraph(components);
+  // we don't have to await this until we get user input but a pending promise blocks
+  // the terminal ui paint thread (terminology might be incorrect) which means
+  // input feels unresponsive
+  const componentsApparentProps = await getApparentProps(components, dependencyGraph);
+
+  const { component: changedComponentName, prop: changedPropName } = await inquirer.prompt([
+    { message: 'What component changed (name):', name: 'component' },
+    { message: 'What prop changed (name):', name: 'prop' },
+  ]);
+
+  const affectedComponents = Array.from(componentsApparentProps.entries())
+    .filter(([, apparentProps]) => {
+      return Object.entries(apparentProps).some(
+        ([propName, prop]) =>
+          propName === changedPropName && prop.implementedBy === changedComponentName,
+      );
+    })
+    .map(([componentName]) => componentName)
+    .sort((a, b) => a.localeCompare(b));
+
+  console.log(
+    `Changing the prop '${changedPropName}' in '${changedComponentName}' affects the following components:\n${affectedComponents
+      .map(name => `  - ${name}`)
+      .join('\n')}`,
+  );
+}
+
+run().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/docs/src/modules/utils/getApparentProps.js
+++ b/docs/src/modules/utils/getApparentProps.js
@@ -1,0 +1,72 @@
+import * as fse from 'fs-extra';
+import * as lodash from 'lodash';
+import * as path from 'path';
+import { parse as docgenParse } from 'react-docgen';
+
+/**
+ * Maps the inheritance chain for each component to their respective props that specific
+ * component implements.
+ *
+ * @param {Map<string, {}>} componentsBaseProps
+ * @param {Map<string, string[]>} dependencyGraph
+ * @returns {Map<string, Array<{interface: {}, implementedBy: string}>>}
+ */
+function resolveProps(componentsBaseProps, dependencyGraph) {
+  const componentNames = Array.from(dependencyGraph.keys());
+
+  const resolvedEntries = componentNames.map(derivedComponentName => {
+    const inheritsFrom = dependencyGraph.get(derivedComponentName) || [];
+    const inheritanceChain = [derivedComponentName, ...inheritsFrom];
+
+    const resolvedProps = inheritanceChain.reduce((partialProps, componentName) => {
+      const props = componentsBaseProps.get(componentName) || {};
+      return {
+        ...partialProps,
+        ...lodash.mapValues(props, prop => {
+          return {
+            interface: prop,
+            implementedBy: componentName,
+          };
+        }),
+      };
+    }, []);
+
+    return [derivedComponentName, resolvedProps];
+  });
+
+  return new Map(resolvedEntries);
+}
+
+/**
+ * The result is a mapping from a component to a list of all the props that are available
+ * with a field for the interface of that prop and the name of the component that implements
+ * that prop.
+ *
+ * @param {Array<{filename: string}>} components
+ * @param {Map<string, string[]>} dependencyGraph
+ */
+export default async function getApparentProps(components, dependencyGraph) {
+  const componentsBaseProps = new Map();
+  await Promise.all(
+    components.map(async component => {
+      const componentSource = await fse.readFile(component.filename, { encoding: 'utf8' });
+
+      const componentName = path.basename(component.filename, '.js');
+
+      let reactAPI = null;
+      try {
+        reactAPI = docgenParse(componentSource, null, null, {
+          filename: component.filename,
+        });
+      } catch (error) {
+        // ignore
+      }
+
+      if (reactAPI !== null) {
+        componentsBaseProps.set(componentName, reactAPI.props);
+      }
+    }),
+  );
+
+  return resolveProps(componentsBaseProps, dependencyGraph);
+}

--- a/docs/src/modules/utils/getDependencyGraph.js
+++ b/docs/src/modules/utils/getDependencyGraph.js
@@ -1,0 +1,53 @@
+import * as path from 'path';
+import parseTest from './parseTest';
+
+function resolveInheritanceChain(inheritanceChain) {
+  const entries = Array.from(inheritanceChain.entries());
+  const resolvedEntries = entries.map(([derived, bases]) => {
+    if (bases.length > 1) {
+      throw new Error('Already resolved. Should only have at most one immediate base');
+    }
+
+    const resolvedChain = [];
+    let [base] = bases;
+    while (base !== undefined) {
+      resolvedChain.push(base);
+
+      // `base` might not appear in inheritance graph for 3rd party libraries
+      [base] = inheritanceChain.get(base) || [];
+    }
+
+    return [derived, resolvedChain];
+  });
+
+  return new Map(resolvedEntries);
+}
+
+export default async function getDependencyGraph(components) {
+  const componentsInheritance = new Map();
+  await Promise.all(
+    components.map(async component => {
+      let testInfo = null;
+      try {
+        testInfo = await parseTest(component.filename);
+      } catch (err) {
+        // ignore non-existing
+      }
+
+      if (testInfo !== null) {
+        const componentName = path.basename(component.filename, '.js');
+        const { inheritComponent } = testInfo;
+
+        if (!componentsInheritance.has(componentName)) {
+          componentsInheritance.set(componentName, []);
+        }
+
+        if (inheritComponent !== undefined) {
+          componentsInheritance.get(componentName).push(inheritComponent);
+        }
+      }
+    }),
+  );
+
+  return resolveInheritanceChain(componentsInheritance);
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://material-ui.com/",
   "scripts": {
     "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN",
+    "dev:what-changes": "BABEL_ENV=test yarn babel-node docs/scripts/componentsAffected.js",
     "docs:api": "rimraf ./pages/api && cross-env BABEL_ENV=test babel-node ./docs/scripts/buildApi.js ./packages/material-ui/src ./pages/api && cross-env BABEL_ENV=test babel-node ./docs/scripts/buildApi.js ./packages/material-ui-lab/src ./pages/api",
     "docs:build": "rimraf .next && cross-env NODE_ENV=production BABEL_ENV=docs-production next build",
     "docs:build-sw": "babel-node ./docs/scripts/buildServiceWorker.js",
@@ -139,6 +140,7 @@
     "glob": "^7.1.2",
     "glob-gitignore": "^1.0.11",
     "gm": "^1.23.0",
+    "inquirer": "^6.3.1",
     "isomorphic-fetch": "^2.2.1",
     "jsdom": "^15.0.0",
     "jsonlint": "^1.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1746,13 +1746,13 @@
     write-file-atomic "^2.3.0"
 
 "@material-ui/core@^3.9.3":
-  version "4.0.0-beta.0"
+  version "4.0.0-beta.1"
   dependencies:
     "@babel/runtime" "^7.2.0"
-    "@material-ui/styles" "^4.0.0-beta.0"
-    "@material-ui/system" "^4.0.0-beta.0"
-    "@material-ui/types" "^1.0.0"
-    "@material-ui/utils" "^4.0.0-beta.0"
+    "@material-ui/styles" "^4.0.0-beta.1"
+    "@material-ui/system" "^4.0.0-beta.1"
+    "@material-ui/types" "^4.0.0-beta.2"
+    "@material-ui/utils" "^4.0.0-beta.1"
     "@types/react-transition-group" "^2.0.16"
     clsx "^1.0.2"
     convert-css-length "^1.0.2"
@@ -7348,7 +7348,7 @@ init-package-json@^1.10.3:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-inquirer@^6.2.0, inquirer@^6.2.2:
+inquirer@^6.2.0, inquirer@^6.2.2, inquirer@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.3.1.tgz#7a413b5e7950811013a3db491c61d1f3b776e8e7"
   integrity sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==


### PR DESCRIPTION
Build this while working on the migration docs. It's specifically important for `component` in `ButtonBase` which affects a lot of components. 

```bash
$ yarn dev:what-changes
Building meta data. This might take a while.
? What component changed (name)?: ButtonBase
? What prop changed (name)?: component
Changing the prop 'component' in 'ButtonBase' affects the following components:
  - BottomNavigationAction
  - Button
  - ButtonBase
  - CardActionArea
  - Checkbox
  - ExpansionPanelSummary
  - Fab
  - IconButton
  - Radio
  - StepButton
  - Tab
  - TableSortLabel
```

It wouldn't catch the original report in https://github.com/mui-org/material-ui/issues/15598#issuecomment-490014911 since it relies on static analysis from `inheritComponent` and our `propTypes` documentation but it's a start.

This means that it also won't recognize pass-through props that are documented on derived components i.e. if component `Derived` has a `propType` for `component` even though it just passes it to `Base` the cli will think `Derived` implemented it. This will be improved once we stop doing this. It's currently useful to highlight useful props from base components.



It duplicates some code from `docs:api` which I plan to consolidate later. The whole docs/ workspace needs a restructuring