### PR TITLE
[TouchRipple] Fix ripple staying on fast updates

### DIFF
--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -230,7 +230,6 @@ class TouchRipple extends React.PureComponent {
 
   stop = (event, cb) => {
     clearTimeout(this.startTimer);
-    const { ripples } = this.state;
 
     // The touch interaction occurs too quickly.
     // We still want to show ripple effect.
@@ -246,14 +245,12 @@ class TouchRipple extends React.PureComponent {
 
     this.startTimerCommit = null;
 
-    if (ripples && ripples.length) {
-      this.setState(
-        {
-          ripples: ripples.slice(1),
-        },
-        cb,
-      );
-    }
+    this.setState(({ ripples }) => {
+      if (ripples && ripples.length) {
+        return { ripples: ripples.slice(1) };
+      }
+      return null;
+    }, cb);
   };
 
   render() {


### PR DESCRIPTION
How to reproduce:
- get slow machine (4x CPU slowdown was enough)
- goto https://material-ui.com/
- tab into drawer
- hold down tab
- touch ripples (focus visible) persist

![](https://files.gitter.im/mui-org/material-ui/mui-collaborators/lTo5/mui-focus-visible-hang.gif)

Issue: Doing state updates based on previous state without using the callback form of setState. 

What was probably happening is that we started and stopped the ripples before react processed state updates. In the stop we would see no existing ripples and do nothing. Now react would process the the state update and add one ripple.

Now we queue two state updates that are processed after start/stop was called. We add one ripple and then read from the new state, see a ripple and remove it again.

Hope that makes sense. Graphic would be better but I guess the result should speak for itself.