### PR TITLE
[icons] Fix #16138 by correctly typing icon components as typeof SvgIcon

### DIFF
--- a/packages/material-ui-icons/scripts/create-typings.js
+++ b/packages/material-ui-icons/scripts/create-typings.js
@@ -22,7 +22,7 @@ function createIndexTyping(files) {
   const contents = `
 import SvgIcon from  '@material-ui/core/SvgIcon';
 
-${files.map(file => `export const ${normalizeFileName(file)}: SvgIcon;`).join('\n')}
+${files.map(file => `export const ${normalizeFileName(file)}: typeof SvgIcon;`).join('\n')}
 `;
 
   return fse.writeFile(path.resolve(TARGET_DIR, 'index.d.ts'), contents, 'utf8');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
