### PR TITLE
[core] theme.spacing - remove string from SpacingArgument

### DIFF
--- a/packages/material-ui/src/styles/createSpacing.d.ts
+++ b/packages/material-ui/src/styles/createSpacing.d.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:unified-signatures */
 
-export type SpacingArgument = number | string;
+export type SpacingArgument = number;
 
 export interface Spacing {
   (): number;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Remove string from `SpacingArgument`

The type definition for `theme.spacing` allows the use of strings, but the implementation does not.