### PR TITLE
[test] Add Select a11y fixture

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -26,6 +26,7 @@
     "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:umd": "cross-env BABEL_ENV=production-umd rollup -c scripts/rollup.config.js",
+    "build:umd:dev-only": "cross-env BABEL_ENV=production-umd DEV_ONLY=true rollup -c scripts/rollup.config.js",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag latest",

--- a/packages/material-ui/scripts/rollup.config.js
+++ b/packages/material-ui/scripts/rollup.config.js
@@ -42,43 +42,44 @@ function onwarn(warning) {
   throw Error(warning.message);
 }
 
-export default [
-  {
-    input,
-    onwarn,
-    output: {
-      file: 'build/umd/material-ui.development.js',
-      format: 'umd',
-      name: 'MaterialUI',
-      globals,
-    },
-    external: Object.keys(globals),
-    plugins: [
-      nodeResolve(),
-      babel(babelOptions),
-      commonjs(commonjsOptions),
-      nodeGlobals(), // Wait for https://github.com/cssinjs/jss/pull/893
-      replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
-    ],
+const developmentBundle = {
+  input,
+  onwarn,
+  output: {
+    file: 'build/umd/material-ui.development.js',
+    format: 'umd',
+    name: 'MaterialUI',
+    globals,
   },
-  {
-    input,
-    onwarn,
-    output: {
-      file: 'build/umd/material-ui.production.min.js',
-      format: 'umd',
-      name: 'MaterialUI',
-      globals,
-    },
-    external: Object.keys(globals),
-    plugins: [
-      nodeResolve(),
-      babel(babelOptions),
-      commonjs(commonjsOptions),
-      nodeGlobals(), // Wait for https://github.com/cssinjs/jss/pull/893
-      replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
-      sizeSnapshot({ snapshotPath: 'size-snapshot.json' }),
-      terser(),
-    ],
+  external: Object.keys(globals),
+  plugins: [
+    nodeResolve(),
+    babel(babelOptions),
+    commonjs(commonjsOptions),
+    nodeGlobals(), // Wait for https://github.com/cssinjs/jss/pull/893
+    replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
+  ],
+};
+
+const productionBundle = {
+  input,
+  onwarn,
+  output: {
+    file: 'build/umd/material-ui.production.min.js',
+    format: 'umd',
+    name: 'MaterialUI',
+    globals,
   },
-];
+  external: Object.keys(globals),
+  plugins: [
+    nodeResolve(),
+    babel(babelOptions),
+    commonjs(commonjsOptions),
+    nodeGlobals(), // Wait for https://github.com/cssinjs/jss/pull/893
+    replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+    sizeSnapshot({ snapshotPath: 'size-snapshot.json' }),
+    terser(),
+  ],
+};
+
+export default (process.env.DEV_ONLY ? developmentBundle : [developmentBundle, productionBundle]);

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -8,7 +8,7 @@ Before the instructions is a description of the initial state.
 
 ```bash
 # all commands in the workspace root
-$ yarn workspace @material-ui/core build:umd --watch
+$ yarn workspace @material-ui/core build:umd:dev-only --watch
 # in another terminal
 $ npx serve
 # goto http://localhost:5000/test/fixtures/ to find an overview of the fixtures

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -1,0 +1,15 @@
+# fixtures
+
+Collection of test fixtures for manual e2e testing. Each fixture has unambiguous
+instructions that consist of a before state, an action and the state after.
+Before the instructions is a description of the initial state.
+
+## Usage
+
+```bash
+# all commands in the workspace root
+$ yarn workspace @material-ui/core build:umd --watch
+# in another terminal
+$ npx serve
+# goto http://localhost:5000/test/fixtures/ to find an overview of the fixtures
+```

--- a/test/fixtures/select-a11y/no-default.html
+++ b/test/fixtures/select-a11y/no-default.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Select keyboard nav | Material-UI</title>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react@16/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@16/umd/react-dom.development.js"></script>
+    <script
+      crossorigin
+      src="../../../packages/material-ui/build/umd/material-ui.development.js"
+    ></script>
+  </head>
+  <body>
+    <h1>Select keyboard navigation no default</h1>
+    <p>Keyboard navigation for the Select component with no value selected by default</p>
+    <h2>Instructions</h2>
+    In the initial state focus should be on the "ready!" link. If the link only displays
+    "initializing" something is broken. To reset the test click the link (or just reload). Based on
+    <a href="https://www.w3.org/TR/wai-aria-practices-1.1/#menu"
+      >WAI-ARIA menu keyboard interaction</a
+    >
+    <table>
+      <thead>
+        <tr>
+          <th>Before</th>
+          <th>Act</th>
+          <th>After</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Initial state</td>
+          <td>Press tab</td>
+          <td>Focus on Select</td>
+        </tr>
+        <tr>
+          <td>Focus on Select</td>
+          <td>Press <em>Enter</em></td>
+          <td>Select menu opens, Focus is on the first item</td>
+        </tr>
+        <tr>
+          <td>Select focus or focus-within</td>
+          <td>Press <em>Down Arrow</em></td>
+          <td>Focus moves to the second item</td>
+        </tr>
+        <tr>
+          <td>Select focus or focus-within</td>
+          <td>Press <em>Up Arrow</em></td>
+          <td>Focus moves to the first item</td>
+        </tr>
+        <tr>
+          <td>Select focus or focus-within</td>
+          <td>Press <em>End</em></td>
+          <td>Focus moves to the last item</td>
+        </tr>
+        <tr>
+          <td>Select focus or focus-within</td>
+          <td>Press <em>Home</em></td>
+          <td>Focus moves to the first item</td>
+        </tr>
+        <tr>
+          <td>Select focus or focus-within</td>
+          <td>Press <em>Escape</em></td>
+          <td>Menu closes</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div id="fixture"></div>
+
+    <script type="text/babel" data-presets="react">
+      const { MenuItem, TextField } = MaterialUI;
+
+      function Test() {
+        const [value, setValue] = React.useState(0);
+
+        function handleChange(event) {
+          setValue(event.target.value);
+        }
+
+        return (
+          <TextField id="age" label="Age" onChange={handleChange} select value={value}>
+            <MenuItem value={10}>Ten</MenuItem>
+            <MenuItem value={20}>Twenty</MenuItem>
+            <MenuItem value={30}>Thirty</MenuItem>
+            <MenuItem value={40}>Forty</MenuItem>
+            <MenuItem value={50}>Fifty</MenuItem>
+            <MenuItem value={60}>Sixty</MenuItem>
+            <MenuItem value={70}>Seventy</MenuItem>
+            <MenuItem value={80}>Eighty</MenuItem>
+            <MenuItem value={Number.PositiveInfinity}>That's a lot of damage!</MenuItem>
+          </TextField>
+        );
+      }
+
+      function Fixture() {
+        // ready?, ready!
+        const [ready, isReady] = React.useReducer(() => true, false);
+
+        const buttonRef = React.useRef(null);
+        React.useEffect(() => {
+          buttonRef.current.focus();
+        }, []);
+
+        return (
+          <React.Fragment>
+            <a href="" onFocus={isReady} ref={buttonRef} style={{ display: 'block', margin: 20 }}>
+              {ready ? 'Ready!' : 'Initializing'}
+            </a>
+            <Test />
+          </React.Fragment>
+        );
+      }
+
+      ReactDOM.render(<Fixture />, document.querySelector('#fixture'));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Adds a very basic setup to verify keyboard navigation for the Select component. The introduced test is failing right now but (partially) fixed with #16294. Opened this separately in case we need to discuss the test. Wanted to make sure we separate the test and implementation.

Interesting part is 933986b10e58e6ef06a8ca3fbbf7e9a1c6388126. The rest is just DX.

Thought about moving instructions into a separate README but then you need two separate windows so I'd rather have these next to each other.

/cc @ianschmitz @ryancogswell 