### PR TITLE
[system] Add flex to FlexboxProps type definitions

### DIFF
--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -68,6 +68,7 @@ export const flexbox: SimpleStyleFunction<
   | 'alignItems'
   | 'alignContent'
   | 'order'
+  | 'flex'
   | 'flexGrow'
   | 'flexShrink'
   | 'alignSelf'


### PR DESCRIPTION
Adds `flex` to `FlexboxProps` as suggested [here](https://github.com/mui-org/material-ui/pull/15884#issuecomment-498635806).

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).