### PR TITLE
[styles] Make StyleRules backwards compatible

### DIFF
--- a/docs/src/pages/customization/components/DynamicInlineStyle.js
+++ b/docs/src/pages/customization/components/DynamicInlineStyle.js
@@ -2,7 +2,6 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
-import '@material-ui/core/styles';
 
 const styles = {
   button: {

--- a/docs/src/pages/customization/components/DynamicInlineStyle.tsx
+++ b/docs/src/pages/customization/components/DynamicInlineStyle.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import Button from '@material-ui/core/Button';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
-import '@material-ui/core/styles';
+import { createStyles } from '@material-ui/core/styles';
 
-const styles = {
+const styles = createStyles({
   button: {
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
     borderRadius: 3,
@@ -18,12 +18,12 @@ const styles = {
     background: 'linear-gradient(45deg, #2196f3 30%, #21cbf3 90%)',
     boxShadow: '0 3px 5px 2px rgba(33, 203, 243, .30)',
   },
-};
+});
 
 export default function DynamicInlineStyle() {
   const [color, setColor] = React.useState('default');
 
-  const handleChange = event => {
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setColor(event.target.checked ? 'blue' : 'default');
   };
 

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -5,38 +5,7 @@ import {
   Styles,
   WithStylesOptions,
 } from '@material-ui/styles/withStyles';
-import { IsAny, Omit } from '@material-ui/types';
-
-export type Or<A, B, C = false> = A extends true
-  ? true
-  : B extends true
-  ? true
-  : C extends true
-  ? true
-  : false;
-export type And<A, B, C = true> = A extends true
-  ? B extends true
-    ? C extends true
-      ? true
-      : false
-    : false
-  : false;
-
-/**
- * @internal
- *
- * check if a type is `{}`
- *
- * 1. false if the given type has any members
- * 2. false if the type is `object` which is the only other type with no members
- *  {} is a top type so e.g. `string extends {}` but not `string extends object`
- * 3. false if the given type is `unknown`
- */
-export type IsEmptyInterface<T> = And<
-  keyof T extends never ? true : false,
-  string extends T ? true : false,
-  unknown extends T ? false : true
->;
+import { Omit, IsAny, Or, IsEmptyInterface } from '@material-ui/types';
 
 /**
  * @internal

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PropInjector, CoerceEmptyInterface } from '@material-ui/types';
+import { PropInjector, CoerceEmptyInterface, IsEmptyInterface } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 
@@ -32,7 +32,9 @@ export interface CreateCSSProperties<Props extends object = {}>
  */
 export type StyleRules<Props extends object = {}, ClassKey extends string = string> = Record<
   ClassKey,
-  CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
+  IsEmptyInterface<Props> extends true
+    ? CSSProperties | (() => CSSProperties)
+    : CreateCSSProperties<Props> | ((props: Props) => CreateCSSProperties<Props>)
 >;
 
 /**

--- a/packages/material-ui-styles/test/IsEmptyInterface.spec.ts
+++ b/packages/material-ui-styles/test/IsEmptyInterface.spec.ts
@@ -1,7 +1,7 @@
 /**
  * unit testing for IsEmptyInterface utility type
  */
-import { IsEmptyInterface } from '@material-ui/styles/makeStyles';
+import { IsEmptyInterface } from '@material-ui/types';
 
 // $ExpectType true
 type EmptyInterfaceIsValid = IsEmptyInterface<{}>;

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -449,3 +449,33 @@ function forwardRefTest() {
   // $ExpectType string
   const root2 = styles.root2;
 }
+
+{
+  // If there are no props, use the definition that doesn't accept them
+  // https://github.com/mui-org/material-ui/issues/16198
+
+  // $ExpectType Record<"root", CSSProperties | (() => CSSProperties)>
+  const styles = createStyles({
+    root: {
+      width: 1,
+    },
+  });
+
+  // $ExpectType Record<"root", CSSProperties | (() => CSSProperties)>
+  const styles2 = createStyles({
+    root: () => ({
+      width: 1,
+    }),
+  });
+
+  interface testProps {
+    foo: boolean;
+  }
+
+  // $ExpectType Record<"root", CreateCSSProperties<testProps> | ((props: testProps) => CreateCSSProperties<testProps>)>
+  const styles3 = createStyles({
+    root: (props: testProps) => ({
+      width: 1,
+    }),
+  });
+}

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -55,3 +55,35 @@ export type IsAny<T> = 0 extends (1 & T) ? true : false;
  * Returns an empty object type if T is any, otherwise returns T
  */
 export type CoerceEmptyInterface<T> = IsAny<T> extends true ? {} : T;
+
+export type Or<A, B, C = false> = A extends true
+  ? true
+  : B extends true
+  ? true
+  : C extends true
+  ? true
+  : false;
+
+export type And<A, B, C = true> = A extends true
+  ? B extends true
+    ? C extends true
+      ? true
+      : false
+    : false
+  : false;
+
+/**
+ * @internal
+ *
+ * check if a type is `{}`
+ *
+ * 1. false if the given type has any members
+ * 2. false if the type is `object` which is the only other type with no members
+ *  {} is a top type so e.g. `string extends {}` but not `string extends object`
+ * 3. false if the given type is `unknown`
+ */
+export type IsEmptyInterface<T> = And<
+  keyof T extends never ? true : false,
+  string extends T ? true : false,
+  unknown extends T ? false : true
+>;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Move some types out to `@material-ui/types`
* If props is an empty interface default types to `CSSProperties`
* Add typescript version of `customization/components/DynamicInlineStyle`

~Blocked by #16199~

Closes #16198