### PR TITLE
[Menu] Add missing `autoFocus` TypeScript types

### DIFF
--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -5,6 +5,7 @@ import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 export interface ListItemTypeMap<P, D extends React.ElementType> {
   props: P & {
     alignItems?: 'flex-start' | 'center';
+    autoFocus?: boolean;
     button?: boolean;
     ContainerComponent?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
     ContainerProps?: React.HTMLAttributes<HTMLDivElement>;

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -13,6 +13,7 @@ export interface MenuProps
   PopoverClasses?: PopoverProps['classes'];
   transitionDuration?: TransitionProps['timeout'] | 'auto';
   variant?: 'menu' | 'selectedMenu';
+  autoFocus?: boolean;
 }
 
 export type MenuClassKey = 'paper';

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -7,13 +7,13 @@ import { TransitionHandlerProps, TransitionProps } from '../transitions/transiti
 
 export interface MenuProps
   extends StandardProps<PopoverProps & Partial<TransitionHandlerProps>, MenuClassKey> {
+  autoFocus?: boolean;
   disableAutoFocusItem?: boolean;
   MenuListProps?: Partial<MenuListProps>;
   PaperProps?: Partial<PaperProps>;
   PopoverClasses?: PopoverProps['classes'];
   transitionDuration?: TransitionProps['timeout'] | 'auto';
   variant?: 'menu' | 'selectedMenu';
-  autoFocus?: boolean;
 }
 
 export type MenuClassKey = 'paper';

--- a/packages/material-ui/src/MenuList/MenuList.d.ts
+++ b/packages/material-ui/src/MenuList/MenuList.d.ts
@@ -3,6 +3,7 @@ import { StandardProps } from '..';
 import { ListProps, ListClassKey } from '../List';
 
 export interface MenuListProps extends StandardProps<ListProps, MenuListClassKey, 'onKeyDown'> {
+  autoFocus?: boolean;
   disableListWrap?: boolean;
   onKeyDown?: React.ReactEventHandler<React.KeyboardEvent<any>>;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Edit @eps1lon:
Closes #16189
