### PR TITLE
[core] Add missing fontStyle type to TypographyStyle

### DIFF
--- a/docs/src/pages/customization/typography/TypographyTheme.tsx
+++ b/docs/src/pages/customization/typography/TypographyTheme.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import { createMuiTheme, makeStyles } from '@material-ui/core/styles';
+import { createMuiTheme, makeStyles, createStyles } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles({
-  root: {
-    display: 'flex',
-  },
-});
+const useStyles = makeStyles(
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+  }),
+);
 
 const theme = createMuiTheme({
   typography: {

--- a/packages/material-ui/src/styles/createTypography.d.ts
+++ b/packages/material-ui/src/styles/createTypography.d.ts
@@ -31,7 +31,7 @@ export interface FontStyleOptions extends Partial<FontStyle> {
 }
 
 export type TypographyStyle = Required<
-  Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'color'>
+  Pick<CSSProperties, 'fontFamily' | 'fontSize' | 'fontWeight' | 'fontStyle' | 'color'>
 > &
   Partial<Pick<CSSProperties, 'letterSpacing' | 'lineHeight' | 'textTransform'>>;
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

* Add `fontStyle` to `createTypography.d.ts`
* Add TypeScript version of the `TypographyTheme` demo
* Switch to `makeStyles`