### PR TITLE
[CardMedia] Change prop requirements to conform html picture semantics

### DIFF
--- a/packages/material-ui/src/CardMedia/CardMedia.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.js
@@ -31,7 +31,6 @@ const CardMedia = React.forwardRef(function CardMedia(props, ref) {
   );
 
   const isMediaComponent = MEDIA_COMPONENTS.indexOf(Component) !== -1;
-  const isPictureComponent = Component === 'picture';
   const composedStyle =
     !isMediaComponent && image ? { backgroundImage: `url("${image}")`, ...style } : style;
 
@@ -46,7 +45,7 @@ const CardMedia = React.forwardRef(function CardMedia(props, ref) {
       )}
       ref={ref}
       style={composedStyle}
-      src={isMediaComponent && !isPictureComponent ? image || src : undefined}
+      src={isMediaComponent ? image || src : undefined}
       {...other}
     />
   );

--- a/packages/material-ui/src/CardMedia/CardMedia.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.js
@@ -26,11 +26,12 @@ const CardMedia = React.forwardRef(function CardMedia(props, ref) {
   const { classes, className, component: Component = 'div', image, src, style, ...other } = props;
 
   warning(
-    Boolean(image || src),
-    'Material-UI: either `image` or `src` property must be specified.',
+    'children' in other || Boolean(image || src),
+    'Material-UI: either `children`, `image` or `src` property must be specified.',
   );
 
   const isMediaComponent = MEDIA_COMPONENTS.indexOf(Component) !== -1;
+  const isPictureComponent = Component === 'picture';
   const composedStyle =
     !isMediaComponent && image ? { backgroundImage: `url("${image}")`, ...style } : style;
 
@@ -45,7 +46,7 @@ const CardMedia = React.forwardRef(function CardMedia(props, ref) {
       )}
       ref={ref}
       style={composedStyle}
-      src={isMediaComponent ? image || src : undefined}
+      src={isMediaComponent && !isPictureComponent ? image || src : undefined}
       {...other}
     />
   );

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -56,6 +56,11 @@ describe('<CardMedia />', () => {
       assert.strictEqual(wrapper.props().src, '/foo.jpg');
     });
 
+    it('should not have `src` prop when picture media component specified', () => {
+      const wrapper = shallow(<CardMedia image="/foo.jpg" component="picture" />);
+      assert.strictEqual(wrapper.props().src, undefined);
+    });
+
     it('should not have default inline style when media component specified', () => {
       const wrapper = shallow(<CardMedia src="/foo.jpg" component="picture" />);
       assert.strictEqual(wrapper.props().style, undefined);

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -1,17 +1,15 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import CardMedia from './CardMedia';
 
 describe('<CardMedia />', () => {
   let mount;
-  let shallow;
   let classes;
 
   before(() => {
     mount = createMount({ strict: true });
-    shallow = createShallow({ untilSelector: 'CardMedia' });
     classes = getClasses(<CardMedia image="/foo.jpg" />);
   });
 
@@ -28,47 +26,56 @@ describe('<CardMedia />', () => {
   }));
 
   it('should have the backgroundImage specified', () => {
-    const wrapper = shallow(<CardMedia image="/foo.jpg" />);
-    assert.strictEqual(wrapper.props().style.backgroundImage, 'url("/foo.jpg")');
+    const wrapper = mount(<CardMedia image="/foo.jpg" />);
+    assert.strictEqual(
+      findOutermostIntrinsic(wrapper).props().style.backgroundImage,
+      'url("/foo.jpg")',
+    );
   });
 
   it('should have backgroundImage specified even though custom styles got passed', () => {
-    const wrapper = shallow(<CardMedia image="/foo.jpg" style={{ height: 200 }} />);
-    assert.strictEqual(wrapper.props().style.backgroundImage, 'url("/foo.jpg")');
-    assert.strictEqual(wrapper.props().style.height, 200);
+    const wrapper = mount(<CardMedia image="/foo.jpg" style={{ height: 200 }} />);
+    assert.strictEqual(
+      findOutermostIntrinsic(wrapper).props().style.backgroundImage,
+      'url("/foo.jpg")',
+    );
+    assert.strictEqual(findOutermostIntrinsic(wrapper).props().style.height, 200);
   });
 
   it('should be possible to overwrite backgroundImage via custom styles', () => {
-    const wrapper = shallow(
+    const wrapper = mount(
       <CardMedia image="/foo.jpg" style={{ backgroundImage: 'url(/bar.jpg)' }} />,
     );
-    assert.strictEqual(wrapper.props().style.backgroundImage, 'url(/bar.jpg)');
+    assert.strictEqual(
+      findOutermostIntrinsic(wrapper).props().style.backgroundImage,
+      'url(/bar.jpg)',
+    );
   });
 
   describe('prop: component', () => {
-    it('should render `img` component when `img` specified', () => {
-      const wrapper = shallow(<CardMedia image="/foo.jpg" component="img" />);
-      assert.strictEqual(wrapper.type(), 'img');
-    });
-
     it('should have `src` prop when media component specified', () => {
-      const wrapper = shallow(<CardMedia image="/foo.jpg" component="iframe" />);
-      assert.strictEqual(wrapper.props().src, '/foo.jpg');
+      const wrapper = mount(<CardMedia image="/foo.jpg" component="iframe" />);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).props().src, '/foo.jpg');
     });
 
     it('should not have `src` prop when picture media component specified', () => {
-      const wrapper = shallow(<CardMedia image="/foo.jpg" component="picture" />);
-      assert.strictEqual(wrapper.props().src, undefined);
+      const wrapper = mount(
+        <CardMedia component="picture">
+          <source media="(min-width: 600px)" srcSet="big-cat.jpg" />
+          <img src="cat.jpg" alt="hello" />
+        </CardMedia>,
+      );
+      assert.strictEqual(findOutermostIntrinsic(wrapper).props().src, undefined);
     });
 
     it('should not have default inline style when media component specified', () => {
-      const wrapper = shallow(<CardMedia src="/foo.jpg" component="picture" />);
-      assert.strictEqual(wrapper.props().style, undefined);
+      const wrapper = mount(<CardMedia src="/foo.jpg" component="picture" />);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).props().style, undefined);
     });
 
     it('should not have `src` prop if not media component specified', () => {
-      const wrapper = shallow(<CardMedia image="/foo.jpg" component="table" />);
-      assert.strictEqual(wrapper.props().src, undefined);
+      const wrapper = mount(<CardMedia image="/foo.jpg" component="table" />);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).props().src, undefined);
     });
   });
 });


### PR DESCRIPTION
Update so that CardMedia can be used without a `src` or `image` prop if one is using html picture with children.

Use case:
```jsx
<CardMedia
  component="picture"
  // src="cat.jpg"
>
  <source media="(min-width: 600px)" srcSet="big-cat.jpg" />
  <img src="cat.jpg" />
<CardMedia>
```