### PR TITLE
[styles] Handle styled props of type any

### DIFF
--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -12,7 +12,7 @@ import * as React from 'react';
 export type ComponentCreator<Component extends React.ElementType> = <Theme, Props extends {} = any>(
   styles:
     | CreateCSSProperties<Props>
-    | (({ theme, ...props }: { theme: Theme } & Props) => CreateCSSProperties<Props>),
+    | ((props: { theme: Theme } & CoerceEmptyInterface<Props>) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
   Omit<

--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -20,7 +20,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
 >(
   styles:
     | CreateCSSProperties<Props>
-    | (({ theme, ...props }: { theme: Theme } & Props) => CreateCSSProperties<Props>),
+    | ((props: { theme: Theme } & CoerceEmptyInterface<Props>) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
   Omit<

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -5,17 +5,15 @@ import {
   createMuiTheme,
   Theme,
   withTheme,
-  StyleRules,
   StyleRulesCallback,
-  StyledComponentProps,
   WithStyles,
   WithTheme,
   makeStyles,
+  styled,
 } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import { blue } from '@material-ui/core/colors';
-import { StandardProps } from '@material-ui/core';
 
 // Shared types for examples
 interface ComponentProps extends WithStyles<typeof styles> {
@@ -562,4 +560,41 @@ withStyles(theme =>
       }),
     }));
   }
+}
+
+{
+  // Make sure theme and props have the correct types
+  // https://github.com/mui-org/material-ui/issues/16351
+
+  // Theme has default type
+  styled(Button)(({ theme }) => {
+    // $ExpectType Theme
+    theme;
+
+    return { padding: theme.spacing(1) };
+  });
+
+  interface myProps {
+    testValue: boolean;
+  }
+
+  // Type of props follow all the way to css properties
+  styled(Button)<Theme, myProps>(({ theme, testValue }) => {
+    // $ExpectType Theme
+    theme;
+
+    // $ExpectType boolean
+    testValue;
+
+    return {
+      padding: props => {
+        // $ExpectType myProps
+        props;
+
+        // $ExpectType boolean
+        props.testValue;
+        return theme.spacing(1);
+      },
+    };
+  });
 }


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Wrap Props with `CoerceEmptyInterface` for `styled` in `core` and `styles`

Closes #16351