### PR TITLE
[docs] Use immediate export when there is no HOC

### DIFF
--- a/docs/src/pages/components/app-bar/BottomAppBar.js
+++ b/docs/src/pages/components/app-bar/BottomAppBar.js
@@ -99,6 +99,7 @@ const useStyles = makeStyles(theme => ({
 
 function BottomAppBar() {
   const classes = useStyles();
+
   return (
     <React.Fragment>
       <CssBaseline />

--- a/docs/src/pages/components/app-bar/BottomAppBar.tsx
+++ b/docs/src/pages/components/app-bar/BottomAppBar.tsx
@@ -101,6 +101,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 function BottomAppBar() {
   const classes = useStyles();
+
   return (
     <React.Fragment>
       <CssBaseline />

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -21,6 +21,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function ButtonAppBar() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <AppBar position="static">

--- a/docs/src/pages/components/app-bar/ButtonAppBar.js
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function ButtonAppBar() {
+export default function ButtonAppBar() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -37,5 +37,3 @@ function ButtonAppBar() {
     </div>
   );
 }
-
-export default ButtonAppBar;

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function ButtonAppBar() {
+export default function ButtonAppBar() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -39,5 +39,3 @@ function ButtonAppBar() {
     </div>
   );
 }
-
-export default ButtonAppBar;

--- a/docs/src/pages/components/app-bar/ButtonAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ButtonAppBar.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function ButtonAppBar() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <AppBar position="static">

--- a/docs/src/pages/components/app-bar/DenseAppBar.js
+++ b/docs/src/pages/components/app-bar/DenseAppBar.js
@@ -17,6 +17,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function DenseAppBar() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <AppBar position="static">

--- a/docs/src/pages/components/app-bar/DenseAppBar.js
+++ b/docs/src/pages/components/app-bar/DenseAppBar.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function DenseAppBar() {
+export default function DenseAppBar() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -32,4 +32,3 @@ function DenseAppBar() {
     </div>
   );
 }
-export default DenseAppBar;

--- a/docs/src/pages/components/app-bar/DenseAppBar.tsx
+++ b/docs/src/pages/components/app-bar/DenseAppBar.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function DenseAppBar() {
+export default function DenseAppBar() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -34,4 +34,3 @@ function DenseAppBar() {
     </div>
   );
 }
-export default DenseAppBar;

--- a/docs/src/pages/components/app-bar/DenseAppBar.tsx
+++ b/docs/src/pages/components/app-bar/DenseAppBar.tsx
@@ -19,6 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function DenseAppBar() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <AppBar position="static">

--- a/docs/src/pages/components/app-bar/SearchAppBar.js
+++ b/docs/src/pages/components/app-bar/SearchAppBar.js
@@ -64,6 +64,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function SearchAppBar() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <AppBar position="static">

--- a/docs/src/pages/components/app-bar/SearchAppBar.js
+++ b/docs/src/pages/components/app-bar/SearchAppBar.js
@@ -62,7 +62,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function SearchAppBar() {
+export default function SearchAppBar() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -97,5 +97,3 @@ function SearchAppBar() {
     </div>
   );
 }
-
-export default SearchAppBar;

--- a/docs/src/pages/components/app-bar/SearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/SearchAppBar.tsx
@@ -66,6 +66,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function SearchAppBar() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <AppBar position="static">

--- a/docs/src/pages/components/app-bar/SearchAppBar.tsx
+++ b/docs/src/pages/components/app-bar/SearchAppBar.tsx
@@ -64,7 +64,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function SearchAppBar() {
+export default function SearchAppBar() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
@@ -99,5 +99,3 @@ function SearchAppBar() {
     </div>
   );
 }
-
-export default SearchAppBar;

--- a/docs/src/pages/components/app-bar/SimpleAppBar.js
+++ b/docs/src/pages/components/app-bar/SimpleAppBar.js
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
   },
 });
 
-function SimpleAppBar() {
+export default function SimpleAppBar() {
   const classes = useStyles();
 
   return (
@@ -25,5 +25,3 @@ function SimpleAppBar() {
     </div>
   );
 }
-
-export default SimpleAppBar;

--- a/docs/src/pages/components/app-bar/SimpleAppBar.tsx
+++ b/docs/src/pages/components/app-bar/SimpleAppBar.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
   },
 });
 
-function SimpleAppBar() {
+export default function SimpleAppBar() {
   const classes = useStyles();
 
   return (
@@ -25,5 +25,3 @@ function SimpleAppBar() {
     </div>
   );
 }
-
-export default SimpleAppBar;

--- a/docs/src/pages/components/avatars/IconAvatars.js
+++ b/docs/src/pages/components/avatars/IconAvatars.js
@@ -24,7 +24,7 @@ const useStyles = makeStyles({
   },
 });
 
-function IconAvatars() {
+export default function IconAvatars() {
   const classes = useStyles();
 
   return (
@@ -41,5 +41,3 @@ function IconAvatars() {
     </Grid>
   );
 }
-
-export default IconAvatars;

--- a/docs/src/pages/components/avatars/IconAvatars.tsx
+++ b/docs/src/pages/components/avatars/IconAvatars.tsx
@@ -26,7 +26,7 @@ const useStyles = makeStyles(
   }),
 );
 
-function IconAvatars() {
+export default function IconAvatars() {
   const classes = useStyles();
 
   return (
@@ -43,5 +43,3 @@ function IconAvatars() {
     </Grid>
   );
 }
-
-export default IconAvatars;

--- a/docs/src/pages/components/avatars/ImageAvatars.js
+++ b/docs/src/pages/components/avatars/ImageAvatars.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   },
 });
 
-function ImageAvatars() {
+export default function ImageAvatars() {
   const classes = useStyles();
 
   return (
@@ -24,5 +24,3 @@ function ImageAvatars() {
     </Grid>
   );
 }
-
-export default ImageAvatars;

--- a/docs/src/pages/components/avatars/ImageAvatars.tsx
+++ b/docs/src/pages/components/avatars/ImageAvatars.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles(
   }),
 );
 
-function ImageAvatars() {
+export default function ImageAvatars() {
   const classes = useStyles();
 
   return (
@@ -26,5 +26,3 @@ function ImageAvatars() {
     </Grid>
   );
 }
-
-export default ImageAvatars;

--- a/docs/src/pages/components/avatars/LetterAvatars.js
+++ b/docs/src/pages/components/avatars/LetterAvatars.js
@@ -21,7 +21,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LetterAvatars() {
+export default function LetterAvatars() {
   const classes = useStyles();
 
   return (
@@ -32,5 +32,3 @@ function LetterAvatars() {
     </Grid>
   );
 }
-
-export default LetterAvatars;

--- a/docs/src/pages/components/avatars/LetterAvatars.tsx
+++ b/docs/src/pages/components/avatars/LetterAvatars.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles(
   }),
 );
 
-function LetterAvatars() {
+export default function LetterAvatars() {
   const classes = useStyles();
 
   return (
@@ -34,5 +34,3 @@ function LetterAvatars() {
     </Grid>
   );
 }
-
-export default LetterAvatars;

--- a/docs/src/pages/components/badges/BadgeMax.js
+++ b/docs/src/pages/components/badges/BadgeMax.js
@@ -10,7 +10,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function BadgeMax() {
+export default function BadgeMax() {
   const classes = useStyles();
 
   return (
@@ -27,5 +27,3 @@ function BadgeMax() {
     </React.Fragment>
   );
 }
-
-export default BadgeMax;

--- a/docs/src/pages/components/badges/BadgeMax.tsx
+++ b/docs/src/pages/components/badges/BadgeMax.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function BadgeMax() {
+export default function BadgeMax() {
   const classes = useStyles();
 
   return (
@@ -29,5 +29,3 @@ function BadgeMax() {
     </React.Fragment>
   );
 }
-
-export default BadgeMax;

--- a/docs/src/pages/components/badges/CustomizedBadges.js
+++ b/docs/src/pages/components/badges/CustomizedBadges.js
@@ -15,7 +15,7 @@ const StyledBadge = withStyles(theme => ({
   },
 }))(Badge);
 
-function CustomizedBadges() {
+export default function CustomizedBadges() {
   return (
     <IconButton aria-label="Cart">
       <StyledBadge badgeContent={4} color="primary">
@@ -24,5 +24,3 @@ function CustomizedBadges() {
     </IconButton>
   );
 }
-
-export default CustomizedBadges;

--- a/docs/src/pages/components/badges/CustomizedBadges.tsx
+++ b/docs/src/pages/components/badges/CustomizedBadges.tsx
@@ -15,7 +15,7 @@ const StyledBadge = withStyles((theme: Theme) => ({
   },
 }))(Badge);
 
-function CustomizedBadges() {
+export default function CustomizedBadges() {
   return (
     <IconButton aria-label="Cart">
       <StyledBadge badgeContent={4} color="primary">
@@ -24,5 +24,3 @@ function CustomizedBadges() {
     </IconButton>
   );
 }
-
-export default CustomizedBadges;

--- a/docs/src/pages/components/badges/DotBadge.js
+++ b/docs/src/pages/components/badges/DotBadge.js
@@ -10,7 +10,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function DotBadge() {
+export default function DotBadge() {
   const classes = useStyles();
 
   return (
@@ -29,5 +29,3 @@ function DotBadge() {
     </div>
   );
 }
-
-export default DotBadge;

--- a/docs/src/pages/components/badges/DotBadge.tsx
+++ b/docs/src/pages/components/badges/DotBadge.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function DotBadge() {
+export default function DotBadge() {
   const classes = useStyles();
 
   return (
@@ -31,5 +31,3 @@ function DotBadge() {
     </div>
   );
 }
-
-export default DotBadge;

--- a/docs/src/pages/components/bottom-navigation/LabelBottomNavigation.js
+++ b/docs/src/pages/components/bottom-navigation/LabelBottomNavigation.js
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LabelBottomNavigation() {
+export default function LabelBottomNavigation() {
   const classes = useStyles();
   const [value, setValue] = React.useState('recents');
 
@@ -30,5 +30,3 @@ function LabelBottomNavigation() {
     </BottomNavigation>
   );
 }
-
-export default LabelBottomNavigation;

--- a/docs/src/pages/components/bottom-navigation/LabelBottomNavigation.tsx
+++ b/docs/src/pages/components/bottom-navigation/LabelBottomNavigation.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LabelBottomNavigation() {
+export default function LabelBottomNavigation() {
   const classes = useStyles();
   const [value, setValue] = React.useState('recents');
 
@@ -30,5 +30,3 @@ function LabelBottomNavigation() {
     </BottomNavigation>
   );
 }
-
-export default LabelBottomNavigation;

--- a/docs/src/pages/components/bottom-navigation/SimpleBottomNavigation.js
+++ b/docs/src/pages/components/bottom-navigation/SimpleBottomNavigation.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
   },
 });
 
-function SimpleBottomNavigation() {
+export default function SimpleBottomNavigation() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -31,5 +31,3 @@ function SimpleBottomNavigation() {
     </BottomNavigation>
   );
 }
-
-export default SimpleBottomNavigation;

--- a/docs/src/pages/components/bottom-navigation/SimpleBottomNavigation.tsx
+++ b/docs/src/pages/components/bottom-navigation/SimpleBottomNavigation.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
   },
 });
 
-function SimpleBottomNavigation() {
+export default function SimpleBottomNavigation() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -31,5 +31,3 @@ function SimpleBottomNavigation() {
     </BottomNavigation>
   );
 }
-
-export default SimpleBottomNavigation;

--- a/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.js
@@ -29,6 +29,7 @@ function handleClick(event) {
 
 function IconBreadcrumbs() {
   const classes = useStyles();
+
   return (
     <Paper elevation={0} className={classes.root}>
       <Breadcrumbs aria-label="Breadcrumb">

--- a/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/IconBreadcrumbs.tsx
@@ -31,6 +31,7 @@ function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
 
 function IconBreadcrumbs() {
   const classes = useStyles();
+
   return (
     <Paper elevation={0} className={classes.root}>
       <Breadcrumbs aria-label="Breadcrumb">

--- a/docs/src/pages/components/breadcrumbs/SimpleBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/SimpleBreadcrumbs.js
@@ -22,6 +22,7 @@ function handleClick(event) {
 
 function SimpleBreadcrumbs() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <Paper elevation={0} className={classes.paper}>

--- a/docs/src/pages/components/breadcrumbs/SimpleBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/SimpleBreadcrumbs.tsx
@@ -24,6 +24,7 @@ function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
 
 function SimpleBreadcrumbs() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <Paper elevation={0} className={classes.paper}>

--- a/docs/src/pages/components/buttons/ButtonBases.js
+++ b/docs/src/pages/components/buttons/ButtonBases.js
@@ -94,7 +94,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function ButtonBases() {
+export default function ButtonBases() {
   const classes = useStyles();
 
   return (
@@ -132,5 +132,3 @@ function ButtonBases() {
     </div>
   );
 }
-
-export default ButtonBases;

--- a/docs/src/pages/components/buttons/ButtonBases.tsx
+++ b/docs/src/pages/components/buttons/ButtonBases.tsx
@@ -96,7 +96,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function ButtonBases() {
+export default function ButtonBases() {
   const classes = useStyles();
 
   return (
@@ -134,5 +134,3 @@ function ButtonBases() {
     </div>
   );
 }
-
-export default ButtonBases;

--- a/docs/src/pages/components/buttons/ButtonRouter.js
+++ b/docs/src/pages/components/buttons/ButtonRouter.js
@@ -11,7 +11,7 @@ const CollisionLink = React.forwardRef((props, ref) => (
   <Link innerRef={ref} to="/getting-started/installation/" {...props} />
 ));
 
-function ButtonRouter() {
+export default function ButtonRouter() {
   return (
     <Router>
       <Button color="primary" component={AdapterLink} to="/">
@@ -21,5 +21,3 @@ function ButtonRouter() {
     </Router>
   );
 }
-
-export default ButtonRouter;

--- a/docs/src/pages/components/buttons/ButtonRouter.tsx
+++ b/docs/src/pages/components/buttons/ButtonRouter.tsx
@@ -14,7 +14,7 @@ const CollisionLink = React.forwardRef<HTMLAnchorElement, Omit<LinkProps, 'inner
   (props, ref) => <Link innerRef={ref as any} to="/getting-started/installation/" {...props} />,
 );
 
-function ButtonRouter() {
+export default function ButtonRouter() {
   return (
     <Router>
       <Button color="primary" component={AdapterLink} to="/">
@@ -24,5 +24,3 @@ function ButtonRouter() {
     </Router>
   );
 }
-
-export default ButtonRouter;

--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -19,6 +19,7 @@ const useStyles = makeStyles(theme => ({
 
 function ButtonSizes() {
   const classes = useStyles();
+
   return (
     <div>
       <div>

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 function ButtonSizes() {
   const classes = useStyles();
+
   return (
     <div>
       <div>

--- a/docs/src/pages/components/buttons/ContainedButtons.js
+++ b/docs/src/pages/components/buttons/ContainedButtons.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function ContainedButtons() {
+export default function ContainedButtons() {
   const classes = useStyles();
 
   return (
@@ -46,5 +46,3 @@ function ContainedButtons() {
     </div>
   );
 }
-
-export default ContainedButtons;

--- a/docs/src/pages/components/buttons/ContainedButtons.tsx
+++ b/docs/src/pages/components/buttons/ContainedButtons.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function ContainedButtons() {
+export default function ContainedButtons() {
   const classes = useStyles();
 
   return (
@@ -48,5 +48,3 @@ function ContainedButtons() {
     </div>
   );
 }
-
-export default ContainedButtons;

--- a/docs/src/pages/components/buttons/CustomizedButtons.js
+++ b/docs/src/pages/components/buttons/CustomizedButtons.js
@@ -64,7 +64,7 @@ const theme = createMuiTheme({
   },
 });
 
-function CustomizedButtons() {
+export default function CustomizedButtons() {
   const classes = useStyles();
 
   return (
@@ -83,5 +83,3 @@ function CustomizedButtons() {
     </div>
   );
 }
-
-export default CustomizedButtons;

--- a/docs/src/pages/components/buttons/CustomizedButtons.tsx
+++ b/docs/src/pages/components/buttons/CustomizedButtons.tsx
@@ -72,7 +72,7 @@ const theme = createMuiTheme({
   },
 });
 
-function CustomizedButtons() {
+export default function CustomizedButtons() {
   const classes = useStyles();
 
   return (
@@ -91,5 +91,3 @@ function CustomizedButtons() {
     </div>
   );
 }
-
-export default CustomizedButtons;

--- a/docs/src/pages/components/buttons/FloatingActionButtons.js
+++ b/docs/src/pages/components/buttons/FloatingActionButtons.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function FloatingActionButtons() {
+export default function FloatingActionButtons() {
   const classes = useStyles();
 
   return (
@@ -36,5 +36,3 @@ function FloatingActionButtons() {
     </div>
   );
 }
-
-export default FloatingActionButtons;

--- a/docs/src/pages/components/buttons/FloatingActionButtons.tsx
+++ b/docs/src/pages/components/buttons/FloatingActionButtons.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function FloatingActionButtons() {
+export default function FloatingActionButtons() {
   const classes = useStyles();
 
   return (
@@ -38,5 +38,3 @@ function FloatingActionButtons() {
     </div>
   );
 }
-
-export default FloatingActionButtons;

--- a/docs/src/pages/components/buttons/IconButtons.js
+++ b/docs/src/pages/components/buttons/IconButtons.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function IconButtons() {
+export default function IconButtons() {
   const classes = useStyles();
 
   return (
@@ -46,5 +46,3 @@ function IconButtons() {
     </div>
   );
 }
-
-export default IconButtons;

--- a/docs/src/pages/components/buttons/IconButtons.tsx
+++ b/docs/src/pages/components/buttons/IconButtons.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function IconButtons() {
+export default function IconButtons() {
   const classes = useStyles();
 
   return (
@@ -48,5 +48,3 @@ function IconButtons() {
     </div>
   );
 }
-
-export default IconButtons;

--- a/docs/src/pages/components/buttons/TextButtons.js
+++ b/docs/src/pages/components/buttons/TextButtons.js
@@ -11,7 +11,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function TextButtons() {
+export default function TextButtons() {
   const classes = useStyles();
 
   return (
@@ -44,5 +44,3 @@ function TextButtons() {
     </div>
   );
 }
-
-export default TextButtons;

--- a/docs/src/pages/components/buttons/TextButtons.tsx
+++ b/docs/src/pages/components/buttons/TextButtons.tsx
@@ -13,7 +13,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function TextButtons() {
+export default function TextButtons() {
   const classes = useStyles();
 
   return (
@@ -46,5 +46,3 @@ function TextButtons() {
     </div>
   );
 }
-
-export default TextButtons;

--- a/docs/src/pages/components/cards/MediaCard.js
+++ b/docs/src/pages/components/cards/MediaCard.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
   },
 });
 
-function MediaCard() {
+export default function MediaCard() {
   const classes = useStyles();
 
   return (
@@ -49,5 +49,3 @@ function MediaCard() {
     </Card>
   );
 }
-
-export default MediaCard;

--- a/docs/src/pages/components/cards/MediaCard.tsx
+++ b/docs/src/pages/components/cards/MediaCard.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles(
   }),
 );
 
-function MediaCard() {
+export default function MediaCard() {
   const classes = useStyles();
 
   return (
@@ -51,5 +51,3 @@ function MediaCard() {
     </Card>
   );
 }
-
-export default MediaCard;

--- a/docs/src/pages/components/cards/SimpleCard.js
+++ b/docs/src/pages/components/cards/SimpleCard.js
@@ -23,7 +23,7 @@ const useStyles = makeStyles({
   },
 });
 
-function SimpleCard() {
+export default function SimpleCard() {
   const classes = useStyles();
   const bull = <span className={classes.bullet}>•</span>;
 
@@ -55,5 +55,3 @@ function SimpleCard() {
     </Card>
   );
 }
-
-export default SimpleCard;

--- a/docs/src/pages/components/cards/SimpleCard.tsx
+++ b/docs/src/pages/components/cards/SimpleCard.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles(
   }),
 );
 
-function SimpleCard() {
+export default function SimpleCard() {
   const classes = useStyles();
   const bull = <span className={classes.bullet}>•</span>;
 
@@ -57,5 +57,3 @@ function SimpleCard() {
     </Card>
   );
 }
-
-export default SimpleCard;

--- a/docs/src/pages/components/dividers/InsetDividers.js
+++ b/docs/src/pages/components/dividers/InsetDividers.js
@@ -18,7 +18,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function InsetDividers() {
+export default function InsetDividers() {
   const classes = useStyles();
 
   return (
@@ -52,5 +52,3 @@ function InsetDividers() {
     </List>
   );
 }
-
-export default InsetDividers;

--- a/docs/src/pages/components/dividers/InsetDividers.tsx
+++ b/docs/src/pages/components/dividers/InsetDividers.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function InsetDividers() {
+export default function InsetDividers() {
   const classes = useStyles();
 
   return (
@@ -54,5 +54,3 @@ function InsetDividers() {
     </List>
   );
 }
-
-export default InsetDividers;

--- a/docs/src/pages/components/dividers/ListDividers.js
+++ b/docs/src/pages/components/dividers/ListDividers.js
@@ -13,7 +13,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function ListDividers() {
+export default function ListDividers() {
   const classes = useStyles();
 
   return (
@@ -35,5 +35,3 @@ function ListDividers() {
     </List>
   );
 }
-
-export default ListDividers;

--- a/docs/src/pages/components/dividers/ListDividers.tsx
+++ b/docs/src/pages/components/dividers/ListDividers.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function ListDividers() {
+export default function ListDividers() {
   const classes = useStyles();
 
   return (
@@ -37,5 +37,3 @@ function ListDividers() {
     </List>
   );
 }
-
-export default ListDividers;

--- a/docs/src/pages/components/grid-list/AdvancedGridList.js
+++ b/docs/src/pages/components/grid-list/AdvancedGridList.js
@@ -49,7 +49,7 @@ const useStyles = makeStyles(theme => ({
  *   },
  * ];
  */
-function AdvancedGridList() {
+export default function AdvancedGridList() {
   const classes = useStyles();
 
   return (
@@ -75,5 +75,3 @@ function AdvancedGridList() {
     </div>
   );
 }
-
-export default AdvancedGridList;

--- a/docs/src/pages/components/grid-list/AdvancedGridList.tsx
+++ b/docs/src/pages/components/grid-list/AdvancedGridList.tsx
@@ -51,7 +51,7 @@ const useStyles = makeStyles((theme: Theme) =>
  *   },
  * ];
  */
-function AdvancedGridList() {
+export default function AdvancedGridList() {
   const classes = useStyles();
 
   return (
@@ -77,5 +77,3 @@ function AdvancedGridList() {
     </div>
   );
 }
-
-export default AdvancedGridList;

--- a/docs/src/pages/components/grid-list/ImageGridList.js
+++ b/docs/src/pages/components/grid-list/ImageGridList.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles(theme => ({
  *   },
  * ];
  */
-function ImageGridList() {
+export default function ImageGridList() {
   const classes = useStyles();
 
   return (
@@ -51,5 +51,3 @@ function ImageGridList() {
     </div>
   );
 }
-
-export default ImageGridList;

--- a/docs/src/pages/components/grid-list/ImageGridList.tsx
+++ b/docs/src/pages/components/grid-list/ImageGridList.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
  *   },
  * ];
  */
-function ImageGridList() {
+export default function ImageGridList() {
   const classes = useStyles();
 
   return (
@@ -53,5 +53,3 @@ function ImageGridList() {
     </div>
   );
 }
-
-export default ImageGridList;

--- a/docs/src/pages/components/grid-list/SingleLineGridList.js
+++ b/docs/src/pages/components/grid-list/SingleLineGridList.js
@@ -46,7 +46,7 @@ const useStyles = makeStyles(theme => ({
  *   },
  * ];
  */
-function SingleLineGridList() {
+export default function SingleLineGridList() {
   const classes = useStyles();
 
   return (
@@ -73,5 +73,3 @@ function SingleLineGridList() {
     </div>
   );
 }
-
-export default SingleLineGridList;

--- a/docs/src/pages/components/grid-list/SingleLineGridList.tsx
+++ b/docs/src/pages/components/grid-list/SingleLineGridList.tsx
@@ -48,7 +48,7 @@ const useStyles = makeStyles((theme: Theme) =>
  *   },
  * ];
  */
-function SingleLineGridList() {
+export default function SingleLineGridList() {
   const classes = useStyles();
 
   return (
@@ -75,5 +75,3 @@ function SingleLineGridList() {
     </div>
   );
 }
-
-export default SingleLineGridList;

--- a/docs/src/pages/components/grid-list/TitlebarGridList.js
+++ b/docs/src/pages/components/grid-list/TitlebarGridList.js
@@ -42,7 +42,7 @@ const useStyles = makeStyles(theme => ({
  *   },
  * ];
  */
-function TitlebarGridList() {
+export default function TitlebarGridList() {
   const classes = useStyles();
 
   return (
@@ -69,5 +69,3 @@ function TitlebarGridList() {
     </div>
   );
 }
-
-export default TitlebarGridList;

--- a/docs/src/pages/components/grid-list/TitlebarGridList.tsx
+++ b/docs/src/pages/components/grid-list/TitlebarGridList.tsx
@@ -44,7 +44,7 @@ const useStyles = makeStyles((theme: Theme) =>
  *   },
  * ];
  */
-function TitlebarGridList() {
+export default function TitlebarGridList() {
   const classes = useStyles();
 
   return (
@@ -71,5 +71,3 @@ function TitlebarGridList() {
     </div>
   );
 }
-
-export default TitlebarGridList;

--- a/docs/src/pages/components/grid/AutoGrid.js
+++ b/docs/src/pages/components/grid/AutoGrid.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function AutoGrid() {
+export default function AutoGrid() {
   const classes = useStyles();
 
   return (
@@ -44,5 +44,3 @@ function AutoGrid() {
     </div>
   );
 }
-
-export default AutoGrid;

--- a/docs/src/pages/components/grid/AutoGrid.tsx
+++ b/docs/src/pages/components/grid/AutoGrid.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function AutoGrid() {
+export default function AutoGrid() {
   const classes = useStyles();
 
   return (
@@ -46,5 +46,3 @@ function AutoGrid() {
     </div>
   );
 }
-
-export default AutoGrid;

--- a/docs/src/pages/components/grid/CenteredGrid.js
+++ b/docs/src/pages/components/grid/CenteredGrid.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function CenteredGrid() {
+export default function CenteredGrid() {
   const classes = useStyles();
 
   return (
@@ -45,5 +45,3 @@ function CenteredGrid() {
     </div>
   );
 }
-
-export default CenteredGrid;

--- a/docs/src/pages/components/grid/CenteredGrid.tsx
+++ b/docs/src/pages/components/grid/CenteredGrid.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function CenteredGrid() {
+export default function CenteredGrid() {
   const classes = useStyles();
 
   return (
@@ -47,5 +47,3 @@ function CenteredGrid() {
     </div>
   );
 }
-
-export default CenteredGrid;

--- a/docs/src/pages/components/grid/FullWidthGrid.js
+++ b/docs/src/pages/components/grid/FullWidthGrid.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function FullWidthGrid() {
+export default function FullWidthGrid() {
   const classes = useStyles();
 
   return (
@@ -45,5 +45,3 @@ function FullWidthGrid() {
     </div>
   );
 }
-
-export default FullWidthGrid;

--- a/docs/src/pages/components/grid/FullWidthGrid.tsx
+++ b/docs/src/pages/components/grid/FullWidthGrid.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function FullWidthGrid() {
+export default function FullWidthGrid() {
   const classes = useStyles();
 
   return (
@@ -47,5 +47,3 @@ function FullWidthGrid() {
     </div>
   );
 }
-
-export default FullWidthGrid;

--- a/docs/src/pages/components/grid/NestedGrid.js
+++ b/docs/src/pages/components/grid/NestedGrid.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function NestedGrid() {
+export default function NestedGrid() {
   const classes = useStyles();
 
   function FormRow() {
@@ -49,5 +49,3 @@ function NestedGrid() {
     </div>
   );
 }
-
-export default NestedGrid;

--- a/docs/src/pages/components/grid/NestedGrid.tsx
+++ b/docs/src/pages/components/grid/NestedGrid.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function NestedGrid() {
+export default function NestedGrid() {
   const classes = useStyles();
 
   function FormRow() {
@@ -51,5 +51,3 @@ function NestedGrid() {
     </div>
   );
 }
-
-export default NestedGrid;

--- a/docs/src/pages/components/icons/FontAwesome.js
+++ b/docs/src/pages/components/icons/FontAwesome.js
@@ -22,7 +22,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function FontAwesome() {
+export default function FontAwesome() {
   const classes = useStyles();
 
   React.useEffect(() => {
@@ -47,5 +47,3 @@ function FontAwesome() {
     </div>
   );
 }
-
-export default FontAwesome;

--- a/docs/src/pages/components/icons/FontAwesome.tsx
+++ b/docs/src/pages/components/icons/FontAwesome.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function FontAwesome() {
+export default function FontAwesome() {
   const classes = useStyles();
 
   React.useEffect(() => {
@@ -49,5 +49,3 @@ function FontAwesome() {
     </div>
   );
 }
-
-export default FontAwesome;

--- a/docs/src/pages/components/icons/Icons.js
+++ b/docs/src/pages/components/icons/Icons.js
@@ -20,7 +20,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function Icons() {
+export default function Icons() {
   const classes = useStyles();
 
   return (
@@ -44,5 +44,3 @@ function Icons() {
     </div>
   );
 }
-
-export default Icons;

--- a/docs/src/pages/components/icons/Icons.tsx
+++ b/docs/src/pages/components/icons/Icons.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function Icons() {
+export default function Icons() {
   const classes = useStyles();
 
   return (
@@ -46,5 +46,3 @@ function Icons() {
     </div>
   );
 }
-
-export default Icons;

--- a/docs/src/pages/components/icons/SvgIcons.js
+++ b/docs/src/pages/components/icons/SvgIcons.js
@@ -31,6 +31,7 @@ function HomeIcon(props) {
 
 function SvgIcons() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <HomeIcon className={classes.icon} />

--- a/docs/src/pages/components/icons/SvgIcons.tsx
+++ b/docs/src/pages/components/icons/SvgIcons.tsx
@@ -33,6 +33,7 @@ function HomeIcon(props: SvgIconProps) {
 
 function SvgIcons() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <HomeIcon className={classes.icon} />

--- a/docs/src/pages/components/icons/SvgMaterialIcons.js
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.js
@@ -28,6 +28,7 @@ const useStyles = makeStyles(theme => ({
 
 function SvgMaterialIcons() {
   const classes = useStyles();
+
   return (
     <Grid container className={classes.root}>
       <Grid item xs={4}>

--- a/docs/src/pages/components/icons/SvgMaterialIcons.tsx
+++ b/docs/src/pages/components/icons/SvgMaterialIcons.tsx
@@ -30,6 +30,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 function SvgMaterialIcons() {
   const classes = useStyles();
+
   return (
     <Grid container className={classes.root}>
       <Grid item xs={4}>

--- a/docs/src/pages/components/links/LinkRouter.js
+++ b/docs/src/pages/components/links/LinkRouter.js
@@ -12,7 +12,7 @@ const CollisionLink = React.forwardRef((props, ref) => (
   <RouterLink innerRef={ref} to="/getting-started/installation/" {...props} />
 ));
 
-function LinkRouter() {
+export default function LinkRouter() {
   return (
     <Router>
       <div>
@@ -29,5 +29,3 @@ function LinkRouter() {
     </Router>
   );
 }
-
-export default LinkRouter;

--- a/docs/src/pages/components/links/LinkRouter.tsx
+++ b/docs/src/pages/components/links/LinkRouter.tsx
@@ -17,7 +17,7 @@ const CollisionLink = React.forwardRef<HTMLAnchorElement, Omit<RouterLinkProps, 
   ),
 );
 
-function LinkRouter() {
+export default function LinkRouter() {
   return (
     <Router>
       <div>
@@ -34,5 +34,3 @@ function LinkRouter() {
     </Router>
   );
 }
-
-export default LinkRouter;

--- a/docs/src/pages/components/lists/FolderList.js
+++ b/docs/src/pages/components/lists/FolderList.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function FolderList() {
+export default function FolderList() {
   const classes = useStyles();
 
   return (
@@ -49,5 +49,3 @@ function FolderList() {
     </List>
   );
 }
-
-export default FolderList;

--- a/docs/src/pages/components/lists/FolderList.tsx
+++ b/docs/src/pages/components/lists/FolderList.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function FolderList() {
+export default function FolderList() {
   const classes = useStyles();
 
   return (
@@ -51,5 +51,3 @@ function FolderList() {
     </List>
   );
 }
-
-export default FolderList;

--- a/docs/src/pages/components/lists/InsetList.js
+++ b/docs/src/pages/components/lists/InsetList.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function InsetList() {
+export default function InsetList() {
   const classes = useStyles();
 
   return (
@@ -31,5 +31,3 @@ function InsetList() {
     </List>
   );
 }
-
-export default InsetList;

--- a/docs/src/pages/components/lists/InsetList.tsx
+++ b/docs/src/pages/components/lists/InsetList.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function InsetList() {
+export default function InsetList() {
   const classes = useStyles();
 
   return (
@@ -33,5 +33,3 @@ function InsetList() {
     </List>
   );
 }
-
-export default InsetList;

--- a/docs/src/pages/components/lists/PinnedSubheaderList.js
+++ b/docs/src/pages/components/lists/PinnedSubheaderList.js
@@ -23,7 +23,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function PinnedSubheaderList() {
+export default function PinnedSubheaderList() {
   const classes = useStyles();
 
   return (
@@ -43,5 +43,3 @@ function PinnedSubheaderList() {
     </List>
   );
 }
-
-export default PinnedSubheaderList;

--- a/docs/src/pages/components/lists/PinnedSubheaderList.tsx
+++ b/docs/src/pages/components/lists/PinnedSubheaderList.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function PinnedSubheaderList() {
+export default function PinnedSubheaderList() {
   const classes = useStyles();
 
   return (
@@ -45,5 +45,3 @@ function PinnedSubheaderList() {
     </List>
   );
 }
-
-export default PinnedSubheaderList;

--- a/docs/src/pages/components/menus/FadeMenu.js
+++ b/docs/src/pages/components/menus/FadeMenu.js
@@ -4,7 +4,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Fade from '@material-ui/core/Fade';
 
-function FadeMenu() {
+export default function FadeMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
 
@@ -36,5 +36,3 @@ function FadeMenu() {
     </div>
   );
 }
-
-export default FadeMenu;

--- a/docs/src/pages/components/menus/FadeMenu.tsx
+++ b/docs/src/pages/components/menus/FadeMenu.tsx
@@ -4,7 +4,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Fade from '@material-ui/core/Fade';
 
-function FadeMenu() {
+export default function FadeMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
@@ -36,5 +36,3 @@ function FadeMenu() {
     </div>
   );
 }
-
-export default FadeMenu;

--- a/docs/src/pages/components/menus/LongMenu.js
+++ b/docs/src/pages/components/menus/LongMenu.js
@@ -23,7 +23,7 @@ const options = [
 
 const ITEM_HEIGHT = 48;
 
-function LongMenu() {
+export default function LongMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const open = Boolean(anchorEl);
 
@@ -67,5 +67,3 @@ function LongMenu() {
     </div>
   );
 }
-
-export default LongMenu;

--- a/docs/src/pages/components/menus/LongMenu.tsx
+++ b/docs/src/pages/components/menus/LongMenu.tsx
@@ -23,7 +23,7 @@ const options = [
 
 const ITEM_HEIGHT = 48;
 
-function LongMenu() {
+export default function LongMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
 
@@ -67,5 +67,3 @@ function LongMenu() {
     </div>
   );
 }
-
-export default LongMenu;

--- a/docs/src/pages/components/menus/SimpleMenu.js
+++ b/docs/src/pages/components/menus/SimpleMenu.js
@@ -3,7 +3,7 @@ import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 
-function SimpleMenu() {
+export default function SimpleMenu() {
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   function handleClick(event) {
@@ -33,5 +33,3 @@ function SimpleMenu() {
     </div>
   );
 }
-
-export default SimpleMenu;

--- a/docs/src/pages/components/menus/SimpleMenu.tsx
+++ b/docs/src/pages/components/menus/SimpleMenu.tsx
@@ -3,7 +3,7 @@ import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 
-function SimpleMenu() {
+export default function SimpleMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
   function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
@@ -33,5 +33,3 @@ function SimpleMenu() {
     </div>
   );
 }
-
-export default SimpleMenu;

--- a/docs/src/pages/components/menus/TypographyMenu.js
+++ b/docs/src/pages/components/menus/TypographyMenu.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
   },
 });
 
-function TypographyMenu() {
+export default function TypographyMenu() {
   const classes = useStyles();
 
   return (
@@ -45,5 +45,3 @@ function TypographyMenu() {
     </Paper>
   );
 }
-
-export default TypographyMenu;

--- a/docs/src/pages/components/menus/TypographyMenu.tsx
+++ b/docs/src/pages/components/menus/TypographyMenu.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
   },
 });
 
-function TypographyMenu() {
+export default function TypographyMenu() {
   const classes = useStyles();
 
   return (
@@ -45,5 +45,3 @@ function TypographyMenu() {
     </Paper>
   );
 }
-
-export default TypographyMenu;

--- a/docs/src/pages/components/paper/PaperSheet.js
+++ b/docs/src/pages/components/paper/PaperSheet.js
@@ -9,7 +9,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function PaperSheet() {
+export default function PaperSheet() {
   const classes = useStyles();
 
   return (
@@ -25,5 +25,3 @@ function PaperSheet() {
     </div>
   );
 }
-
-export default PaperSheet;

--- a/docs/src/pages/components/paper/PaperSheet.tsx
+++ b/docs/src/pages/components/paper/PaperSheet.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function PaperSheet() {
+export default function PaperSheet() {
   const classes = useStyles();
 
   return (
@@ -27,5 +27,3 @@ function PaperSheet() {
     </div>
   );
 }
-
-export default PaperSheet;

--- a/docs/src/pages/components/pickers/DateAndTimePickers.js
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function DateAndTimePickers() {
+export default function DateAndTimePickers() {
   const classes = useStyles();
 
   return (
@@ -32,5 +32,3 @@ function DateAndTimePickers() {
     </form>
   );
 }
-
-export default DateAndTimePickers;

--- a/docs/src/pages/components/pickers/DateAndTimePickers.tsx
+++ b/docs/src/pages/components/pickers/DateAndTimePickers.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function DateAndTimePickers() {
+export default function DateAndTimePickers() {
   const classes = useStyles();
 
   return (
@@ -34,5 +34,3 @@ function DateAndTimePickers() {
     </form>
   );
 }
-
-export default DateAndTimePickers;

--- a/docs/src/pages/components/pickers/DatePickers.js
+++ b/docs/src/pages/components/pickers/DatePickers.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function DatePickers() {
+export default function DatePickers() {
   const classes = useStyles();
 
   return (
@@ -32,5 +32,3 @@ function DatePickers() {
     </form>
   );
 }
-
-export default DatePickers;

--- a/docs/src/pages/components/pickers/DatePickers.tsx
+++ b/docs/src/pages/components/pickers/DatePickers.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function DatePickers() {
+export default function DatePickers() {
   const classes = useStyles();
 
   return (
@@ -34,5 +34,3 @@ function DatePickers() {
     </form>
   );
 }
-
-export default DatePickers;

--- a/docs/src/pages/components/pickers/TimePickers.js
+++ b/docs/src/pages/components/pickers/TimePickers.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function TimePickers() {
+export default function TimePickers() {
   const classes = useStyles();
 
   return (
@@ -35,5 +35,3 @@ function TimePickers() {
     </form>
   );
 }
-
-export default TimePickers;

--- a/docs/src/pages/components/pickers/TimePickers.tsx
+++ b/docs/src/pages/components/pickers/TimePickers.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function TimePickers() {
+export default function TimePickers() {
   const classes = useStyles();
 
   return (
@@ -37,5 +37,3 @@ function TimePickers() {
     </form>
   );
 }
-
-export default TimePickers;

--- a/docs/src/pages/components/portal/SimplePortal.js
+++ b/docs/src/pages/components/portal/SimplePortal.js
@@ -13,7 +13,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function SimplePortal() {
+export default function SimplePortal() {
   const [show, setShow] = React.useState(false);
   const container = React.useRef(null);
   const classes = useStyles();
@@ -37,5 +37,3 @@ function SimplePortal() {
     </div>
   );
 }
-
-export default SimplePortal;

--- a/docs/src/pages/components/portal/SimplePortal.tsx
+++ b/docs/src/pages/components/portal/SimplePortal.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function SimplePortal() {
+export default function SimplePortal() {
   const [show, setShow] = React.useState(false);
   const container = React.useRef(null);
   const classes = useStyles();
@@ -39,5 +39,3 @@ function SimplePortal() {
     </div>
   );
 }
-
-export default SimplePortal;

--- a/docs/src/pages/components/progress/CircularDeterminate.js
+++ b/docs/src/pages/components/progress/CircularDeterminate.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function CircularDeterminate() {
+export default function CircularDeterminate() {
   const classes = useStyles();
   const [progress, setProgress] = React.useState(0);
 
@@ -36,5 +36,3 @@ function CircularDeterminate() {
     </div>
   );
 }
-
-export default CircularDeterminate;

--- a/docs/src/pages/components/progress/CircularDeterminate.tsx
+++ b/docs/src/pages/components/progress/CircularDeterminate.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function CircularDeterminate() {
+export default function CircularDeterminate() {
   const classes = useStyles();
   const [progress, setProgress] = React.useState(0);
 
@@ -38,5 +38,3 @@ function CircularDeterminate() {
     </div>
   );
 }
-
-export default CircularDeterminate;

--- a/docs/src/pages/components/progress/CircularIndeterminate.js
+++ b/docs/src/pages/components/progress/CircularIndeterminate.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function CircularIndeterminate() {
+export default function CircularIndeterminate() {
   const classes = useStyles();
 
   return (
@@ -18,5 +18,3 @@ function CircularIndeterminate() {
     </div>
   );
 }
-
-export default CircularIndeterminate;

--- a/docs/src/pages/components/progress/CircularIndeterminate.tsx
+++ b/docs/src/pages/components/progress/CircularIndeterminate.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function CircularIndeterminate() {
+export default function CircularIndeterminate() {
   const classes = useStyles();
 
   return (
@@ -20,5 +20,3 @@ function CircularIndeterminate() {
     </div>
   );
 }
-
-export default CircularIndeterminate;

--- a/docs/src/pages/components/progress/CircularStatic.js
+++ b/docs/src/pages/components/progress/CircularStatic.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function CircularStatic() {
+export default function CircularStatic() {
   const classes = useStyles();
   const [completed, setCompleted] = React.useState(0);
 
@@ -34,5 +34,3 @@ function CircularStatic() {
     </div>
   );
 }
-
-export default CircularStatic;

--- a/docs/src/pages/components/progress/CircularStatic.tsx
+++ b/docs/src/pages/components/progress/CircularStatic.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function CircularStatic() {
+export default function CircularStatic() {
   const classes = useStyles();
   const [completed, setCompleted] = React.useState(0);
 
@@ -36,5 +36,3 @@ function CircularStatic() {
     </div>
   );
 }
-
-export default CircularStatic;

--- a/docs/src/pages/components/progress/CircularUnderLoad.js
+++ b/docs/src/pages/components/progress/CircularUnderLoad.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
-function CircularUnderLoad() {
+export default function CircularUnderLoad() {
   return <CircularProgress disableShrink />;
 }
-
-export default CircularUnderLoad;

--- a/docs/src/pages/components/progress/CircularUnderLoad.tsx
+++ b/docs/src/pages/components/progress/CircularUnderLoad.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import CircularProgress from '@material-ui/core/CircularProgress';
 
-function CircularUnderLoad() {
+export default function CircularUnderLoad() {
   return <CircularProgress disableShrink />;
 }
-
-export default CircularUnderLoad;

--- a/docs/src/pages/components/progress/LinearBuffer.js
+++ b/docs/src/pages/components/progress/LinearBuffer.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LinearBuffer() {
+export default function LinearBuffer() {
   const classes = useStyles();
   const [completed, setCompleted] = React.useState(0);
   const [buffer, setBuffer] = React.useState(10);
@@ -47,5 +47,3 @@ function LinearBuffer() {
     </div>
   );
 }
-
-export default LinearBuffer;

--- a/docs/src/pages/components/progress/LinearBuffer.tsx
+++ b/docs/src/pages/components/progress/LinearBuffer.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LinearBuffer() {
+export default function LinearBuffer() {
   const classes = useStyles();
   const [completed, setCompleted] = React.useState(0);
   const [buffer, setBuffer] = React.useState(10);
@@ -47,5 +47,3 @@ function LinearBuffer() {
     </div>
   );
 }
-
-export default LinearBuffer;

--- a/docs/src/pages/components/progress/LinearDeterminate.js
+++ b/docs/src/pages/components/progress/LinearDeterminate.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LinearDeterminate() {
+export default function LinearDeterminate() {
   const classes = useStyles();
   const [completed, setCompleted] = React.useState(0);
 
@@ -37,5 +37,3 @@ function LinearDeterminate() {
     </div>
   );
 }
-
-export default LinearDeterminate;

--- a/docs/src/pages/components/progress/LinearDeterminate.tsx
+++ b/docs/src/pages/components/progress/LinearDeterminate.tsx
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LinearDeterminate() {
+export default function LinearDeterminate() {
   const classes = useStyles();
   const [completed, setCompleted] = React.useState(0);
 
@@ -37,5 +37,3 @@ function LinearDeterminate() {
     </div>
   );
 }
-
-export default LinearDeterminate;

--- a/docs/src/pages/components/progress/LinearIndeterminate.js
+++ b/docs/src/pages/components/progress/LinearIndeterminate.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LinearIndeterminate() {
+export default function LinearIndeterminate() {
   const classes = useStyles();
 
   return (
@@ -19,5 +19,3 @@ function LinearIndeterminate() {
     </div>
   );
 }
-
-export default LinearIndeterminate;

--- a/docs/src/pages/components/progress/LinearIndeterminate.tsx
+++ b/docs/src/pages/components/progress/LinearIndeterminate.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles(
   }),
 );
 
-function LinearIndeterminate() {
+export default function LinearIndeterminate() {
   const classes = useStyles();
 
   return (
@@ -21,5 +21,3 @@ function LinearIndeterminate() {
     </div>
   );
 }
-
-export default LinearIndeterminate;

--- a/docs/src/pages/components/progress/LinearQuery.js
+++ b/docs/src/pages/components/progress/LinearQuery.js
@@ -8,7 +8,7 @@ const useStyles = makeStyles({
   },
 });
 
-function LinearQuery() {
+export default function LinearQuery() {
   const classes = useStyles();
 
   return (
@@ -19,5 +19,3 @@ function LinearQuery() {
     </div>
   );
 }
-
-export default LinearQuery;

--- a/docs/src/pages/components/progress/LinearQuery.tsx
+++ b/docs/src/pages/components/progress/LinearQuery.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles(
   }),
 );
 
-function LinearQuery() {
+export default function LinearQuery() {
   const classes = useStyles();
 
   return (
@@ -21,5 +21,3 @@ function LinearQuery() {
     </div>
   );
 }
-
-export default LinearQuery;

--- a/docs/src/pages/components/slider/CustomizedSlider.js
+++ b/docs/src/pages/components/slider/CustomizedSlider.js
@@ -39,7 +39,7 @@ const StyledSlider = withStyles({
   jumped: {},
 })(Slider);
 
-function CustomizedSlider() {
+export default function CustomizedSlider() {
   const classes = useStyles();
   const [value, setValue] = React.useState(50);
 
@@ -53,5 +53,3 @@ function CustomizedSlider() {
     </Paper>
   );
 }
-
-export default CustomizedSlider;

--- a/docs/src/pages/components/slider/CustomizedSlider.tsx
+++ b/docs/src/pages/components/slider/CustomizedSlider.tsx
@@ -39,7 +39,7 @@ const StyledSlider = withStyles({
   jumped: {},
 })(Slider);
 
-function CustomizedSlider() {
+export default function CustomizedSlider() {
   const classes = useStyles();
   const [value, setValue] = React.useState(50);
 
@@ -53,5 +53,3 @@ function CustomizedSlider() {
     </Paper>
   );
 }
-
-export default CustomizedSlider;

--- a/docs/src/pages/components/snackbars/IntegrationNotistack.js
+++ b/docs/src/pages/components/snackbars/IntegrationNotistack.js
@@ -29,12 +29,10 @@ App.propTypes = {
 
 const MyApp = withSnackbar(App);
 
-function IntegrationNotistack() {
+export default function IntegrationNotistack() {
   return (
     <SnackbarProvider maxSnack={3}>
       <MyApp />
     </SnackbarProvider>
   );
 }
-
-export default IntegrationNotistack;

--- a/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
+++ b/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
@@ -29,12 +29,10 @@ class App extends React.Component<withSnackbarProps> {
 
 const MyApp = withSnackbar(App);
 
-function IntegrationNotistack() {
+export default function IntegrationNotistack() {
   return (
     <SnackbarProvider maxSnack={3}>
       <MyApp />
     </SnackbarProvider>
   );
 }
-
-export default IntegrationNotistack;

--- a/docs/src/pages/components/snackbars/LongTextSnackbar.js
+++ b/docs/src/pages/components/snackbars/LongTextSnackbar.js
@@ -18,7 +18,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function LongTextSnackbar() {
+export default function LongTextSnackbar() {
   const classes = useStyles();
 
   return (
@@ -47,5 +47,3 @@ function LongTextSnackbar() {
     </div>
   );
 }
-
-export default LongTextSnackbar;

--- a/docs/src/pages/components/snackbars/LongTextSnackbar.tsx
+++ b/docs/src/pages/components/snackbars/LongTextSnackbar.tsx
@@ -20,7 +20,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function LongTextSnackbar() {
+export default function LongTextSnackbar() {
   const classes = useStyles();
 
   return (
@@ -49,5 +49,3 @@ function LongTextSnackbar() {
     </div>
   );
 }
-
-export default LongTextSnackbar;

--- a/docs/src/pages/components/steppers/DotsMobileStepper.js
+++ b/docs/src/pages/components/steppers/DotsMobileStepper.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
   },
 });
 
-function DotsMobileStepper() {
+export default function DotsMobileStepper() {
   const classes = useStyles();
   const theme = useTheme();
   const [activeStep, setActiveStep] = React.useState(0);
@@ -47,5 +47,3 @@ function DotsMobileStepper() {
     />
   );
 }
-
-export default DotsMobileStepper;

--- a/docs/src/pages/components/steppers/DotsMobileStepper.tsx
+++ b/docs/src/pages/components/steppers/DotsMobileStepper.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
   },
 });
 
-function DotsMobileStepper() {
+export default function DotsMobileStepper() {
   const classes = useStyles();
   const theme = useTheme();
   const [activeStep, setActiveStep] = React.useState(0);
@@ -47,5 +47,3 @@ function DotsMobileStepper() {
     />
   );
 }
-
-export default DotsMobileStepper;

--- a/docs/src/pages/components/steppers/ProgressMobileStepper.js
+++ b/docs/src/pages/components/steppers/ProgressMobileStepper.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
   },
 });
 
-function ProgressMobileStepper() {
+export default function ProgressMobileStepper() {
   const classes = useStyles();
   const theme = useTheme();
   const [activeStep, setActiveStep] = React.useState(0);
@@ -47,5 +47,3 @@ function ProgressMobileStepper() {
     />
   );
 }
-
-export default ProgressMobileStepper;

--- a/docs/src/pages/components/steppers/ProgressMobileStepper.tsx
+++ b/docs/src/pages/components/steppers/ProgressMobileStepper.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
   },
 });
 
-function ProgressMobileStepper() {
+export default function ProgressMobileStepper() {
   const classes = useStyles();
   const theme = useTheme();
   const [activeStep, setActiveStep] = React.useState(0);
@@ -47,5 +47,3 @@ function ProgressMobileStepper() {
     />
   );
 }
-
-export default ProgressMobileStepper;

--- a/docs/src/pages/components/tabs/CenteredTabs.js
+++ b/docs/src/pages/components/tabs/CenteredTabs.js
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
   },
 });
 
-function CenteredTabs() {
+export default function CenteredTabs() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -34,5 +34,3 @@ function CenteredTabs() {
     </Paper>
   );
 }
-
-export default CenteredTabs;

--- a/docs/src/pages/components/tabs/CenteredTabs.tsx
+++ b/docs/src/pages/components/tabs/CenteredTabs.tsx
@@ -10,7 +10,7 @@ const useStyles = makeStyles({
   },
 });
 
-function CenteredTabs() {
+export default function CenteredTabs() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -34,5 +34,3 @@ function CenteredTabs() {
     </Paper>
   );
 }
-
-export default CenteredTabs;

--- a/docs/src/pages/components/tabs/CustomizedTabs.js
+++ b/docs/src/pages/components/tabs/CustomizedTabs.js
@@ -87,7 +87,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function CustomizedTabs() {
+export default function CustomizedTabs() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -116,5 +116,3 @@ function CustomizedTabs() {
     </div>
   );
 }
-
-export default CustomizedTabs;

--- a/docs/src/pages/components/tabs/CustomizedTabs.tsx
+++ b/docs/src/pages/components/tabs/CustomizedTabs.tsx
@@ -102,7 +102,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function CustomizedTabs() {
+export default function CustomizedTabs() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -131,5 +131,3 @@ function CustomizedTabs() {
     </div>
   );
 }
-
-export default CustomizedTabs;

--- a/docs/src/pages/components/tabs/DisabledTabs.js
+++ b/docs/src/pages/components/tabs/DisabledTabs.js
@@ -3,7 +3,7 @@ import Paper from '@material-ui/core/Paper';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 
-function DisabledTabs() {
+export default function DisabledTabs() {
   const [value, setValue] = React.useState(2);
 
   function handleChange(event, newValue) {
@@ -20,5 +20,3 @@ function DisabledTabs() {
     </Paper>
   );
 }
-
-export default DisabledTabs;

--- a/docs/src/pages/components/tabs/DisabledTabs.tsx
+++ b/docs/src/pages/components/tabs/DisabledTabs.tsx
@@ -3,7 +3,7 @@ import Paper from '@material-ui/core/Paper';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 
-function DisabledTabs() {
+export default function DisabledTabs() {
   const [value, setValue] = React.useState(2);
 
   function handleChange(event: React.ChangeEvent<{}>, newValue: number) {
@@ -20,5 +20,3 @@ function DisabledTabs() {
     </Paper>
   );
 }
-
-export default DisabledTabs;

--- a/docs/src/pages/components/tabs/IconLabelTabs.js
+++ b/docs/src/pages/components/tabs/IconLabelTabs.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   },
 });
 
-function IconLabelTabs() {
+export default function IconLabelTabs() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -38,5 +38,3 @@ function IconLabelTabs() {
     </Paper>
   );
 }
-
-export default IconLabelTabs;

--- a/docs/src/pages/components/tabs/IconLabelTabs.tsx
+++ b/docs/src/pages/components/tabs/IconLabelTabs.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   },
 });
 
-function IconLabelTabs() {
+export default function IconLabelTabs() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -38,5 +38,3 @@ function IconLabelTabs() {
     </Paper>
   );
 }
-
-export default IconLabelTabs;

--- a/docs/src/pages/components/tabs/IconTabs.js
+++ b/docs/src/pages/components/tabs/IconTabs.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   },
 });
 
-function IconTabs() {
+export default function IconTabs() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -38,5 +38,3 @@ function IconTabs() {
     </Paper>
   );
 }
-
-export default IconTabs;

--- a/docs/src/pages/components/tabs/IconTabs.tsx
+++ b/docs/src/pages/components/tabs/IconTabs.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles({
   },
 });
 
-function IconTabs() {
+export default function IconTabs() {
   const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
@@ -38,5 +38,3 @@ function IconTabs() {
     </Paper>
   );
 }
-
-export default IconTabs;

--- a/docs/src/pages/components/text-fields/CustomizedInputBase.js
+++ b/docs/src/pages/components/text-fields/CustomizedInputBase.js
@@ -29,7 +29,7 @@ const useStyles = makeStyles({
   },
 });
 
-function CustomizedInputBase() {
+export default function CustomizedInputBase() {
   const classes = useStyles();
 
   return (
@@ -52,5 +52,3 @@ function CustomizedInputBase() {
     </Paper>
   );
 }
-
-export default CustomizedInputBase;

--- a/docs/src/pages/components/text-fields/CustomizedInputBase.tsx
+++ b/docs/src/pages/components/text-fields/CustomizedInputBase.tsx
@@ -31,7 +31,7 @@ const useStyles = makeStyles(
   }),
 );
 
-function CustomizedInputBase() {
+export default function CustomizedInputBase() {
   const classes = useStyles();
 
   return (
@@ -54,5 +54,3 @@ function CustomizedInputBase() {
     </Paper>
   );
 }
-
-export default CustomizedInputBase;

--- a/docs/src/pages/components/text-fields/Inputs.js
+++ b/docs/src/pages/components/text-fields/Inputs.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function Inputs() {
+export default function Inputs() {
   const classes = useStyles();
 
   return (
@@ -50,5 +50,3 @@ function Inputs() {
     </div>
   );
 }
-
-export default Inputs;

--- a/docs/src/pages/components/text-fields/Inputs.tsx
+++ b/docs/src/pages/components/text-fields/Inputs.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function Inputs() {
+export default function Inputs() {
   const classes = useStyles();
 
   return (
@@ -52,5 +52,3 @@ function Inputs() {
     </div>
   );
 }
-
-export default Inputs;

--- a/docs/src/pages/components/text-fields/TextFieldMargins.js
+++ b/docs/src/pages/components/text-fields/TextFieldMargins.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function TextFieldMargins() {
+export default function TextFieldMargins() {
   const classes = useStyles();
 
   return (
@@ -45,5 +45,3 @@ function TextFieldMargins() {
     </div>
   );
 }
-
-export default TextFieldMargins;

--- a/docs/src/pages/components/text-fields/TextFieldMargins.tsx
+++ b/docs/src/pages/components/text-fields/TextFieldMargins.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function TextFieldMargins() {
+export default function TextFieldMargins() {
   const classes = useStyles();
 
   return (
@@ -47,5 +47,3 @@ function TextFieldMargins() {
     </div>
   );
 }
-
-export default TextFieldMargins;

--- a/docs/src/pages/components/tooltips/ControlledTooltips.js
+++ b/docs/src/pages/components/tooltips/ControlledTooltips.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-function ControlledTooltips() {
+export default function ControlledTooltips() {
   const [open, setOpen] = React.useState(false);
 
   function handleTooltipClose() {
@@ -19,5 +19,3 @@ function ControlledTooltips() {
     </Tooltip>
   );
 }
-
-export default ControlledTooltips;

--- a/docs/src/pages/components/tooltips/ControlledTooltips.tsx
+++ b/docs/src/pages/components/tooltips/ControlledTooltips.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-function ControlledTooltips() {
+export default function ControlledTooltips() {
   const [open, setOpen] = React.useState(false);
 
   function handleTooltipClose() {
@@ -19,5 +19,3 @@ function ControlledTooltips() {
     </Tooltip>
   );
 }
-
-export default ControlledTooltips;

--- a/docs/src/pages/components/tooltips/DelayTooltips.js
+++ b/docs/src/pages/components/tooltips/DelayTooltips.js
@@ -2,12 +2,10 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-function DelayTooltips() {
+export default function DelayTooltips() {
   return (
     <Tooltip title="Add" enterDelay={500} leaveDelay={200}>
       <Button>[500ms, 200ms]</Button>
     </Tooltip>
   );
 }
-
-export default DelayTooltips;

--- a/docs/src/pages/components/tooltips/DelayTooltips.tsx
+++ b/docs/src/pages/components/tooltips/DelayTooltips.tsx
@@ -2,12 +2,10 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-function DelayTooltips() {
+export default function DelayTooltips() {
   return (
     <Tooltip title="Add" enterDelay={500} leaveDelay={200}>
       <Button>[500ms, 200ms]</Button>
     </Tooltip>
   );
 }
-
-export default DelayTooltips;

--- a/docs/src/pages/components/tooltips/DisabledTooltips.js
+++ b/docs/src/pages/components/tooltips/DisabledTooltips.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-function DisabledTooltips() {
+export default function DisabledTooltips() {
   return (
     <Tooltip title="You don't have permission to do this">
       <span>
@@ -11,5 +11,3 @@ function DisabledTooltips() {
     </Tooltip>
   );
 }
-
-export default DisabledTooltips;

--- a/docs/src/pages/components/tooltips/DisabledTooltips.tsx
+++ b/docs/src/pages/components/tooltips/DisabledTooltips.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 
-function DisabledTooltips() {
+export default function DisabledTooltips() {
   return (
     <Tooltip title="You don't have permission to do this">
       <span>
@@ -11,5 +11,3 @@ function DisabledTooltips() {
     </Tooltip>
   );
 }
-
-export default DisabledTooltips;

--- a/docs/src/pages/components/tooltips/InteractiveTooltips.js
+++ b/docs/src/pages/components/tooltips/InteractiveTooltips.js
@@ -9,7 +9,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function InteractiveTooltips() {
+export default function InteractiveTooltips() {
   const classes = useStyles();
 
   return (
@@ -23,5 +23,3 @@ function InteractiveTooltips() {
     </div>
   );
 }
-
-export default InteractiveTooltips;

--- a/docs/src/pages/components/tooltips/InteractiveTooltips.tsx
+++ b/docs/src/pages/components/tooltips/InteractiveTooltips.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function InteractiveTooltips() {
+export default function InteractiveTooltips() {
   const classes = useStyles();
 
   return (
@@ -25,5 +25,3 @@ function InteractiveTooltips() {
     </div>
   );
 }
-
-export default InteractiveTooltips;

--- a/docs/src/pages/components/tooltips/PositionedTooltips.js
+++ b/docs/src/pages/components/tooltips/PositionedTooltips.js
@@ -12,6 +12,7 @@ const useStyles = makeStyles({
 
 function PositionedTooltips() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <Grid container justify="center">

--- a/docs/src/pages/components/tooltips/PositionedTooltips.tsx
+++ b/docs/src/pages/components/tooltips/PositionedTooltips.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles(
 
 function PositionedTooltips() {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <Grid container justify="center">

--- a/docs/src/pages/components/tooltips/SimpleTooltips.js
+++ b/docs/src/pages/components/tooltips/SimpleTooltips.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function SimpleTooltips() {
+export default function SimpleTooltips() {
   const classes = useStyles();
   return (
     <div>
@@ -39,5 +39,3 @@ function SimpleTooltips() {
     </div>
   );
 }
-
-export default SimpleTooltips;

--- a/docs/src/pages/components/tooltips/SimpleTooltips.js
+++ b/docs/src/pages/components/tooltips/SimpleTooltips.js
@@ -19,6 +19,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function SimpleTooltips() {
   const classes = useStyles();
+
   return (
     <div>
       <Tooltip title="Delete">

--- a/docs/src/pages/components/tooltips/SimpleTooltips.tsx
+++ b/docs/src/pages/components/tooltips/SimpleTooltips.tsx
@@ -19,7 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function SimpleTooltips() {
+export default function SimpleTooltips() {
   const classes = useStyles();
   return (
     <div>
@@ -41,5 +41,3 @@ function SimpleTooltips() {
     </div>
   );
 }
-
-export default SimpleTooltips;

--- a/docs/src/pages/components/tooltips/SimpleTooltips.tsx
+++ b/docs/src/pages/components/tooltips/SimpleTooltips.tsx
@@ -21,6 +21,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 export default function SimpleTooltips() {
   const classes = useStyles();
+
   return (
     <div>
       <Tooltip title="Delete">

--- a/docs/src/pages/components/tooltips/TransitionsTooltips.js
+++ b/docs/src/pages/components/tooltips/TransitionsTooltips.js
@@ -4,7 +4,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Fade from '@material-ui/core/Fade';
 import Zoom from '@material-ui/core/Zoom';
 
-function TransitionsTooltips() {
+export default function TransitionsTooltips() {
   return (
     <div>
       <Tooltip title="Add">
@@ -19,5 +19,3 @@ function TransitionsTooltips() {
     </div>
   );
 }
-
-export default TransitionsTooltips;

--- a/docs/src/pages/components/tooltips/TransitionsTooltips.tsx
+++ b/docs/src/pages/components/tooltips/TransitionsTooltips.tsx
@@ -4,7 +4,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Fade from '@material-ui/core/Fade';
 import Zoom from '@material-ui/core/Zoom';
 
-function TransitionsTooltips() {
+export default function TransitionsTooltips() {
   return (
     <div>
       <Tooltip title="Add">
@@ -19,5 +19,3 @@ function TransitionsTooltips() {
     </div>
   );
 }
-
-export default TransitionsTooltips;

--- a/docs/src/pages/components/tooltips/VariableWidth.js
+++ b/docs/src/pages/components/tooltips/VariableWidth.js
@@ -21,7 +21,7 @@ Praesent non nunc mollis, fermentum neque at, semper arcu.
 Nullam eget est sed sem iaculis gravida eget vitae justo.
 `;
 
-function VariableWidth() {
+export default function VariableWidth() {
   const classes = useStyles();
   return (
     <div>
@@ -37,5 +37,3 @@ function VariableWidth() {
     </div>
   );
 }
-
-export default VariableWidth;

--- a/docs/src/pages/components/tooltips/VariableWidth.js
+++ b/docs/src/pages/components/tooltips/VariableWidth.js
@@ -23,6 +23,7 @@ Nullam eget est sed sem iaculis gravida eget vitae justo.
 
 export default function VariableWidth() {
   const classes = useStyles();
+
   return (
     <div>
       <Tooltip title={longText}>

--- a/docs/src/pages/components/tooltips/VariableWidth.tsx
+++ b/docs/src/pages/components/tooltips/VariableWidth.tsx
@@ -25,6 +25,7 @@ Nullam eget est sed sem iaculis gravida eget vitae justo.
 
 export default function VariableWidth() {
   const classes = useStyles();
+
   return (
     <div>
       <Tooltip title={longText}>

--- a/docs/src/pages/components/tooltips/VariableWidth.tsx
+++ b/docs/src/pages/components/tooltips/VariableWidth.tsx
@@ -23,7 +23,7 @@ Praesent non nunc mollis, fermentum neque at, semper arcu.
 Nullam eget est sed sem iaculis gravida eget vitae justo.
 `;
 
-function VariableWidth() {
+export default function VariableWidth() {
   const classes = useStyles();
   return (
     <div>
@@ -39,5 +39,3 @@ function VariableWidth() {
     </div>
   );
 }
-
-export default VariableWidth;

--- a/docs/src/pages/customization/typography/TypographyTheme.js
+++ b/docs/src/pages/customization/typography/TypographyTheme.js
@@ -38,7 +38,7 @@ const theme = createMuiTheme({
   },
 });
 
-function TypographyTheme() {
+export default function TypographyTheme() {
   const classes = useStyles();
 
   const children = (
@@ -56,5 +56,3 @@ function TypographyTheme() {
     </div>
   );
 }
-
-export default TypographyTheme;

--- a/docs/src/pages/customization/typography/TypographyTheme.tsx
+++ b/docs/src/pages/customization/typography/TypographyTheme.tsx
@@ -40,7 +40,7 @@ const theme = createMuiTheme({
   },
 });
 
-function TypographyTheme() {
+export default function TypographyTheme() {
   const classes = useStyles();
 
   const children = (
@@ -58,5 +58,3 @@ function TypographyTheme() {
     </div>
   );
 }
-
-export default TypographyTheme;

--- a/docs/src/pages/guides/interoperability/StyledComponents.js
+++ b/docs/src/pages/guides/interoperability/StyledComponents.js
@@ -13,7 +13,7 @@ const StyledButton = styled(Button)`
   box-shadow: 0 3px 5px 2px rgba(255, 105, 135, 0.3);
 `;
 
-function StyledComponents() {
+export default function StyledComponents() {
   return (
     <NoSsr>
       <div>
@@ -23,5 +23,3 @@ function StyledComponents() {
     </NoSsr>
   );
 }
-
-export default StyledComponents;

--- a/docs/src/pages/guides/interoperability/StyledComponents.tsx
+++ b/docs/src/pages/guides/interoperability/StyledComponents.tsx
@@ -13,7 +13,7 @@ const StyledButton = styled(Button)`
   box-shadow: 0 3px 5px 2px rgba(255, 105, 135, 0.3);
 `;
 
-function StyledComponents() {
+export default function StyledComponents() {
   return (
     <NoSsr>
       <div>
@@ -23,5 +23,3 @@ function StyledComponents() {
     </NoSsr>
   );
 }
-
-export default StyledComponents;

--- a/docs/src/pages/styles/basics/NestedStylesHook.js
+++ b/docs/src/pages/styles/basics/NestedStylesHook.js
@@ -17,6 +17,7 @@ const useStyles = makeStyles({
 
 export default function NestedStylesHook() {
   const classes = useStyles();
+
   return (
     <Paper className={classes.root}>
       This is red since it is inside the paper.

--- a/docs/src/pages/styles/basics/NestedStylesHook.tsx
+++ b/docs/src/pages/styles/basics/NestedStylesHook.tsx
@@ -17,6 +17,7 @@ const useStyles = makeStyles({
 
 export default function NestedStylesHook() {
   const classes = useStyles();
+
   return (
     <Paper className={classes.root}>
       This is red since it is inside the paper.

--- a/docs/src/pages/system/basics/CssProp.js
+++ b/docs/src/pages/system/basics/CssProp.js
@@ -15,7 +15,7 @@ const Box = styled.div`
 
 const theme = createMuiTheme();
 
-function CssProp() {
+export default function CssProp() {
   return (
     <NoSsr>
       <ThemeProvider theme={theme}>
@@ -26,5 +26,3 @@ function CssProp() {
     </NoSsr>
   );
 }
-
-export default CssProp;

--- a/docs/src/pages/system/basics/CssProp.tsx
+++ b/docs/src/pages/system/basics/CssProp.tsx
@@ -15,7 +15,7 @@ const Box = styled.div`
 
 const theme = createMuiTheme();
 
-function CssProp() {
+export default function CssProp() {
   return (
     <NoSsr>
       <ThemeProvider theme={theme}>
@@ -26,5 +26,3 @@ function CssProp() {
     </NoSsr>
   );
 }
-
-export default CssProp;

--- a/docs/src/pages/system/basics/Demo.js
+++ b/docs/src/pages/system/basics/Demo.js
@@ -9,7 +9,7 @@ const Box = styled.div`${palette}${spacing}${typography}`;
 
 const theme = createMuiTheme();
 
-function Demo() {
+export default function Demo() {
   return (
     <NoSsr>
       <ThemeProvider theme={theme}>
@@ -26,5 +26,3 @@ function Demo() {
     </NoSsr>
   );
 }
-
-export default Demo;

--- a/docs/src/pages/system/basics/Demo.tsx
+++ b/docs/src/pages/system/basics/Demo.tsx
@@ -18,7 +18,7 @@ const Box = styled.div<
 
 const theme = createMuiTheme();
 
-function Demo() {
+export default function Demo() {
   return (
     <NoSsr>
       <ThemeProvider theme={theme}>
@@ -35,5 +35,3 @@ function Demo() {
     </NoSsr>
   );
 }
-
-export default Demo;

--- a/docs/src/pages/system/basics/Emotion.js
+++ b/docs/src/pages/system/basics/Emotion.js
@@ -8,7 +8,7 @@ const Box = styled.div`
   ${spacing}
 `;
 
-function Emotion() {
+export default function Emotion() {
   return (
     <NoSsr>
       <Box color="white" bgcolor="palevioletred" p={1}>
@@ -17,5 +17,3 @@ function Emotion() {
     </NoSsr>
   );
 }
-
-export default Emotion;

--- a/docs/src/pages/system/basics/Emotion.tsx
+++ b/docs/src/pages/system/basics/Emotion.tsx
@@ -8,7 +8,7 @@ const Box = styled.div<PaletteProps & SpacingProps>`
   ${spacing}
 `;
 
-function Emotion() {
+export default function Emotion() {
   return (
     <NoSsr>
       <Box color="white" bgcolor="palevioletred" p={1}>
@@ -17,5 +17,3 @@ function Emotion() {
     </NoSsr>
   );
 }
-
-export default Emotion;

--- a/docs/src/pages/system/basics/RealWorld.js
+++ b/docs/src/pages/system/basics/RealWorld.js
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
 
-function RealWorld() {
+export default function RealWorld() {
   return (
     <Box clone pt={2} pr={1} pb={1} pl={2}>
       <Paper elevation={0}>
@@ -32,5 +32,3 @@ function RealWorld() {
     </Box>
   );
 }
-
-export default RealWorld;

--- a/docs/src/pages/system/basics/RealWorld.tsx
+++ b/docs/src/pages/system/basics/RealWorld.tsx
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
 
-function RealWorld() {
+export default function RealWorld() {
   return (
     <Box clone pt={2} pr={1} pb={1} pl={2}>
       <Paper elevation={0}>
@@ -32,5 +32,3 @@ function RealWorld() {
     </Box>
   );
 }
-
-export default RealWorld;

--- a/docs/src/pages/system/basics/StyledComponents.js
+++ b/docs/src/pages/system/basics/StyledComponents.js
@@ -8,7 +8,7 @@ const Box = styled.div`
   ${spacing}
 `;
 
-function StyledComponents() {
+export default function StyledComponents() {
   return (
     <NoSsr>
       <Box color="white" bgcolor="palevioletred" p={1}>
@@ -17,5 +17,3 @@ function StyledComponents() {
     </NoSsr>
   );
 }
-
-export default StyledComponents;

--- a/docs/src/pages/system/basics/StyledComponents.tsx
+++ b/docs/src/pages/system/basics/StyledComponents.tsx
@@ -8,7 +8,7 @@ const Box = styled.div<PaletteProps & SpacingProps>`
   ${spacing}
 `;
 
-function StyledComponents() {
+export default function StyledComponents() {
   return (
     <NoSsr>
       <Box color="white" bgcolor="palevioletred" p={1}>
@@ -17,5 +17,3 @@ function StyledComponents() {
     </NoSsr>
   );
 }
-
-export default StyledComponents;

--- a/docs/src/pages/system/basics/Variant.js
+++ b/docs/src/pages/system/basics/Variant.js
@@ -30,7 +30,7 @@ const theme = {
   },
 };
 
-function Variant() {
+export default function Variant() {
   return (
     <NoSsr>
       <ThemeProvider theme={theme}>
@@ -49,5 +49,3 @@ function Variant() {
     </NoSsr>
   );
 }
-
-export default Variant;

--- a/docs/src/pages/system/basics/Variant.tsx
+++ b/docs/src/pages/system/basics/Variant.tsx
@@ -30,7 +30,7 @@ const theme = {
   },
 };
 
-function Variant() {
+export default function Variant() {
   return (
     <NoSsr>
       <ThemeProvider theme={theme}>
@@ -49,5 +49,3 @@ function Variant() {
     </NoSsr>
   );
 }
-
-export default Variant;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Use immediate export if there is no HOC
* Consistent spacing between `const classes = useStyles();` and `return`

Only applied to demos with a typescript version

See https://github.com/mui-org/material-ui/pull/16003#discussion_r289658779