### PR TITLE
[system] Add missing TypeScript types for display, flexbox positions, shadows

### DIFF
--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -12,7 +12,7 @@ interface WithTheme<Theme extends object> {
 export type PropsFor<SomeStyleFunction> = SomeStyleFunction extends StyleFunction<infer Props>
   ? Props
   : never;
-export type StyleFunction<Props> = (props: Props) => any;
+export type StyleFunction<Props> = (props: Props & { theme?: any }) => any;
 type SimpleStyleFunction<PropKey extends keyof any> = StyleFunction<Partial<Record<PropKey, any>>>;
 
 // borders.js
@@ -61,9 +61,21 @@ export function css<Props>(
   styleFunction: StyleFunction<Props>,
 ): StyleFunction<Props & { css: Omit<Props, 'theme'> }>;
 
-// default display.js TODO
+export const display: SimpleStyleFunction<'display' | 'displayPrint'>;
+export type DisplayProps = PropsFor<typeof display>;
 
-// * flexbox.js TODO
+export const flexbox: SimpleStyleFunction<
+  | 'flexboxDirection'
+  | 'flexWrap'
+  | 'justifyContent'
+  | 'alignItems'
+  | 'alignContent'
+  | 'order'
+  | 'flexGrow'
+  | 'flexShrink'
+  | 'alignSelf'
+>
+export type FlexboxProps = PropsFor<typeof flexbox>;
 
 // palette.js
 export const color: SimpleStyleFunction<'color'>;
@@ -71,9 +83,13 @@ export const bgcolor: SimpleStyleFunction<'bgcolor'>;
 export const palette: SimpleStyleFunction<'bgcolor' | 'color'>;
 export type PaletteProps = PropsFor<typeof palette>;
 
-// * positions.js TODO
+export const positions: SimpleStyleFunction<
+  'zIndex' | 'position' | 'top' | 'right' | 'bottom' | 'left'
+>
+export type PositionsProps = PropsFor<typeof positions>;
 
-// default shadows.js TODO
+export const shadows: SimpleStyleFunction<'boxShadow'>
+export type ShadowsProps = PropsFor<typeof shadows>;
 
 // * sizing.js TODO
 export const width: SimpleStyleFunction<'width'>;

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -153,7 +153,7 @@ export interface StyleOptions<PropKey, Theme extends object> {
 }
 export function style<PropKey extends string, Theme extends object>(
   options: StyleOptions<PropKey, Theme>,
-): StyleFunction<{ [K in PropKey]: unknown }>;
+): StyleFunction<{ [K in PropKey]: unknown } & { theme: Theme }>;
 
 // typography.js
 export const fontFamily: SimpleStyleFunction<'fontFamily'>;

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -74,7 +74,7 @@ export const flexbox: SimpleStyleFunction<
   | 'flexGrow'
   | 'flexShrink'
   | 'alignSelf'
->
+>;
 export type FlexboxProps = PropsFor<typeof flexbox>;
 
 // palette.js
@@ -85,10 +85,10 @@ export type PaletteProps = PropsFor<typeof palette>;
 
 export const positions: SimpleStyleFunction<
   'zIndex' | 'position' | 'top' | 'right' | 'bottom' | 'left'
->
+>;
 export type PositionsProps = PropsFor<typeof positions>;
 
-export const shadows: SimpleStyleFunction<'boxShadow'>
+export const shadows: SimpleStyleFunction<'boxShadow'>;
 export type ShadowsProps = PropsFor<typeof shadows>;
 
 // * sizing.js TODO

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -12,7 +12,7 @@ interface WithTheme<Theme extends object> {
 export type PropsFor<SomeStyleFunction> = SomeStyleFunction extends StyleFunction<infer Props>
   ? Props
   : never;
-export type StyleFunction<Props> = (props: Props & { theme?: any }) => any;
+export type StyleFunction<Props> = (props: Props) => any;
 type SimpleStyleFunction<PropKey extends keyof any> = StyleFunction<Partial<Record<PropKey, any>>>;
 
 // borders.js
@@ -153,7 +153,7 @@ export interface StyleOptions<PropKey, Theme extends object> {
 }
 export function style<PropKey extends string, Theme extends object>(
   options: StyleOptions<PropKey, Theme>,
-): StyleFunction<{ [K in PropKey]: unknown } & { theme: Theme }>;
+): StyleFunction<{ [K in PropKey]: unknown }>;
 
 // typography.js
 export const fontFamily: SimpleStyleFunction<'fontFamily'>;


### PR DESCRIPTION
Adds display, flexbox, positions and shadows style functions and props.

I've tried to follow from where @eps1lon left off but might be a bit off the mark (wondering if there's a reason these were still todo?).
