### PR TITLE
[docs] Improve the CssBaseline description

### DIFF
--- a/docs/src/pages/components/css-baseline/css-baseline.md
+++ b/docs/src/pages/components/css-baseline/css-baseline.md
@@ -42,8 +42,9 @@ which ensures that the declared width of the element is never exceeded due to pa
 
 ### Typography
 
-- Font antialiasing is enabled for better display of the Roboto font.
 - No base font-size is declared on the `<html>`, but 16px is assumed (the browser default).
 You can learn more about the implications of changing the `<html>` default font size in [the theme documentation](/customization/typography/#typography-html-font-size) page.
+- Set the `theme.typography.body2` style on the `<body>` element.
 - Set the font-weight to "bolder" for the `<b>` and `<strong>` elements.
   Bolder is one font weight heavier than the parent element (among the available weights of the font).
+- Font antialiasing is enabled for better display of the Roboto font.

--- a/packages/material-ui/src/CssBaseline/CssBaseline.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.js
@@ -21,7 +21,7 @@ const useStyles = makeStyles(
       },
       body: {
         ...theme.typography.body2,
-	margin: 0, // Remove the margin in all browsers.
+        margin: 0, // Remove the margin in all browsers.
         color: theme.palette.text.primary,
         backgroundColor: theme.palette.background.default,
         '@media print': {

--- a/packages/material-ui/src/CssBaseline/CssBaseline.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.js
@@ -20,9 +20,9 @@ const useStyles = makeStyles(
         fontWeight: 'bolder',
       },
       body: {
-        margin: 0, // Remove the margin in all browsers.
-        color: theme.palette.text.primary,
         ...theme.typography.body2,
+	margin: 0, // Remove the margin in all browsers.
+        color: theme.palette.text.primary,
         backgroundColor: theme.palette.background.default,
         '@media print': {
           // Save printer ink.

--- a/packages/material-ui/src/CssBaseline/CssBaseline.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.js
@@ -20,9 +20,9 @@ const useStyles = makeStyles(
         fontWeight: 'bolder',
       },
       body: {
-        ...theme.typography.body2,
         margin: 0, // Remove the margin in all browsers.
         color: theme.palette.text.primary,
+        ...theme.typography.body2,
         backgroundColor: theme.palette.background.default,
         '@media print': {
           // Save printer ink.

--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -33,7 +33,6 @@ export default function createTypography(palette, typography) {
   const coef = fontSize / 14;
   const pxToRem = size => `${(size / htmlFontSize) * coef}rem`;
   const buildVariant = (fontWeight, size, lineHeight, letterSpacing, casing) => ({
-    // color: palette.text.primary,
     fontFamily,
     fontWeight,
     fontSize: pxToRem(size),


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fixes bug in CssBaseline where spreading `theme.typography.body2` attributes overwrites default body font colors (if they exist on `body2` for some reason).
