### PR TITLE
[core] Fix withStyles not including props

### DIFF
--- a/docs/src/pages/styles/basics/AdaptingHOC.tsx
+++ b/docs/src/pages/styles/basics/AdaptingHOC.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/styles';
-import Button from '@material-ui/core/Button';
+import { withStyles, createStyles, WithStyles } from '@material-ui/styles';
+import Button, { ButtonProps } from '@material-ui/core/Button';
+import { Omit } from '@material-ui/types';
 
-const styles = {
+const styles = createStyles({
   root: {
-    background: props =>
+    background: (props: MyButtonRawProps) =>
       props.color === 'red'
         ? 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)'
         : 'linear-gradient(45deg, #2196F3 30%, #21CBF3 90%)',
     border: 0,
     borderRadius: 3,
-    boxShadow: props =>
+    boxShadow: (props: MyButtonRawProps) =>
       props.color === 'red'
         ? '0 3px 5px 2px rgba(255, 105, 135, .3)'
         : '0 3px 5px 2px rgba(33, 203, 243, .3)',
@@ -20,14 +21,18 @@ const styles = {
     padding: '0 30px',
     margin: 8,
   },
-};
+});
 
-function MyButtonRaw(props) {
+interface MyButtonRawProps {
+  color: 'red' | 'blue';
+}
+
+function MyButtonRaw(props: WithStyles<typeof styles> & Omit<ButtonProps, keyof MyButtonRawProps>) {
   const { classes, color, ...other } = props;
   return <Button className={classes.root} {...other} />;
 }
 
-MyButtonRaw.propTypes = {
+(MyButtonRaw as any).propTypes = {
   classes: PropTypes.object.isRequired,
   color: PropTypes.oneOf(['red', 'blue']).isRequired,
 };

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -97,5 +97,5 @@ export default function withStyles<
   options?: Options,
 ): PropInjector<
   WithStyles<StylesType, Options['withTheme']>,
-  StyledComponentProps<ClassKeyOfStyles<StylesType>>
+  StyledComponentProps<ClassKeyOfStyles<StylesType>> & PropsOfStyles<StylesType>
 >;

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PropInjector } from '@material-ui/types';
+import { PropInjector, CoerceEmptyInterface } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 
@@ -70,7 +70,9 @@ export type ClassKeyOfStyles<StylesOrClassKey> = StylesOrClassKey extends string
 /**
  * infers the type of the theme used in the styles
  */
-export type PropsOfStyles<StylesType> = StylesType extends Styles<any, infer Props> ? Props : {};
+export type PropsOfStyles<StylesType> = StylesType extends Styles<any, infer Props>
+  ? CoerceEmptyInterface<Props>
+  : {};
 /**
  * infers the type of the props used in the styles
  */

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -10,7 +10,6 @@ import {
   StyleRulesCallback,
   Styles,
   ClassKeyOfStyles,
-  PropsOfStyles,
 } from '@material-ui/styles/withStyles';
 
 export {
@@ -37,7 +36,7 @@ export type WithStyles<
   IncludeTheme extends boolean | undefined = false
 > = (IncludeTheme extends true ? { theme: Theme } : {}) & {
   classes: ClassNameMap<ClassKeyOfStyles<StylesOrClassKey>>;
-} & PropsOfStyles<StylesOrClassKey>;
+};
 
 export default function withStyles<
   ClassKey extends string,

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,4 +1,4 @@
-import { PropInjector } from '@material-ui/types';
+import { PropInjector, CoerceEmptyInterface } from '@material-ui/types';
 import { Theme } from './createMuiTheme';
 import {
   CreateCSSProperties,
@@ -10,6 +10,7 @@ import {
   StyleRulesCallback,
   Styles,
   ClassKeyOfStyles,
+  PropsOfStyles,
 } from '@material-ui/styles/withStyles';
 
 export {
@@ -36,7 +37,7 @@ export type WithStyles<
   IncludeTheme extends boolean | undefined = false
 > = (IncludeTheme extends true ? { theme: Theme } : {}) & {
   classes: ClassNameMap<ClassKeyOfStyles<StylesOrClassKey>>;
-};
+} & PropsOfStyles<StylesOrClassKey>;
 
 export default function withStyles<
   ClassKey extends string,
@@ -45,4 +46,7 @@ export default function withStyles<
 >(
   style: Styles<Theme, Props, ClassKey>,
   options?: Options,
-): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey>>;
+): PropInjector<
+  WithStyles<ClassKey, Options['withTheme']>,
+  StyledComponentProps<ClassKey> & CoerceEmptyInterface<Props>
+>;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Alternative to #15953

* [core] Fix withStyles not including properties
* [styles] Fix withStyles not including properties
* [styles] Fix PropsOfStyles not using CoerceEmptyInterface
* [docs] Add typescript version of `styles/basics/AdaptingHOC`

Closes #15553
Closes #15953
