### PR TITLE
[docs] Pseudo-class: the style rules that require an increase of specificity

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -56,9 +56,9 @@ export const styles = theme => ({
       paddingLeft: 12,
     },
   },
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
-  /* Styles applied to the root element if `selected={true}`. */
+  /* Pseudo-class applied to the root element if `selected={true}`. */
   selected: {},
   /* Styles applied to the `label` wrapper element. */
   label: {

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js
@@ -24,9 +24,9 @@ export const styles = theme => ({
       color: theme.palette.primary.main,
     },
   },
-  /* Styles applied to the root element if selected. */
+  /* Pseudo-class applied to the root element if selected. */
   selected: {},
-  /* Styles applied to the root element if `showLabel={false}` and not selected. */
+  /* Pseudo-class applied to the root element if `showLabel={false}` and not selected. */
   iconOnly: {},
   /* Styles applied to the span element that wraps the icon and label. */
   wrapper: {

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -157,9 +157,9 @@ export const styles = theme => ({
       },
     },
   },
-  /* Styles applied to the ButtonBase root element if the button is keyboard focused. */
+  /* Pseudo-class applied to the ButtonBase root element if the button is keyboard focused. */
   focusVisible: {},
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the root element if `color="inherit"`. */
   colorInherit: {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -41,9 +41,9 @@ export const styles = {
       cursor: 'default',
     },
   },
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
-  /* Styles applied to the root element if keyboard focused. */
+  /* Pseudo-class applied to the root element if keyboard focused. */
   focusVisible: {},
 };
 

--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -17,7 +17,7 @@ export const styles = theme => ({
       opacity: 0.12,
     },
   },
