### PR TITLE
[core] Prepare focus visible polyfill in ref phase

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -110,20 +110,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
   if (disabled && focusVisible) {
     setFocusVisible(false);
   }
-  const getOwnerDocument = React.useCallback(() => {
-    const button = getButtonNode();
-    if (button == null) {
-      throw new Error(
-        [
-          `Material-UI: expected an Element but found ${button}.`,
-          'Please check your console for additional warnings and try fixing those.',
-          'If the error persists please file an issue.',
-        ].join(' '),
-      );
-    }
-    return button.ownerDocument;
-  }, []);
-  const { isFocusVisible, onBlurVisible } = useIsFocusVisible(getOwnerDocument);
+  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
 
   React.useImperativeHandle(
     action,
@@ -281,7 +268,8 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
   }
 
   const handleUserRef = useForkRef(buttonRefProp, ref);
-  const handleRef = useForkRef(handleUserRef, buttonRef);
+  const handleOwnRef = useForkRef(focusVisibleRef, buttonRef);
+  const handleRef = useForkRef(handleUserRef, handleOwnRef);
 
   return (
     <ComponentProp

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -637,7 +637,7 @@ describe('<ButtonBase />', () => {
       PropTypes.resetWarningCache();
     });
 
-    it('throws with additional warnings on invalid `component` prop', () => {
+    it('warns on invalid `component` prop', () => {
       // Only run the test on node. On the browser the thrown error is not caught
       if (!/jsdom/.test(window.navigator.userAgent)) {
         return;
@@ -648,18 +648,11 @@ describe('<ButtonBase />', () => {
       }
 
       // cant match the error message here because flakiness with mocha watchmode
-      assert.throws(() => mount(<ButtonBase component={Component} />));
+      mount(<ButtonBase component={Component} />);
 
       assert.include(
         consoleErrorMock.args()[0][0],
         'Invalid prop `component` supplied to `ForwardRef(ButtonBase)`. Expected an element type that can hold a ref',
-      );
-      // first mount includes React warning that isn't logged on subsequent calls
-      // in watchmode because it's cached
-      const customErrorIndex = consoleErrorMock.callCount() === 3 ? 1 : 2;
-      assert.include(
-        consoleErrorMock.args()[customErrorIndex][0],
-        'Error: Material-UI: expected an Element but found null. Please check your console for additional warnings and try fixing those.',
       );
     });
   });

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -113,12 +113,6 @@ function Tooltip(props) {
   const enterTimer = React.useRef();
   const leaveTimer = React.useRef();
   const touchTimer = React.useRef();
-  // can be removed once we drop support for non ref forwarding class components
-  const handleOwnRef = React.useCallback(instance => {
-    // #StrictMode ready
-    setChildNode(ReactDOM.findDOMNode(instance));
-  }, []);
-  const handleRef = useForkRef(children.ref, handleOwnRef);
 
   React.useEffect(() => {
     warning(
@@ -205,13 +199,7 @@ function Tooltip(props) {
     }
   };
 
-  const getOwnerDocument = React.useCallback(() => {
-    if (childNode == null) {
-      return null;
-    }
-    return childNode.ownerDocument;
-  }, [childNode]);
-  const { isFocusVisible, onBlurVisible } = useIsFocusVisible(getOwnerDocument);
+  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
   const [childIsFocusVisible, setChildIsFocusVisible] = React.useState(false);
   function handleBlur() {
     if (childIsFocusVisible) {
@@ -309,6 +297,16 @@ function Tooltip(props) {
       handleClose(event);
     }, leaveTouchDelay);
   };
+
+  // can be removed once we drop support for non ref forwarding class components
+  const handleOwnRef = useForkRef(
+    React.useCallback(instance => {
+      // #StrictMode ready
+      setChildNode(ReactDOM.findDOMNode(instance));
+    }, []),
+    focusVisibleRef,
+  );
+  const handleRef = useForkRef(children.ref, handleOwnRef);
 
   let open = isControlled ? openProp : openState;
 

--- a/packages/material-ui/src/utils/focusVisible.js
+++ b/packages/material-ui/src/utils/focusVisible.js
@@ -1,5 +1,6 @@
 // based on https://github.com/WICG/focus-visible/blob/v4.1.5/src/focus-visible.js
 import React from 'react';
+import ReactDOM from 'react-dom';
 
 let hadKeyboardEvent = true;
 let hadFocusVisibleRecently = false;
@@ -122,13 +123,13 @@ export function handleBlurVisible() {
   }, 100);
 }
 
-export function useIsFocusVisible(getOwnerDocument) {
-  React.useEffect(() => {
-    const ownerDocument = getOwnerDocument();
-    if (ownerDocument != null) {
-      prepare(ownerDocument);
+export function useIsFocusVisible() {
+  const ref = React.useCallback(instance => {
+    const node = ReactDOM.findDOMNode(instance);
+    if (node != null) {
+      prepare(node.ownerDocument);
     }
-  }, [getOwnerDocument]);
+  }, []);
 
-  return { isFocusVisible, onBlurVisible: handleBlurVisible };
+  return { isFocusVisible, onBlurVisible: handleBlurVisible, ref };
 }

--- a/packages/material-ui/src/utils/focusVisible.test.js
+++ b/packages/material-ui/src/utils/focusVisible.test.js
@@ -17,17 +17,9 @@ function simulatePointerDevice() {
 }
 
 const SimpleButton = React.forwardRef(function SimpleButton(props, ref) {
-  const [element, setElement] = React.useState(null);
-  const getOwnerDocument = React.useCallback(() => {
-    if (element === null) {
-      return null;
-    }
+  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
 
-    return element.ownerDocument;
-  }, [element]);
-  const { isFocusVisible, onBlurVisible } = useIsFocusVisible(getOwnerDocument);
-
-  const handleRef = useForkRef(setElement, ref);
+  const handleRef = useForkRef(focusVisibleRef, ref);
 
   const [focusVisible, setFocusVisible] = React.useState(false);
 


### PR DESCRIPTION
Moves the the setup of the focus-visible polyfill from the passive? side-effect phase into the ref phase. This has some benefits:
1. As far as I know useEffect will have a lower priority than user inputs in concurrent react. This would mean that potentially no focus visible styling is applied on the first user inputs.
2. No more false positive errors in test environments without fully mocked host instances (e.g. react-test-renderer snapshots)
3. In case the host instance changes to one with another ownerDocument (no idea how this would look) we get the polyfill properly setup. This was not the case previously.

However this means that setup of the event listeners is now synchronously. Once the scheduler is stable we should schedule this with a user input priority.

Closes #15598 (actually),
Closes #15842