### PR TITLE
[ci] Move TypeScript tests into separate job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,12 +85,6 @@ jobs:
       - checkout
       - install_js
       - run:
-          name: Transpile TypeScript demos
-          command: yarn docs:typescript:formatted --disable-cache
-      - run:
-          name: Are the compiled TypeScript demos equivalent to the JavaScript demos?
-          command: git add -A && git diff --exit-code --staged
-      - run:
           name: Can we generate the documentation?
           command: yarn docs:api
       - run:
@@ -105,6 +99,17 @@ jobs:
       - run:
           name: Lint JSON
           command: yarn jsonlint
+  test_types:
+    <<: *defaults
+    steps:
+      - checkout
+      - install_js
+      - run:
+          name: Transpile TypeScript demos
+          command: yarn docs:typescript:formatted --disable-cache
+      - run:
+          name: Are the compiled TypeScript demos equivalent to the JavaScript demos?
+          command: git add -A && git diff --exit-code --staged
       - run:
           name: Tests TypeScript definitions
           command: yarn typescript
@@ -169,5 +174,6 @@ workflows:
           requires:
             - test_unit
             - test_static
+            - test_types
             - test_browser
             - test_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,7 @@ workflows:
       - test_static:
           requires:
             - checkout
-      - test_material-ui-x:
+      - test_types:
           requires:
             - checkout
       - test_browser:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,22 @@ jobs:
               exit 1
             fi
       - run:
+          name: material-ui-icons
+          command: |
+            # latest commit
+            LATEST_COMMIT=$(git rev-parse HEAD)
+
+            # latest commit where packages/material-ui-icons was changed
+            FOLDER_COMMIT=$(git log -1 --format=format:%H --full-diff packages/material-ui-icons)
+
+            if [ $FOLDER_COMMIT = $LATEST_COMMIT ]; then
+              echo "changes, let's run the tests"
+              yarn workspace @material-ui/icons build:typings
+              yarn workspace @material-ui/icons test:built-typings
+            else
+              echo "no changes"
+            fi
+      - run:
           name: Coverage
           command: bash <(curl -s https://codecov.io/bash) -Z -C $CIRCLE_SHA1
   test_static:
@@ -92,73 +108,6 @@ jobs:
       - run:
           name: Tests TypeScript definitions
           command: yarn typescript
-  test_material-ui-x:
-    <<: *defaults
-    steps:
-      - checkout
-      - install_js
-      - run:
-          name: material-ui-icons
-          command: |
-            # latest commit
-            LATEST_COMMIT=$(git rev-parse HEAD)
-
-            # latest commit where packages/material-ui-icons was changed
-            FOLDER_COMMIT=$(git log -1 --format=format:%H --full-diff packages/material-ui-icons)
-
-            if [ $FOLDER_COMMIT = $LATEST_COMMIT ]; then
-              echo "changes, let's run the tests"
-              cd packages/material-ui-icons && yarn test
-              yarn build:typings
-              yarn test:built-typings
-            else
-              echo "no changes"
-            fi
-      - run:
-          name: material-ui-codemod
-          command: |
-            # latest commit
-            LATEST_COMMIT=$(git rev-parse HEAD)
-
-            # latest commit where packages/material-ui-codemod was changed
-            FOLDER_COMMIT=$(git log -1 --format=format:%H --full-diff packages/material-ui-codemod)
-
-            if [ $FOLDER_COMMIT = $LATEST_COMMIT ]; then
-              echo "changes, let's run the tests"
-              cd packages/material-ui-codemod && yarn test
-            else
-              echo "no changes"
-            fi
-      - run:
-          name: material-ui-lab
-          command: |
-            # latest commit
-            LATEST_COMMIT=$(git rev-parse HEAD)
-
-            # latest commit where packages/material-ui-lab was changed
-            FOLDER_COMMIT=$(git log -1 --format=format:%H --full-diff packages/material-ui-lab)
-
-            if [ $FOLDER_COMMIT = $LATEST_COMMIT ]; then
-              echo "changes, let's run the tests"
-              cd packages/material-ui-lab && yarn test
-            else
-              echo "no changes"
-            fi
-      - run:
-          name: eslint-plugin-material-ui
-          command: |
-            # latest commit
-            LATEST_COMMIT=$(git rev-parse HEAD)
-
-            # latest commit where packages/eslint-plugin-material-ui was changed
-            FOLDER_COMMIT=$(git log -1 --format=format:%H --full-diff packages/eslint-plugin-material-ui)
-
-            if [ $FOLDER_COMMIT = $LATEST_COMMIT ]; then
-              echo "changes, let's run the tests"
-              cd packages/eslint-plugin-material-ui && yarn test
-            else
-              echo "no changes"
-            fi
   test_production:
     <<: *defaults
     steps:
@@ -218,7 +167,6 @@ workflows:
             - checkout
       - test_regressions:
           requires:
-            - test_material-ui-x
             - test_unit
             - test_static
             - test_browser


### PR DESCRIPTION
As of right now `test_static` is the longest running job with typescript using up most of the time. This time will only go up with increasing type coverage. 

I moved it into a separate job. To not starve the available parallel jobs I removed the `material-ui-x` jon which only had redundant tests. With the exception of `@material-ui/icons test:built-typings` all tests are already covered by `test:coverage`. At least it appears that way from the glob pattern `packages/**/*.test.js` but maybe I'm missing something.

`@material-ui/icons test:built-typing` was moved into `test_unit`.

To be mergable someone with repo admin access needs to remove `test_material-ui-x` from the required checks and replace it with `test_types`.

Edit: [Looks good](https://circleci.com/workflow-run/c7901dea-40af-42c7-b196-f5484b4efd31) though test_types is still the slowest. Maybe we need to take a look into composite projects for typescript but this is a good enough start.