### PR TITLE
[docs] Redirect next.material-ui.com to material-ui.com

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -6,6 +6,9 @@
 
 /size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/next/latest/size-snapshot.json 200
 
+# To remove when work starts on v5.
+https://next.material-ui.com/* https://material-ui.com/:splat 301!
+
 # To remove at some point (2020).
 /demos/selection-controls/ /components/radio-buttons/ 301
 /page-layout-examples/* /getting-started/page-layout-examples/:splat 301

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -7,7 +7,11 @@
 /size-snapshot https://s3.eu-central-1.amazonaws.com/eps1lon-material-ui/artifacts/next/latest/size-snapshot.json 200
 
 # To remove when work starts on v5.
-https://next.material-ui.com/* https://material-ui.com/:splat 301!
+https://next.material-ui.com/* https://material-ui.com/:splat 301
+
+# We like to have multiple domains O:)
+https://material-ui-next.com/* https://material-ui.com/:splat 301
+https://material-ui.dev/* https://material-ui.com/:splat 301
 
 # To remove at some point (2020).
 /demos/selection-controls/ /components/radio-buttons/ 301


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Once DNS propagates, next.material-ui.com should be aliased to material-ui.com. The redirect will simply strip the subdomain.