### PR TITLE
[styles] Fix react-hot-loader regression

### DIFF
--- a/packages/material-ui-styles/src/makeStyles/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.js
@@ -161,20 +161,16 @@ function detach({ state, theme, stylesOptions, stylesCreator }) {
 }
 
 function useSynchronousEffect(func, values) {
-  const ref = React.useRef([]);
+  const key = React.useRef([]);
   let output;
 
-  if (ref.current.length !== values.length) {
-    ref.current = values;
+  // Store "generation" key. Just returns a new object every time
+  const currentKey = React.useMemo(() => ({}), values); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // "the first render", or "memo dropped the value"
+  if (key.current !== currentKey) {
+    key.current = currentKey;
     output = func();
-  } else {
-    for (let i = 0; i < values.length; i += 1) {
-      if (values[i] !== ref.current[i]) {
-        ref.current = values;
-        output = func();
-        break;
-      }
-    }
   }
 
   React.useEffect(
@@ -183,7 +179,7 @@ function useSynchronousEffect(func, values) {
         output();
       }
     },
-    values, // eslint-disable-line react-hooks/exhaustive-deps
+    [currentKey], // eslint-disable-line react-hooks/exhaustive-deps
   );
 }
 


### PR DESCRIPTION
I have spent the afternoon/evening trying to migrate to react-jss's `createUseStyles` instead of us having to maintain the logic.
However, I'm short on time. It will be more challenging than I first thought. There are a couple of problems to solve, but it will worth it. I have benchmarked a x2 boost when using dynamic style functions.

Instead, I'm going with the "quick-win" approach proposed by @theKashey. Thanks! The logic looks simpler.

Closes #15999

I will continue the react-jss effort migration once this is fixed.