### PR TITLE
[Link] Better support of component="button"

### DIFF
--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -17,7 +17,8 @@ export type LinkClassKey =
   | 'underlineNone'
   | 'underlineHover'
   | 'underlineAlways'
-  | 'button';
+  | 'button'
+  | 'focusVisible';
 
 export type LinkBaseProps = React.AnchorHTMLAttributes<HTMLAnchorElement> &
   Omit<TypographyProps, 'component'>;

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -50,6 +50,7 @@ export const styles = {
       outline: 'auto',
     },
   },
+  /* Styles applied to the root element if the link is keyboard focused. */
   focusVisible: {},
 };
 

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -68,11 +68,9 @@ const Link = React.forwardRef(function Link(props, ref) {
     ...other
   } = props;
 
-  const linkRef = React.useRef();
-  // TODO: Olivier originally included an arg of `() => linkRef.current.ownerDocument`. Am i missing something?
-  const { isFocusVisible, onBlurVisible } = useIsFocusVisible();
+  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
   const [focusVisible, setFocusVisible] = React.useState(false);
-  const handlerRef = useForkRef(linkRef, ref);
+  const handlerRef = useForkRef(ref, focusVisibleRef);
   const handleBlur = event => {
     if (focusVisible) {
       onBlurVisible();

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
+import { spy } from 'sinon';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Link from './Link';

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -36,12 +36,12 @@ describe('<Link />', () => {
   }));
 
   it('should render children', () => {
-    const wrapper = shallow(<Link href="/">Home</Link>);
+    const wrapper = mount(<Link href="/">Home</Link>);
     assert.strictEqual(wrapper.contains('Home'), true);
   });
 
   it('should pass props to the <Typography> component', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <Link href="/" color="primary">
         Test
       </Link>,

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -5,6 +5,12 @@ import describeConformance from '../test-utils/describeConformance';
 import Link from './Link';
 import Typography from '../Typography';
 
+function focusVisible(element) {
+  element.blur();
+  document.dispatchEvent(new window.Event('keydown'));
+  element.focus();
+}
+
 describe('<Link />', () => {
   let mount;
   let shallow;
@@ -41,5 +47,41 @@ describe('<Link />', () => {
     );
     const typography = wrapper.find(Typography);
     assert.strictEqual(typography.props().color, 'primary');
+  });
+
+  describe('event callbacks', () => {
+    it('should fire event callbacks', () => {
+      const events = ['onBlur', 'onFocus'];
+
+      const handlers = events.reduce((result, n) => {
+        result[n] = spy();
+        return result;
+      }, {});
+
+      const wrapper = shallow(
+        <Link href="/" {...handlers}>
+          Home
+        </Link>,
+      );
+
+      events.forEach(n => {
+        const event = n.charAt(2).toLowerCase() + n.slice(3);
+        wrapper.simulate(event, { target: { tagName: 'a' } });
+        assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
+      });
+    });
+  });
+
+  describe('keyboard focus', () => {
+    it('should add the focusVisible class when focused', () => {
+      const wrapper = mount(<Link href="/">Home</Link>);
+      const anchor = wrapper.find('a').instance();
+
+      assert.strictEqual(anchor.classList.contains(classes.focusVisible), false);
+      focusVisible(anchor);
+      assert.strictEqual(anchor.classList.contains(classes.focusVisible), true);
+      anchor.blur();
+      assert.strictEqual(anchor.classList.contains(classes.focusVisible), false);
+    });
   });
 });

--- a/pages/api/link.md
+++ b/pages/api/link.md
@@ -43,6 +43,7 @@ This property accepts the following keys:
 | <span class="prop-name">underlineHover</span> | Styles applied to the root element if `underline="hover"`.
 | <span class="prop-name">underlineAlways</span> | Styles applied to the root element if `underline="always"`.
 | <span class="prop-name">button</span> | Styles applied to the root element if `component="button"`.
+| <span class="prop-name">focusVisible</span> | Styles applied to the root element if the link is keyboard focused.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Link/Link.js)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fixes #15840.

This PR resets the `outline` styling to `auto` when keyboard focusing a `Link` component that is configured to render using a `button` element.