### PR TITLE
[docs] Demo MenuList composition: remove keepMounted prop

### DIFF
--- a/docs/src/pages/components/menus/MenuListComposition.tsx
+++ b/docs/src/pages/components/menus/MenuListComposition.tsx
@@ -54,7 +54,7 @@ export default function MenuListComposition() {
         >
           Toggle Menu Grow
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} keepMounted transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}


### PR DESCRIPTION
The prop keepMounted used on Popper component breaks layout. If you open the Popper and close it again it causes the first MenuList to grow in size as Popper component still takes space in layout after it has been closed. Is it really necessary to use keepMounted?

https://codesandbox.io/s/material-demo-rmu1d?fontsize=14 (without keepMounted)
https://codesandbox.io/s/material-demo-d4l80?fontsize=14 (with keepMounted ) 

