### PR TITLE
[docs] Better react-router-dom version comment

### DIFF
--- a/docs/src/pages/components/links/LinkRouter.js
+++ b/docs/src/pages/components/links/LinkRouter.js
@@ -4,7 +4,7 @@ import { MemoryRouter as Router } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
 import Link from '@material-ui/core/Link';
 
-// required for react-router-dom < 6.0.0
+// required for react-router-dom < 5.0.0
 // see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
 const AdapterLink = React.forwardRef((props, ref) => <RouterLink innerRef={ref} {...props} />);
 

--- a/docs/src/pages/components/links/LinkRouter.js
+++ b/docs/src/pages/components/links/LinkRouter.js
@@ -4,7 +4,7 @@ import { MemoryRouter as Router } from 'react-router';
 import { Link as RouterLink } from 'react-router-dom';
 import Link from '@material-ui/core/Link';
 
-// required for react-router-dom < 5.0.0
+// The usage of React.forwardRef will no longer be required for react-router-dom v6.
 // see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
 const AdapterLink = React.forwardRef((props, ref) => <RouterLink innerRef={ref} {...props} />);
 

--- a/docs/src/pages/components/links/LinkRouter.tsx
+++ b/docs/src/pages/components/links/LinkRouter.tsx
@@ -5,7 +5,7 @@ import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-d
 import Link from '@material-ui/core/Link';
 import { Omit } from '@material-ui/types';
 
-// required for react-router-dom < 6.0.0
+// required for react-router-dom < 5.0.0
 // see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
 const AdapterLink = React.forwardRef<HTMLAnchorElement, RouterLinkProps>((props, ref) => (
   <RouterLink innerRef={ref as any} {...props} />

--- a/docs/src/pages/components/links/LinkRouter.tsx
+++ b/docs/src/pages/components/links/LinkRouter.tsx
@@ -5,7 +5,7 @@ import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-d
 import Link from '@material-ui/core/Link';
 import { Omit } from '@material-ui/types';
 
-// The usage of React.forwardRef might no longer be required in react-router-dom v6.
+// The usage of React.forwardRef will no longer be required for react-router-dom v6.
 // see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
 const AdapterLink = React.forwardRef<HTMLAnchorElement, RouterLinkProps>((props, ref) => (
   <RouterLink innerRef={ref as any} {...props} />

--- a/docs/src/pages/components/links/LinkRouter.tsx
+++ b/docs/src/pages/components/links/LinkRouter.tsx
@@ -5,7 +5,7 @@ import { Link as RouterLink, LinkProps as RouterLinkProps } from 'react-router-d
 import Link from '@material-ui/core/Link';
 import { Omit } from '@material-ui/types';
 
-// required for react-router-dom < 5.0.0
+// The usage of React.forwardRef might no longer be required in react-router-dom v6.
 // see https://github.com/ReactTraining/react-router/issues/6056#issuecomment-435524678
 const AdapterLink = React.forwardRef<HTMLAnchorElement, RouterLinkProps>((props, ref) => (
   <RouterLink innerRef={ref as any} {...props} />


### PR DESCRIPTION
The comment in the linked issue specifies version 5 of `react-router-dom` and not 6. In fact, there is no version 6 or greater. At this time, the current version of `react-router-dom` is 5.0.1. So, I updated the comment to say *react-router-dom < 5.0.0*

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
