### PR TITLE
[docs] Document if a component is StrictMode compatible

### DIFF
--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -150,6 +150,7 @@ async function buildDocs(options) {
   const testInfo = await parseTest(componentObject.filename);
   // no Object.assign to visually check for collisions
   reactAPI.forwardsRefTo = testInfo.forwardsRefTo;
+  reactAPI.strictModeReady = testInfo.strictModeReady;
 
   // if (reactAPI.name !== 'TableCell') {
   //   return;

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -380,7 +380,9 @@ function generateInheritance(reactAPI) {
 The properties of the [${inheritance.component}](${Router._rewriteUrlForNextExport(
     inheritance.pathname,
   )}) component${suffix} are also available.
-You can take advantage of this behavior to [target nested components](/guides/api/#spread).`;
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).
+
+`;
 }
 
 function generateDemos(reactAPI) {
@@ -425,7 +427,9 @@ function generateNotes(reactAPI) {
   const { strictModeReady } = reactAPI;
   return `## Notes
 
-The component is${!strictModeReady ? ' **not**' : ''} StrictMode ready.`;
+The component is${!strictModeReady ? ' **not**' : ''} StrictMode ready.
+
+`;
 }
 
 export default function generateMarkdown(reactAPI) {
@@ -445,10 +449,8 @@ export default function generateMarkdown(reactAPI) {
     '',
     generateProps(reactAPI),
     '',
-    `${generateClasses(reactAPI)}${generateInheritance(reactAPI)}`,
-    '',
-    generateNotes(reactAPI),
-    '',
-    generateDemos(reactAPI),
+    `${generateClasses(reactAPI)}${generateInheritance(reactAPI)}${generateNotes(
+      reactAPI,
+    )}${generateDemos(reactAPI)}`,
   ].join('\n');
 }

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -380,9 +380,7 @@ function generateInheritance(reactAPI) {
 The properties of the [${inheritance.component}](${Router._rewriteUrlForNextExport(
     inheritance.pathname,
   )}) component${suffix} are also available.
-You can take advantage of this behavior to [target nested components](/guides/api/#spread).
-
-`;
+You can take advantage of this behavior to [target nested components](/guides/api/#spread).`;
 }
 
 function generateDemos(reactAPI) {
@@ -423,6 +421,13 @@ import ${reactAPI.name} from '${source}';
 \`\`\``;
 }
 
+function generateNotes(reactAPI) {
+  const { strictModeReady } = reactAPI;
+  return `## Notes
+
+The component is${!strictModeReady ? ' **not**' : ''} StrictMode ready.`;
+}
+
 export default function generateMarkdown(reactAPI) {
   return [
     generateHeader(reactAPI),
@@ -440,6 +445,10 @@ export default function generateMarkdown(reactAPI) {
     '',
     generateProps(reactAPI),
     '',
-    `${generateClasses(reactAPI)}${generateInheritance(reactAPI)}${generateDemos(reactAPI)}`,
+    `${generateClasses(reactAPI)}${generateInheritance(reactAPI)}`,
+    '',
+    generateNotes(reactAPI),
+    '',
+    generateDemos(reactAPI),
   ].join('\n');
 }

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -425,9 +425,14 @@ import ${reactAPI.name} from '${source}';
 
 function generateNotes(reactAPI) {
   const { strictModeReady } = reactAPI;
+  const strictModeLinked = '[StrictMode](https://reactjs.org/docs/strict-mode.html)';
   return `## Notes
 
-The component is${!strictModeReady ? ' **not**' : ''} StrictMode ready.
+The component ${
+    !strictModeReady
+      ? `can cause issues in ${strictModeLinked}`
+      : `is fully ${strictModeLinked} compatible`
+  }.
 
 `;
 }

--- a/docs/src/modules/utils/parseTest.js
+++ b/docs/src/modules/utils/parseTest.js
@@ -48,6 +48,40 @@ function findConformanceDescriptor(program) {
 }
 
 /**
+ * Finds if `mount` was created with `strict: true`
+ * Only supports a single pattern
+ * ```js
+ * // somewhere in the code, not necessarily the same binding
+ * mount = createMount({ strict: true });
+ * ```
+ * 
+ * @param {import('@babel/types').Identifier} mountIdentifier 
+ * @param {import('@babel/types').Program} program 
+ */
+function isStrictMount(mountIdentifier, program) {
+  // assume the path is above the mountNode in the AST and no variable is shadowed
+  function isSameMountBinding(assignmentPath) {
+    return mountIdentifier.name === assignmentPath.node.left.name;
+  }
+
+  let isStrict = null;
+  babel.traverse(program, {
+    AssignmentExpression(babelPath) {
+      if (isSameMountBinding(babelPath)) {
+        // find `strict: literal` in `mount = someFunction({ })`
+        const strictProperty = babelPath.node.right.arguments[0].properties.find(
+          property => property.key.name === 'strict',
+        );
+
+        isStrict = strictProperty.value.value;
+      }
+    },
+  });
+
+  return isStrict;
+}
+
+/**
  *
  * @param {import('@babel/core').Node} valueNode
  */
@@ -77,6 +111,7 @@ function getInheritComponentName(valueNode) {
 /**
  * @typedef {Object} ParseResult
  * @property {string?} forwardsRefTo
+ * @property {boolean?} strictModeReady
  */
 
 /**
@@ -92,6 +127,7 @@ export default async function parseTest(componentFilename) {
   const result = {
     forwardsRefTo: undefined,
     inheritComponent: undefined,
+    strictModeReady: undefined,
   };
 
   const { properties = [] } = descriptor;
@@ -104,6 +140,9 @@ export default async function parseTest(componentFilename) {
         break;
       case 'inheritComponent':
         result.inheritComponent = getInheritComponentName(property.value);
+        break;
+      case 'mount':
+        result.strictModeReady = isStrictMount(property.value, babelParseResult.program);
         break;
       default:
         break;

--- a/docs/src/modules/utils/parseTest.js
+++ b/docs/src/modules/utils/parseTest.js
@@ -54,9 +54,9 @@ function findConformanceDescriptor(program) {
  * // somewhere in the code, not necessarily the same binding
  * mount = createMount({ strict: true });
  * ```
- * 
- * @param {import('@babel/types').Identifier} mountIdentifier 
- * @param {import('@babel/types').Program} program 
+ *
+ * @param {import('@babel/types').Identifier} mountIdentifier
+ * @param {import('@babel/types').Program} program
  */
 function isStrictMount(mountIdentifier, program) {
   // assume the path is above the mountNode in the AST and no variable is shadowed
@@ -69,9 +69,11 @@ function isStrictMount(mountIdentifier, program) {
     AssignmentExpression(babelPath) {
       if (isSameMountBinding(babelPath)) {
         // find `strict: literal` in `mount = someFunction({ })`
-        const strictProperty = babelPath.node.right.arguments[0].properties.find(
-          property => property.key.name === 'strict',
-        );
+        const options = babelPath.node.right.arguments[0];
+        if (options === undefined) {
+          return;
+        }
+        const strictProperty = options.properties.find(property => property.key.name === 'strict');
 
         isStrict = strictProperty.value.value;
       }

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -59,7 +59,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/app-bar.md
+++ b/pages/api/app-bar.md
@@ -57,6 +57,10 @@ you need to use the following style sheet name: `MuiAppBar`.
 The properties of the [Paper](/api/paper/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [App Bar](/components/app-bar/)

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -50,6 +50,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiAvatar`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Avatars](/components/avatars/)

--- a/pages/api/avatar.md
+++ b/pages/api/avatar.md
@@ -52,7 +52,7 @@ you need to use the following style sheet name: `MuiAvatar`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/backdrop.md
+++ b/pages/api/backdrop.md
@@ -45,3 +45,7 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiBackdrop`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+

--- a/pages/api/backdrop.md
+++ b/pages/api/backdrop.md
@@ -47,5 +47,5 @@ you need to use the following style sheet name: `MuiBackdrop`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -55,6 +55,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiBadge`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Badges](/components/badges/)

--- a/pages/api/badge.md
+++ b/pages/api/badge.md
@@ -57,7 +57,7 @@ you need to use the following style sheet name: `MuiBadge`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -55,6 +55,10 @@ you need to use the following style sheet name: `MuiBottomNavigationAction`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Bottom Navigation](/components/bottom-navigation/)

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -57,7 +57,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -48,7 +48,7 @@ you need to use the following style sheet name: `MuiBottomNavigation`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -46,6 +46,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiBottomNavigation`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Bottom Navigation](/components/bottom-navigation/)

--- a/pages/api/breadcrumbs.md
+++ b/pages/api/breadcrumbs.md
@@ -32,7 +32,7 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/breadcrumbs.md
+++ b/pages/api/breadcrumbs.md
@@ -30,6 +30,10 @@ The `ref` is forwarded to the root element.
 
 Any other properties supplied will be provided to the root element (native element).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Breadcrumbs](/components/breadcrumbs/)

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -58,6 +58,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiButtonBase`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Buttons](/components/buttons/)

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -60,7 +60,7 @@ you need to use the following style sheet name: `MuiButtonBase`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -72,6 +72,10 @@ you need to use the following style sheet name: `MuiButton`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Buttons](/components/buttons/)

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -74,7 +74,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/card-action-area.md
+++ b/pages/api/card-action-area.md
@@ -51,7 +51,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/card-action-area.md
+++ b/pages/api/card-action-area.md
@@ -49,6 +49,10 @@ you need to use the following style sheet name: `MuiCardActionArea`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Cards](/components/cards/)

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -46,7 +46,7 @@ you need to use the following style sheet name: `MuiCardActions`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/card-actions.md
+++ b/pages/api/card-actions.md
@@ -44,6 +44,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiCardActions`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Cards](/components/cards/)

--- a/pages/api/card-content.md
+++ b/pages/api/card-content.md
@@ -44,7 +44,7 @@ you need to use the following style sheet name: `MuiCardContent`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/card-content.md
+++ b/pages/api/card-content.md
@@ -42,6 +42,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiCardContent`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Cards](/components/cards/)

--- a/pages/api/card-header.md
+++ b/pages/api/card-header.md
@@ -54,6 +54,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiCardHeader`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Cards](/components/cards/)

--- a/pages/api/card-header.md
+++ b/pages/api/card-header.md
@@ -56,7 +56,7 @@ you need to use the following style sheet name: `MuiCardHeader`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -45,6 +45,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiCardMedia`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Cards](/components/cards/)

--- a/pages/api/card-media.md
+++ b/pages/api/card-media.md
@@ -47,7 +47,7 @@ you need to use the following style sheet name: `MuiCardMedia`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/card.md
+++ b/pages/api/card.md
@@ -49,7 +49,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/card.md
+++ b/pages/api/card.md
@@ -47,6 +47,10 @@ you need to use the following style sheet name: `MuiCard`.
 The properties of the [Paper](/api/paper/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Cards](/components/cards/)

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -67,7 +67,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -65,6 +65,10 @@ you need to use the following style sheet name: `MuiCheckbox`.
 The properties of the [IconButton](/api/icon-button/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Checkboxes](/components/checkboxes/)

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -75,6 +75,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiChip`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Chips](/components/chips/)

--- a/pages/api/chip.md
+++ b/pages/api/chip.md
@@ -77,7 +77,7 @@ you need to use the following style sheet name: `MuiChip`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -62,7 +62,7 @@ you need to use the following style sheet name: `MuiCircularProgress`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/circular-progress.md
+++ b/pages/api/circular-progress.md
@@ -60,6 +60,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiCircularProgress`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Progress](/components/progress/)

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -27,6 +27,10 @@ For instance, if you need to hide a menu when people click anywhere else on your
 The component cannot hold a ref.
 
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Click Away Listener](/components/click-away-listener/)

--- a/pages/api/click-away-listener.md
+++ b/pages/api/click-away-listener.md
@@ -29,7 +29,7 @@ The component cannot hold a ref.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -57,6 +57,10 @@ you need to use the following style sheet name: `MuiCollapse`.
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Cards](/components/cards/)

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -59,7 +59,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/container.md
+++ b/pages/api/container.md
@@ -48,6 +48,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiContainer`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Container](/components/container/)

--- a/pages/api/container.md
+++ b/pages/api/container.md
@@ -50,7 +50,7 @@ you need to use the following style sheet name: `MuiContainer`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -25,7 +25,7 @@ The component cannot hold a ref.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/css-baseline.md
+++ b/pages/api/css-baseline.md
@@ -23,6 +23,10 @@ Kickstart an elegant, consistent, and simple baseline to build upon.
 The component cannot hold a ref.
 
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Css Baseline](/components/css-baseline/)

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -44,6 +44,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiDialogActions`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Dialogs](/components/dialogs/)

--- a/pages/api/dialog-actions.md
+++ b/pages/api/dialog-actions.md
@@ -46,7 +46,7 @@ you need to use the following style sheet name: `MuiDialogActions`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -49,7 +49,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/dialog-content-text.md
+++ b/pages/api/dialog-content-text.md
@@ -47,6 +47,10 @@ you need to use the following style sheet name: `MuiDialogContentText`.
 The properties of the [Typography](/api/typography/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Dialogs](/components/dialogs/)

--- a/pages/api/dialog-content.md
+++ b/pages/api/dialog-content.md
@@ -44,6 +44,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiDialogContent`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Dialogs](/components/dialogs/)

