### PR TITLE
[docs] Improve colors reliably

### DIFF
--- a/docs/src/modules/components/Ad.js
+++ b/docs/src/modules/components/Ad.js
@@ -28,7 +28,7 @@ const styles = theme => ({
   },
   paper: {
     padding: theme.spacing(1),
-    backgroundColor: theme.palette.background.level1,
+    backgroundColor: theme.palette.background.level2,
     display: 'block',
   },
 });

--- a/docs/src/modules/components/AdCarbon.js
+++ b/docs/src/modules/components/AdCarbon.js
@@ -6,7 +6,7 @@ const styles = theme => ({
   '@global': {
     '#carbonads': {
       overflow: 'hidden',
-      backgroundColor: theme.palette.background.level1,
+      backgroundColor: theme.palette.background.level2,
       padding: `${theme.spacing(1)}px ${theme.spacing(1)}px ${theme.spacing(1)}px ${theme.spacing(
         1,
       ) + 130}px`,

--- a/docs/src/modules/components/AdCodeFund.js
+++ b/docs/src/modules/components/AdCodeFund.js
@@ -6,7 +6,7 @@ const styles = theme => ({
   '@global': {
     '#cf': {
       overflow: 'hidden',
-      backgroundColor: theme.palette.background.level1,
+      backgroundColor: theme.palette.background.level2,
       padding: `${theme.spacing(1)}px ${theme.spacing(1)}px ${theme.spacing(1)}px ${theme.spacing(
         1,
       ) + 130}px`,

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -53,6 +53,7 @@ PersistScroll.propTypes = {
 const styles = theme => ({
   paper: {
     width: 240,
+    backgroundColor: theme.palette.background.level1,
   },
   title: {
     color: theme.palette.text.secondary,

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -86,6 +86,7 @@ export const languages = [
 const styles = theme => ({
   root: {
     display: 'flex',
+    backgroundColor: theme.palette.background.level1,
   },
   grow: {
     flex: '1 1 auto',

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -118,6 +118,8 @@ const styles = theme => ({
     },
   },
   appBar: {
+    color: theme.palette.type === 'dark' ? '#fff' : null,
+    backgroundColor: theme.palette.type === 'dark' ? theme.palette.background.level2 : null,
     transition: theme.transitions.create('width'),
     '@media print': {
       position: 'absolute',

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -53,7 +53,7 @@ const styles = theme => ({
     outline: 'none',
     margin: 'auto',
     borderRadius: theme.shape.borderRadius,
-    backgroundColor: theme.palette.background.level1,
+    backgroundColor: theme.palette.background.level2,
     display: 'flex',
     justifyContent: 'center',
     padding: 20,

--- a/docs/src/modules/components/HomeBackers.js
+++ b/docs/src/modules/components/HomeBackers.js
@@ -13,7 +13,6 @@ const backers = mapTranslations(req, 'md');
 
 const styles = theme => ({
   root: {
-    backgroundColor: theme.palette.background.paper,
     minHeight: 600,
   },
   markdownElement: {

--- a/docs/src/modules/components/HomeFooter.js
+++ b/docs/src/modules/components/HomeFooter.js
@@ -11,7 +11,7 @@ import compose from 'docs/src/modules/utils/compose';
 
 const styles = theme => ({
   root: {
-    backgroundColor: theme.palette.background.level0,
+    backgroundColor: theme.palette.background.level2,
   },
   footer: {
     padding: theme.spacing(3, 0),

--- a/docs/src/modules/components/HomeQuickWord.js
+++ b/docs/src/modules/components/HomeQuickWord.js
@@ -43,7 +43,6 @@ const backers = [
 
 const styles = theme => ({
   root: {
-    backgroundColor: theme.palette.background.paper,
     textAlign: 'center',
     minHeight: 60,
     paddingBottom: theme.spacing(2),

--- a/docs/src/modules/components/HomeSteps.js
+++ b/docs/src/modules/components/HomeSteps.js
@@ -25,9 +25,9 @@ const UsageLink = React.forwardRef((buttonProps, ref) => (
 
 const styles = theme => ({
   step: {
-    border: `12px solid ${theme.palette.background.paper}`,
+    border: `12px solid ${theme.palette.background.level1}`,
     padding: theme.spacing(3, 2),
-    backgroundColor: theme.palette.background.level0,
+    backgroundColor: theme.palette.background.level2,
     borderRightWidth: 0,
     borderLeftWidth: 0,
     [theme.breakpoints.up('sm')]: {
@@ -58,7 +58,7 @@ const styles = theme => ({
     alignItems: 'center',
   },
   stepIcon: {
-    color: theme.palette.primary.dark,
+    color: theme.palette.primary.main,
     marginRight: theme.spacing(2),
     fontSize: 30,
   },
@@ -68,11 +68,11 @@ const styles = theme => ({
   markdownElement: {
     maxWidth: `calc(100vw - ${(theme.spacing(5) + 1) * 2}px)`,
     '& pre, & pre[class*="language-"], & code': {
-      backgroundColor: 'transparent',
+      // backgroundColor: 'transparent',
     },
     '& pre, & pre[class*="language-"]': {
-      padding: theme.spacing(1),
-      margin: 0,
+      padding: theme.spacing(1, 0),
+      margin: theme.spacing(1, 0),
     },
   },
   divider: {

--- a/docs/src/modules/components/HomeUsers.js
+++ b/docs/src/modules/components/HomeUsers.js
@@ -36,7 +36,6 @@ const users = [
 const styles = theme => ({
   root: {
     padding: theme.spacing(2),
-    backgroundColor: theme.palette.background.paper,
     minHeight: 160,
     paddingTop: theme.spacing(5),
   },

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -119,33 +119,32 @@ const styles = theme => ({
     '& pre': {
       margin: '24px 0',
       padding: '12px 18px',
-      backgroundColor: theme.palette.background.level1,
+      backgroundColor: '#333',
       direction: 'ltr',
       borderRadius: theme.shape.borderRadius,
       overflow: 'auto',
       WebkitOverflowScrolling: 'touch', // iOS momentum scrolling.
     },
-    '& code[class*="language-"]': {
-      boxShadow: 'none',
-    },
     '& code': {
       display: 'inline-block',
       fontFamily: 'Consolas, "Liberation Mono", Menlo, Courier, monospace',
+      WebkitFontSmoothing: 'subpixel-antialiased',
       padding: '2px 6px',
       color: theme.palette.text.primary,
-      backgroundColor: theme.palette.background.level1,
+      backgroundColor:
+        theme.palette.type === 'dark' ? 'rgba(255,229,100,0.2)' : 'rgba(255,229,100,0.1)',
       fontSize: 14,
       borderRadius: 2,
+    },
+    '& code[class*="language-"]': {
+      backgroundColor: '#333',
+      color: '#fff',
     },
     '& p code, & ul code, & pre code': {
       fontSize: 14,
     },
     '& .token.operator': {
       background: 'transparent',
-    },
-    '& .token.property, .token.tag,.token.constant, .token.symbol, .token.deleted': {
-      // adjust prism-okaidia to reach AA ratio
-      color: theme.palette.type === 'dark' ? '#f483ad' : undefined,
     },
     '& h1': {
       ...theme.typography.h2,
@@ -217,12 +216,12 @@ const styles = theme => ({
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
       },
       '& .required': {
-        color: theme.palette.type === 'light' ? '#006500' : '#9bc89b',
+        color: theme.palette.type === 'light' ? '#006500' : '#a5ffa5',
       },
       '& .prop-type': {
         fontSize: 13,
         fontFamily: 'Consolas, "Liberation Mono", Menlo, monospace',
-        color: theme.palette.type === 'light' ? '#932981' : '#dbb0d0',
+        color: theme.palette.type === 'light' ? '#932981' : '#ffb6ec',
       },
       '& .prop-default': {
         fontSize: 13,
@@ -272,8 +271,8 @@ const styles = theme => ({
       height: 64,
     },
     '& blockquote': {
-      borderLeft: `5px solid ${theme.palette.text.hint}`,
-      backgroundColor: theme.palette.background.level1,
+      borderLeft: '5px solid #ffe564',
+      backgroundColor: 'rgba(255,229,100,0.2)',
       padding: '4px 24px',
       margin: '24px 0',
     },

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -1,21 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from '@material-ui/styles';
-import { createMuiTheme, darken } from '@material-ui/core/styles';
+import { createMuiTheme, darken, lighten } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { blue, pink } from '@material-ui/core/colors';
 import { getCookie } from 'docs/src/modules/utils/helpers';
-import { lightTheme, darkTheme, setPrismTheme } from 'docs/src/modules/components/prism';
+import { darkTheme, setPrismTheme } from 'docs/src/modules/components/prism';
 
 export const themeInitialOptions = {
   direction: 'ltr',
   paletteColors: {
     primary: {
-      main: blue[500],
-    },
-    secondary: {
-      // Darken so we reach the AA contrast ratio level.
-      main: darken(pink.A400, 0.08),
+      main: blue[700],
     },
   },
 };
@@ -52,8 +48,8 @@ export function Provider(props) {
   const { direction, paletteColors, paletteType = preferredType } = themeOptions;
 
   React.useEffect(() => {
-    setPrismTheme(paletteType === 'light' ? lightTheme : darkTheme);
-  }, [paletteType]);
+    setPrismTheme(darkTheme);
+  }, []);
 
   React.useEffect(() => {
     if (process.browser) {
@@ -83,19 +79,26 @@ export function Provider(props) {
         color: paletteType === 'light' ? '#000' : '#fff',
       },
       palette: {
-        ...paletteColors,
+        primary: {
+          main: paletteType === 'light' ? blue[700] : blue[500],
+        },
+        secondary: {
+          // Darken / lighten so we reach the AA contrast ratio level.
+          main: paletteType === 'light' ? darken(pink.A400, 0.1) : lighten(pink.A400, 0.5),
+        },
         type: paletteType,
         background: {
-          default: paletteType === 'light' ? '#fff' : '#303030',
+          default: paletteType === 'light' ? '#fff' : '#121212',
         },
+        ...paletteColors,
       },
     });
 
-    nextTheme.palette.background.level1 =
-      paletteType === 'light' ? nextTheme.palette.grey[100] : nextTheme.palette.grey[900];
+    nextTheme.palette.background.level2 =
+      paletteType === 'light' ? nextTheme.palette.grey[100] : '#333';
 
-    nextTheme.palette.background.level0 =
-      paletteType === 'light' ? nextTheme.palette.grey[50] : nextTheme.palette.grey[900];
+    nextTheme.palette.background.level1 =
+      paletteType === 'light' ? '#fff' : nextTheme.palette.grey[900];
 
     return nextTheme;
   }, [direction, paletteColors, paletteType]);

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from '@material-ui/styles';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createMuiTheme, darken } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { blue, pink } from '@material-ui/core/colors';
 import { getCookie } from 'docs/src/modules/utils/helpers';
@@ -81,7 +81,7 @@ export function Provider(props) {
           main: paletteType === 'light' ? blue[700] : blue[200],
         },
         secondary: {
-          main: paletteType === 'light' ? pink[600] : pink[200],
+          main: paletteType === 'light' ? darken(pink.A400, 0.1) : pink[200],
         },
         type: paletteType,
         background: {

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -1,19 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from '@material-ui/styles';
-import { createMuiTheme, darken, lighten } from '@material-ui/core/styles';
+import { createMuiTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { blue, pink } from '@material-ui/core/colors';
 import { getCookie } from 'docs/src/modules/utils/helpers';
 import { darkTheme, setPrismTheme } from 'docs/src/modules/components/prism';
 
-export const themeInitialOptions = {
+export const themeColor = blue[700];
+
+const themeInitialOptions = {
   direction: 'ltr',
-  paletteColors: {
-    primary: {
-      main: blue[700],
-    },
-  },
+  paletteColors: {},
 };
 
 export const DispatchContext = React.createContext(() => {
@@ -80,11 +78,10 @@ export function Provider(props) {
       },
       palette: {
         primary: {
-          main: paletteType === 'light' ? blue[700] : blue[500],
+          main: paletteType === 'light' ? blue[700] : blue[200],
         },
         secondary: {
-          // Darken / lighten so we reach the AA contrast ratio level.
-          main: paletteType === 'light' ? darken(pink.A400, 0.1) : lighten(pink.A400, 0.5),
+          main: paletteType === 'light' ? pink[600] : pink[200],
         },
         type: paletteType,
         background: {

--- a/docs/src/modules/components/prism-okaidia.css
+++ b/docs/src/modules/components/prism-okaidia.css
@@ -1,0 +1,147 @@
+/**
+ * https://unpkg.com/prismjs/themes/prism-okaidia.css
+ *
+ * okaidia theme for JavaScript, CSS and HTML
+ * Loosely based on Monokai textmate theme by http://www.monokai.nl/
+ * @author ocodia
+ */
+
+code[class*="language-"],
+pre[class*="language-"] {
+  color: #f8f8f2;
+  background: none;
+  text-shadow: 0 1px rgba(0, 0, 0, 0.3);
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 1em;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Code blocks */
+pre[class*="language-"] {
+  padding: 1em;
+  margin: .5em 0;
+  overflow: auto;
+  border-radius: 0.3em;
+}
+
+:not(pre) > code[class*="language-"],
+pre[class*="language-"] {
+  background: #272822;
+}
+
+/* Inline code */
+:not(pre) > code[class*="language-"] {
+  padding: .1em;
+  border-radius: .3em;
+  white-space: normal;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: slategray;
+}
+
+.token.punctuation {
+  color: #f8f8f2;
+}
+
+.namespace {
+  opacity: .7;
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: #f92672;
+}
+
+.token.boolean,
+.token.number {
+  color: #ae81ff;
+}
+
+.token.selector,
+.token.attr-name,
+.token.string,
+.token.char,
+.token.builtin,
+.token.inserted {
+  color: #a6e22e;
+}
+
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string,
+.token.variable {
+  color: #f8f8f2;
+}
+
+.token.atrule,
+.token.attr-value,
+.token.function,
+.token.class-name {
+  color: #e6db74;
+}
+
+.token.keyword {
+  color: #66d9ef;
+}
+
+.token.regex,
+.token.important {
+  color: #fd971f;
+}
+
+.token.important,
+.token.bold {
+  font-weight: bold;
+}
+.token.italic {
+  font-style: italic;
+}
+
+.token.entity {
+  cursor: help;
+}
+
+/* Overrides to reach AA, copied from https://reactjs.org */
+
+code[class*="language-"],
+pre[class*="language-"] {
+  text-shadow: none;
+}
+
+.token.comment,
+.token.prolog,
+.token.doctype,
+.token.cdata {
+  color: rgb(178, 178, 178);
+}
+
+.token.property,
+.token.tag,
+.token.constant,
+.token.symbol,
+.token.deleted {
+  color: rgb(252, 146, 158);
+}

--- a/docs/src/modules/components/prism.js
+++ b/docs/src/modules/components/prism.js
@@ -10,17 +10,14 @@ import 'prismjs/components/prism-markup';
 import 'prismjs/components/prism-tsx';
 
 let styleNode;
-let lightTheme;
 let darkTheme;
 
 if (process.browser) {
-  lightTheme = require('prismjs/themes/prism.css');
-  darkTheme = require('prismjs/themes/prism-okaidia.css');
-
+  darkTheme = require('./prism-okaidia.css');
   styleNode = document.querySelector('#prismjs');
 }
 
-export { lightTheme, darkTheme };
+export { darkTheme };
 
 export function setPrismTheme(theme) {
   styleNode.textContent = theme;

--- a/docs/src/pages/components/snackbars/CustomizedSnackbars.js
+++ b/docs/src/pages/components/snackbars/CustomizedSnackbars.js
@@ -28,7 +28,7 @@ const useStyles1 = makeStyles(theme => ({
     backgroundColor: theme.palette.error.dark,
   },
   info: {
-    backgroundColor: theme.palette.primary.dark,
+    backgroundColor: theme.palette.primary.main,
   },
   warning: {
     backgroundColor: amber[700],

--- a/docs/src/pages/components/snackbars/CustomizedSnackbars.tsx
+++ b/docs/src/pages/components/snackbars/CustomizedSnackbars.tsx
@@ -28,7 +28,7 @@ const useStyles1 = makeStyles((theme: Theme) => ({
     backgroundColor: theme.palette.error.dark,
   },
   info: {
-    backgroundColor: theme.palette.primary.dark,
+    backgroundColor: theme.palette.primary.main,
   },
   warning: {
     backgroundColor: amber[700],

--- a/docs/src/pages/customization/color/ColorDemo.js
+++ b/docs/src/pages/customization/color/ColorDemo.js
@@ -8,7 +8,6 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import Typography from '@material-ui/core/Typography';
 import AddIcon from '@material-ui/icons/Add';
-import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 
 const styles = theme => ({
   root: {
@@ -28,10 +27,8 @@ const styles = theme => ({
     marginRight: 20,
   },
   code: {
-    marginTop: theme.spacing(1),
-    '& pre': {
-      margin: '0px !important',
-    },
+    margin: theme.spacing(2),
+    fontSize: 16,
   },
   fab: {
     position: 'absolute',
@@ -80,17 +77,14 @@ function ColorDemo(props) {
             </Typography>
           </Toolbar>
         </AppBar>
-        <MarkdownElement
-          className={classes.code}
-          text={`\`\`\`jsx
-{
+        <pre className={classes.code}>
+          {`{
   palette: {
     primary: ${primary.output},
     secondary: ${secondary.output},
   },
-}
-\`\`\``}
-        />
+}`}
+        </pre>
         <Fab className={classes.fab} style={{ backgroundColor: secondary.main }} aria-label="Add">
           <AddIcon htmlColor={secondary.contrastText} />
         </Fab>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -6,7 +6,7 @@ import Document, { Head, Main, NextScript } from 'next/document';
 import { Router } from 'next/router';
 import { LANGUAGES } from 'docs/src/modules/constants';
 import { pathnameToLanguage } from 'docs/src/modules/utils/helpers';
-import { themeInitialOptions } from 'docs/src/modules/components/ThemeContext';
+import { themeColor } from 'docs/src/modules/components/ThemeContext';
 
 // You can find a benchmark of the available CSS minifiers under
 // https://github.com/GoalSmashers/css-minification-benchmark
@@ -48,7 +48,7 @@ class MyDocument extends Document {
           */}
           <link rel="manifest" href="/static/manifest.json" />
           {/* PWA primary color */}
-          <meta name="theme-color" content={themeInitialOptions.paletteColors.primary.main} />
+          <meta name="theme-color" content={themeColor} />
           <link rel="shortcut icon" href="/static/favicon.ico" />
           {/* SEO */}
           <link

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,8 +40,7 @@ const styles = theme => ({
   },
   hero: {
     paddingTop: 64,
-    backgroundColor: theme.palette.background.paper,
-    color: theme.palette.type === 'light' ? theme.palette.primary.dark : theme.palette.primary.main,
+    color: theme.palette.primary.main,
   },
   content: {
     display: 'flex',
@@ -83,7 +82,6 @@ const styles = theme => ({
     marginTop: theme.spacing(4),
   },
   social: {
-    backgroundColor: theme.palette.background.paper,
     padding: theme.spacing(2, 0),
     display: 'flex',
     justifyContent: 'center',


### PR DESCRIPTION
Preview: https://deploy-preview-16324--material-ui.netlify.com/

- Remove the light demo theme
- Follow the [dark theme guideline](https://material.io/design/color/dark-theme.html)
- Improve color contrast
- Use https://reactjs.org as inspiration, try to provide people the same landmark.

From
![Capture d’écran 2019-06-21 à 16 26 42](https://user-images.githubusercontent.com/3165635/59929577-646a8b80-9441-11e9-914a-bb9417e7e661.png)

To
![Capture d’écran 2019-06-21 à 16 26 39](https://user-images.githubusercontent.com/3165635/59929576-63d1f500-9441-11e9-84c9-e148e2457808.png)