### PR TITLE
update type definition for ListItem.

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -20,7 +20,7 @@ export interface ListItemTypeMap<P, D extends React.ElementType> {
 }
 
 declare const ListItem: OverridableComponent<ListItemTypeMap<{ button?: false }, 'li'>> &
-  ExtendButtonBase<ListItemTypeMap<{ button: true }, 'div'>>;
+  ExtendButtonBase<ListItemTypeMap<{ button?: true }, 'div'>>;
 
 export type ListItemClassKey =
   | 'root'


### PR DESCRIPTION
The current `type` definition show error when using LitsItem and not passing the `button` flag. Which is very obvious from the below line:
```
declare const ListItem: OverridableComponent<ListItemTypeMap<{ button?: false }, 'li'>> &
  ExtendButtonBase<ListItemTypeMap<{ button: true }, 'div'>>;
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

> `button` as `false`

![image](https://user-images.githubusercontent.com/515011/58098389-1a4e7a00-7bf7-11e9-8669-5c21dc1b0b15.png)
> Not passisng it

![image](https://user-images.githubusercontent.com/515011/58117177-9bb80380-7c1b-11e9-8004-3a1114b570d1.png)