--- a/pages/api/dialog-content.md
+++ b/pages/api/dialog-content.md
@@ -46,7 +46,7 @@ you need to use the following style sheet name: `MuiDialogContent`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/dialog-title.md
+++ b/pages/api/dialog-title.md
@@ -43,6 +43,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiDialogTitle`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Dialogs](/components/dialogs/)

--- a/pages/api/dialog-title.md
+++ b/pages/api/dialog-title.md
@@ -45,7 +45,7 @@ you need to use the following style sheet name: `MuiDialogTitle`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -84,7 +84,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -82,6 +82,10 @@ you need to use the following style sheet name: `MuiDialog`.
 The properties of the [Modal](/api/modal/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Dialogs](/components/dialogs/)

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -49,6 +49,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiDivider`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Dividers](/components/dividers/)

--- a/pages/api/divider.md
+++ b/pages/api/divider.md
@@ -51,7 +51,7 @@ you need to use the following style sheet name: `MuiDivider`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -65,7 +65,7 @@ you need to use the following style sheet name: `MuiDrawer`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -63,6 +63,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiDrawer`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Drawers](/components/drawers/)

--- a/pages/api/expansion-panel-actions.md
+++ b/pages/api/expansion-panel-actions.md
@@ -46,7 +46,7 @@ you need to use the following style sheet name: `MuiExpansionPanelActions`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/expansion-panel-actions.md
+++ b/pages/api/expansion-panel-actions.md
@@ -44,6 +44,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiExpansionPanelActions`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Expansion Panels](/components/expansion-panels/)

