### PR TITLE
[ci] Persist/Report only if previous steps succeeded

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ steps:
   - script: |
       node scripts/sizeSnapshot/upload
     displayName: 'persist size snapshot'
-    condition: ne(variables['Build.Reason'], 'PullRequest')
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
       AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
@@ -46,6 +46,6 @@ steps:
   - script: |
       yarn danger ci
     displayName: 'run danger on PRs'
-    condition: eq(variables['Build.Reason'], 'PullRequest')
+    condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     env:
       DANGER_GITHUB_API_TOKEN: $(GITHUB_API_TOKEN)


### PR DESCRIPTION
@oliviertassinari I guess this is what you meant by "azure doesn't report failures?"? I misinterpreted it as notifications. Seems like steps have an implicit `succeeded` condition that is removed by adding a custom one: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/conditions?view=azure-devops&tabs=yaml