### PR TITLE
[styles] Default props to any in makeStyles and withStyles

### DIFF
--- a/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.d.ts
+++ b/packages/material-ui-styles/src/getStylesCreator/getStylesCreator.d.ts
@@ -6,6 +6,4 @@ export interface StylesCreator<Theme, Props extends object, ClassKey extends str
   themingEnabled: boolean;
 }
 
-export default function getStylesCreator<S extends Styles<any, any>>(
-  style: S,
-): StylesCreator<any, any>;
+export default function getStylesCreator<S extends Styles<any>>(style: S): StylesCreator<any, any>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -65,7 +65,7 @@ export type StylesRequireProps<S> = Or<
  * from which the typechecker could infer a type so it falls back to `any`.
  * See the test cases for examples and implications of explicit `any` annotation
  */
-export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> extends false
+export type StylesHook<S extends Styles<any>> = StylesRequireProps<S> extends false
   ? (props?: any) => ClassNameMap<ClassKeyOfStyles<S>>
   : (props: PropsOfStyles<S>) => ClassNameMap<ClassKeyOfStyles<S>>;
 

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -71,7 +71,7 @@ export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> exten
 
 export default function makeStyles<
   Theme = unknown,
-  Props extends {} = {},
+  Props extends {} = any,
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -28,7 +28,7 @@ export type StyleRulesCallback<Theme, Props extends object, ClassKey extends str
   theme: Theme,
 ) => StyleRules<Props, ClassKey>;
 
-export type Styles<Theme, Props extends {}, ClassKey extends string = string> =
+export type Styles<Theme, Props extends {} = any, ClassKey extends string = string> =
   | StyleRules<Props, ClassKey>
   | StyleRulesCallback<Theme, Props, ClassKey>;
 

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -60,7 +60,7 @@ export type PropsOfStyles<S> = S extends Styles<any, infer Props> ? Props : {};
 /**
  * infers the type of the props used in the styles
  */
-export type ThemeOfStyles<S> = S extends Styles<infer Theme, any> ? Theme : {};
+export type ThemeOfStyles<S> = S extends Styles<infer Theme> ? Theme : {};
 
 export type WithStyles<
   S extends ClassKeyInferable<any, any>,
@@ -76,7 +76,7 @@ export interface StyledComponentProps<ClassKey extends string = string> {
 }
 
 export default function withStyles<
-  S extends Styles<any, any>,
+  S extends Styles<any>,
   Options extends WithStylesOptions<ThemeOfStyles<S>> = {}
 >(
   style: S,

--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -4,7 +4,7 @@ import { StylesHook } from '@material-ui/styles/makeStyles';
 
 export default function makeStyles<
   Theme = DefaultTheme,
-  Props extends {} = {},
+  Props extends {} = any,
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Defaults the props type to any, causing `StylesRequireProps` to work as expected in TypeScript v3.5.1 with 
```json
"strictNullChecks": false
```

This targets core and styles, but core is just a re-export of styles with a theme set.

Fixes https://github.com/mui-org/material-ui/issues/15942#issuecomment-499457180