### PR TITLE
Updated typings to support custom theme variables.

### DIFF
--- a/packages/material-ui/src/styles/createMuiTheme.d.ts
+++ b/packages/material-ui/src/styles/createMuiTheme.d.ts
@@ -42,4 +42,4 @@ export interface Theme {
   zIndex: ZIndex;
 }
 
-export default function createMuiTheme(options?: ThemeOptions): Theme;
+export default function createMuiTheme<T extends {} = {}>(options?: ThemeOptions & T): Theme & T;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Updated typings to support custom variables in Themes as documented [here](https://material-ui.com/customization/themes/#custom-variables).

Example usage:

```ts
const myTheme = createMuiTheme({
  status: {
    // My business variables
    danger: orange[500],
  },
});

// Following line will not be an error
// myTheme.status
```

The custom Theme type can be reused as follows:
```ts
// Export type for reuse
export type CustomTheme = typeof myTheme;

// Import in Component
const useStyles = makeStyles((theme: CustomTheme) => ({
  ...
});
```