### PR TITLE
[core] theme.spacing - support string and function arguments

### DIFF
--- a/packages/material-ui/src/styles/createSpacing.d.ts
+++ b/packages/material-ui/src/styles/createSpacing.d.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:unified-signatures */
 
-export type SpacingArgument = number | string;
+export type SpacingArgument = number | string | ((unit: number) => number | string);
 
 export interface Spacing {
   (): number;

--- a/packages/material-ui/src/styles/createSpacing.js
+++ b/packages/material-ui/src/styles/createSpacing.js
@@ -25,8 +25,8 @@ export default function createSpacing(spacingInput = 8) {
     transform = factor => {
       const factorType = typeof factor;
       warning(
-        factorType === 'number' || factorType === 'string',
-        `Expected spacing argument to be a number or string, got ${factor}`,
+        factorType === 'number' || factorType === 'string' || factorType === 'function',
+        `Expected spacing argument to be a number, string, or function, got ${factor}`,
       );
 
       if (factorType === 'string') {
@@ -36,6 +36,11 @@ export default function createSpacing(spacingInput = 8) {
 
         return factor;
       }
+
+      if (factorType === 'function') {
+        return factor(spacingInput);
+      }
+
       return spacingInput * factor;
     };
   }

--- a/packages/material-ui/src/styles/createSpacing.js
+++ b/packages/material-ui/src/styles/createSpacing.js
@@ -23,10 +23,19 @@ export default function createSpacing(spacingInput = 8) {
       ].join('\n'),
     );
     transform = factor => {
+      const factorType = typeof factor;
       warning(
-        typeof factor === 'number',
-        `Expected spacing argument to be a number, got ${factor}`,
+        factorType === 'number' || factorType === 'string',
+        `Expected spacing argument to be a number or string, got ${factor}`,
       );
+
+      if (factorType === 'string') {
+        if (factor.length === 0 || /^\d*$/.test(factor)) {
+          return Number(factor);
+        }
+
+        return factor;
+      }
       return spacingInput * factor;
     };
   }

--- a/packages/material-ui/src/styles/createSpacing.test.js
+++ b/packages/material-ui/src/styles/createSpacing.test.js
@@ -38,6 +38,11 @@ describe('createSpacing', () => {
     assert.strictEqual(spacing(1, 2), '0.25rem 0.5rem');
   });
 
+  it('should support string arguments', () => {
+    const spacing = createSpacing();
+    assert.strictEqual(spacing(1, '2', '', '3rem'), '8px 2px 0px 3rem');
+  });
+
   describe('warnings', () => {
     beforeEach(() => {
       consoleErrorMock.spy();

--- a/packages/material-ui/src/styles/createSpacing.test.js
+++ b/packages/material-ui/src/styles/createSpacing.test.js
@@ -43,6 +43,11 @@ describe('createSpacing', () => {
     assert.strictEqual(spacing(1, '2', '', '3rem'), '8px 2px 0px 3rem');
   });
 
+  it('should support function arguments', () => {
+    const spacing = createSpacing();
+    assert.strictEqual(spacing(1, 1, 1, unit => unit + 1), '8px 8px 8px 9px');
+  });
+
   describe('warnings', () => {
     beforeEach(() => {
       consoleErrorMock.spy();


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Support strings as arguments, type definitions already allowed it but the implementation did not.
* Support functions as arguments, for cases like this https://github.com/mui-org/material-ui/blob/f69797ffa61fa3ae94cf62987c197d6acea371c9/docs/src/modules/components/AdCarbon.js#L10-L12