### PR TITLE
[InputBase] Fix height of multiline input not matching non-multiline input

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -61,6 +61,9 @@ export const styles = theme => {
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: `${8 - 2}px 0 ${8 - 1}px`,
+      '&$marginDense': {
+        paddingTop: 4 - 1,
+      },
     },
     /* Styles applied to the root element if `fullWidth={true}`. */
     fullWidth: {
@@ -121,6 +124,7 @@ export const styles = theme => {
       height: 'auto',
       resize: 'none',
       padding: 0,
+      lineHeight: '1.1875em',
     },
     /* Styles applied to the `input` element if `type="search"`. */
     inputTypeSearch: {

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -124,7 +124,6 @@ export const styles = theme => {
       height: 'auto',
       resize: 'none',
       padding: 0,
-      lineHeight: '1.1875em',
     },
     /* Styles applied to the `input` element if `type="search"`. */
     inputTypeSearch: {

--- a/packages/material-ui/src/InputBase/Textarea.js
+++ b/packages/material-ui/src/InputBase/Textarea.js
@@ -45,12 +45,18 @@ const Textarea = React.forwardRef(function Textarea(props, ref) {
     inputShallow.value = input.value || props.placeholder || 'x';
 
     // The height of the inner content
-    const innerHeight = inputShallow.scrollHeight;
+    let innerHeight = inputShallow.scrollHeight;
     const boxSizing = computedStyle['box-sizing'];
 
     // Measure height of a textarea with a single row
-    inputShallow.value = 'x';
-    const singleRowHeight = inputShallow.scrollHeight;
+    inputShallow.value = 'y';
+    const singleRowHeight = getStyleValue(window.getComputedStyle(inputShallow), 'line-height');
+    const rowsCount = Math.floor(innerHeight / singleRowHeight);
+    const descendersHeight = inputShallow.scrollHeight - singleRowHeight;
+
+    // Force one-line multiline input to have the same height as a non-multiline input
+    // but add the descenders height otherwise
+    innerHeight = rowsCount <= 1 ? singleRowHeight : rowsCount * singleRowHeight + descendersHeight;
 
     // The height of the outer content
     let outerHeight = innerHeight;

--- a/packages/material-ui/src/InputBase/Textarea.js
+++ b/packages/material-ui/src/InputBase/Textarea.js
@@ -47,6 +47,11 @@ const Textarea = React.forwardRef(function Textarea(props, ref) {
     // The height of the inner content
     let innerHeight = inputShallow.scrollHeight;
     const boxSizing = computedStyle['box-sizing'];
+    if (boxSizing === 'content-box') {
+      innerHeight -=
+        getStyleValue(computedStyle, 'padding-bottom') +
+        getStyleValue(computedStyle, 'padding-top');
+    }
 
     // Measure height of a textarea with a single row
     inputShallow.value = 'y';

--- a/packages/material-ui/src/InputBase/Textarea.test.js
+++ b/packages/material-ui/src/InputBase/Textarea.test.js
@@ -35,7 +35,7 @@ describe('<Textarea />', () => {
       return;
     }
 
-    const getComputedStyleStub = {};
+    let getComputedStyleStub = {};
 
     function setLayout(wrapper, { getComputedStyle, scrollHeight, lineHeight }) {
       const input = wrapper
@@ -60,6 +60,11 @@ describe('<Textarea />', () => {
       stub(window, 'getComputedStyle').value(node => getComputedStyleStub[node] || {});
     });
 
+    beforeEach(() => {
+      // Reset previously applied styles
+      getComputedStyleStub = {};
+    });
+
     after(() => {
       sinon.restore();
     });
@@ -81,6 +86,7 @@ describe('<Textarea />', () => {
         setLayout(wrapper, {
           getComputedStyle: {
             'box-sizing': 'content-box',
+            'line-height': '15px',
           },
           scrollHeight: 30,
           lineHeight: 15,
@@ -99,6 +105,7 @@ describe('<Textarea />', () => {
       setLayout(wrapper, {
         getComputedStyle: {
           'box-sizing': 'content-box',
+          'line-height': '15px',
         },
         scrollHeight: 30,
         lineHeight: 15,
@@ -120,6 +127,7 @@ describe('<Textarea />', () => {
         getComputedStyle: {
           'box-sizing': 'border-box',
           'border-bottom-width': `${border}px`,
+          'line-height': '15px',
         },
         scrollHeight: 30,
         lineHeight: 15,
@@ -136,6 +144,7 @@ describe('<Textarea />', () => {
         getComputedStyle: {
           'box-sizing': 'content-box',
           'padding-top': `${padding}px`,
+          'line-height': '15px',
         },
         scrollHeight: 30,
         lineHeight: 15,
@@ -152,6 +161,7 @@ describe('<Textarea />', () => {
       setLayout(wrapper, {
         getComputedStyle: {
           'box-sizing': 'content-box',
+          'line-height': `${lineHeight}px`,
         },
         scrollHeight: 30,
         lineHeight,
@@ -168,6 +178,7 @@ describe('<Textarea />', () => {
       setLayout(wrapper, {
         getComputedStyle: {
           'box-sizing': 'content-box',
+          'line-height': `${lineHeight}px`,
         },
         scrollHeight: 100,
         lineHeight,

--- a/packages/material-ui/src/InputBase/Textarea.test.js
+++ b/packages/material-ui/src/InputBase/Textarea.test.js
@@ -146,7 +146,7 @@ describe('<Textarea />', () => {
           'padding-top': `${padding}px`,
           'line-height': '15px',
         },
-        scrollHeight: 30,
+        scrollHeight: 35, // 2 lines + padding
         lineHeight: 15,
       });
       wrapper.setProps();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This fixes #15821.

1. The padding of a multiline dense input now matches the normal dense input.
2. That still left an off-by-one error in the height due to the textarea height calculation (as explained [here](https://github.com/mui-org/material-ui/issues/15821#issuecomment-495804541)). [Turns out](https://stackoverflow.com/a/32442522) that the native textarea adds a bit of space below the last line (if the last line isn't empty) for the descenders (like the bottom part of a "y"), and for our font, that space is the one pixel* that was too much.   
I updated the calculation to force the height to match the non-multiline input if there is only one line but keep the descenders space for more than one line (otherwise the text input would scroll while typing a new line).   
      
  *On displays with different resolutions, it might be more or less than a pixel.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
