### PR TITLE
[docs] Improve dark mode

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -165,7 +165,6 @@ function AppFrame(props) {
   const changeTheme = useChangeTheme();
   function handleTogglePaletteType() {
     const paletteType = theme.palette.type === 'light' ? 'dark' : 'light';
-    document.cookie = `paletteType=${paletteType};path=/;max-age=31536000`;
 
     changeTheme({ paletteType });
   }

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -106,8 +106,14 @@ const useStyles = makeStyles(theme => ({
         textDecoration: 'none',
         backgroundColor: theme.palette.background.paper,
       },
-      '& .algolia-docsearch-suggestion--title': theme.typography.h6,
-      '& .algolia-docsearch-suggestion--text': theme.typography.body2,
+      '& .algolia-docsearch-suggestion--title': {
+        ...theme.typography.h6,
+        color: theme.palette.text.primary,
+      },
+      '& .algolia-docsearch-suggestion--text': {
+        ...theme.typography.body2,
+        color: theme.palette.text.secondary,
+      },
       '&& .algolia-docsearch-suggestion--no-results': {
         width: '100%',
         '&::before': {

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -116,13 +116,16 @@ const styles = theme => ({
       marginTop: -96, // Offset for the anchor.
       position: 'absolute',
     },
-    '& pre, & pre[class*="language-"]': {
+    '& pre': {
       margin: '24px 0',
       padding: '12px 18px',
       backgroundColor: theme.palette.background.level1,
       borderRadius: theme.shape.borderRadius,
       overflow: 'auto',
       WebkitOverflowScrolling: 'touch', // iOS momentum scrolling.
+    },
+    '& code[class*="language-"]': {
+      boxShadow: 'none',
     },
     '& code': {
       display: 'inline-block',
@@ -138,6 +141,10 @@ const styles = theme => ({
     },
     '& .token.operator': {
       background: 'transparent',
+    },
+    '& .token.property, .token.tag,.token.constant, .token.symbol, .token.deleted': {
+      // adjust prism-okaidia to reach AA ratio
+      color: theme.palette.type === 'dark' ? '#f483ad' : undefined,
     },
     '& h1': {
       ...theme.typography.h2,

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -49,7 +49,7 @@ export function Provider(props) {
     }
   }, themeInitialOptions);
 
-  const prefersDarkMode = useMediaQuery('prefers-color-scheme: dark');
+  const prefersDarkMode = useMediaQuery('@media (prefers-color-scheme: dark)');
   const preferredType = prefersDarkMode ? 'dark' : 'light';
   const { direction, paletteColors, paletteType = preferredType } = themeOptions;
 

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -54,6 +54,11 @@ export function Provider(props) {
     setPrismTheme(paletteType === 'light' ? lightTheme : darkTheme);
   }, [paletteType]);
 
+  // persist paletteType
+  React.useEffect(() => {
+    document.cookie = `paletteType=${paletteType};path=/;max-age=31536000`;
+  }, [paletteType]);
+
   useEnhancedEffect(() => {
     document.body.dir = direction;
   }, [direction]);

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from '@material-ui/styles';
 import { createMuiTheme } from '@material-ui/core/styles';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 import blue from '@material-ui/core/colors/blue';
 import pink from '@material-ui/core/colors/pink';
 import { darken } from '@material-ui/core/styles/colorManipulator';
@@ -10,7 +11,6 @@ import { lightTheme, darkTheme, setPrismTheme } from 'docs/src/modules/component
 
 export const themeInitialOptions = {
   direction: 'ltr',
-  paletteType: 'light',
   paletteColors: {
     primary: {
       main: blue[500],
@@ -48,11 +48,26 @@ export function Provider(props) {
         throw new Error(`Unrecognized type ${action.type}`);
     }
   }, themeInitialOptions);
-  const { direction, paletteColors, paletteType } = themeOptions;
+
+  const prefersDarkMode = useMediaQuery('prefers-color-scheme: dark');
+  const preferredType = prefersDarkMode ? 'dark' : 'light';
+  const { direction, paletteColors, paletteType = preferredType } = themeOptions;
 
   React.useEffect(() => {
     setPrismTheme(paletteType === 'light' ? lightTheme : darkTheme);
   }, [paletteType]);
+
+  React.useEffect(() => {
+    if (process.browser) {
+      const nextPaletteColors = JSON.parse(getCookie('paletteColors') || 'null');
+      const nextPaletteType = getCookie('paletteType');
+
+      dispatch({
+        type: 'CHANGE',
+        payload: { paletteColors: nextPaletteColors, paletteType: nextPaletteType },
+      });
+    }
+  }, []);
 
   // persist paletteType
   React.useEffect(() => {
@@ -93,18 +108,6 @@ export function Provider(props) {
       window.theme = theme;
     }
   }, [theme]);
-
-  React.useEffect(() => {
-    if (process.browser) {
-      const nextPaletteColors = JSON.parse(getCookie('paletteColors') || 'null');
-      const nextPaletteType = getCookie('paletteType');
-
-      dispatch({
-        type: 'CHANGE',
-        payload: { paletteColors: nextPaletteColors, paletteType: nextPaletteType },
-      });
-    }
-  }, []);
 
   return (
     <ThemeProvider theme={theme}>

--- a/docs/src/modules/components/prism.js
+++ b/docs/src/modules/components/prism.js
@@ -17,9 +17,7 @@ if (process.browser) {
   lightTheme = require('prismjs/themes/prism.css');
   darkTheme = require('prismjs/themes/prism-okaidia.css');
 
-  styleNode = document.createElement('style');
-  styleNode.setAttribute('data-prism', 'true');
-  document.head.appendChild(styleNode);
+  styleNode = document.querySelector('#prismjs');
 }
 
 export { lightTheme, darkTheme };

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -81,6 +81,7 @@ class MyDocument extends Document {
           <style id="material-icon-font" />
           <style id="font-awesome-css" />
           <style id="app-search" />
+          <style id="prismjs" />
           <style id="insertion-point-jss" />
         </Head>
         <body>


### PR DESCRIPTION
- dark mode prism theme should reach AA contrast ratio now (added a custom override for tokens using `#f92672` in `prism-okadia` and brightened it a bit to `#f483ad`. ratio is now 6.66 which hits AA rating while the color is still similar)
- improve legibility of algolia search results in dark mode (they weren't considering theme colors
- use [`prefers-media-schema`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)` ([impl status](https://www.chromestatus.com/feature/5109758977638400)) if no type is configured via cookie. Need to test if this works on windows. If nobody can verify if this works we should probably remove that change until we can test it.