### PR TITLE
[ButtonBase] Extend error message for invalid `component` prop

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -5,7 +5,6 @@
 /spam / 301
 
 /size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/next/latest/size-snapshot.json 200
-/bug https://github.com/mui-org/material-ui/issues/new/choose 301
 
 # To remove at some point (2020).
 /demos/selection-controls/ /components/radio-buttons/ 301

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -5,7 +5,7 @@
 /spam / 301
 
 /size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/next/latest/size-snapshot.json 200
-/bug https://github.com/mui-org/material-ui/issues/new?template=1.bug.md 301
+/bug https://github.com/mui-org/material-ui/issues/new/choose 301
 
 # To remove at some point (2020).
 /demos/selection-controls/ /components/radio-buttons/ 301

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -5,7 +5,7 @@
 /spam / 301
 
 /size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/next/latest/size-snapshot.json 200
-/bug https://github.com/mui-org/material-ui/issues/new?template=1.bug.md 200
+/bug https://github.com/mui-org/material-ui/issues/new?template=1.bug.md 301
 
 # To remove at some point (2020).
 /demos/selection-controls/ /components/radio-buttons/ 301

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -5,6 +5,7 @@
 /spam / 301
 
 /size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/next/latest/size-snapshot.json 200
+/bug https://github.com/mui-org/material-ui/issues/new?template=1.bug.md 200
 
 # To remove at some point (2020).
 /demos/selection-controls/ /components/radio-buttons/ 301

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -93,7 +93,7 @@ class ButtonBase extends React.Component {
     if (button == null) {
       throw new Error(
         [
-          `Expected an Element but found ${button}.`,
+          `Material-UI: expected an Element but found ${button}.`,
           'Please check your console for additional warnings and try fixing those.',
           'If the error persists please file an issue: https://next.material-ui.com/bug',
         ].join(' '),

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -95,7 +95,7 @@ class ButtonBase extends React.Component {
         [
           `Material-UI: expected an Element but found ${button}.`,
           'Please check your console for additional warnings and try fixing those.',
-          'If the error persists please file an issue: https://next.material-ui.com/bug',
+          'If the error persists please file an issue.',
         ].join(' '),
       );
     }

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -89,7 +89,18 @@ class ButtonBase extends React.Component {
   });
 
   componentDidMount() {
-    prepareFocusVisible(this.getButtonNode().ownerDocument);
+    const button = this.getButtonNode();
+    if (button == null) {
+      throw new Error(
+        [
+          `Expected an Element but found ${button}.`,
+          'Please check your console for additional warnings and try fixing those.',
+          'If the error persists please file an issue: https://next.material-ui.com/bug',
+        ].join(' '),
+      );
+    }
+    prepareFocusVisible(button.ownerDocument);
+
     if (this.props.action) {
       this.props.action({
         focusVisible: () => {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -682,58 +682,28 @@ describe('<ButtonBase />', () => {
     });
 
     it('throws with additional warnings on invalid `component` prop', () => {
+      // Only run the test on node. On the browser the thrown error is not caught
+      if (!/jsdom/.test(window.navigator.userAgent)) {
+        return;
+      }
+
       function Component(props) {
         return <button type="button" {...props} />;
       }
 
-      class Test extends React.Component {
-        static getDerivedStateFromError() {
-          return { hasError: true };
-        }
-
-        state = {
-          hasError: false,
-        };
-
-        render() {
-          const { hasError } = this.state;
-
-          if (hasError) {
-            return null;
-          }
-
-          return <ButtonBase component={Component} />;
-        }
-      }
-
-      // assert.throws or try-catch still throws in test:karma
-      const wrapper = mount(<Test />);
       // cant match the error message here because flakiness with mocha watchmode
-      assert.strictEqual(wrapper.find('Test').instance().state.hasError, true);
+      assert.throws(() => mount(<ButtonBase component={Component} />));
 
-      // order of errors changes between node and browser env and subsequent runs
-      // in watchmode
-      assert.strictEqual(
-        consoleErrorMock
-          .args()
-          .some(args =>
-            /Invalid prop `component` supplied to `ButtonBase`. Expected an element type that can hold a ref/.test(
-              args[0],
-            ),
-          ),
-        true,
-        'has invalid component prop-types warnings',
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'Invalid prop `component` supplied to `ButtonBase`. Expected an element type that can hold a ref',
       );
-      assert.strictEqual(
-        consoleErrorMock
-          .args()
-          .some(args =>
-            /Error: Expected an Element but found null. Please check your console for additional warnings and try fixing those./.test(
-              args[0],
-            ),
-          ),
-        true,
-        'has custom error message',
+      // first mount includes React warning that isn't logged on subsequent calls
+      // in watchmode because it's cached
+      const customErrorIndex = consoleErrorMock.callCount() === 3 ? 1 : 2;
+      assert.include(
+        consoleErrorMock.args()[customErrorIndex][0],
+        'Error: Expected an Element but found null. Please check your console for additional warnings and try fixing those.',
       );
     });
   });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -689,16 +689,29 @@ describe('<ButtonBase />', () => {
       // cant match the error message here because flakiness with mocha watchmode
       assert.throws(() => mount(<ButtonBase component={Component} />));
 
-      assert.include(
-        consoleErrorMock.args()[0][0],
-        'Invalid prop `component` supplied to `ButtonBase`. Expected an element type that can hold a ref',
+      // order of errors changes between node and browser env and subsequent runs
+      // in watchmode
+      assert.strictEqual(
+        consoleErrorMock
+          .args()
+          .some(args =>
+            /Invalid prop `component` supplied to `ButtonBase`. Expected an element type that can hold a ref/.test(
+              args[0],
+            ),
+          ),
+        true,
+        'has invalid component prop-types warnings',
       );
-      // first mount includes React warning that isn't logged on subsequent calls
-      // in watchmode because it's cached
-      const customErrorIndex = consoleErrorMock.callCount() === 3 ? 1 : 2;
-      assert.include(
-        consoleErrorMock.args()[customErrorIndex][0],
-        'Error: Expected an Element but found null. Please check your console for additional warnings and try fixing those.',
+      assert.strictEqual(
+        consoleErrorMock
+          .args()
+          .some(args =>
+            /Error: Expected an Element but found null. Please check your console for additional warnings and try fixing those./.test(
+              args[0],
+            ),
+          ),
+        true,
+        'has custom error message',
       );
     });
   });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -12,6 +12,8 @@ import {
 } from '@material-ui/core/test-utils';
 import TouchRipple from './TouchRipple';
 import ButtonBase from './ButtonBase';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
+import * as PropTypes from 'prop-types';
 
 const ButtonBaseNaked = unwrap(ButtonBase);
 
@@ -665,6 +667,38 @@ describe('<ButtonBase />', () => {
       assert.strictEqual(
         rerender.updates.filter(update => update.displayName !== 'NoSsr').length,
         3,
+      );
+    });
+  });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      consoleErrorMock.spy();
+    });
+
+    afterEach(() => {
+      consoleErrorMock.reset();
+      PropTypes.resetWarningCache();
+    });
+
+    it('throws with additional warnings on invalid `component` prop', () => {
+      function Component(props) {
+        return <button type="button" {...props} />;
+      }
+
+      // cant match the error message here because flakiness with mocha watchmode
+      assert.throws(() => mount(<ButtonBase component={Component} />));
+
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'Invalid prop `component` supplied to `ButtonBase`. Expected an element type that can hold a ref',
+      );
+      // first mount includes React warning that isn't logged on subsequent calls
+      // in watchmode because it's cached
+      const customErrorIndex = consoleErrorMock.callCount() === 3 ? 1 : 2;
+      assert.include(
+        consoleErrorMock.args()[customErrorIndex][0],
+        'Error: Expected an Element but found null. Please check your console for additional warnings and try fixing those.',
       );
     });
   });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -686,8 +686,30 @@ describe('<ButtonBase />', () => {
         return <button type="button" {...props} />;
       }
 
+      class Test extends React.Component {
+        static getDerivedStateFromError() {
+          return { hasError: true };
+        }
+
+        state = {
+          hasError: false,
+        };
+
+        render() {
+          const { hasError } = this.state;
+
+          if (hasError) {
+            return null;
+          }
+
+          return <ButtonBase component={Component} />;
+        }
+      }
+
+      // assert.throws or try-catch still throws in test:karma
+      const wrapper = mount(<Test />);
       // cant match the error message here because flakiness with mocha watchmode
-      assert.throws(() => mount(<ButtonBase component={Component} />));
+      assert.strictEqual(wrapper.find('Test').instance().state.hasError, true);
 
       // order of errors changes between node and browser env and subsequent runs
       // in watchmode

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -703,7 +703,7 @@ describe('<ButtonBase />', () => {
       const customErrorIndex = consoleErrorMock.callCount() === 3 ? 1 : 2;
       assert.include(
         consoleErrorMock.args()[customErrorIndex][0],
-        'Error: Expected an Element but found null. Please check your console for additional warnings and try fixing those.',
+        'Error: Material-UI: expected an Element but found null. Please check your console for additional warnings and try fixing those.',
       );
     });
   });


### PR DESCRIPTION
Closes #15598

Throw a custom error instead of a cryptic `Cannot read ownerDocument of null` which just points to the console warnings that explain the issue in more details with links to fix prescriptions.

Adds a redirect from https://next.material-ui.com/bug to the bug report issue template.

My preferred solution would be a custom error boundary around all our components that catches and rethrows errors while also prefixing error messages with a hint to the console and helpful links. This would be a dev only boundary which requires some thought about build infra etc. But it's definitely something I want to explore later. For now this custom solution should be sufficient. 