### PR TITLE
Proper default argument assignment on makeStyles

### DIFF
--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -5,9 +5,7 @@ import {
   Styles,
   WithStylesOptions,
 } from '@material-ui/styles/withStyles';
-
-// https://stackoverflow.com/a/49928360/3406963 without generic branch types
-export type IsAny<T> = 0 extends (1 & T) ? true : false;
+import { IsAny } from '@material-ui/types';
 
 export type Or<A, B, C = false> = A extends true
   ? true

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -69,7 +69,7 @@ export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> exten
 
 export default function makeStyles<
   Theme = unknown,
-  Props extends {} = any,
+  Props extends {} = unknown,
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -30,12 +30,10 @@ export type And<A, B, C = true> = A extends true
  * 1. false if the given type has any members
  * 2. false if the type is `object` which is the only other type with no members
  *  {} is a top type so e.g. `string extends {}` but not `string extends object`
- * 3. false if the given type is `unknown`
  */
 export type IsEmptyInterface<T> = And<
   keyof T extends never ? true : false,
-  string extends T ? true : false,
-  unknown extends T ? false : true
+  string extends T ? true : false
 >;
 
 /**
@@ -69,7 +67,7 @@ export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> exten
 
 export default function makeStyles<
   Theme = unknown,
-  Props extends {} = unknown,
+  Props extends {} = {},
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -5,7 +5,9 @@ import {
   Styles,
   WithStylesOptions,
 } from '@material-ui/styles/withStyles';
-import { IsAny } from '@material-ui/types';
+
+// https://stackoverflow.com/a/49928360/3406963 without generic branch types
+export type IsAny<T> = 0 extends (1 & T) ? true : false;
 
 export type Or<A, B, C = false> = A extends true
   ? true
@@ -30,10 +32,12 @@ export type And<A, B, C = true> = A extends true
  * 1. false if the given type has any members
  * 2. false if the type is `object` which is the only other type with no members
  *  {} is a top type so e.g. `string extends {}` but not `string extends object`
+ * 3. false if the given type is `unknown`
  */
 export type IsEmptyInterface<T> = And<
   keyof T extends never ? true : false,
-  string extends T ? true : false
+  string extends T ? true : false,
+  unknown extends T ? false : true
 >;
 
 /**
@@ -67,7 +71,7 @@ export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> exten
 
 export default function makeStyles<
   Theme = unknown,
-  Props extends {} = {},
+  Props extends object = {},
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -69,7 +69,7 @@ export type StylesHook<S extends Styles<any, any>> = StylesRequireProps<S> exten
 
 export default function makeStyles<
   Theme = unknown,
-  Props extends {} = {},
+  Props extends {} = any,
   ClassKey extends string = string
 >(
   styles: Styles<Theme, Props, ClassKey>,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
```
const useStyles = makeStyles({
    Uline: {
        textDecoration: 'underline',
    },
    circle: {
        listStyle: 'disc',
    },
});
```
### Currently

useStyles type will be `const useStyles: (props: {}) => Record<"Uline" | "circle", string>`

This is causing **TS2554: Expected 1 arguments, but got 0.** errors all over our codebase

### After

useStyles type will be `const useStyles: (props?: any) => Record<"Uline" | "circle", string>`