### PR TITLE
Fix useMediaQuery server-side example

### DIFF
--- a/docs/src/pages/components/use-media-query/ServerSide.js
+++ b/docs/src/pages/components/use-media-query/ServerSide.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import mediaQuery from 'css-mediaquery';
 import { ThemeProvider } from '@material-ui/styles';
-import useMediaQueryTheme from '@material-ui/core/useMediaQuery';
+import useMediaQueryTheme from '@material-ui/core/useMediaQuery/useMediaQueryTheme';
 
 function MyComponent() {
   const matches = useMediaQueryTheme('@media (min-width:600px)');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Note that this import is really hard to guess, I'd prefer that useMediaQueryTheme is exported in the main index.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
