### PR TITLE
[icons] Fix the TypeScript definition of createSvgIcon

### DIFF
--- a/packages/material-ui-icons/src/utils/createSvgIcon.d.ts
+++ b/packages/material-ui-icons/src/utils/createSvgIcon.d.ts
@@ -1,5 +1,5 @@
 import SvgIcon from '@material-ui/core/SvgIcon';
 
-declare function createSvgIcon(path: React.ComponentType, displayName: string): typeof SvgIcon;
+declare function createSvgIcon(path: React.ReactNode, displayName: string): typeof SvgIcon;
 
 export default createSvgIcon;


### PR DESCRIPTION
`createSvgIcon` accepts a React element as first argument, not a React component.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
