### PR TITLE
[core] Update babel-plugin-optimize-clsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "babel-loader": "^8.0.0",
     "babel-plugin-istanbul": "^5.0.0",
     "babel-plugin-module-resolver": "^3.0.0",
-    "babel-plugin-optimize-clsx": "^1.1.2",
+    "babel-plugin-optimize-clsx": "^2.1.0",
     "babel-plugin-preval": "^2.0.0",
     "babel-plugin-react-remove-properties": "^0.3.0",
     "babel-plugin-tester": "^5.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,10 +3085,10 @@ babel-plugin-module-resolver@^3.0.0:
     reselect "^3.0.1"
     resolve "^1.4.0"
 
-babel-plugin-optimize-clsx@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-optimize-clsx/-/babel-plugin-optimize-clsx-1.1.2.tgz#b9489379c76b447b6e4bf3a41f0a319dd717aaf0"
-  integrity sha512-FzzAIg6yYGm3eAOsDtADA3weQbOcDMCpkATyPMOYL2EJglg9Bb1Ez+Ju9YQ/dL8YPJ4yW5MnrtOujG25qdIIJQ==
+babel-plugin-optimize-clsx@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-optimize-clsx/-/babel-plugin-optimize-clsx-2.1.0.tgz#fc136ca6719c0d013bd48cfb1844e9f155120358"
+  integrity sha512-gUXdDoXh5M+D2wR/gl16zSILL2wayLf6mbNumizXLvBllq+ptgQNJ7bc/q/rO6Hpf9osyyqeLHzHWW2kOdIqzw==
   dependencies:
     "@babel/generator" "^7.4.4"
     "@babel/types" "^7.4.4"


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Has some new features and bug fixes so it generates even faster and smaller code

Output from `yarn workspace @material-ui/core build`:
```
// No plugin
Computed sizes of "build/umd/material-ui.production.min.js" with "umd" format
  bundler parsing size: 845,370 B
  browser parsing size (minified with terser): 296,705 B
  download size (minified and gzipped): 84,586 B

// 1.1.2
Computed sizes of "build/umd/material-ui.production.min.js" with "umd" format
  bundler parsing size: 837,672 B
  browser parsing size (minified with terser): 294,841 B
  download size (minified and gzipped): 83,987 B

// 2.1.0
Computed sizes of "build/umd/material-ui.production.min.js" with "umd" format
  bundler parsing size: 837,380 B
  browser parsing size (minified with terser): 294,670 B
  download size (minified and gzipped): 83,953 B
```