### PR TITLE
[docs] Add redirect for typography migration

### DIFF
--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -13,6 +13,10 @@ https://next.material-ui.com/* https://material-ui.com/:splat 301!
 https://material-ui-next.com/* https://material-ui.com/:splat 301!
 https://material-ui.dev/* https://material-ui.com/:splat 301!
 
+# old code links
+# likely /style/typography#migration-to-typography-v2
+/style/typography https://v3-9-0.material-ui.com/style/typography/#migration-to-typography-v2
+
 # To remove at some point (2020).
 /demos/selection-controls/ /components/radio-buttons/ 301
 /page-layout-examples/* /getting-started/page-layout-examples/:splat 301

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -15,7 +15,7 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 
 # old code links
 # likely /style/typography#migration-to-typography-v2
-/style/typography https://v3-9-0.material-ui.com/style/typography/#migration-to-typography-v2
+/style/typography https://v3-9-0.material-ui.com/style/typography/#migration-to-typography-v2 301
 
 # To remove at some point (2020).
 /demos/selection-controls/ /components/radio-buttons/ 301
@@ -38,9 +38,9 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /premium-themes* https://themes.material-ui.com/ 301
 
 # link shortener
-/r/styles-instance-warning https://material-ui.com/getting-started/faq#i-have-several-instances-of-styles-on-the-page
-/r/caveat-with-refs-guide https://material-ui.com/guides/composition/#caveat-with-refs
-/r/pseudo-classes-guide https://material-ui.com/guides/composition/#caveat-with-refs
+/r/styles-instance-warning https://material-ui.com/getting-started/faq#i-have-several-instances-of-styles-on-the-page 307
+/r/caveat-with-refs-guide https://material-ui.com/guides/composition/#caveat-with-refs 307
+/r/pseudo-classes-guide https://material-ui.com/guides/composition/#caveat-with-refs 307
 
 # Legacy
 /v0.20.0 https://v0.material-ui.com/v0.20.0

--- a/docs/static/_redirects
+++ b/docs/static/_redirects
@@ -37,6 +37,11 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /css-in-js/* /styles/:splat 301
 /premium-themes* https://themes.material-ui.com/ 301
 
+# link shortener
+/r/styles-instance-warning https://material-ui.com/getting-started/faq#i-have-several-instances-of-styles-on-the-page
+/r/caveat-with-refs-guide https://material-ui.com/guides/composition/#caveat-with-refs
+/r/pseudo-classes-guide https://material-ui.com/guides/composition/#caveat-with-refs
+
 # Legacy
 /v0.20.0 https://v0.material-ui.com/v0.20.0
 /v0.19.4 https://v0.material-ui.com/v0.19.4

--- a/packages/material-ui-styles/src/index.js
+++ b/packages/material-ui-styles/src/index.js
@@ -13,7 +13,7 @@ if (process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test') {
         'This may cause theme propagation issues, broken class names ' +
           'and makes your application bigger without a good reason.',
         '',
-        'See https://material-ui.com/getting-started/faq#i-have-several-instances-of-styles-on-the-page for more info.',
+        'See https://material-ui.com/r/styles-instance-warning for more info.',
       ].join('\n'),
     );
   }

--- a/packages/material-ui-utils/src/elementAcceptingRef.js
+++ b/packages/material-ui-utils/src/elementAcceptingRef.js
@@ -36,7 +36,7 @@ function acceptingRef(props, propName, componentName, location, propFullName) {
     return new Error(
       `Invalid ${location} \`${safePropName}\` supplied to \`${componentName}\`. ` +
         `Expected an element that can hold a ref. ${warningHint} ` +
-        'For more information see https://material-ui.com/guides/composition/#caveat-with-refs',
+        'For more information see https://material-ui.com/r/caveat-with-refs-guide',
     );
   }
 

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.js
@@ -35,7 +35,7 @@ function elementTypeAcceptingRef(props, propName, componentName, location, propF
     return new Error(
       `Invalid ${location} \`${safePropName}\` supplied to \`${componentName}\`. ` +
         `Expected an element type that can hold a ref. ${warningHint} ` +
-        'For more information see https://material-ui.com/guides/composition/#caveat-with-refs',
+        'For more information see https://material-ui.com/r/caveat-with-refs-guide',
     );
   }
 

--- a/packages/material-ui/src/styles/createMuiTheme.js
+++ b/packages/material-ui/src/styles/createMuiTheme.js
@@ -90,7 +90,7 @@ function createMuiTheme(options = {}) {
                 2,
               ),
               '',
-              'https://material-ui.com/customization/components/#pseudo-classes',
+              'https://material-ui.com/r/pseudo-classes-guide',
             ].join('\n'),
           );
           // Remove the style to prevent global conflicts.


### PR DESCRIPTION
Links in code should be perma links which we control. Once the link becomes outdated we can just switch the redirect which ensures that the links are still valid in older versions of the code.

Closes #16011

/cc @Pajn 