-  /* Styles applied to the ButtonBase root element if the action area is keyboard focused. */
+  /* Pseudo-class applied to the ButtonBase root element if the action area is keyboard focused. */
   focusVisible: {},
   /* Styles applied to the overlay that covers the action area when it is keyboard focused. */
   focusHighlight: {

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -14,11 +14,11 @@ export const styles = theme => ({
   root: {
     color: theme.palette.text.secondary,
   },
-  /* Styles applied to the root element if `checked={true}`. */
+  /* Pseudo-class applied to the root element if `checked={true}`. */
   checked: {},
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
-  /* Styles applied to the root element if `indeterminate={true}`. */
+  /* Pseudo-class applied to the root element if `indeterminate={true}`. */
   indeterminate: {},
   /* Styles applied to the root element if `color="primary"`. */
   colorPrimary: {

--- a/packages/material-ui/src/Fab/Fab.js
+++ b/packages/material-ui/src/Fab/Fab.js
@@ -99,9 +99,9 @@ export const styles = theme => ({
       height: 40,
     },
   },
-  /* Styles applied to the ButtonBase root element if the button is keyboard focused. */
+  /* Pseudo-class applied to the ButtonBase root element if the button is keyboard focused. */
   focusVisible: {},
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the root element if `color="inherit"`. */
   colorInherit: {

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -38,7 +38,7 @@ export const styles = theme => ({
     flexDirection: 'column',
     marginLeft: 16,
   },
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the label's Typography component. */
   label: {

--- a/packages/material-ui/src/FormHelperText/FormHelperText.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.js
@@ -22,9 +22,9 @@ export const styles = theme => ({
       color: theme.palette.error.main,
     },
   },
-  /* Styles applied to the root element if `error={true}`. */
+  /* Pseudo-class applied to the root element if `error={true}`. */
   error: {},
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the root element if `margin="dense"`. */
   marginDense: {
@@ -34,11 +34,11 @@ export const styles = theme => ({
   contained: {
     margin: '8px 12px 0',
   },
-  /* Styles applied to the root element if `focused={true}`. */
+  /* Pseudo-class applied to the root element if `focused={true}`. */
   focused: {},
-  /* Styles applied to the root element if `filled={true}`. */
+  /* Pseudo-class applied to the root element if `filled={true}`. */
   filled: {},
-  /* Styles applied to the root element if `required={true}`. */
+  /* Pseudo-class applied to the root element if `required={true}`. */
   required: {},
 });
 

--- a/packages/material-ui/src/FormLabel/FormLabel.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.js
@@ -22,15 +22,15 @@ export const styles = theme => ({
       color: theme.palette.error.main,
     },
   },
-  /* Styles applied to the root element if `focused={true}`. */
+  /* Pseudo-class applied to the root element if `focused={true}`. */
   focused: {},
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
-  /* Styles applied to the root element if `error={true}`. */
+  /* Pseudo-class applied to the root element if `error={true}`. */
   error: {},
-  /* Styles applied to the root element if `filled={true}`. */
+  /* Pseudo-class applied to the root element if `filled={true}`. */
   filled: {},
-  /* Styles applied to the root element if `required={true}`. */
+  /* Pseudo-class applied to the root element if `required={true}`. */
   required: {},
   /* Styles applied to the asterisk element. */
   asterisk: {

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -72,7 +72,7 @@ export const styles = theme => ({
       },
     },
   },
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the root element if `size="small"`. */
   sizeSmall: {

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -12,15 +12,15 @@ export const styles = theme => ({
     display: 'block',
     transformOrigin: 'top left',
   },
-  /* Styles applied to the root element if `focused={true}`. */
+  /* Pseudo-class applied to the root element if `focused={true}`. */
   focused: {},
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
-  /* Styles applied to the root element if `error={true}`. */
+  /* Pseudo-class applied to the root element if `error={true}`. */
   error: {},
-  /* Styles applied to the root element if `required={true}`. */
+  /* Pseudo-class applied to the root element if `required={true}`. */
   required: {},
-  /* Styles applied to the asterisk element. */
+  /* Pseudo-class applied to the asterisk element. */
   asterisk: {},
   /* Styles applied to the root element if the component is a descendant of `FormControl`. */
   formControl: {

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -50,7 +50,7 @@ export const styles = {
       outline: 'auto',
     },
   },
-  /* Styles applied to the root element if the link is keyboard focused. */
+  /* Pseudo-class applied to the root element if the link is keyboard focused. */
   focusVisible: {},
 };
 

--- a/packages/material-ui/src/ListItem/ListItem.js
+++ b/packages/material-ui/src/ListItem/ListItem.js
@@ -36,7 +36,7 @@ export const styles = theme => ({
   container: {
     position: 'relative',
   },
-  /* Styles applied to the `component`'s `focusVisibleClassName` property if `button={true}`. */
+  /* Pseudo-class applied to the `component`'s `focusVisibleClassName` property if `button={true}`. */
   focusVisible: {},
   /* Styles applied to the `component` element if dense. */
   dense: {
@@ -47,7 +47,7 @@ export const styles = theme => ({
   alignItemsFlexStart: {
     alignItems: 'flex-start',
   },
-  /* Styles applied to the inner `component` element if `disabled={true}`. */
+  /* Pseudo-class applied to the inner `component` element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the inner `component` element if `divider={true}`. */
   divider: {
@@ -79,7 +79,7 @@ export const styles = theme => ({
     // is absolutely positioned.
     paddingRight: 48,
   },
-  /* Styles applied to the root element if `selected={true}`. */
+  /* Pseudo-class applied to the root element if `selected={true}`. */
   selected: {},
 });
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -62,7 +62,7 @@ export const styles = theme => ({
     whiteSpace: 'nowrap',
     overflow: 'hidden',
   },
-  /* Styles applied to the `Input` component `disabled` class. */
+  /* Pseudo-class applied to the `Input` component `disabled` class. */
   disabled: {},
   /* Styles applied to the `Input` component `icon` class. */
   icon: {

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -13,9 +13,9 @@ export const styles = theme => ({
   root: {
     color: theme.palette.text.secondary,
   },
-  /* Styles applied to the root element if `checked={true}`. */
+  /* Pseudo-class applied to the root element if `checked={true}`. */
   checked: {},
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the root element if `color="primary"`. */
   colorPrimary: {

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -25,7 +25,7 @@ export const styles = {
     flex: 1,
     position: 'relative',
   },
-  /* Styles applied to the root element if `completed={true}`. */
+  /* Pseudo-class applied to the root element if `completed={true}`. */
   completed: {},
 };
 

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -22,11 +22,11 @@ export const styles = theme => ({
     left: 'calc(-50% + 20px)',
     right: 'calc(50% + 20px)',
   },
-  /* Styles applied to the root element if `active={true}`. */
+  /* Pseudo-class applied to the root element if `active={true}`. */
   active: {},
-  /* Styles applied to the root element if `completed={true}`. */
+  /* Pseudo-class applied to the root element if `completed={true}`. */
   completed: {},
-  /* Styles applied to the root element if `disabled={true}`. */
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the line element. */
   line: {

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -27,11 +27,11 @@ export const styles = theme => ({
     fontSize: theme.typography.caption.fontSize,
     fontFamily: theme.typography.fontFamily,
   },
-  /* Styles applied to the root element if `active={true}`. */
+  /* Pseudo-class applied to the root element if `active={true}`. */
   active: {},
-  /* Styles applied to the root element if `completed={true}`. */
+  /* Pseudo-class applied to the root element if `completed={true}`. */
   completed: {},
-  /* Styles applied to the root element if `error={true}`. */
+  /* Pseudo-class applied to the root element if `error={true}`. */
   error: {},
 });
 

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -40,13 +40,13 @@ export const styles = theme => ({
       color: theme.palette.error.main,
     },
   },
-  /* Styles applied to the `Typography` component if `active={true}`. */
+  /* Pseudo-class applied to the `Typography` component if `active={true}`. */
   active: {},
-  /* Styles applied to the `Typography` component if `completed={true}`. */
+  /* Pseudo-class applied to the `Typography` component if `completed={true}`. */
   completed: {},
-  /* Styles applied to the root element and `Typography` component if `error={true}`. */
+  /* Pseudo-class applied to the root element and `Typography` component if `error={true}`. */
   error: {},
-  /* Styles applied to the root element and `Typography` component if `disabled={true}`. */
+  /* Pseudo-class applied to the root element and `Typography` component if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the `icon` container element. */
   iconContainer: {
@@ -57,7 +57,7 @@ export const styles = theme => ({
       paddingRight: 0,
     },
   },
-  /* Styles applied to the root & icon container and `Typography` if `alternativeLabel={true}`. */
+  /* Pseudo-class applied to the root & icon container and `Typography` if `alternativeLabel={true}`. */
   alternativeLabel: {},
   /* Styles applied to the container element which wraps `Typography` and `optional`. */
   labelContainer: {
@@ -148,7 +148,7 @@ StepLabel.propTypes = {
   active: PropTypes.bool,
   /**
    * @ignore
-   * Set internally by Stepper when it's supplied with the alternativeLabel property.
+   * Set internally by Stepper when it's supplied with the alternativeLabel prop.
    */
   alternativeLabel: PropTypes.bool,
   /**

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -91,9 +91,9 @@ export const styles = theme => ({
         theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
     },
   },
-  /* Styles applied to the internal `SwitchBase` component's `checked` class. */
+  /* Pseudo-class applied to the internal `SwitchBase` component's `checked` class. */
   checked: {},
-  /* Styles applied to the internal SwitchBase component's disabled class. */
+  /* Pseudo-class applied to the internal SwitchBase component's disabled class. */
   disabled: {},
   /* Styles applied to the internal SwitchBase component's input element. */
   input: {

--- a/packages/material-ui/src/Tab/Tab.js
+++ b/packages/material-ui/src/Tab/Tab.js
@@ -67,9 +67,9 @@ export const styles = theme => ({
       color: theme.palette.text.disabled,
     },
   },
-  /* Styles applied to the root element if `selected={true}` (controlled by the Tabs component). */
+  /* Pseudo-class applied to the root element if `selected={true}` (controlled by the Tabs component). */
   selected: {},
-  /* Styles applied to the root element if `disabled={true}` (controlled by the Tabs component). */
+  /* Pseudo-class applied to the root element if `disabled={true}` (controlled by the Tabs component). */
   disabled: {},
   /* Styles applied to the root element if `fullWidth={true}` (controlled by the Tabs component). */
   fullWidth: {

--- a/packages/material-ui/src/TableRow/TableRow.js
+++ b/packages/material-ui/src/TableRow/TableRow.js
@@ -25,9 +25,9 @@ export const styles = theme => ({
           : 'rgba(255, 255, 255, 0.14)',
     },
   },
-  /* Styles applied to the root element if `selected={true}`. */
+  /* Pseudo-class applied to the root element if `selected={true}`. */
   selected: {},
-  /* Styles applied to the root element if `hover={true}`. */
+  /* Pseudo-class applied to the root element if `hover={true}`. */
   hover: {},
   /* Styles applied to the root element if table variant="head". */
   head: {},

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -33,7 +33,7 @@ export const styles = theme => ({
       },
     },
   },
-  /* Styles applied to the root element if `active={true}`. */
+  /* Pseudo-class applied to the root element if `active={true}`. */
   active: {},
   /* Styles applied to the icon component. */
   icon: {

--- a/pages/api/bottom-navigation-action.md
+++ b/pages/api/bottom-navigation-action.md
@@ -38,8 +38,8 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">selected</span> | Styles applied to the root element if selected.
-| <span class="prop-name">iconOnly</span> | Styles applied to the root element if `showLabel={false}` and not selected.
+| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if selected.
+| <span class="prop-name">iconOnly</span> | Pseudo-class applied to the root element if `showLabel={false}` and not selected.
 | <span class="prop-name">wrapper</span> | Styles applied to the span element that wraps the icon and label.
 | <span class="prop-name">label</span> | Styles applied to the label's span element.
 

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -48,8 +48,8 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">focusVisible</span> | Styles applied to the root element if keyboard focused.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the root element if keyboard focused.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonBase/ButtonBase.js)

--- a/pages/api/button.md
+++ b/pages/api/button.md
@@ -53,8 +53,8 @@ This property accepts the following keys:
 | <span class="prop-name">contained</span> | Styles applied to the root element if `variant="contained"`.
 | <span class="prop-name">containedPrimary</span> | Styles applied to the root element if `variant="contained"` and `color="primary"`.
 | <span class="prop-name">containedSecondary</span> | Styles applied to the root element if `variant="contained"` and `color="secondary"`.
-| <span class="prop-name">focusVisible</span> | Styles applied to the ButtonBase root element if the button is keyboard focused.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the button is keyboard focused.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
 | <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.

--- a/pages/api/card-action-area.md
+++ b/pages/api/card-action-area.md
@@ -34,7 +34,7 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focusVisible</span> | Styles applied to the ButtonBase root element if the action area is keyboard focused.
+| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the action area is keyboard focused.
 | <span class="prop-name">focusHighlight</span> | Styles applied to the overlay that covers the action area when it is keyboard focused.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -47,9 +47,9 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">checked</span> | Styles applied to the root element if `checked={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">indeterminate</span> | Styles applied to the root element if `indeterminate={true}`.
+| <span class="prop-name">checked</span> | Pseudo-class applied to the root element if `checked={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">indeterminate</span> | Pseudo-class applied to the root element if `indeterminate={true}`.
 | <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
 

--- a/pages/api/fab.md
+++ b/pages/api/fab.md
@@ -46,8 +46,8 @@ This property accepts the following keys:
 | <span class="prop-name">primary</span> | Styles applied to the root element if `color="primary"`.
 | <span class="prop-name">secondary</span> | Styles applied to the root element if `color="secondary"`.
 | <span class="prop-name">extended</span> | Styles applied to the root element if `variant="extended"`.
-| <span class="prop-name">focusVisible</span> | Styles applied to the ButtonBase root element if the button is keyboard focused.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the button is keyboard focused.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
 | <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"``.
 | <span class="prop-name">sizeMedium</span> | Styles applied to the root element if `size="medium"``.

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -46,7 +46,7 @@ This property accepts the following keys:
 | <span class="prop-name">labelPlacementStart</span> | Styles applied to the root element if `labelPlacement="start"`.
 | <span class="prop-name">labelPlacementTop</span> | Styles applied to the root element if `labelPlacement="top"`.
 | <span class="prop-name">labelPlacementBottom</span> | Styles applied to the root element if `labelPlacement="bottom"`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">label</span> | Styles applied to the label's Typography component.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section

--- a/pages/api/form-helper-text.md
+++ b/pages/api/form-helper-text.md
@@ -42,13 +42,13 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">error</span> | Pseudo-class applied to the root element if `error={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
 | <span class="prop-name">contained</span> | Styles applied to the root element if `variant="filled"` or `variant="outlined"`.
-| <span class="prop-name">focused</span> | Styles applied to the root element if `focused={true}`.
-| <span class="prop-name">filled</span> | Styles applied to the root element if `filled={true}`.
-| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
+| <span class="prop-name">focused</span> | Pseudo-class applied to the root element if `focused={true}`.
+| <span class="prop-name">filled</span> | Pseudo-class applied to the root element if `filled={true}`.
+| <span class="prop-name">required</span> | Pseudo-class applied to the root element if `required={true}`.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormHelperText/FormHelperText.js)

--- a/pages/api/form-label.md
+++ b/pages/api/form-label.md
@@ -40,11 +40,11 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focused</span> | Styles applied to the root element if `focused={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">filled</span> | Styles applied to the root element if `filled={true}`.
-| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
+| <span class="prop-name">focused</span> | Pseudo-class applied to the root element if `focused={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">error</span> | Pseudo-class applied to the root element if `error={true}`.
+| <span class="prop-name">filled</span> | Pseudo-class applied to the root element if `filled={true}`.
+| <span class="prop-name">required</span> | Pseudo-class applied to the root element if `required={true}`.
 | <span class="prop-name">asterisk</span> | Styles applied to the asterisk element.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -46,7 +46,7 @@ This property accepts the following keys:
 | <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
 | <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">label</span> | Styles applied to the children container element.
 

--- a/pages/api/input-label.md
+++ b/pages/api/input-label.md
@@ -42,11 +42,11 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focused</span> | Styles applied to the root element if `focused={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">required</span> | Styles applied to the root element if `required={true}`.
-| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element.
+| <span class="prop-name">focused</span> | Pseudo-class applied to the root element if `focused={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">error</span> | Pseudo-class applied to the root element if `error={true}`.
+| <span class="prop-name">required</span> | Pseudo-class applied to the root element if `required={true}`.
+| <span class="prop-name">asterisk</span> | Pseudo-class applied to the asterisk element.
 | <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
 | <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
 | <span class="prop-name">shrink</span> | Styles applied to the `input` element if `shrink={true}`.

--- a/pages/api/link.md
+++ b/pages/api/link.md
@@ -43,7 +43,7 @@ This property accepts the following keys:
 | <span class="prop-name">underlineHover</span> | Styles applied to the root element if `underline="hover"`.
 | <span class="prop-name">underlineAlways</span> | Styles applied to the root element if `underline="always"`.
 | <span class="prop-name">button</span> | Styles applied to the root element if `component="button"`.
-| <span class="prop-name">focusVisible</span> | Styles applied to the root element if the link is keyboard focused.
+| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the root element if the link is keyboard focused.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Link/Link.js)

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -46,15 +46,15 @@ This property accepts the following keys:
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the (normally root) `component` element. May be wrapped by a `container`.
 | <span class="prop-name">container</span> | Styles applied to the `container` element if `children` includes `ListItemSecondaryAction`.
-| <span class="prop-name">focusVisible</span> | Styles applied to the `component`'s `focusVisibleClassName` property if `button={true}`.
+| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the `component`'s `focusVisibleClassName` property if `button={true}`.
 | <span class="prop-name">dense</span> | Styles applied to the `component` element if dense.
 | <span class="prop-name">alignItemsFlexStart</span> | Styles applied to the `component` element if `alignItems="flex-start"`.
-| <span class="prop-name">disabled</span> | Styles applied to the inner `component` element if `disabled={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the inner `component` element if `disabled={true}`.
 | <span class="prop-name">divider</span> | Styles applied to the inner `component` element if `divider={true}`.
 | <span class="prop-name">gutters</span> | Styles applied to the inner `component` element if `disableGutters={false}`.
 | <span class="prop-name">button</span> | Styles applied to the inner `component` element if `button={true}`.
 | <span class="prop-name">secondaryAction</span> | Styles applied to the `component` element if `children` includes `ListItemSecondaryAction`.
-| <span class="prop-name">selected</span> | Styles applied to the root element if `selected={true}`.
+| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if `selected={true}`.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItem/ListItem.js)

--- a/pages/api/native-select.md
+++ b/pages/api/native-select.md
@@ -44,7 +44,7 @@ This property accepts the following keys:
 | <span class="prop-name">filled</span> | Styles applied to the `Input` component if `variant="filled"`.
 | <span class="prop-name">outlined</span> | Styles applied to the `Input` component if `variant="outlined"`.
 | <span class="prop-name">selectMenu</span> | Styles applied to the `Input` component `selectMenu` class.
-| <span class="prop-name">disabled</span> | Styles applied to the `Input` component `disabled` class.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the `Input` component `disabled` class.
 | <span class="prop-name">icon</span> | Styles applied to the `Input` component `icon` class.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -46,8 +46,8 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">checked</span> | Styles applied to the root element if `checked={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">checked</span> | Pseudo-class applied to the root element if `checked={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
 

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -54,7 +54,7 @@ This property accepts the following keys:
 | <span class="prop-name">filled</span> | Styles applied to the `Input` component if `variant="filled"`.
 | <span class="prop-name">outlined</span> | Styles applied to the `Input` component if `variant="outlined"`.
 | <span class="prop-name">selectMenu</span> | Styles applied to the `Input` component `selectMenu` class.
-| <span class="prop-name">disabled</span> | Styles applied to the `Input` component `disabled` class.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the `Input` component `disabled` class.
 | <span class="prop-name">icon</span> | Styles applied to the `Input` component `icon` class.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section

--- a/pages/api/step-connector.md
+++ b/pages/api/step-connector.md
@@ -36,9 +36,9 @@ This property accepts the following keys:
 | <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
 | <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical"`.
 | <span class="prop-name">alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
-| <span class="prop-name">active</span> | Styles applied to the root element if `active={true}`.
-| <span class="prop-name">completed</span> | Styles applied to the root element if `completed={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">active</span> | Pseudo-class applied to the root element if `active={true}`.
+| <span class="prop-name">completed</span> | Pseudo-class applied to the root element if `completed={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">line</span> | Styles applied to the line element.
 | <span class="prop-name">lineHorizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
 | <span class="prop-name">lineVertical</span> | Styles applied to the root element if `orientation="vertical"`.

--- a/pages/api/step-icon.md
+++ b/pages/api/step-icon.md
@@ -38,9 +38,9 @@ This property accepts the following keys:
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">text</span> | Styles applied to the SVG text element.
-| <span class="prop-name">active</span> | Styles applied to the root element if `active={true}`.
-| <span class="prop-name">completed</span> | Styles applied to the root element if `completed={true}`.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">active</span> | Pseudo-class applied to the root element if `active={true}`.
+| <span class="prop-name">completed</span> | Pseudo-class applied to the root element if `completed={true}`.
+| <span class="prop-name">error</span> | Pseudo-class applied to the root element if `error={true}`.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepIcon/StepIcon.js)

--- a/pages/api/step-label.md
+++ b/pages/api/step-label.md
@@ -43,12 +43,12 @@ This property accepts the following keys:
 | <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal".
 | <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical".
 | <span class="prop-name">label</span> | Styles applied to the `Typography` component which wraps `children`.
-| <span class="prop-name">active</span> | Styles applied to the `Typography` component if `active={true}`.
-| <span class="prop-name">completed</span> | Styles applied to the `Typography` component if `completed={true}`.
-| <span class="prop-name">error</span> | Styles applied to the root element and `Typography` component if `error={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element and `Typography` component if `disabled={true}`.
+| <span class="prop-name">active</span> | Pseudo-class applied to the `Typography` component if `active={true}`.
+| <span class="prop-name">completed</span> | Pseudo-class applied to the `Typography` component if `completed={true}`.
+| <span class="prop-name">error</span> | Pseudo-class applied to the root element and `Typography` component if `error={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element and `Typography` component if `disabled={true}`.
 | <span class="prop-name">iconContainer</span> | Styles applied to the `icon` container element.
-| <span class="prop-name">alternativeLabel</span> | Styles applied to the root & icon container and `Typography` if `alternativeLabel={true}`.
+| <span class="prop-name">alternativeLabel</span> | Pseudo-class applied to the root & icon container and `Typography` if `alternativeLabel={true}`.
 | <span class="prop-name">labelContainer</span> | Styles applied to the container element which wraps `Typography` and `optional`.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section

--- a/pages/api/step.md
+++ b/pages/api/step.md
@@ -40,7 +40,7 @@ This property accepts the following keys:
 | <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
 | <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical"`.
 | <span class="prop-name">alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
-| <span class="prop-name">completed</span> | Styles applied to the root element if `completed={true}`.
+| <span class="prop-name">completed</span> | Pseudo-class applied to the root element if `completed={true}`.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Step/Step.js)

--- a/pages/api/switch.md
+++ b/pages/api/switch.md
@@ -51,8 +51,8 @@ This property accepts the following keys:
 | <span class="prop-name">switchBase</span> | Styles applied to the internal `SwitchBase` component's `root` class.
 | <span class="prop-name">colorPrimary</span> | Styles applied to the internal SwitchBase component's root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | Styles applied to the internal SwitchBase component's root element if `color="secondary"`.
-| <span class="prop-name">checked</span> | Styles applied to the internal `SwitchBase` component's `checked` class.
-| <span class="prop-name">disabled</span> | Styles applied to the internal SwitchBase component's disabled class.
+| <span class="prop-name">checked</span> | Pseudo-class applied to the internal `SwitchBase` component's `checked` class.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the internal SwitchBase component's disabled class.
 | <span class="prop-name">input</span> | Styles applied to the internal SwitchBase component's input element.
 | <span class="prop-name">thumb</span> | Styles used to create the thumb passed to the internal `SwitchBase` component `icon` prop.
 | <span class="prop-name">track</span> | Styles applied to the track element.

--- a/pages/api/tab.md
+++ b/pages/api/tab.md
@@ -45,8 +45,8 @@ This property accepts the following keys:
 | <span class="prop-name">textColorInherit</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="inherit"`.
 | <span class="prop-name">textColorPrimary</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="primary"`.
 | <span class="prop-name">textColorSecondary</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="secondary"`.
-| <span class="prop-name">selected</span> | Styles applied to the root element if `selected={true}` (controlled by the Tabs component).
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}` (controlled by the Tabs component).
+| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if `selected={true}` (controlled by the Tabs component).
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}` (controlled by the Tabs component).
 | <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}` (controlled by the Tabs component).
 | <span class="prop-name">wrapped</span> | Styles applied to the root element if `wrapped={true}`.
 | <span class="prop-name">wrapper</span> | Styles applied to the `icon` and `label`'s wrapper element.

--- a/pages/api/table-row.md
+++ b/pages/api/table-row.md
@@ -38,8 +38,8 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">selected</span> | Styles applied to the root element if `selected={true}`.
-| <span class="prop-name">hover</span> | Styles applied to the root element if `hover={true}`.
+| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if `selected={true}`.
+| <span class="prop-name">hover</span> | Pseudo-class applied to the root element if `hover={true}`.
 | <span class="prop-name">head</span> | Styles applied to the root element if table variant="head".
 | <span class="prop-name">footer</span> | Styles applied to the root element if table variant="footer".
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -38,7 +38,7 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">active</span> | Styles applied to the root element if `active={true}`.
+| <span class="prop-name">active</span> | Pseudo-class applied to the root element if `active={true}`.
 | <span class="prop-name">icon</span> | Styles applied to the icon component.
 | <span class="prop-name">iconDirectionDesc</span> | Styles applied to the icon component if `direction="desc"`.
 | <span class="prop-name">iconDirectionAsc</span> | Styles applied to the icon component if `direction="asc"`.

--- a/pages/api/toggle-button.md
+++ b/pages/api/toggle-button.md
@@ -39,8 +39,8 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">selected</span> | Styles applied to the root element if `selected={true}`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if `selected={true}`.
 | <span class="prop-name">label</span> | Styles applied to the `label` wrapper element.
 | <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.


### PR DESCRIPTION
This changes the description of the style rules that are used as pseudo-classes. Meaning, that they are applied based on the component state and that they are overriding some default style with higher class name specificity (not order).

This new description will signal our users the existence of the difference.

Closes #16051

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
