### PR TITLE
[docs] Fix wrong variable name (styles => useStyles)

### DIFF
--- a/docs/src/pages/styles/api/api.md
+++ b/docs/src/pages/styles/api/api.md
@@ -53,7 +53,7 @@ style rules to `makeStyles`/`withStyles` which are a function of the `Theme`.
 ```jsx
 import { makeStyles, createStyles } from '@material-ui/styles';
 
-const styles = makeStyles((theme: Theme) => createStyles({
+const useStyles = makeStyles((theme: Theme) => createStyles({
   root: {
     backgroundColor: theme.color.red,
   },


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

I fixes styles api document.
`const sytles` to `const useStyles`.

I read contributing guide, but I'm not good at English.
Please, teach me fix points, if I misunderstanding.
I'll try to fix it !! thank you :)