### PR TITLE
[core] Drop partial chrome 41 support

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -55,7 +55,6 @@ module.exports = {
     'babel-plugin-optimize-clsx',
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
-    '@babel/plugin-transform-object-assign',
     '@babel/plugin-transform-runtime',
   ],
   ignore: [/@babel[\\|/]runtime/], // Fix a Windows issue.

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -13,7 +13,7 @@ You don't need to provide any JavaScript polyfill as we manage unsupported brows
 | 11    | >= 14  | >= 52   | >= 49  | >= 10  | ✅        |
 
 Because Googlebot uses a web rendering service (WRS) to index the page content, it's critical that Material-UI supports it.
-[WRS is based on Chrome 41](https://developers.google.com/search/docs/guides/rendering).
+[WRS regularly updates the rendering engine it uses](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html).
 You can expect Material-UI's components to render without major issues.
 
 ## Server

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -101,7 +101,7 @@ module.exports = function setKarmaConfig(config) {
           os: 'OS X',
           os_version: 'Sierra',
           browser: 'Chrome',
-          browser_version: '41.0',
+          browser_version: '49.0',
         },
         BrowserStack_Firefox: {
           base: 'BrowserStack',


### PR DESCRIPTION
The supported chrome version was always in a weird spot. Transpilation target was 49 but we included `transform-object-assign` specifically for chrome 41 (which is used by the googlebot).

[Now that googlebot runs on chrome 74](https://webmasters.googleblog.com/2019/05/the-new-evergreen-googlebot.html) there's no more reason to include this transform.

Since we were smart enough not to explicitly support chrome 41 but rather 49 + googlebot we can safely drop the transform in a feature release. Releasing this during a beta should make it extra safe.