### PR TITLE
[ToggleButtonGroup] Added missing size prop to type declarations

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -7,7 +7,6 @@ declare const ToggleButton: ExtendButtonBase<{
     disableFocusRipple?: boolean;
     disableRipple?: boolean;
     selected?: boolean;
-    size?: 'small' | 'medium' | 'large';
     value?: any;
   };
   defaultComponent: 'button';

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -7,6 +7,7 @@ declare const ToggleButton: ExtendButtonBase<{
     disableFocusRipple?: boolean;
     disableRipple?: boolean;
     selected?: boolean;
+    size?: 'small' | 'medium' | 'large';
     value?: any;
   };
   defaultComponent: 'button';

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -12,6 +12,7 @@ export interface ToggleButtonGroupProps
   selected?: boolean;
   exclusive?: boolean;
   onChange?: (event: React.MouseEvent<HTMLElement>, value: any) => void;
+  size?: 'small' | 'medium' | 'large';
   value?: any;
 }
 


### PR DESCRIPTION
Just noticed size prop is missing in ToggleButtonGroup.d.ts and ToggleButton.d.ts from #15644 