### PR TITLE
[ListItemSecondaryAction] Add missing types for props spread

### DIFF
--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
@@ -1,9 +1,7 @@
 import { StandardProps } from '..';
 
 export interface ListItemSecondaryActionProps
-  extends StandardProps<{}, ListItemSecondaryActionClassKey> {
-  children: React.ReactElement;
-}
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ListItemSecondaryActionClassKey> {}
 
 export type ListItemSecondaryActionClassKey = 'root';
 

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
@@ -1,7 +1,9 @@
 import { StandardProps } from '..';
 
 export interface ListItemSecondaryActionProps
-  extends StandardProps<{}, ListItemSecondaryActionClassKey> {}
+  extends StandardProps<{}, ListItemSecondaryActionClassKey> {
+  children: React.ReactElement;
+}
 
 export type ListItemSecondaryActionClassKey = 'root';
 


### PR DESCRIPTION
It's defined in js:
https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js#L29
but missing in type definitions

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
