### PR TITLE
[core] Add MuiCardActionArea prop

### DIFF
--- a/packages/material-ui/src/styles/props.d.ts
+++ b/packages/material-ui/src/styles/props.d.ts
@@ -9,7 +9,7 @@ import { ButtonBaseProps } from '../ButtonBase';
 import { ButtonProps } from '../Button';
 import { ButtonGroupProps } from '../ButtonGroup';
 import { CardActionsProps } from '../CardActions';
-import { CardActionAreaProps } from '../CardActionArea'
+import { CardActionAreaProps } from '../CardActionArea';
 import { CardContentProps } from '../CardContent';
 import { CardHeaderProps } from '../CardHeader';
 import { CardMediaProps } from '../CardMedia';

--- a/packages/material-ui/src/styles/props.d.ts
+++ b/packages/material-ui/src/styles/props.d.ts
@@ -9,6 +9,7 @@ import { ButtonBaseProps } from '../ButtonBase';
 import { ButtonProps } from '../Button';
 import { ButtonGroupProps } from '../ButtonGroup';
 import { CardActionsProps } from '../CardActions';
+import { CardActionAreaProps } from '../CardActionArea'
 import { CardContentProps } from '../CardContent';
 import { CardHeaderProps } from '../CardHeader';
 import { CardMediaProps } from '../CardMedia';
@@ -108,6 +109,7 @@ export interface ComponentsPropsList {
   MuiButtonGroup: ButtonGroupProps;
   MuiCard: CardProps;
   MuiCardActions: CardActionsProps;
+  MuiCardActionArea: CardActionAreaProps;
   MuiCardContent: CardContentProps;
   MuiCardHeader: CardHeaderProps;
   MuiCardMedia: CardMediaProps;


### PR DESCRIPTION
MuiCardActionArea prop was missing. Added that

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
