### PR TITLE
[docs] Lowercase text to demo text-transform

### DIFF
--- a/docs/src/pages/customization/components/ClassesShorthand.js
+++ b/docs/src/pages/customization/components/ClassesShorthand.js
@@ -20,5 +20,5 @@ const StyledButton = withStyles({
 })(Button);
 
 export default function ClassesShorthand() {
-  return <StyledButton>Classes Shorthand</StyledButton>;
+  return <StyledButton>classes shorthand</StyledButton>;
 }

--- a/docs/src/pages/customization/components/ClassesShorthand.tsx
+++ b/docs/src/pages/customization/components/ClassesShorthand.tsx
@@ -20,5 +20,5 @@ const StyledButton = withStyles({
 })(Button);
 
 export default function ClassesShorthand() {
-  return <StyledButton>Classes Shorthand</StyledButton>;
+  return <StyledButton>classes shorthand</StyledButton>;
 }


### PR DESCRIPTION

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

The [current docs](https://material-ui.com/customization/components/#shorthand) apply `text-transform: capitalize` to already title-cased text. Following the earlier example, this makes the html text lowercase to show that the customisation is having an impact.
