### PR TITLE
[docs] Add system example for prop + theme key

### DIFF
--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -265,7 +265,7 @@ const borderColor = style({
   transform: value => `${value} !important`,
 });
 ```
-We can create a component that supports some CSS grid properties like `grid-gap`. By supplying `spacing` as the `themeKey` we can reuse logic enabling the behaivior we see in other spacing properties like `padding`.
+We can create a component that supports some CSS grid properties like `grid-gap`. By supplying `spacing` as the `themeKey` we can reuse logic enabling the behavior we see in other spacing properties like `padding`.
 ```jsx
 import styled from 'styled-components';
 import { style } from '@material-ui/system'

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -255,8 +255,26 @@ It's also possible that you want to change the theme path prefix.
 
 #### Examples
 
-```js
-import { style } from '@material-ui/system'
+We can create a component that supports some CSS grid properties like `grid-gap`. By supplying `spacing` as the `themeKey` we can reuse logic enabling the behavior we see in other spacing properties like `padding`.
+```jsx
+import styled from 'styled-components';
+import { style } from '@material-ui/system';
+import { Box } from '@material-ui/core';
+
+const gridGap = style({
+  prop: 'gridGap',
+  themeKey: 'spacing',
+});
+
+const Grid = styled(Box)`${gridGap}`;
+const example = <Grid display="grid" gridGap={[2, 3]}>...</Grid>;
+```
+
+We can also customize the prop name by adding both a `prop` and `cssProperty` and transform the value by adding a `transform` function.
+
+```jsx
+import styled from 'styled-components';
+import { style } from '@material-ui/system';
 
 const borderColor = style({
   prop: 'bc',
@@ -264,20 +282,9 @@ const borderColor = style({
   themeKey: 'palette',
   transform: value => `${value} !important`,
 });
-```
-We can create a component that supports some CSS grid properties like `grid-gap`. By supplying `spacing` as the `themeKey` we can reuse logic enabling the behavior we see in other spacing properties like `padding`.
-```jsx
-import styled from 'styled-components';
-import { style } from '@material-ui/system'
-import { Box } from '@material-ui/core';
 
-const gridGap = style({
-  prop: 'gridGap', 
-  themeKey: 'spacing' 
-});
-
-const Grid = styled(Box)`${gridGap}`;
-const example = <Grid display="grid" gridGap={[2, 3]}>...</Grid>
+const Colored = styled.div`${borderColor}`;
+const example = <Colored bc="primary.main">...</Colored>;
 ```
 
 ### `compose(...style functions) => style function`

--- a/docs/src/pages/system/basics/basics.md
+++ b/docs/src/pages/system/basics/basics.md
@@ -265,6 +265,20 @@ const borderColor = style({
   transform: value => `${value} !important`,
 });
 ```
+We can create a component that supports some CSS grid properties like `grid-gap`. By supplying `spacing` as the `themeKey` we can reuse logic enabling the behaivior we see in other spacing properties like `padding`.
+```jsx
+import styled from 'styled-components';
+import { style } from '@material-ui/system'
+import { Box } from '@material-ui/core';
+
+const gridGap = style({
+  prop: 'gridGap', 
+  themeKey: 'spacing' 
+});
+
+const Grid = styled(Box)`${gridGap}`;
+const example = <Grid display="grid" gridGap={[2, 3]}>...</Grid>
+```
 
 ### `compose(...style functions) => style function`
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This PR adds an extra example to the custom style props documentation. 
It took me quite a while to figure out that by using this `themeKey` we also get the logic that in the case of `padding` enables the use of arrays etc. I hope this example will clarify that for others.