### PR TITLE
[typescript] #15553: Add missing style props to withStyles HOC components

### DIFF
--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -65,10 +65,10 @@ export type ThemeOfStyles<S> = S extends Styles<infer Theme, any> ? Theme : {};
 export type WithStyles<
   S extends ClassKeyInferable<any, any>,
   IncludeTheme extends boolean | undefined = false
-> = (IncludeTheme extends true ? { theme: ThemeOfStyles<S> } : {}) & {
-  classes: ClassNameMap<ClassKeyOfStyles<S>>;
-  innerRef?: React.Ref<any> | React.RefObject<any>;
-} & PropsOfStyles<S>;
+  > = (IncludeTheme extends true ? { theme: ThemeOfStyles<S> } : {}) & {
+    classes: ClassNameMap<ClassKeyOfStyles<S>>;
+    innerRef?: React.Ref<any> | React.RefObject<any>;
+  } & PropsOfStyles<S>;
 
 export interface StyledComponentProps<ClassKey extends string = string> {
   classes?: Partial<ClassNameMap<ClassKey>>;
@@ -81,4 +81,4 @@ export default function withStyles<
 >(
   style: S,
   options?: Options,
-): PropInjector<WithStyles<S, Options['withTheme']>, StyledComponentProps<ClassKeyOfStyles<S>>>;
+): PropInjector<WithStyles<S, Options['withTheme']>, StyledComponentProps<ClassKeyOfStyles<S>> & PropsOfStyles<S>>;

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -81,4 +81,7 @@ export default function withStyles<
 >(
   style: S,
   options?: Options,
-): PropInjector<WithStyles<S, Options['withTheme']>, StyledComponentProps<ClassKeyOfStyles<S>> & PropsOfStyles<S>>;
+): PropInjector<
+  WithStyles<S, Options['withTheme']>,
+  StyledComponentProps<ClassKeyOfStyles<S>> & PropsOfStyles<S>
+>;

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -65,10 +65,10 @@ export type ThemeOfStyles<S> = S extends Styles<infer Theme, any> ? Theme : {};
 export type WithStyles<
   S extends ClassKeyInferable<any, any>,
   IncludeTheme extends boolean | undefined = false
-  > = (IncludeTheme extends true ? { theme: ThemeOfStyles<S> } : {}) & {
-    classes: ClassNameMap<ClassKeyOfStyles<S>>;
-    innerRef?: React.Ref<any> | React.RefObject<any>;
-  } & PropsOfStyles<S>;
+> = (IncludeTheme extends true ? { theme: ThemeOfStyles<S> } : {}) & {
+  classes: ClassNameMap<ClassKeyOfStyles<S>>;
+  innerRef?: React.Ref<any> | React.RefObject<any>;
+} & PropsOfStyles<S>;
 
 export interface StyledComponentProps<ClassKey extends string = string> {
   classes?: Partial<ClassNameMap<ClassKey>>;

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -355,10 +355,11 @@ withStyles(theme =>
   // styles from props
   interface StyleProps {
     color?: 'blue' | 'red';
+    default: 'green' | 'yellow';
   }
 
   const styles = (theme: Theme) => ({
-    root: (props: StyleProps) => ({ backgroundColor: props.color || theme.palette.primary.main }),
+    root: (props: StyleProps) => ({ backgroundColor: props.color || props.default }),
   });
 
   interface MyComponentProps extends WithStyles<typeof styles> {
@@ -377,8 +378,11 @@ withStyles(theme =>
   }
 
   const StyledMyComponent = withStyles(styles)(MyComponent);
-  const renderedStyledMyComponentDefault = <StyledMyComponent message="Hi" />;
-  const renderedStyledMyComponentGreen = <StyledMyComponent message="Hi" color="blue" />;
+  const renderedStyledMyComponentNoDefault = <StyledMyComponent message="Hi" />; // $ExpectError
+  const renderedStyledMyComponentWithDefault = <StyledMyComponent message="Hi" default="green" />;
+  const renderedStyledMyComponentBlue = (
+    <StyledMyComponent message="Hi" default="green" color="blue" />
+  );
 
   //  number is not assignable to 'blue' | 'red'
   // $ExpectError

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -377,7 +377,8 @@ withStyles(theme =>
   }
 
   const StyledMyComponent = withStyles(styles)(MyComponent);
-  const renderedStyledMyComponent = <StyledMyComponent message="Hi" />;
+  const renderedStyledMyComponentDefault = <StyledMyComponent message="Hi" />;
+  const renderedStyledMyComponentGreen = <StyledMyComponent message="Hi" color="blue" />;
 
   //  number is not assignable to 'blue' | 'red'
   // $ExpectError


### PR DESCRIPTION
Following up from my comment on issue https://github.com/mui-org/material-ui/issues/15553#issuecomment-497160415 about Typescript components missing style props when wrapping with `withStyles()`.

This adds a new type intersection within the `PropInjector` usage within `withStyles()` to compensate for `React.ComponentProps<C>` removing props used in style functions.

```ts
function withStyles<
    S extends Styles<any, any>,
    Options extends WithStylesOptions<ThemeOfStyles<S>> = {}
>(style: S, options?: Options): PropInjector<
    WithStyles<S, Options['withTheme']>, 
    // Intersect with the Style Props here
    StyledComponentProps<ClassKeyOfStyles<S>> & PropsOfStyles<S>
>;
```

This enables the following

```ts
type StyleProps = { color?: string };
function stylesWithTheme(theme: Theme) {
    return createStyles({
        root: (props: StyleProps) => ({ color: props.color ? props.color : 'yellow' })
    });
}
interface PersonProps extends WithStyles<typeof stylesWithTheme> {
    name: string;
}
function Person(props: PersonProps) {
    return <Typography className={this.props.classes.root}>{this.props.name}</Typography>;
}
function App() {
    // Note use of color attribute
    return <PersonTheme name="Joe Montana" color="green" />;
}
ReactDOM.render(<App />, document.getElementById('root'));
```

Also, I can't determine the file structure to figure out what files to edit. Was `packages/material-ui-styles/src/withStyles/withStyles.d.ts` the correct one or should I have used `packages/material-ui/src/styles/withStyles.d.ts`?

Closes #15553 