### PR TITLE
RFC: [core] Add border helper function to theme

### DIFF
--- a/packages/material-ui/src/styles/createBorder.d.ts
+++ b/packages/material-ui/src/styles/createBorder.d.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:unified-signatures */
 import { BorderInlineStyleProperty } from 'csstype';
 
 export interface Border {

--- a/packages/material-ui/src/styles/createBorder.d.ts
+++ b/packages/material-ui/src/styles/createBorder.d.ts
@@ -1,0 +1,20 @@
+import { BorderInlineStyleProperty } from 'csstype';
+
+export interface Border {
+  (): string;
+  (width: number | string): string;
+  (width: number | string, style: BorderInlineStyleProperty): string;
+  (width: number | string, style: BorderInlineStyleProperty, color: string): string;
+}
+
+export interface BorderOptions {
+  defaultWidth: number | string;
+  defaultStyle: BorderInlineStyleProperty;
+  defaultColor: string;
+}
+
+export default function createBorder(
+  defaultWidth: number | string,
+  defaultStyle: BorderInlineStyleProperty,
+  defaultColor: string,
+): string;

--- a/packages/material-ui/src/styles/createBorder.js
+++ b/packages/material-ui/src/styles/createBorder.js
@@ -1,0 +1,11 @@
+export default function createBorder(defaultWidth, defaultStyle, defaultColor) {
+  const border = (widthArg, styleArg, colorArg) => {
+    const width = widthArg || defaultWidth;
+    const style = styleArg || defaultStyle;
+    const color = colorArg || defaultColor;
+
+    return `${typeof width === 'number' ? `${width}px` : width} ${style} ${color}`;
+  };
+
+  return border;
+}

--- a/packages/material-ui/src/styles/createMuiTheme.d.ts
+++ b/packages/material-ui/src/styles/createMuiTheme.d.ts
@@ -5,6 +5,7 @@ import { Typography, TypographyOptions } from './createTypography';
 import { Shadows } from './shadows';
 import { Shape, ShapeOptions } from './shape';
 import { Spacing, SpacingOptions } from './createSpacing';
+import { Border, BorderOptions } from './createBorder';
 import { Transitions, TransitionsOptions } from './transitions';
 import { ZIndex, ZIndexOptions } from './zIndex';
 import { Overrides } from './overrides';
@@ -22,6 +23,7 @@ export interface ThemeOptions {
   props?: ComponentsProps;
   shadows?: Shadows;
   spacing?: SpacingOptions;
+  border?: BorderOptions;
   transitions?: TransitionsOptions;
   typography?: TypographyOptions | ((palette: Palette) => TypographyOptions);
   zIndex?: ZIndexOptions;
@@ -37,6 +39,7 @@ export interface Theme {
   props?: ComponentsProps;
   shadows: Shadows;
   spacing: Spacing;
+  border: Border;
   transitions: Transitions;
   typography: Typography;
   zIndex: ZIndex;

--- a/packages/material-ui/src/styles/createMuiTheme.js
+++ b/packages/material-ui/src/styles/createMuiTheme.js
@@ -8,6 +8,7 @@ import createTypography from './createTypography';
 import shadows from './shadows';
 import shape from './shape';
 import createSpacing from './createSpacing';
+import createBorder from './createBorder';
 import transitions from './transitions';
 import zIndex from './zIndex';
 
@@ -19,12 +20,20 @@ function createMuiTheme(options = {}) {
     shadows: shadowsInput,
     spacing: spacingInput,
     typography: typographyInput = {},
+    border: borderInput = {},
     ...other
   } = options;
 
   const palette = createPalette(paletteInput);
   const breakpoints = createBreakpoints(breakpointsInput);
   const spacing = createSpacing(spacingInput);
+
+  const {
+    defaultWidth = '1px',
+    defaultStyle = 'solid',
+    defaultColor = palette.divider,
+  } = borderInput;
+  const border = createBorder(defaultWidth, defaultStyle, defaultColor);
 
   const muiTheme = {
     breakpoints,
@@ -36,6 +45,7 @@ function createMuiTheme(options = {}) {
     shadows: shadowsInput || shadows,
     typography: createTypography(palette, typographyInput),
     spacing,
+    border,
     ...deepmerge(
       {
         shape,


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This is just a simple proof of concept, hence the RFC.

Idea for how the function should work:
```javascript
theme.border();
// -> "1px solid rgba(255, 255, 255, 0.12)"

theme.border(2);
// -> "2px solid rgba(255, 255, 255, 0.12)"

theme.border('2rem');
// -> "2rem solid rgba(255, 255, 255, 0.12)"

theme.border(2, 'dotted');
// -> "2px dotted rgba(255, 255, 255, 0.12)"

theme.border(2, 'dotted', 'red');
// -> "2px dotted red"
```

Defaults can be changed using createMuiTheme
```javascript
createMuiTheme({
  border: {
    defaultWidth: "1px",
    defaultStyle: 'solid',
    // theme.palette.divider
    defaultColor: 'rgba(255, 255, 255, 0.12)'
  }
})
```