### PR TITLE
[system] Add support for marginX, marginY, paddingX, and paddingY

### DIFF
--- a/docs/src/pages/system/spacing/spacing.md
+++ b/docs/src/pages/system/spacing/spacing.md
@@ -109,9 +109,14 @@ import { spacing } from '@material-ui/system';
 | `spacing` | `px` | `padding-left`, `padding-right` | [`spacing`](/customization/default-theme/?expend-path=$.spacing) |
 | `spacing` | `py` | `padding-top`, `padding-bottom` | [`spacing`](/customization/default-theme/?expend-path=$.spacing) |
 
-*Some people find the property shorthand confusing, you can use the full version if you prefer:*
+*Some people find the prop shorthand confusing, you can use the full version if you prefer:*
 
 ```diff
 -<Box pt={2} />
 +<Box paddingTop={2} />
+```
+
+```diff
+-<Box px={2} />
++<Box paddingX={2} />
 ```

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -130,15 +130,19 @@ export const spacing: SimpleStyleFunction<
   | 'px'
   | 'py'
   | 'margin'
-  | 'marginLeft'
   | 'marginTop'
   | 'marginRight'
   | 'marginBottom'
+  | 'marginLeft'
+  | 'marginX'
+  | 'marginY'
   | 'padding'
   | 'paddingTop'
   | 'paddingRight'
   | 'paddingBottom'
   | 'paddingLeft'
+  | 'paddingX'
+  | 'paddingY'
 >;
 export type SpacingProps = PropsFor<typeof spacing>;
 

--- a/packages/material-ui-system/src/spacing.js
+++ b/packages/material-ui-system/src/spacing.js
@@ -18,33 +18,24 @@ const directions = {
   y: ['Top', 'Bottom'],
 };
 
+const aliases = {
+  marginX: 'mx',
+  marginY: 'my',
+  paddingX: 'px',
+  paddingY: 'py',
+};
+
 // memoize() impact:
 // From 300,000 ops/sec
 // To 350,000 ops/sec
 const getCssProperties = memoize(prop => {
-  switch (prop) {
-    case 'marginX':
-      prop = 'mx';
-      break;
-
-    case 'marginY':
-      prop = 'mx';
-      break;
-
-    case 'paddingX':
-      prop = 'px';
-      break;
-
-    case 'paddingY':
-      prop = 'py';
-      break;
-
-    default:
-  }
-
   // It's not a shorthand notation.
   if (prop.length > 2) {
-    return [prop];
+    if (aliases[prop]) {
+      prop = aliases[prop];
+    } else {
+      return [prop];
+    }
   }
 
   const [a, b] = prop.split('');

--- a/packages/material-ui-system/src/spacing.js
+++ b/packages/material-ui-system/src/spacing.js
@@ -22,8 +22,28 @@ const directions = {
 // From 300,000 ops/sec
 // To 350,000 ops/sec
 const getCssProperties = memoize(prop => {
+  switch (prop) {
+    case 'marginX':
+      prop = 'mx';
+      break;
+
+    case 'marginY':
+      prop = 'mx';
+      break;
+
+    case 'paddingX':
+      prop = 'px';
+      break;
+
+    case 'paddingY':
+      prop = 'py';
+      break;
+
+    default:
+  }
+
   // It's not a shorthand notation.
-  if (prop.length > 3) {
+  if (prop.length > 2) {
     return [prop];
   }
 
@@ -49,15 +69,19 @@ const spacingKeys = [
   'px',
   'py',
   'margin',
-  'marginLeft',
   'marginTop',
   'marginRight',
   'marginBottom',
+  'marginLeft',
+  'marginX',
+  'marginY',
   'padding',
   'paddingTop',
   'paddingRight',
   'paddingBottom',
   'paddingLeft',
+  'paddingX',
+  'paddingY',
 ];
 
 function getTransformer(theme) {
@@ -130,7 +154,7 @@ function spacing(props) {
 
   return Object.keys(props)
     .map(prop => {
-      // Using a hash computation over an array iteration could be faster, but with only 14 items,
+      // Using a hash computation over an array iteration could be faster, but with only 28 items,
       // it's doesn't worth the bundle size.
       if (spacingKeys.indexOf(prop) === -1) {
         return null;

--- a/packages/material-ui-system/src/spacing.test.js
+++ b/packages/material-ui-system/src/spacing.test.js
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import spacing from './spacing';
 
-describe('spacing', () => {
+describe.only('spacing', () => {
   describe('themeTransformer', () => {
     it('should have a default unit value', () => {
       const output = spacing({
@@ -157,11 +157,19 @@ describe('spacing', () => {
   });
 
   it('should support full version', () => {
-    const output = spacing({
+    const output1 = spacing({
       theme: {},
       paddingTop: 1,
     });
-    assert.deepEqual(output, {
+    assert.deepEqual(output1, {
+      paddingTop: 8,
+    });
+    const output2 = spacing({
+      theme: {},
+      paddingY: 1,
+    });
+    assert.deepEqual(output2, {
+      paddingBottom: 8,
       paddingTop: 8,
     });
   });

--- a/packages/material-ui-system/src/spacing.test.js
+++ b/packages/material-ui-system/src/spacing.test.js
@@ -2,7 +2,7 @@ import { assert } from 'chai';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import spacing from './spacing';
 
-describe.only('spacing', () => {
+describe('spacing', () => {
   describe('themeTransformer', () => {
     it('should have a default unit value', () => {
       const output = spacing({


### PR DESCRIPTION
I strongly prefer not using the "single letter" shorthand for clarity's sake.  That said.. I do really like the `mx`, `my`, `px`, `py` concepts.  I tried to change as little as possible to accomplish this.  Thoughts?