### PR TITLE
[codemod] Improve theme codemod to handle destructured theme.spacing

### DIFF
--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.js
@@ -78,11 +78,79 @@ function transformThemeSpacingApi(j, root) {
   replaceApi(functionDeclarations);
 }
 
+/**
+ * Update all `spacing.unit` usages to use `spacing()`.
+ * Find and replace string literal AST nodes to ensure all spacing API usages get updated, regardless
+ * of any calculation being performed.
+ * @param {jscodeshift_api_object} j
+ * @param {jscodeshift_ast_object} root
+ */
+function transformThemeSpacingApiDestructured(j, root) {
+  const mightContainApi = path => {
+    return (
+      j(path)
+        .find(j.MemberExpression, {
+          object: {
+            name: 'spacing',
+          },
+          property: {
+            name: 'unit',
+          },
+        })
+        .size() > 0
+    );
+  };
+
+  const replaceApi = pathArg => {
+    pathArg
+      .find(j.MemberExpression, {
+        object: {
+          name: 'spacing',
+        },
+        property: {
+          name: 'unit',
+        },
+      })
+      .replaceWith(path => {
+        let param = null;
+
+        const spacingParam = path.node.object.name;
+        if (j.BinaryExpression.check(path.parent.node)) {
+          const expression = path.parent.node;
+          const operation = expression.operator;
+
+          // check if it's a variable
+          if (j.Identifier.check(expression.right)) {
+            param = expression.right;
+          } else if (j.Literal.check(expression.right)) {
+            const value = expression.right.value;
+            if (operation === '*' || operation === '/') {
+              param = j.literal(eval(`1 ${operation} ${value}`));
+            }
+          }
+        }
+
+        if (param) {
+          path.parent.replace(j.callExpression(j.identifier(spacingParam), [param]));
+          return path.node;
+        }
+        return j.callExpression(j.identifier(spacingParam), [j.literal(1)]);
+      });
+  };
+
+  const arrowFunctions = root.find(j.ArrowFunctionExpression).filter(mightContainApi);
+  const functionDeclarations = root.find(j.FunctionDeclaration).filter(mightContainApi);
+
+  replaceApi(arrowFunctions);
+  replaceApi(functionDeclarations);
+}
+
 module.exports = function transformer(fileInfo, api) {
   const j = api.jscodeshift;
   const root = j(fileInfo.source);
 
   // transforms
   transformThemeSpacingApi(j, root);
+  transformThemeSpacingApiDestructured(j, root);
   return root.toSource({ quote: 'single' });
 };

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test.js
@@ -30,6 +30,21 @@ describe('@material-ui/codemod', () => {
           'The transformed version should be correct',
         );
       });
+
+      it('update theme spacing API for destructured', () => {
+        const actual = transform(
+          { source: read('./theme-spacing-api.test/actual_destructured.js') },
+          { jscodeshift },
+        );
+
+        const expected = read('./theme-spacing-api.test/expected_destructured.js');
+
+        assert.strictEqual(
+          trim(actual),
+          trim(expected),
+          'The transformed version should be correct',
+        );
+      });
     });
   });
 });

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual_destructured.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/actual_destructured.js
@@ -1,0 +1,39 @@
+const spacingAlone = ({spacing}) => ({
+  spacing: spacing.unit,
+});
+
+const spacingMultiply = ({spacing}) => ({
+  spacing: spacing.unit * 5,
+});
+
+const spacingDivide = ({spacing}) => ({
+  spacing: spacing.unit / 5,
+});
+
+const spacingAdd = ({spacing}) => ({
+  spacing: spacing.unit + 5,
+});
+
+const spacingSubtract = ({spacing}) => ({
+  spacing: spacing.unit - 5,
+});
+
+const variable = 3;
+
+const spacingVariable = ({spacing}) => ({
+  spacing: spacing.unit * variable,
+});
+
+const spacingParamNameChange = muiTheme => ({
+  spacing: muiTheme.spacing.unit,
+});
+
+function styleFunction({spacing}) {
+  return {
+    spacing: spacing.unit,
+  };
+}
+
+const longChain = ({spacing}) => ({
+  spacing: spacing.unit * 5 * 5,
+});

--- a/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected_destructured.js
+++ b/packages/material-ui-codemod/src/v4.0.0/theme-spacing-api.test/expected_destructured.js
@@ -1,0 +1,39 @@
+const spacingAlone = ({spacing}) => ({
+  spacing: spacing(1),
+});
+
+const spacingMultiply = ({spacing}) => ({
+  spacing: spacing(5),
+});
+
+const spacingDivide = ({spacing}) => ({
+  spacing: spacing(0.2),
+});
+
+const spacingAdd = ({spacing}) => ({
+  spacing: spacing(1) + 5,
+});
+
+const spacingSubtract = ({spacing}) => ({
+  spacing: spacing(1) - 5,
+});
+
+const variable = 3;
+
+const spacingVariable = ({spacing}) => ({
+  spacing: spacing(variable),
+});
+
+const spacingParamNameChange = muiTheme => ({
+  spacing: muiTheme.spacing(1),
+});
+
+function styleFunction({spacing}) {
+  return {
+    spacing: spacing(1),
+  };
+}
+
+const longChain = ({spacing}) => ({
+  spacing: spacing(5) * 5,
+});


### PR DESCRIPTION
Hi, this PR add function to codemod for updating spacing in destructured theme parameter.
Exemple:
In v3
```
const styles = ({spacing}) => ({
  spacing: spacing.unit,
});
```
Become in v4:
```
const styles = ({spacing}) => ({
  spacing: spacing(1),
});
```

- [ X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
