### PR TITLE
[core] Fix yarn docs:api removing <br> tags on windows

### DIFF
--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -101,9 +101,8 @@ function generatePropDescription(prop) {
   // Two new lines result in a newline in the table.
   // All other new lines must be eliminated to prevent markdown mayhem.
   const jsDocText = escapeCell(parsed.description)
-    .replace(/\n\n/g, '<br>')
-    .replace(/\n/g, ' ')
-    .replace(/\r/g, '');
+    .replace(/(\r?\n){2}/g, '<br>')
+    .replace(/\r?\n/g, ' ');
 
   if (parsed.tags.some(tag => tag.title === 'ignore')) {
     return null;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Properly handle line endings on windows

Extracted from #16146

Closes #15657