### PR TITLE
[ButtonBase] Fix riple not stoping on mouse up

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -92,6 +92,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     onTouchEnd,
     onTouchMove,
     onTouchStart,
+    onDragEnd,
     tabIndex = 0,
     TouchRippleProps,
     type = 'button',
@@ -145,6 +146,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
   }
 
   const handleMouseDown = useRippleHandler('start', onMouseDown);
+  const handleDragEnd = useRippleHandler('stop', onDragEnd);
   const handleMouseUp = useRippleHandler('stop', onMouseUp);
   const handleMouseLeave = useRippleHandler('stop', event => {
     if (focusVisible) {
@@ -282,6 +284,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
       onMouseDown={handleMouseDown}
       onMouseLeave={handleMouseLeave}
       onMouseUp={handleMouseUp}
+      onDragEnd={handleDragEnd}
       onTouchEnd={handleTouchEnd}
       onTouchMove={handleTouchMove}
       onTouchStart={handleTouchStart}
@@ -376,6 +379,10 @@ ButtonBase.propTypes = {
    * @ignore
    */
   onClick: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onDragEnd: PropTypes.func,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -113,6 +113,7 @@ describe('<ButtonBase />', () => {
         'onMouseDown',
         'onMouseLeave',
         'onMouseUp',
+        'onDragEnd',
         'onTouchEnd',
         'onTouchStart',
       ];
@@ -232,6 +233,26 @@ describe('<ButtonBase />', () => {
         wrapper.update();
 
         assert.strictEqual(wrapper.find('.ripple-visible .child-leaving').length, 3);
+        assert.strictEqual(wrapper.find('.ripple-visible .child:not(.child-leaving)').length, 0);
+      });
+
+      it('should start the ripple when the mouse is pressed 4', () => {
+        act(() => {
+          wrapper.simulate('mouseDown');
+        });
+        wrapper.update();
+
+        assert.strictEqual(wrapper.find('.ripple-visible .child-leaving').length, 3);
+        assert.strictEqual(wrapper.find('.ripple-visible .child:not(.child-leaving)').length, 1);
+      });
+
+      it('should stop the ripple when dragging has finished', () => {
+        act(() => {
+          wrapper.simulate('dragEnd');
+        });
+        wrapper.update();
+
+        assert.strictEqual(wrapper.find('.ripple-visible .child-leaving').length, 4);
         assert.strictEqual(wrapper.find('.ripple-visible .child:not(.child-leaving)').length, 0);
       });
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

On chrome after a `mousedown` followed by a `mousemove`, `mouseup` won't fire on anchors.
Fixed by adding `dragend` listener to stop the riple.

Closes #15937
Closes #11696