### PR TITLE
[icons] Forward ref

### DIFF
--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -1,18 +1,20 @@
 import React from 'react';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
-function createSvgIcon(path, displayName) {
-  let Icon = props => (
-    <SvgIcon {...props}>
-      {path}
-    </SvgIcon>
+export default function createSvgIcon(path, displayName) {
+  const Component = React.memo(
+    React.forwardRef((props, ref) => (
+      <SvgIcon {...props} ref={ref}>
+        {path}
+      </SvgIcon>
+    )),
   );
 
-  Icon.displayName = `${displayName}Icon`;
-  Icon = React.memo(Icon);
-  Icon.muiName = 'SvgIcon';
+  if (process.env.NODE_ENV !== 'production') {
+    Component.displayName = `memo(${displayName})`;
+  }
 
-  return Icon;
-};
+  Component.muiName = SvgIcon.muiName;
 
-export default createSvgIcon;
+  return Component;
+}

--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -11,7 +11,7 @@ export default function createSvgIcon(path, displayName) {
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    Component.displayName = `memo(${displayName})`;
+    Component.displayName = displayName;
   }
 
   Component.muiName = SvgIcon.muiName;

--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -4,7 +4,7 @@ import SvgIcon from '@material-ui/core/SvgIcon';
 export default function createSvgIcon(path, displayName) {
   const Component = React.memo(
     React.forwardRef((props, ref) => (
-      <SvgIcon {...props} ref={ref}>
+      <SvgIcon {...props} data-mui-test={`${displayName}Icon`} ref={ref}>
         {path}
       </SvgIcon>
     )),

--- a/packages/material-ui-icons/src/utils/createSvgIcon.js
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.js
@@ -11,7 +11,7 @@ export default function createSvgIcon(path, displayName) {
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    Component.displayName = displayName;
+    Component.displayName = `${displayName}Icon`;
   }
 
   Component.muiName = SvgIcon.muiName;

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { assert } from 'chai';
-import IndeterminateCheckBoxIcon from '../internal/svg-icons/IndeterminateCheckBox';
 import { describeConformance, getClasses, createMount } from '@material-ui/core/test-utils';
 import Checkbox from './Checkbox';
 import IconButton from '../IconButton';
@@ -36,7 +35,7 @@ describe('<Checkbox />', () => {
   describe('prop: indeterminate', () => {
     it('should render an indeterminate icon', () => {
       const wrapper = mount(<Checkbox indeterminate />);
-      assert.strictEqual(wrapper.find(IndeterminateCheckBoxIcon).length, 1);
+      assert.strictEqual(wrapper.find('svg[data-mui-test="IndeterminateCheckBoxIcon"]').length, 1);
     });
   });
 });

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -2,8 +2,12 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';
 import CheckBox from '../internal/svg-icons/CheckBox';
-import CancelIcon from '../internal/svg-icons/Cancel';
-import { createMount, describeConformance, getClasses } from '@material-ui/core/test-utils';
+import {
+  createMount,
+  describeConformance,
+  findOutermostIntrinsic,
+  getClasses,
+} from '@material-ui/core/test-utils';
 import Avatar from '../Avatar';
 import Chip from './Chip';
 
@@ -182,7 +186,7 @@ describe('<Chip />', () => {
       assert.strictEqual(chip.type(), 'div');
       assert.strictEqual(chip.childAt(0).type(), Avatar);
       assert.strictEqual(chip.childAt(1).name(), 'span');
-      assert.strictEqual(chip.childAt(2).type(), CancelIcon);
+      assert.strictEqual(findOutermostIntrinsic(chip.childAt(2)).type(), 'svg');
     });
 
     it('should merge user classes & spread custom props to the root node', () => {
@@ -208,7 +212,7 @@ describe('<Chip />', () => {
 
       // simulate seems to not work on memo components
       wrapper
-        .find(CancelIcon)
+        .find('svg[data-mui-test="CancelIcon"]')
         .props()
         .onClick({ stopPropagation: () => {} });
       assert.strictEqual(onDeleteSpy.callCount, 1);
@@ -220,7 +224,7 @@ describe('<Chip />', () => {
       wrapper.setProps({ onDelete: onDeleteSpy });
 
       wrapper
-        .find(CancelIcon)
+        .find('svg[data-mui-test="CancelIcon"]')
         .props()
         .onClick({ stopPropagation: stopPropagationSpy });
       assert.strictEqual(stopPropagationSpy.callCount, 1);
@@ -300,7 +304,7 @@ describe('<Chip />', () => {
       );
 
       wrapper
-        .find(CheckBox)
+        .find('svg[data-mui-test="CheckBoxIcon"]')
         .props()
         .onClick({ stopPropagation: () => {} });
       assert.strictEqual(onDeleteSpy.callCount, 1, 'should have called the onDelete handler');
@@ -308,7 +312,7 @@ describe('<Chip />', () => {
 
     it('should render a default icon', () => {
       const wrapper = mount(<Chip label="Custom delete icon Chip" onDelete={() => {}} />);
-      assert.strictEqual(wrapper.find(CancelIcon).length, 1);
+      assert.strictEqual(wrapper.find('svg[data-mui-test="CancelIcon"]').length, 1);
     });
 
     it(
@@ -328,7 +332,7 @@ describe('<Chip />', () => {
         assert.strictEqual(chip.exists(), true);
         assert.strictEqual(chip.hasClass(classes.deletable), true);
 
-        const iconWrapper = wrapper.find(CancelIcon);
+        const iconWrapper = wrapper.find('svg[data-mui-test="CancelIcon"]');
         assert.strictEqual(iconWrapper.hasClass(classes.deleteIcon), true);
         assert.strictEqual(iconWrapper.hasClass(classes.deleteIconOutlinedColorSecondary), true);
       },
@@ -341,7 +345,7 @@ describe('<Chip />', () => {
       assert.strictEqual(chip.exists(), true);
       assert.strictEqual(chip.hasClass(classes.deletable), true);
 
-      const iconWrapper = wrapper.find(CancelIcon);
+      const iconWrapper = wrapper.find('svg[data-mui-test="CancelIcon"]');
       assert.strictEqual(iconWrapper.hasClass(classes.deleteIcon), true);
     });
 
@@ -356,7 +360,7 @@ describe('<Chip />', () => {
       assert.strictEqual(chip.hasClass(classes.deletable), true);
       assert.strictEqual(chip.hasClass(classes.deletableColorPrimary), true);
 
-      const iconWrapper = wrapper.find(CancelIcon);
+      const iconWrapper = wrapper.find('svg[data-mui-test="CancelIcon"]');
       assert.strictEqual(iconWrapper.hasClass(classes.deleteIcon), true);
       assert.strictEqual(iconWrapper.hasClass(classes.deleteIconColorPrimary), true);
     });
@@ -371,7 +375,7 @@ describe('<Chip />', () => {
       assert.strictEqual(chip.hasClass(classes.deletable), true);
       assert.strictEqual(chip.hasClass(classes.deletableColorSecondary), true);
 
-      const iconWrapper = wrapper.find(CancelIcon);
+      const iconWrapper = wrapper.find('svg[data-mui-test="CancelIcon"]');
       assert.strictEqual(iconWrapper.hasClass(classes.deleteIcon), true);
       assert.strictEqual(iconWrapper.hasClass(classes.deleteIconColorSecondary), true);
     });

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -73,14 +73,14 @@ describe('<MobileStepper />', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} />);
     const backButton = findOutermostIntrinsic(wrapper).childAt(0);
     assert.strictEqual(backButton.text(), 'Back');
-    assert.lengthOf(backButton.find(KeyboardArrowLeft), 1);
+    assert.lengthOf(backButton.find('svg[data-mui-test="KeyboardArrowLeftIcon"]'), 1);
   });
 
   it('should render next button', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} />);
     const nextButton = findOutermostIntrinsic(wrapper).childAt(2);
     assert.strictEqual(nextButton.childAt(0).text(), 'Next');
-    assert.lengthOf(nextButton.find(KeyboardArrowRight), 1);
+    assert.lengthOf(nextButton.find('svg[data-mui-test="KeyboardArrowRightIcon"]'), 1);
   });
 
   it('should render backButton custom text', () => {

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { assert } from 'chai';
-import RadioButtonCheckedIcon from '../internal/svg-icons/RadioButtonChecked';
-import RadioButtonUncheckedIcon from '../internal/svg-icons/RadioButtonUnchecked';
 import { getClasses, createMount, describeConformance } from '@material-ui/core/test-utils';
 import Radio from './Radio';
 import IconButton from '../IconButton';
@@ -39,14 +37,14 @@ describe('<Radio />', () => {
   describe('prop: unchecked', () => {
     it('should render an unchecked icon', () => {
       const wrapper = mount(<Radio />);
-      assert.strictEqual(wrapper.find(RadioButtonUncheckedIcon).length, 1);
+      assert.strictEqual(wrapper.find('svg[data-mui-test="RadioButtonUncheckedIcon"]').length, 1);
     });
   });
 
   describe('prop: checked', () => {
     it('should render a checked icon', () => {
       const wrapper = mount(<Radio checked />);
-      assert.strictEqual(wrapper.find(RadioButtonCheckedIcon).length, 1);
+      assert.strictEqual(wrapper.find('svg[data-mui-test="RadioButtonCheckedIcon"]').length, 1);
     });
   });
 });

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { assert } from 'chai';
-import CheckCircle from '../internal/svg-icons/CheckCircle';
-import Warning from '../internal/svg-icons/Warning';
 import { createShallow, createMount, describeConformance } from '@material-ui/core/test-utils';
 import StepIcon from './StepIcon';
 import SvgIcon from '../SvgIcon';
@@ -27,13 +25,13 @@ describe('<StepIcon />', () => {
 
   it('renders <CheckCircle> when completed', () => {
     const wrapper = mount(<StepIcon icon={1} completed />);
-    const checkCircle = wrapper.find(CheckCircle);
+    const checkCircle = wrapper.find('svg[data-mui-test="CheckCircleIcon"]');
     assert.strictEqual(checkCircle.length, 1, 'should have an <CheckCircle />');
   });
 
   it('renders <Warning> when error occurred', () => {
     const wrapper = mount(<StepIcon icon={1} error />);
-    const warning = wrapper.find(Warning);
+    const warning = wrapper.find('svg[data-mui-test="WarningIcon"]');
     assert.strictEqual(warning.length, 1, 'should have an <Warning />');
   });
 

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -77,11 +77,8 @@ describe('<TableSortLabel />', () => {
     it('should accept a custom icon for the sort icon', () => {
       const wrapper = mount(<TableSortLabel IconComponent={Sort} />);
       assert.strictEqual(
-        wrapper
-          .find(`.${classes.icon}`)
-          .first()
-          .type(),
-        Sort,
+        wrapper.find(`svg.${classes.icon}[data-mui-test="SortIcon"]`).exists(),
+        true,
       );
     });
   });

--- a/packages/material-ui/src/Tabs/TabScrollButton.test.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.test.js
@@ -1,7 +1,5 @@
 import React from 'react';
 import { assert } from 'chai';
-import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
-import KeyboardArrowRight from '../internal/svg-icons/KeyboardArrowRight';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import TabScrollButton from './TabScrollButton';
 import ButtonBase from '../ButtonBase';
@@ -54,12 +52,12 @@ describe('<TabScrollButton />', () => {
   describe('prop: direction', () => {
     it('should render with the left icon', () => {
       const wrapper = mount(<TabScrollButton {...props} direction="left" visible />);
-      assert.strictEqual(wrapper.find(KeyboardArrowLeft).length, 1);
+      assert.strictEqual(wrapper.find('svg[data-mui-test="KeyboardArrowLeftIcon"]').length, 1);
     });
 
     it('should render with the right icon', () => {
       const wrapper = mount(<TabScrollButton {...props} direction="right" visible />);
-      assert.strictEqual(wrapper.find(KeyboardArrowRight).length, 1);
+      assert.strictEqual(wrapper.find('svg[data-mui-test="KeyboardArrowRightIcon"]').length, 1);
     });
   });
 });

--- a/packages/material-ui/src/internal/svg-icons/createSvgIcon.js
+++ b/packages/material-ui/src/internal/svg-icons/createSvgIcon.js
@@ -2,7 +2,13 @@ import React from 'react';
 import SvgIcon from '../../SvgIcon';
 
 export default function createSvgIcon(path, displayName) {
-  const Component = React.memo(props => <SvgIcon {...props}>{path}</SvgIcon>);
+  const Component = React.memo(
+    React.forwardRef((props, ref) => (
+      <SvgIcon {...props} ref={ref}>
+        {path}
+      </SvgIcon>
+    )),
+  );
 
   if (process.env.NODE_ENV !== 'production') {
     Component.displayName = `memo(${displayName})`;

--- a/packages/material-ui/src/internal/svg-icons/createSvgIcon.js
+++ b/packages/material-ui/src/internal/svg-icons/createSvgIcon.js
@@ -11,7 +11,7 @@ export default function createSvgIcon(path, displayName) {
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    Component.displayName = `memo(${displayName})`;
+    Component.displayName = displayName;
   }
 
   Component.muiName = SvgIcon.muiName;

--- a/packages/material-ui/src/internal/svg-icons/createSvgIcon.js
+++ b/packages/material-ui/src/internal/svg-icons/createSvgIcon.js
@@ -11,7 +11,7 @@ export default function createSvgIcon(path, displayName) {
   );
 
   if (process.env.NODE_ENV !== 'production') {
-    Component.displayName = displayName;
+    Component.displayName = `${displayName}Icon`;
   }
 
   Component.muiName = SvgIcon.muiName;

--- a/packages/material-ui/src/internal/svg-icons/createSvgIcon.js
+++ b/packages/material-ui/src/internal/svg-icons/createSvgIcon.js
@@ -4,7 +4,7 @@ import SvgIcon from '../../SvgIcon';
 export default function createSvgIcon(path, displayName) {
   const Component = React.memo(
     React.forwardRef((props, ref) => (
-      <SvgIcon {...props} ref={ref}>
+      <SvgIcon {...props} data-mui-test={`${displayName}Icon`} ref={ref}>
         {path}
       </SvgIcon>
     )),


### PR DESCRIPTION
Also applied to internal icons for symmetry. Required to allow popups on icons.

Can't just break the fork by putting it into utils because `createSvgIcon` depends on core but then core would also depend on utils creating a (package-only) circular dependency.