### PR TITLE
[core] Start the migration to makeStyles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ jobs:
               curl -X PUT --header "x-api-key: $CIRCLE_AWS_API_KEY" https://t6nulys5kl.execute-api.us-east-1.amazonaws.com/v1/persist-size-snapshot?build-id=$CIRCLE_BUILD_NUM
             else
               echo "pull request; let's run dangerJS"
-              yarn danger ci
+              yarn cross-env DANGER_DISABLE_TRANSPILATION=true danger ci
             fi
 workflows:
   version: 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -7,6 +7,7 @@
 /examples/preact/config
 /examples/preact/scripts
 /packages/babel-plugin-unwrap-createStyles/test/__fixtures__/
+/packages/babel-plugin-set-component-name/test/__fixtures__/
 /packages/material-ui-codemod/lib
 /packages/material-ui-codemod/src/*/*.test
 /packages/material-ui-codemod/src/*/*.test.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -53,13 +53,18 @@ module.exports = {
   presets: defaultPresets.concat(['@babel/preset-react']),
   plugins: [
     'babel-plugin-optimize-clsx',
+    'babel-plugin-set-component-name',
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
     '@babel/plugin-transform-runtime',
     // for IE 11 support
     '@babel/plugin-transform-object-assign',
   ],
-  ignore: [/@babel[\\|/]runtime/], // Fix a Windows issue.
+  ignore: [
+    // Fix a Windows issue.
+    /@babel[\\|/]runtime/,
+    `${__dirname}/packages/babel-plugin-set-component-name/src`,
+  ],
   env: {
     cjs: {
       plugins: productionPlugins,

--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -96,12 +96,12 @@ async function buildDocs(options) {
     descriptions: {},
   };
 
-  if (component.styles && component.default.options) {
+  if (component.styles && component.muiDisplayName) {
     // Collect the customization points of the `classes` property.
     styles.classes = Object.keys(getStylesCreator(component.styles).create(theme)).filter(
       className => !className.match(/^(@media|@keyframes)/),
     );
-    styles.name = component.default.options.name;
+    styles.name = component.muiDisplayName;
 
     let styleSrc = src;
     // Exception for Select where the classes are imported from NativeSelect

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -101,9 +101,8 @@ function generatePropDescription(prop) {
   // Two new lines result in a newline in the table.
   // All other new lines must be eliminated to prevent markdown mayhem.
   const jsDocText = escapeCell(parsed.description)
-    .replace(/\n\n/g, '<br>')
-    .replace(/\n/g, ' ')
-    .replace(/\r/g, '');
+    .replace(/(\r?\n){2}/g, '<br>')
+    .replace(/\r?\n/g, ' ');
 
   if (parsed.tags.some(tag => tag.title === 'ignore')) {
     return null;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN",
-    "docs:api": "rimraf ./pages/api && cross-env BABEL_ENV=test babel-node ./docs/scripts/buildApi.js ./packages/material-ui/src ./pages/api && cross-env BABEL_ENV=test babel-node ./docs/scripts/buildApi.js ./packages/material-ui-lab/src ./pages/api",
+    "docs:api": "rimraf ./pages/api && cross-env BABEL_ENV=test BABEL_DISABLE_CACHE=1 babel-node ./docs/scripts/buildApi.js ./packages/material-ui/src ./pages/api && cross-env BABEL_ENV=test BABEL_DISABLE_CACHE=1 babel-node ./docs/scripts/buildApi.js ./packages/material-ui-lab/src ./pages/api",
     "docs:build": "rimraf .next && cross-env NODE_ENV=production BABEL_ENV=docs-production next build",
     "docs:build-sw": "node ./docs/scripts/buildServiceWorker.js",
     "docs:deploy": "git push material-ui-docs master:latest",
@@ -89,6 +89,7 @@
     "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.21",
     "babel-plugin-unwrap-createStyles": "link:packages/babel-plugin-unwrap-createStyles",
+    "babel-plugin-set-component-name": "link:packages/babel-plugin-set-component-name",
     "chai": "^4.1.2",
     "classnames": "^2.2.6",
     "clean-css": "^4.1.11",

--- a/packages/babel-plugin-set-component-name/package.json
+++ b/packages/babel-plugin-set-component-name/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "babel-plugin-set-component-name",
+  "private": true,
+  "version": "4.1.0",
+  "description": "TBD",
+  "main": "src/index.js",
+  "author": "Material-UI Team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui.git"
+  },
+  "bugs": {
+    "url": "https://github.com/mui-org/material-ui/issues"
+  },
+  "scripts": {
+    "test": "cd ../../ && cross-env NODE_ENV=test mocha packages/babel-plugin-set-component-name/test"
+  }
+}

--- a/packages/babel-plugin-set-component-name/src/index.js
+++ b/packages/babel-plugin-set-component-name/src/index.js
@@ -1,0 +1,52 @@
+module.exports = ({ template, types: t }) => {
+  function getDisplayName(paths) {
+    let name;
+
+    paths.some(nodePath => {
+      const { node } = nodePath;
+      if (
+        // componentName.propTypes = ...
+        t.isExpressionStatement(node) &&
+        t.isAssignmentExpression(node.expression, { operator: '=' }) &&
+        t.isMemberExpression(node.expression.left)
+      ) {
+        // componentName.propTypes
+        const expr = node.expression.left;
+        if (t.isIdentifier(expr.object) && t.isIdentifier(expr.property, { name: 'propTypes' })) {
+          name = `Mui${expr.object.name}`;
+
+          if (process.env.NODE_ENV !== 'production') {
+            nodePath.insertBefore(template.ast(`export const muiDisplayName = '${name}';`));
+          }
+          return true;
+        }
+      }
+      return false;
+    });
+
+    return name;
+  }
+
+  return {
+    visitor: {
+      Program(path, state) {
+        if (
+          // Skip files in node_modules
+          /node_modules/.test(state.filename) ||
+          // See if file contains prop-types import
+          !path.node.body.some(
+            node =>
+              t.isImportDeclaration(node) &&
+              t.isStringLiteral(node.source, { value: 'prop-types' }),
+          )
+        ) {
+          return;
+        }
+
+        const paths = path.get('body');
+
+        getDisplayName(paths);
+      },
+    },
+  };
+};

--- a/packages/babel-plugin-set-component-name/test/.gitattributes
+++ b/packages/babel-plugin-set-component-name/test/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf

--- a/packages/babel-plugin-set-component-name/test/__fixtures__/displayName/code.js
+++ b/packages/babel-plugin-set-component-name/test/__fixtures__/displayName/code.js
@@ -1,0 +1,8 @@
+import PropTypes from 'prop-types';
+
+const forwardRef = f => f;
+const AppBar = forwardRef(function AppBar() {});
+
+AppBar.propTypes = {
+  classes: PropTypes.object,
+};

--- a/packages/babel-plugin-set-component-name/test/__fixtures__/displayName/output.js
+++ b/packages/babel-plugin-set-component-name/test/__fixtures__/displayName/output.js
@@ -1,0 +1,9 @@
+import PropTypes from 'prop-types';
+
+const forwardRef = f => f;
+
+const AppBar = forwardRef(function AppBar() {});
+export const muiDisplayName = 'MuiAppBar';
+AppBar.propTypes = {
+  classes: PropTypes.object
+};

--- a/packages/babel-plugin-set-component-name/test/setComponentName.test.js
+++ b/packages/babel-plugin-set-component-name/test/setComponentName.test.js
@@ -1,0 +1,12 @@
+import pluginTester from 'babel-plugin-tester';
+import * as path from 'path';
+import setComponentName from '../src';
+
+pluginTester({
+  plugin: setComponentName,
+  pluginName: 'setComponentName',
+  fixtures: path.join(__dirname, '__fixtures__'),
+  babelOptions: {
+    root: __dirname,
+  },
+});

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -23,7 +23,7 @@ function getHasTransition(props) {
   return props.children ? props.children.props.hasOwnProperty('in') : false;
 }
 
-export const styles = theme => ({
+const styles = theme => ({
   /* Styles applied to the root element. */
   root: {
     position: 'fixed',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3094,6 +3094,10 @@ babel-plugin-react-require@3.0.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-react-require/-/babel-plugin-react-require-3.0.0.tgz#2e4e7b4496b93a654a1c80042276de4e4eeb20e3"
   integrity sha1-Lk57RJa5OmVKHIAEInbeTk7rIOM=
 
+"babel-plugin-set-component-name@link:packages/babel-plugin-set-component-name":
+  version "0.0.0"
+  uid ""
+
 "babel-plugin-styled-components@>= 1":
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

**Backstory**
In #15023 @oliviertassinari started migrating `Table` to use the new `makeStyles` API. For the tests and documentation to continue to work he made a `muiComponent` helper. That function allowed the tests to get the `useStyles` instance, and the docs to get the `className` and styles used. However the downside of this was overhead at runtime and more code.

**Goal**
The goal of this PR is to use a babel plugin to inject the information needed by the tests and docs without the runtime overhead. And then migrate the components to `makeStyles`

**Note**
Title is a work in progress, edits welcome

**Todo**
- [x] export `muiDisplayName`
- [ ] export `muiStylesOrCreator`
- [ ] Inject name in makeStyles automatically
- [ ] Start the migration to `makeStyles`