### PR TITLE
[docs] Icon TypeScript demos

### DIFF
--- a/docs/src/pages/components/checkboxes/CheckboxesGroup.tsx
+++ b/docs/src/pages/components/checkboxes/CheckboxesGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import FormLabel from '@material-ui/core/FormLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormGroup from '@material-ui/core/FormGroup';
@@ -7,14 +7,16 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Checkbox from '@material-ui/core/Checkbox';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    display: 'flex',
-  },
-  formControl: {
-    margin: theme.spacing(3),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    formControl: {
+      margin: theme.spacing(3),
+    },
+  }),
+);
 
 function CheckboxesGroup() {
   const classes = useStyles();

--- a/docs/src/pages/components/dialogs/ConfirmationDialog.tsx
+++ b/docs/src/pages/components/dialogs/ConfirmationDialog.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -104,17 +104,19 @@ ConfirmationDialogRaw.propTypes = {
   value: PropTypes.string,
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '100%',
-    maxWidth: 360,
-    backgroundColor: theme.palette.background.paper,
-  },
-  paper: {
-    width: '80%',
-    maxHeight: 435,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: theme.palette.background.paper,
+    },
+    paper: {
+      width: '80%',
+      maxHeight: 435,
+    },
+  }),
+);
 
 function ConfirmationDialog() {
   const classes = useStyles();

--- a/docs/src/pages/components/drawers/PersistentDrawerLeft.tsx
+++ b/docs/src/pages/components/drawers/PersistentDrawerLeft.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import { makeStyles, useTheme, Theme } from '@material-ui/core/styles';
+import { makeStyles, useTheme, Theme, createStyles } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';
@@ -20,61 +20,63 @@ import MailIcon from '@material-ui/icons/Mail';
 
 const drawerWidth = 240;
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    display: 'flex',
-  },
-  appBar: {
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-  },
-  appBarShift: {
-    width: `calc(100% - ${drawerWidth}px)`,
-    marginLeft: drawerWidth,
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-  },
-  menuButton: {
-    marginRight: theme.spacing(2),
-  },
-  hide: {
-    display: 'none',
-  },
-  drawer: {
-    width: drawerWidth,
-    flexShrink: 0,
-  },
-  drawerPaper: {
-    width: drawerWidth,
-  },
-  drawerHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    padding: '0 8px',
-    ...theme.mixins.toolbar,
-    justifyContent: 'flex-end',
-  },
-  content: {
-    flexGrow: 1,
-    padding: theme.spacing(3),
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    marginLeft: -drawerWidth,
-  },
-  contentShift: {
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-    marginLeft: 0,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    appBar: {
+      transition: theme.transitions.create(['margin', 'width'], {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+    },
+    appBarShift: {
+      width: `calc(100% - ${drawerWidth}px)`,
+      marginLeft: drawerWidth,
+      transition: theme.transitions.create(['margin', 'width'], {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+    },
+    hide: {
+      display: 'none',
+    },
+    drawer: {
+      width: drawerWidth,
+      flexShrink: 0,
+    },
+    drawerPaper: {
+      width: drawerWidth,
+    },
+    drawerHeader: {
+      display: 'flex',
+      alignItems: 'center',
+      padding: '0 8px',
+      ...theme.mixins.toolbar,
+      justifyContent: 'flex-end',
+    },
+    content: {
+      flexGrow: 1,
+      padding: theme.spacing(3),
+      transition: theme.transitions.create('margin', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+      marginLeft: -drawerWidth,
+    },
+    contentShift: {
+      transition: theme.transitions.create('margin', {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+      marginLeft: 0,
+    },
+  }),
+);
 
 function PersistentDrawerLeft() {
   const classes = useStyles();

--- a/docs/src/pages/components/drawers/PersistentDrawerRight.tsx
+++ b/docs/src/pages/components/drawers/PersistentDrawerRight.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import { makeStyles, useTheme, Theme } from '@material-ui/core/styles';
+import { makeStyles, useTheme, Theme, createStyles } from '@material-ui/core/styles';
 import Drawer from '@material-ui/core/Drawer';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
@@ -20,61 +20,63 @@ import MailIcon from '@material-ui/icons/Mail';
 
 const drawerWidth = 240;
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    display: 'flex',
-  },
-  appBar: {
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-  },
-  appBarShift: {
-    width: `calc(100% - ${drawerWidth}px)`,
-    transition: theme.transitions.create(['margin', 'width'], {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-    marginRight: drawerWidth,
-  },
-  title: {
-    flexGrow: 1,
-  },
-  hide: {
-    display: 'none',
-  },
-  drawer: {
-    width: drawerWidth,
-    flexShrink: 0,
-  },
-  drawerPaper: {
-    width: drawerWidth,
-  },
-  drawerHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    padding: '0 8px',
-    ...theme.mixins.toolbar,
-    justifyContent: 'flex-start',
-  },
-  content: {
-    flexGrow: 1,
-    padding: theme.spacing(3),
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.sharp,
-      duration: theme.transitions.duration.leavingScreen,
-    }),
-    marginRight: -drawerWidth,
-  },
-  contentShift: {
-    transition: theme.transitions.create('margin', {
-      easing: theme.transitions.easing.easeOut,
-      duration: theme.transitions.duration.enteringScreen,
-    }),
-    marginRight: 0,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    appBar: {
+      transition: theme.transitions.create(['margin', 'width'], {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+    },
+    appBarShift: {
+      width: `calc(100% - ${drawerWidth}px)`,
+      transition: theme.transitions.create(['margin', 'width'], {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+      marginRight: drawerWidth,
+    },
+    title: {
+      flexGrow: 1,
+    },
+    hide: {
+      display: 'none',
+    },
+    drawer: {
+      width: drawerWidth,
+      flexShrink: 0,
+    },
+    drawerPaper: {
+      width: drawerWidth,
+    },
+    drawerHeader: {
+      display: 'flex',
+      alignItems: 'center',
+      padding: '0 8px',
+      ...theme.mixins.toolbar,
+      justifyContent: 'flex-start',
+    },
+    content: {
+      flexGrow: 1,
+      padding: theme.spacing(3),
+      transition: theme.transitions.create('margin', {
+        easing: theme.transitions.easing.sharp,
+        duration: theme.transitions.duration.leavingScreen,
+      }),
+      marginRight: -drawerWidth,
+    },
+    contentShift: {
+      transition: theme.transitions.create('margin', {
+        easing: theme.transitions.easing.easeOut,
+        duration: theme.transitions.duration.enteringScreen,
+      }),
+      marginRight: 0,
+    },
+  }),
+);
 
 function PersistentDrawerRight() {
   const classes = useStyles();

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
@@ -15,41 +15,43 @@ import MailIcon from '@material-ui/icons/Mail';
 import MenuIcon from '@material-ui/icons/Menu';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import { makeStyles, useTheme, Theme } from '@material-ui/core/styles';
+import { makeStyles, useTheme, Theme, createStyles } from '@material-ui/core/styles';
 
 const drawerWidth = 240;
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    display: 'flex',
-  },
-  drawer: {
-    [theme.breakpoints.up('sm')]: {
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    drawer: {
+      [theme.breakpoints.up('sm')]: {
+        width: drawerWidth,
+        flexShrink: 0,
+      },
+    },
+    appBar: {
+      marginLeft: drawerWidth,
+      [theme.breakpoints.up('sm')]: {
+        width: `calc(100% - ${drawerWidth}px)`,
+      },
+    },
+    menuButton: {
+      marginRight: theme.spacing(2),
+      [theme.breakpoints.up('sm')]: {
+        display: 'none',
+      },
+    },
+    toolbar: theme.mixins.toolbar,
+    drawerPaper: {
       width: drawerWidth,
-      flexShrink: 0,
     },
-  },
-  appBar: {
-    marginLeft: drawerWidth,
-    [theme.breakpoints.up('sm')]: {
-      width: `calc(100% - ${drawerWidth}px)`,
+    content: {
+      flexGrow: 1,
+      padding: theme.spacing(3),
     },
-  },
-  menuButton: {
-    marginRight: theme.spacing(2),
-    [theme.breakpoints.up('sm')]: {
-      display: 'none',
-    },
-  },
-  toolbar: theme.mixins.toolbar,
-  drawerPaper: {
-    width: drawerWidth,
-  },
-  content: {
-    flexGrow: 1,
-    padding: theme.spacing(3),
-  },
-}));
+  }),
+);
 
 interface ResponsiveDrawerProps {
   // Injected by the documentation to work in an iframe.

--- a/docs/src/pages/components/icons/FontAwesome.js
+++ b/docs/src/pages/components/icons/FontAwesome.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { loadCSS } from 'fg-loadcss';
 import { withStyles } from '@material-ui/core/styles';
@@ -54,9 +53,5 @@ class FontAwesome extends React.Component {
     );
   }
 }
-
-FontAwesome.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(FontAwesome);

--- a/docs/src/pages/components/icons/FontAwesome.js
+++ b/docs/src/pages/components/icons/FontAwesome.js
@@ -22,34 +22,30 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export default class FontAwesome extends React.Component {
-  componentDidMount() {
+function FontAwesome() {
+  const classes = useStyles();
+
+  React.useEffect(() => {
     loadCSS(
       'https://use.fontawesome.com/releases/v5.1.0/css/all.css',
       document.querySelector('#font-awesome-css'),
     );
-  }
+  }, []);
 
-  render() {
-    const classes = useStyles();
-
-    return (
-      <div className={classes.root}>
-        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} />
-        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="primary" />
-        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="secondary" />
-        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="action" />
-        <Icon
-          className={clsx(classes.iconHover, 'fa fa-plus-circle')}
-          color="error"
-          style={{ fontSize: 30 }}
-        />
-        <Icon
-          className={clsx(classes.icon, 'fa fa-plus-circle')}
-          color="disabled"
-          fontSize="large"
-        />
-      </div>
-    );
-  }
+  return (
+    <div className={classes.root}>
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} />
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="primary" />
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="secondary" />
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="action" />
+      <Icon
+        className={clsx(classes.iconHover, 'fa fa-plus-circle')}
+        color="error"
+        style={{ fontSize: 30 }}
+      />
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="disabled" fontSize="large" />
+    </div>
+  );
 }
