### PR TITLE
[slider] Mitigate floating point errors

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -67,8 +67,15 @@ function percentToValue(percent, min, max) {
   return (max - min) * percent + min;
 }
 
+function ensurePrecision(value, step) {
+  const stepDecimalPart = step.toString().split('.')[1];
+  const stepPrecision = stepDecimalPart ? stepDecimalPart.length : 0;
+
+  return Number(value.toFixed(stepPrecision));
+}
+
 function roundValueToStep(value, step) {
-  return Math.round(value / step) * step;
+  return ensurePrecision(Math.round(value / step) * step, step);
 }
 
 function setValueIndex({ values, source, newValue, index }) {

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -265,6 +265,13 @@ describe('<Slider />', () => {
       thumb.simulate('keydown', moveRightEvent);
       assert.strictEqual(wrapper.props().value, 30);
     });
+
+    it('should round value to step precision', () => {
+      wrapper.setProps({ value: 0.2, step: 0.1, min: 0 });
+      const thumb = findThumb(wrapper);
+      thumb.simulate('keydown', moveRightEvent);
+      assert.strictEqual(wrapper.props().value, 0.3);
+    });
   });
 
   describe('markActive state', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

When step was a decimal number the calculated value form a value change was coming with floating point errors.

This fixes it by rounding the calculated value to step precision.

Closes #16151
