### PR TITLE
[Box] Fix prop-types and TypeScript warnings

### DIFF
--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -53,8 +53,10 @@ export function breakpoints<Props extends { theme: { breakpoints?: unknown } }>(
  */
 type ComposedArg<T> = T extends Array<(arg: infer P) => any> ? P : never;
 type ComposedStyleProps<T> = ComposedArg<T>;
-type Composed<T extends Array<StyleFunction<any>>> = StyleFunction<ComposedStyleProps<T>>;
-export function compose<T extends Array<StyleFunction<any>>>(...args: T): Composed<T>;
+export type ComposedStyleFunction<T extends Array<StyleFunction<any>>> = StyleFunction<
+  ComposedStyleProps<T>
+>;
+export function compose<T extends Array<StyleFunction<any>>>(...args: T): ComposedStyleFunction<T>;
 
 // css.js
 export function css<Props>(

--- a/packages/material-ui-system/src/responsivePropType.js
+++ b/packages/material-ui-system/src/responsivePropType.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 const responsivePropType =
   process.env.NODE_ENV !== 'production'
-    ? PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object])
+    ? PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.object, PropTypes.array])
     : {};
 
 export default responsivePropType;

--- a/packages/material-ui/src/Box/Box.d.ts
+++ b/packages/material-ui/src/Box/Box.d.ts
@@ -1,69 +1,42 @@
 import * as React from 'react';
+import {
+  borders,
+  ComposedStyleFunction,
+  display,
+  flexbox,
+  palette,
+  positions,
+  shadows,
+  sizing,
+  spacing,
+  typography,
+  PropsFor,
+} from '@material-ui/system';
+import { Omit } from '..';
 
-export interface BoxProps
-  extends React.HTMLAttributes<HTMLElement>,
-    Pick<
-      React.CSSProperties,
-      | 'alignContent'
-      | 'alignItems'
-      | 'alignSelf'
-      | 'border'
-      | 'borderBottom'
-      | 'borderColor'
-      | 'borderLeft'
-      | 'borderRadius'
-      | 'borderRight'
-      | 'borderTop'
-      | 'bottom'
-      | 'boxShadow'
-      | 'color'
-      | 'cursor'
-      | 'display'
-      | 'flex'
-      | 'flexDirection'
-      | 'flexGrow'
-      | 'flexShrink'
-      | 'flexWrap'
-      | 'fontFamily'
-      | 'fontSize'
-      | 'fontWeight'
-      | 'height'
-      | 'justifyContent'
-      | 'left'
-      | 'maxHeight'
-      | 'maxWidth'
-      | 'minHeight'
-      | 'minWidth'
-      | 'overflowX'
-      | 'overflowY'
-      | 'position'
-      | 'right'
-      | 'textAlign'
-      | 'top'
-      | 'width'
-      | 'zIndex'
-    > {
-  component?: React.ElementType;
+type BoxStyleFunction = ComposedStyleFunction<
+  [
+    typeof borders,
+    typeof display,
+    typeof flexbox,
+    typeof palette,
+    typeof positions,
+    typeof shadows,
+    typeof sizing,
+    typeof spacing,
+    typeof typography
+  ]
+>;
+
+type SystemProps = PropsFor<BoxStyleFunction>;
+type ElementProps = Omit<React.HTMLAttributes<HTMLElement>, keyof SystemProps>;
+
+export interface BoxProps extends ElementProps, SystemProps {
   // styled API
+  component?: React.ElementType;
   clone?: boolean;
-  // Box specific props
-  bgcolor?: string;
-  displayPrint?: string;
-  m?: string | number;
-  mb?: string | number;
-  ml?: string | number;
-  mr?: string | number;
-  mt?: string | number;
-  mx?: string | number;
-  my?: string | number;
-  order?: string | number;
-  p?: string | number;
-  pb?: string | number;
-  pl?: string | number;
-  pr?: string | number;
-  pt?: string | number;
-  px?: string | number;
-  py?: string | number;
+  // workaround for https://github.com/mui-org/material-ui/pull/15611
+  css?: SystemProps;
 }
 
 declare const Box: React.ComponentType<BoxProps>;

--- a/packages/material-ui/src/Box/Box.spec.tsx
+++ b/packages/material-ui/src/Box/Box.spec.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import Box from '@material-ui/core/Box';
+
+function responsiveTest() {
+  <Box p={[2, 3, 4]} />;
+  <Box p={{ xs: 2, sm: 3, md: 4 }} />;
+  // undesired
+  <Box p={{ xs: 2, sm: { you: "are dealing with 'any' here" }, md: 4 }} />;
+}


### PR DESCRIPTION
Fix Box prop-types warning when using an array for breakpoint dependents props.

Props related to mui/system aren't type checked anymore i.e. use `any` which is the state of the mui/system types currently.

We can tighten this later by reading the available breakpoints from a generic theme. Might come with other issues since it needs generics.

Closes #15877