+
+export default FontAwesome;

--- a/docs/src/pages/components/icons/FontAwesome.js
+++ b/docs/src/pages/components/icons/FontAwesome.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import clsx from 'clsx';
 import { loadCSS } from 'fg-loadcss';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     justifyContent: 'center',
@@ -20,9 +20,9 @@ const styles = theme => ({
       color: red[800],
     },
   },
-});
+}));
 
-class FontAwesome extends React.Component {
+export default class FontAwesome extends React.Component {
   componentDidMount() {
     loadCSS(
       'https://use.fontawesome.com/releases/v5.1.0/css/all.css',
@@ -31,7 +31,7 @@ class FontAwesome extends React.Component {
   }
 
   render() {
-    const { classes } = this.props;
+    const classes = useStyles();
 
     return (
       <div className={classes.root}>
@@ -53,5 +53,3 @@ class FontAwesome extends React.Component {
     );
   }
 }
-
-export default withStyles(styles)(FontAwesome);

--- a/docs/src/pages/components/icons/FontAwesome.tsx
+++ b/docs/src/pages/components/icons/FontAwesome.tsx
@@ -1,26 +1,28 @@
 import React from 'react';
 import clsx from 'clsx';
 import { loadCSS } from 'fg-loadcss';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'flex-end',
-  },
-  icon: {
-    margin: theme.spacing(2),
-  },
-  iconHover: {
-    margin: theme.spacing(2),
-    '&:hover': {
-      color: red[800],
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'flex-end',
     },
-  },
-}));
+    icon: {
+      margin: theme.spacing(2),
+    },
+    iconHover: {
+      margin: theme.spacing(2),
+      '&:hover': {
+        color: red[800],
+      },
+    },
+  }),
+);
 
 function FontAwesome() {
   const classes = useStyles();

--- a/docs/src/pages/components/icons/FontAwesome.tsx
+++ b/docs/src/pages/components/icons/FontAwesome.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import clsx from 'clsx';
+import { loadCSS } from 'fg-loadcss';
+import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import red from '@material-ui/core/colors/red';
+import Icon from '@material-ui/core/Icon';
+
+const styles = (theme: Theme) =>
+  createStyles({
+  root: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  icon: {
+    margin: theme.spacing(2),
+  },
+  iconHover: {
+    margin: theme.spacing(2),
+    '&:hover': {
+      color: red[800],
+    },
+  },
+});
+
+class FontAwesome extends React.Component<WithStyles<typeof styles>> {
+  componentDidMount() {
+    loadCSS(
+      'https://use.fontawesome.com/releases/v5.1.0/css/all.css',
+      document.querySelector('#font-awesome-css'),
+    );
+  }
+
+  render() {
+    const { classes } = this.props;
+
+    return (
+      <div className={classes.root}>
+        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} />
+        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="primary" />
+        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="secondary" />
+        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="action" />
+        <Icon
+          className={clsx(classes.iconHover, 'fa fa-plus-circle')}
+          color="error"
+          style={{ fontSize: 30 }}
+        />
+        <Icon
+          className={clsx(classes.icon, 'fa fa-plus-circle')}
+          color="disabled"
+          fontSize="large"
+        />
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(FontAwesome);

--- a/docs/src/pages/components/icons/FontAwesome.tsx
+++ b/docs/src/pages/components/icons/FontAwesome.tsx
@@ -7,21 +7,21 @@ import Icon from '@material-ui/core/Icon';
 
 const styles = (theme: Theme) =>
   createStyles({
-  root: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'flex-end',
-  },
-  icon: {
-    margin: theme.spacing(2),
-  },
-  iconHover: {
-    margin: theme.spacing(2),
-    '&:hover': {
-      color: red[800],
+    root: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'flex-end',
     },
-  },
-});
+    icon: {
+      margin: theme.spacing(2),
+    },
+    iconHover: {
+      margin: theme.spacing(2),
+      '&:hover': {
+        color: red[800],
+      },
+    },
+  });
 
 class FontAwesome extends React.Component<WithStyles<typeof styles>> {
   componentDidMount() {

--- a/docs/src/pages/components/icons/FontAwesome.tsx
+++ b/docs/src/pages/components/icons/FontAwesome.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import clsx from 'clsx';
 import { loadCSS } from 'fg-loadcss';
-import { Theme, makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     justifyContent: 'center',
@@ -22,34 +22,30 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-export default class FontAwesome extends React.Component {
-  componentDidMount() {
+function FontAwesome() {
+  const classes = useStyles();
+
+  React.useEffect(() => {
     loadCSS(
       'https://use.fontawesome.com/releases/v5.1.0/css/all.css',
       document.querySelector('#font-awesome-css'),
     );
-  }
+  }, []);
 
-  render() {
-    const classes = useStyles();
-
-    return (
-      <div className={classes.root}>
-        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} />
-        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="primary" />
-        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="secondary" />
-        <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="action" />
-        <Icon
-          className={clsx(classes.iconHover, 'fa fa-plus-circle')}
-          color="error"
-          style={{ fontSize: 30 }}
-        />
-        <Icon
-          className={clsx(classes.icon, 'fa fa-plus-circle')}
-          color="disabled"
-          fontSize="large"
-        />
-      </div>
-    );
-  }
+  return (
+    <div className={classes.root}>
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} />
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="primary" />
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="secondary" />
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="action" />
+      <Icon
+        className={clsx(classes.iconHover, 'fa fa-plus-circle')}
+        color="error"
+        style={{ fontSize: 30 }}
+      />
+      <Icon className={clsx(classes.icon, 'fa fa-plus-circle')} color="disabled" fontSize="large" />
+    </div>
+  );
 }
+
+export default FontAwesome;

--- a/docs/src/pages/components/icons/FontAwesome.tsx
+++ b/docs/src/pages/components/icons/FontAwesome.tsx
@@ -1,29 +1,28 @@
 import React from 'react';
 import clsx from 'clsx';
 import { loadCSS } from 'fg-loadcss';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { Theme, makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'flex-end',
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  icon: {
+    margin: theme.spacing(2),
+  },
+  iconHover: {
+    margin: theme.spacing(2),
+    '&:hover': {
+      color: red[800],
     },
-    icon: {
-      margin: theme.spacing(2),
-    },
-    iconHover: {
-      margin: theme.spacing(2),
-      '&:hover': {
-        color: red[800],
-      },
-    },
-  });
+  },
+}));
 
