### PR TITLE
[Tabs] Update rendering of auto-scrollable buttons

### DIFF
--- a/packages/material-ui/src/Tabs/TabScrollButton.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.js
@@ -12,7 +12,7 @@ export const styles = {
   /* Styles applied to the root element. */
   root: {
     color: 'inherit',
-    width: 56,
+    width: 40,
     flexShrink: 0,
   },
 };
@@ -39,7 +39,11 @@ const TabScrollButton = React.forwardRef(function TabScrollButton(props, ref) {
       tabIndex={null}
       {...other}
     >
-      {direction === 'left' ? <KeyboardArrowLeft /> : <KeyboardArrowRight />}
+      {direction === 'left' ? (
+        <KeyboardArrowLeft fontSize="small" />
+      ) : (
+        <KeyboardArrowRight fontSize="small" />
+      )}
     </ButtonBase>
   );
 });

--- a/packages/material-ui/src/Tabs/Tabs.d.ts
+++ b/packages/material-ui/src/Tabs/Tabs.d.ts
@@ -11,7 +11,7 @@ declare const Tabs: OverridableComponent<{
     indicatorColor?: 'secondary' | 'primary' | string;
     onChange?: (event: React.ChangeEvent<{}>, value: any) => void;
     ScrollButtonComponent?: React.ElementType;
-    scrollButtons?: 'auto' | 'on' | 'off';
+    scrollButtons?: 'auto' | 'desktop' | 'on' | 'off';
     TabIndicatorProps?: Partial<TabIndicatorProps>;
     textColor?: 'secondary' | 'primary' | 'inherit' | string;
     value: any;
@@ -30,7 +30,7 @@ export type TabsClassKey =
   | 'scrollable'
   | 'centered'
   | 'scrollButtons'
-  | 'scrollButtonsAuto'
+  | 'scrollButtonsDesktop'
   | 'indicator';
 
 export interface TabsActions {

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -53,6 +53,10 @@ export const styles = theme => ({
       display: 'none',
     },
   },
+  /* Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"` & `showLeftScroll={false}` & `showRightScroll={false}`. */
+  scrollButtonsAutoHidden: {
+    display: 'none',
+  },
   /* Styles applied to the `TabIndicator` component. */
   indicator: {},
 });
