### PR TITLE
[StepImage]: Show selection of completed Step

### DIFF
--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -11,10 +11,10 @@ export const styles = theme => ({
   root: {
     display: 'block',
     color: theme.palette.text.disabled,
-    '&$active': {
+    '&$completed': {
       color: theme.palette.primary.main,
     },
-    '&$completed': {
+    '&$active': {
       color: theme.palette.primary.main,
     },
     '&$error': {
@@ -39,17 +39,20 @@ const StepIcon = React.forwardRef(function StepIcon(props, ref) {
   const { completed = false, icon, active = false, error = false, classes } = props;
 
   if (typeof icon === 'number' || typeof icon === 'string') {
+    const className = clsx(classes.root, {
+      [classes.completed]: completed,
+      [classes.active]: active,
+      [classes.error]: error,
+    });
+    var Icon = SvgIcon;
     if (error) {
-      return <Warning className={clsx(classes.root, classes.error)} ref={ref} />;
-    }
-    if (completed) {
-      return <CheckCircle className={clsx(classes.root, classes.completed)} ref={ref} />;
+      Icon = Warning;
+    } else if (completed) {
+      Icon = CheckCircle;
     }
     return (
-      <SvgIcon
-        className={clsx(classes.root, {
-          [classes.active]: active,
-        })}
+      <Icon
+        className={className}
         ref={ref}
       >
         <circle cx="12" cy="12" r="12" />

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -59,7 +59,7 @@ const StepIcon = React.forwardRef(function StepIcon(props, ref) {
         <text className={classes.text} x="12" y="16" textAnchor="middle">
           {icon}
         </text>
-      </SvgIcon>
+      </Icon>
     );
   }
 


### PR DESCRIPTION
This fixes #15437 to allow `Stepper` to show selection on completed `Step`s as well.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I believe I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
