### PR TITLE
[MenuItem] Fix type deceleration not using MenuItemClassKey

### DIFF
--- a/packages/material-ui/src/MenuItem/MenuItem.d.ts
+++ b/packages/material-ui/src/MenuItem/MenuItem.d.ts
@@ -4,11 +4,18 @@ import { ExtendButtonBase } from '../ButtonBase';
 
 export type MenuItemClassKey = 'root' | 'gutters' | 'selected';
 
-declare const MenuItem: OverridableComponent<ListItemTypeMap<{ button: false }, 'li'>> &
-  ExtendButtonBase<ListItemTypeMap<{ button?: true }, 'li'>>;
+export type MenuItemTypeMap<P, D extends React.ElementType> = Omit<
+  ListItemTypeMap<P, D>,
+  'classKey'
+> & {
+  classKey: MenuItemClassKey;
+};
+
+declare const MenuItem: OverridableComponent<MenuItemTypeMap<{ button: false }, 'li'>> &
+  ExtendButtonBase<MenuItemTypeMap<{ button?: true }, 'li'>>;
 
 export type MenuItemProps<D extends React.ElementType = 'li', P = {}> = OverrideProps<
-  ListItemTypeMap<P, D>,
+  MenuItemTypeMap<P, D>,
   D
 >;
 

--- a/packages/material-ui/src/MenuItem/MenuItem.d.ts
+++ b/packages/material-ui/src/MenuItem/MenuItem.d.ts
@@ -1,6 +1,7 @@
 import { ListItemTypeMap } from '../ListItem';
 import { OverridableComponent, OverrideProps } from '../OverridableComponent';
 import { ExtendButtonBase } from '../ButtonBase';
+import { Omit } from '@material-ui/types';
 
 export type MenuItemClassKey = 'root' | 'gutters' | 'selected';
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

* Fixed MenuItem type deceleration not using `MenuItemClassKey`

Closes #16122