### PR TITLE
[Tooltip] Fix alignment issues

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -19,7 +19,7 @@ export const styles = theme => ({
     pointerEvents: 'none',
     position: 'absolute',
     top: '0px',
-    left: '0px', /* */
+    left: '0px',
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
   popperInteractive: {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -19,7 +19,7 @@ export const styles = theme => ({
     pointerEvents: 'none',
     position: 'absolute',
     top: '0px',
-    left: '0px',
+    left: '0px', /* */
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
   popperInteractive: {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -18,8 +18,8 @@ export const styles = theme => ({
     zIndex: theme.zIndex.tooltip,
     pointerEvents: 'none',
     position: 'absolute',
-    top: '0px',
-    left: '0px',
+    top: 0,
+    left: 0,
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
   popperInteractive: {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -19,7 +19,7 @@ export const styles = theme => ({
     pointerEvents: 'none',
     position: 'absolute',
     top: '0px',
-    left: '0px'
+    left: '0px',
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
   popperInteractive: {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -17,6 +17,9 @@ export const styles = theme => ({
   popper: {
     zIndex: theme.zIndex.tooltip,
     pointerEvents: 'none',
+    position: 'absolute',
+    top: '0px',
+    left: '0px'
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
   popperInteractive: {


### PR DESCRIPTION
Fixes #15194 and fixes #15731.

These bugs seem to be caused by the tooltip popper adding unintended spacing to the DOM just before calculating the transform, making the calculations incorrect when the actual tooltip popper style attribute is filled. By forcing the tooltip popper to never cause spacing when it enters the DOM, the calculation is now correct.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
