### PR TITLE
[Tabs] scrollButtons have an empty button error in compliance tools

### DIFF
--- a/packages/material-ui/src/Tabs/TabScrollButton.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.js
@@ -28,7 +28,7 @@ const TabScrollButton = React.forwardRef(function TabScrollButton(props, ref) {
   }
 
   return (
-    <ButtonBase className={className} onClick={onClick} ref={ref} tabIndex={-1} {...other}>
+    <ButtonBase aria-label={direction} className={className} onClick={onClick} ref={ref} tabIndex={-1} {...other}>
       {direction === 'left' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
     </ButtonBase>
   );

--- a/packages/material-ui/src/Tabs/TabScrollButton.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.js
@@ -28,7 +28,14 @@ const TabScrollButton = React.forwardRef(function TabScrollButton(props, ref) {
   }
 
   return (
-    <ButtonBase aria-label={direction} className={className} onClick={onClick} ref={ref} tabIndex={-1} {...other}>
+    <ButtonBase
+      aria-label={direction}
+      className={className}
+      onClick={onClick}
+      ref={ref}
+      tabIndex={-1}
+      {...other}
+    >
       {direction === 'left' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
     </ButtonBase>
   );

--- a/packages/material-ui/src/Tabs/TabScrollButton.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.js
@@ -1,3 +1,5 @@
+/* eslint-disable jsx-a11y/aria-role */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
@@ -24,15 +26,16 @@ const TabScrollButton = React.forwardRef(function TabScrollButton(props, ref) {
   const className = clsx(classes.root, classNameProp);
 
   if (!visible) {
-    return <span className={className} />;
+    return <div className={className} />;
   }
 
   return (
     <ButtonBase
-      component="span"
+      component="div"
       className={className}
       onClick={onClick}
       ref={ref}
+      role={null}
       tabIndex={null}
       {...other}
     >

--- a/packages/material-ui/src/Tabs/TabScrollButton.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.js
@@ -24,16 +24,16 @@ const TabScrollButton = React.forwardRef(function TabScrollButton(props, ref) {
   const className = clsx(classes.root, classNameProp);
 
   if (!visible) {
-    return <div className={className} />;
+    return <span className={className} />;
   }
 
   return (
     <ButtonBase
-      aria-label={direction}
+      component="span"
       className={className}
       onClick={onClick}
       ref={ref}
-      tabIndex={-1}
+      tabIndex={null}
       {...other}
     >
       {direction === 'left' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}

--- a/packages/material-ui/src/Tabs/TabScrollButton.test.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.test.js
@@ -35,10 +35,10 @@ describe('<TabScrollButton />', () => {
   });
 
   describe('prop: !visible', () => {
-    it('should render as a div with root class', () => {
+    it('should render as a span with root class', () => {
       const wrapper = shallow(<TabScrollButton {...props} visible={false} />);
 
-      assert.strictEqual(wrapper.name(), 'div');
+      assert.strictEqual(wrapper.name(), 'span');
       assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
   });

--- a/packages/material-ui/src/Tabs/TabScrollButton.test.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.test.js
@@ -35,10 +35,10 @@ describe('<TabScrollButton />', () => {
   });
 
   describe('prop: !visible', () => {
-    it('should render as a span with root class', () => {
+    it('should render as a div with root class', () => {
       const wrapper = shallow(<TabScrollButton {...props} visible={false} />);
 
-      assert.strictEqual(wrapper.name(), 'span');
+      assert.strictEqual(wrapper.name(), 'div');
       assert.strictEqual(wrapper.hasClass(classes.root), true);
     });
   });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -21,7 +21,7 @@ AccessibleTabScrollButton.propTypes = {
   direction: PropTypes.string.isRequired,
 };
 
-const findScrollButton = (wrapper, direction) => wrapper.find(`button[aria-label="${direction}"]`);
+const findScrollButton = (wrapper, direction) => wrapper.find(`span[aria-label="${direction}"]`);
 const hasLeftScrollButton = wrapper => findScrollButton(wrapper, 'left').exists();
 const hasRightScrollButton = wrapper => findScrollButton(wrapper, 'right').exists();
 

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -15,13 +15,13 @@ import TabScrollButton from './TabScrollButton';
 import TabIndicator from './TabIndicator';
 
 function AccessibleTabScrollButton(props) {
-  return <TabScrollButton aria-label={props.direction} {...props} />;
+  return <TabScrollButton data-direction={props.direction} {...props} />;
 }
 AccessibleTabScrollButton.propTypes = {
   direction: PropTypes.string.isRequired,
 };
 
-const findScrollButton = (wrapper, direction) => wrapper.find(`span[aria-label="${direction}"]`);
+const findScrollButton = (wrapper, direction) => wrapper.find(`div[data-direction="${direction}"]`);
 const hasLeftScrollButton = wrapper => findScrollButton(wrapper, 'left').exists();
 const hasRightScrollButton = wrapper => findScrollButton(wrapper, 'right').exists();
 


### PR DESCRIPTION
Closes #15371

Adds aria-label to TabScrollButtons, fixing an issue where accessibility tools pickup the buttons for not having discernible text

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
