### PR TITLE
[Breadcrumbs] Add theme props and overrides TypeScript definitions

### DIFF
--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -6,6 +6,7 @@ import { BackdropClassKey } from '../Backdrop';
 import { BadgeClassKey } from '../Badge';
 import { BottomNavigationClassKey } from '../BottomNavigation';
 import { BottomNavigationActionClassKey } from '../BottomNavigationAction';
+import { BreadcrumbsClassKey } from '../Breadcrumbs';
 import { ButtonClassKey } from '../Button';
 import { ButtonBaseClassKey } from '../ButtonBase';
 import { TouchRippleClassKey } from '../ButtonBase/TouchRipple';
@@ -105,6 +106,7 @@ export interface ComponentNameToClassKey {
   MuiBadge: BadgeClassKey;
   MuiBottomNavigation: BottomNavigationClassKey;
   MuiBottomNavigationAction: BottomNavigationActionClassKey;
+  MuiBreadcrumbs: BreadcrumbsClassKey;
   MuiButton: ButtonClassKey;
   MuiButtonBase: ButtonBaseClassKey;
   MuiCard: CardClassKey;

--- a/packages/material-ui/src/styles/props.d.ts
+++ b/packages/material-ui/src/styles/props.d.ts
@@ -4,6 +4,7 @@ import { BackdropProps } from '../Backdrop';
 import { BadgeProps } from '../Badge';
 import { BottomNavigationActionProps } from '../BottomNavigationAction';
 import { BottomNavigationProps } from '../BottomNavigation';
+import { BreadcrumbsProps } from '../Breadcrumbs';
 import { ButtonBaseProps } from '../ButtonBase';
 import { ButtonProps } from '../Button';
 import { CardActionsProps } from '../CardActions';
@@ -99,6 +100,7 @@ export interface ComponentsPropsList {
   MuiBadge: BadgeProps;
   MuiBottomNavigation: BottomNavigationProps;
   MuiBottomNavigationAction: BottomNavigationActionProps;
+  MuiBreadcrumbs: BreadcrumbsProps;
   MuiButton: ButtonProps;
   MuiButtonBase: ButtonBaseProps;
   MuiCard: CardProps;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Looks like the `Breadcrumbs` component was just missing the relevant entries in `overrides.d.ts` and `props.d.ts`. Easy fix.