### PR TITLE
[styles] Add MuiLink to ComponentsPropsList

### DIFF
--- a/packages/material-ui/src/styles/props.d.ts
+++ b/packages/material-ui/src/styles/props.d.ts
@@ -42,6 +42,7 @@ import { InputAdornmentProps } from '../InputAdornment';
 import { InputLabelProps } from '../InputLabel';
 import { InputProps } from '../Input';
 import { LinearProgressProps } from '../LinearProgress';
+import { LinkProps } from '../Link';
 import { ListItemAvatarProps } from '../ListItemAvatar';
 import { ListItemIconProps } from '../ListItemIcon';
 import { ListItemProps } from '../ListItem';
@@ -136,6 +137,7 @@ export interface ComponentsPropsList {
   MuiInputAdornment: InputAdornmentProps;
   MuiInputLabel: InputLabelProps;
   MuiLinearProgress: LinearProgressProps;
+  MuiLink: LinkProps;
   MuiList: ListProps;
   MuiListItem: ListItemProps;
   MuiListItemAvatar: ListItemAvatarProps;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

This fixes #15752. The solution is as @eps1lon suggests - MuiLink is missing from the ComponentsPropsList interface. This causes an unnecessary type error when overriding MuiLink in the theme. I have tested that the issue is fixed by adding a Link and a MuiOverride for it to the create-react-app-with-typescript example locally. The PR is pointing to "master" as it is currently ahead of "next".