### PR TITLE
[core] Change cssutils responsiveProperty unit type

### DIFF
--- a/packages/material-ui/src/styles/cssUtils.js
+++ b/packages/material-ui/src/styles/cssUtils.js
@@ -39,7 +39,7 @@ export function fontGrid({ lineHeight, pixels, htmlFontSize }) {
  * @param {string} params.cssProperty - The CSS property to be made responsive
  * @param {number} params.min - The smallest value of the CSS property
  * @param {number} params.max - The largest value of the CSS property
- * @param {number} [params.unit] - The unit to be used for the CSS property
+ * @param {string} [params.unit] - The unit to be used for the CSS property
  * @param {Array.number} [params.breakpoints]  - An array of breakpoints
  * @param {number} [params.alignStep] - Round scaled value to fall under this grid
  * @returns {Object} responsive styles for {params.cssProperty}


### PR DESCRIPTION
responsiveProperty accepts a property of `unit` that is a string, not a number

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