--- a/pages/api/expansion-panel-details.md
+++ b/pages/api/expansion-panel-details.md
@@ -44,7 +44,7 @@ you need to use the following style sheet name: `MuiExpansionPanelDetails`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/expansion-panel-details.md
+++ b/pages/api/expansion-panel-details.md
@@ -42,6 +42,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiExpansionPanelDetails`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Expansion Panels](/components/expansion-panels/)

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -54,6 +54,10 @@ you need to use the following style sheet name: `MuiExpansionPanelSummary`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Expansion Panels](/components/expansion-panels/)

--- a/pages/api/expansion-panel-summary.md
+++ b/pages/api/expansion-panel-summary.md
@@ -56,7 +56,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/expansion-panel.md
+++ b/pages/api/expansion-panel.md
@@ -58,7 +58,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/expansion-panel.md
+++ b/pages/api/expansion-panel.md
@@ -56,6 +56,10 @@ you need to use the following style sheet name: `MuiExpansionPanel`.
 The properties of the [Paper](/api/paper/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Expansion Panels](/components/expansion-panels/)

--- a/pages/api/fab.md
+++ b/pages/api/fab.md
@@ -66,7 +66,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/fab.md
+++ b/pages/api/fab.md
@@ -64,6 +64,10 @@ you need to use the following style sheet name: `MuiFab`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Buttons](/components/buttons/)

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -32,6 +32,10 @@ Any other properties supplied will be provided to the root element ([Transition]
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Transitions](/components/transitions/)

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -34,7 +34,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/filled-input.md
+++ b/pages/api/filled-input.md
@@ -83,6 +83,10 @@ you need to use the following style sheet name: `MuiFilledInput`.
 The properties of the [InputBase](/api/input-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Text Fields](/components/text-fields/)

--- a/pages/api/filled-input.md
+++ b/pages/api/filled-input.md
@@ -85,7 +85,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -56,6 +56,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiFormControlLabel`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Checkboxes](/components/checkboxes/)

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -58,7 +58,7 @@ you need to use the following style sheet name: `MuiFormControlLabel`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -63,7 +63,7 @@ you need to use the following style sheet name: `MuiFormControl`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/form-control.md
+++ b/pages/api/form-control.md
@@ -61,6 +61,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiFormControl`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Checkboxes](/components/checkboxes/)

--- a/pages/api/form-group.md
+++ b/pages/api/form-group.md
@@ -48,7 +48,7 @@ you need to use the following style sheet name: `MuiFormGroup`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/form-group.md
+++ b/pages/api/form-group.md
@@ -46,6 +46,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiFormGroup`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Checkboxes](/components/checkboxes/)

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -59,7 +59,7 @@ you need to use the following style sheet name: `MuiFormHelperText`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -57,6 +57,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiFormHelperText`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Text Fields](/components/text-fields/)

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -56,7 +56,7 @@ you need to use the following style sheet name: `MuiFormLabel`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -54,6 +54,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiFormLabel`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Checkboxes](/components/checkboxes/)

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -58,7 +58,7 @@ you need to use the following style sheet name: `MuiGridListTileBar`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/grid-list-tile-bar.md
+++ b/pages/api/grid-list-tile-bar.md
@@ -56,6 +56,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiGridListTileBar`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Grid List](/components/grid-list/)

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -50,7 +50,7 @@ you need to use the following style sheet name: `MuiGridListTile`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/grid-list-tile.md
+++ b/pages/api/grid-list-tile.md
@@ -48,6 +48,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiGridListTile`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Grid List](/components/grid-list/)