@@ -114,6 +118,7 @@ class Tabs extends React.Component {
 
   getConditionalElements = () => {
     const { classes, ScrollButtonComponent, scrollButtons, theme, variant } = this.props;
+    const { showLeftScroll, showRightScroll } = this.state;
     const conditionalElements = {};
     const scrollable = variant === 'scrollable';
     conditionalElements.scrollbarSizeListener = scrollable ? (
@@ -121,14 +126,16 @@ class Tabs extends React.Component {
     ) : null;
 
     const showScrollButtons = scrollable && (scrollButtons === 'auto' || scrollButtons === 'on');
+    const scrollButtonsActive = showLeftScroll || showRightScroll;
 
     conditionalElements.scrollButtonLeft = showScrollButtons ? (
       <ScrollButtonComponent
         direction={theme && theme.direction === 'rtl' ? 'right' : 'left'}
         onClick={this.handleLeftScrollClick}
-        visible={this.state.showLeftScroll}
+        visible={showLeftScroll}
         className={clsx(classes.scrollButtons, {
           [classes.scrollButtonsAuto]: scrollButtons === 'auto',
+          [classes.scrollButtonsAutoHidden]: scrollButtons === 'auto' && !scrollButtonsActive,
         })}
       />
     ) : null;
@@ -137,9 +144,10 @@ class Tabs extends React.Component {
       <ScrollButtonComponent
         direction={theme && theme.direction === 'rtl' ? 'left' : 'right'}
         onClick={this.handleRightScrollClick}
-        visible={this.state.showRightScroll}
+        visible={showRightScroll}
         className={clsx(classes.scrollButtons, {
           [classes.scrollButtonsAuto]: scrollButtons === 'auto',
+          [classes.scrollButtonsAutoHidden]: scrollButtons === 'auto' && !scrollButtonsActive,
         })}
       />
     ) : null;

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -47,15 +47,11 @@ export const styles = theme => ({
   },
   /* Styles applied to the `ScrollButtonComponent` component. */
   scrollButtons: {},
-  /* Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"`. */
-  scrollButtonsAuto: {
+  /* Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"` or scrollButtons="desktop"`. */
+  scrollButtonsDesktop: {
     [theme.breakpoints.down('xs')]: {
       display: 'none',
     },
-  },
-  /* Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"` & `showLeftScroll={false}` & `showRightScroll={false}`. */
-  scrollButtonsAutoHidden: {
-    display: 'none',
   },
   /* Styles applied to the `TabIndicator` component. */
   indicator: {},
@@ -125,29 +121,31 @@ class Tabs extends React.Component {
       <ScrollbarSize onChange={this.handleScrollbarSizeChange} />
     ) : null;
 
-    const showScrollButtons = scrollable && (scrollButtons === 'auto' || scrollButtons === 'on');
     const scrollButtonsActive = showLeftScroll || showRightScroll;
+    const showScrollButtons =
+      scrollable &&
+      ((scrollButtons === 'auto' && scrollButtonsActive) ||
+        scrollButtons === 'desktop' ||
+        scrollButtons === 'on');
 
     conditionalElements.scrollButtonLeft = showScrollButtons ? (
       <ScrollButtonComponent
-        direction={theme && theme.direction === 'rtl' ? 'right' : 'left'}
+        direction={theme.direction === 'rtl' ? 'right' : 'left'}
         onClick={this.handleLeftScrollClick}
         visible={showLeftScroll}
         className={clsx(classes.scrollButtons, {
-          [classes.scrollButtonsAuto]: scrollButtons === 'auto',
-          [classes.scrollButtonsAutoHidden]: scrollButtons === 'auto' && !scrollButtonsActive,
+          [classes.scrollButtonsDesktop]: scrollButtons !== 'on',
         })}
       />
     ) : null;
 
     conditionalElements.scrollButtonRight = showScrollButtons ? (
       <ScrollButtonComponent
-        direction={theme && theme.direction === 'rtl' ? 'left' : 'right'}
+        direction={theme.direction === 'rtl' ? 'left' : 'right'}
         onClick={this.handleRightScrollClick}
         visible={showRightScroll}
         className={clsx(classes.scrollButtons, {
-          [classes.scrollButtonsAuto]: scrollButtons === 'auto',
-          [classes.scrollButtonsAutoHidden]: scrollButtons === 'auto' && !scrollButtonsActive,
+          [classes.scrollButtonsDesktop]: scrollButtons !== 'on',
         })}
       />
     ) : null;
@@ -461,11 +459,13 @@ Tabs.propTypes = {
   ScrollButtonComponent: PropTypes.elementType,
   /**
    * Determine behavior of scroll buttons when tabs are set to scroll
-   * `auto` will only present them on medium and larger viewports
-   * `on` will always present them
-   * `off` will never present them
+   *
+   * - `auto` will only present them when not all the items are visible.
+   * - `desktop` will only present them on medium and larger viewports.
+   * - `on` will always present them.
+   * - `off` will never present them.
    */
-  scrollButtons: PropTypes.oneOf(['auto', 'on', 'off']),
+  scrollButtons: PropTypes.oneOf(['auto', 'desktop', 'on', 'off']),
   /**
    * Properties applied to the `TabIndicator` element.
    */
@@ -485,6 +485,7 @@ Tabs.propTypes = {
   value: PropTypes.any,
   /**
    *  Determines additional display behavior of the tabs:
+   *
    *  - `scrollable` will invoke scrolling properties and allow for horizontally
    *  scrolling (or swiping) of the tab bar.
    *  -`fullWidth` will make the tabs grow to use all the available space,

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -398,14 +398,16 @@ describe('<Tabs />', () => {
 
     it('should render scroll buttons automatically', () => {
       const wrapper = mount(
-        <Tabs width="md" onChange={noop} value={0} variant="scrollable" scrollButtons="auto">
+        <Tabs width="md" onChange={noop} value={0} variant="scrollable" scrollButtons="desktop">
           <Tab />
           <Tab />
         </Tabs>,
       );
       assert.strictEqual(wrapper.find(TabScrollButton).length, 2);
       assert.strictEqual(
-        wrapper.find(TabScrollButton).everyWhere(node => node.hasClass(classes.scrollButtonsAuto)),
+        wrapper
+          .find(TabScrollButton)
+          .everyWhere(node => node.hasClass(classes.scrollButtonsDesktop)),
         true,
       );
     });

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -52,6 +52,7 @@ This property accepts the following keys:
 | <span class="prop-name">scrollable</span> | Styles applied to the tablist element if `variant="scrollable"`.
 | <span class="prop-name">scrollButtons</span> | Styles applied to the `ScrollButtonComponent` component.
 | <span class="prop-name">scrollButtonsAuto</span> | Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"`.
+| <span class="prop-name">scrollButtonsAutoHidden</span> | Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"` & `showLeftScroll={false}` & `showRightScroll={false}`.
 | <span class="prop-name">indicator</span> | Styles applied to the `TabIndicator` component.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -26,11 +26,11 @@ import Tabs from '@material-ui/core/Tabs';
 | <span class="prop-name">indicatorColor</span> | <span class="prop-type">enum:&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'primary'<br></span> | <span class="prop-default">'secondary'</span> | Determines the color of the indicator. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: any) => void`<br>*event:* The event source of the callback<br>*value:* We default to the index of the child (number) |
 | <span class="prop-name">ScrollButtonComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">TabScrollButton</span> | The component used to render the scroll buttons. |
-| <span class="prop-name">scrollButtons</span> | <span class="prop-type">enum:&nbsp;'auto'&nbsp;&#124;<br>&nbsp;'on'&nbsp;&#124;<br>&nbsp;'off'<br></span> | <span class="prop-default">'auto'</span> | Determine behavior of scroll buttons when tabs are set to scroll `auto` will only present them on medium and larger viewports `on` will always present them `off` will never present them |
+| <span class="prop-name">scrollButtons</span> | <span class="prop-type">enum:&nbsp;'auto'&nbsp;&#124;<br>&nbsp;'desktop'&nbsp;&#124;<br>&nbsp;'on'&nbsp;&#124;<br>&nbsp;'off'<br></span> | <span class="prop-default">'auto'</span> | Determine behavior of scroll buttons when tabs are set to scroll<br>- `auto` will only present them when not all the items are visible. - `desktop` will only present them on medium and larger viewports. - `on` will always present them. - `off` will never present them. |
 | <span class="prop-name">TabIndicatorProps</span> | <span class="prop-type">object</span> |  | Properties applied to the `TabIndicator` element. |
 | <span class="prop-name">textColor</span> | <span class="prop-type">enum:&nbsp;'secondary'&nbsp;&#124;<br>&nbsp;'primary'&nbsp;&#124;<br>&nbsp;'inherit'<br></span> | <span class="prop-default">'inherit'</span> | Determines the color of the `Tab`. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the currently selected `Tab`. If you don't want any selected `Tab`, you can set this property to `false`. |
-| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'scrollable'&nbsp;&#124;<br>&nbsp;'fullWidth'<br></span> | <span class="prop-default">'standard'</span> | Determines additional display behavior of the tabs:  - `scrollable` will invoke scrolling properties and allow for horizontally  scrolling (or swiping) of the tab bar.  -`fullWidth` will make the tabs grow to use all the available space,  which should be used for small views, like on mobile.  - `standard` will render the default state. |
+| <span class="prop-name">variant</span> | <span class="prop-type">enum:&nbsp;'standard'&nbsp;&#124;<br>&nbsp;'scrollable'&nbsp;&#124;<br>&nbsp;'fullWidth'<br></span> | <span class="prop-default">'standard'</span> | Determines additional display behavior of the tabs:<br> - `scrollable` will invoke scrolling properties and allow for horizontally  scrolling (or swiping) of the tab bar.  -`fullWidth` will make the tabs grow to use all the available space,  which should be used for small views, like on mobile.  - `standard` will render the default state. |
 
 The `ref` is forwarded to the root element.
 
@@ -51,8 +51,7 @@ This property accepts the following keys:
 | <span class="prop-name">fixed</span> | Styles applied to the tablist element if `!variant="scrollable"`.
 | <span class="prop-name">scrollable</span> | Styles applied to the tablist element if `variant="scrollable"`.
 | <span class="prop-name">scrollButtons</span> | Styles applied to the `ScrollButtonComponent` component.
-| <span class="prop-name">scrollButtonsAuto</span> | Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"`.
-| <span class="prop-name">scrollButtonsAutoHidden</span> | Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"` & `showLeftScroll={false}` & `showRightScroll={false}`.
+| <span class="prop-name">scrollButtonsDesktop</span> | Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"` or scrollButtons="desktop"`.
 | <span class="prop-name">indicator</span> | Styles applied to the `TabIndicator` component.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section


### PR DESCRIPTION
### Summary
When using tabs where scrollButtons="auto", if no buttons are active do not render the buttons at all. This prevents an unnecessary 56px space when there are not enough tabs to activate scroll.

#### Before

![Screenshot 2019-05-13 at 14 44 30](https://user-images.githubusercontent.com/22003061/57622452-e5567d80-758d-11e9-9d9c-78c39b3534c8.png)

#### After

![Screenshot 2019-05-13 at 14 45 11](https://user-images.githubusercontent.com/22003061/57622467-ec7d8b80-758d-11e9-90d9-86c3ce5e62b3.png)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Closes #12358