### PR TITLE
[docs] Revert unreleased changes to the useMediaQuery API

### DIFF
--- a/docs/src/pages/components/use-media-query/UseWidth.js
+++ b/docs/src/pages/components/use-media-query/UseWidth.js
@@ -11,10 +11,11 @@ import { createMuiTheme } from '@material-ui/core/styles';
 function useWidth() {
   const theme = useTheme();
   const keys = [...theme.breakpoints.keys].reverse();
-  const queries = useMediaQuery(keys.map(key => theme.breakpoints.only(key)));
   return (
-    queries.reduce((output, matches, index) => {
-      return !output && matches ? keys[index] : output;
+    keys.reduce((output, key) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const matches = useMediaQuery(theme.breakpoints.only(key));
+      return !output && matches ? key : output;
     }, null) || 'xs'
   );
 }

--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -58,13 +58,19 @@ The `withWidth()` higher-order component injects the screen width of the page.
 You can reproduce the same behavior with a `useWidth` hook:
 
 ```jsx
+/**
+ * Be careful using this hook. It only works because the number of
+ * breakpoints in theme is static. It will break once you change the number of
+ * breakpoints. See https://reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level
+ */
 function useWidth() {
   const theme = useTheme();
   const keys = [...theme.breakpoints.keys].reverse();
-  const queries = useMediaQuery(keys.map(key => theme.breakpoints.only(key)));
   return (
-    queries.reduce((output, matches, index) => {
-      return !output && matches ? keys[index] : output;
+    keys.reduce((output, key) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      const matches = useMediaQuery(theme.breakpoints.only(key));
+      return !output && matches ? key : output;
     }, null) || 'xs'
   );
 }


### PR DESCRIPTION
This is a quick follow-up on https://github.com/mui-org/material-ui/pull/15678#discussion_r291818253 so the documentation has no trace of a `useMediaQuery([array])` API. It's internal only.
