### PR TITLE
[core] Fix incorrect typings for hexToRgb

### DIFF
--- a/packages/material-ui/src/styles/colorManipulator.d.ts
+++ b/packages/material-ui/src/styles/colorManipulator.d.ts
@@ -4,10 +4,11 @@ export interface ColorObject {
   values: [number, number, number] | [number, number, number, number];
 }
 
-export function recomposeColor(color: ColorObject): string;
-export function convertHexToRGB(hex: string): string;
+export function hexToRgb(hex: string): string;
 export function rgbToHex(color: string): string;
+export function hslToRgb(color: string): string;
 export function decomposeColor(color: string): ColorObject;
+export function recomposeColor(color: ColorObject): string;
 export function getContrastRatio(foreground: string, background: string): number;
 export function getLuminance(color: string): number;
 export function emphasize(color: string, coefficient?: number): string;


### PR DESCRIPTION
In #14391 the Function `convertHexToRGB` was renamed to `hexToRgb`.

Unfortunately, the typings were not updated to reflect the above change :(

Also, an additional Function was exported, `hslToRgb`,

This PR updates the `hexToRgb` typings and adds an export for `hslToRgb`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
