### PR TITLE
[core] Fix delete hover style for mobile

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -39,7 +39,7 @@ export const styles = theme => ({
       textDecoration: 'none',
       // Reset on mouse devices
       backgroundColor: fade(theme.palette.text.primary, 0.05),
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
       '&$disabled': {

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -23,7 +23,7 @@ export const styles = theme => ({
       textDecoration: 'none',
       backgroundColor: fade(theme.palette.text.primary, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
       '&$disabled': {
@@ -51,7 +51,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
     },
@@ -62,7 +62,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: fade(theme.palette.secondary.main, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
     },
@@ -85,7 +85,7 @@ export const styles = theme => ({
       border: `1px solid ${theme.palette.primary.main}`,
       backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
     },
@@ -98,7 +98,7 @@ export const styles = theme => ({
       border: `1px solid ${theme.palette.secondary.main}`,
       backgroundColor: fade(theme.palette.secondary.main, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
     },
@@ -125,7 +125,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: theme.palette.grey.A100,
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: theme.palette.grey[300],
       },
       '&$disabled': {
@@ -140,7 +140,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: theme.palette.primary.dark,
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: theme.palette.primary.main,
       },
     },
@@ -152,7 +152,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: theme.palette.secondary.dark,
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: theme.palette.secondary.main,
       },
     },

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -27,7 +27,7 @@ export const styles = theme => ({
       '&:hover': {
         backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
         // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
+        '@media (hover: none), (pointer: coarse)': {
           backgroundColor: 'transparent',
         },
       },
@@ -43,7 +43,7 @@ export const styles = theme => ({
       '&:hover': {
         backgroundColor: fade(theme.palette.secondary.main, theme.palette.action.hoverOpacity),
         // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
+        '@media (hover: none), (pointer: coarse)': {
           backgroundColor: 'transparent',
         },
       },

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -31,7 +31,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: theme.palette.grey.A100,
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: theme.palette.grey[300],
       },
       '&$disabled': {
@@ -59,7 +59,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: theme.palette.primary.dark,
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: theme.palette.primary.main,
       },
     },
@@ -71,7 +71,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: theme.palette.secondary.dark,
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: theme.palette.secondary.main,
       },
     },

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -23,7 +23,7 @@ export const styles = theme => {
       '&:hover': {
         backgroundColor: light ? 'rgba(0, 0, 0, 0.13)' : 'rgba(255, 255, 255, 0.13)',
         // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
+        '@media (hover: none), (pointer: coarse)': {
           backgroundColor,
         },
       },

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -23,7 +23,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: fade(theme.palette.action.active, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
     },
@@ -56,7 +56,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
     },
@@ -67,7 +67,7 @@ export const styles = theme => ({
     '&:hover': {
       backgroundColor: fade(theme.palette.secondary.main, theme.palette.action.hoverOpacity),
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
     },

--- a/packages/material-ui/src/Input/Input.js
+++ b/packages/material-ui/src/Input/Input.js
@@ -63,7 +63,7 @@ export const styles = theme => {
       '&:hover:not($disabled):before': {
         borderBottom: `2px solid ${theme.palette.text.primary}`,
         // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
+        '@media (hover: none), (pointer: coarse)': {
           borderBottom: `1px solid ${bottomLineColor}`,
         },
       },

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -68,7 +68,7 @@ export const styles = theme => ({
       textDecoration: 'none',
       backgroundColor: theme.palette.action.hover,
       // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
+      '@media (hover: none), (pointer: coarse)': {
         backgroundColor: 'transparent',
       },
     },

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -19,7 +19,7 @@ export const styles = theme => {
       '&:hover $notchedOutline': {
         borderColor: theme.palette.text.primary,
         // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
+        '@media (hover: none), (pointer: coarse)': {
           borderColor,
         },
       },

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -24,7 +24,7 @@ export const styles = theme => ({
       '&:hover': {
         backgroundColor: fade(theme.palette.primary.main, theme.palette.action.hoverOpacity),
         // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
+        '@media (hover: none), (pointer: coarse)': {
           backgroundColor: 'transparent',
         },
       },
@@ -40,7 +40,7 @@ export const styles = theme => ({
       '&:hover': {
         backgroundColor: fade(theme.palette.secondary.main, theme.palette.action.hoverOpacity),
         // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
+        '@media (hover: none), (pointer: coarse)': {
           backgroundColor: 'transparent',
         },
       },


### PR DESCRIPTION
When use android v6.0.1+ `@media (hover: none)` is not working.
[Bug] https://github.com/mui-org/material-ui/issues/15736