### PR TITLE
[icons] Simplify generated index.d.ts to reduce TS compile time

### DIFF
--- a/packages/material-ui-icons/scripts/create-typings.js
+++ b/packages/material-ui-icons/scripts/create-typings.js
@@ -19,12 +19,11 @@ function createIconTyping(file) {
 }
 
 function createIndexTyping(files) {
-  const contents = files
-    .map(file => {
-      const name = normalizeFileName(file);
-      return `export { default as ${name} } from './${name}';`;
-    })
-    .join('\n');
+  const contents = `
+import SvgIcon from  '@material-ui/core/SvgIcon';
+
+${files.map(file => `export const ${normalizeFileName(file)}: SvgIcon;`).join('\n')}
+`;
 
   return fse.writeFile(path.resolve(TARGET_DIR, 'index.d.ts'), contents, 'utf8');
 }


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This will create a `index.d.ts` for `@material-ui/icons` that looks like this:

```typescript
import SvgIcon from  '@material-ui/core/SvgIcon';

export const AccessAlarm: SvgIcon;
export const AccessAlarmOutlined: SvgIcon;
export const AccessAlarmRounded: SvgIcon;
export const AccessAlarms: SvgIcon;
// [...]
```

instead of this:

```typescript
export { default as AccessAlarm } from './AccessAlarm';
export { default as AccessAlarmOutlined } from './AccessAlarmOutlined';
export { default as AccessAlarmRounded } from './AccessAlarmRounded';
export { default as AccessAlarms } from './AccessAlarms';
// [...]
```

(where every of the reference files only contains `export { default } from '@material-ui/core/SvgIcon';`).

This prevents the typescript compiler from (in the worst case) opening (and potentially watching) about 5000 files, reducing build times on my system by a few seconds.
