### PR TITLE
[core] Change <> to <React.Fragment>

### DIFF
--- a/packages/material-ui-styles/test/index.spec.tsx
+++ b/packages/material-ui-styles/test/index.spec.tsx
@@ -177,9 +177,9 @@ import styled, { StyledProps } from '@material-ui/styles/styled';
     }),
   );
   const renderedMyComponent = (
-    <>
+    <React.Fragment>
       <MyComponent className="test" />
       <StyledMyComponent theme={MyThemeInstance} />
-    </>
+    </React.Fragment>
   );
 }

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -969,7 +969,7 @@ const ClickAwayListenerComponentTest = () => (
 );
 
 const TransitionTest = () => (
-  <>
+  <React.Fragment>
     <Fade in={false}>
       <div />
     </Fade>
@@ -979,7 +979,7 @@ const TransitionTest = () => (
     <Grow in={false} timeout="auto" onEnter={() => {}}>
       <div />
     </Grow>
-  </>
+  </React.Fragment>
 );
 
 const BackdropTest = () => <Backdrop open onTouchMove={() => {}} />;


### PR DESCRIPTION
Changed `<>` to `<React.Fragment>` as mentioned [here](https://github.com/mui-org/material-ui/pull/16137#discussion_r293360258)