### PR TITLE
[docs] Instapaper, fix contained+secondary button border

### DIFF
--- a/docs/src/pages/premium-themes/instapaper/theme/instapaper/components/button.js
+++ b/docs/src/pages/premium-themes/instapaper/theme/instapaper/components/button.js
@@ -63,5 +63,8 @@ export default ({ attach, nest, primary, theme, red, white, BUTTON, ICON }) => (
         opacity: 0.6,
       },
     },
+    containedSecondary: {
+      borderColor: theme.palette.secondary.main,
+    }
   },
 });

--- a/docs/src/pages/premium-themes/instapaper/theme/instapaper/components/button.js
+++ b/docs/src/pages/premium-themes/instapaper/theme/instapaper/components/button.js
@@ -35,7 +35,6 @@ export default ({ attach, nest, primary, theme, red, white, BUTTON, ICON }) => (
       },
     },
     contained: {
-      borderColor: primary.main,
       boxShadow: theme.shadows[0],
       '&$focusVisible': {
         boxShadow: theme.shadows[0],
@@ -55,7 +54,6 @@ export default ({ attach, nest, primary, theme, red, white, BUTTON, ICON }) => (
       },
     },
     containedPrimary: {
-      color: theme.palette.common.white,
       '&:hover': {
         backgroundColor: primary.main,
       },
@@ -63,8 +61,5 @@ export default ({ attach, nest, primary, theme, red, white, BUTTON, ICON }) => (
         opacity: 0.6,
       },
     },
-    containedSecondary: {
-      borderColor: theme.palette.secondary.main,
-    }
   },
 });


### PR DESCRIPTION
Color mismatch for contained+secondary button.
backgroundColor is pink but borderColor remains blue. 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

<img width="164" alt="before" src="https://user-images.githubusercontent.com/1034157/59508927-316a4a00-8ecd-11e9-9345-569e39c1b19e.png">
<img width="152" alt="after" src="https://user-images.githubusercontent.com/1034157/59508929-34fdd100-8ecd-11e9-99a1-358fefeb63ba.png">

