### PR TITLE
[core] Update package.json to use jss v10-alpha.16

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -50,6 +50,7 @@
     "deepmerge": "^3.0.0",
     "hoist-non-react-statics": "^3.2.1",
     "is-plain-object": "^2.0.4",
+    "jss": "^10.0.0-alpha.16",
     "normalize-scroll-left": "^0.1.2",
     "popper.js": "^1.14.1",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Fixes #15926
The package depends on JSS v10. But isn't listed in package.json. So it is updated to use JSS v10.