### PR TITLE
[test] Extend StrictMode tests

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.test.js
+++ b/packages/material-ui/src/Avatar/Avatar.test.js
@@ -15,7 +15,7 @@ describe('<Avatar />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Avatar />);
   });

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -51,10 +51,9 @@ describe('<Badge />', () => {
     assert.strictEqual(findBadge(wrapper).hasClass(badgeClassName), true);
   });
 
-  it('renders children and className', () => {
+  it('renders children', () => {
     const wrapper = mount(<Badge className="testClassName" {...defaultProps} />);
     assert.strictEqual(wrapper.contains(defaultProps.children), true);
-    assert.strictEqual(wrapper.hasClass('testClassName'), true);
   });
 
   describe('prop: color', () => {

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -16,7 +16,7 @@ describe('<Badge />', () => {
   };
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<Badge {...defaultProps} />);
   });
 

--- a/packages/material-ui/src/Box/Box.test.js
+++ b/packages/material-ui/src/Box/Box.test.js
@@ -7,7 +7,7 @@ describe('<Box />', () => {
   let mount;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -11,7 +11,7 @@ describe('<Breadcrumbs />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(
       <Breadcrumbs>
         <span>Hello World</span>

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -98,7 +98,7 @@ describe('<Breadcrumbs />', () => {
       );
       assert.strictEqual(wrapper.find(BreadcrumbSeparator).length, 3);
       assert.strictEqual(wrapper.find(BreadcrumbCollapsed).length, 0);
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.strictEqual(consoleErrorMock.callCount(), 2);
       assert.include(
         consoleErrorMock.args()[0][0],
         'you have provided an invalid combination of properties to the',

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -18,7 +18,7 @@ describe('<Button />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     render = createRender();
     classes = getClasses(<Button>Hello World</Button>);

--- a/packages/material-ui/src/Card/Card.test.js
+++ b/packages/material-ui/src/Card/Card.test.js
@@ -9,7 +9,7 @@ describe('<Card />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<Card />);
   });
 

--- a/packages/material-ui/src/CardActionArea/CardActionArea.test.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.test.js
@@ -8,7 +8,7 @@ describe('<CardActionArea />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<CardActionArea />);
   });
 

--- a/packages/material-ui/src/CardActions/CardActions.test.js
+++ b/packages/material-ui/src/CardActions/CardActions.test.js
@@ -7,7 +7,7 @@ describe('<CardActions />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<CardActions />);
   });
 

--- a/packages/material-ui/src/CardContent/CardContent.test.js
+++ b/packages/material-ui/src/CardContent/CardContent.test.js
@@ -7,7 +7,7 @@ describe('<CardContent />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<CardContent />);
   });
 

--- a/packages/material-ui/src/CardHeader/CardHeader.test.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.test.js
@@ -15,7 +15,7 @@ describe('<CardHeader />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ untilSelector: 'div' });
     classes = getClasses(<CardHeader />);
   });

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -14,7 +14,7 @@ describe('<CardMedia />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ untilSelector: 'CardMedia' });
     classes = getClasses(<CardMedia image="/foo.jpg" />);
   });

--- a/packages/material-ui/src/CircularProgress/CircularProgress.test.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.test.js
@@ -14,7 +14,7 @@ describe('<CircularProgress />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<CircularProgress />);
   });

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -15,7 +15,8 @@ describe('<Collapse />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
     classes = getClasses(<Collapse {...defaultProps} />);
   });
 

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -15,7 +15,7 @@ describe('<Collapse />', () => {
   };
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<Collapse {...defaultProps} />);
   });
 

--- a/packages/material-ui/src/DialogContent/DialogContent.test.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.test.js
@@ -14,7 +14,7 @@ describe('<DialogContent />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<DialogContent />);
   });

--- a/packages/material-ui/src/DialogContentText/DialogContentText.test.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.test.js
@@ -10,7 +10,7 @@ describe('<DialogContentText />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<DialogContentText />);
   });

--- a/packages/material-ui/src/DialogTitle/DialogTitle.test.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.test.js
@@ -14,7 +14,7 @@ describe('<DialogTitle />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<DialogTitle>foo</DialogTitle>);
   });

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -14,7 +14,7 @@ describe('<Divider />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Divider />);
   });

--- a/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.test.js
+++ b/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.test.js
@@ -7,7 +7,7 @@ describe('<ExpansionPanelActions />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<ExpansionPanelActions>foo</ExpansionPanelActions>);
   });
 

--- a/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.test.js
+++ b/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.test.js
@@ -14,7 +14,7 @@ describe('<ExpansionPanelDetails />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<ExpansionPanelDetails>foo</ExpansionPanelDetails>);
   });

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -18,7 +18,7 @@ describe('<Fab />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     render = createRender();
     classes = getClasses(<Fab>Fab</Fab>);

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -14,7 +14,7 @@ describe('<FormGroup />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<FormGroup />);
   });

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -14,7 +14,7 @@ describe('<Grid />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Grid />);
   });

