### PR TITLE
[styles] Add test for removing styles via `overrides`

### DIFF
--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -244,45 +244,80 @@ describe('makeStyles', () => {
       assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root' });
     });
 
-    it('should support the overrides key', () => {
-      const useStyles = makeStyles(
-        {
-          root: {
-            padding: 8,
-            margin: [1, 3],
+    describe('overrides', () => {
+      it('should support the overrides key', () => {
+        const useStyles = makeStyles(
+          {
+            root: {
+              padding: 8,
+              margin: [1, 3],
+            },
           },
-        },
-        {
-          name: 'MuiTextField',
-        },
-      );
-      const StyledComponent = () => {
-        useStyles();
-        return <div />;
-      };
+          {
+            name: 'MuiTextField',
+          },
+        );
+        const StyledComponent = () => {
+          useStyles();
+          return <div />;
+        };
 
-      mount(
-        <ThemeProvider
-          theme={createMuiTheme({
-            overrides: {
-              MuiTextField: {
-                root: {
-                  padding: 9,
-                  margin: [2, 2, 3],
+        mount(
+          <ThemeProvider
+            theme={createMuiTheme({
+              overrides: {
+                MuiTextField: {
+                  root: {
+                    padding: 9,
+                    margin: [2, 2, 3],
+                  },
                 },
               },
-            },
-          })}
-        >
-          <StylesProvider sheetsRegistry={sheetsRegistry} sheetsCache={new Map()}>
-            <StyledComponent />
-          </StylesProvider>
-        </ThemeProvider>,
-      );
+            })}
+          >
+            <StylesProvider sheetsRegistry={sheetsRegistry} sheetsCache={new Map()}>
+              <StyledComponent />
+            </StylesProvider>
+          </ThemeProvider>,
+        );
 
-      assert.strictEqual(sheetsRegistry.registry.length, 1);
-      assert.deepEqual(sheetsRegistry.registry[0].rules.raw, {
-        root: { padding: 9, margin: [2, 2, 3] },
+        assert.strictEqual(sheetsRegistry.registry.length, 1);
+        assert.deepEqual(sheetsRegistry.registry[0].rules.raw, {
+          root: { padding: 9, margin: [2, 2, 3] },
+        });
+      });
+
+      it('can be used to remove styles', () => {
+        const theme = {
+          overrides: {
+            Test: {
+              root: {
+                margin: null,
+              },
+            },
+          },
+        };
+
+        const useStyles = makeStyles({ root: { margin: 5, padding: 3 } }, { name: 'Test' });
+        function Test() {
+          const classes = useStyles();
+          return <div className={classes.root} />;
+        }
+
+        const wrapper = mount(
+          <ThemeProvider theme={theme}>
+            <StylesProvider sheetsRegistry={sheetsRegistry} sheetsCache={new Map()}>
+              <Test />
+            </StylesProvider>
+          </ThemeProvider>,
+        );
+
+        const div = wrapper.find('div').instance();
+
+        assert.strictEqual(sheetsRegistry.registry.length, 1);
+        assert.deepEqual(sheetsRegistry.registry[0].rules.raw, {
+          root: { margin: null, padding: 3 },
+        });
       });
     });
 


### PR DESCRIPTION
Adding a test for https://github.com/mui-org/material-ui/issues/11857#issuecomment-506931426

I think this is a handy pattern for when you want to reset a style in a certain variant that is applied in the `root` i.e. `root` has marginTop: 5 but you just want to reset this in the `fancyVariant`. Is there an easier CSS-only approach?

This may be obvious from an implementation standpoint but it could very reject nullish values or do something like `overriddenPropertyValue || originalPropertyValue`. In other words: `overrides` could very well mean "override with defined values". If there's already a test this can be closed.