### PR TITLE
[docs] Fix empty v4 blog post link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 4.0.0
 ###### *May 23, 2019*
 
-[Material-UI v4 is out 🎉]()
+[Material-UI v4 is out 🎉](https://medium.com/material-ui/material-ui-v4-is-out-4b7587d1e701)
 
 Some statistics with v4 compared to the release of v1 one year ago:
 


### PR DESCRIPTION
due to empty markdown link "Material-UI v4 is out 🎉" link was directing to 404 github page

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md#submitting-a-pull-request).
