### PR TITLE
[styles] Fix createStyles for TypeScript v3.5

### DIFF
--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -8,6 +8,10 @@ import { StyleRules } from '@material-ui/styles/withStyles';
  * @param styles a set of style mappings
  * @returns the same styles that were passed in
  */
-export default function createStyles<C extends string, P extends object>(
+// For TypeScript v3.5 P has to extend {} instead of object
+// See https://github.com/mui-org/material-ui/issues/15942
+// and the breaking changes section here
+// https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/
+export default function createStyles<C extends string, P extends {}>(
   styles: StyleRules<P, C>,
 ): StyleRules<P, C>;

--- a/packages/material-ui-styles/src/createStyles/createStyles.d.ts
+++ b/packages/material-ui-styles/src/createStyles/createStyles.d.ts
@@ -10,8 +10,7 @@ import { StyleRules } from '@material-ui/styles/withStyles';
  */
 // For TypeScript v3.5 P has to extend {} instead of object
 // See https://github.com/mui-org/material-ui/issues/15942
-// and the breaking changes section here
-// https://devblogs.microsoft.com/typescript/announcing-typescript-3-5/
+// and https://github.com/microsoft/TypeScript/issues/31735
 export default function createStyles<C extends string, P extends {}>(
   styles: StyleRules<P, C>,
 ): StyleRules<P, C>;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

> For TypeScript v3.5 P has to extend {} instead of object
See https://github.com/mui-org/material-ui/issues/15942
and https://github.com/microsoft/TypeScript/issues/31735

Closes #15942 