### PR TITLE
[TrapFocus] Fix error restoring focus when activeElement is null

### DIFF
--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -102,9 +102,10 @@ function TrapFocus(props) {
 
       // restoreLastFocus()
       if (!disableRestoreFocus) {
+        // In IE 11 it is possible for document.activeElement to be null resulting
+        // in lastFocus.current being null.
         // Not all elements in IE 11 have a focus method.
-        // Because IE 11 market share is low, we accept the restore focus being broken
-        // and we silent the issue.
+        // Once IE 11 support is dropped the focus() call can be unconditional.
         if (lastFocus.current && lastFocus.current.focus) {
           lastFocus.current.focus();
         }

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -105,7 +105,7 @@ function TrapFocus(props) {
         // Not all elements in IE 11 have a focus method.
         // Because IE 11 market share is low, we accept the restore focus being broken
         // and we silent the issue.
-        if (lastFocus.current.focus) {
+        if (lastFocus.current && lastFocus.current.focus) {
           lastFocus.current.focus();
         }
 


### PR DESCRIPTION
`document.activeElement` is null in IE 11 after unmounting the element that had focus.

You can see this behavior by putting the following into an html page:

```html
<input id="testInput" autofocus>
<script>
function afterTimeout() {
        // input element has focus
	console.log("afterTimeout", document.activeElement);
	var testInput = document.getElementById("testInput");
	testInput.parentNode.removeChild(testInput);
        // null in IE 11, body element in Chrome
	console.log("after removeChild", document.activeElement);
}
function handleLoaded() {
        // body element has focus
	console.log("handleLoaded", document.activeElement);
	setTimeout(afterTimeout);
}
window.addEventListener("load", handleLoaded);
</script>
```

The use case where we saw this involved clicking a button in one dialog which closed that dialog (unmounting the button that was just clicked and was therefore the focus element) and then opened a new dialog. Closing the new dialog then caused an error since `lastFocus.current` was null.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
