### PR TITLE
[core] Fix type definition for theme.spacing

### DIFF
--- a/packages/material-ui/src/styles/createSpacing.d.ts
+++ b/packages/material-ui/src/styles/createSpacing.d.ts
@@ -3,6 +3,7 @@
 export type SpacingArgument = number | string;
 
 export interface Spacing {
+  (): number;
   (value1: SpacingArgument): number;
   (value1: SpacingArgument, value2: SpacingArgument): string;
   (value1: SpacingArgument, value2: SpacingArgument, value3: SpacingArgument): string;

--- a/packages/material-ui/src/styles/createSpacing.js
+++ b/packages/material-ui/src/styles/createSpacing.js
@@ -32,7 +32,7 @@ export default function createSpacing(spacingInput = 8) {
   }
 
   const spacing = (...args) => {
-    warning(args.length <= 4, `Too many arguments, expected between 0 and 4, got ${args.length}`);
+    warning(args.length <= 4, `Material-UI: Too many arguments provided, expected between 0 and 4, got ${args.length}`);
 
     if (args.length === 0) {
       return transform(1);

--- a/packages/material-ui/src/styles/createSpacing.js
+++ b/packages/material-ui/src/styles/createSpacing.js
@@ -32,7 +32,7 @@ export default function createSpacing(spacingInput = 8) {
   }
 
   const spacing = (...args) => {
-    warning(args.length <= 4, `Too many arguments, expected between 1 and 4, got ${args.length}`);
+    warning(args.length <= 4, `Too many arguments, expected between 0 and 4, got ${args.length}`);
 
     if (args.length === 0) {
       return transform(1);

--- a/packages/material-ui/src/styles/createSpacing.js
+++ b/packages/material-ui/src/styles/createSpacing.js
@@ -32,7 +32,10 @@ export default function createSpacing(spacingInput = 8) {
   }
 
   const spacing = (...args) => {
-    warning(args.length <= 4, `Material-UI: Too many arguments provided, expected between 0 and 4, got ${args.length}`);
+    warning(
+      args.length <= 4,
+      `Material-UI: Too many arguments provided, expected between 0 and 4, got ${args.length}`,
+    );
 
     if (args.length === 0) {
       return transform(1);


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fixed type definition not allowing zero arguments, followup to https://github.com/mui-org/material-ui/pull/15891

/cc @mbrookes