### PR TITLE
[styles] Support augmenting CSS properties

### DIFF
--- a/docs/src/pages/guides/right-to-left/RtlOptOut.js
+++ b/docs/src/pages/guides/right-to-left/RtlOptOut.js
@@ -1,8 +1,7 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
-const styles = theme => ({
+const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
     marginTop: theme.spacing(4),
@@ -15,10 +14,10 @@ const styles = theme => ({
     flip: false,
     textAlign: 'right',
   },
-});
+}));
 
-function RtlOptOut(props) {
-  const { classes } = props;
+export default function RtlOptOut() {
+  const classes = useStyles();
 
   return (
     <div className={classes.root}>
@@ -27,9 +26,3 @@ function RtlOptOut(props) {
     </div>
   );
 }
-
-RtlOptOut.propTypes = {
-  classes: PropTypes.object.isRequired,
-};
-
-export default withStyles(styles)(RtlOptOut);

--- a/docs/src/pages/guides/right-to-left/RtlOptOut.tsx
+++ b/docs/src/pages/guides/right-to-left/RtlOptOut.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      width: '100%',
+      marginTop: theme.spacing(4),
+      marginRight: theme.spacing(2),
+    },
+    affected: {
+      textAlign: 'right',
+    },
+    unaffected: {
+      flip: false,
+      textAlign: 'right',
+    },
+  }),
+);
+
+export default function RtlOptOut() {
+  const classes = useStyles();
+
+  return (
+    <div className={classes.root}>
+      <div className={classes.affected}>Affected</div>
+      <div className={classes.unaffected}>Unaffected</div>
+    </div>
+  );
+}

--- a/docs/src/pages/guides/right-to-left/RtlOptOut.tsx
+++ b/docs/src/pages/guides/right-to-left/RtlOptOut.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 
 declare module '@material-ui/core/styles/withStyles' {
+  // Augment the BaseCSSProperties so that we can control jss-rtl
   interface BaseCSSProperties {
     /**
      * Used to control if the rule-set should be affected by rtl transformation

--- a/docs/src/pages/guides/right-to-left/RtlOptOut.tsx
+++ b/docs/src/pages/guides/right-to-left/RtlOptOut.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 
+declare module '@material-ui/core/styles/withStyles' {
+  interface BaseCSSProperties {
+    /**
+     * Used to control if the rule-set should be affected by rtl transformation
+     */
+    flip?: boolean;
+  }
+}
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -3,15 +3,20 @@ import { PropInjector, CoerceEmptyInterface, IsEmptyInterface } from '@material-
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 
-export interface CSSProperties extends CSS.Properties<number | string> {
+export interface BaseCSSProperties extends CSS.Properties<number | string> {
+  /**
+   * Used to control if the rule-set should be affected by rtl transformation
+   */
+  flip?: boolean;
+}
+
+export interface CSSProperties extends BaseCSSProperties {
   // Allow pseudo selectors and media queries
-  [k: string]: CSS.Properties<number | string>[keyof CSS.Properties] | CSSProperties;
+  [k: string]: BaseCSSProperties[keyof BaseCSSProperties] | CSSProperties;
 }
 
 export type BaseCreateCSSProperties<Props extends object = {}> = {
-  [P in keyof CSS.Properties<number | string>]:
-    | CSS.Properties<number | string>[P]
-    | ((props: Props) => CSS.Properties<number | string>[P])
+  [P in keyof BaseCSSProperties]: BaseCSSProperties[P] | ((props: Props) => BaseCSSProperties[P])
 };
 
 export interface CreateCSSProperties<Props extends object = {}>

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -3,12 +3,10 @@ import { PropInjector, CoerceEmptyInterface, IsEmptyInterface } from '@material-
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 
-export interface BaseCSSProperties extends CSS.Properties<number | string> {
-  /**
-   * Used to control if the rule-set should be affected by rtl transformation
-   */
-  flip?: boolean;
-}
+/**
+ * Allows the user to augment the properties available
+ */
+export interface BaseCSSProperties extends CSS.Properties<number | string> {}
 
 export interface CSSProperties extends BaseCSSProperties {
   // Allow pseudo selectors and media queries

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -10,6 +10,7 @@ import {
   StyleRulesCallback,
   Styles,
   ClassKeyOfStyles,
+  BaseCSSProperties,
 } from '@material-ui/styles/withStyles';
 
 export {
@@ -20,6 +21,7 @@ export {
   Styles,
   WithStylesOptions,
   StyleRulesCallback,
+  BaseCSSProperties,
 };
 
 /**


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Added `BaseCSSProperties` to let users augment which CSS properties are available 
* Added typescript version of `guides/right-to-left/RtlOptOut`