### PR TITLE
[docs] Core a11y improvements

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -90,7 +90,7 @@ const styles = theme => ({
     padding: 4,
     textAlign: 'center',
     backgroundColor: theme.palette.primary.dark,
-    color: theme.palette.getContrastText(theme.palette.primary.dark),
+    color: theme.palette.primary.contrastText,
   },
   grow: {
     flex: '1 1 auto',

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -90,7 +90,7 @@ const styles = theme => ({
     padding: 4,
     textAlign: 'center',
     backgroundColor: theme.palette.primary.dark,
-    color: theme.palette.primary.contrastText,
+    color: theme.palette.getContrastText(theme.palette.primary.dark),
   },
   grow: {
     flex: '1 1 auto',

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -47,7 +47,6 @@ function initDocsearch(userLanguage) {
     }
 
     initialized = docsearchInput;
-    const ariaLabel = docsearchInput.getAttribute('aria-label');
     window.docsearch({
       apiKey: '1d8534f83b9b0cfea8f16498d19fbcab',
       indexName: 'material-ui',
@@ -63,8 +62,6 @@ function initDocsearch(userLanguage) {
       },
       // debug: true, // Set debug to true if you want to inspect the dropdown.
     });
-    // https://github.com/algolia/docsearch/issues/418
-    docsearchInput.setAttribute('aria-label', ariaLabel);
   }, 100);
 }
 

--- a/docs/src/modules/components/prism.js
+++ b/docs/src/modules/components/prism.js
@@ -14,8 +14,8 @@ let lightTheme;
 let darkTheme;
 
 if (process.browser) {
-  lightTheme = require('prismjs/themes/prism.css');
-  darkTheme = require('prismjs/themes/prism-okaidia.css');
+  lightTheme = require('prism-themes/themes/prism-ghcolors.css');
+  darkTheme = require('prism-themes/themes/prism-atom-dark.css');
 
   styleNode = document.createElement('style');
   styleNode.setAttribute('data-prism', 'true');

--- a/docs/src/modules/styles/getTheme.js
+++ b/docs/src/modules/styles/getTheme.js
@@ -12,6 +12,7 @@ function getTheme(uiTheme) {
       background: {
         default: uiTheme.paletteType === 'light' ? '#fff' : '#303030',
       },
+      contrastThreshold: 4.5,
     },
   });
 

--- a/docs/src/modules/styles/getTheme.js
+++ b/docs/src/modules/styles/getTheme.js
@@ -12,7 +12,6 @@ function getTheme(uiTheme) {
       background: {
         default: uiTheme.paletteType === 'light' ? '#fff' : '#303030',
       },
-      contrastThreshold: 4.5,
     },
   });
 

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "nyc": "^13.0.0",
     "postcss": "^7.0.0",
     "prettier": "^1.8.2",
+    "prism-themes": "^1.1.0",
     "prop-types": "^15.7.2",
     "puppeteer": "^1.5.0",
     "raw-loader": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10906,6 +10906,11 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+prism-themes@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/prism-themes/-/prism-themes-1.1.0.tgz#9f4fadf0c9c7ee415773717ea69c2aaa25aedbfd"
+  integrity sha512-xBkflbKbstGGasW3P68KQzAuObLQeH//I5mn37jKVHVDrRLp4Xct/n8F/tV5h+CKIMa3nDAZ2q0bt8ItSiS72A==
+
 prismjs@^1.8.4:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.16.0.tgz#406eb2c8aacb0f5f0f1167930cb83835d10a4308"


### PR DESCRIPTION
Mainly legibility improvements. One thing I noticed is it that the whole dark/light switch doesn't work very well. Dark themes work better with lighter shades. The new  [material dark theme guide](https://material.io/design/color/dark-theme.html#ui-application) recommends 50-200 for dark themes and 500+ for light themes. But this is more of a concern for theme authors.