### PR TITLE
[core] Fix IE 11 crashes in docs and Tabs in development

### DIFF
--- a/docs/src/pages/components/no-ssr/FrameDeferring.js
+++ b/docs/src/pages/components/no-ssr/FrameDeferring.js
@@ -12,7 +12,7 @@ const useStyles = makeStyles({
 });
 
 function LargeTree() {
-  return Array.from(new Array(3000)).map((_, index) => <span key={index}>.</span>);
+  return [...Array(3000)].map((_, index) => <span key={index}>.</span>);
 }
 
 function FrameDeferring() {

--- a/docs/src/pages/components/tables/MaterialTableDemo.js
+++ b/docs/src/pages/components/tables/MaterialTableDemo.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import MaterialTable from 'material-table';
+import Promise from 'core-js-pure/features/promise'; // required for IE 11
 
 export default function MaterialTableDemo() {
   const [state, setState] = React.useState({

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -185,9 +185,9 @@ class Tabs extends React.Component {
             `Material-UI: the value provided \`${value}\` to the Tabs component is invalid.`,
             'None of the Tabs children have this value.',
             this.valueToIndex.keys
-              ? `You can provide one of the following values: ${Array.from(
-                  this.valueToIndex.keys(),
-                ).join(', ')}.`
+              ? `You can provide one of the following values: ${[...this.valueToIndex.keys()].join(
+                  ', ',
+                )}.`
               : null,
           ].join('\n'),
         );


### PR DESCRIPTION
`Array.from` is not supported in IE 11. Only remaining usage is in `/performance/*` which has no entry anyway i.e. is dev only.