--- a/pages/api/grid-list.md
+++ b/pages/api/grid-list.md
@@ -46,6 +46,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiGridList`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Grid List](/components/grid-list/)

--- a/pages/api/grid-list.md
+++ b/pages/api/grid-list.md
@@ -48,7 +48,7 @@ you need to use the following style sheet name: `MuiGridList`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -103,6 +103,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiGrid`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Grid](/components/grid/)

--- a/pages/api/grid.md
+++ b/pages/api/grid.md
@@ -105,7 +105,7 @@ you need to use the following style sheet name: `MuiGrid`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -33,6 +33,10 @@ Any other properties supplied will be provided to the root element ([Transition]
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Popover](/components/popover/)

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -35,7 +35,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/hidden.md
+++ b/pages/api/hidden.md
@@ -37,6 +37,10 @@ The component cannot hold a ref.
 
 Any other properties supplied will be provided to the root element (native element).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Hidden](/components/hidden/)

--- a/pages/api/hidden.md
+++ b/pages/api/hidden.md
@@ -39,7 +39,7 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -62,7 +62,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -60,6 +60,10 @@ you need to use the following style sheet name: `MuiIconButton`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Buttons](/components/buttons/)

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -53,6 +53,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiIcon`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Icons](/components/icons/)

--- a/pages/api/icon.md
+++ b/pages/api/icon.md
@@ -55,7 +55,7 @@ you need to use the following style sheet name: `MuiIcon`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/input-adornment.md
+++ b/pages/api/input-adornment.md
@@ -53,7 +53,7 @@ you need to use the following style sheet name: `MuiInputAdornment`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/input-adornment.md
+++ b/pages/api/input-adornment.md
@@ -51,6 +51,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiInputAdornment`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Text Fields](/components/text-fields/)

