### PR TITLE
[Divider] Add aria role if it's not implicit

### DIFF
--- a/packages/material-ui/src/Divider/Divider.js
+++ b/packages/material-ui/src/Divider/Divider.js
@@ -42,13 +42,10 @@ const Divider = React.forwardRef(function Divider(props, ref) {
     className,
     component: Component = 'hr',
     light = false,
+    role = Component !== 'hr' ? 'separator' : undefined,
     variant = 'fullWidth',
     ...other
   } = props;
-
-  if (Component === 'li' && !other.role) {
-    other.role = 'separator';
-  }
 
   return (
     <Component
@@ -62,6 +59,7 @@ const Divider = React.forwardRef(function Divider(props, ref) {
         },
         className,
       )}
+      role={role}
       ref={ref}
       {...other}
     />
@@ -91,6 +89,10 @@ Divider.propTypes = {
    * If `true`, the divider will have a lighter color.
    */
   light: PropTypes.bool,
+  /**
+   * @ignore
+   */
+  role: PropTypes.string,
   /**
    *  The variant to use.
    */

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -77,7 +77,7 @@ describe('<Divider />', () => {
       assert.strictEqual(wrapper.find('div').props().role, 'separator');
     });
 
-    it('passed roles override', () => {
+    it('overrides the computed role with the provided one', () => {
       // presentation is the only valid aria role
       const wrapper = mount(<Divider role="presentation" />);
       assert.strictEqual(wrapper.find('hr').props().role, 'presentation');

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -65,4 +65,22 @@ describe('<Divider />', () => {
       });
     });
   });
+
+  describe('role', () => {
+    it('avoids adding implicit aria semantics', () => {
+      const wrapper = mount(<Divider />);
+      assert.strictEqual(wrapper.find('hr').props().role, undefined);
+    });
+
+    it('adds a proper role if none is specified', () => {
+      const wrapper = mount(<Divider component="div" />);
+      assert.strictEqual(wrapper.find('div').props().role, 'separator');
+    });
+
+    it('passed roles override', () => {
+      // presentation is the only valid aria role
+      const wrapper = mount(<Divider role="presentation" />);
+      assert.strictEqual(wrapper.find('hr').props().role, 'presentation');
+    });
+  });
 });


### PR DESCRIPTION
Follow-up on #15339 (spotted due to line not being covered)

Setting the role only if a non-default `component` prop is passed follows the behavior in our [Button](https://github.com/mui-org/material-ui/blob/94951eac5799bc2ab3f24a779febbc8ab86419c8/packages/material-ui/src/ButtonBase/ButtonBase.js#L268).

[Rules of aria attributes for hr elements](https://www.w3.org/TR/html-aria/#hr)