### PR TITLE
[useScrollTrigger] Enhance trigger, improve tests

### DIFF
--- a/docs/src/pages/components/app-bar/app-bar.md
+++ b/docs/src/pages/components/app-bar/app-bar.md
@@ -65,7 +65,7 @@ An App Bar that elevates on scroll.
 
   - `options.disableHysteresis` (*Boolan* [optional]): Defaults to `false`. Disable the hysteresis. Ignore the scroll direction when determining the `trigger` value.
   - `options.target` (*Node* [optional]): Defaults to `window`.
-  - `options.threshold` (*Number* [optional]): Defaults to `100`. Change the `trigger` value when the vertical scroll crosses this threshold.
+  - `options.threshold` (*Number* [optional]): Defaults to `100`. Change the `trigger` value when the vertical scroll strictly crosses this threshold (exclusive).
 
 #### Returns
 

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
@@ -5,13 +5,9 @@ function getScrollY(ref) {
 }
 
 function defaultTrigger(event, store, options) {
-  const { disableHysteresis = false, threshold = 100, initialState = false } = options;
+  const { disableHysteresis = false, threshold = 100 } = options;
   const previous = store.current;
   store.current = event ? getScrollY(event.currentTarget) : previous;
-
-  if (store.current === undefined) {
-    return initialState;
-  }
 
   if (!disableHysteresis && previous !== undefined) {
     if (store.current < previous) {

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
@@ -1,15 +1,19 @@
 import React from 'react';
 
 function getScrollY(ref) {
-  return ref.pageYOffset || ref.scrollTop;
+  return ref.pageYOffset !== undefined ? ref.pageYOffset : ref.scrollTop;
 }
 
 function defaultTrigger(event, store, options) {
-  const { disableHysteresis = false, threshold = 100 } = options;
+  const { disableHysteresis = false, threshold = 100, initialState = false } = options;
   const previous = store.current;
   store.current = event ? getScrollY(event.currentTarget) : previous;
 
-  if (!disableHysteresis && previous) {
+  if (store.current === undefined) {
+    return initialState;
+  }
+
+  if (!disableHysteresis && previous !== undefined) {
     if (store.current < previous) {
       return false;
     }

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
@@ -13,7 +13,6 @@ function defaultTrigger(event, store, options) {
     if (store.current < previous) {
       return false;
     }
-    return store.current >= previous && store.current > threshold;
   }
 
   return store.current > threshold;

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
@@ -1,19 +1,19 @@
 import React from 'react';
 
 function getScrollY(ref) {
-  return (ref ? ref.pageYOffset || ref.scrollTop : null) || 0;
+  return ref.pageYOffset || ref.scrollTop;
 }
 
 function defaultTrigger(event, store, options) {
   const { disableHysteresis = false, threshold = 100 } = options;
-  const previous = store.current;
-  store.current = getScrollY(event && event.currentTarget);
+  const previous = store.current || 0;
+  store.current = event && event.currentTarget ? getScrollY(event.currentTarget) : previous;
 
   if (!disableHysteresis) {
     if (store.current < previous) {
       return false;
     }
-    return store.current > previous && store.current > threshold;
+    return store.current >= previous && store.current > threshold;
   }
 
   return store.current > threshold;
@@ -31,6 +31,7 @@ export default function useScrollTrigger(options = {}) {
       setTrigger(getTrigger(event, store, other));
     };
 
+    handleScroll(null); // Re-evaluate trigger when dependencies change
     target.addEventListener('scroll', handleScroll);
     return () => {
       target.removeEventListener('scroll', handleScroll);

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
@@ -1,12 +1,12 @@
 import React from 'react';
 
 function getScrollY(ref) {
-  return ref.pageYOffset || ref.scrollTop;
+  return ref.pageYOffset || ref.scrollTop || null;
 }
 
 function defaultTrigger(event, store, options) {
   const { disableHysteresis = false, threshold = 100 } = options;
-  const previous = store.current || 0;
+  const previous = store.current || null;
   store.current = event && event.currentTarget ? getScrollY(event.currentTarget) : previous;
 
   if (!disableHysteresis) {

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.js
@@ -1,15 +1,15 @@
 import React from 'react';
 
 function getScrollY(ref) {
-  return ref.pageYOffset || ref.scrollTop || null;
+  return ref.pageYOffset || ref.scrollTop;
 }
 
 function defaultTrigger(event, store, options) {
   const { disableHysteresis = false, threshold = 100 } = options;
-  const previous = store.current || null;
-  store.current = event && event.currentTarget ? getScrollY(event.currentTarget) : previous;
+  const previous = store.current;
+  store.current = event ? getScrollY(event.currentTarget) : previous;
 
-  if (!disableHysteresis) {
+  if (!disableHysteresis && previous) {
     if (store.current < previous) {
       return false;
     }

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -34,7 +34,7 @@ describe('useScrollTrigger', () => {
     ref.scrollTop = scrollTop;
     ref.dispatchEvent(new window.Event('scroll', {}));
 
-    const isMacOSXChrome = /\bChrome\b.*\bMac OS X\b/g.test(window.navigator.userAgent);
+    const isMacOSXChrome = /\bMac OS X\b.*\bChrome\b/g.test(window.navigator.userAgent);
     // The Chrome Browser on Mac OS X fails to set pageYOffset, so do not test the result
     return !isMacOSXChrome && ref.scrollTop === scrollTop && ref.pageYOffset === pageYOffset;
   };

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -316,18 +316,8 @@ describe('useScrollTrigger', () => {
         });
       });
 
-    function randomDataSet(dataSetSize, minValue, maxValue) {
-      return new Array(dataSetSize)
-        .fill(0)
-        .map(() => Math.random() * (maxValue - minValue) + minValue);
-    }
-
-    const scrollOffsets = [undefined, null, 0, 100, 101, -1, -100].concat(
-      randomDataSet(1, -100, 1000),
-    );
-
-    const thresholds = [null, -100, -1, 0, 1, 100, 300].concat(randomDataSet(1, -200, 500));
-
+    const scrollOffsets = [undefined, null, 0, 100, 101, -1, -100];
+    const thresholds = [null, -100, -1, 0, 1, 100, 300];
     const initialStates = [true, false];
     const DisableHysteresis = [true, false];
 

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -292,13 +292,21 @@ describe('useScrollTrigger', () => {
       return 'false';
     }
 
-    const testAllCombinations = (props, testValues) =>
+    const testAllCombinations = (props, testValues, testScrollTop) =>
       testValues.forEach(current => {
         testValues.forEach(previous => {
           [
             { offset: undefined, scrollTop: undefined, result: 'false' }, // Baseline
-            { offset: previous, scrollTop: previous, result: 'false' }, // Set previous value
-            { offset: current, scrollTop: current, result: 'false' }, // Test current with previous value
+            {
+              offset: testScrollTop ? undefined : previous,
+              scrollTop: testScrollTop ? previous : undefined,
+              result: 'false',
+            }, // Set previous value
+            {
+              offset: testScrollTop ? undefined : current,
+              scrollTop: testScrollTop ? current : undefined,
+              result: 'false',
+            }, // Test current with previous value
           ].forEach((test, i) => {
             if (dispatchScrollTest(test.offset, test.scrollTop))
               if (i === 2) {
@@ -332,9 +340,17 @@ describe('useScrollTrigger', () => {
             threshold,
             initialState,
           };
-          it(`should validate combinations with props: ${JSON.stringify(props)}`, () => {
+          it(`should validate combinations with props using pageYOffset: ${JSON.stringify(
+            props,
+          )}`, () => {
             mountWrapper(props);
-            testAllCombinations(props, scrollOffsets);
+            testAllCombinations(props, scrollOffsets, false);
+          });
+          it(`should validate combinations with props using scrollTop: ${JSON.stringify(
+            props,
+          )}`, () => {
+            mountWrapper(props);
+            testAllCombinations(props, scrollOffsets, true);
           });
         });
       });

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -99,97 +99,24 @@ describe('useScrollTrigger', () => {
     });
   });
 
-  describe('scrollPositions', () => {
-    it('should trigger correctly with default threshold', () => {
-      mountWrapper();
-      [
-        { offset: 100, result: 'false' },
-        { offset: 201, result: 'true' },
-        { offset: 100, result: 'false' },
-        { offset: 99, result: 'false' },
-        { offset: 100, result: 'false' },
-        { offset: 101, result: 'true' },
-        { offset: 9999, result: 'true' },
-        { offset: 101, result: 'false' },
-        { offset: 99, result: 'false' },
-        { offset: 100, result: 'false' },
-        { offset: 101, result: 'true' },
-        { offset: 100, result: 'false' },
-        { offset: 102, result: 'true' },
-        { offset: -3, result: 'false' },
-        { offset: 3, result: 'false' },
-        { offset: 103, result: 'true' },
-        { offset: 102, result: 'false' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
-      });
-    });
-
-    it('should trigger correctly with custom threshold', () => {
-      mountWrapper({ threshold: 30 });
-      [
-        { offset: 100, result: 'true' },
-        { offset: 101, result: 'true' },
-        { offset: 100, result: 'false' },
-        { offset: 99, result: 'false' },
-        { offset: 100, result: 'true' },
-        { offset: 9999, result: 'true' },
-        { offset: 101, result: 'false' },
-        { offset: 99, result: 'false' },
-        { offset: 75, result: 'false' },
-        { offset: 45, result: 'false' },
-        { offset: 31, result: 'false' },
-        { offset: 30, result: 'false' },
-        { offset: 29, result: 'false' },
-        { offset: 30, result: 'false' },
-        { offset: 31, result: 'true' },
-        { offset: -5, result: 'false' },
-        { offset: 0, result: 'false' },
-        { offset: 1, result: 'false' },
-        { offset: 29, result: 'false' },
-        { offset: 28, result: 'false' },
-        { offset: 30, result: 'false' },
-        { offset: 28, result: 'false' },
-        { offset: 31, result: 'true' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
-      });
-    });
-
-    it('should not trigger with negative direction default threshold', () => {
-      mountWrapper();
-      if (dispatchScroll(300)) assert.strictEqual(text(), 'true');
-      if (dispatchScroll(299)) assert.strictEqual(text(), 'false');
-    });
-
-    it('should trigger with positive direction exceeding default threshold', () => {
-      mountWrapper();
-      if (dispatchScroll(300)) assert.strictEqual(text(), 'true');
-      if (dispatchScroll(299)) assert.strictEqual(text(), 'false');
-      if (dispatchScroll(300)) assert.strictEqual(text(), 'true');
-    });
-  });
-
   describe('scrollPositionsWithRef', () => {
-    it('scroll container should render', () => {
+    it('scroll container should render with ref', () => {
       const wrapper = mountWrapperWithRef();
       const container = wrapper.find(Container);
       assert.strictEqual(container.exists(), true);
     });
-    it('should not trigger from window scroll events', () => {
+    it('should not trigger from window scroll events with ref', () => {
       mountWrapperWithRef();
       [101, 200, 300, -10, 100, 101, 99, 200, 199, 0, 1, -1, 150].forEach((offset, i) => {
         if (dispatchScroll(offset))
           assert.strictEqual(text(), 'false', `Index: ${i} Offset: ${offset}`);
       });
     });
-    it('should trigger above default threshold', () => {
+    it('should trigger above default threshold with ref', () => {
       mountWrapperWithRef();
       if (dispatchScroll(300, getContainer())) assert.strictEqual(text(), 'true');
     });
-    it('should have correct hysteresis triggering threshold', () => {
+    it('should have correct hysteresis triggering threshold with ref', () => {
       mountWrapperWithRef();
       [
         { offset: 100, result: 'false' },
@@ -215,7 +142,7 @@ describe('useScrollTrigger', () => {
       });
     });
 
-    it('should have correct hysteresis triggering with default threshold', () => {
+    it('should have correct hysteresis triggering with default threshold with ref', () => {
       mountWrapperWithRef({ disableHysteresis: true });
       [
         { offset: 100, result: 'false' },
@@ -240,7 +167,7 @@ describe('useScrollTrigger', () => {
       });
     });
 
-    it('should have correct hysteresis triggering with custom threshold', () => {
+    it('should have correct hysteresis triggering with custom threshold with ref', () => {
       mountWrapperWithRef({ disableHysteresis: true, threshold: 50 });
       [
         { offset: 100, result: 'true' },
@@ -263,7 +190,7 @@ describe('useScrollTrigger', () => {
       });
     });
 
-    it('should not trigger at exact threshold value', () => {
+    it('should not trigger at exact threshold value with ref', () => {
       mountWrapperWithRef({ threshold: 100 });
       [
         { offset: 100, result: 'false' },
@@ -279,7 +206,7 @@ describe('useScrollTrigger', () => {
       });
     });
 
-    it('should not trigger at exact threshold value with hysteresis disabled', () => {
+    it('should not trigger at exact threshold value with hysteresis disabled with ref', () => {
       mountWrapperWithRef({ disableHysteresis: true, threshold: 100 });
       [
         { offset: 100, result: 'false' },
@@ -294,7 +221,7 @@ describe('useScrollTrigger', () => {
       });
     });
 
-    it('should correctly evaluate sequential scroll events with identical scrollY offsets', () => {
+    it('should correctly evaluate sequential scroll events with identical scrollY offsets with ref', () => {
       mountWrapperWithRef({ threshold: 199 });
       [
         { offset: 200, result: 'true' },
@@ -311,7 +238,7 @@ describe('useScrollTrigger', () => {
       });
     });
 
-    it('should correctly evaluate sequential scroll events with identical scrollY offsets and hysteresis disabled', () => {
+    it('should correctly evaluate sequential scroll events with identical scrollY offsets and hysteresis disabled with ref', () => {
       mountWrapperWithRef({ disableHysteresis: true, threshold: 199 });
       [
         { offset: 200, result: 'true' },
@@ -327,71 +254,96 @@ describe('useScrollTrigger', () => {
           assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
       });
     });
+  });
 
-    describe('Current and Previous Scroll Positions', () => {
-      function getExpectedResult(previous, current, disableHysteresis) {
-        if (
-          current === undefined ||
-          current === null ||
-          current === 0 ||
-          current === 99 ||
-          current === 100
-        ) {
-          return 'false'; // Should always returns false if the threshold has not been crossed
-        }
-
-        if (current === 101) {
-          if (previous === null || previous === undefined) {
-            // Scroll direction is unknown, assumed postiive
-            return 'true';
-          }
-          if (previous === current) {
-            // No change in scroll position
-            return 'true';
-          }
-          if (previous > current) {
-            // Scroll direction is negative
-            if (disableHysteresis) {
-              return 'false';
-            }
-            return 'true';
-          }
-          if (previous < current) {
-            // Scroll direction is positive
-            return 'true';
-          }
-        }
-        return 'unknown';
+  describe('Current and Previous Scroll Positions', () => {
+    function getExpectedResult(previous, current, disableHysteresis, threshold, initialState) {
+      if (current === undefined) {
+        return initialState.toString();
       }
-      const testAllCombinations = disableHysteresis =>
-        [undefined, null, 0, 99, 100, 101].forEach(current => {
-          [undefined, null, 0, 99, 100, 101].forEach(previous => {
-            [
-              { offset: undefined, scrollTop: undefined, result: 'false' }, // Baseline
-              { offset: previous, scrollTop: previous, result: 'false' }, // Set previous value
-              { offset: current, scrollTop: current, result: 'false' }, // Test current with previous value
-            ].forEach((test, i) => {
-              if (dispatchScrollTest(test.offset, test.scrollTop))
-                if (i === 2) {
-                  // Only test the resulting value
-                  assert.strictEqual(
-                    text(),
-                    getExpectedResult(previous, current, disableHysteresis),
-                    `Current: ${current} Previous: ${previous} Index: ${i} ${JSON.stringify(test)}`,
-                  );
-                }
-            });
+      if (!disableHysteresis) {
+        // Using hysteresis logic
+        if (previous !== undefined) {
+          // A previous scroll exists
+          if (previous <= current) {
+            // Positive or neutral scolling direction
+            if (current > threshold) {
+              // Positive or neutral scrolling direction and threshold exceeded
+              return 'true';
+            }
+            return 'false'; // Positive scrolling direction and threshold is not exceeded
+          }
+          return 'false'; // Negative scrolling direction
+        }
+        // No previous scroll, unknown scrolling direction, use non hysteresis logic
+        if (current > threshold) {
+          return 'true'; // No previous scroll, unknown scrolling direction, threshold exceeded
+        }
+        return 'false'; // No previous scroll, unknown scrolling direction, threshold is not exceeded
+      }
+
+      // Default non hysteresis logic
+      if (current > threshold) {
+        return 'true';
+      }
+      return 'false';
+    }
+
+    const testAllCombinations = (props, testValues) =>
+      testValues.forEach(current => {
+        testValues.forEach(previous => {
+          [
+            { offset: undefined, scrollTop: undefined, result: 'false' }, // Baseline
+            { offset: previous, scrollTop: previous, result: 'false' }, // Set previous value
+            { offset: current, scrollTop: current, result: 'false' }, // Test current with previous value
+          ].forEach((test, i) => {
+            if (dispatchScrollTest(test.offset, test.scrollTop))
+              if (i === 2) {
+                // Validate the test
+                assert.strictEqual(
+                  text(),
+                  getExpectedResult(
+                    previous,
+                    current,
+                    props.disableHysteresis,
+                    props.threshold,
+                    props.initialState,
+                  ),
+                  `Current: ${current} Previous: ${previous} ${JSON.stringify(test)}`,
+                );
+              }
           });
         });
-      it('should evaluate all combinations for previous and current scroll values with hysteresis', () => {
-        const disableHysteresis = false;
-        mountWrapper({ disableHysteresis });
-        testAllCombinations(disableHysteresis);
       });
-      it('should evaluate all combinations for previous and current scroll values without hysteresis', () => {
-        const disableHysteresis = true;
-        mountWrapper({ disableHysteresis });
-        testAllCombinations(disableHysteresis);
+
+    function randomDataSet(dataSetSize, minValue, maxValue) {
+      return new Array(dataSetSize)
+        .fill(0)
+        .map(() => Math.random() * (maxValue - minValue) + minValue);
+    }
+
+    const scrollOffsets = [undefined, null, 0, 100, 101, -1, -100].concat(
+      randomDataSet(1, -100, 1000),
+    );
+
+    const thresholds = [null, -100, -1, 0, 1, 100, 300].concat(randomDataSet(1, -200, 500));
+
+    const initialStates = [true, false];
+    const DisableHysteresis = [true, false];
+
+    thresholds.forEach(threshold => {
+      initialStates.forEach(initialState => {
+        DisableHysteresis.forEach(disableHysteresis => {
+          const props = {
+            disableHysteresis,
+            threshold,
+            initialState,
+          };
+          it(`should validate combinations with props: ${JSON.stringify(props)}`, () => {
+            mountWrapper(props);
+            testAllCombinations(props, scrollOffsets);
+          });
+        });
       });
     });
   });

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { createMount } from '@material-ui/core/test-utils';
-import Container from '@material-ui/core/Container';
-import Box from '@material-ui/core/Box';
+import PropTypes from 'prop-types';
 import { assert } from 'chai';
 import { spy } from 'sinon';
+import { createMount } from '@material-ui/core/test-utils';
+import Container from '../Container';
+import Box from '../Box';
 import useScrollTrigger from './useScrollTrigger';
-import PropTypes from 'prop-types';
 
 describe('useScrollTrigger', () => {
   let mount;
@@ -23,47 +23,32 @@ describe('useScrollTrigger', () => {
     mount.cleanUp();
   });
 
-  const dispatchScroll = (offset, ref = window) => {
-    ref.pageYOffset = offset;
-    ref.dispatchEvent(new window.Event('scroll', {}));
-    return ref.pageYOffset === offset; // The Chrome Browser on Mac OS X fails to set pageYOffset, so do not test the result if pageYoffset was not set
-  };
+  const triggerRef = React.createRef();
+  const containerRef = React.createRef(); // Get the scroll container's parent
+  const getContainer = () => containerRef.current.children[0]; // Get the scroll container
+  const text = () => triggerRef.current.textContent; // Retrieve the trigger value
 
-  const dispatchScrollTest = (pageYOffset, scrollTop, ref = window) => {
-    ref.pageYOffset = pageYOffset;
-    ref.scrollTop = scrollTop;
-    ref.dispatchEvent(new window.Event('scroll', {}));
-
-    const isMacOSXChrome = /\bMac OS X\b.*\bChrome\b/g.test(window.navigator.userAgent);
-    // The Chrome Browser on Mac OS X fails to set pageYOffset, so do not test the result
-    return !isMacOSXChrome && ref.scrollTop === scrollTop && ref.pageYOffset === pageYOffset;
-  };
-
-  const ref = React.createRef();
-  const containerParent = React.createRef(); // Get the scroll container's parent
-  const getContainer = () => containerParent.current.children[0]; // Get the scroll container
-  const mountWrapper = props => mount(<Test {...props} />); // Mount using window as the scroll target
-  const mountWrapperWithRef = props => mount(<Test useContainerRef {...props} />); // Mount using a container ref instead of the default window
-  const text = () => ref.current.textContent; // Retrieve the trigger value
-
-  const Test = props => {
+  function Test(props) {
     const { useContainerRef, ...other } = props;
     const [container, setContainer] = React.useState();
     const trigger = useScrollTrigger({ ...other, target: container });
+
     React.useEffect(() => {
       values(trigger);
     });
+
     return (
       <React.Fragment>
-        <span ref={ref}>{`${trigger}`}</span>
-        <div ref={containerParent}>
-          <Container ref={useContainerRef && setContainer}>
+        <span ref={triggerRef}>{`${trigger}`}</span>
+        <div ref={containerRef}>
+          <Container ref={useContainerRef ? setContainer : null}>
             <Box my={2}>some text here</Box>
           </Container>
         </div>
       </React.Fragment>
     );
-  };
+  }
+
   Test.propTypes = {
     useContainerRef: PropTypes.bool,
   };
@@ -72,8 +57,10 @@ describe('useScrollTrigger', () => {
     it('should be false by default', () => {
       const TestDefault = () => {
         const trigger = useScrollTrigger();
-        React.useEffect(() => values(trigger));
-        return <span ref={ref}>{`${trigger}`}</span>;
+        React.useEffect(() => {
+          values(trigger);
+        });
+        return <span ref={triggerRef}>{`${trigger}`}</span>;
       };
 
       mount(<TestDefault />);
@@ -92,35 +79,50 @@ describe('useScrollTrigger', () => {
         });
         return (
           <React.Fragment>
-            <span ref={ref}>{`${trigger}`}</span>
+            <span ref={triggerRef}>{`${trigger}`}</span>
             <span ref={setContainer} />
           </React.Fragment>
         );
       };
       mount(<TestDefaultWithRef />);
       assert.strictEqual(text(), 'false');
+      assert.strictEqual(values.callCount, 2);
     });
   });
 
-  describe('scrollPositionsWithRef', () => {
+  describe('scroll', () => {
+    // Only run the test on node.
+    if (!/jsdom/.test(window.navigator.userAgent)) {
+      return;
+    }
+
+    function dispatchScroll(offset, element = window) {
+      element.pageYOffset = offset;
+      element.dispatchEvent(new window.Event('scroll', {}));
+    }
+
     it('scroll container should render with ref', () => {
-      const wrapper = mountWrapperWithRef();
+      const wrapper = mount(<Test useContainerRef />);
       const container = wrapper.find(Container);
       assert.strictEqual(container.exists(), true);
     });
+
     it('should not trigger from window scroll events with ref', () => {
-      mountWrapperWithRef();
+      mount(<Test useContainerRef />);
       [101, 200, 300, -10, 100, 101, 99, 200, 199, 0, 1, -1, 150].forEach((offset, i) => {
-        if (dispatchScroll(offset))
-          assert.strictEqual(text(), 'false', `Index: ${i} Offset: ${offset}`);
+        dispatchScroll(offset);
+        assert.strictEqual(text(), 'false', `Index: ${i} Offset: ${offset}`);
       });
     });
+
     it('should trigger above default threshold with ref', () => {
-      mountWrapperWithRef();
-      if (dispatchScroll(300, getContainer())) assert.strictEqual(text(), 'true');
+      mount(<Test useContainerRef />);
+      dispatchScroll(300, getContainer());
+      assert.strictEqual(text(), 'true');
     });
+
     it('should have correct hysteresis triggering threshold with ref', () => {
-      mountWrapperWithRef();
+      mount(<Test useContainerRef />);
       [
         { offset: 100, result: 'false' },
         { offset: 101, result: 'true' },
@@ -128,7 +130,7 @@ describe('useScrollTrigger', () => {
         { offset: 99, result: 'false' },
         { offset: 100, result: 'false' },
         { offset: 101, result: 'true' },
-        { offset: 9999, result: 'true' },
+        { offset: 102, result: 'true' },
         { offset: 101, result: 'false' },
         { offset: 99, result: 'false' },
         { offset: 100, result: 'false' },
@@ -139,14 +141,14 @@ describe('useScrollTrigger', () => {
         { offset: 3, result: 'false' },
         { offset: 103, result: 'true' },
         { offset: 102, result: 'false' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset, getContainer()))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
+      ].forEach((test, index) => {
+        dispatchScroll(test.offset, getContainer());
+        assert.strictEqual(text(), test.result, `Index: ${index} ${JSON.stringify(test)}`);
       });
     });
 
     it('should have correct hysteresis triggering with default threshold with ref', () => {
-      mountWrapperWithRef({ disableHysteresis: true });
+      mount(<Test useContainerRef disableHysteresis />);
       [
         { offset: 100, result: 'false' },
         { offset: 101, result: 'true' },
@@ -164,14 +166,14 @@ describe('useScrollTrigger', () => {
         { offset: -3, result: 'false' },
         { offset: 3, result: 'false' },
         { offset: 103, result: 'true' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset, getContainer()))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
+      ].forEach((test, index) => {
+        dispatchScroll(test.offset, getContainer());
+        assert.strictEqual(text(), test.result, `Index: ${index} ${JSON.stringify(test)}`);
       });
     });
 
     it('should have correct hysteresis triggering with custom threshold with ref', () => {
-      mountWrapperWithRef({ disableHysteresis: true, threshold: 50 });
+      mount(<Test useContainerRef disableHysteresis threshold={50} />);
       [
         { offset: 100, result: 'true' },
         { offset: 101, result: 'true' },
@@ -187,14 +189,14 @@ describe('useScrollTrigger', () => {
         { offset: -50, result: 'false' },
         { offset: 50, result: 'false' },
         { offset: 51, result: 'true' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset, getContainer()))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
+      ].forEach((test, index) => {
+        dispatchScroll(test.offset, getContainer());
+        assert.strictEqual(text(), test.result, `Index: ${index} ${JSON.stringify(test)}`);
       });
     });
 
     it('should not trigger at exact threshold value with ref', () => {
-      mountWrapperWithRef({ threshold: 100 });
+      mount(<Test useContainerRef threshold={100} />);
       [
         { offset: 100, result: 'false' },
         { offset: 99, result: 'false' },
@@ -203,14 +205,14 @@ describe('useScrollTrigger', () => {
         { offset: 100, result: 'false' },
         { offset: 99, result: 'false' },
         { offset: 100, result: 'false' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset, getContainer()))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
+      ].forEach((test, index) => {
+        dispatchScroll(test.offset, getContainer());
+        assert.strictEqual(text(), test.result, `Index: ${index} ${JSON.stringify(test)}`);
       });
     });
 
     it('should not trigger at exact threshold value with hysteresis disabled with ref', () => {
-      mountWrapperWithRef({ disableHysteresis: true, threshold: 100 });
+      mount(<Test useContainerRef disableHysteresis threshold={100} />);
       [
         { offset: 100, result: 'false' },
         { offset: 99, result: 'false' },
@@ -218,14 +220,14 @@ describe('useScrollTrigger', () => {
         { offset: 101, result: 'true' },
         { offset: 100, result: 'false' },
         { offset: 99, result: 'false' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset, getContainer()))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
+      ].forEach((test, index) => {
+        dispatchScroll(test.offset, getContainer());
+        assert.strictEqual(text(), test.result, `Index: ${index} ${JSON.stringify(test)}`);
       });
     });
 
     it('should correctly evaluate sequential scroll events with identical scrollY offsets with ref', () => {
-      mountWrapperWithRef({ threshold: 199 });
+      mount(<Test useContainerRef threshold={199} />);
       [
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
@@ -235,14 +237,14 @@ describe('useScrollTrigger', () => {
         { offset: 199, result: 'false' },
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset, getContainer()))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
+      ].forEach((test, index) => {
+        dispatchScroll(test.offset, getContainer());
+        assert.strictEqual(text(), test.result, `Index: ${index} ${JSON.stringify(test)}`);
       });
     });
 
     it('should correctly evaluate sequential scroll events with identical scrollY offsets and hysteresis disabled with ref', () => {
-      mountWrapperWithRef({ disableHysteresis: true, threshold: 199 });
+      mount(<Test useContainerRef disableHysteresis threshold={199} />);
       [
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
@@ -252,107 +254,9 @@ describe('useScrollTrigger', () => {
         { offset: 199, result: 'false' },
         { offset: 200, result: 'true' },
         { offset: 200, result: 'true' },
-      ].forEach((test, i) => {
-        if (dispatchScroll(test.offset, getContainer()))
-          assert.strictEqual(text(), test.result, `Index: ${i} ${JSON.stringify(test)}`);
-      });
-    });
-  });
-
-  describe('Current and Previous Scroll Positions', () => {
-    function getExpectedResult(previous, current, disableHysteresis, threshold, initialState) {
-      if (current === undefined) {
-        return initialState.toString();
-      }
-      if (!disableHysteresis) {
-        // Using hysteresis logic
-        if (previous !== undefined) {
-          // A previous scroll exists
-          if (previous <= current) {
-            // Positive or neutral scolling direction
-            if (current > threshold) {
-              // Positive or neutral scrolling direction and threshold exceeded
-              return 'true';
-            }
-            return 'false'; // Positive scrolling direction and threshold is not exceeded
-          }
-          return 'false'; // Negative scrolling direction
-        }
-        // No previous scroll, unknown scrolling direction, use non hysteresis logic
-        if (current > threshold) {
-          return 'true'; // No previous scroll, unknown scrolling direction, threshold exceeded
-        }
-        return 'false'; // No previous scroll, unknown scrolling direction, threshold is not exceeded
-      }
-
-      // Default non hysteresis logic
-      if (current > threshold) {
-        return 'true';
-      }
-      return 'false';
-    }
-
-    const testAllCombinations = (props, testValues, testScrollTop) =>
-      testValues.forEach(current => {
-        testValues.forEach(previous => {
-          [
-            { offset: undefined, scrollTop: undefined, result: 'false' }, // Baseline
-            {
-              offset: testScrollTop ? undefined : previous,
-              scrollTop: testScrollTop ? previous : undefined,
-              result: 'false',
-            }, // Set previous value
-            {
-              offset: testScrollTop ? undefined : current,
-              scrollTop: testScrollTop ? current : undefined,
-              result: 'false',
-            }, // Test current with previous value
-          ].forEach((test, i) => {
-            if (dispatchScrollTest(test.offset, test.scrollTop))
-              if (i === 2) {
-                // Validate the test
-                assert.strictEqual(
-                  text(),
-                  getExpectedResult(
-                    previous,
-                    current,
-                    props.disableHysteresis,
-                    props.threshold,
-                    props.initialState,
-                  ),
-                  `Current: ${current} Previous: ${previous} ${JSON.stringify(test)}`,
-                );
-              }
-          });
-        });
-      });
-
-    const scrollOffsets = [undefined, null, 0, 100, 101, -1, -100];
-    const thresholds = [null, -100, -1, 0, 1, 100, 300];
-    const initialStates = [true, false];
-    const DisableHysteresis = [true, false];
-
-    thresholds.forEach(threshold => {
-      initialStates.forEach(initialState => {
-        DisableHysteresis.forEach(disableHysteresis => {
-          const props = {
-            disableHysteresis,
-            threshold,
-            initialState,
-          };
-          it(`should validate combinations with props using pageYOffset: ${JSON.stringify(
-            props,
-          )}`, () => {
-            mountWrapper(props);
-            testAllCombinations(props, scrollOffsets, false);
-          });
-          it(`should validate combinations with props using scrollTop: ${JSON.stringify(
-            props,
-          )}`, () => {
-            mountWrapper(props);
-            testAllCombinations(props, scrollOffsets, true);
-          });
-        });
+      ].forEach((test, index) => {
+        dispatchScroll(test.offset, getContainer());
+        assert.strictEqual(text(), test.result, `Index: ${index} ${JSON.stringify(test)}`);
       });
     });
   });

--- a/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
+++ b/packages/material-ui/src/useScrollTrigger/useScrollTrigger.test.js
@@ -33,7 +33,10 @@ describe('useScrollTrigger', () => {
     ref.pageYOffset = pageYOffset;
     ref.scrollTop = scrollTop;
     ref.dispatchEvent(new window.Event('scroll', {}));
-    return ref.scrollTop === scrollTop && ref.pageYOffset === pageYOffset; // The Chrome Browser on Mac OS X fails to set pageYOffset, so do not test the result if pageYoffset was not set
+
+    const isMacOSXChrome = /\bChrome\b.*\bMac OS X\b/g.test(window.navigator.userAgent);
+    // The Chrome Browser on Mac OS X fails to set pageYOffset, so do not test the result
+    return !isMacOSXChrome && ref.scrollTop === scrollTop && ref.pageYOffset === pageYOffset;
   };
 
   const ref = React.createRef();


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Let me know if you want me to create separate issues for the below items.  This feature is relatively new so a PR alone may be appropriate.

**Hook Updates**
1. Re-evaluate the trigger when dependencies change (i.e threshold prop changes externally).  We are already using this logic for the initial trigger value.  We should also use it for any updated trigger values when dependencies change.

**Default Trigger Updates**
1. Correctly handle sequential hysteresis triggers where scroll.current == previous.  Previously this would return false when scroll.current  = previous.  Example scenarios: a scroll event is triggered that only changes pageXOffset or a user manually dispatches a scroll event that doesn't change the X or Y offset.
2. As a result of the above items, the trigger needs to use the previous value when the event is null, instead of always defaulting to 0.

**Test Updates**
1. Fix a bug in testing logic, changed pageYoffset => pageYOffset.  This was preventing some tests from evaluating.
2. Fix tests to use disableHysteresis prop instead of the old directional prop.
3. Add new tests for above scenarios.
