### PR TITLE
[docs] Upgrade notistack and migrate the demo to hooks

### DIFF
--- a/docs/src/pages/components/snackbars/IntegrationNotistack.js
+++ b/docs/src/pages/components/snackbars/IntegrationNotistack.js
@@ -1,33 +1,26 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
-import { SnackbarProvider, withSnackbar } from 'notistack';
+import { SnackbarProvider, useSnackbar } from 'notistack';
 
-class App extends React.Component {
-  handleClick = () => {
-    this.props.enqueueSnackbar('I love snacks.');
+function MyApp() {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleClick = () => {
+    enqueueSnackbar('I love snacks.');
   };
 
-  handleClickVariant = variant => () => {
+  const handleClickVariant = variant => () => {
     // variant could be success, error, warning, info, or default
-    this.props.enqueueSnackbar('This is a warning message!', { variant });
+    enqueueSnackbar('This is a warning message!', { variant });
   };
 
-  render() {
-    return (
-      <React.Fragment>
-        <Button onClick={this.handleClick}>Show snackbar</Button>
-        <Button onClick={this.handleClickVariant('warning')}>Show warning snackbar</Button>
-      </React.Fragment>
-    );
-  }
+  return (
+    <React.Fragment>
+      <Button onClick={handleClick}>Show snackbar</Button>
+      <Button onClick={handleClickVariant('warning')}>Show warning snackbar</Button>
+    </React.Fragment>
+  );
 }
-
-App.propTypes = {
-  enqueueSnackbar: PropTypes.func.isRequired,
-};
-
-const MyApp = withSnackbar(App);
 
 export default function IntegrationNotistack() {
   return (

--- a/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
+++ b/docs/src/pages/components/snackbars/IntegrationNotistack.tsx
@@ -1,33 +1,26 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
-import { SnackbarProvider, VariantType, withSnackbar, withSnackbarProps } from 'notistack';
+import { SnackbarProvider, VariantType, useSnackbar } from 'notistack';
 
-class App extends React.Component<withSnackbarProps> {
-  handleClick = () => {
-    this.props.enqueueSnackbar('I love snacks.');
+function MyApp() {
+  const { enqueueSnackbar } = useSnackbar();
+
+  const handleClick = () => {
+    enqueueSnackbar('I love snacks.');
   };
 
-  handleClickVariant = (variant: VariantType) => () => {
+  const handleClickVariant = (variant: VariantType) => () => {
     // variant could be success, error, warning, info, or default
-    this.props.enqueueSnackbar('This is a warning message!', { variant });
+    enqueueSnackbar('This is a warning message!', { variant });
   };
 
-  render() {
-    return (
-      <React.Fragment>
-        <Button onClick={this.handleClick}>Show snackbar</Button>
-        <Button onClick={this.handleClickVariant('warning')}>Show warning snackbar</Button>
-      </React.Fragment>
-    );
-  }
+  return (
+    <React.Fragment>
+      <Button onClick={handleClick}>Show snackbar</Button>
+      <Button onClick={handleClickVariant('warning')}>Show warning snackbar</Button>
+    </React.Fragment>
+  );
 }
-
-(App as React.ComponentClass<withSnackbarProps>).propTypes = {
-  enqueueSnackbar: PropTypes.func.isRequired,
-};
-
-const MyApp = withSnackbar(App);
 
 export default function IntegrationNotistack() {
   return (

--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "mocha": "^5.0.0",
     "next": "8.0.5-canary.15",
     "next-plugin-transpile-modules": "^2.0.0",
-    "notistack": "^0.5.0",
+    "notistack": "^0.8.6",
     "nyc": "^13.0.0",
     "postcss": "^7.0.0",
     "prettier": "^1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9652,13 +9652,15 @@ normalize-url@^3.0.0, normalize-url@^3.3.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
-notistack@^0.5.0:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.5.1.tgz#a8b62586afdfbe4c2080d67ea034bf784711f520"
-  integrity sha512-Pym0iWYCDFsC3imDL+zx4lWjkeEu6s/mlIDq6m+VRpHPPNFJErNcHCqo+xakvkkpOOR3fz4Y802GtMk8GDFVIA==
+notistack@^0.8.6:
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.8.6.tgz#8c24ab5ea2bce7bf93f3e6e61fab168d23d430c7"
+  integrity sha512-WJ4Mmk/Q9oEqOtQLJGI52GL1OglWd+GPpUFFHolw4rNq5qfAtl58WAUqIJk6A0t6Jr13BYl6B+QpJhEYH7lDBA==
   dependencies:
     classnames "^2.2.6"
+    hoist-non-react-statics "^3.3.0"
     prop-types "^15.6.2"
+    react-is "^16.8.6"
 
 npm-bundled@^1.0.1:
   version "1.0.6"


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Upgraded notistack to `v0.8.6` https://github.com/iamhosseindhv/notistack/blob/master/CHANGELOG.md
* Migrated the demo to use hooks