### PR TITLE
[system] Add remaining flexbox properties

### DIFF
--- a/packages/material-ui-system/src/flexbox.js
+++ b/packages/material-ui-system/src/flexbox.js
@@ -1,6 +1,10 @@
 import style from './style';
 import compose from './compose';
 
+export const flexBasis = style({
+  prop: 'flexBasis',
+});
+
 export const flexDirection = style({
   prop: 'flexDirection',
 });
@@ -41,7 +45,16 @@ export const alignSelf = style({
   prop: 'alignSelf',
 });
 
+export const justifyItems = style({
+  prop: 'justifyItems',
+});
+
+export const justifySelf = style({
+  prop: 'justifySelf',
+});
+
 const flexbox = compose(
+  flexBasis,
   flexDirection,
   flexWrap,
   justifyContent,
@@ -52,6 +65,8 @@ const flexbox = compose(
   flexGrow,
   flexShrink,
   alignSelf,
+  justifyItems,
+  justifySelf,
 );
 
 export default flexbox;

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -65,6 +65,7 @@ export const display: SimpleStyleFunction<
 export type DisplayProps = PropsFor<typeof display>;
 
 export const flexbox: SimpleStyleFunction<
+  | 'flexBasis'
   | 'flexDirection'
   | 'flexWrap'
   | 'justifyContent'
@@ -75,6 +76,8 @@ export const flexbox: SimpleStyleFunction<
   | 'flexGrow'
   | 'flexShrink'
   | 'alignSelf'
+  | 'justifyItems'
+  | 'justifySelf'
 >;
 export type FlexboxProps = PropsFor<typeof flexbox>;
 


### PR DESCRIPTION
Closes #15876

Now `@material-ui/system` has support of all flexbox properties.