### PR TITLE
[core] Remove direct type dependency to jss/csstype

### DIFF
--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -43,6 +43,7 @@
     "@material-ui/types": "^4.0.1",
     "@material-ui/utils": "^4.0.1",
     "clsx": "^1.0.2",
+    "csstype": "^2.5.2",
     "deepmerge": "^3.0.0",
     "hoist-non-react-statics": "^3.2.1",
     "jss": "^10.0.0-alpha.16",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -45,7 +45,6 @@
     "@types/react-transition-group": "^2.0.16",
     "clsx": "^1.0.2",
     "convert-css-length": "^2.0.0",
-    "csstype": "^2.5.2",
     "debounce": "^1.1.0",
     "deepmerge": "^3.0.0",
     "hoist-non-react-statics": "^3.2.1",

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,13 +1,9 @@
 import * as React from 'react';
+import { CSSProperties, WithStylesOptions } from '@material-ui/styles/withStyles';
 import { PropInjector } from '@material-ui/types';
 import { Theme } from './createMuiTheme';
-import * as CSS from 'csstype';
-import * as JSS from 'jss';
 
-export interface CSSProperties extends CSS.Properties<number | string> {
-  // Allow pseudo selectors and media queries
-  [k: string]: CSS.Properties<number | string>[keyof CSS.Properties] | CSSProperties;
-}
+export { CSSProperties, WithStylesOptions };
 
 /**
  * This is basically the API of JSS. It defines a Map<string, CSS>,
@@ -26,12 +22,6 @@ export interface StylesCreator {
   create(theme: Theme, name: string): StyleRules;
   options: { index: number };
   themingEnabled: boolean;
-}
-
-export interface WithStylesOptions extends JSS.StyleSheetFactoryOptions {
-  flip?: boolean;
-  withTheme?: boolean;
-  name?: string;
 }
 
 export type ClassNameMap<ClassKey extends string = string> = Record<ClassKey, string>;
@@ -56,7 +46,10 @@ export interface StyledComponentProps<ClassKey extends string = string> {
   innerRef?: React.Ref<any> | React.RefObject<any>;
 }
 
-export default function withStyles<ClassKey extends string, Options extends WithStylesOptions = {}>(
+export default function withStyles<
+  ClassKey extends string,
+  Options extends WithStylesOptions<Theme> = {}
+>(
   style: StyleRulesCallback<ClassKey> | StyleRules<ClassKey>,
   options?: Options,
 ): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey>>;


### PR DESCRIPTION
Type dependencies weren't technically correct before. They're now declared where they're used.

Closes #15926