### PR TITLE
[core] Fix IE 11 crashes related to Object.assign

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -56,6 +56,8 @@ module.exports = {
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
     '@babel/plugin-transform-runtime',
+    // for IE 11 support
+    '@babel/plugin-transform-object-assign',
   ],
   ignore: [/@babel[\\|/]runtime/], // Fix a Windows issue.
   env: {


### PR DESCRIPTION
Closes #15860

Something in our test setup is probably polyfilling this. Running unit tests in the browser is probably a bad idea in general (since test runner, library etc have to support it as well). e2e test would probably make more sense i.e. test_regression but that's another topic.