### PR TITLE
[core] Add dependency react>=16.3.0 requested by @emotion/core and react-jss 

### DIFF
--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -30,7 +30,7 @@
     "emotion": "^10.0.9",
     "emotion-server": "^10.0.9",
     "nodemod": "^1.5.19",
-    "react": "16.3.0",
+    "react": "^16.3.0",
     "react-jss": "^10.0.0-alpha.12",
     "styled-system": "^4.0.5"
   }

--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -19,7 +19,6 @@
     "system": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/system.js --inspect=0.0.0.0:9229",
     "test": "exit 0"
   },
-  "devDependencies": {},
   "engines": {
     "node": ">=8.0.0"
   },
@@ -31,6 +30,7 @@
     "emotion": "^10.0.9",
     "emotion-server": "^10.0.9",
     "nodemod": "^1.5.19",
+    "react": "16.3.0",
     "react-jss": "^10.0.0-alpha.12",
     "styled-system": "^4.0.5"
   }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

There is a missing dependency on this worktree, as react is listed as a peer dependency of dependencies @emotion/core and react-jss.

this raises a warning when running with yarn2(berry) and will break PNP when using material-ui as a dependency.

tagging @arcanis as requested in https://yarnpkg.com/en/docs/pnp/troubleshooting