### PR TITLE
[Breadcrumbs] Add li to BreadcrumbsClassKey type

### DIFF
--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.d.ts
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.d.ts
@@ -12,7 +12,7 @@ declare const Breadcrumbs: OverridableComponent<{
   classKey: BreadcrumbsClassKey;
 }>;
 
-export type BreadcrumbsClassKey = 'root' | 'ol' | 'separator';
+export type BreadcrumbsClassKey = 'root' | 'ol' | 'li' | 'separator';
 
 export type BreadcrumbsProps = SimplifiedPropsOf<typeof Breadcrumbs>;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Documentation mentions ability to override `li` styles through `classes` prop for `Breadcrumbs`. Component itself also supports this, but typescript definition doesn't allow it.

This PR fixes this problem by updating this Typescript definition.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
