### PR TITLE
[docs] Fix typo in docs server

### DIFF
--- a/docs/src/server.js
+++ b/docs/src/server.js
@@ -12,7 +12,7 @@ const nextApp = next({
 });
 const nextHandler = nextApp.getRequestHandler();
 
-// Uncatched promise bubbling up to the global scope.
+// Uncaught promise bubbling up to the global scope.
 process.on('unhandledRejection', (reason, promise) => {
   log.fatal({
     name: 'unhandledRejection',


### PR DESCRIPTION
There was a minor typo in a wording inside `docs/src/server.js` file.