--- a/pages/api/input-base.md
+++ b/pages/api/input-base.md
@@ -82,6 +82,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiInputBase`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Text Fields](/components/text-fields/)

--- a/pages/api/input-base.md
+++ b/pages/api/input-base.md
@@ -84,7 +84,7 @@ you need to use the following style sheet name: `MuiInputBase`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -66,6 +66,10 @@ you need to use the following style sheet name: `MuiInputLabel`.
 The properties of the [FormLabel](/api/form-label/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Text Fields](/components/text-fields/)

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -68,7 +68,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -84,7 +84,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/input.md
+++ b/pages/api/input.md
@@ -82,6 +82,10 @@ you need to use the following style sheet name: `MuiInput`.
 The properties of the [InputBase](/api/input-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Text Fields](/components/text-fields/)

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -68,7 +68,7 @@ you need to use the following style sheet name: `MuiLinearProgress`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/linear-progress.md
+++ b/pages/api/linear-progress.md
@@ -66,6 +66,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiLinearProgress`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Progress](/components/progress/)

--- a/pages/api/link.md
+++ b/pages/api/link.md
@@ -58,7 +58,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/link.md
+++ b/pages/api/link.md
@@ -56,6 +56,10 @@ you need to use the following style sheet name: `MuiLink`.
 The properties of the [Typography](/api/typography/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Breadcrumbs](/components/breadcrumbs/)

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -45,7 +45,7 @@ you need to use the following style sheet name: `MuiListItemAvatar`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/list-item-avatar.md
+++ b/pages/api/list-item-avatar.md
@@ -43,6 +43,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiListItemAvatar`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Lists](/components/lists/)

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -42,6 +42,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiListItemIcon`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Lists](/components/lists/)

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -44,7 +44,7 @@ you need to use the following style sheet name: `MuiListItemIcon`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/list-item-secondary-action.md
+++ b/pages/api/list-item-secondary-action.md
@@ -42,6 +42,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiListItemSecondaryAction`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Lists](/components/lists/)

--- a/pages/api/list-item-secondary-action.md
+++ b/pages/api/list-item-secondary-action.md
@@ -44,7 +44,7 @@ you need to use the following style sheet name: `MuiListItemSecondaryAction`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -53,6 +53,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiListItemText`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Lists](/components/lists/)