-class FontAwesome extends React.Component<WithStyles<typeof styles>> {
+export default class FontAwesome extends React.Component {
   componentDidMount() {
     loadCSS(
       'https://use.fontawesome.com/releases/v5.1.0/css/all.css',
@@ -32,7 +31,7 @@ class FontAwesome extends React.Component<WithStyles<typeof styles>> {
   }
 
   render() {
-    const { classes } = this.props;
+    const classes = useStyles();
 
     return (
       <div className={classes.root}>
@@ -54,5 +53,3 @@ class FontAwesome extends React.Component<WithStyles<typeof styles>> {
     );
   }
 }
-
-export default withStyles(styles)(FontAwesome);

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const Icons = () => {
+function Icons() {
   const classes = useStyles();
 
   return (
@@ -43,6 +43,6 @@ const Icons = () => {
       </Icon>
     </div>
   );
-};
+}
 
 export default Icons;

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
@@ -21,7 +20,7 @@ const styles = theme => ({
   },
 });
 
-function Icons(props) {
+const Icons = props => {
   const { classes } = props;
 
   return (
@@ -44,10 +43,6 @@ function Icons(props) {
       </Icon>
     </div>
   );
-}
-
-Icons.propTypes = {
-  classes: PropTypes.object.isRequired,
 };
 
 export default withStyles(styles)(Icons);

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     justifyContent: 'center',
@@ -18,10 +18,10 @@ const styles = theme => ({
       color: red[800],
     },
   },
-});
+}));
 
-const Icons = props => {
-  const { classes } = props;
+const Icons = () => {
+  const classes = useStyles();
 
   return (
     <div className={classes.root}>
@@ -45,4 +45,4 @@ const Icons = props => {
   );
 };
 
-export default withStyles(styles)(Icons);
+export default Icons;

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -1,24 +1,26 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'flex-end',
-  },
-  icon: {
-    margin: theme.spacing(2),
-  },
-  iconHover: {
-    margin: theme.spacing(2),
-    '&:hover': {
-      color: red[800],
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'flex-end',
     },
-  },
-}));
+    icon: {
+      margin: theme.spacing(2),
+    },
+    iconHover: {
+      margin: theme.spacing(2),
+      '&:hover': {
+        color: red[800],
+      },
+    },
+  }),
+);
 
 function Icons() {
   const classes = useStyles();

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Theme, makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     justifyContent: 'center',

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -1,30 +1,27 @@
 import React from 'react';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { Theme, makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import Icon from '@material-ui/core/Icon';
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'flex-end',
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  icon: {
+    margin: theme.spacing(2),
+  },
+  iconHover: {
+    margin: theme.spacing(2),
+    '&:hover': {
+      color: red[800],
     },
-    icon: {
-      margin: theme.spacing(2),
-    },
-    iconHover: {
-      margin: theme.spacing(2),
-      '&:hover': {
-        color: red[800],
-      },
-    },
-  });
+  },
+}));
 
-type Props = WithStyles<typeof styles>;
-
-const Icons = (props: Props) => {
-  const { classes } = props;
+const Icons = () => {
+  const classes = useStyles();
 
   return (
     <div className={classes.root}>
@@ -48,4 +45,4 @@ const Icons = (props: Props) => {
   );
 };
 
-export default withStyles(styles)(Icons);
+export default Icons;

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import red from '@material-ui/core/colors/red';
+import Icon from '@material-ui/core/Icon';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'flex-end',
+    },
+    icon: {
+      margin: theme.spacing(2),
+    },
+    iconHover: {
+      margin: theme.spacing(2),
+      '&:hover': {
+        color: red[800],
+      },
+    },
+  });
+
+export interface Props extends WithStyles<typeof styles> {}
+
+const Icons = (props: Props) => {
+  const { classes } = props;
+
+  return (
+    <div className={classes.root}>
+      <Icon className={classes.icon}>add_circle</Icon>
+      <Icon className={classes.icon} color="primary">
+        add_circle
+      </Icon>
+      <Icon className={classes.icon} color="secondary">
+        add_circle
+      </Icon>
+      <Icon className={classes.icon} color="action">
+        add_circle
+      </Icon>
+      <Icon className={classes.iconHover} color="error" style={{ fontSize: 30 }}>
+        add_circle
+      </Icon>
+      <Icon className={classes.icon} color="disabled" fontSize="large">
+        add_circle
+      </Icon>
+    </div>
+  );
+};
+
+export default withStyles(styles)(Icons);

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const Icons = () => {
+function Icons() {
   const classes = useStyles();
 
   return (
@@ -43,6 +43,6 @@ const Icons = () => {
       </Icon>
     </div>
   );
-};
+}
 
 export default Icons;

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -21,7 +21,7 @@ const styles = (theme: Theme) =>
     },
   });
 
-export interface Props extends WithStyles<typeof styles> {}
+type Props = WithStyles<typeof styles>;
 
 const Icons = (props: Props) => {
   const { classes } = props;

--- a/docs/src/pages/components/icons/SvgIcons.js
+++ b/docs/src/pages/components/icons/SvgIcons.js
@@ -29,7 +29,7 @@ function HomeIcon(props) {
   );
 }
 
-const SvgIcons = () => {
+function SvgIcons() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -61,6 +61,6 @@ const SvgIcons = () => {
       />
     </div>
   );
-};
+}
 
 export default SvgIcons;

