### PR TITLE
[docs] Alias classnames to clsx

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,2 +1,0 @@
-# Aliased to clsx
-classnames

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,2 @@
+# Aliased to clsx
+classnames

--- a/babel.config.js
+++ b/babel.config.js
@@ -35,7 +35,6 @@ const defaultAlias = {
   '@material-ui/styles': './packages/material-ui-styles/src',
   '@material-ui/system': './packages/material-ui-system/src',
   '@material-ui/utils': './packages/material-ui-utils/src',
-  classnames: 'clsx',
 };
 
 const productionPlugins = [
@@ -102,6 +101,7 @@ module.exports = {
               docs: './docs',
               modules: './modules',
               pages: './pages',
+              classnames: 'clsx',
             },
             transformFunctions: ['require', 'require.context'],
             resolvePath,
@@ -122,6 +122,7 @@ module.exports = {
               docs: './docs',
               modules: './modules',
               pages: './pages',
+              classnames: 'clsx',
             },
             transformFunctions: ['require', 'require.context'],
             resolvePath,

--- a/babel.config.js
+++ b/babel.config.js
@@ -35,6 +35,7 @@ const defaultAlias = {
   '@material-ui/styles': './packages/material-ui-styles/src',
   '@material-ui/system': './packages/material-ui-system/src',
   '@material-ui/utils': './packages/material-ui-utils/src',
+  classnames: 'clsx',
 };
 
 const productionPlugins = [

--- a/docs/webpackBaseConfig.js
+++ b/docs/webpackBaseConfig.js
@@ -15,6 +15,7 @@ module.exports = {
       '@material-ui/system': path.resolve(__dirname, '../packages/material-ui-system/src'),
       '@material-ui/utils': path.resolve(__dirname, '../packages/material-ui-utils/src'),
       docs: path.resolve(__dirname, '../docs'),
+      classnames: 'clsx',
     },
   },
   output: {

--- a/next.config.js
+++ b/next.config.js
@@ -9,9 +9,17 @@ const LANGUAGES = ['en', 'zh', 'ru', 'pt', 'fr', 'es', 'de'];
 
 module.exports = withTypescript({
   webpack: (config, options) => {
-    // Alias @material-ui/core peer dependency imports form the following modules to our sources.
     config = withTM({
-      transpileModules: ['notistack', '@material-ui/pickers', 'material-table'],
+      transpileModules: [
+        // Alias @material-ui/core peer dependency imports from the following modules to our sources.
+        'notistack',
+        '@material-ui/pickers',
+        'material-table',
+        // Alias classnames to clsx
+        'react-draggable',
+        'react-select',
+        'recharts',
+      ],
     }).webpack(config, options);
 
     const plugins = config.plugins.concat([

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "react-swipeable-views": "^0.13.0",
     "react-test-renderer": "^16.8.5",
     "react-text-mask": "^5.0.2",
-    "react-virtualized": "^9.21.0",
+    "react-virtualized": "^9.21.1",
     "react-window": "^1.7.1",
     "recast": "^0.17.0",
     "recharts": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3873,7 +3873,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.3, classnames@^2.2.5, classnames@^2.2.6, classnames@~2.2.5:
+classnames@^2.2.5, classnames@^2.2.6, classnames@~2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -3939,7 +3939,7 @@ clone@^1.0.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
   integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
 
-clsx@^1.0.2:
+clsx@^1.0.1, clsx@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.0.4.tgz#0c0171f6d5cb2fe83848463c15fcc26b4df8c2ec"
   integrity sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==
@@ -8512,6 +8512,11 @@ libnpmpublish@^1.1.1:
     semver "^5.5.1"
     ssri "^6.0.1"
 
+linear-layout-vector@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/linear-layout-vector/-/linear-layout-vector-0.0.1.tgz#398114d7303b6ecc7fd6b273af7b8401d8ba9c70"
+  integrity sha1-OYEU1zA7bsx/1rJzr3uEAdi6nHA=
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -11552,14 +11557,15 @@ react-transition-group@^4.0.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtualized@^9.21.0:
-  version "9.21.0"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.0.tgz#8267c40ffb48db35b242a36dea85edcf280a6506"
-  integrity sha512-duKD2HvO33mqld4EtQKm9H9H0p+xce1c++2D5xn59Ma7P8VT7CprfAe5hwjd1OGkyhqzOZiTMlTal7LxjH5yBQ==
+react-virtualized@^9.21.1:
+  version "9.21.1"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.1.tgz#4dbbf8f0a1420e2de3abf28fbb77120815277b3a"
+  integrity sha512-E53vFjRRMCyUTEKuDLuGH1ld/9TFzjf/fFW816PE4HFXWZorESbSTYtiZz1oAjra0MminaUU1EnvUxoGuEFFPA==
   dependencies:
     babel-runtime "^6.26.0"
-    classnames "^2.2.3"
+    clsx "^1.0.1"
     dom-helpers "^2.4.0 || ^3.0.0"
+    linear-layout-vector "0.0.1"
     loose-envify "^1.3.0"
     prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Upgraded `react-virtualized@9.21.0` to `react-virtualized@9.21.1`, which uses `clsx`
* Alias `classnames` to `clsx`
* Fixed a typo