### PR TITLE
[docs] Make demos linkable

### DIFF
--- a/docs/src/modules/components/AppWrapper.js
+++ b/docs/src/modules/components/AppWrapper.js
@@ -17,6 +17,15 @@ const jss = create({
 class SideEffectsRaw extends React.Component {
   componentDidMount() {
     const { options } = this.props;
+    const navigatedCodeVariantMatch = window.location.hash.match(/\.(js|tsx)$/);
+    const navigatedCodeVariant =
+      navigatedCodeVariantMatch !== null ? navigatedCodeVariantMatch[1] : undefined;
+    if (navigatedCodeVariant !== undefined) {
+      const navigatedCodeVariantAsPersistable = navigatedCodeVariant === 'tsx' ? 'TS' : 'JS';
+      document.cookie = `codeVariant=${navigatedCodeVariantAsPersistable};path=/;max-age=31536000`;
+      window.ga('set', 'dimension1', navigatedCodeVariantAsPersistable);
+    }
+
     const codeVariant = getCookie('codeVariant');
 
     if (codeVariant && options.codeVariant !== codeVariant) {

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -228,7 +228,6 @@ function Demo(props) {
   const DemoComponent = demoData.Component;
   const gaCategory = demoOptions.demo;
   const demoName = getDemoName(demoData.githubLocation);
-  const demoExtension = codeVariant === CODE_VARIANTS.TS ? 'tsx' : 'js';
   const demoSandboxedStyle = React.useMemo(
     () => ({
       maxWidth: demoOptions.maxWidth,
@@ -245,7 +244,7 @@ function Demo(props) {
     }
   };
 
-  const [codeOpen, setCodeOpen] = React.useState(demoOptions.defaultCodeOpen);
+  const [codeOpen, setCodeOpen] = React.useState(demoOptions.defaultCodeOpen || false);
 
   React.useEffect(() => {
     const navigatedDemoName = getDemoName(window.location.hash);
@@ -289,8 +288,6 @@ function Demo(props) {
                   data-ga-event-action="expand"
                   onClick={handleClickCodeOpen}
                   color={demoHovered ? 'primary' : 'default'}
-                  component="a"
-                  href={`#${demoName}.${demoExtension}`}
                 >
                   <CodeIcon />
                 </IconButton>

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -94,7 +94,15 @@ const styles = theme => ({
   tooltip: {
     zIndex: theme.zIndex.appBar - 1,
   },
+  anchorLink: {
+    marginTop: -64, // height of toolbar
+    position: 'absolute',
+  },
 });
+
+function getDemoName(location) {
+  return location.replace(/(.+?)(\w+)\.\w+$$/, '$2');
+}
 
 function getDemoData(codeVariant, demo, githubLocation) {
   if (codeVariant === CODE_VARIANTS.TS && demo.rawTS) {
@@ -142,13 +150,6 @@ function Demo(props) {
         },
       });
     }
-  }
-
-  const [codeOpen, setCodeOpen] = React.useState(demoOptions.defaultCodeOpen);
-  function handleClickCodeOpen() {
-    document.cookie = `sourceHintSeen=true;path=/;max-age=31536000`;
-    setCodeOpen(open => !open);
-    setSourceHintSeen(setSourceHintSeen(true));
   }
 
   function handleClickCodeSandbox() {
@@ -226,8 +227,8 @@ function Demo(props) {
   const showSourceHint = demoHovered && !sourceHintSeen;
   const DemoComponent = demoData.Component;
   const gaCategory = demoOptions.demo;
-  // get the last alphanumeric pattern before the file extension
-  const demoName = demoData.githubLocation.replace(/(.+?)(\w+)\.\w+$$/, '$2');
+  const demoName = getDemoName(demoData.githubLocation);
+  const demoExtension = codeVariant === CODE_VARIANTS.TS ? 'tsx' : 'js';
   const demoSandboxedStyle = React.useMemo(
     () => ({
       maxWidth: demoOptions.maxWidth,
@@ -236,8 +237,33 @@ function Demo(props) {
     [demoOptions.height, demoOptions.maxWidth],
   );
 
+  const createHandleCodeSourceLink = anchor => async () => {
+    try {
+      await copy(`${window.location.href.split('#')[0]}#${anchor}`);
+    } finally {
+      handleCloseMore();
+    }
+  };
+
+  const [codeOpen, setCodeOpen] = React.useState(demoOptions.defaultCodeOpen);
+
+  React.useEffect(() => {
+    const navigatedDemoName = getDemoName(window.location.hash);
+    if (demoName === navigatedDemoName) {
+      setCodeOpen(true);
+    }
+  }, [demoName]);
+
+  function handleClickCodeOpen() {
+    document.cookie = `sourceHintSeen=true;path=/;max-age=31536000`;
+    setCodeOpen(open => !open);
+    setSourceHintSeen(setSourceHintSeen(true));
+  }
+
   return (
     <div className={classes.root}>
+      <div className={classes.anchorLink} id={`${demoName}.js`} />
+      <div className={classes.anchorLink} id={`${demoName}.tsx`} />
       {demoOptions.hideHeader ? null : (
         <div>
           <div className={classes.header}>
@@ -263,6 +289,8 @@ function Demo(props) {
                   data-ga-event-action="expand"
                   onClick={handleClickCodeOpen}
                   color={demoHovered ? 'primary' : 'default'}
+                  component="a"
+                  href={`#${demoName}.${demoExtension}`}
                 >
                   <CodeIcon />
                 </IconButton>
@@ -338,6 +366,20 @@ function Demo(props) {
                     {t('stackblitz')}
                   </MenuItem>
                 )}
+                <MenuItem
+                  data-ga-event-category={gaCategory}
+                  data-ga-event-action="copy-js-source-link"
+                  onClick={createHandleCodeSourceLink(`${demoName}.js`)}
+                >
+                  {t('copySourceLinkJS')}
+                </MenuItem>
+                <MenuItem
+                  data-ga-event-category={gaCategory}
+                  data-ga-event-action="copy-ts-source-link"
+                  onClick={createHandleCodeSourceLink(`${demoName}.tsx`)}
+                >
+                  {t('copySourceLinkTS')}
+                </MenuItem>
               </Menu>
             </div>
           </div>

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -64,6 +64,8 @@
   "codesandbox": "Edit in CodeSandbox",
   "seeMore": "See more",
   "copySource": "Copy the source",
+  "copySourceLinkJS": "Copy link to JavaScript source",
+  "copySourceLinkTS": "Copy link to TypeScript source",
   "stackblitz": "Edit in StackBlitz (JS only)",
   "headTitle": "The world's most popular React UI framework - Material-UI",
   "pages": {
@@ -196,7 +198,5 @@
     "/styles/basics": "Basics",
     "/styles/advanced": "Advanced",
     "https://themes.material-ui.com/": "Premium Themes"
-  },
-  "copySourceLinkJS": "Copy link to JavaScript source",
-  "copySourceLinkTS": "Copy link to TypeScript source"
+  }
 }

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -196,5 +196,7 @@
     "/styles/basics": "Basics",
     "/styles/advanced": "Advanced",
     "https://themes.material-ui.com/": "Premium Themes"
-  }
+  },
+  "copySourceLinkJS": "Copy link to JavaScript source",
+  "copySourceLinkTS": "Copy link to TypeScript source"
 }


### PR DESCRIPTION
Introduces linkable demo code:
https://deploy-preview-16063--material-ui.netlify.com/components/buttons/#ContainedButtons.tsx

Something I read about customer support: If you can't link to it people won't find it. In this case:
> You can check out the typings for X by going to this link, click code open and then switch to TS.

Preffered solution: `#contained-buttons.tsx`
Implemented solution: `#ContainedButtons.tsx`

It's not about the format but that the code link is just the link to the demo heading + extension. Hope the current implementation passes as a MVP.

~Not so sure about the UI for getting the links to the demo code. The toggle buttons also act as links now.~ We settled on extra action items in the misc sub menu. Mixing buttons with navigation had an awkward UX. At least if you were used to the old behavior.

I want to solve this ultimately by moving headings into context at which point this becomes fairly easy.