### PR TITLE
[core] Fix not appearing in github used/dependents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,24 +1,5 @@
 {
-  "name": "@material-ui/core",
-  "version": "4.0.0",
   "private": true,
-  "author": "Material-UI Team",
-  "description": "Material-UI's workspace package",
-  "keywords": [
-    "react",
-    "react-component",
-    "material design",
-    "material-ui"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
-  },
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/mui-org/material-ui/issues"
-  },
-  "homepage": "https://material-ui.com/",
   "scripts": {
     "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN",
     "docs:api": "rimraf ./pages/api && cross-env BABEL_ENV=test babel-node ./docs/scripts/buildApi.js ./packages/material-ui/src ./pages/api && cross-env BABEL_ENV=test babel-node ./docs/scripts/buildApi.js ./packages/material-ui-lab/src ./pages/api",
@@ -215,7 +196,6 @@
     "@material-ui/core": "^4.0.0-beta.0",
     "**/hoist-non-react-statics": "^3.2.1"
   },
-  "sideEffects": false,
   "nyc": {
     "include": [
       "packages/material-ui/src/**/*.js",
@@ -227,9 +207,6 @@
     ],
     "sourceMap": false,
     "instrument": false
-  },
-  "engines": {
-    "node": ">=8.0.0"
   },
   "workspaces": [
     "packages/*"

--- a/packages/material-ui-codemod/package.json
+++ b/packages/material-ui-codemod/package.json
@@ -13,7 +13,7 @@
     "jscodeshift"
   ],
   "scripts": {
-    "test": "cd ../../ && mocha 'packages/material-ui-codemod/**/*.test.js'",
+    "test": "cd ../../ && cross-env NODE_ENV=test mocha 'packages/material-ui-codemod/**/*.test.js'",
     "prebuild": "rimraf lib",
     "build": "cross-env NODE_ENV=production babel --config-file ../../babel.config.js ./src --out-dir ./lib --ignore **/*.test.js",
     "release": "yarn build && npm publish"

--- a/packages/material-ui-codemod/package.json
+++ b/packages/material-ui-codemod/package.json
@@ -20,7 +20,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui-codemod"
   },
   "license": "MIT",
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-codemod",

--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui-docs"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui-icons"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui-lab"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui-styles"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui-system"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui-types/package.json
+++ b/packages/material-ui-types/package.json
@@ -17,7 +17,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui-types"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui-utils/package.json
+++ b/packages/material-ui-utils/package.json
@@ -14,7 +14,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui-utils"
   },
   "license": "MIT",
   "bugs": {

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -12,7 +12,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/mui-org/material-ui.git"
+    "url": "https://github.com/mui-org/material-ui.git",
+    "directory": "packages/material-ui"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
It has been bugging me for quite a while that github dependencies didn't list dependents on us. I didn't prioritize until the recent Satellite announcement concerning "used by" which is good advertisement. 

I didn't find explicit documentation for monorepos but in [comparison with react](https://github.com/facebook/react/blob/5fe97dbe19917b4c49618073ccc5632b593ec9fa/packages/react/package.json#L23) we're only missing the `directory` entry in `repository`. Let's see if this helps.

Also removed some unnecessary fields from the workspace root package.json which is only used by contributors.