### PR TITLE
[docs] Improve lighthouse a11y score in demos

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -223,7 +223,7 @@ function AppTableOfContents(props) {
   );
 
   return (
-    <nav className={classes.root}>
+    <nav className={classes.root} aria-label="Page table of contents">
       {itemsServer.length > 0 ? (
         <React.Fragment>
           <Typography gutterBottom className={classes.contents}>

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -234,6 +234,8 @@ class Demo extends React.Component {
     const demoData = this.getDemoData();
     const DemoComponent = demoData.Component;
     const gaCategory = demoOptions.demo;
+    // get the last alphanumeric pattern before the file extension
+    const demoName = demoData.githubLocation.replace(/(.+?)(\w+)\.\w+$$/, '$2');
 
     return (
       <div className={classes.root}>
@@ -360,7 +362,7 @@ class Demo extends React.Component {
             maxWidth: demoOptions.maxWidth,
           }}
         >
-          <DemoSandboxed component={DemoComponent} iframe={demoOptions.iframe} />
+          <DemoSandboxed component={DemoComponent} iframe={demoOptions.iframe} name={demoName} />
         </div>
       </div>
     );

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -45,7 +45,7 @@ class DemoFrame extends React.Component {
   };
 
   render() {
-    const { children, classes } = this.props;
+    const { children, classes, theme, ...other } = this.props;
 
     // NoSsr fixes a strange concurrency issue with iframe and quick React mount/unmount
     return (
@@ -55,6 +55,7 @@ class DemoFrame extends React.Component {
           className={classes.root}
           contentDidMount={this.onContentDidMount}
           contentDidUpdate={this.onContentDidUpdate}
+          {...other}
         >
           <div id="demo-frame-jss" />
           {this.state.ready ? (
@@ -80,11 +81,12 @@ DemoFrame.propTypes = {
 const StyledFrame = withStyles(styles, { withTheme: true })(DemoFrame);
 
 function DemoSandboxed(props) {
-  const { component: Component, iframe } = props;
+  const { component: Component, iframe, name } = props;
   const Sandbox = iframe ? StyledFrame : React.Fragment;
+  const sandboxProps = iframe ? { title: `${name} demo` } : {};
 
   return (
-    <Sandbox>
+    <Sandbox {...sandboxProps}>
       <Component />
     </Sandbox>
   );
@@ -93,6 +95,7 @@ function DemoSandboxed(props) {
 DemoSandboxed.propTypes = {
   component: PropTypes.elementType.isRequired,
   iframe: PropTypes.bool,
+  name: PropTypes.string.isRequired,
 };
 
 export default React.memo(DemoSandboxed);

--- a/docs/src/pages/components/app-bar/MenuAppBar.js
+++ b/docs/src/pages/components/app-bar/MenuAppBar.js
@@ -61,7 +61,8 @@ function MenuAppBar() {
           {auth && (
             <div>
               <IconButton
-                aria-owns={open ? 'menu-appbar' : undefined}
+                aria-label="Account of current user"
+                aria-controls="menu-appbar"
                 aria-haspopup="true"
                 onClick={handleMenu}
                 color="inherit"
@@ -75,6 +76,7 @@ function MenuAppBar() {
                   vertical: 'top',
                   horizontal: 'right',
                 }}
+                keepMounted
                 transformOrigin={{
                   vertical: 'top',
                   horizontal: 'right',

--- a/docs/src/pages/components/app-bar/MenuAppBar.tsx
+++ b/docs/src/pages/components/app-bar/MenuAppBar.tsx
@@ -63,7 +63,8 @@ function MenuAppBar() {
           {auth && (
             <div>
               <IconButton
-                aria-owns={open ? 'menu-appbar' : undefined}
+                aria-label="Account of current user"
+                aria-controls="menu-appbar"
                 aria-haspopup="true"
                 onClick={handleMenu}
                 color="inherit"
@@ -77,6 +78,7 @@ function MenuAppBar() {
                   vertical: 'top',
                   horizontal: 'right',
                 }}
+                keepMounted
                 transformOrigin={{
                   vertical: 'top',
                   horizontal: 'right',

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
@@ -139,7 +139,7 @@ function PrimarySearchAppBar() {
         <p>Messages</p>
       </MenuItem>
       <MenuItem>
-        <IconButton aria-label="Show 17 new notifications" color="inherit">
+        <IconButton aria-label="Show 11 new notifications" color="inherit">
           <Badge badgeContent={11} color="secondary">
             <NotificationsIcon />
           </Badge>

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.js
@@ -103,10 +103,13 @@ function PrimarySearchAppBar() {
     setMobileMoreAnchorEl(event.currentTarget);
   }
 
+  const menuId = 'primary-search-account-menu';
   const renderMenu = (
     <Menu
       anchorEl={anchorEl}
       anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      id={menuId}
+      keepMounted
       transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       open={isMenuOpen}
       onClose={handleMenuClose}
@@ -116,16 +119,19 @@ function PrimarySearchAppBar() {
     </Menu>
   );
 
+  const mobileMenuId = 'primary-search-account-menu-mobile';
   const renderMobileMenu = (
     <Menu
       anchorEl={mobileMoreAnchorEl}
       anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      id={mobileMenuId}
+      keepMounted
       transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       open={isMobileMenuOpen}
       onClose={handleMobileMenuClose}
     >
       <MenuItem>
-        <IconButton color="inherit">
+        <IconButton aria-label="Show 4 new mails" color="inherit">
           <Badge badgeContent={4} color="secondary">
             <MailIcon />
           </Badge>
@@ -133,7 +139,7 @@ function PrimarySearchAppBar() {
         <p>Messages</p>
       </MenuItem>
       <MenuItem>
-        <IconButton color="inherit">
+        <IconButton aria-label="Show 17 new notifications" color="inherit">
           <Badge badgeContent={11} color="secondary">
             <NotificationsIcon />
           </Badge>
@@ -141,7 +147,12 @@ function PrimarySearchAppBar() {
         <p>Notifications</p>
       </MenuItem>
       <MenuItem onClick={handleProfileMenuOpen}>
-        <IconButton color="inherit">
+        <IconButton
+          aria-label="Account of current user"
+          aria-controls="primary-search-account-menu"
+          aria-haspopup="true"
+          color="inherit"
+        >
           <AccountCircle />
         </IconButton>
         <p>Profile</p>
@@ -174,23 +185,25 @@ function PrimarySearchAppBar() {
                 root: classes.inputRoot,
                 input: classes.inputInput,
               }}
+              inputProps={{ 'aria-label': 'Search' }}
             />
           </div>
           <div className={classes.grow} />
           <div className={classes.sectionDesktop}>
-            <IconButton color="inherit">
+            <IconButton aria-label="Show 4 new mails" color="inherit">
               <Badge badgeContent={4} color="secondary">
                 <MailIcon />
               </Badge>
             </IconButton>
-            <IconButton color="inherit">
+            <IconButton aria-label="Show 17 new notifications" color="inherit">
               <Badge badgeContent={17} color="secondary">
                 <NotificationsIcon />
               </Badge>
             </IconButton>
             <IconButton
               edge="end"
-              aria-owns={isMenuOpen ? 'material-appbar' : undefined}
+              aria-label="Account of current user"
+              aria-controls={menuId}
               aria-haspopup="true"
               onClick={handleProfileMenuOpen}
               color="inherit"
@@ -199,14 +212,20 @@ function PrimarySearchAppBar() {
             </IconButton>
           </div>
           <div className={classes.sectionMobile}>
-            <IconButton aria-haspopup="true" onClick={handleMobileMenuOpen} color="inherit">
+            <IconButton
+              aria-label="Show more"
+              aria-controls={mobileMenuId}
+              aria-haspopup="true"
+              onClick={handleMobileMenuOpen}
+              color="inherit"
+            >
               <MoreIcon />
             </IconButton>
           </div>
         </Toolbar>
       </AppBar>
-      {renderMenu}
       {renderMobileMenu}
+      {renderMenu}
     </div>
   );
 }

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
@@ -141,7 +141,7 @@ function PrimarySearchAppBar() {
         <p>Messages</p>
       </MenuItem>
       <MenuItem>
-        <IconButton aria-label="Show 17 new notifications" color="inherit">
+        <IconButton aria-label="Show 11 new notifications" color="inherit">
           <Badge badgeContent={11} color="secondary">
             <NotificationsIcon />
           </Badge>

--- a/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/PrimarySearchAppBar.tsx
@@ -105,10 +105,13 @@ function PrimarySearchAppBar() {
     setMobileMoreAnchorEl(event.currentTarget);
   }
 
+  const menuId = 'primary-search-account-menu';
   const renderMenu = (
     <Menu
       anchorEl={anchorEl}
       anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      id={menuId}
+      keepMounted
       transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       open={isMenuOpen}
       onClose={handleMenuClose}
@@ -118,16 +121,19 @@ function PrimarySearchAppBar() {
     </Menu>
   );
 
+  const mobileMenuId = 'primary-search-account-menu-mobile';
   const renderMobileMenu = (
     <Menu
       anchorEl={mobileMoreAnchorEl}
       anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
+      id={mobileMenuId}
+      keepMounted
       transformOrigin={{ vertical: 'top', horizontal: 'right' }}
       open={isMobileMenuOpen}
       onClose={handleMobileMenuClose}
     >
       <MenuItem>
-        <IconButton color="inherit">
+        <IconButton aria-label="Show 4 new mails" color="inherit">
           <Badge badgeContent={4} color="secondary">
             <MailIcon />
           </Badge>
@@ -135,7 +141,7 @@ function PrimarySearchAppBar() {
         <p>Messages</p>
       </MenuItem>
       <MenuItem>
-        <IconButton color="inherit">
+        <IconButton aria-label="Show 17 new notifications" color="inherit">
           <Badge badgeContent={11} color="secondary">
             <NotificationsIcon />
           </Badge>
@@ -143,7 +149,12 @@ function PrimarySearchAppBar() {
         <p>Notifications</p>
       </MenuItem>
       <MenuItem onClick={handleProfileMenuOpen}>
-        <IconButton color="inherit">
+        <IconButton
+          aria-label="Account of current user"
+          aria-controls="primary-search-account-menu"
+          aria-haspopup="true"
+          color="inherit"
+        >
           <AccountCircle />
         </IconButton>
         <p>Profile</p>
@@ -176,23 +187,25 @@ function PrimarySearchAppBar() {
                 root: classes.inputRoot,
                 input: classes.inputInput,
               }}
+              inputProps={{ 'aria-label': 'Search' }}
             />
           </div>
           <div className={classes.grow} />
           <div className={classes.sectionDesktop}>
-            <IconButton color="inherit">
+            <IconButton aria-label="Show 4 new mails" color="inherit">
               <Badge badgeContent={4} color="secondary">
                 <MailIcon />
               </Badge>
             </IconButton>
-            <IconButton color="inherit">
+            <IconButton aria-label="Show 17 new notifications" color="inherit">
               <Badge badgeContent={17} color="secondary">
                 <NotificationsIcon />
               </Badge>
             </IconButton>
             <IconButton
               edge="end"
-              aria-owns={isMenuOpen ? 'material-appbar' : undefined}
+              aria-label="Account of current user"
+              aria-controls={menuId}
               aria-haspopup="true"
               onClick={handleProfileMenuOpen}
               color="inherit"
@@ -201,14 +214,20 @@ function PrimarySearchAppBar() {
             </IconButton>
           </div>
           <div className={classes.sectionMobile}>
-            <IconButton aria-haspopup="true" onClick={handleMobileMenuOpen} color="inherit">
+            <IconButton
+              aria-label="Show more"
+              aria-controls={mobileMenuId}
+              aria-haspopup="true"
+              onClick={handleMobileMenuOpen}
+              color="inherit"
+            >
               <MoreIcon />
             </IconButton>
           </div>
         </Toolbar>
       </AppBar>
-      {renderMenu}
       {renderMobileMenu}
+      {renderMenu}
     </div>
   );
 }

--- a/docs/src/pages/components/app-bar/SearchAppBar.js
+++ b/docs/src/pages/components/app-bar/SearchAppBar.js
@@ -89,6 +89,7 @@ function SearchAppBar() {
                 root: classes.inputRoot,
                 input: classes.inputInput,
               }}
+              inputProps={{ 'aria-label': 'Search' }}
             />
           </div>
         </Toolbar>

--- a/docs/src/pages/components/app-bar/SearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/SearchAppBar.tsx
@@ -91,6 +91,7 @@ function SearchAppBar() {
                 root: classes.inputRoot,
                 input: classes.inputInput,
               }}
+              inputProps={{ 'aria-label': 'Search' }}
             />
           </div>
         </Toolbar>

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
@@ -101,7 +101,7 @@ class RouterBreadcrumbs extends React.Component {
               );
             }}
           </Route>
-          <nav className={classes.lists}>
+          <nav className={classes.lists} aria-label="Mailbox folders">
             <List>
               <ListItemLink to="/inbox" open={this.state.open} onClick={this.handleClick} />
               <Collapse component="li" in={this.state.open} timeout="auto" unmountOnExit>

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
@@ -101,18 +101,18 @@ class RouterBreadcrumbs extends React.Component {
               );
             }}
           </Route>
-          <div className={classes.lists}>
-            <List component="nav">
+          <nav className={classes.lists}>
+            <List>
               <ListItemLink to="/inbox" open={this.state.open} onClick={this.handleClick} />
-              <Collapse in={this.state.open} timeout="auto" unmountOnExit>
-                <List component="div" disablePadding>
+              <Collapse component="li" in={this.state.open} timeout="auto" unmountOnExit>
+                <List disablePadding>
                   <ListItemLink to="/inbox/important" className={classes.nested} />
                 </List>
               </Collapse>
               <ListItemLink to="/trash" />
               <ListItemLink to="/spam" />
             </List>
-          </div>
+          </nav>
         </div>
       </MemoryRouter>
     );

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
@@ -119,18 +119,18 @@ class RouterBreadcrumbs extends React.Component<RouterBreadcrumbsProp, RouterBre
               );
             }}
           </Route>
-          <div className={classes.lists}>
-            <List component="nav">
+          <nav className={classes.lists}>
+            <List>
               <ListItemLink to="/inbox" open={this.state.open} onClick={this.handleClick} />
-              <Collapse in={this.state.open} timeout="auto" unmountOnExit>
-                <List component="div" disablePadding>
+              <Collapse component="li" in={this.state.open} timeout="auto" unmountOnExit>
+                <List disablePadding>
                   <ListItemLink to="/inbox/important" className={classes.nested} />
                 </List>
               </Collapse>
               <ListItemLink to="/trash" />
               <ListItemLink to="/spam" />
             </List>
-          </div>
+          </nav>
         </div>
       </MemoryRouter>
     );

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
@@ -119,7 +119,7 @@ class RouterBreadcrumbs extends React.Component<RouterBreadcrumbsProp, RouterBre
               );
             }}
           </Route>
-          <nav className={classes.lists}>
+          <nav className={classes.lists} aria-label="Mailbox folders">
             <List>
               <ListItemLink to="/inbox" open={this.state.open} onClick={this.handleClick} />
               <Collapse component="li" in={this.state.open} timeout="auto" unmountOnExit>

--- a/docs/src/pages/components/cards/RecipeReviewCard.js
+++ b/docs/src/pages/components/cards/RecipeReviewCard.js
@@ -56,7 +56,7 @@ function RecipeReviewCard() {
           </Avatar>
         }
         action={
-          <IconButton>
+          <IconButton aria-label="Settings">
             <MoreVertIcon />
           </IconButton>
         }

--- a/docs/src/pages/components/cards/RecipeReviewCard.tsx
+++ b/docs/src/pages/components/cards/RecipeReviewCard.tsx
@@ -58,7 +58,7 @@ function RecipeReviewCard() {
           </Avatar>
         }
         action={
-          <IconButton>
+          <IconButton aria-label="Settings">
             <MoreVertIcon />
           </IconButton>
         }

--- a/docs/src/pages/components/dialogs/ConfirmationDialog.js
+++ b/docs/src/pages/components/dialogs/ConfirmationDialog.js
@@ -125,8 +125,8 @@ function ConfirmationDialog() {
 
   return (
     <div className={classes.root}>
-      <List>
-        <ListItem button divider disabled>
+      <List component="div" role="list">
+        <ListItem button divider disabled role="listitem">
           <ListItemText primary="Interruptions" />
         </ListItem>
         <ListItem
@@ -136,16 +136,19 @@ function ConfirmationDialog() {
           aria-controls="ringtone-menu"
           aria-label="Phone ringtone"
           onClick={handleClickListItem}
+          role="listitem"
         >
           <ListItemText primary="Phone ringtone" secondary={value} />
         </ListItem>
-        <ListItem button divider disabled>
+        <ListItem button divider disabled role="listitem">
           <ListItemText primary="Default notification ringtone" secondary="Tethys" />
         </ListItem>
         <ConfirmationDialogRaw
           classes={{
             paper: classes.paper,
           }}
+          id="ringtone-menu"
+          keepMounted
           open={open}
           onClose={handleClose}
           value={value}

--- a/docs/src/pages/components/dialogs/ConfirmationDialog.tsx
+++ b/docs/src/pages/components/dialogs/ConfirmationDialog.tsx
@@ -32,6 +32,8 @@ const options = [
 
 export interface ConfirmationDialogRawProps {
   classes: Record<'paper', string>;
+  id: string;
+  keepMounted: boolean;
   value: string;
   open: boolean;
   onClose: (value: string) => void;
@@ -132,8 +134,8 @@ function ConfirmationDialog() {
 
   return (
     <div className={classes.root}>
-      <List>
-        <ListItem button divider disabled>
+      <List component="div" role="list">
+        <ListItem button divider disabled role="listitem">
           <ListItemText primary="Interruptions" />
         </ListItem>
         <ListItem
@@ -143,16 +145,19 @@ function ConfirmationDialog() {
           aria-controls="ringtone-menu"
           aria-label="Phone ringtone"
           onClick={handleClickListItem}
+          role="listitem"
         >
           <ListItemText primary="Phone ringtone" secondary={value} />
         </ListItem>
-        <ListItem button divider disabled>
+        <ListItem button divider disabled role="listitem">
           <ListItemText primary="Default notification ringtone" secondary="Tethys" />
         </ListItem>
         <ConfirmationDialogRaw
           classes={{
             paper: classes.paper,
           }}
+          id="ringtone-menu"
+          keepMounted
           open={open}
           onClose={handleClose}
           value={value}

--- a/docs/src/pages/components/dividers/ListDividers.js
+++ b/docs/src/pages/components/dividers/ListDividers.js
@@ -17,7 +17,7 @@ function ListDividers() {
   const classes = useStyles();
 
   return (
-    <List component="nav" className={classes.root}>
+    <List component="nav" className={classes.root} aria-label="Mailbox folders">
       <ListItem button>
         <ListItemText primary="Inbox" />
       </ListItem>

--- a/docs/src/pages/components/dividers/ListDividers.tsx
+++ b/docs/src/pages/components/dividers/ListDividers.tsx
@@ -19,7 +19,7 @@ function ListDividers() {
   const classes = useStyles();
 
   return (
-    <List component="nav" className={classes.root}>
+    <List component="nav" className={classes.root} aria-label="Mailbox folders">
       <ListItem button>
         <ListItemText primary="Inbox" />
       </ListItem>

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.js
@@ -104,7 +104,7 @@ function ResponsiveDrawer(props) {
           </Typography>
         </Toolbar>
       </AppBar>
-      <nav className={classes.drawer}>
+      <nav className={classes.drawer} aria-label="Mailbox folders">
         {/* The implementation can be swapped with js to avoid SEO duplication of links. */}
         <Hidden smUp implementation="css">
           <Drawer

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
@@ -110,7 +110,7 @@ function ResponsiveDrawer(props: ResponsiveDrawerProps) {
           </Typography>
         </Toolbar>
       </AppBar>
-      <nav className={classes.drawer}>
+      <nav className={classes.drawer} aria-label="Mailbox folders">
         {/* The implementation can be swapped with js to avoid SEO duplication of links. */}
         <Hidden smUp implementation="css">
           <Drawer

--- a/docs/src/pages/components/grid-list/AdvancedGridList.js
+++ b/docs/src/pages/components/grid-list/AdvancedGridList.js
@@ -62,7 +62,7 @@ function AdvancedGridList() {
               title={tile.title}
               titlePosition="top"
               actionIcon={
-                <IconButton className={classes.icon}>
+                <IconButton aria-label={`star ${tile.title}`} className={classes.icon}>
                   <StarBorderIcon />
                 </IconButton>
               }

--- a/docs/src/pages/components/grid-list/AdvancedGridList.tsx
+++ b/docs/src/pages/components/grid-list/AdvancedGridList.tsx
@@ -64,7 +64,7 @@ function AdvancedGridList() {
               title={tile.title}
               titlePosition="top"
               actionIcon={
-                <IconButton className={classes.icon}>
+                <IconButton aria-label={`star ${tile.title}`} className={classes.icon}>
                   <StarBorderIcon />
                 </IconButton>
               }

--- a/docs/src/pages/components/grid-list/SingleLineGridList.js
+++ b/docs/src/pages/components/grid-list/SingleLineGridList.js
@@ -62,7 +62,7 @@ function SingleLineGridList() {
                 title: classes.title,
               }}
               actionIcon={
-                <IconButton>
+                <IconButton aria-label={`star ${tile.title}`}>
                   <StarBorderIcon className={classes.title} />
                 </IconButton>
               }

--- a/docs/src/pages/components/grid-list/SingleLineGridList.tsx
+++ b/docs/src/pages/components/grid-list/SingleLineGridList.tsx
@@ -64,7 +64,7 @@ function SingleLineGridList() {
                 title: classes.title,
               }}
               actionIcon={
-                <IconButton>
+                <IconButton aria-label={`star ${tile.title}`}>
                   <StarBorderIcon className={classes.title} />
                 </IconButton>
               }

--- a/docs/src/pages/components/grid-list/TitlebarGridList.js
+++ b/docs/src/pages/components/grid-list/TitlebarGridList.js
@@ -58,7 +58,7 @@ function TitlebarGridList() {
               title={tile.title}
               subtitle={<span>by: {tile.author}</span>}
               actionIcon={
-                <IconButton className={classes.icon}>
+                <IconButton aria-label={`info about ${tile.title}`} className={classes.icon}>
                   <InfoIcon />
                 </IconButton>
               }

--- a/docs/src/pages/components/grid-list/TitlebarGridList.tsx
+++ b/docs/src/pages/components/grid-list/TitlebarGridList.tsx
@@ -60,7 +60,7 @@ function TitlebarGridList() {
               title={tile.title}
               subtitle={<span>by: {tile.author}</span>}
               actionIcon={
-                <IconButton className={classes.icon}>
+                <IconButton aria-label={`info about ${tile.title}`} className={classes.icon}>
                   <InfoIcon />
                 </IconButton>
               }

--- a/docs/src/pages/components/lists/CheckboxList.js
+++ b/docs/src/pages/components/lists/CheckboxList.js
@@ -36,24 +36,29 @@ function CheckboxList() {
 
   return (
     <List className={classes.root}>
-      {[0, 1, 2, 3].map(value => (
-        <ListItem key={value} role={undefined} dense button onClick={handleToggle(value)}>
-          <ListItemIcon>
-            <Checkbox
-              edge="start"
-              checked={checked.indexOf(value) !== -1}
-              tabIndex={-1}
-              disableRipple
-            />
-          </ListItemIcon>
-          <ListItemText primary={`Line item ${value + 1}`} />
-          <ListItemSecondaryAction>
-            <IconButton edge="end" aria-label="Comments">
-              <CommentIcon />
-            </IconButton>
-          </ListItemSecondaryAction>
-        </ListItem>
-      ))}
+      {[0, 1, 2, 3].map(value => {
+        const labelId = `checkbox-list-label-${value}`;
+
+        return (
+          <ListItem key={value} role={undefined} dense button onClick={handleToggle(value)}>
+            <ListItemIcon>
+              <Checkbox
+                edge="start"
+                checked={checked.indexOf(value) !== -1}
+                tabIndex={-1}
+                disableRipple
+                inputProps={{ 'aria-labelledby': labelId }}
+              />
+            </ListItemIcon>
+            <ListItemText id={labelId} primary={`Line item ${value + 1}`} />
+            <ListItemSecondaryAction>
+              <IconButton edge="end" aria-label="Comments">
+                <CommentIcon />
+              </IconButton>
+            </ListItemSecondaryAction>
+          </ListItem>
+        );
+      })}
     </List>
   );
 }

--- a/docs/src/pages/components/lists/CheckboxList.tsx
+++ b/docs/src/pages/components/lists/CheckboxList.tsx
@@ -38,24 +38,29 @@ function CheckboxList() {
 
   return (
     <List className={classes.root}>
-      {[0, 1, 2, 3].map(value => (
-        <ListItem key={value} role={undefined} dense button onClick={handleToggle(value)}>
-          <ListItemIcon>
-            <Checkbox
-              edge="start"
-              checked={checked.indexOf(value) !== -1}
-              tabIndex={-1}
-              disableRipple
-            />
-          </ListItemIcon>
-          <ListItemText primary={`Line item ${value + 1}`} />
-          <ListItemSecondaryAction>
-            <IconButton edge="end" aria-label="Comments">
-              <CommentIcon />
-            </IconButton>
-          </ListItemSecondaryAction>
-        </ListItem>
-      ))}
+      {[0, 1, 2, 3].map(value => {
+        const labelId = `checkbox-list-label-${value}`;
+
+        return (
+          <ListItem key={value} role={undefined} dense button onClick={handleToggle(value)}>
+            <ListItemIcon>
+              <Checkbox
+                edge="start"
+                checked={checked.indexOf(value) !== -1}
+                tabIndex={-1}
+                disableRipple
+                inputProps={{ 'aria-labelledby': labelId }}
+              />
+            </ListItemIcon>
+            <ListItemText id={labelId} primary={`Line item ${value + 1}`} />
+            <ListItemSecondaryAction>
+              <IconButton edge="end" aria-label="Comments">
+                <CommentIcon />
+              </IconButton>
+            </ListItemSecondaryAction>
+          </ListItem>
+        );
+      })}
     </List>
   );
 }

--- a/docs/src/pages/components/lists/CheckboxListSecondary.js
+++ b/docs/src/pages/components/lists/CheckboxListSecondary.js
@@ -35,21 +35,28 @@ function CheckboxListSecondary() {
 
   return (
     <List dense className={classes.root}>
-      {[0, 1, 2, 3].map(value => (
-        <ListItem key={value} button>
-          <ListItemAvatar>
-            <Avatar alt={`Avatar n°${value + 1}`} src={`/static/images/avatar/${value + 1}.jpg`} />
-          </ListItemAvatar>
-          <ListItemText primary={`Line item ${value + 1}`} />
-          <ListItemSecondaryAction>
-            <Checkbox
-              edge="end"
-              onChange={handleToggle(value)}
-              checked={checked.indexOf(value) !== -1}
-            />
-          </ListItemSecondaryAction>
-        </ListItem>
-      ))}
+      {[0, 1, 2, 3].map(value => {
+        const labelId = `checkbox-list-secondary-label-${value}`;
+        return (
+          <ListItem key={value} button>
+            <ListItemAvatar>
+              <Avatar
+                alt={`Avatar n°${value + 1}`}
+                src={`/static/images/avatar/${value + 1}.jpg`}
+              />
+            </ListItemAvatar>
+            <ListItemText id={labelId} primary={`Line item ${value + 1}`} />
+            <ListItemSecondaryAction>
+              <Checkbox
+                edge="end"
+                onChange={handleToggle(value)}
+                checked={checked.indexOf(value) !== -1}
+                inputProps={{ 'aria-labelledby': labelId }}
+              />
+            </ListItemSecondaryAction>
+          </ListItem>
+        );
+      })}
     </List>
   );
 }

--- a/docs/src/pages/components/lists/CheckboxListSecondary.tsx
+++ b/docs/src/pages/components/lists/CheckboxListSecondary.tsx
@@ -37,21 +37,28 @@ function CheckboxListSecondary() {
 
   return (
     <List dense className={classes.root}>
-      {[0, 1, 2, 3].map(value => (
-        <ListItem key={value} button>
-          <ListItemAvatar>
-            <Avatar alt={`Avatar n°${value + 1}`} src={`/static/images/avatar/${value + 1}.jpg`} />
-          </ListItemAvatar>
-          <ListItemText primary={`Line item ${value + 1}`} />
-          <ListItemSecondaryAction>
-            <Checkbox
-              edge="end"
-              onChange={handleToggle(value)}
-              checked={checked.indexOf(value) !== -1}
-            />
-          </ListItemSecondaryAction>
-        </ListItem>
-      ))}
+      {[0, 1, 2, 3].map(value => {
+        const labelId = `checkbox-list-secondary-label-${value}`;
+        return (
+          <ListItem key={value} button>
+            <ListItemAvatar>
+              <Avatar
+                alt={`Avatar n°${value + 1}`}
+                src={`/static/images/avatar/${value + 1}.jpg`}
+              />
+            </ListItemAvatar>
+            <ListItemText id={labelId} primary={`Line item ${value + 1}`} />
+            <ListItemSecondaryAction>
+              <Checkbox
+                edge="end"
+                onChange={handleToggle(value)}
+                checked={checked.indexOf(value) !== -1}
+                inputProps={{ 'aria-labelledby': labelId }}
+              />
+            </ListItemSecondaryAction>
+          </ListItem>
+        );
+      })}
     </List>
   );
 }

--- a/docs/src/pages/components/lists/InsetList.js
+++ b/docs/src/pages/components/lists/InsetList.js
@@ -18,7 +18,7 @@ function InsetList() {
   const classes = useStyles();
 
   return (
-    <List component="nav" className={classes.root}>
+    <List component="nav" className={classes.root} aria-label="Contacts">
       <ListItem button>
         <ListItemIcon>
           <StarIcon />

--- a/docs/src/pages/components/lists/InsetList.tsx
+++ b/docs/src/pages/components/lists/InsetList.tsx
@@ -20,7 +20,7 @@ function InsetList() {
   const classes = useStyles();
 
   return (
-    <List component="nav" className={classes.root}>
+    <List component="nav" className={classes.root} aria-label="Contacts">
       <ListItem button>
         <ListItemIcon>
           <StarIcon />

--- a/docs/src/pages/components/lists/NestedList.js
+++ b/docs/src/pages/components/lists/NestedList.js
@@ -35,7 +35,12 @@ function NestedList() {
   return (
     <List
       component="nav"
-      subheader={<ListSubheader component="div">Nested List Items</ListSubheader>}
+      aria-labelledby="nested-list-subheader"
+      subheader={
+        <ListSubheader component="div" id="nested-list-subheader">
+          Nested List Items
+        </ListSubheader>
+      }
       className={classes.root}
     >
       <ListItem button>

--- a/docs/src/pages/components/lists/NestedList.tsx
+++ b/docs/src/pages/components/lists/NestedList.tsx
@@ -35,7 +35,12 @@ function NestedList() {
   return (
     <List
       component="nav"
-      subheader={<ListSubheader component="div">Nested List Items</ListSubheader>}
+      aria-labelledby="nested-list-subheader"
+      subheader={
+        <ListSubheader component="div" id="nested-list-subheader">
+          Nested List Items
+        </ListSubheader>
+      }
       className={classes.root}
     >
       <ListItem button>

--- a/docs/src/pages/components/lists/SelectedListItem.js
+++ b/docs/src/pages/components/lists/SelectedListItem.js
@@ -26,7 +26,7 @@ function SelectedListItem() {
 
   return (
     <div className={classes.root}>
-      <List component="nav">
+      <List component="nav" aria-label="Main mailbox folders">
         <ListItem
           button
           selected={selectedIndex === 0}
@@ -49,7 +49,7 @@ function SelectedListItem() {
         </ListItem>
       </List>
       <Divider />
-      <List component="nav">
+      <List component="nav" aria-label="Secondary mailbox folder">
         <ListItem
           button
           selected={selectedIndex === 2}

--- a/docs/src/pages/components/lists/SelectedListItem.tsx
+++ b/docs/src/pages/components/lists/SelectedListItem.tsx
@@ -29,7 +29,7 @@ function SelectedListItem() {
 
   return (
     <div className={classes.root}>
-      <List component="nav">
+      <List component="nav" aria-label="Main mailbox folders">
         <ListItem
           button
           selected={selectedIndex === 0}
@@ -52,7 +52,7 @@ function SelectedListItem() {
         </ListItem>
       </List>
       <Divider />
-      <List component="nav">
+      <List component="nav" aria-label="Secondary mailbox folder">
         <ListItem
           button
           selected={selectedIndex === 2}

--- a/docs/src/pages/components/lists/SimpleList.js
+++ b/docs/src/pages/components/lists/SimpleList.js
@@ -25,7 +25,7 @@ function SimpleList() {
 
   return (
     <div className={classes.root}>
-      <List component="nav">
+      <List component="nav" aria-label="Main mailbox folders">
         <ListItem button>
           <ListItemIcon>
             <InboxIcon />
@@ -40,7 +40,7 @@ function SimpleList() {
         </ListItem>
       </List>
       <Divider />
-      <List component="nav">
+      <List component="nav" aria-label="Secondary mailbox folders">
         <ListItem button>
           <ListItemText primary="Trash" />
         </ListItem>

--- a/docs/src/pages/components/lists/SimpleList.tsx
+++ b/docs/src/pages/components/lists/SimpleList.tsx
@@ -27,7 +27,7 @@ function SimpleList() {
 
   return (
     <div className={classes.root}>
-      <List component="nav">
+      <List component="nav" aria-label="Main mailbox folders">
         <ListItem button>
           <ListItemIcon>
             <InboxIcon />
@@ -42,7 +42,7 @@ function SimpleList() {
         </ListItem>
       </List>
       <Divider />
-      <List component="nav">
+      <List component="nav" aria-label="Secondary mailbox folders">
         <ListItem button>
           <ListItemText primary="Trash" />
         </ListItem>

--- a/docs/src/pages/components/lists/SwitchListSecondary.js
+++ b/docs/src/pages/components/lists/SwitchListSecondary.js
@@ -41,12 +41,13 @@ function SwitchListSecondary() {
         <ListItemIcon>
           <WifiIcon />
         </ListItemIcon>
-        <ListItemText primary="Wi-Fi" />
+        <ListItemText id="switch-list-label-wifi" primary="Wi-Fi" />
         <ListItemSecondaryAction>
           <Switch
             edge="end"
             onChange={handleToggle('wifi')}
             checked={checked.indexOf('wifi') !== -1}
+            inputProps={{ 'aria-labelledby': 'switch-list-label-wifi' }}
           />
         </ListItemSecondaryAction>
       </ListItem>
@@ -54,12 +55,13 @@ function SwitchListSecondary() {
         <ListItemIcon>
           <BluetoothIcon />
         </ListItemIcon>
-        <ListItemText primary="Bluetooth" />
+        <ListItemText id="switch-list-label-bluetooth" primary="Bluetooth" />
         <ListItemSecondaryAction>
           <Switch
             edge="end"
             onChange={handleToggle('bluetooth')}
             checked={checked.indexOf('bluetooth') !== -1}
+            inputProps={{ 'aria-labelledby': 'switch-list-label-bluetooth' }}
           />
         </ListItemSecondaryAction>
       </ListItem>

--- a/docs/src/pages/components/lists/SwitchListSecondary.tsx
+++ b/docs/src/pages/components/lists/SwitchListSecondary.tsx
@@ -41,12 +41,13 @@ function SwitchListSecondary() {
         <ListItemIcon>
           <WifiIcon />
         </ListItemIcon>
-        <ListItemText primary="Wi-Fi" />
+        <ListItemText id="switch-list-label-wifi" primary="Wi-Fi" />
         <ListItemSecondaryAction>
           <Switch
             edge="end"
             onChange={handleToggle('wifi')}
             checked={checked.indexOf('wifi') !== -1}
+            inputProps={{ 'aria-labelledby': 'switch-list-label-wifi' }}
           />
         </ListItemSecondaryAction>
       </ListItem>
@@ -54,12 +55,13 @@ function SwitchListSecondary() {
         <ListItemIcon>
           <BluetoothIcon />
         </ListItemIcon>
-        <ListItemText primary="Bluetooth" />
+        <ListItemText id="switch-list-label-bluetooth" primary="Bluetooth" />
         <ListItemSecondaryAction>
           <Switch
             edge="end"
             onChange={handleToggle('bluetooth')}
             checked={checked.indexOf('bluetooth') !== -1}
+            inputProps={{ 'aria-labelledby': 'switch-list-label-bluetooth' }}
           />
         </ListItemSecondaryAction>
       </ListItem>

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -65,6 +65,7 @@ function CustomizedMenus() {
       <StyledMenu
         id="customized-menu"
         anchorEl={anchorEl}
+        keepMounted
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >

--- a/docs/src/pages/components/menus/CustomizedMenus.js
+++ b/docs/src/pages/components/menus/CustomizedMenus.js
@@ -54,7 +54,7 @@ function CustomizedMenus() {
   return (
     <div>
       <Button
-        aria-owns={anchorEl ? 'simple-menu' : undefined}
+        aria-controls="customized-menu"
         aria-haspopup="true"
         variant="contained"
         color="primary"
@@ -63,7 +63,7 @@ function CustomizedMenus() {
         Open Menu
       </Button>
       <StyledMenu
-        id="simple-menu"
+        id="customized-menu"
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -65,6 +65,7 @@ function CustomizedMenus() {
       <StyledMenu
         id="customized-menu"
         anchorEl={anchorEl}
+        keepMounted
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >

--- a/docs/src/pages/components/menus/CustomizedMenus.tsx
+++ b/docs/src/pages/components/menus/CustomizedMenus.tsx
@@ -54,7 +54,7 @@ function CustomizedMenus() {
   return (
     <div>
       <Button
-        aria-owns={anchorEl ? 'simple-menu' : undefined}
+        aria-controls="customized-menu"
         aria-haspopup="true"
         variant="contained"
         color="primary"
@@ -63,7 +63,7 @@ function CustomizedMenus() {
         Open Menu
       </Button>
       <StyledMenu
-        id="simple-menu"
+        id="customized-menu"
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleClose}

--- a/docs/src/pages/components/menus/FadeMenu.js
+++ b/docs/src/pages/components/menus/FadeMenu.js
@@ -18,12 +18,13 @@ function FadeMenu() {
 
   return (
     <div>
-      <Button aria-owns={open ? 'fade-menu' : undefined} aria-haspopup="true" onClick={handleClick}>
+      <Button aria-controls="fade-menu" aria-haspopup="true" onClick={handleClick}>
         Open with fade transition
       </Button>
       <Menu
         id="fade-menu"
         anchorEl={anchorEl}
+        keepMounted
         open={open}
         onClose={handleClose}
         TransitionComponent={Fade}

--- a/docs/src/pages/components/menus/FadeMenu.tsx
+++ b/docs/src/pages/components/menus/FadeMenu.tsx
@@ -18,12 +18,13 @@ function FadeMenu() {
 
   return (
     <div>
-      <Button aria-owns={open ? 'fade-menu' : undefined} aria-haspopup="true" onClick={handleClick}>
+      <Button aria-controls="fade-menu" aria-haspopup="true" onClick={handleClick}>
         Open with fade transition
       </Button>
       <Menu
         id="fade-menu"
         anchorEl={anchorEl}
+        keepMounted
         open={open}
         onClose={handleClose}
         TransitionComponent={Fade}

--- a/docs/src/pages/components/menus/LongMenu.js
+++ b/docs/src/pages/components/menus/LongMenu.js
@@ -39,7 +39,7 @@ function LongMenu() {
     <div>
       <IconButton
         aria-label="More"
-        aria-owns={open ? 'long-menu' : undefined}
+        aria-controls="long-menu"
         aria-haspopup="true"
         onClick={handleClick}
       >
@@ -48,6 +48,7 @@ function LongMenu() {
       <Menu
         id="long-menu"
         anchorEl={anchorEl}
+        keepMounted
         open={open}
         onClose={handleClose}
         PaperProps={{

--- a/docs/src/pages/components/menus/LongMenu.tsx
+++ b/docs/src/pages/components/menus/LongMenu.tsx
@@ -39,7 +39,7 @@ function LongMenu() {
     <div>
       <IconButton
         aria-label="More"
-        aria-owns={open ? 'long-menu' : undefined}
+        aria-controls="long-menu"
         aria-haspopup="true"
         onClick={handleClick}
       >
@@ -48,6 +48,7 @@ function LongMenu() {
       <Menu
         id="long-menu"
         anchorEl={anchorEl}
+        keepMounted
         open={open}
         onClose={handleClose}
         PaperProps={{

--- a/docs/src/pages/components/menus/MenuListComposition.js
+++ b/docs/src/pages/components/menus/MenuListComposition.js
@@ -46,13 +46,13 @@ function MenuListComposition() {
       <div>
         <Button
           ref={anchorRef}
-          aria-owns={open ? 'menu-list-grow' : undefined}
+          aria-controls="menu-list-grow"
           aria-haspopup="true"
           onClick={handleToggle}
         >
           Toggle Menu Grow
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} keepMounted transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}

--- a/docs/src/pages/components/menus/MenuListComposition.tsx
+++ b/docs/src/pages/components/menus/MenuListComposition.tsx
@@ -48,13 +48,13 @@ function MenuListComposition() {
       <div>
         <Button
           ref={anchorRef}
-          aria-owns={open ? 'menu-list-grow' : undefined}
+          aria-controls="menu-list-grow"
           aria-haspopup="true"
           onClick={handleToggle}
         >
           Toggle Menu Grow
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} keepMounted transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}

--- a/docs/src/pages/components/menus/SimpleListMenu.js
+++ b/docs/src/pages/components/menus/SimpleListMenu.js
@@ -41,7 +41,7 @@ function SimpleListMenu() {
 
   return (
     <div className={classes.root}>
-      <List component="nav">
+      <List component="nav" aria-label="Device settings">
         <ListItem
           button
           aria-haspopup="true"

--- a/docs/src/pages/components/menus/SimpleListMenu.js
+++ b/docs/src/pages/components/menus/SimpleListMenu.js
@@ -52,7 +52,13 @@ function SimpleListMenu() {
           <ListItemText primary="When device is locked" secondary={options[selectedIndex]} />
         </ListItem>
       </List>
-      <Menu id="lock-menu" anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+      <Menu
+        id="lock-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
         {options.map((option, index) => (
           <MenuItem
             key={option}

--- a/docs/src/pages/components/menus/SimpleListMenu.tsx
+++ b/docs/src/pages/components/menus/SimpleListMenu.tsx
@@ -43,7 +43,7 @@ function SimpleListMenu() {
 
   return (
     <div className={classes.root}>
-      <List component="nav">
+      <List component="nav" aria-label="Device settings">
         <ListItem
           button
           aria-haspopup="true"

--- a/docs/src/pages/components/menus/SimpleListMenu.tsx
+++ b/docs/src/pages/components/menus/SimpleListMenu.tsx
@@ -54,7 +54,13 @@ function SimpleListMenu() {
           <ListItemText primary="When device is locked" secondary={options[selectedIndex]} />
         </ListItem>
       </List>
-      <Menu id="lock-menu" anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+      <Menu
+        id="lock-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
         {options.map((option, index) => (
           <MenuItem
             key={option}

--- a/docs/src/pages/components/menus/SimpleMenu.js
+++ b/docs/src/pages/components/menus/SimpleMenu.js
@@ -16,14 +16,16 @@ function SimpleMenu() {
 
   return (
     <div>
-      <Button
-        aria-owns={anchorEl ? 'simple-menu' : undefined}
-        aria-haspopup="true"
-        onClick={handleClick}
-      >
+      <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
         Open Menu
       </Button>
-      <Menu id="simple-menu" anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+      <Menu
+        id="simple-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>
         <MenuItem onClick={handleClose}>Logout</MenuItem>

--- a/docs/src/pages/components/menus/SimpleMenu.tsx
+++ b/docs/src/pages/components/menus/SimpleMenu.tsx
@@ -16,14 +16,16 @@ function SimpleMenu() {
 
   return (
     <div>
-      <Button
-        aria-owns={anchorEl ? 'simple-menu' : undefined}
-        aria-haspopup="true"
-        onClick={handleClick}
-      >
+      <Button aria-controls="simple-menu" aria-haspopup="true" onClick={handleClick}>
         Open Menu
       </Button>
-      <Menu id="simple-menu" anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={handleClose}>
+      <Menu
+        id="simple-menu"
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
         <MenuItem onClick={handleClose}>Profile</MenuItem>
         <MenuItem onClick={handleClose}>My account</MenuItem>
         <MenuItem onClick={handleClose}>Logout</MenuItem>

--- a/docs/src/pages/components/popper/ScrollPlayground.js
+++ b/docs/src/pages/components/popper/ScrollPlayground.js
@@ -250,7 +250,11 @@ class ScrollPlayground extends React.Component {
                 className={classes.select}
                 label="Placement"
                 select
-                SelectProps={{ native: true }}
+                InputLabelProps={{ id: 'scroll-playground-placement-label' }}
+                SelectProps={{
+                  native: true,
+                  inputProps: { 'aria-labelledby': 'scroll-playground-placement-label' },
+                }}
                 value={placement}
                 onChange={this.handleChangeTarget('placement')}
               >
@@ -289,7 +293,11 @@ class ScrollPlayground extends React.Component {
                 className={classes.select}
                 label="Prevent overflow"
                 select
-                SelectProps={{ native: true }}
+                InputLabelProps={{ id: 'scroll-playground-overflow-label' }}
+                SelectProps={{
+                  native: true,
+                  inputProps: { 'aria-labelledby': 'scroll-playground-overflow-label' },
+                }}
                 value={preventOverflow}
                 onChange={this.handleChangeTarget('preventOverflow')}
               >

--- a/docs/src/pages/components/progress/CircularIntegration.js
+++ b/docs/src/pages/components/progress/CircularIntegration.js
@@ -70,7 +70,12 @@ function CircularIntegration() {
   return (
     <div className={classes.root}>
       <div className={classes.wrapper}>
-        <Fab color="primary" className={buttonClassname} onClick={handleButtonClick}>
+        <Fab
+          aria-label="Save"
+          color="primary"
+          className={buttonClassname}
+          onClick={handleButtonClick}
+        >
           {success ? <CheckIcon /> : <SaveIcon />}
         </Fab>
         {loading && <CircularProgress size={68} className={classes.fabProgress} />}

--- a/docs/src/pages/components/progress/CircularIntegration.tsx
+++ b/docs/src/pages/components/progress/CircularIntegration.tsx
@@ -72,7 +72,12 @@ function CircularIntegration() {
   return (
     <div className={classes.root}>
       <div className={classes.wrapper}>
-        <Fab color="primary" className={buttonClassname} onClick={handleButtonClick}>
+        <Fab
+          aria-label="Save"
+          color="primary"
+          className={buttonClassname}
+          onClick={handleButtonClick}
+        >
           {success ? <CheckIcon /> : <SaveIcon />}
         </Fab>
         {loading && <CircularProgress size={68} className={classes.fabProgress} />}

--- a/docs/src/pages/components/tables/CustomPaginationActionsTable.js
+++ b/docs/src/pages/components/tables/CustomPaginationActionsTable.js
@@ -158,6 +158,7 @@ function CustomPaginationActionsTable() {
                 rowsPerPage={rowsPerPage}
                 page={page}
                 SelectProps={{
+                  inputProps: { 'aria-label': 'Rows per page' },
                   native: true,
                 }}
                 onChangePage={handleChangePage}

--- a/docs/src/pages/components/tables/CustomPaginationActionsTable.tsx
+++ b/docs/src/pages/components/tables/CustomPaginationActionsTable.tsx
@@ -173,6 +173,7 @@ function CustomPaginationActionsTable() {
                 rowsPerPage={rowsPerPage}
                 page={page}
                 SelectProps={{
+                  inputProps: { 'aria-label': 'Rows per page' },
                   native: true,
                 }}
                 onChangePage={handleChangePage}

--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -87,6 +87,7 @@ function EnhancedTableHead(props) {
             indeterminate={numSelected > 0 && numSelected < rowCount}
             checked={numSelected === rowCount}
             onChange={onSelectAllClick}
+            inputProps={{ 'aria-label': 'Select all desserts' }}
           />
         </TableCell>
         {headRows.map(row => (
@@ -288,8 +289,10 @@ function EnhancedTable() {
             <TableBody>
               {stableSort(rows, getSorting(order, orderBy))
                 .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                .map(row => {
+                .map((row, index) => {
                   const isItemSelected = isSelected(row.name);
+                  const labelId = `enhanced-table-checkbox-${index}`;
+
                   return (
                     <TableRow
                       hover
@@ -301,9 +304,12 @@ function EnhancedTable() {
                       selected={isItemSelected}
                     >
                       <TableCell padding="checkbox">
-                        <Checkbox checked={isItemSelected} />
+                        <Checkbox
+                          checked={isItemSelected}
+                          inputProps={{ 'aria-labelledby': labelId }}
+                        />
                       </TableCell>
-                      <TableCell component="th" scope="row" padding="none">
+                      <TableCell component="th" id={labelId} scope="row" padding="none">
                         {row.name}
                       </TableCell>
                       <TableCell align="right">{row.calories}</TableCell>

--- a/docs/src/pages/components/tables/EnhancedTable.tsx
+++ b/docs/src/pages/components/tables/EnhancedTable.tsx
@@ -122,6 +122,7 @@ function EnhancedTableHead(props: EnhancedTableProps) {
             indeterminate={numSelected > 0 && numSelected < rowCount}
             checked={numSelected === rowCount}
             onChange={onSelectAllClick}
+            inputProps={{ 'aria-label': 'Select all desserts' }}
           />
         </TableCell>
         {headRows.map(row => (
@@ -329,8 +330,10 @@ function EnhancedTable() {
             <TableBody>
               {stableSort(rows, getSorting(order, orderBy))
                 .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-                .map(row => {
+                .map((row, index) => {
                   const isItemSelected = isSelected(row.name);
+                  const labelId = `enhanced-table-checkbox-${index}`;
+
                   return (
                     <TableRow
                       hover
@@ -342,9 +345,12 @@ function EnhancedTable() {
                       selected={isItemSelected}
                     >
                       <TableCell padding="checkbox">
-                        <Checkbox checked={isItemSelected} />
+                        <Checkbox
+                          checked={isItemSelected}
+                          inputProps={{ 'aria-labelledby': labelId }}
+                        />
                       </TableCell>
-                      <TableCell component="th" scope="row" padding="none">
+                      <TableCell component="th" id={labelId} scope="row" padding="none">
                         {row.name}
                       </TableCell>
                       <TableCell align="right">{row.calories}</TableCell>

--- a/docs/src/pages/components/transitions/SimpleCollapse.js
+++ b/docs/src/pages/components/transitions/SimpleCollapse.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Collapse from '@material-ui/core/Collapse';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const styles = theme => ({
   root: {
@@ -41,7 +42,10 @@ class SimpleCollapse extends React.Component {
 
     return (
       <div className={classes.root}>
-        <Switch checked={checked} onChange={this.handleChange} aria-label="Collapse" />
+        <FormControlLabel
+          control={<Switch checked={checked} onChange={this.handleChange} />}
+          label="Show"
+        />
         <div className={classes.container}>
           <Collapse in={checked}>
             <Paper elevation={4} className={classes.paper}>

--- a/docs/src/pages/components/transitions/SimpleFade.js
+++ b/docs/src/pages/components/transitions/SimpleFade.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Fade from '@material-ui/core/Fade';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const styles = theme => ({
   root: {
@@ -41,7 +42,10 @@ class SimpleFade extends React.Component {
 
     return (
       <div className={classes.root}>
-        <Switch checked={checked} onChange={this.handleChange} aria-label="Collapse" />
+        <FormControlLabel
+          control={<Switch checked={checked} onChange={this.handleChange} />}
+          label="Show"
+        />
         <div className={classes.container}>
           <Fade in={checked}>
             <Paper elevation={4} className={classes.paper}>

--- a/docs/src/pages/components/transitions/SimpleGrow.js
+++ b/docs/src/pages/components/transitions/SimpleGrow.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Grow from '@material-ui/core/Grow';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const styles = theme => ({
   root: {
@@ -49,7 +50,10 @@ class SimpleGrow extends React.Component {
 
     return (
       <div className={classes.root}>
-        <Switch checked={checked} onChange={this.handleChange} aria-label="Collapse" />
+        <FormControlLabel
+          control={<Switch checked={checked} onChange={this.handleChange} />}
+          label="Show"
+        />
         <div className={classes.container}>
           <Grow in={checked}>{polygon}</Grow>
           {/* Conditionally applies the timeout property to change the entry speed. */}

--- a/docs/src/pages/components/transitions/SimpleSlide.js
+++ b/docs/src/pages/components/transitions/SimpleSlide.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Slide from '@material-ui/core/Slide';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const styles = theme => ({
   root: {
@@ -44,7 +45,10 @@ class SimpleSlide extends React.Component {
     return (
       <div className={classes.root}>
         <div className={classes.wrapper}>
-          <Switch checked={checked} onChange={this.handleChange} aria-label="Collapse" />
+          <FormControlLabel
+            control={<Switch checked={checked} onChange={this.handleChange} />}
+            label="Show"
+          />
           <Slide direction="up" in={checked} mountOnEnter unmountOnExit>
             <Paper elevation={4} className={classes.paper}>
               <svg className={classes.svg}>

--- a/docs/src/pages/components/transitions/SimpleZoom.js
+++ b/docs/src/pages/components/transitions/SimpleZoom.js
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Switch from '@material-ui/core/Switch';
 import Paper from '@material-ui/core/Paper';
 import Zoom from '@material-ui/core/Zoom';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
 
 const styles = theme => ({
   root: {
@@ -41,7 +42,10 @@ class SimpleZoom extends React.Component {
 
     return (
       <div className={classes.root}>
-        <Switch checked={checked} onChange={this.handleChange} aria-label="Collapse" />
+        <FormControlLabel
+          control={<Switch checked={checked} onChange={this.handleChange} />}
+          label="Show"
+        />
         <div className={classes.container}>
           <Zoom in={checked}>
             <Paper elevation={4} className={classes.paper}>

--- a/docs/src/pages/guides/composition/ComponentProperty.js
+++ b/docs/src/pages/guides/composition/ComponentProperty.js
@@ -80,12 +80,12 @@ function ComponentProperty(props) {
           )}
         </Route>
         <div className={classes.lists}>
-          <List component="nav">
+          <List component="nav" aria-label="Main mailbox folders">
             <ListItemLink to="/inbox" primary="Inbox" icon={<InboxIcon />} />
             <ListItemLink to="/drafts" primary="Drafts" icon={<DraftsIcon />} />
           </List>
           <Divider />
-          <List component="nav">
+          <List component="nav" aria-label="Secondary mailbox folders">
             <ListItemLinkShorthand to="/trash" primary="Trash" />
             <ListItemLinkShorthand to="/spam" primary="Spam" />
           </List>

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -2,11 +2,7 @@ import React from 'react';
 import { assert } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import PropTypes from 'prop-types';
-import {
-  createMount,
-  findOutermostIntrinsic,
-  getClasses,
-} from '@material-ui/core/test-utils';
+import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Grow from '../Grow';


### PR DESCRIPTION
Audited every component demo with lighthouse a11y audit using https://github.com/eps1lon/mui-scripts-incubator. The following issues were not fixed because they are caused by 3rd party libraries:
- carbon ad links have discernible text
- codefund ad links have discernible text
- codefund images have alt text
- various issues in /components/table (all caused by material-table, they upgraded to v4, will investigate new version in separate PR)
- invalid usage of aria-readonly in virtualized table demo (fixed by bvaughn/react-virtualized#1380)

~There's also an issue with iframes having no title. Will followup in a different PR once #15874 is resolved.~ Applied in this PR since it directly relates to demos

Fixes can be grouped into the following categories:
- missing aria-label
- label not being associated to inputs (fixed with aria-labelledby)
- aria-controls (was aria-owns) pointing to elements that aren't part of the DOM. They should be otherwise aria-controls doesn't add value. aria-controls is used in https://www.w3.org/TR/wai-aria-practices/examples/menu-button/menu-button-links.html
- ul not containing li or li being part of div