### PR TITLE
[docs] Overhaul bundle size guide

### DIFF
--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -102,7 +102,7 @@ Pick one of the following plugins:
 
 The package published on npm is **transpiled**, with [Babel](https://github.com/babel/babel), to take into account the [supported platforms](/getting-started/supported-platforms/).
 
-We also publish a second version of the components to target **evergreen browsers**.
+We also publish a second version of the components.
 You can find this version under the [`/es` folder](https://unpkg.com/@material-ui/core@next/es/).
 All the non-official syntax is transpiled to the [ECMA-262 standard](https://www.ecma-international.org/publications/standards/Ecma-262.htm), nothing more.
 This can be used to make separate bundles targeting different browsers.

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -12,14 +12,23 @@ Combined with [dangerJS](https://danger.systems/js/) we can inspect
 ## How to reduce the bundle size?
 
 For convenience, Material-UI exposes its full API on the top-level `material-ui` import.
-Using this is fine if you have tree shaking working,
-however, in the case where tree shaking is not supported or configured in your build chain, **this causes the entire library and its dependencies to be included** in your client bundle.
+If you're using ES 6 modules and a bundler that supports tree-shaking ([`webpack` >= 2.x](https://webpack.js.org/guides/tree-shaking/), [`parcel` with a flag](https://en.parceljs.org/cli.html#enable-experimental-scope-hoisting/tree-shaking-support)) you can safely
+use named imports and expect only a minimal set of Material-UI components in your bundle:
 
-You have couple of options to overcome this situation:
+```js
+import { Button, TextField } from '@material-ui/core';
+```
+
+Be aware that tree-shaking is an optimization that is usually only applied on production
+bundles. Development bundles will contain the full library which can lead to slower
+startup times. This is especially noticeable if you import from `@material-ui/icons`.
+Startup times can be approximately 6x slower than without named imports from the top-level API.
+
+If this is an issue for you you have various options:
 
 ### Option 1
 
-You can import directly from `material-ui/` to avoid pulling in unused modules. For instance, instead of:
+You can use paths imports to avoid pulling in unused modules. For instance, instead of:
 
 ```js
 import { Button, TextField } from '@material-ui/core';
@@ -33,24 +42,61 @@ import TextField from '@material-ui/core/TextField';
 ```
 
 While importing directly in this manner doesn't use the exports in [`@material-ui/core/index.js`](https://github.com/mui-org/material-ui/blob/next/packages/material-ui/src/index.js), this file can serve as a handy reference as to which modules are public.
-Anything not listed there should be considered **private**, and subject to change without notice.
-For example, the `Tabs` component is a public module while `TabIndicator` is private.
+
+Be aware that we only support first and second leve imports. Anything below is considered
+private and can cause module duplication in your bundle.
+
+````js
+// OK
+import { Add as AddIcon } from '@material-ui/icons';
+import { Tabs } from '@material-ui/core';
+//                                 ^^^^ 1st or top-level
+
+// OK
+import AddIcon from '@material-ui/icons/Add';
+import Tabs from '@material-ui/core/Tabs';
+//                                  ^^^^ 2nd level
+
+// NOT OK
+import TabIndicator from '@material-ui/core/Tabs/TabIndicator';
+//                                               ^^^^^^^^^^^^ 3rd level
+
 
 ### Option 2
 
-Another option is to keep using the shortened import like the following, but still have the size of the bundle optimized thanks to a **Babel plugin**:
+**Important note**:
+This is only supported for `@material-ui/icons`. We recommend this approach if
+you often restart your development build.
 
-```js
-import { Button, TextField } from '@material-ui/core';
-```
+Another option is to keep using named imports, but still have shorter
+start up times by using `babel` plugins.
 
 Pick one of the following plugins:
 
-- [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) is quite customizable and with enough tweaks works with Material-UI.
-- [babel-transform-imports](https://bitbucket.org/amctheatres/babel-transform-imports) has a different api than a `babel-plugin-import` but does same thing.
-- [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) aims to work out of the box with all the `package.json`.
-
-**Important note**: Both of these options *should be temporary* until you add tree shaking capabilities to your project.
+- [babel-plugin-import](https://github.com/ant-design/babel-plugin-import) with the following configuration:
+  ```js
+  [
+    'babel-plugin-import',
+    {
+      libraryName: '@material-ui/icons',
+      libraryDirectory: 'esm', // or '' if your bundler does not support ES modules
+      camel2DashComponentName: false,
+    },
+  ];
+  ```
+- [babel-plugin-transform-imports](https://www.npmjs.com/package/babel-plugin-transform-import) has a different api than `babel-plugin-import` but does same thing.
+  ```js
+  [
+    'transform-imports',
+    {
+      '@material-ui/icons': {
+        transform: '@material-ui/icons/esm/${member}',
+        // for bundlers not supporting ES modules use:
+        // transform: '@material-ui/icons/${member}',
+      },
+    },
+  ];
+  ```
 
 ## ECMAScript
 
@@ -67,3 +113,4 @@ necessary features. If you need support for other browsers, consider using
 [`@babel/polyfill`](https://www.npmjs.com/package/@babel/polyfill).
 
 ⚠️ In order to minimize duplication of code in users' bundles, we **strongly discourage** library authors from using the `/es` folder.
+````

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -28,7 +28,7 @@ If this is an issue for you you have various options:
 
 ### Option 1
 
-You can use paths imports to avoid pulling in unused modules. For instance, instead of:
+You can use path imports to avoid pulling in unused modules. For instance, instead of:
 
 ```js
 import { Button, TextField } from '@material-ui/core';

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -19,7 +19,7 @@ use named imports and expect only a minimal set of Material-UI components in you
 import { Button, TextField } from '@material-ui/core';
 ```
 
-Be aware that tree-shaking is an optimization that is usually only applied on production
+Be aware that tree-shaking is an optimization that is usually only applied to production
 bundles. Development bundles will contain the full library which can lead to slower
 startup times. This is especially noticeable if you import from `@material-ui/icons`.
 Startup times can be approximately 6x slower than without named imports from the top-level API.

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -46,7 +46,7 @@ While importing directly in this manner doesn't use the exports in [`@material-u
 Be aware that we only support first and second leve imports. Anything below is considered
 private and can cause module duplication in your bundle.
 
-````js
+```js
 // OK
 import { Add as AddIcon } from '@material-ui/icons';
 import { Tabs } from '@material-ui/core';
@@ -60,13 +60,12 @@ import Tabs from '@material-ui/core/Tabs';
 // NOT OK
 import TabIndicator from '@material-ui/core/Tabs/TabIndicator';
 //                                               ^^^^^^^^^^^^ 3rd level
-
+```
 
 ### Option 2
 
-**Important note**:
-This is only supported for `@material-ui/icons`. We recommend this approach if
-you often restart your development build.
+**Important note**: This is only supported for `@material-ui/icons`.
+We recommend this approach if you often restart your development build.
 
 Another option is to keep using named imports, but still have shorter
 start up times by using `babel` plugins.
@@ -113,4 +112,3 @@ necessary features. If you need support for other browsers, consider using
 [`@babel/polyfill`](https://www.npmjs.com/package/@babel/polyfill).
 
 ⚠️ In order to minimize duplication of code in users' bundles, we **strongly discourage** library authors from using the `/es` folder.
-````


### PR DESCRIPTION
Focus on tree-shaking being default behavior and dev build implications (thanks to @rosskevin) and how to fix possible issues for those.

Removed `babel-plugin-lodash` since we already document 2 options and the name implies it might stop working any time. Added configuration for the other plugins that were tested in [eps1lon/material-ui-tree-shaking-options](https://github.com/eps1lon/material-ui-tree-shaking-options).