--- a/pages/api/list-item-text.md
+++ b/pages/api/list-item-text.md
@@ -55,7 +55,7 @@ you need to use the following style sheet name: `MuiListItemText`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -65,7 +65,7 @@ you need to use the following style sheet name: `MuiListItem`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -63,6 +63,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiListItem`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Lists](/components/lists/)

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -54,7 +54,7 @@ you need to use the following style sheet name: `MuiListSubheader`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/list-subheader.md
+++ b/pages/api/list-subheader.md
@@ -52,6 +52,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiListSubheader`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Grid List](/components/grid-list/)

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -51,7 +51,7 @@ you need to use the following style sheet name: `MuiList`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/list.md
+++ b/pages/api/list.md
@@ -49,6 +49,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiList`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Lists](/components/lists/)

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -53,7 +53,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -51,6 +51,10 @@ you need to use the following style sheet name: `MuiMenuItem`.
 The properties of the [ListItem](/api/list-item/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Autocomplete](/components/autocomplete/)

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -33,7 +33,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/menu-list.md
+++ b/pages/api/menu-list.md
@@ -31,6 +31,10 @@ Any other properties supplied will be provided to the root element ([List](/api/
 The properties of the [List](/api/list/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Menus](/components/menus/)

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -65,7 +65,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -63,6 +63,10 @@ you need to use the following style sheet name: `MuiMenu`.
 The properties of the [Popover](/api/popover/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [App Bar](/components/app-bar/)

--- a/pages/api/mobile-stepper.md
+++ b/pages/api/mobile-stepper.md
@@ -60,6 +60,10 @@ you need to use the following style sheet name: `MuiMobileStepper`.
 The properties of the [Paper](/api/paper/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Steppers](/components/steppers/)

--- a/pages/api/mobile-stepper.md
+++ b/pages/api/mobile-stepper.md
@@ -62,7 +62,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -53,7 +53,7 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -51,6 +51,10 @@ The `ref` is forwarded to the root element.
 
 Any other properties supplied will be provided to the root element (native element).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Modal](/components/modal/)

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -59,6 +59,10 @@ you need to use the following style sheet name: `MuiNativeSelect`.
 The properties of the [Input](/api/input/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Selects](/components/selects/)

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -61,7 +61,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/no-ssr.md
+++ b/pages/api/no-ssr.md
@@ -31,6 +31,10 @@ This component can be useful in a variety of situations:
 The component cannot hold a ref.
 
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [No Ssr](/components/no-ssr/)

--- a/pages/api/no-ssr.md
+++ b/pages/api/no-ssr.md
@@ -33,7 +33,7 @@ The component cannot hold a ref.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/outlined-input.md
+++ b/pages/api/outlined-input.md
@@ -84,6 +84,10 @@ you need to use the following style sheet name: `MuiOutlinedInput`.
 The properties of the [InputBase](/api/input-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Text Fields](/components/text-fields/)

--- a/pages/api/outlined-input.md
+++ b/pages/api/outlined-input.md
@@ -86,7 +86,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -71,6 +71,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiPaper`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Autocomplete](/components/autocomplete/)

--- a/pages/api/paper.md
+++ b/pages/api/paper.md
@@ -73,7 +73,7 @@ you need to use the following style sheet name: `MuiPaper`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -70,6 +70,10 @@ you need to use the following style sheet name: `MuiPopover`.
 The properties of the [Modal](/api/modal/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Menus](/components/menus/)

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -72,7 +72,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -35,7 +35,7 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -33,6 +33,10 @@ The `ref` is forwarded to the root element.
 
 Any other properties supplied will be provided to the root element (native element).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Autocomplete](/components/autocomplete/)

