### PR TITLE
[ButtonBase] Fix anchors with href having a button role

### DIFF
--- a/docs/src/modules/components/Link.js
+++ b/docs/src/modules/components/Link.js
@@ -32,6 +32,7 @@ function Link(props) {
     className: classNameProps,
     innerRef,
     naked,
+    role: roleProp,
     router,
     userLanguage,
     ...other
@@ -45,11 +46,16 @@ function Link(props) {
     other.as = `/${userLanguage}${other.href}`;
   }
 
+  // catch role passed from ButtonBase. This is definitely a link
+  const role = roleProp === 'button' ? undefined : roleProp;
+
   if (naked) {
-    return <NextComposed className={className} ref={innerRef} {...other} />;
+    return <NextComposed className={className} ref={innerRef} role={role} {...other} />;
   }
 
-  return <MuiLink component={NextComposed} className={className} ref={innerRef} {...other} />;
+  return (
+    <MuiLink component={NextComposed} className={className} ref={innerRef} role={role} {...other} />
+  );
 }
 
 Link.propTypes = {
@@ -61,6 +67,7 @@ Link.propTypes = {
   naked: PropTypes.bool,
   onClick: PropTypes.func,
   prefetch: PropTypes.bool,
+  role: PropTypes.string,
   router: PropTypes.shape({
     pathname: PropTypes.string.isRequired,
   }).isRequired,

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -268,7 +268,9 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     buttonProps.type = type;
     buttonProps.disabled = disabled;
   } else {
-    buttonProps.role = 'button';
+    if (ComponentProp !== 'a' || !other.href) {
+      buttonProps.role = 'button';
+    }
     buttonProps['aria-disabled'] = disabled;
   }
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -104,15 +104,16 @@ describe('<ButtonBase />', () => {
       expect(button).to.not.have.attribute('type');
     });
 
-    it('should automatically change the button to an a element when href is provided', () => {
-      const { getByRole } = render(<ButtonBase href="https://google.com">Hello</ButtonBase>);
-      const button = getByRole('button');
+    it('should automatically change the button to an anchor element when href is provided', () => {
+      const { getByText } = render(<ButtonBase href="https://google.com">Hello</ButtonBase>);
+      const button = getByText('Hello');
 
       expect(button).to.have.property('nodeName', 'A');
+      expect(button).not.to.have.attribute('role');
       expect(button).to.have.attribute('href', 'https://google.com');
     });
 
-    it('should change the button type to a and set role="button"', () => {
+    it('applies role="button" when an anchor is used without href', () => {
       const { getByRole } = render(<ButtonBase component="a">Hello</ButtonBase>);
       const button = getByRole('button');
 
@@ -120,7 +121,7 @@ describe('<ButtonBase />', () => {
       expect(button).not.to.have.attribute('type');
     });
 
-    it('should not change the button to an a element', () => {
+    it('should not use an anchor element if explicit component and href is passed', () => {
       const { getByRole } = render(
         // @ts-ignore
         <ButtonBase component="span" href="https://google.com">
@@ -601,12 +602,12 @@ describe('<ButtonBase />', () => {
       it('should ignore anchors with href', () => {
         const onClick = spy();
         const onKeyDown = spy(event => event.defaultPrevented);
-        const { getByRole } = render(
+        const { getByText } = render(
           <ButtonBase component="a" href="href" onClick={onClick} onKeyDown={onKeyDown}>
             Hello
           </ButtonBase>,
         );
-        const button = getByRole('button');
+        const button = getByText('Hello');
         button.focus();
         fireEvent.keyDown(document.activeElement || document.body, {
           key: 'Enter',


### PR DESCRIPTION
Closes #15512

`<ButtonBase href="asdas" />`
```diff
-<a href="asdas" role="button" />
+<a href="asdas" />
```

If it's an anchor with a href it's certainly not a button.