### PR TITLE
[docs] Fix spelling and usage of MuiCssBaseline

### DIFF
--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -77,7 +77,7 @@ const theme = createMuiTheme({
   },
   overrides: {
     // Name of the component ⚛️
-    CssBasline: {
+    CssBaseline: {
       // Name of the rule
       '@global': {
         '*, *::before, *::after': {

--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -77,7 +77,7 @@ const theme = createMuiTheme({
   },
   overrides: {
     // Name of the component ⚛️
-    CssBaseline: {
+    MuiCssBaseline: {
       // Name of the rule
       '@global': {
         '*, *::before, *::after': {


### PR DESCRIPTION
This replaces `CssBasline` with `CssBaseline` in the docs.

- [sort of] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

I didn't open an issue first.

As suggested in the contributing guide, I also didn't update the localized versions of the readme.  If it would be better to update those here, I can do that too.