### PR TITLE
[InputLabel] Fix shrunk label click not focusing input

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -115,6 +115,11 @@ export const styles = theme => {
       '&$disabled': {
         opacity: 1, // Reset iOS opacity
       },
+      '&:-webkit-autofill': {
+        // hack to disable background-color. By making the transition slow we
+        // create the illusion no background-color is applied at all
+        'transition-delay': '4815162342s',
+      },
     },
     /* Styles applied to the `input` element if `margin="dense"`. */
     inputMarginDense: {

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -54,11 +54,15 @@ export const styles = theme => ({
     // the input field is drawn last and hides the label with an opaque background color.
     // zIndex: 1 will raise the label above opaque background-colors of input.
     zIndex: 1,
+    // zIndex will change the cursor. use the cursor the would've been displayed
+    // without the zIndex
+    cursor: 'text',
     transform: 'translate(12px, 20px) scale(1)',
     '&$marginDense': {
       transform: 'translate(12px, 17px) scale(1)',
     },
     '&$shrink': {
+      cursor: 'default',
       transform: 'translate(12px, 10px) scale(0.75)',
       '&$marginDense': {
         transform: 'translate(12px, 7px) scale(0.75)',
@@ -69,11 +73,13 @@ export const styles = theme => ({
   outlined: {
     // see comment above on filled.zIndex
     zIndex: 1,
+    cursor: 'text',
     transform: 'translate(14px, 20px) scale(1)',
     '&$marginDense': {
       transform: 'translate(14px, 12px) scale(1)',
     },
     '&$shrink': {
+      cursor: 'default',
       transform: 'translate(14px, -6px) scale(0.75)',
     },
   },

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -54,7 +54,6 @@ export const styles = theme => ({
     // the input field is drawn last and hides the label with an opaque background color.
     // zIndex: 1 will raise the label above opaque background-colors of input.
     zIndex: 1,
-    pointerEvents: 'none',
     transform: 'translate(12px, 20px) scale(1)',
     '&$marginDense': {
       transform: 'translate(12px, 17px) scale(1)',
@@ -70,7 +69,6 @@ export const styles = theme => ({
   outlined: {
     // see comment above on filled.zIndex
     zIndex: 1,
-    pointerEvents: 'none',
     transform: 'translate(14px, 20px) scale(1)',
     '&$marginDense': {
       transform: 'translate(14px, 12px) scale(1)',

--- a/packages/material-ui/src/InputLabel/InputLabel.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.js
@@ -49,20 +49,11 @@ export const styles = theme => ({
   },
   /* Styles applied to the root element if `variant="filled"`. */
   filled: {
-    // Chrome's autofill feature gives the input field a yellow background.
-    // Since the input field is behind the label in the HTML tree,
-    // the input field is drawn last and hides the label with an opaque background color.
-    // zIndex: 1 will raise the label above opaque background-colors of input.
-    zIndex: 1,
-    // zIndex will change the cursor. use the cursor the would've been displayed
-    // without the zIndex
-    cursor: 'text',
     transform: 'translate(12px, 20px) scale(1)',
     '&$marginDense': {
       transform: 'translate(12px, 17px) scale(1)',
     },
     '&$shrink': {
-      cursor: 'default',
       transform: 'translate(12px, 10px) scale(0.75)',
       '&$marginDense': {
         transform: 'translate(12px, 7px) scale(0.75)',
@@ -71,15 +62,11 @@ export const styles = theme => ({
   },
   /* Styles applied to the root element if `variant="outlined"`. */
   outlined: {
-    // see comment above on filled.zIndex
-    zIndex: 1,
-    cursor: 'text',
     transform: 'translate(14px, 20px) scale(1)',
     '&$marginDense': {
       transform: 'translate(14px, 12px) scale(1)',
     },
     '&$shrink': {
-      cursor: 'default',
       transform: 'translate(14px, -6px) scale(0.75)',
     },
   },


### PR DESCRIPTION
Reverts #13040 but should not regress from #12997

Fixes clicking shrunk labels not focusing their associated input: https://deploy-preview-16215--material-ui.netlify.com/components/text-fields/#outlined

I think the issue with #12997 was that the label was not associated with the input. `pointer-events: none` fixed the apparent issue but hides a deeper issue with the a11y of the text field. 

We should optimize for proper a11y setups in which a click on a shrunk label would not focus the text field. Depending on the layout `pointer-events: none` could prevent the default label-input UX.

Would like some feedback about the new cursor logic. I'd be fine without cursor: text trickery. Problem without cursor: text the cursor behaves different on outlined vs standard text fields. But with it you get a short flash when clicking on shrunk labels.

TODO:
- [ ] Need to figure out hover styles.