### PR TITLE
[core] Remove react-event-listener from function components

### DIFF
--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -92,7 +92,7 @@ function ClickAwayListener(props) {
       };
     }
 
-    return () => {};
+    return undefined;
   }, [handleClickAway, handleTouchMove, touchEvent]);
 
   React.useEffect(() => {
@@ -105,7 +105,7 @@ function ClickAwayListener(props) {
       };
     }
 
-    return () => {};
+    return undefined;
   }, [handleClickAway, mouseEvent]);
 
   return <React.Fragment>{React.cloneElement(children, { ref: handleRef })}</React.Fragment>;

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -18,7 +18,7 @@ function useMountedRef() {
 }
 
 function mapEventPropToEvent(eventProp) {
-  if (typeof eventProp === 'string' && eventProp.startsWith('on')) {
+  if (typeof eventProp === 'string' && eventProp.indexOf('on') === 0) {
     return eventProp.substring(2).toLowerCase();
   }
   return eventProp;

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -18,10 +18,7 @@ function useMountedRef() {
 }
 
 function mapEventPropToEvent(eventProp) {
-  if (typeof eventProp === 'string' && eventProp.indexOf('on') === 0) {
-    return eventProp.substring(2).toLowerCase();
-  }
-  return eventProp;
+  return eventProp.substring(2).toLowerCase();
 }
 
 /**
@@ -83,27 +80,33 @@ function ClickAwayListener(props) {
   }, []);
 
   React.useEffect(() => {
-    const mappedMouseEvent = mapEventPropToEvent(mouseEvent);
-    const mappedTouchEvent = mapEventPropToEvent(touchEvent);
-
-    if (mouseEvent !== false) {
-      document.addEventListener(mappedMouseEvent, handleClickAway);
-    }
     if (touchEvent !== false) {
+      const mappedTouchEvent = mapEventPropToEvent(touchEvent);
+
       document.addEventListener(mappedTouchEvent, handleClickAway);
       document.addEventListener('touchmove', handleTouchMove);
+
+      return () => {
+        document.removeEventListener(mappedTouchEvent, handleClickAway);
+        document.removeEventListener('touchmove', handleTouchMove);
+      };
     }
 
-    return () => {
-      if (mouseEvent !== false) {
-        document.removeEventListener(mouseEvent, handleClickAway);
-      }
-      if (touchEvent !== false) {
-        document.removeEventListener(touchEvent, handleClickAway);
-        document.removeEventListener('touchmove', handleTouchMove);
-      }
-    };
-  }, [handleClickAway, handleTouchMove, mouseEvent, touchEvent]);
+    return () => {};
+  }, [handleClickAway, handleTouchMove, touchEvent]);
+
+  React.useEffect(() => {
+    if (mouseEvent !== false) {
+      const mappedMouseEvent = mapEventPropToEvent(mouseEvent);
+      document.addEventListener(mappedMouseEvent, handleClickAway);
+
+      return () => {
+        document.removeEventListener(mappedMouseEvent, handleClickAway);
+      };
+    }
+
+    return () => {};
+  }, [handleClickAway, mouseEvent]);
 
   return <React.Fragment>{React.cloneElement(children, { ref: handleRef })}</React.Fragment>;
 }
@@ -116,15 +119,7 @@ ClickAwayListener.propTypes = {
   /**
    * The mouse event to listen to. You can disable the listener by providing `false`.
    */
-  mouseEvent: PropTypes.oneOf([
-    'click',
-    'onClick',
-    'mousedown',
-    'onMouseDown',
-    'mouseup',
-    'onMouseUp',
-    false,
-  ]),
+  mouseEvent: PropTypes.oneOf(['onClick', 'onMouseDown', 'onMouseUp', false]),
   /**
    * Callback fired when a "click away" event is detected.
    */
@@ -132,7 +127,7 @@ ClickAwayListener.propTypes = {
   /**
    * The touch event to listen to. You can disable the listener by providing `false`.
    */
-  touchEvent: PropTypes.oneOf(['touchstart', 'onTouchStart', 'touchend', 'onTouchEnd', false]),
+  touchEvent: PropTypes.oneOf(['onTouchStart', 'onTouchEnd', false]),
 };
 
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -190,7 +190,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
       };
     }
 
-    return () => {};
+    return undefined;
   }, [direction, inProp]);
 
   React.useEffect(() => {

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -213,7 +213,7 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
       };
     }
 
-    return () => {};
+    return undefined;
   }, [disableWindowBlurListener, handleResume]);
 
   // So we only render active snackbars.

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -206,12 +206,12 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
     if (!disableWindowBlurListener) {
       window.addEventListener('focus', handleResume);
       window.addEventListener('blur', handlePause);
-    }
 
-    return () => {
-      window.removeEventListener('focus', handleResume);
-      window.removeEventListener('blur', handlePause);
-    };
+      return () => {
+        window.removeEventListener('focus', handleResume);
+        window.removeEventListener('blur', handlePause);
+      };
+    }
   }, [disableWindowBlurListener, handleResume]);
 
   // So we only render active snackbars.

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -212,6 +212,8 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
         window.removeEventListener('blur', handlePause);
       };
     }
+
+    return () => {};
   }, [disableWindowBlurListener, handleResume]);
 
   // So we only render active snackbars.

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import EventListener from 'react-event-listener';
 import withStyles from '../styles/withStyles';
 import { duration } from '../styles/transitions';
 import ClickAwayListener from '../ClickAwayListener';
