### PR TITLE
[Popper] Fix casing error on Popper.js import.

### DIFF
--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import PopperJS from 'popper.js';
+import PopperJS from 'Popper.js';
 import { chainPropTypes } from '@material-ui/utils';
 import Portal from '../Portal';
 import { createChainedFunction } from '../utils/helpers';


### PR DESCRIPTION
This should fix this one: https://github.com/mui-org/material-ui/issues/14711