### PR TITLE
[docs] Remove duplicate font icons instruction

### DIFF
--- a/docs/src/pages/getting-started/installation/installation.md
+++ b/docs/src/pages/getting-started/installation/installation.md
@@ -38,11 +38,6 @@ For instance, via Google Web Fonts:
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
 ```
 
-Alternatively, if you are using JSX over HTML to render the head:
-```jsx
-<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-```
-
 ## SVG Icons
 
 In order to use prebuilt SVG Material icons, such as those found in the [icons demos](/components/icons/)


### PR DESCRIPTION
The two examples given for [installing the font icons](https://github.com/mui-org/material-ui/blob/e54cea16f9b8aed379e0adc80198475b94f97f50/docs/src/pages/getting-started/installation/installation.md#font-icons) are identical, so this removes the "JSX" example.