### PR TITLE
[styles] Use react-jss hook API internally

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,2 @@
---install.frozen-lockfile true
+
 network-timeout 150000

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -33,8 +33,8 @@ function handleClick(event) {
 
 let bound = false;
 
-class GoogleAnalytics extends React.Component {
-  componentDidMount() {
+export default function GoogleAnalytics() {
+  React.useEffect(() => {
     // Wait for the title to be updated.
     setTimeout(() => {
       const { canonical } = pathnameToLanguage(window.location.pathname);
@@ -47,11 +47,7 @@ class GoogleAnalytics extends React.Component {
     }
     bound = true;
     document.addEventListener('click', handleClick);
-  }
+  }, []);
 
-  render() {
-    return null;
-  }
+  return null;
 }
-
-export default GoogleAnalytics;

--- a/examples/gatsby/plugins/gatsby-plugin-top-layout/TopLayout.js
+++ b/examples/gatsby/plugins/gatsby-plugin-top-layout/TopLayout.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
-import CssBaseline from '@material-ui/core/CssBaseline';
 import { ThemeProvider } from '@material-ui/styles';
 import theme from '../../src/theme';
 
@@ -19,8 +18,6 @@ export default function TopLayout(props) {
         />
       </Helmet>
       <ThemeProvider theme={theme}>
-        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-        <CssBaseline />
         {props.children}
       </ThemeProvider>
     </React.Fragment>

--- a/examples/gatsby/src/components/ProTip.js
+++ b/examples/gatsby/src/components/ProTip.js
@@ -1,37 +1,18 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Link from '@material-ui/core/Link';
-import SvgIcon from '@material-ui/core/SvgIcon';
-import Typography from '@material-ui/core/Typography';
-
-function LightBulbIcon(props) {
-  return (
-    <SvgIcon {...props}>
-      <path d="M9 21c0 .55.45 1 1 1h4c.55 0 1-.45 1-1v-1H9v1zm3-19C8.14 2 5 5.14 5 9c0 2.38 1.19 4.47 3 5.74V17c0 .55.45 1 1 1h6c.55 0 1-.45 1-1v-2.26c1.81-1.27 3-3.36 3-5.74 0-3.86-3.14-7-7-7zm2.85 11.1l-.85.6V16h-4v-2.3l-.85-.6C7.8 12.16 7 10.63 7 9c0-2.76 2.24-5 5-5s5 2.24 5 5c0 1.63-.8 3.16-2.15 4.1z" />
-    </SvgIcon>
-  );
-}
 
 const useStyles = makeStyles(theme => ({
   root: {
     margin: theme.spacing(6, 0, 3),
-  },
-  lightBulb: {
-    verticalAlign: 'middle',
-    marginRight: theme.spacing(1),
   },
 }));
 
 export default function ProTip() {
   const classes = useStyles();
   return (
-    <Typography className={classes.root} color="textSecondary">
-      <LightBulbIcon className={classes.lightBulb} />
+    <div className={classes.root}>
       Pro tip: See more{' '}
-      <Link href="https://material-ui.com/getting-started/page-layout-examples/">
-        page layout examples
-      </Link>{' '}
       on the Material-UI documentation.
-    </Typography>
+    </div>
   );
 }

--- a/examples/gatsby/src/pages/index.js
+++ b/examples/gatsby/src/pages/index.js
@@ -1,36 +1,8 @@
 import React from 'react';
-import Container from '@material-ui/core/Container';
-import Typography from '@material-ui/core/Typography';
-import Box from '@material-ui/core/Box';
-import MuiLink from '@material-ui/core/Link';
 import ProTip from '../components/ProTip';
-import Link from '../components/Link';
-
-function MadeWithLove() {
-  return (
-    <Typography variant="body2" color="textSecondary" align="center">
-      {'Built with love by the '}
-      <MuiLink color="inherit" href="https://material-ui.com/">
-        Material-UI
-      </MuiLink>
-      {' team.'}
-    </Typography>
-  );
-}
 
 export default function App() {
   return (
-    <Container maxWidth="sm">
-      <Box my={4}>
-        <Typography variant="h4" component="h1" gutterBottom>
-          Gatsby v4-beta example
-        </Typography>
-        <Link to="/about" color="secondary">
-          Go to the about page
-        </Link>
-        <ProTip />
-        <MadeWithLove />
-      </Box>
-    </Container>
+    <ProTip />
   );
 }

--- a/next.config.js
+++ b/next.config.js
@@ -34,8 +34,8 @@ module.exports = withTypescript({
       );
     }
 
-    config.resolve.alias['react-dom$'] = 'react-dom/profiling';
-    config.resolve.alias['scheduler/tracing'] = 'scheduler/tracing-profiling';
+    // config.resolve.alias['react-dom$'] = 'react-dom/profiling';
+    // config.resolve.alias['scheduler/tracing'] = 'scheduler/tracing-profiling';
 
     return Object.assign({}, config, {
       plugins,

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "rollup-plugin-terser": "^5.0.0",
     "sinon": "^7.0.0",
     "size-limit": "^0.21.0",
-    "styled-components": "^4.1.1",
+    "styled-components": "^5.0.0-alpha.2",
     "tslint": "5.14.0",
     "typescript": "3.2.2",
     "url-loader": "^1.0.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -31,7 +31,7 @@ function loadDependencies() {
     'https://fonts.googleapis.com/icon?family=Material+Icons',
     document.querySelector('#material-icon-font'),
   );
-  loadScript('https://www.google-analytics.com/analytics.js', document.querySelector('head'));
+  // loadScript('https://www.google-analytics.com/analytics.js', document.querySelector('head'));
 }
 
 if (process.browser) {

--- a/pages/performance/table-emotion.js
+++ b/pages/performance/table-emotion.js
@@ -15,7 +15,7 @@ const createComponent = defaultComponent => {
   };
 
   return styled(MyComponent)`
-    background: pink;
+    background: ${props => props.x || 'pink'};
   `;
 };
 

--- a/pages/performance/table-hook.js
+++ b/pages/performance/table-hook.js
@@ -6,13 +6,15 @@ import NoSsr from '@material-ui/core/NoSsr';
 const createComponent = defaultComponent => {
   const useStyles = makeStyles({
     root: {
-      background: 'pink',
+      background: props => props.x,
     },
   });
 
   const MyComponent = React.forwardRef(function MyComponent(props, ref) {
     const { component: Component = defaultComponent, ...other } = props;
-    const classes = useStyles();
+    const classes = useStyles({
+      x: 'pink',
+    });
 
     return <Component ref={ref} {...other} className={classes.root} />;
   });
@@ -36,30 +38,32 @@ const rows = Array.from(new Array(100)).map(() => data);
 function TableHook() {
   return (
     <NoSsr defer>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Dessert (100g serving)</TableCell>
-            <TableCell>Calories</TableCell>
-            <TableCell>Fat&nbsp;(g)</TableCell>
-            <TableCell>Carbs&nbsp;(g)</TableCell>
-            <TableCell>Protein&nbsp;(g)</TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>
-          {rows.map((row, index) => (
-            <TableRow key={index}>
-              <TableCell component="th" scope="row">
-                {row.name}
-              </TableCell>
-              <TableCell>{row.calories}</TableCell>
-              <TableCell>{row.fat}</TableCell>
-              <TableCell>{row.carbs}</TableCell>
-              <TableCell>{row.protein}</TableCell>
+      <NoSsr defer>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>Dessert (100g serving)</TableCell>
+              <TableCell>Calories</TableCell>
+              <TableCell>Fat&nbsp;(g)</TableCell>
+              <TableCell>Carbs&nbsp;(g)</TableCell>
+              <TableCell>Protein&nbsp;(g)</TableCell>
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHead>
+          <TableBody>
+            {rows.map((row, index) => (
+              <TableRow key={index}>
+                <TableCell component="th" scope="row">
+                  {row.name}
+                </TableCell>
+                <TableCell>{row.calories}</TableCell>
+                <TableCell>{row.fat}</TableCell>
+                <TableCell>{row.carbs}</TableCell>
+                <TableCell>{row.protein}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </NoSsr>
     </NoSsr>
   );
 }

--- a/pages/performance/table-jss.js
+++ b/pages/performance/table-jss.js
@@ -1,22 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import { createUseStyles } from 'react-jss';
 import NoSsr from '@material-ui/core/NoSsr';
 
 const createComponent = defaultComponent => {
+  const useStyles = createUseStyles({
+    root: {
+      background: props => props.x,
+    },
+  });
+
   const MyComponent = React.forwardRef(function MyComponent(props, ref) {
     const { component: Component = defaultComponent, ...other } = props;
+    const classes = useStyles({
+      x: 'pink',
+    });
 
-    return <Component ref={ref} {...other} />;
+    return <Component ref={ref} {...other} className={classes.root} />;
   });
 
   MyComponent.propTypes = {
     component: PropTypes.elementType,
   };
 
-  return styled(MyComponent)`
-    background: ${props => props.x || 'pink'};
-  `;
+  return MyComponent;
 };
 
 const Table = createComponent('table');
@@ -28,7 +35,7 @@ const TableBody = createComponent('tbody');
 const data = { name: 'Frozen yoghurt', calories: 159, fat: 6.0, carbs: 24, protein: 4.0 };
 const rows = Array.from(new Array(100)).map(() => data);
 
-function TableStyledComponents() {
+function TableHook() {
   return (
     <NoSsr defer>
       <NoSsr defer>
@@ -61,4 +68,4 @@ function TableStyledComponents() {
   );
 }
 
-export default TableStyledComponents;
+export default TableHook;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,10 +1028,17 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
   integrity sha512-ojhgxzUHZ7am3D2jHkMzPpsBAiB005GF5YU4ea+8DNPybMk01JJUM9V9YRlF/GE95tcOm8DxQvWA2jq19bGalQ==
 
-"@emotion/is-prop-valid@0.7.3", "@emotion/is-prop-valid@^0.7.3":
+"@emotion/is-prop-valid@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
   integrity sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==
+  dependencies:
+    "@emotion/memoize" "0.7.1"
+
+"@emotion/is-prop-valid@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.1.tgz#6fb3ae2d24f07c8cd090f233e45771d9cd826d48"
+  integrity sha512-Wtaek/KGUP+HusWIa8DqtOR6U/Tl+QIdVkfJQHV3IT6ZImnJwklP5UVVPKZvkfljeFk3Q45CAPJ5N10gJ5XoLA==
   dependencies:
     "@emotion/memoize" "0.7.1"
 
@@ -7732,6 +7739,11 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
+is-what@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.2.3.tgz#50f76f1bd8e56967e15765d1d34302513701997b"
+  integrity sha512-c4syLgFnjXTH5qd82Fp/qtUIeM0wA69xbI0KH1QpurMIvDaZFrS8UtAa4U52Dc2qSznaMxHit0gErMp6A/Qk1w==
+
 is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
@@ -9032,6 +9044,13 @@ meow@^4.0.0:
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^2.0.0"
+
+merge-anything@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.2.5.tgz#37ef13f36359ee64f09c657d2cef45f7e29493f9"
+  integrity sha512-WgZGR7EQ1D8pyh57uKBbkPhUCJZLGdMzbDaxL4MDTJSGsvtpGdm8myr6DDtgJwT46xiFBlHqxbveDRpFBWlKWQ==
+  dependencies:
+    is-what "^3.2.3"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -12492,6 +12511,11 @@ shallow-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.1.0.tgz#cc022f030dcba0d1c198abf658a3c6c744e171ca"
   integrity sha512-0SW1nWo1hnabO62SEeHsl8nmTVVEzguVWZCj5gaQrgWAxz/BaCja4OWdJBWLVPDxdtE/WU7c98uUCCXyPHSCvw==
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -13076,19 +13100,18 @@ style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
-styled-components@^4.1.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.2.0.tgz#811fbbec4d64c7189f6c7482b9eb6fefa7fefef7"
-  integrity sha512-L/LzkL3ZbBhqIVHdR7DbYujy4tqvTNRfc+4JWDCYyhTatI+8CRRQUmdaR0+ARl03DWsfKLhjewll5uNLrqrl4A==
+styled-components@^5.0.0-alpha.2:
+  version "5.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.0.0-alpha.2.tgz#954ab995b8b3a5efed5403249c1014aa3432effb"
+  integrity sha512-8QkxaZDqy9duqhM15YJGdcA8hKToZqRvChkTYrCsArRK60lRCIDuyfpXWaZ9l3Ob8OAVAf9CZoYoMsUi5b40kg==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/is-prop-valid" "^0.7.3"
+    "@emotion/is-prop-valid" "^0.8.1"
     "@emotion/unitless" "^0.7.0"
     babel-plugin-styled-components ">= 1"
     css-to-react-native "^2.2.2"
-    memoize-one "^5.0.0"
-    prop-types "^15.5.4"
-    react-is "^16.6.0"
+    merge-anything "^2.2.5"
+    shallowequal "^1.1.0"
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
     supports-color "^5.5.0"


### PR DESCRIPTION
As we want to move toward a style adapter architecture (JSS, styled-components, etc) #16238, the more we can depend on the existing style solutions, the better. @kof and his team have done a great job with their new react-jss hook API. it's x2 faster for dynamic props than what we have, and only ~25% slower than styled-components. It should solve most of the problems in 
- #15511 (@jmdsg)
- #16111 (@city41)
- #16316 (@NickCis)