### PR TITLE
[slider] Fix small step regression

### DIFF
--- a/docs/src/pages/components/slider/DiscreteSlider.js
+++ b/docs/src/pages/components/slider/DiscreteSlider.js
@@ -58,6 +58,20 @@ export default function DiscreteSlider() {
         max={110}
       />
       <div className={classes.margin} />
+      <Typography id="discrete-slider-small-steps" gutterBottom>
+        Small Steps
+      </Typography>
+      <Slider
+        defaultValue={0.00000005}
+        getAriaValueText={valuetext}
+        aria-labelledby="discrete-slider-small-steps"
+        step={0.00000001}
+        marks
+        min={-0.00000005}
+        max={0.0000001}
+        valueLabelDisplay="auto"
+      />
+      <div className={classes.margin} />
       <Typography id="discrete-slider-custom" gutterBottom>
         Custom marks
       </Typography>

--- a/docs/src/pages/components/slider/DiscreteSlider.tsx
+++ b/docs/src/pages/components/slider/DiscreteSlider.tsx
@@ -60,6 +60,20 @@ export default function DiscreteSlider() {
         max={110}
       />
       <div className={classes.margin} />
+      <Typography id="discrete-slider-small-steps" gutterBottom>
+        Small Steps
+      </Typography>
+      <Slider
+        defaultValue={0.00000005}
+        getAriaValueText={valuetext}
+        aria-labelledby="discrete-slider-small-steps"
+        step={0.00000001}
+        marks
+        min={-0.00000005}
+        max={0.0000001}
+        valueLabelDisplay="auto"
+      />
+      <div className={classes.margin} />
       <Typography id="discrete-slider-custom" gutterBottom>
         Custom marks
       </Typography>

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -65,15 +65,20 @@ function percentToValue(percent, min, max) {
   return (max - min) * percent + min;
 }
 
-function ensurePrecision(value, step) {
-  const stepDecimalPart = step.toString().split('.')[1];
-  const stepPrecision = stepDecimalPart ? stepDecimalPart.length : 0;
+function getDecimalPrecision(num) {
+  if (Math.abs(num) < 1) {
+    const parts = num.toExponential().split('e-');
+    const matissaDecimalPart = parts[0].split('.')[1];
+    return (matissaDecimalPart ? matissaDecimalPart.length : 0) + parseInt(parts[1], 10);
+  }
 
-  return Number(value.toFixed(stepPrecision));
+  const decimalPart = num.toString().split('.')[1];
+  return decimalPart ? decimalPart.length : 0;
 }
 
 function roundValueToStep(value, step) {
-  return ensurePrecision(Math.round(value / step) * step, step);
+  const nearest = Math.round(value / step) * step;
+  return Number(nearest.toFixed(getDecimalPrecision(step)));
 }
 
 function setValueIndex({ values, source, newValue, index }) {
@@ -322,8 +327,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const marks =
     marksProp === true && step !== null
       ? [...Array(Math.floor((max - min) / step) + 1)].map((_, index) => ({
-          value: min + step * index,
-        }))
+        value: min + step * index,
+      }))
       : marksProp;
 
   instanceRef.current = {

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -327,8 +327,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const marks =
     marksProp === true && step !== null
       ? [...Array(Math.floor((max - min) / step) + 1)].map((_, index) => ({
-        value: min + step * index,
-      }))
+          value: min + step * index,
+        }))
       : marksProp;
 
   instanceRef.current = {

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -66,6 +66,8 @@ function percentToValue(percent, min, max) {
 }
 
 function getDecimalPrecision(num) {
+  // This handles the case when num is very small (0.00000001), js will turn this into 1e-8.
+  // When num is bigger than 1 or less than -1 it won't get converted to this notation so it's fine.
   if (Math.abs(num) < 1) {
     const parts = num.toExponential().split('e-');
     const matissaDecimalPart = parts[0].split('.')[1];

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -261,6 +261,20 @@ describe('<Slider />', () => {
       thumb.simulate('keydown', moveRightEvent);
       assert.strictEqual(wrapper.props().value, 0.3);
     });
+    
+    it('should not fail to round value to step precision when step is very small', () => {
+      wrapper.setProps({ value: 0.00000002, step: 0.00000001, min: 0, max: 0.00000005 });
+      const thumb = findThumb(wrapper);
+      thumb.simulate('keydown', moveRightEvent);
+      assert.strictEqual(wrapper.props().value, 0.00000003);
+    });
+
+    it('should not fail to round value to step precision when step is very small and negative', () => {
+      wrapper.setProps({ value: -0.00000002, step: 0.00000001, min: -0.00000005, max: 0 });
+      const thumb = findThumb(wrapper);
+      thumb.simulate('keydown', moveLeftEvent);
+      assert.strictEqual(wrapper.props().value, -0.00000003);
+    });
   });
 
   describe('markActive state', () => {

--- a/packages/material-ui-lab/src/Slider/Slider.test.js
+++ b/packages/material-ui-lab/src/Slider/Slider.test.js
@@ -261,7 +261,7 @@ describe('<Slider />', () => {
       thumb.simulate('keydown', moveRightEvent);
       assert.strictEqual(wrapper.props().value, 0.3);
     });
-    
+
     it('should not fail to round value to step precision when step is very small', () => {
       wrapper.setProps({ value: 0.00000002, step: 0.00000001, min: 0, max: 0.00000005 });
       const thumb = findThumb(wrapper);


### PR DESCRIPTION
Fixes a [regression](https://github.com/mui-org/material-ui/pull/16252#issuecomment-506227683) introduced by #16252

I added tests and examples. I can remove the example but I thought it might be a good idea to know when it breaks in a different way, small numbers are fragile in js and cryptocurrencies are all tiny.