### PR TITLE
[core] Update es build target

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,6 +1,14 @@
+[production]
 ie 11
 edge >= 14
 firefox >= 52
 chrome >= 49
 safari >= 10
 node 8.0
+
+[es]
+edge >= 18
+firefox >= 66
+chrome >= 73
+safari >= 12.1
+node >= 8.16

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -11,4 +11,4 @@ edge >= 18
 firefox >= 66
 chrome >= 73
 safari >= 12.1
-node >= 8.16
+node >= 12.2

--- a/babel.config.js
+++ b/babel.config.js
@@ -11,11 +11,26 @@ function resolvePath(sourcePath, currentFile, opts) {
 
 let defaultPresets;
 
-// We release a ES version of Material-UI.
-// It's something that matches the latest official supported features of JavaScript.
-// Nothing more (stage-1, etc), nothing less (require, etc).
+// evergreen build
+// see https://next.material-ui.com/guides/minimizing-bundle-size/#evergreen-build
+// TODO rename `es` to something more appropriate
 if (process.env.BABEL_ENV === 'es') {
-  defaultPresets = [];
+  defaultPresets = [
+    [
+      '@babel/preset-env',
+      {
+        modules: false,
+        // snapshot of the latest version of evergreen browsers
+        targets: {
+          chrome: 73,
+          edge: 18,
+          firefox: 66,
+          node: 8,
+          safari: '12.1',
+        },
+      },
+    ],
+  ];
 } else {
   defaultPresets = [
     [

--- a/babel.config.js
+++ b/babel.config.js
@@ -9,37 +9,15 @@ function resolvePath(sourcePath, currentFile, opts) {
   return bpmr.resolvePath(sourcePath, currentFile, opts);
 }
 
-let defaultPresets;
-
-// evergreen build
-// see https://next.material-ui.com/guides/minimizing-bundle-size/#evergreen-build
-if (process.env.BABEL_ENV === 'es') {
-  defaultPresets = [
-    [
-      '@babel/preset-env',
-      {
-        modules: false,
-        // snapshot of the latest version of evergreen browsers
-        targets: {
-          chrome: 73,
-          edge: 18,
-          firefox: 66,
-          node: 8,
-          safari: '12.1',
-        },
-      },
-    ],
-  ];
-} else {
-  defaultPresets = [
-    [
-      '@babel/preset-env',
-      {
-        modules: ['esm', 'production-umd'].includes(process.env.BABEL_ENV) ? false : 'commonjs',
-      },
-    ],
-  ];
-}
+const defaultPresets = [
+  [
+    '@babel/preset-env',
+    {
+      debug: process.env.NODE_ENV === 'production',
+      modules: ['es', 'esm', 'production-umd'].includes(process.env.BABEL_ENV) ? false : 'commonjs',
+    },
+  ],
+];
 
 const defaultAlias = {
   '@material-ui/core': './packages/material-ui/src',

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,6 @@ let defaultPresets;
 
 // evergreen build
 // see https://next.material-ui.com/guides/minimizing-bundle-size/#evergreen-build
-// TODO rename `es` to something more appropriate
 if (process.env.BABEL_ENV === 'es') {
   defaultPresets = [
     [
@@ -68,8 +67,7 @@ module.exports = {
   presets: defaultPresets.concat(['@babel/preset-react']),
   plugins: [
     'babel-plugin-optimize-clsx',
-    ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
+    '@babel/plugin-proposal-class-properties',
     '@babel/plugin-transform-runtime',
   ],
   ignore: [/@babel[\\|/]runtime/], // Fix a Windows issue.

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -77,6 +77,10 @@ Rather use some form of aliasing in your build setup. You can apply
 resolve: {
   alias: {
 +   '@material-ui/core$': '@material-ui/core/es',
++   '@material-ui/lab$': '@material-ui/lab/es',
++   '@material-ui/styles$': '@material-ui/styles/es',
++   '@material-ui/system$': '@material-ui/system/es',
++   '@material-ui/utils$': '@material-ui/utils/es',
   }
 }
 ```

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -52,18 +52,36 @@ Pick one of the following plugins:
 
 **Important note**: Both of these options *should be temporary* until you add tree shaking capabilities to your project.
 
-## ECMAScript
+## evergreen build
 
 The package published on npm is **transpiled**, with [Babel](https://github.com/babel/babel), to take into account the [supported platforms](/getting-started/supported-platforms/).
 
-We also publish a second version of the components to target **evergreen browsers**.
+We also publish a second version of the components to target **evergreen browsers** and
+the [active node version](https://nodejs.org/en/about/releases/#releases). This allows us to apply fewer code transformations
+which results in around 8% less bundle size for `@material-ui/core`.
 You can find this version under the [`/es` folder](https://unpkg.com/@material-ui/core@next/es/).
-All the non-official syntax is transpiled to the [ECMA-262 standard](https://www.ecma-international.org/publications/standards/Ecma-262.htm), nothing more.
-This can be used to make separate bundles targeting different browsers.
-Older browsers will require more JavaScript features to be transpiled,
-which increases the size of the bundle.
-No polyfills are included for ES2015 runtime features. IE11+ and evergreen browsers support all the
-necessary features. If you need support for other browsers, consider using
-[`@babel/polyfill`](https://www.npmjs.com/package/@babel/polyfill).
+
+This build is currently targetting the following versions:
+| Edge   | Firefox | Chrome | Safari  | Node | Googlebot |
+|:-------|:--------|:-------|:--------|:-----|:----------|
+| >= 18  | >= 66   | >= 73  | >= 12.1 | 12.2 | ✅         |
+
+We update these versions in minor releases.
+
+### Usage
+
+You should **not** explicitly import from this build with e.g. `import Button from '@material-ui/core/es/Button'`.
+Rather use some form of aliasing in your build setup. You can apply
+
+```diff
+resolve: {
+  alias: {
++   '@material-ui/core$': '@material-ui/core/es',
+  }
+}
+```
+
+to your webpack config to use the evergreen build for `import { Button } from '@material-ui/core'` as well as
+`import Button from '@material-ui/core/Button'`.
 
 ⚠️ In order to minimize duplication of code in users' bundles, we **strongly discourage** library authors from using the `/es` folder.

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -25,7 +25,7 @@
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
     "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es BROWSERSLIST_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag next",

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -25,7 +25,7 @@
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
     "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es BROWSERSLIST_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag next",

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -25,7 +25,7 @@
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
     "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es BROWSERSLIST_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag next",

--- a/packages/material-ui-utils/package.json
+++ b/packages/material-ui-utils/package.json
@@ -25,7 +25,7 @@
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
     "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es BROWSERSLIST_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag next",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -23,7 +23,7 @@
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:umd && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
     "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
-    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
+    "build:es": "cross-env NODE_ENV=production BABEL_ENV=es BROWSERSLIST_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:umd": "cross-env BABEL_ENV=production-umd rollup -c scripts/rollup.config.js",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -48,14 +48,29 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui-lab/build/esm/index.js',
     },
     {
+      name: '@material-ui/lab-es',
+      webpack: true,
+      path: 'packages/material-ui-lab/build/es/index.js',
+    },
+    {
       name: '@material-ui/styles',
       webpack: true,
       path: 'packages/material-ui-styles/build/esm/index.js',
     },
     {
+      name: '@material-ui/styles-es',
+      webpack: true,
+      path: 'packages/material-ui-styles/build/es/index.js',
+    },
+    {
       name: '@material-ui/system',
       webpack: true,
       path: 'packages/material-ui-system/build/esm/index.js',
+    },
+    {
+      name: '@material-ui/system-es',
+      webpack: true,
+      path: 'packages/material-ui-system/build/es/index.js',
     },
     {
       name: 'colorManipulator',

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -33,7 +33,7 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui/build/esm/index.js',
     },
     {
-      name: '@material-ui/core-es',
+      name: '@material-ui/core/es',
       webpack: true,
       path: 'packages/material-ui/build/es/index.js',
     },
@@ -48,7 +48,7 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui-lab/build/esm/index.js',
     },
     {
-      name: '@material-ui/lab-es',
+      name: '@material-ui/lab/es',
       webpack: true,
       path: 'packages/material-ui-lab/build/es/index.js',
     },
@@ -58,7 +58,7 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui-styles/build/esm/index.js',
     },
     {
-      name: '@material-ui/styles-es',
+      name: '@material-ui/styles/es',
       webpack: true,
       path: 'packages/material-ui-styles/build/es/index.js',
     },
@@ -68,7 +68,7 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui-system/build/esm/index.js',
     },
     {
-      name: '@material-ui/system-es',
+      name: '@material-ui/system/es',
       webpack: true,
       path: 'packages/material-ui-system/build/es/index.js',
     },

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -33,6 +33,11 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui/build/esm/index.js',
     },
     {
+      name: '@material-ui/core-es',
+      webpack: true,
+      path: 'packages/material-ui/build/es/index.js',
+    },
+    {
       name: '@material-ui/core/styles/createMuiTheme',
       webpack: true,
       path: 'packages/material-ui/build/esm/styles/createMuiTheme.js',


### PR DESCRIPTION
Opening this early for bundle size tracking

## Changes
- `/es` build actually targets evergreen browsers. While the docs stated this it was never strictly translated into the build setup. Some syntax was transformed (like object spread properties) but not the full esnext syntax. The change is therefore a SemVer patch.
- remove manual plugins that are handled by preset-env (object-assing, rest-spread etc). This doesn't mean the syntax isn't transpiled anymore. Just that preset-env will decide this from the build target.

TODO:
* [x] `/es` build for other packages? Edit: We're already doing this.
* [x] ~Use separate `.browserslistrc` for the `/es` build?~ Use single `.browserslistrc` with `BROWSERSLIST_ENV` switch
* [x] document target for `/es` build explicitly?
* [x] Improve docs section for `/es` build (`/es` misnomer; "evergreen-build"; savings!)
* [x] ~SemVer (this change and release cycle)?~ Snapshot last 1 version of evergreen + oldest node lts. Default build will use another strategy (+ IE11)