### PR TITLE
[core] Revert strict mode compatible transition components

### DIFF
--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -30,7 +30,7 @@ describe('<SpeedDial />', () => {
   }
 
   before(() => {
-    // StrictModeViolation: uses #simulate
+    // StrictModeViolation: uses ButtonBase
     mount = createMount({ strict: false });
     classes = getClasses(
       <SpeedDial {...defaultProps} icon={icon}>

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -17,7 +17,7 @@ describe('<SpeedDialAction />', () => {
   };
 
   before(() => {
-    // StrictModeViolation: uses #simulate
+    // StrictModeViolation: uses ButtonBase
     mount = createMount({ strict: false });
     classes = getClasses(<SpeedDialAction {...defaultProps} />);
   });

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
@@ -17,7 +17,7 @@ describe('<ToggleButton />', () => {
   let classes;
 
   before(() => {
-    // StrictModeViolation: uses #simulate
+    // StrictModeViolation: uses ButtonBase
     mount = createMount({ strict: false });
     render = createRender();
     classes = getClasses(<ToggleButton value="classes">Hello World</ToggleButton>);

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -11,7 +11,8 @@ describe('<ToggleButtonGroup />', () => {
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(
       <ToggleButtonGroup>
         <ToggleButton value="hello" />

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.2.0",
-    "@material-ui/react-transition-group": "^4.2.0",
     "@material-ui/styles": "^4.1.2",
     "@material-ui/system": "^4.3.0",
     "@material-ui/types": "^4.1.1",
@@ -54,6 +53,7 @@
     "popper.js": "^1.14.1",
     "prop-types": "^15.7.2",
     "react-event-listener": "^0.6.6",
+    "react-transition-group": "^4.0.0",
     "warning": "^4.0.1"
   },
   "sideEffects": false,

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -1,14 +1,18 @@
 import React from 'react';
-import { createMount, getClasses } from '@material-ui/core/test-utils';
+import { assert } from 'chai';
+import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Backdrop from './Backdrop';
 
 describe('<Backdrop />', () => {
   let mount;
+  let shallow;
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Fade
+    mount = createMount({ strict: false });
+    shallow = createShallow({ dive: true });
     classes = getClasses(<Backdrop open />);
   });
 
@@ -23,4 +27,10 @@ describe('<Backdrop />', () => {
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
   }));
+
+  it('should render a backdrop div', () => {
+    const wrapper = shallow(<Backdrop open className="woofBackdrop" />);
+    assert.strictEqual(wrapper.childAt(0).hasClass('woofBackdrop'), true);
+    assert.strictEqual(wrapper.childAt(0).hasClass(classes.root), true);
+  });
 });

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -20,7 +20,8 @@ describe('<BottomNavigation />', () => {
         <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses BottomNavigationAction
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -13,7 +13,7 @@ describe('<BottomNavigationAction />', () => {
   const icon = <Icon>restore</Icon>;
 
   before(() => {
-    // StrictModeViolation: uses #StrictMode
+    // StrictModeViolation: uses ButtonBase
     mount = createMount({ strict: false });
     classes = getClasses(<BottomNavigationAction />);
   });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -29,7 +29,7 @@ describe('<ButtonBase />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true, disableLifecycleMethods: true });
-    // StrictModeViolation: uses simulate
+    // StrictModeViolation: uses TouchRipple
     mount = createMount({ strict: false });
     classes = getClasses(<ButtonBase />);
   });

--- a/packages/material-ui/src/ButtonBase/Ripple.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 
 /**
  * @ignore - internal component.
@@ -40,16 +40,9 @@ function Ripple(props) {
     [classes.childPulsate]: pulsate,
   });
 
-  const rippleRef = React.useRef();
-
   return (
-    <Transition
-      onEnter={handleEnter}
-      onExit={handleExit}
-      {...other}
-      findDOMNode={() => rippleRef.current}
-    >
-      <span className={rippleClassName} ref={rippleRef} style={rippleStyles}>
+    <Transition onEnter={handleEnter} onExit={handleExit} {...other}>
+      <span className={rippleClassName} style={rippleStyles}>
         <span className={childClassName} />
       </span>
     </Transition>

--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TransitionGroup } from '@material-ui/react-transition-group';
+import { TransitionGroup } from 'react-transition-group';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import Ripple from './Ripple';

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -11,7 +11,8 @@ describe('<Checkbox />', () => {
 
   before(() => {
     classes = getClasses(<Checkbox />);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses IconButton
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -1,11 +1,10 @@
 import React from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 import withStyles from '../styles/withStyles';
 import { duration } from '../styles/transitions';
 import { getTransitionProps } from '../transitions/utils';
-import { useForkRef } from '../utils/reactHelpers';
 
 export const styles = theme => ({
   /* Styles applied to the container element. */
@@ -150,9 +149,6 @@ const Collapse = React.forwardRef(function Collapse(props, ref) {
     }
   };
 
-  const ownRef = React.useRef();
-  const handleRef = useForkRef(ownRef, ref);
-
   return (
     <Transition
       in={inProp}
@@ -164,7 +160,6 @@ const Collapse = React.forwardRef(function Collapse(props, ref) {
       addEndListener={addEndListener}
       timeout={timeout === 'auto' ? null : timeout}
       {...other}
-      findDOMNode={() => ownRef.current}
     >
       {(state, childProps) => (
         <Component
@@ -180,7 +175,7 @@ const Collapse = React.forwardRef(function Collapse(props, ref) {
             minHeight: collapsedHeight,
             ...style,
           }}
-          ref={handleRef}
+          ref={ref}
           {...childProps}
         >
           <div className={classes.wrapper} ref={wrapperRef}>

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -5,7 +5,7 @@ import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Collapse from './Collapse';
 import { createMuiTheme } from '@material-ui/core/styles';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 
 describe('<Collapse />', () => {
   let mount;
@@ -16,7 +16,8 @@ describe('<Collapse />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
     classes = getClasses(<Collapse {...defaultProps} />);
   });
 

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -26,7 +26,8 @@ describe('<Dialog />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Fade
+    mount = createMount({ strict: false });
     classes = getClasses(<Dialog {...defaultProps}>foo</Dialog>);
   });
 

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -13,7 +13,8 @@ describe('<Drawer />', () => {
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Slide
+    mount = createMount({ strict: false });
     classes = getClasses(
       <Drawer>
         <div />

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -16,7 +16,8 @@ describe('<ExpansionPanel />', () => {
   const minimalChildren = [<ExpansionPanelSummary key="header" />];
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Collapse
+    mount = createMount({ strict: false });
     classes = getClasses(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
   });
 

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -15,7 +15,7 @@ describe('<ExpansionPanelSummary />', () => {
   }
 
   before(() => {
-    // StrictModeViolation: uses #simulate
+    // StrictModeViolation: uses ButtonBase
     mount = createMount({ strict: false });
     classes = getClasses(<ExpansionPanelSummary />);
   });

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 import { duration } from '../styles/transitions';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
@@ -35,6 +35,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     ...other
   } = props;
   const theme = useTheme();
+  const handleRef = useForkRef(children.ref, ref);
 
   const handleEnter = node => {
     reflow(node); // So the animation always start from the start.
@@ -68,10 +69,6 @@ const Fade = React.forwardRef(function Fade(props, ref) {
     }
   };
 
-  const ownRef = React.useRef();
-  const userRef = useForkRef(children.ref, ref);
-  const handleRef = useForkRef(ownRef, userRef);
-
   return (
     <Transition
       appear
@@ -80,7 +77,6 @@ const Fade = React.forwardRef(function Fade(props, ref) {
       onExit={handleExit}
       timeout={timeout}
       {...other}
-      findDOMNode={() => ownRef.current}
     >
       {(state, childProps) => {
         return React.cloneElement(children, {

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -4,7 +4,7 @@ import { spy, useFakeTimers } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Fade from './Fade';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 
 describe('<Fade />', () => {
   let mount;
@@ -15,7 +15,8 @@ describe('<Fade />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -12,7 +12,8 @@ describe('<FormControlLabel />', () => {
   let classes;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Checkbox in test
+    mount = createMount({ strict: false });
     classes = getClasses(<FormControlLabel label="Pizza" control={<div />} />);
   });
 

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
 import { useForkRef } from '../utils/reactHelpers';
@@ -29,6 +29,7 @@ const Grow = React.forwardRef(function Grow(props, ref) {
   const { children, in: inProp, onEnter, onExit, style, timeout = 'auto', ...other } = props;
   const timer = React.useRef();
   const autoTimeout = React.useRef();
+  const handleRef = useForkRef(children.ref, ref);
   const theme = useTheme();
 
   const handleEnter = node => {
@@ -111,10 +112,6 @@ const Grow = React.forwardRef(function Grow(props, ref) {
     };
   }, []);
 
-  const ownRef = React.useRef();
-  const userRef = useForkRef(children.ref, ref);
-  const handleRef = useForkRef(userRef, ownRef);
-
   return (
     <Transition
       appear
@@ -124,7 +121,6 @@ const Grow = React.forwardRef(function Grow(props, ref) {
       addEndListener={addEndListener}
       timeout={timeout === 'auto' ? null : timeout}
       {...other}
-      findDOMNode={() => ownRef.current}
     >
       {(state, childProps) => {
         return React.cloneElement(children, {

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -5,8 +5,8 @@ import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Grow from './Grow';
 import { createMuiTheme } from '@material-ui/core/styles';
-import { Transition } from '@material-ui/react-transition-group';
 import { ThemeProvider } from '@material-ui/styles';
+import { Transition } from 'react-transition-group';
 import { useForkRef } from '../utils/reactHelpers';
 
 describe('<Grow />', () => {
@@ -17,7 +17,8 @@ describe('<Grow />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -20,7 +20,8 @@ describe('<IconButton />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<IconButton />);
   });
 

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -20,7 +20,8 @@ describe('<ListItem />', () => {
 
   before(() => {
     classes = getClasses(<ListItem />);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -19,7 +19,8 @@ describe('<Menu />', () => {
 
   before(() => {
     classes = getClasses(<Menu {...defaultProps} />);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Popover
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -15,7 +15,8 @@ describe('<MenuItem />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<MenuItem />);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -14,7 +14,8 @@ describe('<Modal />', () => {
   let savedBodyStyle;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Backdrop
+    mount = createMount({ strict: false });
     savedBodyStyle = document.body.style;
   });
 

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -57,7 +57,8 @@ describe('<Popover />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Grow
+    mount = createMount({ strict: false });
     classes = getClasses(
       <Popover {...defaultProps}>
         <div />
@@ -317,7 +318,7 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(anchorElSpy.callCount, 2); // 2 cause StrictMode
+      assert.strictEqual(anchorElSpy.callCount, 1);
     });
   });
 

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -176,7 +176,8 @@ describe('<Popper />', () => {
 
     before(() => {
       clock = useFakeTimers();
-      looseMount = createMount({ strict: true });
+      // StrictModeViolation: uses Grow
+      looseMount = createMount({ strict: false });
     });
 
     after(() => {

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -11,7 +11,8 @@ describe('<Radio />', () => {
 
   before(() => {
     classes = getClasses(<Radio />);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Switchbase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -25,7 +25,8 @@ describe('<Select />', () => {
 
   before(() => {
     classes = getClasses(<Select {...defaultProps} />);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: test uses MenuItem
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -31,7 +31,8 @@ describe('<SelectInput />', () => {
 
   before(() => {
     shallow = createShallow();
-    mount = createMount({ strict: true });
+    // StrictModeViolation: test uses MenuItem
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Slide/Slide.js
+++ b/packages/material-ui/src/Slide/Slide.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import debounce from 'debounce'; // < 1kb payload overhead when lodash/debounce is > 3kb.
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 import { elementAcceptingRef } from '@material-ui/utils';
 import { useForkRef } from '../utils/reactHelpers';
 import useTheme from '../styles/useTheme';
@@ -211,7 +211,6 @@ const Slide = React.forwardRef(function Slide(props, ref) {
       in={inProp}
       timeout={timeout}
       {...other}
-      findDOMNode={() => childrenRef.current}
     >
       {(state, childProps) => {
         return React.cloneElement(children, {

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -5,7 +5,7 @@ import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Slide, { setTranslateValue } from './Slide';
 import createMuiTheme from '../styles/createMuiTheme';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 
 describe('<Slide />', () => {
   let mount;
@@ -16,7 +16,8 @@ describe('<Slide />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -12,7 +12,7 @@ describe('<Snackbar />', () => {
 
   before(() => {
     classes = getClasses(<Snackbar open />);
-    // StrictModeViolation: uses #simulate
+    // StrictModeViolation: uses Slide
     mount = createMount({ strict: false });
   });
 

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -16,7 +16,8 @@ describe('<StepButton />', () => {
   before(() => {
     classes = getClasses(<StepButton />);
     shallow = createShallow({ dive: true });
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -16,7 +16,8 @@ describe('<StepContent />', () => {
   before(() => {
     classes = getClasses(<StepContent />);
     shallow = createShallow({ dive: true });
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Collapse
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -18,7 +18,8 @@ describe('<Stepper />', () => {
   before(() => {
     classes = getClasses(<Stepper />);
     shallow = createShallow({ dive: true });
-    mount = createMount({ strict: true });
+    // StrictModeViolation: test uses StepContent
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -20,7 +20,7 @@ describe('<Tab />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    // StrictModeViolation: uses #simulate
+    // StrictModeViolation: uses ButtonBase
     mount = createMount({ strict: false });
     classes = getClasses(<Tab textColor="inherit" />);
   });

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -32,7 +32,7 @@ describe('<TablePagination />', () => {
     classes = getClasses(
       <TablePagination count={1} onChangePage={() => {}} page={0} rowsPerPage={1} />,
     );
-    // StrictModeViolation: uses #html
+    // StrictModeViolation: uses  ButtonBase
     mount = createMount({ strict: false });
   });
 

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -13,7 +13,8 @@ describe('<TableSortLabel />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<TableSortLabel />);
   });
 

--- a/packages/material-ui/src/Tabs/TabScrollButton.test.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.test.js
@@ -15,7 +15,8 @@ describe('<TabScrollButton />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<TabScrollButton {...props} />);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -49,7 +49,8 @@ describe('<Tabs />', () => {
 
   before(() => {
     classes = getClasses(<Tabs onChange={noop} value={0} />);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     render = createRender();
   });
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -33,7 +33,8 @@ describe('<Tooltip />', () => {
   };
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses Grow and tests a lot of impl details
+    mount = createMount({ strict: undefined });
     classes = getClasses(<Tooltip {...defaultProps} />);
     clock = useFakeTimers();
   });
@@ -45,7 +46,7 @@ describe('<Tooltip />', () => {
 
   it('should render the correct structure', () => {
     const wrapper = mount(<Tooltip {...defaultProps} />);
-    const children = wrapper.childAt(0).childAt(0);
+    const children = wrapper.childAt(0);
     assert.strictEqual(children.childAt(1).type(), Popper);
     assert.strictEqual(children.childAt(1).hasClass(classes.popper), true);
   });

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 import { duration } from '../styles/transitions';
 import useTheme from '../styles/useTheme';
 import { reflow, getTransitionProps } from '../transitions/utils';
@@ -35,7 +35,9 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
     timeout = defaultTimeout,
     ...other
   } = props;
+
   const theme = useTheme();
+  const handleRef = useForkRef(children.ref, ref);
 
   const handleEnter = node => {
     reflow(node); // So the animation always start from the start.
@@ -69,10 +71,6 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
     }
   };
 
-  const ownRef = React.useRef();
-  const userRef = useForkRef(children.ref, ref);
-  const handleRef = useForkRef(userRef, ownRef);
-
   return (
     <Transition
       appear
@@ -81,7 +79,6 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
       onExit={handleExit}
       timeout={timeout}
       {...other}
-      findDOMNode={() => ownRef.current}
     >
       {(state, childProps) => {
         return React.cloneElement(children, {

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -3,14 +3,15 @@ import { assert } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
-import { Transition } from '@material-ui/react-transition-group';
+import { Transition } from 'react-transition-group';
 import Zoom from './Zoom';
 
 describe('<Zoom />', () => {
   let mount;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses react-transition-group
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -77,7 +77,8 @@ describe('<SwitchBase />', () => {
 
   before(() => {
     SwitchBaseNaked = unwrap(SwitchBase);
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses ButtonBase
+    mount = createMount({ strict: false });
     classes = getClasses(<SwitchBase {...defaultProps} />);
   });
 

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -73,7 +73,8 @@ describe('<MenuList> integration', () => {
   }
 
   before(() => {
-    render = createClientRender({ strict: true });
+    // StrictModeViolation: Uses MenuItem
+    render = createClientRender({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/test/integration/NestedMenu.test.js
+++ b/packages/material-ui/test/integration/NestedMenu.test.js
@@ -7,7 +7,8 @@ describe('<NestedMenu> integration', () => {
   let mount;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: test uses Popover
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -7,7 +7,8 @@ describe('<Select> integration', () => {
   let mount;
 
   before(() => {
-    mount = createMount({ strict: true });
+    // StrictModeViolation: uses MenuItem
+    mount = createMount({ strict: false });
   });
 
   after(() => {

--- a/pages/api/backdrop.md
+++ b/pages/api/backdrop.md
@@ -47,5 +47,5 @@ you need to use the following style sheet name: `MuiBackdrop`.
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -48,7 +48,7 @@ you need to use the following style sheet name: `MuiBottomNavigation`.
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -67,7 +67,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/collapse.md
+++ b/pages/api/collapse.md
@@ -59,7 +59,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/dialog.md
+++ b/pages/api/dialog.md
@@ -84,7 +84,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/drawer.md
+++ b/pages/api/drawer.md
@@ -65,7 +65,7 @@ you need to use the following style sheet name: `MuiDrawer`.
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/expansion-panel.md
+++ b/pages/api/expansion-panel.md
@@ -58,7 +58,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/fade.md
+++ b/pages/api/fade.md
@@ -34,7 +34,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -58,7 +58,7 @@ you need to use the following style sheet name: `MuiFormControlLabel`.
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/grow.md
+++ b/pages/api/grow.md
@@ -35,7 +35,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -64,7 +64,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -65,7 +65,7 @@ you need to use the following style sheet name: `MuiListItem`.
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -53,7 +53,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/menu.md
+++ b/pages/api/menu.md
@@ -65,7 +65,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/modal.md
+++ b/pages/api/modal.md
@@ -53,7 +53,7 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/popover.md
+++ b/pages/api/popover.md
@@ -72,7 +72,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -65,7 +65,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/select.md
+++ b/pages/api/select.md
@@ -71,7 +71,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/slide.md
+++ b/pages/api/slide.md
@@ -35,7 +35,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -54,7 +54,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/step-content.md
+++ b/pages/api/step-content.md
@@ -49,7 +49,7 @@ you need to use the following style sheet name: `MuiStepContent`.
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/stepper.md
+++ b/pages/api/stepper.md
@@ -57,7 +57,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -57,7 +57,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -63,7 +63,7 @@ you need to use the following style sheet name: `MuiTabs`.
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/pages/api/zoom.md
+++ b/pages/api/zoom.md
@@ -35,7 +35,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
 
 ## Demos
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,16 +1765,6 @@
     rifm "^0.7.0"
     tslib "^1.9.3"
 
-"@material-ui/react-transition-group@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@material-ui/react-transition-group/-/react-transition-group-4.2.0.tgz#afec833bbcc79f05a9b4d4828b3e07965cc7e321"
-  integrity sha512-4zapZ0gW1ZTws5aH9OGy3IMvtTV/olc7YrVSkM1WFu1FsrEhL+qarEniRjx7LjHt0gukFqoINfElI8v2boVMQA==
-  dependencies:
-    "@babel/runtime" "^7.4.5"
-    dom-helpers "^3.4.0"
-    loose-envify "^1.4.0"
-    prop-types "^15.6.2"
-
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Reverts #16283 which was a breaking change for `Snackbar` with custom children i.e. not components from `@material-ui/*`.

Closes #16347