### PR TITLE
[test] Colocate shadow root test for focus visible with implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test": "yarn lint && yarn typescript && yarn test:coverage",
     "test:coverage": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha 'packages/**/*.test.js' 'docs/**/*.test.js' --exclude '**/node_modules/**' && nyc report -r lcovonly",
     "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha 'packages/**/**/*.test.js' --exclude '**/node_modules/**' && nyc report --reporter=html",
-    "test:karma": "cross-env NODE_ENV=test karma start test/karma.conf.js --single-run",
+    "test:karma": "cross-env NODE_ENV=test karma start test/karma.conf.js",
     "test:regressions": "webpack --config test/regressions/webpack.config.js && rimraf test/regressions/screenshots/chrome/* && vrtest run --config test/vrtest.config.js --record",
     "test:umd": "yarn babel-node packages/material-ui/test/umd/run.js",
     "test:unit": "cross-env NODE_ENV=test mocha 'packages/**/*.test.js' 'docs/**/*.test.js' --exclude '**/node_modules/**'",

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import rerender from 'test/utils/rerender';
@@ -273,46 +272,6 @@ describe('<ButtonBase />', () => {
 
       assert.strictEqual(instanceWrapper.instance().ripple.stop.callCount, 1);
       assert.strictEqual(wrapper.find('button').hasClass(classes.focusVisible), false);
-    });
-  });
-
-  describe('focus inside shadowRoot', () => {
-    // Only run on HeadlessChrome which has native shadowRoot support.
-    // And jsdom which has limited support for shadowRoot (^12.0.0).
-    if (!/HeadlessChrome|jsdom/.test(window.navigator.userAgent)) {
-      return;
-    }
-
-    let rootElement;
-
-    beforeEach(() => {
-      rootElement = document.createElement('div');
-      rootElement.tabIndex = 0;
-      document.body.appendChild(rootElement);
-      rootElement.attachShadow({ mode: 'open' });
-    });
-
-    afterEach(() => {
-      ReactDOM.unmountComponentAtNode(rootElement.shadowRoot);
-      document.body.removeChild(rootElement);
-    });
-
-    it('should set focus state for shadowRoot children', () => {
-      mount(<ButtonBase id="test-button">Hello</ButtonBase>, {
-        attachTo: rootElement.shadowRoot,
-      });
-      simulatePointerDevice();
-
-      const button = rootElement.shadowRoot.getElementById('test-button');
-      if (!button) {
-        throw new Error('missing button');
-      }
-
-      assert.strictEqual(button.classList.contains(classes.focusVisible), false);
-
-      focusVisible(button);
-
-      assert.strictEqual(button.classList.contains(classes.focusVisible), true);
     });
   });
 

--- a/packages/material-ui/src/utils/focusVisible.test.js
+++ b/packages/material-ui/src/utils/focusVisible.test.js
@@ -1,0 +1,122 @@
+import { assert } from 'chai';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { createMount } from '@material-ui/core/test-utils';
+import { teardown, useIsFocusVisible } from './focusVisible';
+import { useForkRef } from './reactHelpers';
+
+function dispatchFocusVisible(element) {
+  element.ownerDocument.dispatchEvent(new window.Event('keydown'));
+  element.focus();
+}
+
+function simulatePointerDevice() {
+  // first focus on a page triggers focus visible until a pointer event
+  // has been dispatched
+  document.dispatchEvent(new window.Event('pointerdown'));
+}
+
+const SimpleButton = React.forwardRef(function SimpleButton(props, ref) {
+  const [element, setElement] = React.useState(null);
+  const getOwnerDocument = React.useCallback(() => {
+    if (element === null) {
+      return null;
+    }
+
+    return element.ownerDocument;
+  }, [element]);
+  const { isFocusVisible, onBlurVisible } = useIsFocusVisible(getOwnerDocument);
+
+  const handleRef = useForkRef(setElement, ref);
+
+  const [focusVisible, setFocusVisible] = React.useState(false);
+
+  function handleBlur() {
+    if (focusVisible) {
+      setFocusVisible(false);
+      onBlurVisible();
+    }
+  }
+
+  function handleFocus(event) {
+    if (isFocusVisible(event)) {
+      setFocusVisible(true);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      {...props}
+      ref={handleRef}
+      className={focusVisible ? 'focus-visible' : null}
+      onBlur={handleBlur}
+      onFocus={handleFocus}
+    />
+  );
+});
+
+describe('focus-visible polyfill', () => {
+  let mount;
+
+  before(() => {
+    // isolate test from previous component test that use the polyfill in the document scope
+    teardown(document);
+    mount = createMount({ strict: true });
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  describe('focus inside shadowRoot', () => {
+    // Only run on HeadlessChrome which has native shadowRoot support.
+    // And jsdom which has limited support for shadowRoot (^12.0.0).
+    if (!/HeadlessChrome|jsdom/.test(window.navigator.userAgent)) {
+      return;
+    }
+
+    let rootElement;
+
+    beforeEach(() => {
+      rootElement = document.createElement('div');
+      document.body.appendChild(rootElement);
+      rootElement.attachShadow({ mode: 'open' });
+    });
+
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(rootElement.shadowRoot);
+      teardown(rootElement.shadowRoot);
+      document.body.removeChild(rootElement);
+    });
+
+    it('should set focus state for shadowRoot children', () => {
+      const buttonRef = React.createRef();
+      mount(
+        <SimpleButton id="test-button" ref={buttonRef}>
+          Hello
+        </SimpleButton>,
+        {
+          attachTo: rootElement.shadowRoot,
+        },
+      );
+      simulatePointerDevice();
+
+      const { current: button } = buttonRef;
+      if (!(button instanceof window.HTMLButtonElement)) {
+        throw new Error('missing button');
+      }
+
+      assert.strictEqual(button.classList.contains('focus-visible'), false);
+
+      button.focus();
+
+      assert.strictEqual(button.classList.contains('focus-visible'), false);
+
+      button.blur();
+      dispatchFocusVisible(button);
+
+      assert.strictEqual(button.classList.contains('focus-visible'), true);
+    });
+  });
+});

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -81,6 +81,7 @@ module.exports = function setKarmaConfig(config) {
         flags: ['--no-sandbox'],
       },
     },
+    singleRun: Boolean(process.env.CI),
   };
 
   let newConfig = baseConfig;


### PR DESCRIPTION
Wanted to see if we need to update the implementation for WICG/focus-visible#196 but it seems like this already works nicely.

Had some issues with the browser test because focus wasn't dispatched if an element already has focus. karma --watch made this easier.