### PR TITLE
[test] Remove FontAwesome from screenshot tests

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -75,6 +75,7 @@ const blacklistFilename = [
 
   // Flaky
   'docs-components-grid-list/ImageGridList.png',
+  'docs-components-icons/FontAwesome.png',
 
   // Redux isolation
   'docs-components-chips/ChipsPlayground.png',


### PR DESCRIPTION
Feels like it's failing 50% of the time. It looks like this is mostly testing font-awesome anyway. We could also hook into the onload of the stylesheet but I don't know if our screenshot tests have the ability to take the screenshot after a certain event occurred. If so I have quite some ideas for it.