--- a/docs/src/pages/components/icons/SvgIcons.js
+++ b/docs/src/pages/components/icons/SvgIcons.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import blue from '@material-ui/core/colors/blue';
@@ -44,24 +43,24 @@ function SvgIcons(props) {
         className={classes.icon}
         color="primary"
         fontSize="large"
-        component={svgProps => (
-          <svg {...svgProps}>
-            <defs>
-              <linearGradient id="gradient1">
-                <stop offset="30%" stopColor={blue[400]} />
-                <stop offset="70%" stopColor={red[400]} />
-              </linearGradient>
-            </defs>
-            {React.cloneElement(svgProps.children[0], { fill: 'url(#gradient1)' })}
-          </svg>
-        )}
+        component={svgProps => {
+          return (
+            <svg {...svgProps}>
+              <defs>
+                <linearGradient id="gradient1">
+                  <stop offset="30%" stopColor={blue[400]} />
+                  <stop offset="70%" stopColor={red[400]} />
+                </linearGradient>
+              </defs>
+              {React.cloneElement(svgProps.children[0], {
+                fill: 'url(#gradient1)',
+              })}
+            </svg>
+          );
+        }}
       />
     </div>
   );
 }
-
-SvgIcons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(SvgIcons);

--- a/docs/src/pages/components/icons/SvgIcons.js
+++ b/docs/src/pages/components/icons/SvgIcons.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import blue from '@material-ui/core/colors/blue';
 import SvgIcon from '@material-ui/core/SvgIcon';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     justifyContent: 'center',
@@ -19,7 +19,7 @@ const styles = theme => ({
       color: red[800],
     },
   },
-});
+}));
 
 function HomeIcon(props) {
   return (
@@ -29,8 +29,8 @@ function HomeIcon(props) {
   );
 }
 
-function SvgIcons(props) {
-  const { classes } = props;
+const SvgIcons = () => {
+  const classes = useStyles();
   return (
     <div className={classes.root}>
       <HomeIcon className={classes.icon} />
@@ -61,6 +61,6 @@ function SvgIcons(props) {
       />
     </div>
   );
-}
+};
 
-export default withStyles(styles)(SvgIcons);
+export default SvgIcons;

--- a/docs/src/pages/components/icons/SvgIcons.tsx
+++ b/docs/src/pages/components/icons/SvgIcons.tsx
@@ -1,28 +1,25 @@
 import React, { ReactElement, ReactNodeArray } from 'react';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { Theme, makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import blue from '@material-ui/core/colors/blue';
 import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      display: 'flex',
-      justifyContent: 'center',
-      alignItems: 'flex-end',
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  icon: {
+    margin: theme.spacing(2),
+  },
+  iconHover: {
+    margin: theme.spacing(2),
+    '&:hover': {
+      color: red[800],
     },
-    icon: {
-      margin: theme.spacing(2),
-    },
-    iconHover: {
-      margin: theme.spacing(2),
-      '&:hover': {
-        color: red[800],
-      },
-    },
-  });
-
-type SvgProps = SvgIconProps & WithStyles<typeof styles>;
+  },
+}));
 
 function HomeIcon(props: SvgIconProps) {
   return (
@@ -32,8 +29,8 @@ function HomeIcon(props: SvgIconProps) {
   );
 }
 
-function SvgIcons(props: SvgProps) {
-  const { classes } = props;
+const SvgIcons = () => {
+  const classes = useStyles();
   return (
     <div className={classes.root}>
       <HomeIcon className={classes.icon} />
@@ -64,6 +61,6 @@ function SvgIcons(props: SvgProps) {
       />
     </div>
   );
-}
+};
 
-export default withStyles(styles)(SvgIcons);
+export default SvgIcons;

--- a/docs/src/pages/components/icons/SvgIcons.tsx
+++ b/docs/src/pages/components/icons/SvgIcons.tsx
@@ -1,10 +1,10 @@
 import React, { ReactElement, ReactNodeArray } from 'react';
-import { Theme, makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import blue from '@material-ui/core/colors/blue';
 import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     justifyContent: 'center',

--- a/docs/src/pages/components/icons/SvgIcons.tsx
+++ b/docs/src/pages/components/icons/SvgIcons.tsx
@@ -1,25 +1,27 @@
-import React, { ReactElement, ReactNodeArray } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import React from 'react';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 import blue from '@material-ui/core/colors/blue';
 import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'flex-end',
-  },
-  icon: {
-    margin: theme.spacing(2),
-  },
-  iconHover: {
-    margin: theme.spacing(2),
-    '&:hover': {
-      color: red[800],
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'flex-end',
     },
-  },
-}));
+    icon: {
+      margin: theme.spacing(2),
+    },
+    iconHover: {
+      margin: theme.spacing(2),
+      '&:hover': {
+        color: red[800],
+      },
+    },
+  }),
+);
 
 function HomeIcon(props: SvgIconProps) {
   return (
@@ -52,9 +54,12 @@ function SvgIcons() {
                   <stop offset="70%" stopColor={red[400]} />
                 </linearGradient>
               </defs>
-              {React.cloneElement((svgProps.children as ReactNodeArray)[0] as ReactElement, {
-                fill: 'url(#gradient1)',
-              })}
+              {React.cloneElement(
+                (svgProps.children as React.ReactNodeArray)[0] as React.ReactElement,
+                {
+                  fill: 'url(#gradient1)',
+                },
+              )}
             </svg>
           );
         }}

--- a/docs/src/pages/components/icons/SvgIcons.tsx
+++ b/docs/src/pages/components/icons/SvgIcons.tsx
@@ -55,9 +55,9 @@ function SvgIcons(props: SvgProps) {
                   <stop offset="70%" stopColor={red[400]} />
                 </linearGradient>
               </defs>
-              {
-                React.cloneElement((svgProps.children as ReactNodeArray)[0] as ReactElement, { fill: 'url(#gradient1)' })
-              }
+              {React.cloneElement((svgProps.children as ReactNodeArray)[0] as ReactElement, {
+                fill: 'url(#gradient1)',
+              })}
             </svg>
           );
         }}

--- a/docs/src/pages/components/icons/SvgIcons.tsx
+++ b/docs/src/pages/components/icons/SvgIcons.tsx
@@ -1,0 +1,69 @@
+import React, { ReactElement, ReactNodeArray } from 'react';
+import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import red from '@material-ui/core/colors/red';
+import blue from '@material-ui/core/colors/blue';
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
+
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'flex-end',
+    },
+    icon: {
+      margin: theme.spacing(2),
+    },
+    iconHover: {
+      margin: theme.spacing(2),
+      '&:hover': {
+        color: red[800],
+      },
+    },
+  });
+
+type SvgProps = SvgIconProps & WithStyles<typeof styles>;
+
+function HomeIcon(props: SvgIconProps) {
+  return (
+    <SvgIcon {...props}>
+      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+    </SvgIcon>
+  );
+}
+
+function SvgIcons(props: SvgProps) {
+  const { classes } = props;
+  return (
+    <div className={classes.root}>
+      <HomeIcon className={classes.icon} />
+      <HomeIcon className={classes.icon} color="primary" />
+      <HomeIcon className={classes.icon} color="secondary" />
+      <HomeIcon className={classes.icon} color="action" />
+      <HomeIcon className={classes.iconHover} color="error" style={{ fontSize: 30 }} />
+      <HomeIcon color="disabled" className={classes.icon} fontSize="large" />
+      <HomeIcon
+        className={classes.icon}
+        color="primary"
+        fontSize="large"
+        component={(svgProps: SvgIconProps) => {
+          return (
+            <svg {...svgProps}>
+              <defs>
+                <linearGradient id="gradient1">
+                  <stop offset="30%" stopColor={blue[400]} />
+                  <stop offset="70%" stopColor={red[400]} />
+                </linearGradient>
+              </defs>
+              {
+                React.cloneElement((svgProps.children as ReactNodeArray)[0] as ReactElement, { fill: 'url(#gradient1)' })
+              }
+            </svg>
+          );
+        }}
+      />
+    </div>
+  );
+}
+
+export default withStyles(styles)(SvgIcons);

