### PR TITLE
[theme] Validate fontSize in createTypography

### DIFF
--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -31,7 +31,7 @@ export default function createTypography(palette, typography) {
   } = typeof typography === 'function' ? typography(palette) : typography;
 
   if (typeof fontSize !== 'number') {
-    throw new Error(`Material-UI: The "fontSize" provided isn't a number`);
+    throw new Error(`Material-UI: the "fontSize" provided isn't a number`);
   }
 
   const coef = fontSize / 14;

--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -32,6 +32,10 @@ export default function createTypography(palette, typography) {
   } = typeof typography === 'function' ? typography(palette) : typography;
 
   warning(typeof fontSize === 'number', `Material-UI: 'fontSize' is required to be a number`);
+  warning(
+    typeof htmlFontSize === 'number',
+    `Material-UI: 'htmlFontSize' is required to be a number`,
+  );
 
   const coef = fontSize / 14;
   const pxToRem = size => `${(size / htmlFontSize) * coef}rem`;

--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -31,10 +31,10 @@ export default function createTypography(palette, typography) {
     ...other
   } = typeof typography === 'function' ? typography(palette) : typography;
 
-  warning(typeof fontSize === 'number', `Material-UI: 'fontSize' is required to be a number`);
+  warning(typeof fontSize === 'number', `Material-UI: 'fontSize' is required to be a number.`);
   warning(
     typeof htmlFontSize === 'number',
-    `Material-UI: 'htmlFontSize' is required to be a number`,
+    `Material-UI: 'htmlFontSize' is required to be a number.`,
   );
 
   const coef = fontSize / 14;

--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -30,6 +30,10 @@ export default function createTypography(palette, typography) {
     ...other
   } = typeof typography === 'function' ? typography(palette) : typography;
 
+  if (typeof fontSize !== 'number') {
+    throw new Error(`Material-UI: The "fontSize" provided isn't a number`);
+  }
+
   const coef = fontSize / 14;
   const pxToRem = size => `${(size / htmlFontSize) * coef}rem`;
   const buildVariant = (fontWeight, size, lineHeight, letterSpacing, casing) => ({

--- a/packages/material-ui/src/styles/createTypography.js
+++ b/packages/material-ui/src/styles/createTypography.js
@@ -1,4 +1,5 @@
 import deepmerge from 'deepmerge'; // < 1kb payload overhead when lodash/merge is > 3kb.
+import warning from 'warning';
 
 function round(value) {
   return Math.round(value * 1e5) / 1e5;
@@ -30,9 +31,7 @@ export default function createTypography(palette, typography) {
     ...other
   } = typeof typography === 'function' ? typography(palette) : typography;
 
-  if (typeof fontSize !== 'number') {
-    throw new Error(`Material-UI: the "fontSize" provided isn't a number`);
-  }
+  warning(typeof fontSize === 'number', `Material-UI: 'fontSize' is required to be a number`);
 
   const coef = fontSize / 14;
   const pxToRem = size => `${(size / htmlFontSize) * coef}rem`;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Warn if `fontSize` and/or `htmlFontSize` isn't a number in `createTypography`

The type definition is correct.

Closes #15980