### PR TITLE
[docs] Use makeStyles from core in layout examples

### DIFF
--- a/docs/src/pages/components/selects/CustomizedSelects.js
+++ b/docs/src/pages/components/selects/CustomizedSelects.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, withStyles } from '@material-ui/styles';
+import { makeStyles, withStyles } from '@material-ui/core/styles';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';

--- a/docs/src/pages/components/selects/CustomizedSelects.tsx
+++ b/docs/src/pages/components/selects/CustomizedSelects.tsx
@@ -1,48 +1,49 @@
 import React from 'react';
-import { createStyles, makeStyles, withStyles } from '@material-ui/styles';
+import { createStyles, makeStyles, withStyles, Theme } from '@material-ui/core/styles';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import NativeSelect from '@material-ui/core/NativeSelect';
 import InputBase from '@material-ui/core/InputBase';
-import { Theme } from '@material-ui/core/styles';
 
-const BootstrapInput = withStyles((theme: Theme) => ({
-  root: {
-    'label + &': {
-      marginTop: theme.spacing(3),
+const BootstrapInput = withStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      'label + &': {
+        marginTop: theme.spacing(3),
+      },
     },
-  },
-  input: {
-    borderRadius: 4,
-    position: 'relative',
-    backgroundColor: theme.palette.background.paper,
-    border: '1px solid #ced4da',
-    fontSize: 16,
-    width: 'auto',
-    padding: '10px 26px 10px 12px',
-    transition: theme.transitions.create(['border-color', 'box-shadow']),
-    // Use the system font instead of the default Roboto font.
-    fontFamily: [
-      '-apple-system',
-      'BlinkMacSystemFont',
-      '"Segoe UI"',
-      'Roboto',
-      '"Helvetica Neue"',
-      'Arial',
-      'sans-serif',
-      '"Apple Color Emoji"',
-      '"Segoe UI Emoji"',
-      '"Segoe UI Symbol"',
-    ].join(','),
-    '&:focus': {
+    input: {
       borderRadius: 4,
-      borderColor: '#80bdff',
-      boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+      position: 'relative',
+      backgroundColor: theme.palette.background.paper,
+      border: '1px solid #ced4da',
+      fontSize: 16,
+      width: 'auto',
+      padding: '10px 26px 10px 12px',
+      transition: theme.transitions.create(['border-color', 'box-shadow']),
+      // Use the system font instead of the default Roboto font.
+      fontFamily: [
+        '-apple-system',
+        'BlinkMacSystemFont',
+        '"Segoe UI"',
+        'Roboto',
+        '"Helvetica Neue"',
+        'Arial',
+        'sans-serif',
+        '"Apple Color Emoji"',
+        '"Segoe UI Emoji"',
+        '"Segoe UI Symbol"',
+      ].join(','),
+      '&:focus': {
+        borderRadius: 4,
+        borderColor: '#80bdff',
+        boxShadow: '0 0 0 0.2rem rgba(0,123,255,.25)',
+      },
     },
-  },
-}))(InputBase);
+  }),
+)(InputBase);
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/docs/src/pages/components/typography/Types.js
+++ b/docs/src/pages/components/typography/Types.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/components/typography/Types.tsx
+++ b/docs/src/pages/components/typography/Types.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles, createStyles } from '@material-ui/styles';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(
   createStyles({

--- a/docs/src/pages/getting-started/page-layout-examples/dashboard/Deposits.js
+++ b/docs/src/pages/getting-started/page-layout-examples/dashboard/Deposits.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Link from '@material-ui/core/Link';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Title from './Title';
 

--- a/docs/src/pages/getting-started/page-layout-examples/dashboard/Orders.js
+++ b/docs/src/pages/getting-started/page-layout-examples/dashboard/Orders.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Link from '@material-ui/core/Link';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';

--- a/docs/src/pages/premium-themes/instapaper/pages/instapaper/Profile.js
+++ b/docs/src/pages/premium-themes/instapaper/pages/instapaper/Profile.js
@@ -3,7 +3,7 @@ import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import IconButton from '@material-ui/core/IconButton';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import atoms from '../../components/atoms';
 import molecules from '../../components/molecules';

--- a/docs/src/pages/premium-themes/tweeper/components/tweeper/Tweet.js
+++ b/docs/src/pages/premium-themes/tweeper/components/tweeper/Tweet.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import ListItem from '@material-ui/core/ListItem/ListItem';
 import Box from '@material-ui/core/Box';
 import atoms from '../atoms';

--- a/docs/src/pages/premium-themes/tweeper/pages/tweeper/Profile.js
+++ b/docs/src/pages/premium-themes/tweeper/pages/tweeper/Profile.js
@@ -3,7 +3,7 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import Grid from '@material-ui/core/Grid';
 import Divider from '@material-ui/core/Divider/Divider';
 import Box from '@material-ui/core/Box';
-import styled from '@material-ui/styles/styled';
+import { styled } from '@material-ui/core/styles';
 import Header from '../../components/tweeper/Header';
 import Tweet from '../../components/tweeper/Tweet';
 import TrackWho from '../../components/tweeper/TrackWho';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This fixes the theme import bug introduced due to a typo while importing _Dashboard_ example from _Page Layout Examples_ into another project.

Fixes #15834 
