### PR TITLE
[TextField] Improve dense height to better match the specification

### DIFF
--- a/docs/src/pages/components/text-fields/FilledTextFields.js
+++ b/docs/src/pages/components/text-fields/FilledTextFields.js
@@ -137,6 +137,15 @@ function FilledTextFields() {
         variant="filled"
       />
       <TextField
+        id="filled-dense-multiline"
+        label="Dense multiline"
+        className={clsx(classes.textField, classes.dense)}
+        margin="dense"
+        variant="filled"
+        multiline
+        rowsMax="4"
+      />
+      <TextField
         id="filled-multiline-flexible"
         label="Multiline"
         multiline

--- a/docs/src/pages/components/text-fields/FilledTextFields.tsx
+++ b/docs/src/pages/components/text-fields/FilledTextFields.tsx
@@ -146,6 +146,15 @@ function FilledTextFields() {
         variant="filled"
       />
       <TextField
+        id="filled-dense-multiline"
+        label="Dense multiline"
+        className={clsx(classes.textField, classes.dense)}
+        margin="dense"
+        variant="filled"
+        multiline
+        rowsMax="4"
+      />
+      <TextField
         id="filled-multiline-flexible"
         label="Multiline"
         multiline

--- a/docs/src/pages/components/text-fields/OutlinedTextFields.js
+++ b/docs/src/pages/components/text-fields/OutlinedTextFields.js
@@ -137,6 +137,15 @@ function OutlinedTextFields() {
         variant="outlined"
       />
       <TextField
+        id="outlined-dense-multiline"
+        label="Dense multiline"
+        className={clsx(classes.textField, classes.dense)}
+        margin="dense"
+        variant="outlined"
+        multiline
+        rowsMax="4"
+      />
+      <TextField
         id="outlined-multiline-flexible"
         label="Multiline"
         multiline

--- a/docs/src/pages/components/text-fields/OutlinedTextFields.tsx
+++ b/docs/src/pages/components/text-fields/OutlinedTextFields.tsx
@@ -146,6 +146,15 @@ function OutlinedTextFields() {
         variant="outlined"
       />
       <TextField
+        id="outlined-dense-multiline"
+        label="Dense multiline"
+        className={clsx(classes.textField, classes.dense)}
+        margin="dense"
+        variant="outlined"
+        multiline
+        rowsMax="4"
+      />
+      <TextField
         id="outlined-multiline-flexible"
         label="Multiline"
         multiline

--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -92,9 +92,15 @@ export const styles = theme => {
     },
     /* Styles applied to the root element if `error={true}`. */
     error: {},
+    /* Styles applied to the `input` element if `margin="dense"`. */
+    marginDense: {},
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: '27px 12px 10px',
+      '&$marginDense': {
+        paddingTop: 23,
+        paddingBottom: 6,
+      },
     },
     /* Styles applied to the `input` element. */
     input: {
@@ -102,7 +108,7 @@ export const styles = theme => {
     },
     /* Styles applied to the `input` element if `margin="dense"`. */
     inputMarginDense: {
-      paddingTop: 24,
+      paddingTop: 23,
       paddingBottom: 6,
     },
     /* Styles applied to the `input` element if `multiline={true}`. */

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -61,6 +61,9 @@ export const styles = theme => {
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: `${8 - 2}px 0 ${8 - 1}px`,
+      '&$marginDense': {
+        paddingTop: 4 - 1,
+      },
     },
     /* Styles applied to the root element if `fullWidth={true}`. */
     fullWidth: {

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -73,7 +73,7 @@ export const styles = theme => ({
     pointerEvents: 'none',
     transform: 'translate(14px, 20px) scale(1)',
     '&$marginDense': {
-      transform: 'translate(14px, 17px) scale(1)',
+      transform: 'translate(14px, 10px) scale(1)',
     },
     '&$shrink': {
       transform: 'translate(14px, -6px) scale(0.75)',

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -73,7 +73,7 @@ export const styles = theme => ({
     pointerEvents: 'none',
     transform: 'translate(14px, 20px) scale(1)',
     '&$marginDense': {
-      transform: 'translate(14px, 11px) scale(1)',
+      transform: 'translate(14px, 12px) scale(1)',
     },
     '&$shrink': {
       transform: 'translate(14px, -6px) scale(0.75)',

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -73,7 +73,7 @@ export const styles = theme => ({
     pointerEvents: 'none',
     transform: 'translate(14px, 20px) scale(1)',
     '&$marginDense': {
-      transform: 'translate(14px, 10px) scale(1)',
+      transform: 'translate(14px, 11px) scale(1)',
     },
     '&$shrink': {
       transform: 'translate(14px, -6px) scale(0.75)',

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -48,9 +48,15 @@ export const styles = theme => {
     },
     /* Styles applied to the root element if `error={true}`. */
     error: {},
+    /* Styles applied to the `input` element if `margin="dense"`. */
+    marginDense: {},
     /* Styles applied to the root element if `multiline={true}`. */
     multiline: {
       padding: '18.5px 14px',
+      '&$marginDense': {
+        paddingTop: 10.5,
+        paddingBottom: 10.5,
+      },
     },
     /* Styles applied to the `NotchedOutline` element. */
     notchedOutline: {},
@@ -60,8 +66,8 @@ export const styles = theme => {
     },
     /* Styles applied to the `input` element if `margin="dense"`. */
     inputMarginDense: {
-      paddingTop: 10,
-      paddingBottom: 11,
+      paddingTop: 10.5,
+      paddingBottom: 10.5,
     },
     /* Styles applied to the `input` element if `multiline={true}`. */
     inputMultiline: {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -60,8 +60,8 @@ export const styles = theme => {
     },
     /* Styles applied to the `input` element if `margin="dense"`. */
     inputMarginDense: {
-      paddingTop: 8,
-      paddingBottom: 8,
+      paddingTop: 10,
+      paddingBottom: 11,
     },
     /* Styles applied to the `input` element if `multiline={true}`. */
     inputMultiline: {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -60,8 +60,8 @@ export const styles = theme => {
     },
     /* Styles applied to the `input` element if `margin="dense"`. */
     inputMarginDense: {
-      paddingTop: 15,
-      paddingBottom: 15,
+      paddingTop: 8,
+      paddingBottom: 8,
     },
     /* Styles applied to the `input` element if `multiline={true}`. */
     inputMultiline: {

--- a/pages/api/filled-input.md
+++ b/pages/api/filled-input.md
@@ -64,6 +64,7 @@ This property accepts the following keys:
 | <span class="prop-name">adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
 | <span class="prop-name">adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
 | <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
 | <span class="prop-name">multiline</span> | Styles applied to the root element if `multiline={true}`.
 | <span class="prop-name">input</span> | Styles applied to the `input` element.
 | <span class="prop-name">inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.

--- a/pages/api/outlined-input.md
+++ b/pages/api/outlined-input.md
@@ -64,6 +64,7 @@ This property accepts the following keys:
 | <span class="prop-name">adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
 | <span class="prop-name">adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
 | <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
 | <span class="prop-name">multiline</span> | Styles applied to the root element if `multiline={true}`.
 | <span class="prop-name">notchedOutline</span> | Styles applied to the `NotchedOutline` element.
 | <span class="prop-name">input</span> | Styles applied to the `input` element.


### PR DESCRIPTION
The dense variant of the Filled and Outlined Inputs do not follow the material specification.

## Expected Behavior 🤔
Heights should be as described in the specification.

see the following sandbox [https://codesandbox.io/s/material-demo-co7nd](https://codesandbox.io/s/material-demo-co7nd)

## Current Behavior 😯

![image](https://user-images.githubusercontent.com/10747768/59023440-1b66e480-8850-11e9-8f1c-2216dfa4fdb2.png)

## Context 🔦

We want to build some more complex dialogs using a lot of input components while following the current material specification.

## Notes

This PR doesn't support the dense, non-label filled input.

Improve #14521
Closes #15821