### PR TITLE
[TextareaAutosize] Fix one possible case of infinite render loop

### DIFF
--- a/packages/material-ui/src/InputBase/Textarea.js
+++ b/packages/material-ui/src/InputBase/Textarea.js
@@ -121,7 +121,9 @@ const Textarea = React.forwardRef(function Textarea(props, ref) {
         ref={handleRef}
         style={{
           height: state.outerHeight,
-          overflow: state.outerHeight === state.innerHeight ? 'hidden' : null,
+          // Need a large enough different to allow scrolling.
+          // This prevents infinite rendering loop.
+          overflow: Math.abs(state.outerHeight - state.innerHeight) <= 1 ? 'hidden' : null,
           ...style,
         }}
         {...other}


### PR DESCRIPTION
Closes #16222 When user sets a padding for `<Input multiline />`, Chrome in a scaled Win10 monitor may display a scrollbar which leads to infinite redering loop. It may has to do with how height is rounded up or down to whole pixels on a non-retina monitor when scaled.

I was not the one who wrote the fix, but I was encouraged to submit the PR.  

Similar logic to compare `innerHeight` and `outerHeight`  was already used in another location in the same file.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
