### PR TITLE
[docs] Convert SideEffects to hooks

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -140,9 +140,6 @@ function Demo(props) {
 
   function handleCodeLanguageClick(event, clickedCodeVariant) {
     if (codeVariant !== clickedCodeVariant) {
-      document.cookie = `codeVariant=${clickedCodeVariant};path=/;max-age=31536000`;
-      window.ga('set', 'dimension1', clickedCodeVariant);
-
       dispatch({
         type: ACTION_TYPES.OPTIONS_CHANGE,
         payload: {


### PR DESCRIPTION
Also moves persistence and tracking into a single place. IMO those things should always listen to committed changes not to queued changes i.e. submit a tracking event after the store value changed (and async) not before (and in sync).

Switching the code variant is now async instead of sync. If we want to display TS (navigation or cookie) you will get a flash of content anyway. Since the demos are most of the time hidden we can deprioritize them.