### PR TITLE
[styles] Remove warning when component with no displayName is provided

### DIFF
--- a/packages/material-ui-styles/src/makeStyles/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.js
@@ -189,7 +189,7 @@ function useSynchronousEffect(func, values) {
 
 function makeStyles(stylesOrCreator, options = {}) {
   const {
-    // An explicit value provided by the developers.
+    // alias for classNamePrefix, if provided will listen to theme (required for theme.overrides)
     name,
     // Help with debuggability.
     classNamePrefix: classNamePrefixOption,

--- a/packages/material-ui-styles/src/styled/styled.js
+++ b/packages/material-ui-styles/src/styled/styled.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import clsx from 'clsx';
-import warning from 'warning';
 import PropTypes from 'prop-types';
 import { chainPropTypes, getDisplayName } from '@material-ui/utils';
 import hoistNonReactStatics from 'hoist-non-react-statics';
@@ -37,14 +36,10 @@ function styled(Component) {
 
     if (process.env.NODE_ENV !== 'production' && !name) {
       // Provide a better DX outside production.
-      classNamePrefix = getDisplayName(Component);
-      warning(
-        typeof classNamePrefix === 'string',
-        [
-          'Material-UI: the component displayName is invalid. It needs to be a string.',
-          `Please fix the following component: ${Component}.`,
-        ].join('\n'),
-      );
+      const displayName = getDisplayName(Component);
+      if (displayName !== undefined) {
+        classNamePrefix = displayName;
+      }
     }
 
     const stylesOrCreator =

--- a/packages/material-ui-styles/src/withStyles/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import warning from 'warning';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import { chainPropTypes, getDisplayName } from '@material-ui/utils';
 import makeStyles from '../makeStyles';
@@ -26,14 +25,10 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
 
   if (process.env.NODE_ENV !== 'production' && !name) {
     // Provide a better DX outside production.
-    classNamePrefix = getDisplayName(Component);
-    warning(
-      typeof classNamePrefix === 'string',
-      [
-        'Material-UI: the component displayName is invalid. It needs to be a string.',
-        `Please fix the following component: ${Component}.`,
-      ].join('\n'),
-    );
+    const displayName = getDisplayName(Component);
+    if (displayName !== undefined) {
+      classNamePrefix = displayName;
+    }
   }
 
   const useStyles = makeStyles(stylesOrCreator, {


### PR DESCRIPTION
Closes #15887

Some observations/proposal for a future breaking change:
- using Component.displayName for behavior only observable in production is dangerous. Maybe other libraries don't do this but we only mutate this in production. Since the `name` option for `makeStyles` is derived from displayName and used to read from `theme.overrides` it can cause different behavior between dev and prod. We should not use the displayName for that reason. Especially since displayName is such a moving field.
- As a generic solution we should document the interaction between `name` and `themes.overrides`. Otherwise it is confusing that `useStyles` would listen to the theme if the styles creator doesn't use the theme.