@@ -165,7 +164,7 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
 
   // Restart the timer when the user is no longer interacting with the Snackbar
   // or when the window is shown back.
-  const handleResume = () => {
+  const handleResume = React.useCallback(() => {
     if (autoHideDuration != null) {
       if (resumeHideDuration != null) {
         setAutoHideTimer(resumeHideDuration);
@@ -173,7 +172,7 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
       }
       setAutoHideTimer(autoHideDuration * 0.5);
     }
-  };
+  }, [autoHideDuration, resumeHideDuration, setAutoHideTimer]);
 
   const handleMouseEnter = event => {
     if (onMouseEnter) {
@@ -203,6 +202,18 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
     setExited(false);
   };
 
+  React.useEffect(() => {
+    if (!disableWindowBlurListener) {
+      window.addEventListener('focus', handleResume);
+      window.addEventListener('blur', handlePause);
+    }
+
+    return () => {
+      window.removeEventListener('focus', handleResume);
+      window.removeEventListener('blur', handlePause);
+    };
+  }, [disableWindowBlurListener, handleResume]);
+
   // So we only render active snackbars.
   if (!open && exited) {
     return null;
@@ -221,11 +232,6 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
         ref={ref}
         {...other}
       >
-        <EventListener
-          target="window"
-          onFocus={disableWindowBlurListener ? undefined : handleResume}
-          onBlur={disableWindowBlurListener ? undefined : handlePause}
-        />
         <TransitionComponent
           appear
           in={open}

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -20,9 +20,9 @@ For instance, if you need to hide a menu when people click anywhere else on your
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The wrapped element.<br>⚠️ [Needs to be able to hold a ref](/guides/composition/#caveat-with-refs). |
-| <span class="prop-name">mouseEvent</span> | <span class="prop-type">enum:&nbsp;'click', 'onClick', 'mousedown', 'onMouseDown', 'mouseup', 'onMouseUp', false<br></span> | <span class="prop-default">'onMouseUp'</span> | The mouse event to listen to. You can disable the listener by providing `false`. |
+| <span class="prop-name">mouseEvent</span> | <span class="prop-type">enum:&nbsp;'onClick'&nbsp;&#124;<br>&nbsp;'onMouseDown'&nbsp;&#124;<br>&nbsp;'onMouseUp'&nbsp;&#124;<br>&nbsp;false<br></span> | <span class="prop-default">'onMouseUp'</span> | The mouse event to listen to. You can disable the listener by providing `false`. |
 | <span class="prop-name required">onClickAway&nbsp;*</span> | <span class="prop-type">func</span> |  | Callback fired when a "click away" event is detected. |
-| <span class="prop-name">touchEvent</span> | <span class="prop-type">enum:&nbsp;'touchstart', 'onTouchStart', 'touchend', 'onTouchEnd', false<br></span> | <span class="prop-default">'onTouchEnd'</span> | The touch event to listen to. You can disable the listener by providing `false`. |
+| <span class="prop-name">touchEvent</span> | <span class="prop-type">enum:&nbsp;'onTouchStart'&nbsp;&#124;<br>&nbsp;'onTouchEnd'&nbsp;&#124;<br>&nbsp;false<br></span> | <span class="prop-default">'onTouchEnd'</span> | The touch event to listen to. You can disable the listener by providing `false`. |
 
 The component cannot hold a ref.
 

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -20,9 +20,9 @@ For instance, if you need to hide a menu when people click anywhere else on your
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The wrapped element.<br>⚠️ [Needs to be able to hold a ref](/guides/composition/#caveat-with-refs). |
-| <span class="prop-name">mouseEvent</span> | <span class="prop-type">enum:&nbsp;'onClick'&nbsp;&#124;<br>&nbsp;'onMouseDown'&nbsp;&#124;<br>&nbsp;'onMouseUp'&nbsp;&#124;<br>&nbsp;false<br></span> | <span class="prop-default">'onMouseUp'</span> | The mouse event to listen to. You can disable the listener by providing `false`. |
+| <span class="prop-name">mouseEvent</span> | <span class="prop-type">enum:&nbsp;'click', 'onClick', 'mousedown', 'onMouseDown', 'mouseup', 'onMouseUp', false<br></span> | <span class="prop-default">'onMouseUp'</span> | The mouse event to listen to. You can disable the listener by providing `false`. |
 | <span class="prop-name required">onClickAway&nbsp;*</span> | <span class="prop-type">func</span> |  | Callback fired when a "click away" event is detected. |
-| <span class="prop-name">touchEvent</span> | <span class="prop-type">enum:&nbsp;'onTouchStart'&nbsp;&#124;<br>&nbsp;'onTouchEnd'&nbsp;&#124;<br>&nbsp;false<br></span> | <span class="prop-default">'onTouchEnd'</span> | The touch event to listen to. You can disable the listener by providing `false`. |
+| <span class="prop-name">touchEvent</span> | <span class="prop-type">enum:&nbsp;'touchstart', 'onTouchStart', 'touchend', 'onTouchEnd', false<br></span> | <span class="prop-default">'onTouchEnd'</span> | The touch event to listen to. You can disable the listener by providing `false`. |
 
 The component cannot hold a ref.
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

I've made the Snackbar change non-breaking for now, we should aim to align with the native event names.

After this, and the Popover conversion is finished, `Tabs` and `withWidth` will be the only things that use it.