### PR TITLE
[docs] Mention Virtuoso as a possible virtualization integration

### DIFF
--- a/docs/src/pages/components/lists/lists.md
+++ b/docs/src/pages/components/lists/lists.md
@@ -93,3 +93,6 @@ It renders 200 rows and can easily handle more.
 Virtualization helps with performance issues.
 
 {{"demo": "pages/components/lists/VirtualizedList.js"}}
+
+We encourage the use of [react-window](https://github.com/bvaughn/react-window) when possible.
+If this library doesn't cover your use case, you should consider using [react-virtualized](https://github.com/bvaughn/react-virtualized), then alternatives like [react-virtuoso](https://github.com/petyosi/react-virtuoso).


### PR DESCRIPTION
Adds a simplified endless scrolling example to the list documentation page, using React Virtuoso. 

For a live (more complex) example and step-by-step explanations, check [this blog post](https://dev.to/petyosi/creating-beautiful-virtualized-lists-with-material-ui-and-react-virtuoso-31i3). 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Thanks for your hard work!