### PR TITLE
[examples] Fix typo in the Gatsby example

### DIFF
--- a/examples/gatsby/src/components/Link.js
+++ b/examples/gatsby/src/components/Link.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import MuiLink from '@material-ui/core/Link';
-import { Link as GastsbyLink } from 'gatsby';
+import { Link as GatsbyLink } from 'gatsby';
 
 const Link = React.forwardRef(function Link(props, ref) {
-  return <MuiLink component={GastsbyLink} ref={ref} {...props} />;
+  return <MuiLink component={GatsbyLink} ref={ref} {...props} />;
 });
 
 export default Link;


### PR DESCRIPTION
## Overview
Change imported variable name from `GastsbyLink` to `GatsbyLink`

## Testing
Naming change only, tests pass as usual.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
