### PR TITLE
[docs] Use makeStyles from core in layout examples

### DIFF
--- a/docs/src/pages/getting-started/page-layout-examples/dashboard/Orders.js
+++ b/docs/src/pages/getting-started/page-layout-examples/dashboard/Orders.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import Link from '@material-ui/core/Link';
-import { makeStyles } from '@material-ui/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';


### PR DESCRIPTION
makeStyles imported from @material-ui/styles causing the error theme.spacing is not a function

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #15834