### PR TITLE
[docs] Add extendedFab migration

### DIFF
--- a/docs/src/pages/guides/migration-v3/migration-v3.md
+++ b/docs/src/pages/guides/migration-v3/migration-v3.md
@@ -187,6 +187,13 @@ yarn add @material-ui/styles@next
   +import Fab from '@material-ui/core/Fab';
   +<Fab />
   ```
+  
+  ```diff
+  -import Button from '@material-ui/core/Button';
+  -<Button variant="extendedFab" />
+  +import Fab from '@material-ui/core/Fab';
+  +<Fab variant="extended />
+  ```
 
 - [ButtonBase] The component passed to the `component` prop needs to be able to hold a ref.
   The [composition guide](/guides/composition/#caveat-with-refs) explains the migration strategy.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

added "extendedFab" button migration to the "Migration From v3 to v4" page

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