--- a/pages/api/portal.md
+++ b/pages/api/portal.md
@@ -29,7 +29,7 @@ The component cannot hold a ref.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/portal.md
+++ b/pages/api/portal.md
@@ -27,6 +27,10 @@ that exists outside the DOM hierarchy of the parent component.
 The component cannot hold a ref.
 
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Portal](/components/portal/)

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -35,7 +35,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/radio-group.md
+++ b/pages/api/radio-group.md
@@ -33,6 +33,10 @@ Any other properties supplied will be provided to the root element ([FormGroup](
 The properties of the [FormGroup](/api/form-group/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Radio Buttons](/components/radio-buttons/)

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -63,6 +63,10 @@ you need to use the following style sheet name: `MuiRadio`.
 The properties of the [IconButton](/api/icon-button/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Radio Buttons](/components/radio-buttons/)

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -65,7 +65,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -60,5 +60,5 @@ The component cannot hold a ref.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 

--- a/pages/api/root-ref.md
+++ b/pages/api/root-ref.md
@@ -58,3 +58,7 @@ class MyComponent extends React.Component {
 The component cannot hold a ref.
 
 
+## Notes
+
+The component is **not** StrictMode ready.
+

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -69,6 +69,10 @@ you need to use the following style sheet name: `MuiSelect`.
 The properties of the [Input](/api/input/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Selects](/components/selects/)

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -71,7 +71,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -33,6 +33,10 @@ Any other properties supplied will be provided to the root element ([Transition]
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Dialogs](/components/dialogs/)

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -35,7 +35,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/slider.md
+++ b/pages/api/slider.md
@@ -68,7 +68,7 @@ you need to use the following style sheet name: `MuiSlider`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/slider.md
+++ b/pages/api/slider.md
@@ -66,6 +66,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSlider`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Slider](/components/slider/)

--- a/pages/api/snackbar-content.md
+++ b/pages/api/snackbar-content.md
@@ -50,6 +50,10 @@ you need to use the following style sheet name: `MuiSnackbarContent`.
 The properties of the [Paper](/api/paper/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Snackbars](/components/snackbars/)

--- a/pages/api/snackbar-content.md
+++ b/pages/api/snackbar-content.md
@@ -52,7 +52,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -68,6 +68,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSnackbar`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Snackbars](/components/snackbars/)

--- a/pages/api/snackbar.md
+++ b/pages/api/snackbar.md
@@ -70,7 +70,7 @@ you need to use the following style sheet name: `MuiSnackbar`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/speed-dial-action.md
+++ b/pages/api/speed-dial-action.md
@@ -54,6 +54,10 @@ you need to use the following style sheet name: `MuiSpeedDialAction`.
 The properties of the [Tooltip](/api/tooltip/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Speed Dial](/components/speed-dial/)

--- a/pages/api/speed-dial-action.md
+++ b/pages/api/speed-dial-action.md
@@ -56,7 +56,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/speed-dial-icon.md
+++ b/pages/api/speed-dial-icon.md
@@ -48,6 +48,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSpeedDialIcon`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Speed Dial](/components/speed-dial/)

--- a/pages/api/speed-dial-icon.md
+++ b/pages/api/speed-dial-icon.md
@@ -50,7 +50,7 @@ you need to use the following style sheet name: `MuiSpeedDialIcon`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/speed-dial.md
+++ b/pages/api/speed-dial.md
@@ -60,6 +60,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSpeedDial`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Speed Dial](/components/speed-dial/)

--- a/pages/api/speed-dial.md
+++ b/pages/api/speed-dial.md
@@ -62,7 +62,7 @@ you need to use the following style sheet name: `MuiSpeedDial`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -52,6 +52,10 @@ you need to use the following style sheet name: `MuiStepButton`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Steppers](/components/steppers/)

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -54,7 +54,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -52,7 +52,7 @@ you need to use the following style sheet name: `MuiStepConnector`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -50,6 +50,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiStepConnector`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Steppers](/components/steppers/)

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -49,7 +49,7 @@ you need to use the following style sheet name: `MuiStepContent`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -47,6 +47,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiStepContent`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Steppers](/components/steppers/)

--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -49,6 +49,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiStepIcon`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Steppers](/components/steppers/)

--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -51,7 +51,7 @@ you need to use the following style sheet name: `MuiStepIcon`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -60,7 +60,7 @@ you need to use the following style sheet name: `MuiStepLabel`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -58,6 +58,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiStepLabel`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Steppers](/components/steppers/)

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -49,6 +49,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiStep`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Steppers](/components/steppers/)

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -51,7 +51,7 @@ you need to use the following style sheet name: `MuiStep`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -55,6 +55,10 @@ you need to use the following style sheet name: `MuiStepper`.
 The properties of the [Paper](/api/paper/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Steppers](/components/steppers/)

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -57,7 +57,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -59,7 +59,7 @@ you need to use the following style sheet name: `MuiSvgIcon`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/svg-icon.md
+++ b/pages/api/svg-icon.md
@@ -57,6 +57,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiSvgIcon`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Icons](/components/icons/)

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -39,6 +39,10 @@ Any other properties supplied will be provided to the root element ([Drawer](/ap
 The properties of the [Drawer](/api/drawer/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Drawers](/components/drawers/)

--- a/pages/api/swipeable-drawer.md
+++ b/pages/api/swipeable-drawer.md
@@ -41,7 +41,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -71,7 +71,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -69,6 +69,10 @@ you need to use the following style sheet name: `MuiSwitch`.
 The properties of the [IconButton](/api/icon-button/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Switches](/components/switches/)

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -63,7 +63,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -61,6 +61,10 @@ you need to use the following style sheet name: `MuiTab`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tabs](/components/tabs/)

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -45,7 +45,7 @@ you need to use the following style sheet name: `MuiTableBody`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/table-body.md
+++ b/pages/api/table-body.md
@@ -43,6 +43,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTableBody`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tables](/components/tables/)

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -59,6 +59,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTableCell`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tables](/components/tables/)

--- a/pages/api/table-cell.md
+++ b/pages/api/table-cell.md
@@ -61,7 +61,7 @@ you need to use the following style sheet name: `MuiTableCell`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -43,6 +43,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTableFooter`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tables](/components/tables/)

--- a/pages/api/table-footer.md
+++ b/pages/api/table-footer.md
@@ -45,7 +45,7 @@ you need to use the following style sheet name: `MuiTableFooter`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -43,6 +43,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTableHead`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tables](/components/tables/)

