### PR TITLE
[Modal] Fix persisting aria-hidden

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -24,7 +24,7 @@ function getHasTransition(props) {
 // Modals don't open on the server so this won't conflict with concurrent requests.
 const defaultManager = new ModalManager();
 
-function getModal(modal, modalRef, mountNodeRef) {
+function getModal(modal, mountNodeRef, modalRef) {
   modal.current.modalRef = modalRef.current;
   modal.current.mountNode = mountNodeRef.current;
   return modal.current;

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -301,7 +301,7 @@ describe('<Modal />', () => {
         </Modal>,
       );
       const modalNode = modalRef.current;
-      assert.strictEqual(modalNode.getAttribute('aria-hidden'), 'true');
+      expect(modalNode).not.to.be.ariaHidden;
     });
 
     // Test case for https://github.com/mui-org/material-ui/issues/15180

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -295,12 +295,15 @@ describe('<Modal />', () => {
 
     it('does not include the children in the a11y tree', () => {
       const modalRef = React.createRef();
-      mount(
+      const wrapper = mount(
         <Modal keepMounted open={false} ref={modalRef}>
-          <div />
+          <div>ModalContent</div>
         </Modal>,
       );
       const modalNode = modalRef.current;
+      expect(modalNode).to.be.ariaHidden;
+
+      wrapper.setProps({ open: true });
       expect(modalNode).not.to.be.ariaHidden;
     });
 

--- a/packages/material-ui/src/Modal/ModalManager.test.js
+++ b/packages/material-ui/src/Modal/ModalManager.test.js
@@ -161,17 +161,17 @@ describe('ModalManager', () => {
       const modal2 = {};
       modalManager.add(modal1, container3);
       modalManager.mount(modal1);
-      expect(container3.children[0]).not.to.be.accessible;
+      expect(container3.children[0]).to.be.ariaHidden;
 
       modalManager.add(modal2, container4);
       modalManager.mount(modal2);
-      expect(container4.children[0]).not.to.be.accessible;
+      expect(container4.children[0]).to.be.ariaHidden;
 
       modalManager.remove(modal2);
-      expect(container4.children[0]).to.be.accessible;
+      expect(container4.children[0]).not.to.be.ariaHidden;
 
       modalManager.remove(modal1);
-      expect(container3.children[0]).to.be.accessible;
+      expect(container3.children[0]).not.to.be.ariaHidden;
     });
 
     afterEach(() => {
@@ -202,14 +202,14 @@ describe('ModalManager', () => {
       const modal2 = document.createElement('div');
       modal2.setAttribute('aria-hidden', 'true');
 
-      expect(modal2).not.to.be.accessible;
+      expect(modal2).to.be.ariaHidden;
       modalManager.add({ modalRef: modal2 }, container2);
-      expect(modal2).to.be.accessible;
+      expect(modal2).not.to.be.ariaHidden;
     });
 
     it('should add aria-hidden to container siblings', () => {
       modalManager.add({}, container2);
-      expect(container2.children[0]).not.to.be.accessible;
+      expect(container2.children[0]).to.be.ariaHidden;
     });
 
     it('should add aria-hidden to previous modals', () => {
@@ -221,13 +221,13 @@ describe('ModalManager', () => {
 
       modalManager.add({ modalRef: modal2 }, container2);
       // Simulate the main React DOM true.
-      expect(container2.children[0]).not.to.be.accessible;
-      expect(container2.children[1]).to.be.accessible;
+      expect(container2.children[0]).to.be.ariaHidden;
+      expect(container2.children[1]).not.to.be.ariaHidden;
 
       modalManager.add({ modalRef: modal3 }, container2);
-      expect(container2.children[0]).not.to.be.accessible;
-      expect(container2.children[1]).not.to.be.accessible;
-      expect(container2.children[2]).to.be.accessible;
+      expect(container2.children[0]).to.be.ariaHidden;
+      expect(container2.children[1]).to.be.ariaHidden;
+      expect(container2.children[2]).not.to.be.ariaHidden;
     });
 
     it('should remove aria-hidden on siblings', () => {
@@ -235,9 +235,9 @@ describe('ModalManager', () => {
 
       modalManager.add(modal, container2);
       modalManager.mount(modal);
-      expect(container2.children[0]).to.be.accessible;
+      expect(container2.children[0]).not.to.be.ariaHidden;
       modalManager.remove(modal, container2);
-      expect(container2.children[0]).not.to.be.accessible;
+      expect(container2.children[0]).to.be.ariaHidden;
     });
 
     it('should keep previous aria-hidden siblings hidden', () => {
@@ -252,11 +252,11 @@ describe('ModalManager', () => {
 
       modalManager.add(modal, container2);
       modalManager.mount(modal);
-      expect(container2.children[0]).to.be.accessible;
+      expect(container2.children[0]).not.to.be.ariaHidden;
       modalManager.remove(modal, container2);
-      expect(container2.children[0]).not.to.be.accessible;
-      expect(container2.children[1]).not.to.be.accessible;
-      expect(container2.children[2]).to.be.accessible;
+      expect(container2.children[0]).to.be.ariaHidden;
+      expect(container2.children[1]).to.be.ariaHidden;
+      expect(container2.children[2]).not.to.be.ariaHidden;
     });
   });
 });

--- a/packages/material-ui/src/Modal/ModalManager.test.js
+++ b/packages/material-ui/src/Modal/ModalManager.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import getScrollbarSize from '../utils/getScrollbarSize';
 import ModalManager from './ModalManager';
 
@@ -161,17 +161,17 @@ describe('ModalManager', () => {
       const modal2 = {};
       modalManager.add(modal1, container3);
       modalManager.mount(modal1);
-      assert.strictEqual(container3.children[0].getAttribute('aria-hidden'), 'true');
+      expect(container3.children[0]).not.to.be.accessible;
 
       modalManager.add(modal2, container4);
       modalManager.mount(modal2);
-      assert.strictEqual(container4.children[0].getAttribute('aria-hidden'), 'true');
+      expect(container4.children[0]).not.to.be.accessible;
 
       modalManager.remove(modal2);
-      assert.strictEqual(container4.children[0].getAttribute('aria-hidden'), null);
+      expect(container4.children[0]).to.be.accessible;
 
       modalManager.remove(modal1);
-      assert.strictEqual(container3.children[0].getAttribute('aria-hidden'), null);
+      expect(container3.children[0]).to.be.accessible;
     });
 
     afterEach(() => {
@@ -202,14 +202,14 @@ describe('ModalManager', () => {
       const modal2 = document.createElement('div');
       modal2.setAttribute('aria-hidden', 'true');
 
-      assert.strictEqual(modal2.getAttribute('aria-hidden'), 'true');
+      expect(modal2).not.to.be.accessible;
       modalManager.add({ modalRef: modal2 }, container2);
-      assert.strictEqual(modal2.getAttribute('aria-hidden'), null);
+      expect(modal2).to.be.accessible;
     });
 
     it('should add aria-hidden to container siblings', () => {
       modalManager.add({}, container2);
-      assert.strictEqual(container2.children[0].getAttribute('aria-hidden'), 'true');
+      expect(container2.children[0]).not.to.be.accessible;
     });
 
     it('should add aria-hidden to previous modals', () => {
@@ -221,13 +221,13 @@ describe('ModalManager', () => {
 
       modalManager.add({ modalRef: modal2 }, container2);
       // Simulate the main React DOM true.
-      assert.strictEqual(container2.children[0].getAttribute('aria-hidden'), 'true');
-      assert.strictEqual(container2.children[1].getAttribute('aria-hidden'), null);
+      expect(container2.children[0]).not.to.be.accessible;
+      expect(container2.children[1]).to.be.accessible;
 
       modalManager.add({ modalRef: modal3 }, container2);
-      assert.strictEqual(container2.children[0].getAttribute('aria-hidden'), 'true');
-      assert.strictEqual(container2.children[1].getAttribute('aria-hidden'), 'true');
-      assert.strictEqual(container2.children[2].getAttribute('aria-hidden'), null);
+      expect(container2.children[0]).not.to.be.accessible;
+      expect(container2.children[1]).not.to.be.accessible;
+      expect(container2.children[2]).to.be.accessible;
     });
 
     it('should remove aria-hidden on siblings', () => {
@@ -235,9 +235,9 @@ describe('ModalManager', () => {
 
       modalManager.add(modal, container2);
       modalManager.mount(modal);
-      assert.strictEqual(container2.children[0].getAttribute('aria-hidden'), null);
+      expect(container2.children[0]).to.be.accessible;
       modalManager.remove(modal, container2);
-      assert.strictEqual(container2.children[0].getAttribute('aria-hidden'), 'true');
+      expect(container2.children[0]).not.to.be.accessible;
     });
 
     it('should keep previous aria-hidden siblings hidden', () => {
@@ -252,11 +252,11 @@ describe('ModalManager', () => {
 
       modalManager.add(modal, container2);
       modalManager.mount(modal);
-      assert.strictEqual(container2.children[0].getAttribute('aria-hidden'), null);
+      expect(container2.children[0]).to.be.accessible;
       modalManager.remove(modal, container2);
-      assert.strictEqual(container2.children[0].getAttribute('aria-hidden'), 'true');
-      assert.strictEqual(container2.children[1].getAttribute('aria-hidden'), 'true');
-      assert.strictEqual(container2.children[2].getAttribute('aria-hidden'), null);
+      expect(container2.children[0]).not.to.be.accessible;
+      expect(container2.children[1]).not.to.be.accessible;
+      expect(container2.children[2]).to.be.accessible;
     });
   });
 });

--- a/test/utils/init.d.ts
+++ b/test/utils/init.d.ts
@@ -2,6 +2,14 @@
 
 declare namespace Chai {
   interface Assertion {
+    /**
+     * checks if the element in question is considered aria-hidden
+     * Does not replace accessibility check as that requires display/visibility/layout
+     */
+    ariaHidden: Assertion;
+    /**
+     * checks if the element is focused
+     */
     focused: Assertion;
   }
 }

--- a/test/utils/init.js
+++ b/test/utils/init.js
@@ -21,10 +21,8 @@ chai.use((chaiAPI, utils) => {
     );
   });
 
-  chai.Assertion.addProperty('accessible', function elementIsAccessible() {
+  chai.Assertion.addProperty('ariaHidden', function elementIsAccessible() {
     const element = utils.flag(this, 'object');
-
-    new chai.Assertion(element).to.be.visible;
 
     // "An element is considered hidden if it, or any of its ancestors are not
     // rendered or have their aria-hidden attribute value set to true."
@@ -43,11 +41,11 @@ chai.use((chaiAPI, utils) => {
     }
 
     this.assert(
-      ariaHidden === false,
+      ariaHidden === true,
+      `expected ${utils.elToString(element)} to be aria-hidden\n${prettyDOM(previousNode)}`,
       `expected ${utils.elToString(element)} to not be aria-hidden, but ${utils.elToString(
         previousNode,
       )} had aria-hidden="true" instead\n${prettyDOM(previousNode)}`,
-      `expected ${utils.elToString(element)} to be aria-hidden\n${prettyDOM(previousNode)}`,
     );
   });
 });

--- a/test/utils/init.js
+++ b/test/utils/init.js
@@ -20,6 +20,36 @@ chai.use((chaiAPI, utils) => {
       prettyDOM(document.activeElement),
     );
   });
+
+  chai.Assertion.addProperty('accessible', function elementIsAccessible() {
+    const element = utils.flag(this, 'object');
+
+    new chai.Assertion(element).to.be.visible;
+
+    // "An element is considered hidden if it, or any of its ancestors are not
+    // rendered or have their aria-hidden attribute value set to true."
+    // -- https://www.w3.org/TR/wai-aria-1.1/#aria-hidden
+    let previousNode = element;
+    let currentNode = element;
+    let ariaHidden = false;
+    while (
+      currentNode !== null &&
+      currentNode !== document.documentElement &&
+      ariaHidden === false
+    ) {
+      ariaHidden = element.getAttribute('aria-hidden') === 'true';
+      previousNode = currentNode;
+      currentNode = currentNode.parentElement;
+    }
+
+    this.assert(
+      ariaHidden === false,
+      `expected ${utils.elToString(element)} to not be aria-hidden, but ${utils.elToString(
+        previousNode,
+      )} had aria-hidden="true" instead\n${prettyDOM(previousNode)}`,
+      `expected ${utils.elToString(element)} to be aria-hidden\n${prettyDOM(previousNode)}`,
+    );
+  });
 });
 
 consoleError();

--- a/test/utils/init.js
+++ b/test/utils/init.js
@@ -24,14 +24,18 @@ chai.use((chaiAPI, utils) => {
   chai.Assertion.addProperty('ariaHidden', function elementIsAccessible() {
     const element = utils.flag(this, 'object');
 
-    // "An element is considered hidden if it, or any of its ancestors are not
-    // rendered or have their aria-hidden attribute value set to true."
-    // -- https://www.w3.org/TR/wai-aria-1.1/#aria-hidden
+    // used for debugging failed assertions, will either point to the top most node
+    // or the node that had aria-hidden="true"
     let previousNode = element;
     let currentNode = element;
     let ariaHidden = false;
+    // "An element is considered hidden if it, or any of its ancestors are not
+    // rendered or have their aria-hidden attribute value set to true."
+    // -- https://www.w3.org/TR/wai-aria-1.1/#aria-hidden
     while (
       currentNode !== null &&
+      // stoping at <html /> so that failed assertion message only prints
+      // <body /> or below. use cases for aria-hidden on <html /> are unknown
       currentNode !== document.documentElement &&
       ariaHidden === false
     ) {


### PR DESCRIPTION
~Not a fix yet just a failing test case.~ Opening this since I have a question: Why do we export `ariaHidden` from the ModalManager and use it in `Modal`? Isn't the point of ModalManager that it manages this stuff in which case it shouldn't be exported? 

I suspected that the issue was with a rogue parent aria-hidden which is why I added a custom matcher (aria-hidden is inherited but not overwriteable).

Closes #16391

/cc @oliviertassinari 