### PR TITLE
[docs] Fix Algolia top level duplication

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -102,7 +102,7 @@ class Ad extends React.Component {
 
     return (
       <span className={classes.root}>
-        {this.random >= 0.9 ? <AdCodeFund /> : <AdCarbon />}
+        {this.random >= 0.8 ? <AdCodeFund /> : <AdCarbon />}
         {adblock === true ? getAdblock(classes, t) : null}
         {adblock === false ? (
           <Tooltip id="ad-info" title={t('adTitle')} placement="left">

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -99,12 +99,16 @@ function reduceChildRoutes({ props, activePage, items, page, depth, t }) {
 
   if (page.children && page.children.length > 1) {
     const title = pageToTitleI18n(page, t);
-    const openImmediately = Boolean(
-      page.subheader || activePage.pathname.indexOf(`${page.pathname}/`) === 0,
-    );
+    const topLevel = activePage.pathname.indexOf(`${page.pathname}/`) === 0;
 
     items.push(
-      <AppDrawerNavItem depth={depth} key={title} openImmediately={openImmediately} title={title}>
+      <AppDrawerNavItem
+        depth={depth}
+        key={title}
+        topLevel={topLevel && !page.subheader}
+        openImmediately={topLevel}
+        title={title}
+      >
         {renderNavItems({ props, pages: page.children, activePage, depth: depth + 1, t })}
       </AppDrawerNavItem>,
     );

--- a/docs/src/modules/components/AppDrawerNavItem.js
+++ b/docs/src/modules/components/AppDrawerNavItem.js
@@ -41,9 +41,18 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function AppDrawerNavItem(props) {
-  const { children, depth, href, onClick, openImmediately, title, ...other } = props;
-  const [open, setOpen] = React.useState(openImmediately);
+  const {
+    children,
+    depth,
+    href,
+    onClick,
+    openImmediately = false,
+    topLevel = false,
+    title,
+    ...other
+  } = props;
   const classes = useStyles();
+  const [open, setOpen] = React.useState(openImmediately);
 
   const handleClick = () => {
     setOpen(oldOpen => !oldOpen);
@@ -77,7 +86,7 @@ function AppDrawerNavItem(props) {
       <Button
         classes={{
           root: classes.button,
-          label: openImmediately ? 'algolia-lvl0' : '',
+          label: topLevel ? 'algolia-lvl0' : '',
         }}
         onClick={handleClick}
         style={style}
@@ -98,10 +107,7 @@ AppDrawerNavItem.propTypes = {
   onClick: PropTypes.func,
   openImmediately: PropTypes.bool,
   title: PropTypes.string.isRequired,
-};
-
-AppDrawerNavItem.defaultProps = {
-  openImmediately: false,
+  topLevel: PropTypes.bool,
 };
 
 export default AppDrawerNavItem;

--- a/docs/src/pages/components/click-away-listener/click-away-listener.md
+++ b/docs/src/pages/components/click-away-listener/click-away-listener.md
@@ -1,17 +1,17 @@
 ---
-title: Click away listener React component
+title: Detect click outside React component
 components: ClickAwayListener
 ---
 
 # Click away listener
 
-<p class="description">Listen for click events that occur somewhere in the document, outside of the element itself.</p>
+<p class="description">Detect if a click event happened outside of an element. It listens for clicks that occur somewhere in the document.</p>
 
 - 📦 [1.4 kB gzipped](/size-snapshot).
 
-## Simple menu
+## Simple menu dropdown
 
-For instance, if you need to hide a menu when people click anywhere else on your page:
+For instance, if you need to hide a menu dropdown when people click anywhere else on your page:
 
 {{"demo": "pages/components/click-away-listener/ClickAway.js"}}
 

--- a/docs/src/pages/components/click-away-listener/click-away-listener.md
+++ b/docs/src/pages/components/click-away-listener/click-away-listener.md
@@ -7,6 +7,8 @@ components: ClickAwayListener
 
 <p class="description">Listen for click events that occur somewhere in the document, outside of the element itself.</p>
 
+- 📦 [1.4 kB gzipped](/size-snapshot).
+
 ## Simple menu
 
 For instance, if you need to hide a menu when people click anywhere else on your page:

--- a/docs/src/pages/components/tabs/CustomizedTabs.js
+++ b/docs/src/pages/components/tabs/CustomizedTabs.js
@@ -4,29 +4,6 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Typography from '@material-ui/core/Typography';
 
-const StyledTabs = withStyles({
-  indicator: {
-    display: 'flex',
-    justifyContent: 'center',
-    backgroundColor: 'transparent',
-    '& > div': {
-      maxWidth: 40,
-      width: '100%',
-      backgroundColor: '#635ee7',
-    },
-  },
-})(props => <Tabs {...props} TabIndicatorProps={{ children: <div /> }} />);
-
-const StyledTab = withStyles(theme => ({
-  root: {
-    textTransform: 'none',
-    color: '#fff',
-    fontWeight: theme.typography.fontWeightRegular,
-    fontSize: theme.typography.pxToRem(15),
-    marginRight: theme.spacing(1),
-  },
-}))(props => <Tab disableRipple {...props} />);
-
 const AntTabs = withStyles({
   root: {
     borderBottom: '1px solid #e8e8e8',
@@ -67,6 +44,32 @@ const AntTab = withStyles(theme => ({
     },
   },
   selected: {},
+}))(props => <Tab disableRipple {...props} />);
+
+const StyledTabs = withStyles({
+  indicator: {
+    display: 'flex',
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+    '& > div': {
+      maxWidth: 40,
+      width: '100%',
+      backgroundColor: '#635ee7',
+    },
+  },
+})(props => <Tabs {...props} TabIndicatorProps={{ children: <div /> }} />);
+
+const StyledTab = withStyles(theme => ({
+  root: {
+    textTransform: 'none',
+    color: '#fff',
+    fontWeight: theme.typography.fontWeightRegular,
+    fontSize: theme.typography.pxToRem(15),
+    marginRight: theme.spacing(1),
+    '&:focus': {
+      opacity: 1,
+    },
+  },
 }))(props => <Tab disableRipple {...props} />);
 
 const useStyles = makeStyles(theme => ({

--- a/docs/src/pages/components/tabs/CustomizedTabs.tsx
+++ b/docs/src/pages/components/tabs/CustomizedTabs.tsx
@@ -4,40 +4,6 @@ import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Typography from '@material-ui/core/Typography';
 
-interface StyledTabsProps {
-  value: number;
-  onChange: (event: React.ChangeEvent<{}>, newValue: number) => void;
-}
-
-const StyledTabs = withStyles({
-  indicator: {
-    display: 'flex',
-    justifyContent: 'center',
-    backgroundColor: 'transparent',
-    '& > div': {
-      maxWidth: 40,
-      width: '100%',
-      backgroundColor: '#635ee7',
-    },
-  },
-})((props: StyledTabsProps) => <Tabs {...props} TabIndicatorProps={{ children: <div /> }} />);
-
-interface StyledTabProps {
-  label: string;
-}
-
-const StyledTab = withStyles((theme: Theme) =>
-  createStyles({
-    root: {
-      textTransform: 'none',
-      color: '#fff',
-      fontWeight: theme.typography.fontWeightRegular,
-      fontSize: theme.typography.pxToRem(15),
-      marginRight: theme.spacing(1),
-    },
-  }),
-)((props: StyledTabProps) => <Tab disableRipple {...props} />);
-
 const AntTabs = withStyles({
   root: {
     borderBottom: '1px solid #e8e8e8',
@@ -79,6 +45,43 @@ const AntTab = withStyles((theme: Theme) =>
       },
     },
     selected: {},
+  }),
+)((props: StyledTabProps) => <Tab disableRipple {...props} />);
+
+interface StyledTabsProps {
+  value: number;
+  onChange: (event: React.ChangeEvent<{}>, newValue: number) => void;
+}
+
+const StyledTabs = withStyles({
+  indicator: {
+    display: 'flex',
+    justifyContent: 'center',
+    backgroundColor: 'transparent',
+    '& > div': {
+      maxWidth: 40,
+      width: '100%',
+      backgroundColor: '#635ee7',
+    },
+  },
+})((props: StyledTabsProps) => <Tabs {...props} TabIndicatorProps={{ children: <div /> }} />);
+
+interface StyledTabProps {
+  label: string;
+}
+
+const StyledTab = withStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      textTransform: 'none',
+      color: '#fff',
+      fontWeight: theme.typography.fontWeightRegular,
+      fontSize: theme.typography.pxToRem(15),
+      marginRight: theme.spacing(1),
+      '&:focus': {
+        opacity: 1,
+      },
+    },
   }),
 )((props: StyledTabProps) => <Tab disableRipple {...props} />);
 

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -100,7 +100,7 @@ async function getSizeLimitBundles() {
       // vs https://bundlephobia.com/result?p=react-outside-click-handler
       name: '@material-ui/core/ClickAwayListener',
       webpack: true,
-      path: 'packages/material-ui/build/esm/ClickAwayListener.js',
+      path: 'packages/material-ui/build/esm/ClickAwayListener/index.js',
     },
     {
       name: 'docs.main',

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -97,6 +97,12 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui/build/esm/InputBase/Textarea.js',
     },
     {
+      // vs https://bundlephobia.com/result?p=react-outside-click-handler
+      name: '@material-ui/core/ClickAwayListener',
+      webpack: true,
+      path: 'packages/material-ui/build/esm/ClickAwayListener.js',
+    },
+    {
       name: 'docs.main',
       webpack: false,
       path: main.path,

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -97,12 +97,6 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui/build/esm/InputBase/Textarea.js',
     },
     {
-      // vs https://bundlephobia.com/result?p=react-outside-click-handler
-      name: '@material-ui/core/ClickAwayListener',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/ClickAwayListener/index.js',
-    },
-    {
       name: 'docs.main',
       webpack: false,
       path: main.path,


### PR DESCRIPTION
- It should only display "Components", not "Components noise noise noise noise noise etc.":

![Capture d’écran 2019-05-18 à 00 25 19](https://user-images.githubusercontent.com/3165635/57964432-723d6600-7903-11e9-8a02-825de91fc9d4.png)

- Increase CodeFund ad split share to 20% as they seem to perform well, let's see.
- Fix a focus style issue with a customization demo.
- Keep track of the bundle size of ClickAwayListener.
`@material-ui/core/ClickAwayListener	+Infinity% 🔺	+Infinity% 🔺	0	3,586	0	1,477`