--- a/pages/api/table-head.md
+++ b/pages/api/table-head.md
@@ -45,7 +45,7 @@ you need to use the following style sheet name: `MuiTableHead`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -68,6 +68,10 @@ you need to use the following style sheet name: `MuiTablePagination`.
 The properties of the [TableCell](/api/table-cell/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tables](/components/tables/)

--- a/pages/api/table-pagination.md
+++ b/pages/api/table-pagination.md
@@ -70,7 +70,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -50,6 +50,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTableRow`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tables](/components/tables/)

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -52,7 +52,7 @@ you need to use the following style sheet name: `MuiTableRow`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -55,6 +55,10 @@ you need to use the following style sheet name: `MuiTableSortLabel`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tables](/components/tables/)

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -57,7 +57,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -45,6 +45,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTable`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Tables](/components/tables/)

--- a/pages/api/table.md
+++ b/pages/api/table.md
@@ -47,7 +47,7 @@ you need to use the following style sheet name: `MuiTable`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -65,7 +65,7 @@ you need to use the following style sheet name: `MuiTabs`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -63,6 +63,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTabs`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tabs](/components/tabs/)

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -87,7 +87,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/text-field.md
+++ b/pages/api/text-field.md
@@ -85,6 +85,10 @@ Any other properties supplied will be provided to the root element ([FormControl
 The properties of the [FormControl](/api/form-control/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Autocomplete](/components/autocomplete/)

--- a/pages/api/toggle-button-group.md
+++ b/pages/api/toggle-button-group.md
@@ -45,6 +45,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiToggleButtonGroup`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Toggle Button](/components/toggle-button/)

--- a/pages/api/toggle-button-group.md
+++ b/pages/api/toggle-button-group.md
@@ -47,7 +47,7 @@ you need to use the following style sheet name: `MuiToggleButtonGroup`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/toggle-button.md
+++ b/pages/api/toggle-button.md
@@ -55,6 +55,10 @@ you need to use the following style sheet name: `MuiToggleButton`.
 The properties of the [ButtonBase](/api/button-base/) component are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Toggle Button](/components/toggle-button/)

--- a/pages/api/toggle-button.md
+++ b/pages/api/toggle-button.md
@@ -57,7 +57,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -48,6 +48,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiToolbar`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [App Bar](/components/app-bar/)

--- a/pages/api/toolbar.md
+++ b/pages/api/toolbar.md
@@ -50,7 +50,7 @@ you need to use the following style sheet name: `MuiToolbar`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -68,7 +68,7 @@ you need to use the following style sheet name: `MuiTooltip`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/tooltip.md
+++ b/pages/api/tooltip.md
@@ -66,6 +66,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTooltip`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Tooltips](/components/tooltips/)

--- a/pages/api/touch-ripple.md
+++ b/pages/api/touch-ripple.md
@@ -50,5 +50,5 @@ you need to use the following style sheet name: `MuiTouchRipple`.
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 

--- a/pages/api/touch-ripple.md
+++ b/pages/api/touch-ripple.md
@@ -48,3 +48,7 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTouchRipple`.
 
+## Notes
+
+The component is **not** StrictMode ready.
+

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -80,6 +80,10 @@ for more detail.
 If using the `overrides` [key of the theme](/customization/themes/#css),
 you need to use the following style sheet name: `MuiTypography`.
 
+## Notes
+
+The component is StrictMode ready.
+
 ## Demos
 
 - [Breadcrumbs](/components/breadcrumbs/)

--- a/pages/api/typography.md
+++ b/pages/api/typography.md
@@ -82,7 +82,7 @@ you need to use the following style sheet name: `MuiTypography`.
 
 ## Notes
 
-The component is StrictMode ready.
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -35,7 +35,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is **not** StrictMode ready.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -33,6 +33,10 @@ Any other properties supplied will be provided to the root element ([Transition]
 The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
+## Notes
+
+The component is **not** StrictMode ready.
+
 ## Demos
 
 - [Buttons](/components/buttons/)


### PR DESCRIPTION
Adds another section to the component API indicating if a component is StrictMode compatible.

>Notes
>The component is StrictMode ready.

-- https://deploy-preview-15718--material-ui.netlify.com/api/app-bar/#notes

Extended `parseTest` to (naively) find if the passed `mount` was created with StrictMode enabled. AST transformer was built based on the following code: https://astexplorer.net/#/gist/a311c5f6266c9012458896de80727bee/4a648bddfc95cf8f7cebe148e6f0aa565851edbe
Should cover all current patterns. The more mounts are used in a test and the more convoluted their bindings the less likely it is we can correctly determine if a component is actually StrictMode compatible. But that's the nature of AST analysis and less convoluted code helps humans as much as computers.

TODO:
- [x] improve wording/links for StrictMode compat