--- a/docs/src/pages/components/icons/SvgIcons.tsx
+++ b/docs/src/pages/components/icons/SvgIcons.tsx
@@ -29,7 +29,7 @@ function HomeIcon(props: SvgIconProps) {
   );
 }
 
-const SvgIcons = () => {
+function SvgIcons() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -61,6 +61,6 @@ const SvgIcons = () => {
       />
     </div>
   );
-};
+}
 
 export default SvgIcons;

--- a/docs/src/pages/components/icons/SvgMaterialIcons.js
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const SvgMaterialIcons = () => {
+function SvgMaterialIcons() {
   const classes = useStyles();
   return (
     <Grid container className={classes.root}>
@@ -75,6 +75,6 @@ const SvgMaterialIcons = () => {
       </Grid>
     </Grid>
   );
-};
+}
 
 export default SvgMaterialIcons;

--- a/docs/src/pages/components/icons/SvgMaterialIcons.js
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.js
@@ -14,9 +14,9 @@ import DeleteForeverSharpIcon from '@material-ui/icons/DeleteForeverSharp';
 import ThreeDRotationIcon from '@material-ui/icons/ThreeDRotation';
 import FourKIcon from '@material-ui/icons/FourK';
 import ThreeSixtyIcon from '@material-ui/icons/ThreeSixty';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     color: theme.palette.text.primary,
   },
@@ -24,10 +24,10 @@ const styles = theme => ({
     margin: theme.spacing(1),
     fontSize: 32,
   },
-});
+}));
 
-function SvgMaterialIcons(props) {
-  const { classes } = props;
+const SvgMaterialIcons = () => {
+  const classes = useStyles();
   return (
     <Grid container className={classes.root}>
       <Grid item xs={4}>
@@ -75,6 +75,6 @@ function SvgMaterialIcons(props) {
       </Grid>
     </Grid>
   );
-}
+};
 
-export default withStyles(styles)(SvgMaterialIcons);
+export default SvgMaterialIcons;

--- a/docs/src/pages/components/icons/SvgMaterialIcons.js
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Grid from '@material-ui/core/Grid';
 import Typography from '@material-ui/core/Typography';
 import DeleteIcon from '@material-ui/icons/Delete';
@@ -77,9 +76,5 @@ function SvgMaterialIcons(props) {
     </Grid>
   );
 }
-
-SvgMaterialIcons.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
 
 export default withStyles(styles)(SvgMaterialIcons);

--- a/docs/src/pages/components/icons/SvgMaterialIcons.tsx
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.tsx
@@ -14,17 +14,19 @@ import DeleteForeverSharpIcon from '@material-ui/icons/DeleteForeverSharp';
 import ThreeDRotationIcon from '@material-ui/icons/ThreeDRotation';
 import FourKIcon from '@material-ui/icons/FourK';
 import ThreeSixtyIcon from '@material-ui/icons/ThreeSixty';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    color: theme.palette.text.primary,
-  },
-  icon: {
-    margin: theme.spacing(1),
-    fontSize: 32,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      color: theme.palette.text.primary,
+    },
+    icon: {
+      margin: theme.spacing(1),
+      fontSize: 32,
+    },
+  }),
+);
 
 function SvgMaterialIcons() {
   const classes = useStyles();

--- a/docs/src/pages/components/icons/SvgMaterialIcons.tsx
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.tsx
@@ -14,23 +14,20 @@ import DeleteForeverSharpIcon from '@material-ui/icons/DeleteForeverSharp';
 import ThreeDRotationIcon from '@material-ui/icons/ThreeDRotation';
 import FourKIcon from '@material-ui/icons/FourK';
 import ThreeSixtyIcon from '@material-ui/icons/ThreeSixty';
-import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 
-const styles = (theme: Theme) =>
-  createStyles({
-    root: {
-      color: theme.palette.text.primary,
-    },
-    icon: {
-      margin: theme.spacing(1),
-      fontSize: 32,
-    },
-  });
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    color: theme.palette.text.primary,
+  },
+  icon: {
+    margin: theme.spacing(1),
+    fontSize: 32,
+  },
+}));
 
