### PR TITLE
[SpeedDial] Pass event parameter to onClick callback

### DIFF
--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
@@ -88,10 +88,10 @@ class SpeedDialAction extends React.Component {
         onTouchStart: () => {
           startTime = new Date();
         },
-        onTouchEnd: () => {
+        onTouchEnd: event => {
           // only perform action if the touch is a tap, i.e. not long press
           if (new Date() - startTime < 500) {
-            onClick();
+            onClick(event);
           }
         },
       };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Pass the event parameter to the onClick callback when the touch events are enabled. 

This bug has been fixed on the [next](https://github.com/mui-org/material-ui/blob/201ca7738946c46da0d841084b0bf4c0b611d3bf/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js#L95) branch but it hasn't been on the master branch. 
https://github.com/mui-org/material-ui/blob/201ca7738946c46da0d841084b0bf4c0b611d3bf/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js#L92-L96