### PR TITLE
[Popups] Allow Element as anchor el

### DIFF
--- a/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
+++ b/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
-import { SnackbarProvider, VariantType, withSnackbar, withSnackbarProps } from 'notistack';
+import { SnackbarProvider, VariantType, withSnackbar, WithSnackbarProps } from 'notistack';
 
-class App extends React.Component<withSnackbarProps> {
+class App extends React.Component<WithSnackbarProps> {
   handleClick = () => {
     this.props.enqueueSnackbar('I love snacks.');
   };
@@ -23,7 +23,7 @@ class App extends React.Component<withSnackbarProps> {
   }
 }
 
-(App as React.ComponentClass<withSnackbarProps>).propTypes = {
+(App as React.ComponentClass<WithSnackbarProps>).propTypes = {
   enqueueSnackbar: PropTypes.func.isRequired,
 };
 

--- a/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
+++ b/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
-import { SnackbarProvider, VariantType, withSnackbar, WithSnackbarProps } from 'notistack';
+import { SnackbarProvider, VariantType, withSnackbar, withSnackbarProps } from 'notistack';
 
-class App extends React.Component<WithSnackbarProps> {
+class App extends React.Component<withSnackbarProps> {
   handleClick = () => {
     this.props.enqueueSnackbar('I love snacks.');
   };
@@ -23,7 +23,7 @@ class App extends React.Component<WithSnackbarProps> {
   }
 }
 
-(App as React.ComponentClass<WithSnackbarProps>).propTypes = {
+(App as React.ComponentClass<withSnackbarProps>).propTypes = {
   enqueueSnackbar: PropTypes.func.isRequired,
 };
 

--- a/packages/material-ui/src/Popover/Popover.d.ts
+++ b/packages/material-ui/src/Popover/Popover.d.ts
@@ -19,13 +19,13 @@ export type PopoverReference = 'anchorEl' | 'anchorPosition' | 'none';
 export interface PopoverProps
   extends StandardProps<ModalProps & Partial<TransitionHandlerProps>, PopoverClassKey, 'children'> {
   action?: (actions: PopoverActions) => void;
-  anchorEl?: null | HTMLElement | ((element: HTMLElement) => HTMLElement);
+  anchorEl?: null | Element | ((element: Element) => Element);
   anchorOrigin?: PopoverOrigin;
   anchorPosition?: PopoverPosition;
   anchorReference?: PopoverReference;
   children?: React.ReactNode;
   elevation?: number;
-  getContentAnchorEl?: null | ((element: HTMLElement) => HTMLElement);
+  getContentAnchorEl?: null | ((element: Element) => Element);
   marginThreshold?: number;
   modal?: boolean;
   ModalClasses?: ModalProps['classes'];

--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -219,9 +219,7 @@ class Popover extends React.Component {
     const resolvedAnchorEl = getAnchorEl(anchorEl);
     // If an anchor element wasn't provided, just use the parent body element of this Popover
     const anchorElement =
-      resolvedAnchorEl instanceof HTMLElement
-        ? resolvedAnchorEl
-        : ownerDocument(this.paperRef).body;
+      resolvedAnchorEl instanceof Element ? resolvedAnchorEl : ownerDocument(this.paperRef).body;
     const anchorRect = anchorElement.getBoundingClientRect();
     const anchorVertical = contentAnchorOffset === 0 ? anchorOrigin.vertical : 'center';
 
@@ -379,7 +377,7 @@ Popover.propTypes = {
     if (props.open && props.anchorReference === 'anchorEl') {
       const resolvedAnchorEl = getAnchorEl(props.anchorEl);
 
-      if (resolvedAnchorEl instanceof HTMLElement) {
+      if (resolvedAnchorEl instanceof Element) {
         const box = resolvedAnchorEl.getBoundingClientRect();
 
         if (
@@ -400,7 +398,7 @@ Popover.propTypes = {
         return new Error(
           [
             'Material-UI: the `anchorEl` prop provided to the component is invalid.',
-            `It should be a HTMLElement instance but it's \`${resolvedAnchorEl}\` instead.`,
+            `It should be an Element instance but it's \`${resolvedAnchorEl}\` instead.`,
           ].join('\n'),
         );
       }

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -21,7 +21,7 @@ describe('<Popover />', () => {
   let classes;
   const defaultProps = {
     open: false,
-    anchorEl: () => document.createElement('div'),
+    anchorEl: () => document.createElement('svg'),
   };
 
   before(() => {
@@ -472,7 +472,7 @@ describe('<Popover />', () => {
       const otherWrapper = mount(<Popover open />);
       assert.strictEqual(otherWrapper.find(Modal).props().container, undefined);
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.args()[0][0], 'It should be a HTMLElement instance');
+      assert.include(consoleErrorMock.args()[0][0], 'It should be an Element instance');
     });
 
     it('warns if a component for the Paper is used that cant hold a ref', () => {

--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -19,7 +19,7 @@ export type PopperPlacementType =
 
 export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   transition?: boolean;
-  anchorEl?: null | HTMLElement | ReferenceObject | ((element: HTMLElement) => HTMLElement);
+  anchorEl?: null | Element | ReferenceObject | (() => Element);
   children:
     | React.ReactNode
     | ((props: {

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -174,7 +174,7 @@ Popper.propTypes = {
     if (props.open) {
       const resolvedAnchorEl = getAnchorEl(props.anchorEl);
 
-      if (resolvedAnchorEl instanceof HTMLElement) {
+      if (resolvedAnchorEl instanceof Element) {
         const box = resolvedAnchorEl.getBoundingClientRect();
 
         if (
@@ -195,7 +195,7 @@ Popper.propTypes = {
         return new Error(
           [
             'Material-UI: the `anchorEl` prop provided to the component is invalid.',
-            `It should be a HTMLElement instance but it's \`${resolvedAnchorEl}\` instead.`,
+            `It should be an Element instance but it's \`${resolvedAnchorEl}\` instead.`,
           ].join('\n'),
         );
       }

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -10,7 +10,7 @@ import Popper from './Popper';
 describe('<Popper />', () => {
   let mount;
   const defaultProps = {
-    anchorEl: () => window.document.createElement('div'),
+    anchorEl: () => window.document.createElement('svg'),
     children: <span>Hello World</span>,
     open: true,
   };
@@ -212,7 +212,7 @@ describe('<Popper />', () => {
     it('should warn if anchorEl is not valid', () => {
       mount(<Popper {...defaultProps} open anchorEl={null} />);
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.args()[0][0], 'It should be a HTMLElement instance');
+      assert.include(consoleErrorMock.args()[0][0], 'It should be an Element instance');
     });
 
     // it('should warn if anchorEl is not visible', () => {

--- a/test/utils/createDOM.js
+++ b/test/utils/createDOM.js
@@ -2,7 +2,7 @@ const { JSDOM } = require('jsdom');
 const Node = require('jsdom/lib/jsdom/living/node-document-position');
 
 // We can use jsdom-global at some point if maintaining these lists is a burden.
-const whitelist = ['HTMLElement', 'HTMLInputElement', 'Performance'];
+const whitelist = ['Element', 'HTMLElement', 'HTMLInputElement', 'Performance'];
 const blacklist = ['sessionStorage', 'localStorage'];
 
 function createDOM() {


### PR DESCRIPTION
We restricted this to `HTMLElement` only which would disallow e.g. svg elements. We only use `Element.get​Bounding​Client​Rect`, `Node.ownerDocument` and `new PopperJS(anchorEl)` which means we can safely relax this restriction.