### PR TITLE
[docs] Fix outdated react-transition-group docs link

### DIFF
--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -64,7 +64,7 @@ function getInheritance(testInfo, src) {
 
   switch (inheritedComponentName) {
     case 'Transition':
-      pathname = 'https://reactcommunity.org/react-transition-group/#Transition';
+      pathname = 'https://reactcommunity.org/react-transition-group/transition';
       break;
 
     default:

--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -64,7 +64,7 @@ function getInheritance(testInfo, src) {
 
   switch (inheritedComponentName) {
     case 'Transition':
-      pathname = 'https://reactcommunity.org/react-transition-group/transition';
+      pathname = 'https://reactcommunity.org/react-transition-group/transition#Transition-props';
       break;
 
     default:

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -29,7 +29,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The `ref` is forwarded to the root element.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props)).
 
 ## CSS
 
@@ -54,7 +54,7 @@ you need to use the following style sheet name: `MuiCollapse`.
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -29,7 +29,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The `ref` is forwarded to the root element.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
 
 ## CSS
 
@@ -54,7 +54,7 @@ you need to use the following style sheet name: `MuiCollapse`.
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -25,11 +25,11 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props)).
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -25,11 +25,11 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -26,11 +26,11 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -26,11 +26,11 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props)).
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -26,11 +26,11 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The `ref` is attached to a component class.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props)).
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -26,11 +26,11 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The `ref` is attached to a component class.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -26,11 +26,11 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/#Transition)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/#Transition) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -26,11 +26,11 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The component cannot hold a ref.
 
-Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/)).
+Any other properties supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props)).
 
 ## Inheritance
 
-The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/) component, from react-transition-group, are also available.
+The properties of the [Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props) component, from react-transition-group, are also available.
 You can take advantage of this behavior to [target nested components](/guides/api/#spread).
 
 ## Notes


### PR DESCRIPTION
New one is: https://reactcommunity.org/react-transition-group/transition

* [ ] contribute props heading anchor to rtg docs