### PR TITLE
[ListItemIcon] Add margin to line up when using flex-start

### DIFF
--- a/packages/material-ui/src/List/ListContext.js
+++ b/packages/material-ui/src/List/ListContext.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useContext } from 'react';
 
 /**
  * @ignore - internal component.
  */
 const ListContext = React.createContext({});
+
+export const useListContext = () => useContext(ListContext);
 
 export default ListContext;

--- a/packages/material-ui/src/List/ListContext.js
+++ b/packages/material-ui/src/List/ListContext.js
@@ -1,10 +1,8 @@
-import React, { useContext } from 'react';
+import React from 'react';
 
 /**
  * @ignore - internal component.
  */
 const ListContext = React.createContext({});
-
-export const useListContext = () => useContext(ListContext);
 
 export default ListContext;

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
-import { useListContext } from '../List/ListContext';
+import ListContext from '../List/ListContext';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -12,6 +12,7 @@ export const styles = theme => ({
     flexShrink: 0,
     display: 'inline-flex',
   },
+  /* Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`. */
   alignItemsFlexStart: {
     marginTop: 8,
   },
@@ -22,14 +23,14 @@ export const styles = theme => ({
  */
 const ListItemIcon = React.forwardRef(function ListItemIcon(props, ref) {
   const { classes, className, ...other } = props;
-  const { alignItems } = useListContext();
+  const context = React.useContext(ListContext);
 
   return (
     <div
       className={clsx(
         classes.root,
         {
-          [classes.alignItemsFlexStart]: alignItems === 'flex-start',
+          [classes.alignItemsFlexStart]: context.alignItems === 'flex-start',
         },
         className,
       )}

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
-import ListContext from '../List/ListContext';
+import { useListContext } from '../List/ListContext';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -22,14 +22,14 @@ export const styles = theme => ({
  */
 const ListItemIcon = React.forwardRef(function ListItemIcon(props, ref) {
   const { classes, className, ...other } = props;
-  const context = React.useContext(ListContext);
+  const {alignItems} = useListContext();
 
   return (
     <div
       className={clsx(
         classes.root,
         {
-          [classes.alignItemsFlexStart]: context.alignItems === 'flex-start',
+          [classes.alignItemsFlexStart]: alignItems === 'flex-start',
         },
         className,
       )}

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -22,7 +22,7 @@ export const styles = theme => ({
  */
 const ListItemIcon = React.forwardRef(function ListItemIcon(props, ref) {
   const { classes, className, ...other } = props;
-  const {alignItems} = useListContext();
+  const { alignItems } = useListContext();
 
   return (
     <div

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
+import ListContext from '../List/ListContext';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -11,6 +12,9 @@ export const styles = theme => ({
     flexShrink: 0,
     display: 'inline-flex',
   },
+  alignItemsFlexStart: {
+    marginTop: 8,
+  },
 });
 
 /**
@@ -18,8 +22,21 @@ export const styles = theme => ({
  */
 const ListItemIcon = React.forwardRef(function ListItemIcon(props, ref) {
   const { classes, className, ...other } = props;
+  const context = React.useContext(ListContext);
 
-  return <div className={clsx(classes.root, className)} ref={ref} {...other} />;
+  return (
+    <div
+      className={clsx(
+        classes.root,
+        {
+          [classes.alignItemsFlexStart]: context.alignItems === 'flex-start',
+        },
+        className,
+      )}
+      ref={ref}
+      {...other}
+    />
+  );
 });
 
 ListItemIcon.propTypes = {

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createMount, createShallow, getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import ListItemIcon from './ListItemIcon';
 
@@ -44,5 +44,18 @@ describe('<ListItemIcon />', () => {
     );
     assert.strictEqual(wrapper.name(), 'div');
     assert.strictEqual(wrapper.children().name(), 'span');
+  });
+
+  it('should not use alignItemsFlexStart class when the align-items different from flex start', () => {
+    React.createContext({
+      alignItems: 'flex-start'
+    });
+    const wrapper = shallow(
+      <ListItemIcon>
+        <span />
+      </ListItemIcon>,
+    );
+
+    assert.equal(findOutermostIntrinsic(wrapper).hasClass(classes.alignItemsFlexStart), false);
   });
 });

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -1,22 +1,14 @@
 import React from 'react';
-import { assert } from 'chai';
-import {
-  createMount,
-  createShallow,
-  getClasses,
-  findOutermostIntrinsic,
-} from '@material-ui/core/test-utils';
+import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import ListItemIcon from './ListItemIcon';
 
 describe('<ListItemIcon />', () => {
   let mount;
-  let shallow;
   let classes;
 
   before(() => {
     mount = createMount({ strict: true });
-    shallow = createShallow({ dive: true });
     classes = getClasses(
       <ListItemIcon>
         <span />
@@ -40,27 +32,4 @@ describe('<ListItemIcon />', () => {
       skip: ['componentProp'],
     }),
   );
-
-  it('should render a span inside a div', () => {
-    const wrapper = shallow(
-      <ListItemIcon>
-        <span />
-      </ListItemIcon>,
-    );
-    assert.strictEqual(wrapper.name(), 'div');
-    assert.strictEqual(wrapper.children().name(), 'span');
-  });
-
-  it('should not use alignItemsFlexStart class when the align-items different from flex start', () => {
-    React.createContext({
-      alignItems: 'flex-start',
-    });
-    const wrapper = shallow(
-      <ListItemIcon>
-        <span />
-      </ListItemIcon>,
-    );
-
-    assert.equal(findOutermostIntrinsic(wrapper).hasClass(classes.alignItemsFlexStart), false);
-  });
 });

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.test.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createMount, createShallow, getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
+import {
+  createMount,
+  createShallow,
+  getClasses,
+  findOutermostIntrinsic,
+} from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import ListItemIcon from './ListItemIcon';
 
@@ -48,7 +53,7 @@ describe('<ListItemIcon />', () => {
 
   it('should not use alignItemsFlexStart class when the align-items different from flex start', () => {
     React.createContext({
-      alignItems: 'flex-start'
+      alignItems: 'flex-start',
     });
     const wrapper = shallow(
       <ListItemIcon>

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -34,7 +34,7 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">alignItemsFlexStart</span> | 
+| <span class="prop-name">alignItemsFlexStart</span> | Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemIcon/ListItemIcon.js)

--- a/pages/api/list-item-icon.md
+++ b/pages/api/list-item-icon.md
@@ -34,6 +34,7 @@ This property accepts the following keys:
 | Name | Description |
 |:-----|:------------|
 | <span class="prop-name">root</span> | Styles applied to the root element.
+| <span class="prop-name">alignItemsFlexStart</span> | 
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemIcon/ListItemIcon.js)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
According to #16371 there is a problem when using `flex-start`, the text and List Item are not on the same line.
This PR fix the shift between the two elements when using `flex-start`.
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #16371