### PR TITLE
[core] Move size tracking to azure pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,7 @@ jobs:
       - checkout
       - install_js
       - run:
-          name: Can we generate the @material-ui/core build?
+          name: Can we generate the @material-ui/core umd build?
           command: yarn workspace @material-ui/core build:umd
       - prepare_chrome_headless
       - run:
@@ -213,7 +213,7 @@ workflows:
       - test_browser:
           requires:
             - checkout
-      - test_build:
+      - test_production:
           requires:
             - checkout
       - test_regressions:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,35 +159,14 @@ jobs:
             else
               echo "no changes"
             fi
-  test_build:
+  test_production:
     <<: *defaults
     steps:
       - checkout
       - install_js
       - run:
           name: Can we generate the @material-ui/core build?
-          command: cd packages/material-ui && yarn build
-      - run:
-          name: Can we generate the @material-ui/lab build?
-          command: cd packages/material-ui-lab && yarn build
-      - run:
-          name: Can we generate the @material-ui/styles build?
-          command: cd packages/material-ui-styles && yarn build
-      - run:
-          name: Can we generate the @material-ui/utils build?
-          command: cd packages/material-ui-utils && yarn build
-      - run:
-          name: Can we generate the @material-ui/system build?
-          command: cd packages/material-ui-system && yarn build
-      - run:
-          name: Prepare persisting workspace
-          command: tar cfvz builds.tar.gz packages/*/build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - builds.tar.gz
-            # rollup snapshot
-            - packages/material-ui/size-snapshot.json
+          command: yarn workspace @material-ui/core build:umd
       - prepare_chrome_headless
       - run:
           name: Test umd release
@@ -214,44 +193,6 @@ jobs:
           command: |
             DOCKER_TEST_URL=http://$(ip addr show lo | grep "inet\b" | awk '{print $2}' | cut -d/ -f1):3090 yarn test:regressions
             yarn argos
-  size_snapshot:
-    <<: *defaults
-    steps:
-      - checkout
-      - install_js
-      - attach_workspace:
-          at: /tmp/workspace
-      - run:
-          name: Restore build
-          command: |
-            mv /tmp/workspace/builds.tar.gz ./
-            tar xfvz builds.tar.gz
-            mv /tmp/workspace/packages/material-ui/size-snapshot.json packages/material-ui/size-snapshot.json
-      # Netlify already do it for us but we need to check the size.
-      - run:
-          name: Can we build the docs?
-          command: yarn docs:build
-      - run:
-          name: Create a size snapshot
-          command: yarn size:snapshot
-      # downloaded by aws lambda to s3 bucket
-      # lambda allowes us to limit this to mui-org-branches-only while hiding credentials
-      # that allow write access to s3
-      - store_artifacts:
-          path: size-snapshot.json
-      # for debugging purposes, this is created by webpack called from size:snapshot
-      - store_artifacts:
-          path: scripts/sizeSnapshot/build/stats.json
-      - run:
-          name: Possibly persist size snapshot
-          command: |
-            if [ -z "$CI_PULL_REQUEST" ]; then
-              echo "no pull request; lets persist the size snapshot"
-              curl -X PUT --header "x-api-key: $CIRCLE_AWS_API_KEY" https://t6nulys5kl.execute-api.us-east-1.amazonaws.com/v1/persist-size-snapshot?build-id=$CIRCLE_BUILD_NUM
-            else
-              echo "pull request; let's run dangerJS"
-              yarn danger ci
-            fi
 workflows:
   version: 2
   pipeline:
@@ -281,7 +222,4 @@ workflows:
             - test_unit
             - test_static
             - test_browser
-            - test_build
-      - size_snapshot:
-          requires:
-            - test_build
+            - test_production

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,48 @@
+trigger:
+  - azure-pipelines
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '10.x'
+    displayName: 'Install Node.js'
+
+  - script: |
+      yarn install
+    displayName: 'install dependencies'
+
+  - script: |
+      yarn workspace @material-ui/core build
+    displayName: 'build @material-ui/core'
+
+  - script: |
+      yarn workspace @material-ui/lab build
+    displayName: 'build @material-ui/lab'
+
+  - script: |
+      yarn workspace @material-ui/styles build
+    displayName: 'build @material-ui/styles'
+
+  - script: |
+      yarn workspace @material-ui/utils build
+    displayName: 'build @material-ui/utils'
+
+  - script: |
+      yarn workspace @material-ui/system build
+    displayName: 'build @material-ui/system'
+
+  - script: |
+      yarn docs:build
+    displayName: 'build docs'
+
+  - script: |
+      yarn size:snapshot
+    displayName: 'create a size snapshot'
+
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: 'size-snapshot'
+      targetPath: 'scripts/sizeSnapshot/build/stats.json'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,3 +54,10 @@ steps:
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
       AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
+
+  - script: |
+      yarn danger ci
+    displayName: 'run danger on PRs'
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    env:
+      DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,3 +46,11 @@ steps:
     inputs:
       artifactName: 'size-snapshot'
       targetPath: 'scripts/sizeSnapshot/build/stats.json'
+
+  - script: |
+      node scripts/sizeSnapshot/upload
+    displayName: 'persist size snapshot'
+    condition: ne(variables['Build.Reason'], 'PullRequest')
+    env:
+      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "ast-types": "^0.12.4",
     "autoprefixer": "^9.0.0",
     "autosuggest-highlight": "^3.1.1",
+    "aws-sdk": "^2.471.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.0.0",

--- a/scripts/sizeSnapshot/upload.js
+++ b/scripts/sizeSnapshot/upload.js
@@ -30,7 +30,7 @@ async function main() {
 
   const branch = process.env.BUILD_SOURCEBRANCHNAME.replace(/^refs\/head\//, '');
 
-  const snapshot = {}; // await fse.readJSON(snapshotDestPath);
+  const snapshot = await fse.readJSON(snapshotDestPath);
 
   function upload(revision) {
     const uploadOptions = {

--- a/scripts/sizeSnapshot/upload.js
+++ b/scripts/sizeSnapshot/upload.js
@@ -1,0 +1,52 @@
+/* eslint-disable no-console */
+const aws = require('aws-sdk');
+const fse = require('fs-extra');
+const path = require('path');
+
+const workspaceRoot = path.join(__dirname, '../../');
+const snapshotDestPath = path.join(workspaceRoot, 'size-snapshot.json');
+
+async function main() {
+  function uploadArtifact(artifact, options) {
+    return new Promise(async (resolve, reject) => {
+      const s3 = new aws.S3();
+
+      s3.upload(
+        {
+          ...options,
+          Body: JSON.stringify(artifact, null, 2),
+          ContentType: 'application/json',
+        },
+        (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        },
+      );
+    });
+  }
+
+  const branch = process.env.BUILD_SOURCEBRANCHNAME.replace(/^refs\/head\//, '');
+
+  const snapshot = {}; // await fse.readJSON(snapshotDestPath);
+
+  function upload(revision) {
+    const uploadOptions = {
+      Bucket: 'eps1lon-material-ui',
+      Key: `artifacts/${branch}/${revision}/size-snapshot.json`,
+    };
+    return uploadArtifact(snapshot, uploadOptions);
+  }
+
+  // save snapshot under the commit id as well as imitating a symlink `latest`
+  // to the commit id
+  const [uploaded] = await Promise.all([upload(process.env.BUILD_SOURCEVERSION), upload('latest')]);
+  console.log(uploaded);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2926,6 +2926,21 @@ autosuggest-highlight@^3.1.1:
   dependencies:
     diacritic "0.0.2"
 
+aws-sdk@^2.471.0:
+  version "2.471.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.471.0.tgz#08d9ad6fe7216ee4c7c4ea99d7e66b33d9e07930"
+  integrity sha512-c7e1939Nep03xLyN+qV1uzzotxYVqtcj+5x87C1s3qOPSG7aSVIbtJfcu4RUdtsKty5qUef6muJ6ohNMRYrW6g==
+  dependencies:
+    buffer "4.9.1"
+    events "1.1.1"
+    ieee754 "1.1.8"
+    jmespath "0.15.0"
+    querystring "0.2.0"
+    sax "1.2.1"
+    url "0.10.3"
+    uuid "3.3.2"
+    xml2js "0.4.19"
+
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
@@ -3509,7 +3524,7 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@^4.3.0:
+buffer@4.9.1, buffer@^4.3.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.1.tgz#6d1bb601b07a4efced97094132093027c95bc298"
   integrity sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=
@@ -5930,6 +5945,11 @@ eventemitter3@^3.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
+events@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
+  integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
 events@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
@@ -7180,6 +7200,11 @@ icss-utils@^4.1.0:
   dependencies:
     postcss "^7.0.14"
 
+ieee754@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
+  integrity sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
@@ -7859,6 +7884,11 @@ jest-worker@^24.6.0:
   dependencies:
     merge-stream "^1.0.1"
     supports-color "^6.1.0"
+
+jmespath@0.15.0:
+  version "0.15.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
+  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
 js-levenshtein@^1.1.3:
   version "1.1.6"
@@ -12283,6 +12313,11 @@ samsam@~1.1:
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.3.tgz#9f5087419b4d091f232571e7fa52e90b0f552621"
   integrity sha1-n1CHQZtNCR8jJXHn+lLpCw9VJiE=
 
+sax@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+  integrity sha1-e45lYZCyKOgaZq6nSEgNgozS03o=
+
 sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -13824,6 +13859,14 @@ url-template@^2.0.8:
   resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
   integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
+url@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/url/-/url-0.10.3.tgz#021e4d9c7705f21bbf37d03ceb58767402774c64"
+  integrity sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=
+  dependencies:
+    punycode "1.3.2"
+    querystring "0.2.0"
+
 url@0.11.0, url@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
@@ -14351,7 +14394,7 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@^0.4.17:
+xml2js@0.4.19, xml2js@^0.4.17:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
   integrity sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==


### PR DESCRIPTION
Introducing https://dev.azure.com/mui-org/Material-UI

`test_build` and `size_snapshot` move from CircleCI to azure pipelines. The UMD smoke test is handled by a new job (`test_production`). 

This will reduce load on CircleCI hoepfully reducing queue times.

TODO:
- [x] create azure org
- [x] discuss governance
- [x] invite team
- [ ] config pipeline like https://dev.azure.com/silbermannsebastian/material-ui-fork
- [ ] Remove `size_snapshot`, `test_build` from required gh checks
- [ ] Add `test_production` to required gh checks (and `test_static` while we're at tit)