### PR TITLE
[docs] Revert the marked change

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -141,6 +141,9 @@ const styles = theme => ({
     '& p code, & ul code, & pre code': {
       fontSize: 14,
     },
+    '& .token.operator': {
+      background: 'transparent',
+    },
     '& h1': {
       ...theme.typography.h2,
       margin: '32px 0 16px',

--- a/docs/src/modules/components/prism.js
+++ b/docs/src/modules/components/prism.js
@@ -14,8 +14,8 @@ let lightTheme;
 let darkTheme;
 
 if (process.browser) {
-  lightTheme = require('prism-themes/themes/prism-ghcolors.css');
-  darkTheme = require('prism-themes/themes/prism-atom-dark.css');
+  lightTheme = require('prismjs/themes/prism.css');
+  darkTheme = require('prismjs/themes/prism-okaidia.css');
 
   styleNode = document.createElement('style');
   styleNode.setAttribute('data-prism', 'true');

--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "nyc": "^13.0.0",
     "postcss": "^7.0.0",
     "prettier": "^1.8.2",
-    "prism-themes": "^1.1.0",
     "prop-types": "^15.7.2",
     "puppeteer": "^1.5.0",
     "raw-loader": "^1.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10914,11 +10914,6 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-prism-themes@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/prism-themes/-/prism-themes-1.1.0.tgz#9f4fadf0c9c7ee415773717ea69c2aaa25aedbfd"
-  integrity sha512-xBkflbKbstGGasW3P68KQzAuObLQeH//I5mn37jKVHVDrRLp4Xct/n8F/tV5h+CKIMa3nDAZ2q0bt8ItSiS72A==
-
 prismjs@^1.8.4:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.16.0.tgz#406eb2c8aacb0f5f0f1167930cb83835d10a4308"


### PR DESCRIPTION
@eps1lon Related to https://github.com/mui-org/material-ui/pull/15748/files#r285685878. I think that it's more caution to spend more time on this concern. The way we format the source is important.
Going forward, I would like to explore the following:

- What's wrong with the way it's handled after this change?
- What the other libraries are using? How can we leverage it?
- There is something I have been wondering about, what about always displaying a dark theme? I like how the problem is solved in https://reactjs.org/, but it's only an example among others: Vue, Gatsby, Next, Bootstrap, Antd, etc.

Related to #15790