### PR TITLE
[slider] Fix textAlign prop affecting Slider rail

### DIFF
--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -182,6 +182,7 @@ export const styles = theme => ({
   /* Styles applied to the rail element. */
   rail: {
     position: 'absolute',
+    left: 0,
     width: '100%',
     height: 2,
     borderRadius: 1,

--- a/packages/material-ui-lab/src/Slider/Slider.js
+++ b/packages/material-ui-lab/src/Slider/Slider.js
@@ -181,8 +181,8 @@ export const styles = theme => ({
   disabled: {},
   /* Styles applied to the rail element. */
   rail: {
+    display: 'block',
     position: 'absolute',
-    left: 0,
     width: '100%',
     height: 2,
     borderRadius: 1,
@@ -195,6 +195,7 @@ export const styles = theme => ({
   },
   /* Styles applied to the track element. */
   track: {
+    display: 'block',
     position: 'absolute',
     height: 2,
     borderRadius: 1,


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This change affects styling for the Slider component, and should fix #16437 
I have looked over the tests but see that #16416 is still unmerged.
My first PR here, so feedback very welcome. :)

Closes #16437