### PR TITLE
[Popper] Add popperRef prop

### DIFF
--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -18,7 +18,7 @@ export type PopperPlacementType =
   | 'top';
 
 export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
-  anchorEl?: null | Element | ReferenceObject | (() => Element);
+  anchorEl?: null | ReferenceObject | (() => ReferenceObject);
   children:
     | React.ReactNode
     | ((props: {

--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -32,7 +32,7 @@ export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   open: boolean;
   placement?: PopperPlacementType;
   popperOptions?: object;
-  popperRef?: React.RefObject<PopperJs>;
+  popperRef?: React.Ref<PopperJs>;
   transition?: boolean;
 }
 

--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -17,9 +17,12 @@ export type PopperPlacementType =
   | 'top-start'
   | 'top';
 
+export interface PopperRef {
+  update(): void;
+}
+
 export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
-  transition?: boolean;
-  anchorEl?: null | ReferenceObject | (() => ReferenceObject);
+  anchorEl?: null | Element | ReferenceObject | (() => Element);
   children:
     | React.ReactNode
     | ((props: {
@@ -33,6 +36,8 @@ export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   open: boolean;
   placement?: PopperPlacementType;
   popperOptions?: object;
+  popperRef?: React.RefObject<PopperRef>;
+  transition?: boolean;
 }
 
 declare const Popper: React.ComponentType<PopperProps>;

--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ReferenceObject } from 'popper.js';
+import PopperJs, { ReferenceObject } from 'popper.js';
 import { PortalProps } from '../Portal';
 import { TransitionProps } from '../transitions/transition';
 
@@ -17,10 +17,6 @@ export type PopperPlacementType =
   | 'top-start'
   | 'top';
 
-export interface PopperRef {
-  update(): void;
-}
-
 export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   anchorEl?: null | Element | ReferenceObject | (() => Element);
   children:
@@ -36,7 +32,7 @@ export interface PopperProps extends React.HTMLAttributes<HTMLDivElement> {
   open: boolean;
   placement?: PopperPlacementType;
   popperOptions?: object;
-  popperRef?: React.RefObject<PopperRef>;
+  popperRef?: React.RefObject<PopperJs>;
   transition?: boolean;
 }
 

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -31,6 +31,8 @@ function getAnchorEl(anchorEl) {
   return typeof anchorEl === 'function' ? anchorEl() : anchorEl;
 }
 
+const useEnhancedEffect = typeof window !== 'undefined' ? React.useLayoutEffect : React.useEffect;
+
 const defaultPopperOptions = {};
 
 /**
@@ -57,9 +59,10 @@ const Popper = React.forwardRef(function Popper(props, ref) {
   const popperRef = React.useRef(null);
   const instance = React.useRef();
   const handlePopperRef = useForkRef(popperRef, popperRefProp);
-  React.useEffect(() => {
+  useEnhancedEffect(() => {
     instance.current = handlePopperRef;
-  });
+  }, [handlePopperRef]);
+  React.useImperativeHandle(popperRefProp, () => popperRef.current, []);
 
   const [exited, setExited] = React.useState(!props.open);
   const [placement, setPlacement] = React.useState();

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -79,7 +79,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
 
     if (popperRef.current) {
       popperRef.current.destroy();
-      instance.current(null)
+      instance.current(null);
     }
 
     const popper = new PopperJS(getAnchorEl(anchorEl), popperNode, {
@@ -102,7 +102,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
       onCreate: createChainedFunction(handlePopperUpdate, popperOptions.onCreate),
       onUpdate: createChainedFunction(handlePopperUpdate, popperOptions.onUpdate),
     });
-    instance.current(popper)
+    instance.current(popper);
   }, [anchorEl, disablePortal, modifiers, open, placement, placementProps, popperOptions]);
 
   const handleEnter = () => {
@@ -115,7 +115,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
     }
 
     popperRef.current.destroy();
-    instance.current(null)
+    instance.current(null);
   };
 
   const handleExited = () => {

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -57,7 +57,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
   const handleRef = useForkRef(tooltipRef, ref);
 
   const popperRef = React.useRef(null);
-  const instance = React.useRef();
+  const handlePopperRefRef = React.useRef();
   const handlePopperRef = useForkRef(popperRef, popperRefProp);
   useEnhancedEffect(() => {
     instance.current = handlePopperRef;

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -60,7 +60,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
   const handlePopperRefRef = React.useRef();
   const handlePopperRef = useForkRef(popperRef, popperRefProp);
   useEnhancedEffect(() => {
-    instance.current = handlePopperRef;
+    handlePopperRefRef.current = handlePopperRef;
   }, [handlePopperRef]);
   React.useImperativeHandle(popperRefProp, () => popperRef.current, []);
 
@@ -82,7 +82,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
 
     if (popperRef.current) {
       popperRef.current.destroy();
-      instance.current(null);
+      handlePopperRefRef.current(null);
     }
 
     const popper = new PopperJS(getAnchorEl(anchorEl), popperNode, {
@@ -105,7 +105,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
       onCreate: createChainedFunction(handlePopperUpdate, popperOptions.onCreate),
       onUpdate: createChainedFunction(handlePopperUpdate, popperOptions.onUpdate),
     });
-    instance.current(popper);
+    handlePopperRefRef.current(popper);
   }, [anchorEl, disablePortal, modifiers, open, placement, placementProps, popperOptions]);
 
   const handleEnter = () => {
@@ -118,7 +118,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
     }
 
     popperRef.current.destroy();
-    instance.current(null);
+    handlePopperRefRef.current(null);
   };
 
   const handleExited = () => {

--- a/packages/material-ui/src/Popper/Popper.spec.tsx
+++ b/packages/material-ui/src/Popper/Popper.spec.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import Tooltip from '@material-ui/core/Tooltip';
+import PopperJs from 'popper.js';
+
+interface Props {
+  children: React.ReactElement;
+  value: number;
+}
+
+export default function ThumbLabelComponent(props: Props) {
+  const { children, value } = props;
+
+  const popperRef = React.useRef<PopperJs | null>(null);
+  React.useEffect(() => {
+    if (popperRef.current) {
+      popperRef.current.update();
+    }
+  });
+
+  return (
+    <Tooltip
+      PopperProps={{
+        popperRef,
+      }}
+      enterTouchDelay={0}
+      placement="top"
+      title={value}
+    >
+      {children}
+    </Tooltip>
+  );
+}

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
+import PopperJS from 'popper.js';
 import Grow from '../Grow';
 import Popper from './Popper';
 
@@ -200,6 +201,14 @@ describe('<Popper />', () => {
       clock.tick(0);
       wrapper.update();
       assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+    });
+  });
+
+  describe('prop: popperRef', () => {
+    it('should return a ref', () => {
+      const ref = React.createRef();
+      mount(<Popper {...defaultProps} popperRef={ref} />);
+      assert.strictEqual(ref.current instanceof PopperJS, true);
     });
   });
 

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -206,9 +206,15 @@ describe('<Popper />', () => {
 
   describe('prop: popperRef', () => {
     it('should return a ref', () => {
-      const ref = React.createRef();
-      mount(<Popper {...defaultProps} popperRef={ref} />);
-      assert.strictEqual(ref.current instanceof PopperJS, true);
+      const ref1 = React.createRef();
+      const ref2 = React.createRef();
+      const wrapper = mount(<Popper {...defaultProps} popperRef={ref1} />);
+      assert.strictEqual(ref1.current instanceof PopperJS, true);
+      wrapper.setProps({
+        popperRef: ref2,
+      });
+      assert.strictEqual(ref1.current, null);
+      assert.strictEqual(ref2.current instanceof PopperJS, true);
     });
   });
 

--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 import { TransitionProps } from '../transitions/transition';
+import { PopperProps } from '../Popper/Popper';
 
 export interface TooltipProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title', false> {
@@ -30,7 +31,7 @@ export interface TooltipProps
     | 'top-end'
     | 'top-start'
     | 'top';
-  PopperProps?: object;
+  PopperProps?: Partial<PopperProps>;
   title: React.ReactNode;
   TransitionComponent?: React.ComponentType<TransitionProps>;
   TransitionProps?: TransitionProps;

--- a/pages/api/popper.md
+++ b/pages/api/popper.md
@@ -27,6 +27,7 @@ Poppers rely on the 3rd party library [Popper.js](https://github.com/FezVrasta/p
 | <span class="prop-name required">open&nbsp;*</span> | <span class="prop-type">bool</span> |  | If `true`, the popper is visible. |
 | <span class="prop-name">placement</span> | <span class="prop-type">enum:&nbsp;'bottom-end', 'bottom-start', 'bottom', 'left-end', 'left-start', 'left', 'right-end', 'right-start', 'right', 'top-end', 'top-start', 'top'<br></span> | <span class="prop-default">'bottom'</span> | Popper placement. |
 | <span class="prop-name">popperOptions</span> | <span class="prop-type">object</span> | <span class="prop-default">{}</span> | Options provided to the [`popper.js`](https://github.com/FezVrasta/popper.js) instance. |
+| <span class="prop-name">popperRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |  | Callback fired when a new popper instance is used. |
 | <span class="prop-name">transition</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Help supporting a react-transition-group/Transition component. |
 
 The `ref` is forwarded to the root element.


### PR DESCRIPTION
Closes #15802.

These changes are extracted from #15703:

- First, the Popper.js instance is now persisted between two renders (perf fix). You gonna like this one @eps1lon. We were using `{}` as default prop value. This is a new reference at each render. Most of the time, it's fine. The problem, in this case, is that we are using the value as an effect dependency. It reruns systematically. I have noticed it with a poor slider update performance.
- It exposes a `popperRef` prop that behaves like a reference. It can be used to programmatically update the position of the popper, e.g. when the slider's thumb value changes.