### PR TITLE
[TextField] Fix media hover specificity issue

### DIFF
--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -20,8 +20,10 @@ export const styles = theme => {
         borderColor: theme.palette.text.primary,
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
-          borderColor,
-        },
+          '&:hover $notchedOutline': {
+              borderColor,
+            },
+          },
       },
       '&$focused $notchedOutline': {
         borderColor: theme.palette.primary.main,

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -18,11 +18,11 @@ export const styles = theme => {
       },
       '&:hover $notchedOutline': {
         borderColor: theme.palette.text.primary,
-        // Reset on touch devices, it doesn't add specificity
-        '@media (hover: none)': {
-          '&:hover $notchedOutline': {
-            borderColor,
-          },
+      },
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        '&:hover $notchedOutline': {
+          borderColor,
         },
       },
       '&$focused $notchedOutline': {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -21,9 +21,9 @@ export const styles = theme => {
         // Reset on touch devices, it doesn't add specificity
         '@media (hover: none)': {
           '&:hover $notchedOutline': {
-              borderColor,
-            },
+            borderColor,
           },
+        },
       },
       '&$focused $notchedOutline': {
         borderColor: theme.palette.primary.main,


### PR DESCRIPTION
Closes #16149 

Highlight TextField varient outlines border color on focus event on mobile

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
