### PR TITLE
Broken test: declare props separate from usage for Button, MenuItem, ListItem

### DIFF
--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -82,6 +82,7 @@ import { Link as ReactRouterLink } from 'react-router-dom';
 import { ButtonBaseActions } from '@material-ui/core/ButtonBase';
 import { MenuItemProps } from '@material-ui/core/MenuItem/MenuItem';
 import { ButtonProps } from '@material-ui/core/Button';
+import { ListItemProps } from '@material-ui/core/ListItem';
 
 const log = console.log;
 const FakeIcon = () => <div>ICON</div>;
@@ -553,6 +554,11 @@ const ListTest = () => (
     </ListItem>
   </List>
 );
+
+const ListItemTest = () => {
+  const p: ListItemProps = {};
+  return <ListItem {...p} />;
+};
 
 const MenuItemTest = () => {
   const p: MenuItemProps = {};

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -80,6 +80,8 @@ import {
 import { DialogProps } from '@material-ui/core/Dialog';
 import { Link as ReactRouterLink } from 'react-router-dom';
 import { ButtonBaseActions } from '@material-ui/core/ButtonBase';
+import { MenuItemProps } from '@material-ui/core/MenuItem/MenuItem';
+import { ButtonProps } from '@material-ui/core/Button';
 
 const log = console.log;
 const FakeIcon = () => <div>ICON</div>;
@@ -167,6 +169,20 @@ const BottomNavigationTest = () => {
       <BottomNavigationAction label="Favorites" />
       <BottomNavigationAction label={<span>Nearby</span>} icon={<FakeIcon />} />
     </BottomNavigation>
+  );
+};
+
+const ButtonTest = () => {
+  const p: ButtonProps = {
+    component: 'span',
+    role: 'checkbox',
+    'aria-checked': false,
+  };
+
+  return (
+    <div>
+      <Button {...p} />
+    </div>
   );
 };
 
@@ -537,6 +553,11 @@ const ListTest = () => (
     </ListItem>
   </List>
 );
+
+const MenuItemTest = () => {
+  const p: MenuItemProps = {};
+  return <MenuItem {...p} />;
+};
 
 const MenuTest = () => {
   const anchorEl = document.getElementById('foo')!;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
I've discovered a typescript issue when trying to migrate a 3.x codebase to 4.x

On the 4.x master, it seems that declaring/constructing props separate from usage, while it may be valid, fails to typecheck.  A representative error is:

```
  Types of property 'button' are incompatible.
    Type 'boolean | undefined' is not assignable to type 'true | undefined'.
      Type 'false' is not assignable to type 'true | undefined'.
```

for 

```tsx
const MenuItemTest = () => {
  const p: MenuItemProps = {};
  return <MenuItem {...p} />;
};
```

@eps1lon @pelotom thoughts?


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

/issue MenuItem #16245
/issue ListItem #14971
/issue Button #15827