### PR TITLE
[codemod] Create spacing api codemod

### DIFF
--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -145,6 +145,9 @@ yarn add @material-ui/styles@next
 
   *Tip: you can provide more than 1 argument: theme.spacing(1, 2) // = '8px 16px'*
 
+  You can use [the migration helper](https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod) on your project to make this smoother.
+
+
 ### Layout
 
 - [Grid] In order to support arbitrary spacing values and to remove the need to mentally count by 8, we are changing the spacing API:

--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -145,8 +145,7 @@ yarn add @material-ui/styles@next
 
   *Tip: you can provide more than 1 argument: theme.spacing(1, 2) // = '8px 16px'*
 
-  You can use [the migration helper](https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod) on your project to make this smoother.
-
+  You can use [the migration helper](https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod/README.md#theme-spacing-api) on your project to make this smoother.
 
 ### Layout
 

--- a/packages/material-ui-codemod/README.md
+++ b/packages/material-ui-codemod/README.md
@@ -19,6 +19,33 @@ APIs.
 
 ## Included Scripts
 
+### v4.0.0
+
+#### `theme-spacing-api`
+
+Updates the `theme-spacing-api` from `theme.spacing.unit x` to `theme.spacing(x)`.
+The diff should look like this:
+
+```diff
+-const spacing = theme.spacing.unit;
++const spacing = theme.spacing(1);
+```
+
+```sh
+find src -name '*.js' -print | xargs jscodeshift -t node_modules/@material-ui/codemod/lib/v4.0.0/theme-spacing-api.js
+```
+
+This codemod tries to perform a basic expression simplification which can be improved for expressions that use more than one operation.
+
+```diff
+-const spacing = theme.spacing.unit / 5;
++const spacing = theme.spacing(0.2);
+
+// Limitation
+-const spacing = theme.spacing.unit * 5 * 5;
++const spacing = theme.spacing(5) * 5;
+```
+
 ### v1.0.0
 
 #### `import-path`

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.js
@@ -1,0 +1,56 @@
+/**
+ * Update all `theme.spacing.unit` usages to use `theme.spacing()`.
+ * Find and replace string literal AST nodes to ensure all spacing API usages get updated, regardless
+ * of any calculation being performed.
+ * @param {jscodeshift_api_object} j
+ * @param {jscodeshift_ast_object} root
+ */
+function transformThemeSpacingApi(j, root) {
+  const spacingPath = root.find(j.MemberExpression, {
+    object: {
+      object: {
+        name: 'theme',
+      },
+      property: {
+        name: 'spacing',
+      },
+    },
+    property: {
+      name: 'unit',
+    },
+  });
+
+  spacingPath.replaceWith(path => {
+    let mathPart = null;
+
+    if (j.BinaryExpression.check(path.parent.node)) {
+      const expression = path.parent.node;
+      const operation = expression.operator;
+      const value = expression.right.value;
+      if (operation === '*' || operation === '/') {
+        mathPart = eval(`1 ${operation} ${value}`);
+      }
+    }
+
+    if (mathPart) {
+      path.parent.replace(
+        j.callExpression(j.memberExpression(j.identifier('theme'), j.identifier('spacing')), [
+          j.literal(mathPart),
+        ]),
+      );
+    } else {
+      return j.callExpression(j.memberExpression(j.identifier('theme'), j.identifier('spacing')), [
+        j.literal(1),
+      ]);
+    }
+  });
+}
+
+module.exports = function transformer(fileInfo, api) {
+  const j = api.jscodeshift;
+  const root = j(fileInfo.source);
+
+  // transforms
+  transformThemeSpacingApi(j, root);
+  return root.toSource({ quote: 'single' });
+};

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
@@ -19,7 +19,7 @@ describe('@material-ui/codemod', () => {
       it('update theme spacing API', () => {
         const actual = transform(
           { source: read('./theme-spacing-api.test/actual.js') },
-          { jscodeshift: jscodeshift },
+          { jscodeshift },
         );
 
         const expected = read('./theme-spacing-api.test/expected.js');

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import path from 'path';
+import { assert } from 'chai';
+import jscodeshift from 'jscodeshift';
+import transform from './theme-spacing-api';
+
+function trim(str) {
+  return str.replace(/^\s+|\s+$/, '');
+}
+
+function read(fileName) {
+  return fs.readFileSync(path.join(__dirname, fileName), 'utf8').toString();
+}
+
+describe('@material-ui/codemod', () => {
+  describe('v5.0.0', () => {
+    describe('theme-spacing', () => {
+      it('update theme spacing API', () => {
+        const actual = transform(
+          { source: read('./theme-spacing-api.test/actual.js') },
+          { jscodeshift: jscodeshift },
+        );
+
+        const expected = read('./theme-spacing-api.test/expected.js');
+
+        assert.strictEqual(
+          trim(actual),
+          trim(expected),
+          'The transformed version should be correct',
+        );
+      });
+    });
+  });
+});

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
@@ -1,11 +1,12 @@
 import fs from 'fs';
 import path from 'path';
+import { EOL } from 'os';
 import { assert } from 'chai';
 import jscodeshift from 'jscodeshift';
 import transform from './theme-spacing-api';
 
 function trim(str) {
-  return str.replace(/^\s+|\s+$/, '');
+  return str.replace(/^\s+|\s+$/, '').replace(/\r*\n/g, EOL);
 }
 
 function read(fileName) {
@@ -13,7 +14,7 @@ function read(fileName) {
 }
 
 describe('@material-ui/codemod', () => {
-  describe('v5.0.0', () => {
+  describe('v4.0.0', () => {
     describe('theme-spacing', () => {
       it('update theme spacing API', () => {
         const actual = transform(

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
@@ -1,0 +1,19 @@
+const spacingAlone = theme => ({
+  spacing: theme.spacing.unit,
+});
+
+const spacingMultiply = theme => ({
+  spacing: theme.spacing.unit * 5,
+});
+
+const spacingDivide = theme => ({
+  spacing: theme.spacing.unit / 5,
+});
+
+const spacingAdd = theme => ({
+  spacing: theme.spacing.unit + 5,
+});
+
+const spacingSubtract = theme => ({
+  spacing: theme.spacing.unit - 5,
+});

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
@@ -23,3 +23,13 @@ const variable = 3;
 const spacingVariable = theme => ({
   spacing: theme.spacing.unit * variable,
 });
+
+const spacingParamNameChange = muiTheme => ({
+  spacing: muiTheme.spacing.unit,
+});
+
+function styleFunction(theme) {
+  return {
+    spacing: theme.spacing.unit,
+  };
+}

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
@@ -33,3 +33,8 @@ function styleFunction(theme) {
     spacing: theme.spacing.unit,
   };
 }
+
+const theme = {};
+const shouldntTouch = theme.spacing.unit;
+
+const styles = muiTheme => ({ root: { spacing: muiTheme.spacing.unit } });

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
@@ -17,3 +17,9 @@ const spacingAdd = theme => ({
 const spacingSubtract = theme => ({
   spacing: theme.spacing.unit - 5,
 });
+
+const variable = 3;
+
+const spacingVariable = theme => ({
+  spacing: theme.spacing.unit * variable,
+});

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual.js
@@ -38,3 +38,7 @@ const theme = {};
 const shouldntTouch = theme.spacing.unit;
 
 const styles = muiTheme => ({ root: { spacing: muiTheme.spacing.unit } });
+
+const longChain = theme => ({
+  spacing: theme.spacing.unit * 5 * 5,
+});

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
@@ -1,0 +1,19 @@
+const spacingAlone = theme => ({
+  spacing: theme.spacing(1),
+});
+
+const spacingMultiply = theme => ({
+  spacing: theme.spacing(5),
+});
+
+const spacingDivide = theme => ({
+  spacing: theme.spacing(0.2),
+});
+
+const spacingAdd = theme => ({
+  spacing: theme.spacing(1) + 5,
+});
+
+const spacingSubtract = theme => ({
+  spacing: theme.spacing(1) - 5,
+});

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
@@ -38,3 +38,7 @@ const theme = {};
 const shouldntTouch = theme.spacing.unit;
 
 const styles = muiTheme => ({ root: { spacing: muiTheme.spacing(1) } });
+
+const longChain = theme => ({
+  spacing: theme.spacing(5) * 5,
+});

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
@@ -23,3 +23,13 @@ const variable = 3;
 const spacingVariable = theme => ({
   spacing: theme.spacing(variable),
 });
+
+const spacingParamNameChange = muiTheme => ({
+  spacing: muiTheme.spacing(1),
+});
+
+function styleFunction(theme) {
+  return {
+    spacing: theme.spacing(1),
+  };
+}

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
@@ -33,3 +33,8 @@ function styleFunction(theme) {
     spacing: theme.spacing(1),
   };
 }
+
+const theme = {};
+const shouldntTouch = theme.spacing.unit;
+
+const styles = muiTheme => ({ root: { spacing: muiTheme.spacing(1) } });

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected.js
@@ -17,3 +17,9 @@ const spacingAdd = theme => ({
 const spacingSubtract = theme => ({
   spacing: theme.spacing(1) - 5,
 });
+
+const variable = 3;
+
+const spacingVariable = theme => ({
+  spacing: theme.spacing(variable),
+});

--- a/packages/material-ui/src/styles/createSpacing.js
+++ b/packages/material-ui/src/styles/createSpacing.js
@@ -56,6 +56,7 @@ export default function createSpacing(spacingInput = 8) {
             'Material-UI: theme.spacing.unit usage has been deprecated.',
             'It will be removed in v5.',
             'You can replace `theme.spacing.unit * y` with `theme.spacing(y)`.',
+            'You can use the `https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod` migration helper to make the process smoother.',
           ].join('\n'),
         );
         warnOnce = true;

--- a/packages/material-ui/src/styles/createSpacing.js
+++ b/packages/material-ui/src/styles/createSpacing.js
@@ -56,7 +56,8 @@ export default function createSpacing(spacingInput = 8) {
             'Material-UI: theme.spacing.unit usage has been deprecated.',
             'It will be removed in v5.',
             'You can replace `theme.spacing.unit * y` with `theme.spacing(y)`.',
-            'You can use the `https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod` migration helper to make the process smoother.',
+            '',
+            'You can use the `https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod/README.md#theme-spacing-api` migration helper to make the process smoother.',
           ].join('\n'),
         );
         warnOnce = true;


### PR DESCRIPTION
🔥 [Usage instructions](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-codemod/README.md#theme-spacing-api) 🔥

---

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Aims:

- [x] Handle `theme.spacing.unit`
- [x] Handle `theme.spacing.unit <simple literal expression>`
- [x] Handle `theme.spacing.unit <simple variable expression>`

Nice to have:

- [ ] Handle and simplify complex chains
  - The easiest way to do this would be to add mathjs or a similar library to handle this but I think it's fine to leave it out