### PR TITLE
[docs] Remove import if there are no specifiers left

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "babel-plugin-optimize-clsx": "^2.1.0",
     "babel-plugin-preval": "^2.0.0",
     "babel-plugin-react-remove-properties": "^0.3.0",
-    "babel-plugin-tester": "^5.5.1",
+    "babel-plugin-tester": "^6.4.0",
     "babel-plugin-transform-dev-warning": "^0.1.0",
     "babel-plugin-transform-react-constant-elements": "^6.23.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.21",

--- a/packages/babel-plugin-unwrap-createStyles/src/unwrapCreateStyles.js
+++ b/packages/babel-plugin-unwrap-createStyles/src/unwrapCreateStyles.js
@@ -18,7 +18,7 @@ function isCreateStylesCall({ callee }) {
  *
  * @param {babel.types.ImportSpecifier} param0
  */
-function isCreateStylesImportSepcifier({ imported }) {
+function isCreateStylesImportSpecifier({ imported }) {
   return imported.name === 'createStyles';
 }
 
@@ -42,8 +42,12 @@ module.exports = function unwrapCreateStyles({ types: t }) {
         }
       },
       ImportSpecifier(path) {
-        if (isImportFromStyles(path.parent) && isCreateStylesImportSepcifier(path.node)) {
+        if (isImportFromStyles(path.parent) && isCreateStylesImportSpecifier(path.node)) {
           path.remove();
+
+          if (path.parent.specifiers.length === 0) {
+            path.parentPath.remove();
+          }
         }
       },
     },

--- a/packages/babel-plugin-unwrap-createStyles/test/.gitattributes
+++ b/packages/babel-plugin-unwrap-createStyles/test/.gitattributes
@@ -1,1 +1,0 @@
-*.js text eol=lf

--- a/packages/babel-plugin-unwrap-createStyles/test/__fixtures__/remove-import/code.js
+++ b/packages/babel-plugin-unwrap-createStyles/test/__fixtures__/remove-import/code.js
@@ -1,0 +1,3 @@
+import { createStyles } from '@material-ui/core/styles';
+
+const styles = createStyles({});

--- a/packages/babel-plugin-unwrap-createStyles/test/__fixtures__/remove-import/output.js
+++ b/packages/babel-plugin-unwrap-createStyles/test/__fixtures__/remove-import/output.js
@@ -1,0 +1,1 @@
+const styles = {};

--- a/packages/babel-plugin-unwrap-createStyles/test/unwrapCreateStyles.test.js
+++ b/packages/babel-plugin-unwrap-createStyles/test/unwrapCreateStyles.test.js
@@ -5,6 +5,7 @@ import unwrapCreateStylesPlugin from '../src';
 pluginTester({
   plugin: unwrapCreateStylesPlugin,
   pluginName: 'unwrapCreateStylesPlugin',
+  endOfLine: 'preserve',
   fixtures: path.join(__dirname, '__fixtures__'),
   babelOptions: {
     root: __dirname,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3109,14 +3109,14 @@ babel-plugin-syntax-jsx@6.18.0, babel-plugin-syntax-jsx@^6.18.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
   integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
-babel-plugin-tester@^5.5.1:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-tester/-/babel-plugin-tester-5.5.2.tgz#593ab7978d30450c1b3ebf4aa9c884b04952fe09"
-  integrity sha512-Ycsy0wTxKZtKagDYGzuB5YlaY6nmKmbgOvPoEcrRvDLTpMEQZuD3mc+MZ7pO7TG18E2pEJRjRWv6h7FJmbe6rQ==
+babel-plugin-tester@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-tester/-/babel-plugin-tester-6.4.0.tgz#cdbc430794c375bf4c207a0287a00a68346529e9"
+  integrity sha512-Eyr6YmDuKRStZX6Jamv+C0IW40RxiJLJb6ogaf0jNcIwZ+/r9Nq2vaDUTZgWLps+bQBMTmn6rtHD3zJQecF3nA==
   dependencies:
     common-tags "^1.4.0"
     invariant "^2.2.2"
-    lodash.merge "^4.6.0"
+    lodash.mergewith "^4.6.0"
     path-exists "^3.0.0"
     strip-indent "^2.0.0"
 
@@ -8634,10 +8634,10 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.merge@^4.6.0:
+lodash.mergewith@^4.6.0:
   version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
-  integrity sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==
+  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
+  integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
 
 lodash.omit@^4.5.0:
   version "4.5.0"


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Upgrade `babel-plugin-tester` -> don't need to force `lf` in `.gitattributes` anymore, which did nothing when adding files manually
* Remove import if there are no specifiers left
* Corrected a typo

Required for (at least) `docs/src/pages/customization/components/DynamicInlineStyle.js` to be migrated to TypeScript