### PR TITLE
[styles] Swap generic types of styled function for accessing props

### DIFF
--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -15,8 +15,8 @@ import * as React from 'react';
  * @internal
  */
 export type ComponentCreator<Component extends React.ElementType> = <
-  Theme = DefaultTheme,
-  Props extends {} = any
+  Props extends {} = any,
+  Theme = DefaultTheme
 >(
   styles:
     | CreateCSSProperties<Props>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

#16133 added typings for the `styled`-based styling solution. However, if we want to access the **props** given to the component, currently, we also need to specify the `Theme` type before we can specify the properties type, like:

```
import { Button } from "@material-ui/core"
import { styled, Theme } from "@material-ui/core/styles"
import { Color } from "csstype"

type Props = {
	color: Color
}

const StyledButton = styled(Button)<Theme, Props>({
	color: props => props.color
})
```

Since `Theme` will always be of the same type (and, if one wants to add more properties to it, [module augmentation](https://material-ui.com/guides/typescript/#customization-of-theme) can be used), it makes sense to swap the generic types (declared in `ComponentCreator`), so we only have to specify the properties type:

```
import { Button } from "@material-ui/core"
import { styled } from "@material-ui/core/styles"
import { Color } from "csstype"

type Props = {
	color: Color
}

const StyledButton = styled(Button)<Props>({
	color: props => props.color
})
```