### PR TITLE
[ci] Use sinon browser build

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -62,14 +62,20 @@ module.exports = function setKarmaConfig(config) {
           {
             test: /\.js$/,
             loader: 'babel-loader',
-            // https://github.com/sinonjs/sinon/issues/1951
-            exclude: /node_modules(\\|\/)(?!(sinon)(\\|\/)).*/,
+            exclude: /node_modules/,
           },
         ],
       },
       node: {
         // Some tests import fs
         fs: 'empty',
+      },
+      resolve: {
+        alias: {
+          // https://github.com/sinonjs/sinon/issues/1951
+          // use the cdn main field. module nor main are supported for browserbuilds
+          sinon: 'sinon/pkg/sinon.js',
+        },
       },
     },
     webpackServer: {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -73,7 +73,7 @@ module.exports = function setKarmaConfig(config) {
       resolve: {
         alias: {
           // https://github.com/sinonjs/sinon/issues/1951
-          // use the cdn main field. module nor main are supported for browserbuilds
+          // use the cdn main field. Neither module nor main are supported for browserbuilds
           sinon: 'sinon/pkg/sinon.js',
         },
       },


### PR DESCRIPTION
Use webpack alias instead of transpiling the full sinon build. Bundling time went down to 26s from 62s locally. CI only takes 36s so we'll see how much faster that is. Should be at least 10s.