### PR TITLE
[lab] Add missing clsx calls

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -541,14 +541,14 @@ class Slider extends React.Component {
 
     const percent = clamp(((value - min) * 100) / (max - min));
 
-    const commonClasses = {
+    const commonClasses = clsx({
       [classes.disabled]: disabled,
       [classes.jumped]: !disabled && currentState === 'jumped',
       [classes.focused]: !disabled && currentState === 'focused',
       [classes.activated]: !disabled && currentState === 'activated',
       [classes.vertical]: vertical,
       [classes.rtl]: theme.direction === 'rtl',
-    };
+    });
 
     const className = clsx(
       classes.root,

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.js
@@ -222,12 +222,12 @@ const SpeedDial = React.forwardRef(function SpeedDial(props, ref) {
     return iconProp;
   };
 
-  const actionsPlacementClass = {
+  const actionsPlacementClass = clsx({
     [classes.directionUp]: direction === 'up',
     [classes.directionDown]: direction === 'down',
     [classes.directionLeft]: direction === 'left',
     [classes.directionRight]: direction === 'right',
-  };
+  });
 
   let clickProp = { onClick };
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

Added two missing `clsx` calls, without them the `clsx` calls using the objects later all have to go over the object, wasting resources.