### PR TITLE
[core] Add cross-env to docs:size-why

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "docs:dev": "rimraf node_modules/.cache/babel-loader && cross-env BABEL_ENV=docs-development babel-node docs/src/server.js",
     "docs:export": "rimraf docs/export && next export -o docs/export && yarn docs:build-sw && cp -r docs/static/. docs/export",
     "docs:icons": "rimraf static/icons/* && babel-node ./docs/scripts/buildIcons.js",
-    "docs:size-why": "DOCS_STATS_ENABLED=true yarn docs:build",
+    "docs:size-why": "cross-env DOCS_STATS_ENABLED=true yarn docs:build",
     "docs:start": "next start",
     "docs:i18n": "cross-env BABEL_ENV=test babel-node ./docs/scripts/i18n.js",
     "docs:typescript": "node docs/scripts/formattedTSDemos --watch",


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).

* Added `cross-env` to the `docs:size-why` command.

Was trying to find the size of the compiled docs website, when `yarn docs:size-why` failed due to a missing `cross-env`. 
However I was hoping for an output similar to the one from `yarn workspace @material-ui/core build`, is there a possibility to add that to `yarn docs:build` as well?