-type Props = WithStyles<typeof styles>;
-
-function SvgMaterialIcons(props: Props) {
-  const { classes } = props;
+const SvgMaterialIcons = () => {
+  const classes = useStyles();
   return (
     <Grid container className={classes.root}>
       <Grid item xs={4}>
@@ -78,6 +75,6 @@ function SvgMaterialIcons(props: Props) {
       </Grid>
     </Grid>
   );
-}
+};
 
-export default withStyles(styles)(SvgMaterialIcons);
+export default SvgMaterialIcons;

--- a/docs/src/pages/components/icons/SvgMaterialIcons.tsx
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.tsx
@@ -16,15 +16,16 @@ import FourKIcon from '@material-ui/icons/FourK';
 import ThreeSixtyIcon from '@material-ui/icons/ThreeSixty';
 import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
 
-const styles = (theme: Theme) => createStyles({
-  root: {
-    color: theme.palette.text.primary,
-  },
-  icon: {
-    margin: theme.spacing(1),
-    fontSize: 32,
-  },
-});
+const styles = (theme: Theme) =>
+  createStyles({
+    root: {
+      color: theme.palette.text.primary,
+    },
+    icon: {
+      margin: theme.spacing(1),
+      fontSize: 32,
+    },
+  });
 
 type Props = WithStyles<typeof styles>;
 

--- a/docs/src/pages/components/icons/SvgMaterialIcons.tsx
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const SvgMaterialIcons = () => {
+function SvgMaterialIcons() {
   const classes = useStyles();
   return (
     <Grid container className={classes.root}>
@@ -75,6 +75,6 @@ const SvgMaterialIcons = () => {
       </Grid>
     </Grid>
   );
-};
+}
 
 export default SvgMaterialIcons;

--- a/docs/src/pages/components/icons/SvgMaterialIcons.tsx
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
+import DeleteIcon from '@material-ui/icons/Delete';
+import DeleteOutlinedIcon from '@material-ui/icons/DeleteOutlined';
+import DeleteRoundedIcon from '@material-ui/icons/DeleteRounded';
+import DeleteTwoToneIcon from '@material-ui/icons/DeleteTwoTone';
+import DeleteSharpIcon from '@material-ui/icons/DeleteSharp';
+import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
+import DeleteForeverOutlinedIcon from '@material-ui/icons/DeleteForeverOutlined';
+import DeleteForeverRoundedIcon from '@material-ui/icons/DeleteForeverRounded';
+import DeleteForeverTwoToneIcon from '@material-ui/icons/DeleteForeverTwoTone';
+import DeleteForeverSharpIcon from '@material-ui/icons/DeleteForeverSharp';
+import ThreeDRotationIcon from '@material-ui/icons/ThreeDRotation';
+import FourKIcon from '@material-ui/icons/FourK';
+import ThreeSixtyIcon from '@material-ui/icons/ThreeSixty';
+import { createStyles, Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+
+const styles = (theme: Theme) => createStyles({
+  root: {
+    color: theme.palette.text.primary,
+  },
+  icon: {
+    margin: theme.spacing(1),
+    fontSize: 32,
+  },
+});
+
+type Props = WithStyles<typeof styles>;
+
+function SvgMaterialIcons(props: Props) {
+  const { classes } = props;
+  return (
+    <Grid container className={classes.root}>
+      <Grid item xs={4}>
+        <Typography>Filled</Typography>
+      </Grid>
+      <Grid item xs={8}>
+        <DeleteIcon className={classes.icon} />
+        <DeleteForeverIcon className={classes.icon} />
+      </Grid>
+      <Grid item xs={4}>
+        <Typography>Outlined</Typography>
+      </Grid>
+      <Grid item xs={8}>
+        <DeleteOutlinedIcon className={classes.icon} />
+        <DeleteForeverOutlinedIcon className={classes.icon} />
+      </Grid>
+      <Grid item xs={4}>
+        <Typography>Rounded</Typography>
+      </Grid>
+      <Grid item xs={8}>
+        <DeleteRoundedIcon className={classes.icon} />
+        <DeleteForeverRoundedIcon className={classes.icon} />
+      </Grid>
+      <Grid item xs={4}>
+        <Typography>Two Tone</Typography>
+      </Grid>
+      <Grid item xs={8}>
+        <DeleteTwoToneIcon className={classes.icon} />
+        <DeleteForeverTwoToneIcon className={classes.icon} />
+      </Grid>
+      <Grid item xs={4}>
+        <Typography>Sharp</Typography>
+      </Grid>
+      <Grid item xs={8}>
+        <DeleteSharpIcon className={classes.icon} />
+        <DeleteForeverSharpIcon className={classes.icon} />
+      </Grid>
+      <Grid item xs={4}>
+        <Typography>Edge-cases</Typography>
+      </Grid>
+      <Grid item xs={8}>
+        <ThreeDRotationIcon className={classes.icon} />
+        <FourKIcon className={classes.icon} />
+        <ThreeSixtyIcon className={classes.icon} />
+      </Grid>
+    </Grid>
+  );
+}
+
+export default withStyles(styles)(SvgMaterialIcons);

--- a/docs/src/pages/components/icons/SvgMaterialIcons.tsx
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.tsx
@@ -14,9 +14,9 @@ import DeleteForeverSharpIcon from '@material-ui/icons/DeleteForeverSharp';
 import ThreeDRotationIcon from '@material-ui/icons/ThreeDRotation';
 import FourKIcon from '@material-ui/icons/FourK';
 import ThreeSixtyIcon from '@material-ui/icons/ThreeSixty';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(theme => ({
   root: {
     color: theme.palette.text.primary,
   },

--- a/docs/src/pages/components/lists/InteractiveList.tsx
+++ b/docs/src/pages/components/lists/InteractiveList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemAvatar from '@material-ui/core/ListItemAvatar';
@@ -16,18 +16,20 @@ import Typography from '@material-ui/core/Typography';
 import FolderIcon from '@material-ui/icons/Folder';
 import DeleteIcon from '@material-ui/icons/Delete';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    flexGrow: 1,
-    maxWidth: 752,
-  },
-  demo: {
-    backgroundColor: theme.palette.background.paper,
-  },
-  title: {
-    margin: theme.spacing(4, 0, 2),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      maxWidth: 752,
+    },
+    demo: {
+      backgroundColor: theme.palette.background.paper,
+    },
+    title: {
+      margin: theme.spacing(4, 0, 2),
+    },
+  }),
+);
 
 function generate(element: React.ReactElement) {
   return [0, 1, 2].map(value =>

--- a/docs/src/pages/components/lists/NestedList.tsx
+++ b/docs/src/pages/components/lists/NestedList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import ListSubheader from '@material-ui/core/ListSubheader';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -13,16 +13,18 @@ import ExpandLess from '@material-ui/icons/ExpandLess';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import StarBorder from '@material-ui/icons/StarBorder';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '100%',
-    maxWidth: 360,
-    backgroundColor: theme.palette.background.paper,
-  },
-  nested: {
-    paddingLeft: theme.spacing(4),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: theme.palette.background.paper,
+    },
+    nested: {
+      paddingLeft: theme.spacing(4),
+    },
+  }),
+);
 
 function NestedList() {
   const classes = useStyles();

--- a/docs/src/pages/components/lists/SelectedListItem.tsx
+++ b/docs/src/pages/components/lists/SelectedListItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -8,13 +8,15 @@ import Divider from '@material-ui/core/Divider';
 import InboxIcon from '@material-ui/icons/Inbox';
 import DraftsIcon from '@material-ui/icons/Drafts';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '100%',
-    maxWidth: 360,
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: theme.palette.background.paper,
+    },
+  }),
+);
 
 function SelectedListItem() {
   const classes = useStyles();

--- a/docs/src/pages/components/lists/SwitchListSecondary.tsx
+++ b/docs/src/pages/components/lists/SwitchListSecondary.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -10,13 +10,15 @@ import Switch from '@material-ui/core/Switch';
 import WifiIcon from '@material-ui/icons/Wifi';
 import BluetoothIcon from '@material-ui/icons/Bluetooth';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '100%',
-    maxWidth: 360,
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      maxWidth: 360,
+      backgroundColor: theme.palette.background.paper,
+    },
+  }),
+);
 
 function SwitchListSecondary() {
   const classes = useStyles();

--- a/docs/src/pages/components/progress/CircularDeterminate.tsx
+++ b/docs/src/pages/components/progress/CircularDeterminate.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  progress: {
-    margin: theme.spacing(2),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    progress: {
+      margin: theme.spacing(2),
+    },
+  }),
+);
 
 function CircularDeterminate() {
   const classes = useStyles();

--- a/docs/src/pages/components/progress/CircularStatic.tsx
+++ b/docs/src/pages/components/progress/CircularStatic.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  progress: {
-    margin: theme.spacing(2),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    progress: {
+      margin: theme.spacing(2),
+    },
+  }),
+);
 
 function CircularStatic() {
   const classes = useStyles();

--- a/docs/src/pages/components/radio-buttons/RadioButtonsGroup.tsx
+++ b/docs/src/pages/components/radio-buttons/RadioButtonsGroup.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormHelperText from '@material-ui/core/FormHelperText';
@@ -7,17 +7,19 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    display: 'flex',
-  },
-  formControl: {
-    margin: theme.spacing(3),
-  },
-  group: {
-    margin: theme.spacing(1, 0),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+    },
+    formControl: {
+      margin: theme.spacing(3),
+    },
+    group: {
+      margin: theme.spacing(1, 0),
+    },
+  }),
+);
 
 function RadioButtonsGroup() {
   const classes = useStyles();

--- a/docs/src/pages/components/selects/ControlledOpenSelect.tsx
+++ b/docs/src/pages/components/selects/ControlledOpenSelect.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import Button from '@material-ui/core/Button';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  button: {
-    display: 'block',
-    marginTop: theme.spacing(2),
-  },
-  formControl: {
-    margin: theme.spacing(1),
-    minWidth: 120,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    button: {
+      display: 'block',
+      marginTop: theme.spacing(2),
+    },
+    formControl: {
+      margin: theme.spacing(1),
+      minWidth: 120,
+    },
+  }),
+);
 
 function ControlledOpenSelect() {
   const classes = useStyles();

--- a/docs/src/pages/components/snackbars/SimpleSnackbar.tsx
+++ b/docs/src/pages/components/snackbars/SimpleSnackbar.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import Snackbar from '@material-ui/core/Snackbar';
 import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  close: {
-    padding: theme.spacing(0.5),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    close: {
+      padding: theme.spacing(0.5),
+    },
+  }),
+);
 
 function SimpleSnackbar() {
   const classes = useStyles();

--- a/docs/src/pages/components/steppers/CustomizedSteppers.tsx
+++ b/docs/src/pages/components/steppers/CustomizedSteppers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
@@ -7,36 +7,38 @@ import StepConnector from '@material-ui/core/StepConnector';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '90%',
-  },
-  button: {
-    marginRight: theme.spacing(1),
-  },
-  instructions: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-  },
-  connectorActive: {
-    '& $connectorLine': {
-      borderColor: theme.palette.secondary.main,
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '90%',
     },
-  },
-  connectorCompleted: {
-    '& $connectorLine': {
-      borderColor: theme.palette.primary.main,
+    button: {
+      marginRight: theme.spacing(1),
     },
-  },
-  connectorDisabled: {
-    '& $connectorLine': {
-      borderColor: theme.palette.grey[100],
+    instructions: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
     },
-  },
-  connectorLine: {
-    transition: theme.transitions.create('border-color'),
-  },
-}));
+    connectorActive: {
+      '& $connectorLine': {
+        borderColor: theme.palette.secondary.main,
+      },
+    },
+    connectorCompleted: {
+      '& $connectorLine': {
+        borderColor: theme.palette.primary.main,
+      },
+    },
+    connectorDisabled: {
+      '& $connectorLine': {
+        borderColor: theme.palette.grey[100],
+      },
+    },
+    connectorLine: {
+      transition: theme.transitions.create('border-color'),
+    },
+  }),
+);
 
 function getSteps() {
   return ['Select campaign settings', 'Create an ad group', 'Create an ad'];

--- a/docs/src/pages/components/steppers/HorizontalLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalLinearAlternativeLabelStepper.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '90%',
-  },
-  backButton: {
-    marginRight: theme.spacing(1),
-  },
-  instructions: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '90%',
+    },
+    backButton: {
+      marginRight: theme.spacing(1),
+    },
+    instructions: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    },
+  }),
+);
 
 function getSteps() {
   return ['Select master blaster campaign settings', 'Create an ad group', 'Create an ad'];

--- a/docs/src/pages/components/steppers/HorizontalLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalLinearStepper.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '90%',
-  },
-  button: {
-    marginRight: theme.spacing(1),
-  },
-  instructions: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '90%',
+    },
+    button: {
+      marginRight: theme.spacing(1),
+    },
+    instructions: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    },
+  }),
+);
 
 function getSteps() {
   return ['Select campaign settings', 'Create an ad group', 'Create an ad'];

--- a/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearAlternativeLabelStepper.tsx
@@ -1,29 +1,31 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepButton from '@material-ui/core/StepButton';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '90%',
-  },
-  button: {
-    marginRight: theme.spacing(1),
-  },
-  backButton: {
-    marginRight: theme.spacing(1),
-  },
-  completed: {
-    display: 'inline-block',
-  },
-  instructions: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '90%',
+    },
+    button: {
+      marginRight: theme.spacing(1),
+    },
+    backButton: {
+      marginRight: theme.spacing(1),
+    },
+    completed: {
+      display: 'inline-block',
+    },
+    instructions: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    },
+  }),
+);
 
 function getSteps() {
   return ['Select campaign settings', 'Create an ad group', 'Create an ad'];

--- a/docs/src/pages/components/steppers/HorizontalNonLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearStepper.tsx
@@ -1,26 +1,28 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepButton from '@material-ui/core/StepButton';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '90%',
-  },
-  button: {
-    marginRight: theme.spacing(1),
-  },
-  completed: {
-    display: 'inline-block',
-  },
-  instructions: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '90%',
+    },
+    button: {
+      marginRight: theme.spacing(1),
+    },
+    completed: {
+      display: 'inline-block',
+    },
+    instructions: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    },
+  }),
+);
 
 function getSteps() {
   return ['Select campaign settings', 'Create an ad group', 'Create an ad'];

--- a/docs/src/pages/components/steppers/HorizontalNonLinearStepperWithError.tsx
+++ b/docs/src/pages/components/steppers/HorizontalNonLinearStepperWithError.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '90%',
-  },
-  button: {
-    marginRight: theme.spacing(1),
-  },
-  instructions: {
-    marginTop: theme.spacing(1),
-    marginBottom: theme.spacing(1),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '90%',
+    },
+    button: {
+      marginRight: theme.spacing(1),
+    },
+    instructions: {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    },
+  }),
+);
 
 function getSteps() {
   return ['Select campaign settings', 'Create an ad group', 'Create an ad'];

--- a/docs/src/pages/components/steppers/TextMobileStepper.tsx
+++ b/docs/src/pages/components/steppers/TextMobileStepper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
+import { makeStyles, Theme, useTheme, createStyles } from '@material-ui/core/styles';
 import MobileStepper from '@material-ui/core/MobileStepper';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
@@ -35,26 +35,28 @@ const tutorialSteps = [
   },
 ];
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    maxWidth: 400,
-    flexGrow: 1,
-  },
-  header: {
-    display: 'flex',
-    alignItems: 'center',
-    height: 50,
-    paddingLeft: theme.spacing(4),
-    backgroundColor: theme.palette.background.default,
-  },
-  img: {
-    height: 255,
-    maxWidth: 400,
-    overflow: 'hidden',
-    display: 'block',
-    width: '100%',
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      maxWidth: 400,
+      flexGrow: 1,
+    },
+    header: {
+      display: 'flex',
+      alignItems: 'center',
+      height: 50,
+      paddingLeft: theme.spacing(4),
+      backgroundColor: theme.palette.background.default,
+    },
+    img: {
+      height: 255,
+      maxWidth: 400,
+      overflow: 'hidden',
+      display: 'block',
+      width: '100%',
+    },
+  }),
+);
 
 function TextMobileStepper() {
   const classes = useStyles();

--- a/docs/src/pages/components/steppers/VerticalLinearStepper.tsx
+++ b/docs/src/pages/components/steppers/VerticalLinearStepper.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Stepper from '@material-ui/core/Stepper';
 import Step from '@material-ui/core/Step';
 import StepLabel from '@material-ui/core/StepLabel';
@@ -8,21 +8,23 @@ import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    width: '90%',
-  },
-  button: {
-    marginTop: theme.spacing(1),
-    marginRight: theme.spacing(1),
-  },
-  actionsContainer: {
-    marginBottom: theme.spacing(2),
-  },
-  resetContainer: {
-    padding: theme.spacing(3),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '90%',
+    },
+    button: {
+      marginTop: theme.spacing(1),
+      marginRight: theme.spacing(1),
+    },
+    actionsContainer: {
+      marginBottom: theme.spacing(2),
+    },
+    resetContainer: {
+      padding: theme.spacing(3),
+    },
+  }),
+);
 
 function getSteps() {
   return ['Select campaign settings', 'Create an ad group', 'Create an ad'];

--- a/docs/src/pages/components/tables/EnhancedTable.tsx
+++ b/docs/src/pages/components/tables/EnhancedTable.tsx
@@ -154,31 +154,33 @@ EnhancedTableHead.propTypes = {
   rowCount: PropTypes.number.isRequired,
 };
 
-const useToolbarStyles = makeStyles(theme => ({
-  root: {
-    paddingLeft: theme.spacing(2),
-    paddingRight: theme.spacing(1),
-  },
-  highlight:
-    theme.palette.type === 'light'
-      ? {
-          color: theme.palette.secondary.main,
-          backgroundColor: lighten(theme.palette.secondary.light, 0.85),
-        }
-      : {
-          color: theme.palette.text.primary,
-          backgroundColor: theme.palette.secondary.dark,
-        },
-  spacer: {
-    flex: '1 1 100%',
-  },
-  actions: {
-    color: theme.palette.text.secondary,
-  },
-  title: {
-    flex: '0 0 auto',
-  },
-}));
+const useToolbarStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      paddingLeft: theme.spacing(2),
+      paddingRight: theme.spacing(1),
+    },
+    highlight:
+      theme.palette.type === 'light'
+        ? {
+            color: theme.palette.secondary.main,
+            backgroundColor: lighten(theme.palette.secondary.light, 0.85),
+          }
+        : {
+            color: theme.palette.text.primary,
+            backgroundColor: theme.palette.secondary.dark,
+          },
+    spacer: {
+      flex: '1 1 100%',
+    },
+    actions: {
+      color: theme.palette.text.secondary,
+    },
+    title: {
+      flex: '0 0 auto',
+    },
+  }),
+);
 
 interface EnhancedTableToolbarProps {
   numSelected: number;

--- a/docs/src/pages/components/tabs/FullWidthTabs.tsx
+++ b/docs/src/pages/components/tabs/FullWidthTabs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import SwipeableViews from 'react-swipeable-views';
-import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
+import { makeStyles, Theme, useTheme, createStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -25,12 +25,14 @@ TabContainer.propTypes = {
   dir: PropTypes.string.isRequired,
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    backgroundColor: theme.palette.background.paper,
-    width: 500,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      backgroundColor: theme.palette.background.paper,
+      width: 500,
+    },
+  }),
+);
 
 function FullWidthTabs() {
   const classes = useStyles();

--- a/docs/src/pages/components/tabs/NavTabs.tsx
+++ b/docs/src/pages/components/tabs/NavTabs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -39,12 +39,14 @@ function LinkTab(props: LinkTabProps) {
   );
 }
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    flexGrow: 1,
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      backgroundColor: theme.palette.background.paper,
+    },
+  }),
+);
 
 function NavTabs() {
   const classes = useStyles();

--- a/docs/src/pages/components/tabs/ScrollableTabsButtonAuto.tsx
+++ b/docs/src/pages/components/tabs/ScrollableTabsButtonAuto.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -22,13 +22,15 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    flexGrow: 1,
-    width: '100%',
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      width: '100%',
+      backgroundColor: theme.palette.background.paper,
+    },
+  }),
+);
 
 function ScrollableTabsButtonAuto() {
   const classes = useStyles();

--- a/docs/src/pages/components/tabs/ScrollableTabsButtonForce.tsx
+++ b/docs/src/pages/components/tabs/ScrollableTabsButtonForce.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -29,13 +29,15 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    flexGrow: 1,
-    width: '100%',
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      width: '100%',
+      backgroundColor: theme.palette.background.paper,
+    },
+  }),
+);
 
 function ScrollableTabsButtonForce() {
   const classes = useStyles();

--- a/docs/src/pages/components/tabs/ScrollableTabsButtonPrevent.tsx
+++ b/docs/src/pages/components/tabs/ScrollableTabsButtonPrevent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -29,13 +29,15 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    flexGrow: 1,
-    width: '100%',
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      width: '100%',
+      backgroundColor: theme.palette.background.paper,
+    },
+  }),
+);
 
 function ScrollableTabsButtonPrevent() {
   const classes = useStyles();

--- a/docs/src/pages/components/tabs/SimpleTabs.tsx
+++ b/docs/src/pages/components/tabs/SimpleTabs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -22,12 +22,14 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    flexGrow: 1,
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      backgroundColor: theme.palette.background.paper,
+    },
+  }),
+);
 
 function SimpleTabs() {
   const classes = useStyles();

--- a/docs/src/pages/components/tabs/TabsWrappedLabel.tsx
+++ b/docs/src/pages/components/tabs/TabsWrappedLabel.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
@@ -22,12 +22,14 @@ TabContainer.propTypes = {
   children: PropTypes.node.isRequired,
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    flexGrow: 1,
-    backgroundColor: theme.palette.background.paper,
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      flexGrow: 1,
+      backgroundColor: theme.palette.background.paper,
+    },
+  }),
+);
 
 function TabsWrappedLabel() {
   const classes = useStyles();

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import Card from '@material-ui/core/Card';
@@ -11,23 +11,25 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    margin: 'auto',
-  },
-  cardHeader: {
-    padding: theme.spacing(1, 2),
-  },
-  list: {
-    width: 200,
-    height: 230,
-    backgroundColor: theme.palette.background.paper,
-    overflow: 'auto',
-  },
-  button: {
-    margin: theme.spacing(0.5, 0),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      margin: 'auto',
+    },
+    cardHeader: {
+      padding: theme.spacing(1, 2),
+    },
+    list: {
+      width: 200,
+      height: 230,
+      backgroundColor: theme.palette.background.paper,
+      overflow: 'auto',
+    },
+    button: {
+      margin: theme.spacing(0.5, 0),
+    },
+  }),
+);
 
 function not(a: number[], b: number[]) {
   return a.filter(value => b.indexOf(value) === -1);

--- a/docs/src/pages/components/transfer-list/TransferList.tsx
+++ b/docs/src/pages/components/transfer-list/TransferList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
@@ -9,19 +9,21 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 
-const useStyles = makeStyles((theme: Theme) => ({
-  root: {
-    margin: 'auto',
-  },
-  paper: {
-    width: 200,
-    height: 230,
-    overflow: 'auto',
-  },
-  button: {
-    margin: theme.spacing(0.5, 0),
-  },
-}));
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      margin: 'auto',
+    },
+    paper: {
+      width: 200,
+      height: 230,
+      overflow: 'auto',
+    },
+    button: {
+      margin: theme.spacing(0.5, 0),
+    },
+  }),
+);
 
 function not(a: number[], b: number[]) {
   return a.filter(value => b.indexOf(value) === -1);

--- a/docs/types/fg-loadcss.d.ts
+++ b/docs/types/fg-loadcss.d.ts
@@ -1,0 +1,1 @@
+declare module 'fg-loadcss';


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Added tsx files for `FontAwesome`, `Icons`, `SvgIcons`, and `SvgMaterialIcons`.
* Added `fg-loadcss` type definition stub
* Replace usages of `withStyles` with `makeStyles` in these Icon doc files and removed `propTypes`
* Had to add a few `as` to work around `cloneElement`.