--- a/packages/material-ui/src/GridList/GridList.test.js
+++ b/packages/material-ui/src/GridList/GridList.test.js
@@ -28,7 +28,7 @@ describe('<GridList />', () => {
 
   before(() => {
     classes = getClasses(<GridList />);
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
   });
 

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
@@ -15,7 +15,7 @@ describe('<GridListTileBar />', () => {
 
   before(() => {
     classes = getClasses(<GridListTileBar title="classes" />);
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
   });
 

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -14,7 +14,7 @@ describe('<Grow />', () => {
   };
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -14,7 +14,8 @@ describe('<Grow />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -14,7 +14,7 @@ describe('<Icon />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Icon />);
   });

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -15,7 +15,7 @@ describe('<LinearProgress />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<LinearProgress />);
   });

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -15,7 +15,7 @@ describe('<Link />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Link href="/">Home</Link>);
   });

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -14,7 +14,7 @@ describe('<ListItemIcon />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(
       <ListItemIcon>

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.test.js
@@ -7,7 +7,7 @@ describe('<ListItemSecondaryAction />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<ListItemSecondaryAction />);
   });
 

--- a/packages/material-ui/src/ListSubheader/ListSubheader.test.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.test.js
@@ -14,7 +14,7 @@ describe('<ListSubheader />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<ListSubheader />);
   });

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -19,13 +19,13 @@ describe('<MobileStepper />', () => {
   const defaultProps = {
     steps: 2,
     nextButton: (
-      <Button>
+      <Button aria-label="next">
         Next
         <KeyboardArrowRight />
       </Button>
     ),
     backButton: (
-      <Button>
+      <Button aria-label="back">
         <KeyboardArrowLeft />
         Back
       </Button>
@@ -71,79 +71,23 @@ describe('<MobileStepper />', () => {
 
   it('should render the back button', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} />);
-    const backButton = findOutermostIntrinsic(wrapper).childAt(0);
-    assert.strictEqual(backButton.text(), 'Back');
+    const backButton = wrapper.find('button[aria-label="back"]');
+    assert.strictEqual(backButton.exists(), true);
     assert.lengthOf(backButton.find('svg[data-mui-test="KeyboardArrowLeftIcon"]'), 1);
   });
 
   it('should render next button', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} />);
-    const nextButton = findOutermostIntrinsic(wrapper).childAt(2);
-    assert.strictEqual(nextButton.childAt(0).text(), 'Next');
+    const nextButton = wrapper.find('button[aria-label="next"]');
+    assert.strictEqual(nextButton.exists(), true);
     assert.lengthOf(nextButton.find('svg[data-mui-test="KeyboardArrowRightIcon"]'), 1);
-  });
-
-  it('should render backButton custom text', () => {
-    const wrapper = mount(
-      <MobileStepper
-        {...defaultProps}
-        backButton={
-          <Button>
-            <KeyboardArrowLeft />
-            Past
-          </Button>
-        }
-      />,
-    );
-    assert.strictEqual(
-      findOutermostIntrinsic(wrapper)
-        .childAt(0)
-        .text(),
-      'Past',
-    );
-  });
-
-  it('should render nextButton custom text', () => {
-    const wrapper = mount(
-      <MobileStepper
-        {...defaultProps}
-        nextButton={
-          <Button>
-            Future
-            <KeyboardArrowRight />
-          </Button>
-        }
-      />,
-    );
-    assert.strictEqual(
-      findOutermostIntrinsic(wrapper)
-        .childAt(2)
-        .text(),
-      'Future',
-    );
-  });
-
-  it('should render disabled backButton', () => {
-    const wrapper = mount(
-      <MobileStepper {...defaultProps} backButton={<Button disabled>back</Button>} />,
-    );
-    const backButton = findOutermostIntrinsic(wrapper).childAt(0);
-    assert.strictEqual(backButton.props().disabled, true);
-  });
-
-  it('should render disabled nextButton', () => {
-    const wrapper = mount(
-      <MobileStepper {...defaultProps} nextButton={<Button disabled>back</Button>} />,
-    );
-    const nextButton = findOutermostIntrinsic(wrapper).childAt(2);
-    assert.strictEqual(nextButton.props().disabled, true);
   });
 
   it('should render two buttons and text displaying progress when supplied with variant text', () => {
     const wrapper = mount(
       <MobileStepper {...defaultProps} variant="text" activeStep={1} steps={3} />,
     );
-    assert.strictEqual(wrapper.text(), 'Back2 / 3Next');
+    assert.strictEqual(findOutermostIntrinsic(wrapper).instance().textContent, 'Back2 / 3Next');
   });
 
   it('should render dots when supplied with variant dots', () => {

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -33,7 +33,7 @@ describe('<MobileStepper />', () => {
   };
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     classes = getClasses(<MobileStepper {...defaultProps} />);
   });
 

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
@@ -15,7 +15,7 @@ describe('<SnackbarContent />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ untilSelector: 'withStyles(Paper)' });
     classes = getClasses(<SnackbarContent message="message" />);
   });

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -16,7 +16,7 @@ describe('<Switch />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ untilSelector: 'span' });
     classes = getClasses(<Switch />);
   });

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -15,7 +15,7 @@ describe('<Toolbar />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Toolbar>foo</Toolbar>);
   });

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -33,7 +33,7 @@ describe('<Tooltip />', () => {
   };
 
   before(() => {
-    // StrictModeViolation: uses RootRef, Grow and tests a lot of impl details
+    // StrictModeViolation: uses Grow and tests a lot of impl details
     mount = createMount({ strict: undefined });
     classes = getClasses(<Tooltip {...defaultProps} />);
     clock = useFakeTimers();

--- a/packages/material-ui/src/Typography/Typography.test.js
+++ b/packages/material-ui/src/Typography/Typography.test.js
@@ -14,7 +14,7 @@ describe('<Typography />', () => {
   let classes;
 
   before(() => {
-    mount = createMount();
+    mount = createMount({ strict: true });
     shallow = createShallow({ dive: true });
     classes = getClasses(<Typography />);
   });


### PR DESCRIPTION
Specify if StrictMode compatible or not on the remaining tests.

`findHostNodeSomehow(wrapper).instance().textContent` is a StrictMode compatible alternative to `wrapper.text()`.