### PR TITLE
[Rating] Add a new component

### DIFF
--- a/docs/src/pages.js
+++ b/docs/src/pages.js
@@ -112,6 +112,7 @@ const pages = [
         subheader: '/components/lab',
         children: [
           { pathname: '/components/about-the-lab' },
+          { pathname: '/components/rating' },
           { pathname: '/components/speed-dial' },
           { pathname: '/components/toggle-button' },
         ],

--- a/docs/src/pages/components/rating/CustomizedRatings.js
+++ b/docs/src/pages/components/rating/CustomizedRatings.js
@@ -15,6 +15,10 @@ const StyledRating = withStyles({
   },
 })(Rating);
 
+function getLabelText(value) {
+  return `${value} Heart${value !== 1 ? 's' : ''}`;
+}
+
 export default function CustomizedRatings() {
   return (
     <div>
@@ -30,6 +34,7 @@ export default function CustomizedRatings() {
       <StyledRating
         name="customized-color"
         value={2}
+        getLabelText={getLabelText}
         precision={0.5}
         icon={<FavoriteIcon fontSize="inherit" />}
       />

--- a/docs/src/pages/components/rating/CustomizedRatings.js
+++ b/docs/src/pages/components/rating/CustomizedRatings.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import Rating from '@material-ui/lab/Rating';
+import StarBorderIcon from '@material-ui/icons/StarBorder';
+import FavoriteIcon from '@material-ui/icons/Favorite';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+const StyledRating = withStyles({
+  iconFilled: {
+    color: '#ff6d75',
+  },
+  iconHover: {
+    color: '#ff3d47',
+  },
+})(Rating);
+
+export default function CustomizedRatings() {
+  return (
+    <div>
+      <Typography gutterBottom>Custom empty icon</Typography>
+      <Rating
+        name="customized-empty"
+        value={2}
+        precision={0.5}
+        emptyIcon={<StarBorderIcon fontSize="inherit" />}
+      />
+      <Box mt={3} />
+      <Typography gutterBottom>Custom icon and color</Typography>
+      <StyledRating
+        name="customized-color"
+        value={2}
+        precision={0.5}
+        icon={<FavoriteIcon fontSize="inherit" />}
+      />
+      <Box mt={3} />
+      <Typography gutterBottom>10 stars</Typography>
+      <Rating name="customized-10" value={2} max={10} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/CustomizedRatings.js
+++ b/docs/src/pages/components/rating/CustomizedRatings.js
@@ -22,25 +22,29 @@ function getLabelText(value) {
 export default function CustomizedRatings() {
   return (
     <div>
-      <Typography gutterBottom>Custom empty icon</Typography>
-      <Rating
-        name="customized-empty"
-        value={2}
-        precision={0.5}
-        emptyIcon={<StarBorderIcon fontSize="inherit" />}
-      />
-      <Box mt={3} />
-      <Typography gutterBottom>Custom icon and color</Typography>
-      <StyledRating
-        name="customized-color"
-        value={2}
-        getLabelText={getLabelText}
-        precision={0.5}
-        icon={<FavoriteIcon fontSize="inherit" />}
-      />
-      <Box mt={3} />
-      <Typography gutterBottom>10 stars</Typography>
-      <Rating name="customized-10" value={2} max={10} />
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Custom empty icon</Typography>
+        <Rating
+          name="customized-empty"
+          value={2}
+          precision={0.5}
+          emptyIcon={<StarBorderIcon fontSize="inherit" />}
+        />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Custom icon and color</Typography>
+        <StyledRating
+          name="customized-color"
+          value={2}
+          getLabelText={getLabelText}
+          precision={0.5}
+          icon={<FavoriteIcon fontSize="inherit" />}
+        />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">10 stars</Typography>
+        <Rating name="customized-10" value={2} max={10} />
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/components/rating/CustomizedRatings.tsx
+++ b/docs/src/pages/components/rating/CustomizedRatings.tsx
@@ -22,25 +22,29 @@ function getLabelText(value: number) {
 export default function CustomizedRatings() {
   return (
     <div>
-      <Typography gutterBottom>Custom empty icon</Typography>
-      <Rating
-        name="customized-empty"
-        value={2}
-        precision={0.5}
-        emptyIcon={<StarBorderIcon fontSize="inherit" />}
-      />
-      <Box mt={3} />
-      <Typography gutterBottom>Custom icon and color</Typography>
-      <StyledRating
-        name="customized-color"
-        value={2}
-        getLabelText={getLabelText}
-        precision={0.5}
-        icon={<FavoriteIcon fontSize="inherit" />}
-      />
-      <Box mt={3} />
-      <Typography gutterBottom>10 stars</Typography>
-      <Rating name="customized-10" value={2} max={10} />
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Custom empty icon</Typography>
+        <Rating
+          name="customized-empty"
+          value={2}
+          precision={0.5}
+          emptyIcon={<StarBorderIcon fontSize="inherit" />}
+        />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Custom icon and color</Typography>
+        <StyledRating
+          name="customized-color"
+          value={2}
+          getLabelText={getLabelText}
+          precision={0.5}
+          icon={<FavoriteIcon fontSize="inherit" />}
+        />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">10 stars</Typography>
+        <Rating name="customized-10" value={2} max={10} />
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/components/rating/CustomizedRatings.tsx
+++ b/docs/src/pages/components/rating/CustomizedRatings.tsx
@@ -15,6 +15,10 @@ const StyledRating = withStyles({
   },
 })(Rating);
 
+function getLabelText(value: number) {
+  return `${value} Heart${value !== 1 ? 's' : ''}`;
+}
+
 export default function CustomizedRatings() {
   return (
     <div>
@@ -30,6 +34,7 @@ export default function CustomizedRatings() {
       <StyledRating
         name="customized-color"
         value={2}
+        getLabelText={getLabelText}
         precision={0.5}
         icon={<FavoriteIcon fontSize="inherit" />}
       />

--- a/docs/src/pages/components/rating/CustomizedRatings.tsx
+++ b/docs/src/pages/components/rating/CustomizedRatings.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
+import Rating from '@material-ui/lab/Rating';
+import StarBorderIcon from '@material-ui/icons/StarBorder';
+import FavoriteIcon from '@material-ui/icons/Favorite';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+const StyledRating = withStyles({
+  iconFilled: {
+    color: '#ff6d75',
+  },
+  iconHover: {
+    color: '#ff3d47',
+  },
+})(Rating);
+
+export default function CustomizedRatings() {
+  return (
+    <div>
+      <Typography gutterBottom>Custom empty icon</Typography>
+      <Rating
+        name="customized-empty"
+        value={2}
+        precision={0.5}
+        emptyIcon={<StarBorderIcon fontSize="inherit" />}
+      />
+      <Box mt={3} />
+      <Typography gutterBottom>Custom icon and color</Typography>
+      <StyledRating
+        name="customized-color"
+        value={2}
+        precision={0.5}
+        icon={<FavoriteIcon fontSize="inherit" />}
+      />
+      <Box mt={3} />
+      <Typography gutterBottom>10 stars</Typography>
+      <Rating name="customized-10" value={2} max={10} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/HalfRating.js
+++ b/docs/src/pages/components/rating/HalfRating.js
@@ -1,16 +1,10 @@
 import React from 'react';
 import Rating from '@material-ui/lab/Rating';
-import Typography from '@material-ui/core/Typography';
-import Box from '@material-ui/core/Box';
 
 export default function HalfRating() {
   return (
     <div>
-      <Typography gutterBottom>value=2.5</Typography>
-      <Rating name="half-rating" value={2.5} />
-      <Box mt={3} />
-      <Typography gutterBottom>precision=0.5</Typography>
-      <Rating name="half-rating-precision" value={2.5} precision={0.5} />
+      <Rating name="half-rating" value={2.5} precision={0.5} />
     </div>
   );
 }

--- a/docs/src/pages/components/rating/HalfRating.js
+++ b/docs/src/pages/components/rating/HalfRating.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Rating from '@material-ui/lab/Rating';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+export default function HalfRating() {
+  return (
+    <div>
+      <Typography gutterBottom>value=2.5</Typography>
+      <Rating name="half-rating" value={2.5} />
+      <Box mt={3} />
+      <Typography gutterBottom>precision=0.5</Typography>
+      <Rating name="half-rating-precision" value={2.5} precision={0.5} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/HalfRating.tsx
+++ b/docs/src/pages/components/rating/HalfRating.tsx
@@ -1,16 +1,10 @@
 import React from 'react';
 import Rating from '@material-ui/lab/Rating';
-import Typography from '@material-ui/core/Typography';
-import Box from '@material-ui/core/Box';
 
 export default function HalfRating() {
   return (
     <div>
-      <Typography gutterBottom>value=2.5</Typography>
-      <Rating name="half-rating" value={2.5} />
-      <Box mt={3} />
-      <Typography gutterBottom>precision=0.5</Typography>
-      <Rating name="half-rating-precision" value={2.5} precision={0.5} />
+      <Rating name="half-rating" value={2.5} precision={0.5} />
     </div>
   );
 }

--- a/docs/src/pages/components/rating/HalfRating.tsx
+++ b/docs/src/pages/components/rating/HalfRating.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import Rating from '@material-ui/lab/Rating';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+export default function HalfRating() {
+  return (
+    <div>
+      <Typography gutterBottom>value=2.5</Typography>
+      <Rating name="half-rating" value={2.5} />
+      <Box mt={3} />
+      <Typography gutterBottom>precision=0.5</Typography>
+      <Rating name="half-rating-precision" value={2.5} precision={0.5} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/HoverRating.js
+++ b/docs/src/pages/components/rating/HoverRating.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Rating from '@material-ui/lab/Rating';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+const labels = {
+  1: 'Useless',
+  1.5: 'Useless+',
+  2: 'Poor',
+  2.5: 'Poor+',
+  3: 'Ok',
+  3.5: 'Ok+',
+  4: 'Good',
+  4.5: 'Good+',
+  5: 'Excellent',
+};
+
+function IconContainer(props) {
+  const { value, ...other } = props;
+  return (
+    <Tooltip title={labels[value] || ''}>
+      <div {...other} />
+    </Tooltip>
+  );
+}
+
+IconContainer.propTypes = {
+  value: PropTypes.number.isRequired,
+};
+
+const useStyles = makeStyles({
+  rating1: {
+    width: 200,
+    display: 'flex',
+    alignItems: 'center',
+  },
+});
+
+export default function HoverRating() {
+  const value = 2;
+  const [hover, setHover] = React.useState(-1);
+  const classes = useStyles();
+
+  return (
+    <div>
+      <Typography gutterBottom>Side</Typography>
+      <div className={classes.rating1}>
+        <Rating
+          name="hover-side"
+          value={value}
+          precision={0.5}
+          onChangeHover={(event, newHover) => {
+            setHover(newHover);
+          }}
+        />
+        <Box ml={2}>{labels[hover !== -1 ? hover : value]}</Box>
+      </div>
+      <Box mt={3} />
+      <Typography gutterBottom>Tooltip</Typography>
+      <Rating
+        name="hover-tooltip"
+        value={value}
+        precision={0.5}
+        IconContainerComponent={IconContainer}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/HoverRating.js
+++ b/docs/src/pages/components/rating/HoverRating.js
@@ -47,26 +47,29 @@ export default function HoverRating() {
 
   return (
     <div>
-      <Typography gutterBottom>Side</Typography>
-      <div className={classes.rating1}>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Side</Typography>
+        <div className={classes.rating1}>
+          <Rating
+            name="hover-side"
+            value={value}
+            precision={0.5}
+            onChangeActive={(event, newHover) => {
+              setHover(newHover);
+            }}
+          />
+          <Box ml={2}>{labels[hover !== -1 ? hover : value]}</Box>
+        </div>
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Tooltip</Typography>
         <Rating
-          name="hover-side"
+          name="hover-tooltip"
           value={value}
           precision={0.5}
-          onChangeActive={(event, newHover) => {
-            setHover(newHover);
-          }}
+          IconContainerComponent={IconContainer}
         />
-        <Box ml={2}>{labels[hover !== -1 ? hover : value]}</Box>
-      </div>
-      <Box mt={3} />
-      <Typography gutterBottom>Tooltip</Typography>
-      <Rating
-        name="hover-tooltip"
-        value={value}
-        precision={0.5}
-        IconContainerComponent={IconContainer}
-      />
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/components/rating/HoverRating.js
+++ b/docs/src/pages/components/rating/HoverRating.js
@@ -7,15 +7,16 @@ import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 
 const labels = {
-  1: 'Useless',
-  1.5: 'Useless+',
-  2: 'Poor',
-  2.5: 'Poor+',
-  3: 'Ok',
-  3.5: 'Ok+',
-  4: 'Good',
-  4.5: 'Good+',
-  5: 'Excellent',
+  0.5: 'Useless',
+  1: 'Useless+',
+  1.5: 'Poor',
+  2: 'Poor+',
+  2.5: 'Ok',
+  3: 'Ok+',
+  3.5: 'Good',
+  4: 'Good+',
+  4.5: 'Excellent',
+  5: 'Excellent+',
 };
 
 function IconContainer(props) {

--- a/docs/src/pages/components/rating/HoverRating.js
+++ b/docs/src/pages/components/rating/HoverRating.js
@@ -53,7 +53,7 @@ export default function HoverRating() {
           name="hover-side"
           value={value}
           precision={0.5}
-          onChangeHover={(event, newHover) => {
+          onChangeActive={(event, newHover) => {
             setHover(newHover);
           }}
         />

--- a/docs/src/pages/components/rating/HoverRating.tsx
+++ b/docs/src/pages/components/rating/HoverRating.tsx
@@ -47,26 +47,29 @@ export default function HoverRating() {
 
   return (
     <div>
-      <Typography gutterBottom>Side</Typography>
-      <div className={classes.rating1}>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Side</Typography>
+        <div className={classes.rating1}>
+          <Rating
+            name="hover-side"
+            value={value}
+            precision={0.5}
+            onChangeActive={(event, newHover) => {
+              setHover(newHover);
+            }}
+          />
+          <Box ml={2}>{labels[hover !== -1 ? hover : value]}</Box>
+        </div>
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Tooltip</Typography>
         <Rating
-          name="hover-side"
+          name="hover-tooltip"
           value={value}
           precision={0.5}
-          onChangeActive={(event, newHover) => {
-            setHover(newHover);
-          }}
+          IconContainerComponent={IconContainer}
         />
-        <Box ml={2}>{labels[hover !== -1 ? hover : value]}</Box>
-      </div>
-      <Box mt={3} />
-      <Typography gutterBottom>Tooltip</Typography>
-      <Rating
-        name="hover-tooltip"
-        value={value}
-        precision={0.5}
-        IconContainerComponent={IconContainer}
-      />
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/components/rating/HoverRating.tsx
+++ b/docs/src/pages/components/rating/HoverRating.tsx
@@ -7,15 +7,16 @@ import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 
 const labels: { [index: string]: string } = {
-  1: 'Useless',
-  1.5: 'Useless+',
-  2: 'Poor',
-  2.5: 'Poor+',
-  3: 'Ok',
-  3.5: 'Ok+',
-  4: 'Good',
-  4.5: 'Good+',
-  5: 'Excellent',
+  0.5: 'Useless',
+  1: 'Useless+',
+  1.5: 'Poor',
+  2: 'Poor+',
+  2.5: 'Ok',
+  3: 'Ok+',
+  3.5: 'Good',
+  4: 'Good+',
+  4.5: 'Excellent',
+  5: 'Excellent+',
 };
 
 function IconContainer(props: IconContainerProps) {
@@ -48,7 +49,8 @@ export default function HoverRating() {
     <div>
       <Typography gutterBottom>Side</Typography>
       <div className={classes.rating1}>
-        <Rating name="hover-side"
+        <Rating
+          name="hover-side"
           value={value}
           precision={0.5}
           onChangeHover={(event, newHover) => {
@@ -59,7 +61,12 @@ export default function HoverRating() {
       </div>
       <Box mt={3} />
       <Typography gutterBottom>Tooltip</Typography>
-      <Rating name="hover-tooltip" value={value} precision={0.5} IconContainerComponent={IconContainer} />
+      <Rating
+        name="hover-tooltip"
+        value={value}
+        precision={0.5}
+        IconContainerComponent={IconContainer}
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/rating/HoverRating.tsx
+++ b/docs/src/pages/components/rating/HoverRating.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Rating, { IconContainerProps } from '@material-ui/lab/Rating';
+import Tooltip from '@material-ui/core/Tooltip';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+const labels: { [index: string]: string } = {
+  1: 'Useless',
+  1.5: 'Useless+',
+  2: 'Poor',
+  2.5: 'Poor+',
+  3: 'Ok',
+  3.5: 'Ok+',
+  4: 'Good',
+  4.5: 'Good+',
+  5: 'Excellent',
+};
+
+function IconContainer(props: IconContainerProps) {
+  const { value, ...other } = props;
+  return (
+    <Tooltip title={labels[value] || ''}>
+      <div {...other} />
+    </Tooltip>
+  );
+}
+
+IconContainer.propTypes = {
+  value: PropTypes.number.isRequired,
+} as any;
+
+const useStyles = makeStyles({
+  rating1: {
+    width: 200,
+    display: 'flex',
+    alignItems: 'center',
+  },
+});
+
+export default function HoverRating() {
+  const value = 2;
+  const [hover, setHover] = React.useState(-1);
+  const classes = useStyles();
+
+  return (
+    <div>
+      <Typography gutterBottom>Side</Typography>
+      <div className={classes.rating1}>
+        <Rating name="hover-side"
+          value={value}
+          precision={0.5}
+          onChangeHover={(event, newHover) => {
+            setHover(newHover);
+          }}
+        />
+        <Box ml={2}>{labels[hover !== -1 ? hover : value]}</Box>
+      </div>
+      <Box mt={3} />
+      <Typography gutterBottom>Tooltip</Typography>
+      <Rating name="hover-tooltip" value={value} precision={0.5} IconContainerComponent={IconContainer} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/HoverRating.tsx
+++ b/docs/src/pages/components/rating/HoverRating.tsx
@@ -53,7 +53,7 @@ export default function HoverRating() {
           name="hover-side"
           value={value}
           precision={0.5}
-          onChangeHover={(event, newHover) => {
+          onChangeActive={(event, newHover) => {
             setHover(newHover);
           }}
         />

--- a/docs/src/pages/components/rating/RatingSize.js
+++ b/docs/src/pages/components/rating/RatingSize.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Rating from '@material-ui/lab/Rating';
+
+export default function RatingSize() {
+  return (
+    <div>
+      <Rating name="size-small" value={2} size="small" />
+      <Rating name="size-medium" value={2} />
+      <Rating name="size-large" value={2} size="large" />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/RatingSize.tsx
+++ b/docs/src/pages/components/rating/RatingSize.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import Rating from '@material-ui/lab/Rating';
+
+export default function RatingSize() {
+  return (
+    <div>
+      <Rating name="size-small" value={2} size="small" />
+      <Rating name="size-medium" value={2} />
+      <Rating name="size-large" value={2} size="large" />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/SimpleRating.js
+++ b/docs/src/pages/components/rating/SimpleRating.js
@@ -24,7 +24,7 @@ export default function SimpleRating() {
       <Rating value={value} disabled />
       <Box mt={3} />
       <Typography gutterBottom>Pristine</Typography>
-      <Rating name="pristin" value={null} />
+      <Rating name="pristine" value={null} />
     </div>
   );
 }

--- a/docs/src/pages/components/rating/SimpleRating.js
+++ b/docs/src/pages/components/rating/SimpleRating.js
@@ -23,7 +23,7 @@ export default function SimpleRating() {
       <Typography gutterBottom>Disabled</Typography>
       <Rating value={value} disabled />
       <Box mt={3} />
-      <Typography gutterBottom>Pristin</Typography>
+      <Typography gutterBottom>Pristine</Typography>
       <Rating name="pristin" value={null} />
     </div>
   );

--- a/docs/src/pages/components/rating/SimpleRating.js
+++ b/docs/src/pages/components/rating/SimpleRating.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import Rating from '@material-ui/lab/Rating';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+export default function SimpleRating() {
+  const [value, setValue] = React.useState(2);
+
+  return (
+    <div>
+      <Typography gutterBottom>Controlled</Typography>
+      <Rating
+        name="simple-controlled"
+        value={value}
+        onChange={(event, newValue) => {
+          setValue(newValue);
+        }}
+      />
+      <Box mt={3} />
+      <Typography gutterBottom>Read only</Typography>
+      <Rating value={value} readOnly />
+      <Box mt={3} />
+      <Typography gutterBottom>Disabled</Typography>
+      <Rating value={value} disabled />
+      <Box mt={3} />
+      <Typography gutterBottom>Pristin</Typography>
+      <Rating name="pristin" value={null} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/SimpleRating.js
+++ b/docs/src/pages/components/rating/SimpleRating.js
@@ -8,23 +8,28 @@ export default function SimpleRating() {
 
   return (
     <div>
-      <Typography gutterBottom>Controlled</Typography>
-      <Rating
-        name="simple-controlled"
-        value={value}
-        onChange={(event, newValue) => {
-          setValue(newValue);
-        }}
-      />
-      <Box mt={3} />
-      <Typography gutterBottom>Read only</Typography>
-      <Rating value={value} readOnly />
-      <Box mt={3} />
-      <Typography gutterBottom>Disabled</Typography>
-      <Rating value={value} disabled />
-      <Box mt={3} />
-      <Typography gutterBottom>Pristine</Typography>
-      <Rating name="pristine" value={null} />
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Controlled</Typography>
+        <Rating
+          name="simple-controlled"
+          value={value}
+          onChange={(event, newValue) => {
+            setValue(newValue);
+          }}
+        />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Read only</Typography>
+        <Rating value={value} readOnly />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Disabled</Typography>
+        <Rating value={value} disabled />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Pristine</Typography>
+        <Rating name="pristine" value={null} />
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/components/rating/SimpleRating.tsx
+++ b/docs/src/pages/components/rating/SimpleRating.tsx
@@ -24,7 +24,7 @@ export default function SimpleRating() {
       <Rating value={value} disabled />
       <Box mt={3} />
       <Typography gutterBottom>Pristine</Typography>
-      <Rating name="pristin" value={null} />
+      <Rating name="pristine" value={null} />
     </div>
   );
 }

--- a/docs/src/pages/components/rating/SimpleRating.tsx
+++ b/docs/src/pages/components/rating/SimpleRating.tsx
@@ -23,7 +23,7 @@ export default function SimpleRating() {
       <Typography gutterBottom>Disabled</Typography>
       <Rating value={value} disabled />
       <Box mt={3} />
-      <Typography gutterBottom>Pristin</Typography>
+      <Typography gutterBottom>Pristine</Typography>
       <Rating name="pristin" value={null} />
     </div>
   );

--- a/docs/src/pages/components/rating/SimpleRating.tsx
+++ b/docs/src/pages/components/rating/SimpleRating.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Rating from '@material-ui/lab/Rating';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+export default function SimpleRating() {
+  const [value, setValue] = React.useState(2);
+
+  return (
+    <div>
+      <Typography gutterBottom>Controlled</Typography>
+      <Rating
+        name="simple-controlled"
+        value={value}
+        onChange={(event, newValue) => {
+          setValue(newValue);
+        }}
+      />
+      <Box mt={3} />
+      <Typography gutterBottom>Read only</Typography>
+      <Rating value={value} readOnly />
+      <Box mt={3} />
+      <Typography gutterBottom>Disabled</Typography>
+      <Rating value={value} disabled />
+      <Box mt={3} />
+      <Typography gutterBottom>Pristin</Typography>
+      <Rating name="pristin" value={null} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/rating/SimpleRating.tsx
+++ b/docs/src/pages/components/rating/SimpleRating.tsx
@@ -8,23 +8,28 @@ export default function SimpleRating() {
 
   return (
     <div>
-      <Typography gutterBottom>Controlled</Typography>
-      <Rating
-        name="simple-controlled"
-        value={value}
-        onChange={(event, newValue) => {
-          setValue(newValue);
-        }}
-      />
-      <Box mt={3} />
-      <Typography gutterBottom>Read only</Typography>
-      <Rating value={value} readOnly />
-      <Box mt={3} />
-      <Typography gutterBottom>Disabled</Typography>
-      <Rating value={value} disabled />
-      <Box mt={3} />
-      <Typography gutterBottom>Pristine</Typography>
-      <Rating name="pristine" value={null} />
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Controlled</Typography>
+        <Rating
+          name="simple-controlled"
+          value={value}
+          onChange={(event, newValue) => {
+            setValue(newValue);
+          }}
+        />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Read only</Typography>
+        <Rating value={value} readOnly />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Disabled</Typography>
+        <Rating value={value} disabled />
+      </Box>
+      <Box component="fieldset" mb={3} borderColor="transparent">
+        <Typography component="legend">Pristine</Typography>
+        <Rating name="pristine" value={null} />
+      </Box>
     </div>
   );
 }

--- a/docs/src/pages/components/rating/rating.md
+++ b/docs/src/pages/components/rating/rating.md
@@ -36,6 +36,6 @@ Fancy larger or smaller ratings? Use the `size` property.
 ## Hover feedback
 
 You can display a label on hover to help users pick the correct rating value.
-The first demo uses the `onChangeHover` prop while the last one uses the `IconContainerComponent` prop.
+The first demo uses the `onChangeActive` prop while the last one uses the `IconContainerComponent` prop.
 
 {{"demo": "pages/components/rating/HoverRating.js"}}

--- a/docs/src/pages/components/rating/rating.md
+++ b/docs/src/pages/components/rating/rating.md
@@ -1,0 +1,41 @@
+---
+title: Rating React component
+components: Rating
+---
+
+# Rating
+
+<p class="description">Ratings provide insight regarding others’ opinions and experiences with a product. Users can also rate products they’ve purchased.</p>
+
+- 📦 [20 kB gzipped](/size-snapshot) (but only 6 kB without @material-ui/styles).
+
+## Simple ratings
+
+{{"demo": "pages/components/rating/SimpleRating.js"}}
+
+## Half ratings
+
+The rating can display any float number with the `value` prop.
+Use the `precision` prop to define the minimum increment value change allowed.
+
+{{"demo": "pages/components/rating/HalfRating.js"}}
+
+## Customized ratings
+
+Here are some examples of customizing the component. You can learn more about this in the
+[overrides documentation page](/customization/components/).
+
+{{"demo": "pages/components/rating/CustomizedRatings.js"}}
+
+## Sizes
+
+Fancy larger or smaller ratings? Use the `size` property.
+
+{{"demo": "pages/components/rating/RatingSize.js"}}
+
+## Hover feedback
+
+You can display a label on hover to help users pick the correct rating value.
+The first demo uses the `onChangeHover` prop while the last one uses the `IconContainerComponent` prop.
+
+{{"demo": "pages/components/rating/HoverRating.js"}}

--- a/docs/src/pages/components/rating/rating.md
+++ b/docs/src/pages/components/rating/rating.md
@@ -39,3 +39,11 @@ You can display a label on hover to help users pick the correct rating value.
 The first demo uses the `onChangeActive` prop while the last one uses the `IconContainerComponent` prop.
 
 {{"demo": "pages/components/rating/HoverRating.js"}}
+
+## Accessibility
+
+The accessibility of this component relies on:
+
+- A radio group is used with its fields visually hidden.
+It contains six radio buttons, one for each star and another for 0 stars, which is checked by default. Make sure you are providing a `name` prop that is unique to the parent form.
+- The labels for the radio buttons contain actual text (“1 Star”, “2 Stars”, …), make sure you provide a `getLabelText` prop when the page language is not English.

--- a/docs/src/pages/components/slider/slider.md
+++ b/docs/src/pages/components/slider/slider.md
@@ -9,7 +9,7 @@ components: Slider
 
 [Sliders](https://material.io/design/components/sliders.html) reflect a range of values along a bar, from which users may select a single value. They are ideal for adjusting settings such as volume, brightness, or applying image filters.
 
-- 📦 [22 kB gzipped](/size-snapshot) (but only 6 kB without @material-ui/styles).
+- 📦 [22 kB gzipped](/size-snapshot) (but only 8 kB without @material-ui/styles).
 
 ## Continuous sliders
 

--- a/packages/material-ui-lab/src/Rating/Rating.d.ts
+++ b/packages/material-ui-lab/src/Rating/Rating.d.ts
@@ -9,16 +9,17 @@ export interface RatingProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, RatingClassKey, 'onChange'> {
   component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   disabled?: boolean;
+  emptyIcon?: React.ReactElement;
   icon?: React.ReactElement;
   IconContainerComponent?: React.ElementType<IconContainerProps>;
   max?: number;
+  name?: string;
   onChange?: (event: React.ChangeEvent<{}>, value: number) => void;
   onChangeHover?: (event: React.ChangeEvent<{}>, value: number) => void;
   precision?: number;
   readOnly?: boolean;
   size?: 'small' | 'medium' | 'large';
-  emptyIcon?: React.ReactElement;
-  value: number;
+  value: number | null;
 }
 
 export type RatingClassKey =

--- a/packages/material-ui-lab/src/Rating/Rating.d.ts
+++ b/packages/material-ui-lab/src/Rating/Rating.d.ts
@@ -7,7 +7,6 @@ export interface IconContainerProps extends React.HTMLAttributes<HTMLDivElement>
 
 export interface RatingProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, RatingClassKey, 'onChange'> {
-  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   disabled?: boolean;
   emptyIcon?: React.ReactElement;
   getLabelText?: (value: number) => string;

--- a/packages/material-ui-lab/src/Rating/Rating.d.ts
+++ b/packages/material-ui-lab/src/Rating/Rating.d.ts
@@ -10,12 +10,13 @@ export interface RatingProps
   component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
   disabled?: boolean;
   emptyIcon?: React.ReactElement;
+  getLabelText?: (value: number) => string;
   icon?: React.ReactElement;
   IconContainerComponent?: React.ElementType<IconContainerProps>;
   max?: number;
   name?: string;
   onChange?: (event: React.ChangeEvent<{}>, value: number) => void;
-  onChangeHover?: (event: React.ChangeEvent<{}>, value: number) => void;
+  onChangeActive?: (event: React.ChangeEvent<{}>, value: number) => void;
   precision?: number;
   readOnly?: boolean;
   size?: 'small' | 'medium' | 'large';
@@ -26,12 +27,17 @@ export type RatingClassKey =
   | 'root'
   | 'sizeSmall'
   | 'sizeLarge'
-  | 'disabled'
   | 'readOnly'
+  | 'disabled'
+  | 'focusVisible'
+  | 'visuallyhidden'
+  | 'pristine'
+  | 'label'
   | 'icon'
   | 'iconEmpty'
   | 'iconFilled'
   | 'iconHover'
+  | 'iconFocus'
   | 'iconActive'
   | 'decimal';
 

--- a/packages/material-ui-lab/src/Rating/Rating.d.ts
+++ b/packages/material-ui-lab/src/Rating/Rating.d.ts
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { StandardProps } from '@material-ui/core';
+
+export interface IconContainerProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: number;
+}
+
+export interface RatingProps
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, RatingClassKey, 'onChange'> {
+  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
+  disabled?: boolean;
+  icon?: React.ReactElement;
+  IconContainerComponent?: React.ElementType<IconContainerProps>;
+  max?: number;
+  onChange?: (event: React.ChangeEvent<{}>, value: number) => void;
+  onChangeHover?: (event: React.ChangeEvent<{}>, value: number) => void;
+  precision?: number;
+  readOnly?: boolean;
+  size?: 'small' | 'medium' | 'large';
+  emptyIcon?: React.ReactElement;
+  value: number;
+}
+
+export type RatingClassKey =
+  | 'root'
+  | 'sizeSmall'
+  | 'sizeLarge'
+  | 'disabled'
+  | 'readOnly'
+  | 'icon'
+  | 'iconEmpty'
+  | 'iconFilled'
+  | 'iconHover'
+  | 'iconActive'
+  | 'decimal';
+
+declare const Rating: React.ComponentType<RatingProps>;
+
+export default Rating;

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -1,0 +1,412 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { useTheme, withStyles } from '@material-ui/core/styles';
+import { capitalize, useForkRef, ownerWindow } from '@material-ui/core/utils';
+import Star from '../internal/svg-icons/Star';
+
+function clamp(value, min, max) {
+  if (value < min) {
+    return min;
+  }
+  if (value > max) {
+    return max;
+  }
+  return value;
+}
+
+export const styles = theme => ({
+  /* Styles applied to the root element. */
+  root: {
+    display: 'flex',
+    fontSize: theme.typography.pxToRem(24),
+    color: '#ffb400',
+    cursor: 'pointer',
+    '&$disabled': {
+      opacity: 0.4,
+      pointerEvents: 'none',
+    },
+  },
+  /* Styles applied to the root element if `size="small"`. */
+  sizeSmall: {
+    fontSize: theme.typography.pxToRem(18),
+  },
+  /* Styles applied to the root element if `size="large"`. */
+  sizeLarge: {
+    fontSize: theme.typography.pxToRem(30),
+  },
+  /* Pseudo-class applied to the root element if `disabled={true}`. */
+  disabled: {},
+  /* Pseudo-class applied to the root element if `readOnly={true}`. */
+  readOnly: {
+    pointerEvents: 'none',
+  },
+  visuallyhidden: {
+    border: 0,
+    clip: 'rect(0 0 0 0)',
+    height: 1,
+    margin: -1,
+    overflow: 'hidden',
+    padding: 0,
+    position: 'absolute',
+    top: 20,
+    width: 1,
+  },
+  /* Pseudo-class applied to the icon wrapping elements. */
+  icon: {
+    display: 'flex',
+    transition: theme.transitions.create('transform', {
+      duration: theme.transitions.duration.shortest,
+    }),
+  },
+  /* Pseudo-class applied to the icon wrapping elements when empty. */
+  iconEmpty: {
+    color: theme.palette.action.disabled,
+  },
+  /* Pseudo-class applied to the icon wrapping elements when filled. */
+  iconFilled: {},
+  /* Pseudo-class applied to the icon wrapping elements when hover. */
+  iconHover: {},
+  /* Pseudo-class applied to the icon wrapping elements when active. */
+  iconActive: {
+    transform: 'scale(1.2)',
+  },
+  /* Pseudo-class applied to the icon wrapping elements when decimals are necessary. */
+  decimal: {
+    position: 'relative',
+  },
+});
+
+function IconContainer(props) {
+  const { value, ...other } = props;
+  return <div {...other} />;
+}
+
+IconContainer.propTypes = {
+  value: PropTypes.number.isRequired,
+};
+
+const defaultIcon = <Star fontSize="inherit" />;
+
+function defaultLabelText(value) {
+  return `${value} star${value !== 1 ? 's' : ''}`;
+}
+
+const Rating = React.forwardRef(function Rating(props, ref) {
+  const {
+    classes,
+    className,
+    component: Component = 'div',
+    disabled = false,
+    emptyIcon,
+    getLabelText = defaultLabelText,
+    icon = defaultIcon,
+    IconContainerComponent = IconContainer,
+    max = 5,
+    name,
+    onChange,
+    onChangeHover,
+    onMouseLeave,
+    onMouseMove,
+    precision = 1,
+    readOnly = false,
+    size = 'medium',
+    value: valueProp,
+    ...other
+  } = props;
+
+  const theme = useTheme();
+  const [hover, setHover] = React.useState(-1);
+  const value = hover !== -1 ? hover : valueProp;
+
+  const rootRef = React.useRef();
+  const handleRef = useForkRef(rootRef, ref);
+
+  const handleMouseMove = event => {
+    if (onMouseMove) {
+      onMouseMove(event);
+    }
+
+    const rootNode = rootRef.current;
+    const { right, left } = rootNode.getBoundingClientRect();
+    const { width } = rootNode.firstChild.getBoundingClientRect();
+    let percent;
+
+    if (theme.direction === 'rtl') {
+      percent = (right - event.pageX - ownerWindow(rootNode).pageXOffset) / (width * max);
+    } else {
+      percent = (event.pageX - left - ownerWindow(rootNode).pageXOffset) / (width * max);
+    }
+
+    let newHover = Math.ceil((max * percent) / precision) * precision;
+    newHover = clamp(newHover, precision, max);
+
+    setHover(newHover);
+    if (onChangeHover && hover !== newHover) {
+      onChangeHover(event, newHover);
+    }
+  };
+
+  const handleMouseLeave = event => {
+    if (onMouseLeave) {
+      onMouseLeave(event);
+    }
+
+    const newHover = -1;
+
+    setHover(newHover);
+    if (onChangeHover && hover !== newHover) {
+      onChangeHover(event, newHover);
+    }
+  };
+
+  const handleChange = event => {
+    console.log('handleChange', parseFloat(event.target.value));
+    if (onChange) {
+      onChange(event, parseFloat(event.target.value));
+    }
+  };
+
+  const handleFocus = event => {
+    const newHover = parseFloat(event.target.value);
+
+    setHover(newHover);
+    if (onChangeHover && hover !== newHover) {
+      onChangeHover(event, newHover);
+    }
+  };
+
+  const handleBlur = event => {
+    const newHover = -1;
+
+    setHover(newHover);
+    if (onChangeHover && hover !== newHover) {
+      onChangeHover(event, newHover);
+    }
+  };
+
+  const item = (propsItem, state) => {
+    const id = `${name}-${String(propsItem.value).replace('.', '-')}`;
+    const container = (
+      <IconContainerComponent
+        {...propsItem}
+        className={clsx(
+          classes.icon,
+          {
+            [classes.iconEmpty]: !state.filled,
+            [classes.iconFilled]: state.filled,
+            [classes.iconHover]: state.hover,
+            [classes.iconActive]: state.active,
+          },
+          propsItem.className,
+        )}
+      >
+        {emptyIcon && !state.filled ? emptyIcon : icon}
+      </IconContainerComponent>
+    );
+
+    if (readOnly || disabled) {
+      return (
+        <React.Fragment key={propsItem.value}>
+          <span className={classes.visuallyhidden}>{getLabelText(propsItem.value)}</span>
+          {container}
+        </React.Fragment>
+      );
+    }
+
+    return (
+      <React.Fragment key={propsItem.value}>
+        <label htmlFor={id}>
+          <span className={classes.visuallyhidden}>{getLabelText(propsItem.value)}</span>
+          {container}
+        </label>
+        <input
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onChange={handleChange}
+          value={propsItem.value}
+          id={id}
+          type="radio"
+          name={name}
+          checked={state.checked}
+          className={classes.visuallyhidden}
+        />
+      </React.Fragment>
+    );
+  };
+
+  return (
+    <Component
+      ref={handleRef}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+      className={clsx(
+        classes.root,
+        {
+          [classes[`size${capitalize(size)}`]]: size !== 'medium',
+          [classes.disabled]: disabled,
+          [classes.readOnly]: readOnly,
+        },
+        className,
+      )}
+      {...other}
+    >
+      {!readOnly && !disabled && value == null && (
+        <input
+          value="0"
+          id={`${name}-0`}
+          type="radio"
+          name={name}
+          defaultChecked
+          className={classes.visuallyhidden}
+        />
+      )}
+      {Array.from(new Array(max)).map((_, index) => {
+        const itemValue = index + 1;
+        const items = Array.from(new Array(1 / precision));
+
+        if (precision < 1) {
+          return (
+            <div
+              key={itemValue}
+              className={clsx(classes.decimal, {
+                [classes.iconActive]: itemValue === Math.ceil(hover),
+              })}
+            >
+              {items.map(($, indexDecimal) => {
+                let width = `${(itemValue - value) * 100}%`;
+
+                if (itemValue - value <= 0) {
+                  width = '100%';
+                }
+
+                if (itemValue - value >= 1) {
+                  width = '0%';
+                }
+
+                return item(
+                  {
+                    value: itemValue - 1 + (indexDecimal + 1) * precision,
+                    style:
+                      items.length - 1 === indexDecimal
+                        ? {}
+                        : {
+                            width,
+                            overflow: 'hidden',
+                            zIndex: 1,
+                            position: 'absolute',
+                          },
+                  },
+                  {
+                    filled: itemValue <= Math.ceil(value) && indexDecimal === 0,
+                    hover: itemValue <= Math.ceil(hover) && indexDecimal === 0,
+                    checked: itemValue - 1 + (indexDecimal + 1) * precision === valueProp,
+                  },
+                );
+              })}
+            </div>
+          );
+        }
+
+        return item(
+          {
+            value: itemValue,
+          },
+          {
+            filled: itemValue <= value,
+            hover: itemValue <= hover,
+            checked: itemValue === Math.round(valueProp),
+            active: itemValue === hover,
+          },
+        );
+      })}
+    </Component>
+  );
+});
+
+Rating.propTypes = {
+  /**
+   * Override or extend the styles applied to the component.
+   * See [CSS API](#css) below for more details.
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * If `true`, the rating will be disabled.
+   */
+  disabled: PropTypes.bool,
+  /**
+   * The icon to display when empty.
+   */
+  emptyIcon: PropTypes.node,
+  /**
+   * Accepts a function which returns a string value that provides a user-friendly name for the current value of the rating.
+   *
+   * @param {number} value The rating label's value to format
+   */
+  getLabelText: PropTypes.func,
+  /**
+   * The icon to display.
+   */
+  icon: PropTypes.node,
+  /**
+   * The component containing the icon.
+   */
+  IconContainerComponent: PropTypes.elementType,
+  /**
+   * Maximum rating.
+   */
+  max: PropTypes.number,
+  /**
+   * Name attribute of the radio `input` elements.
+   */
+  name: PropTypes.string,
+  /**
+   * Callback fired when the value changes.
+   *
+   * @param {object} event The event source of the callback
+   * @param {number} value The new value
+   */
+  onChange: PropTypes.func,
+  /**
+   * Callback function that is fired when the hover state changes.
+   *
+   * @param {object} event The event source of the callback
+   * @param {any} value The new value
+   */
+  onChangeHover: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onMouseLeave: PropTypes.func,
+  /**
+   * @ignore
+   */
+  onMouseMove: PropTypes.func,
+  /**
+   * The minimum increment value change allowed.
+   */
+  precision: PropTypes.number,
+  /**
+   * Removes all hover effects and pointer events.
+   */
+  readOnly: PropTypes.bool,
+  /**
+   * The size of the rating.
+   */
+  size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /**
+   * The rating value.
+   */
+  value: PropTypes.number,
+};
+
+export default withStyles(styles, { name: 'MuiRating' })(Rating);

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -161,7 +161,6 @@ const Rating = React.forwardRef(function Rating(props, ref) {
   };
 
   const handleChange = event => {
-    console.log('handleChange', parseFloat(event.target.value));
     if (onChange) {
       onChange(event, parseFloat(event.target.value));
     }
@@ -201,25 +200,18 @@ const Rating = React.forwardRef(function Rating(props, ref) {
           propsItem.className,
         )}
       >
+        <span className={classes.visuallyhidden}>{getLabelText(propsItem.value)}</span>
         {emptyIcon && !state.filled ? emptyIcon : icon}
       </IconContainerComponent>
     );
 
     if (readOnly || disabled) {
-      return (
-        <React.Fragment key={propsItem.value}>
-          <span className={classes.visuallyhidden}>{getLabelText(propsItem.value)}</span>
-          {container}
-        </React.Fragment>
-      );
+      return <React.Fragment key={propsItem.value}>{container}</React.Fragment>;
     }
 
     return (
       <React.Fragment key={propsItem.value}>
-        <label htmlFor={id}>
-          <span className={classes.visuallyhidden}>{getLabelText(propsItem.value)}</span>
-          {container}
-        </label>
+        <label htmlFor={id}>{container}</label>
         <input
           onFocus={handleFocus}
           onBlur={handleBlur}

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -133,7 +133,7 @@ const Rating = React.forwardRef(function Rating(props, ref) {
     precision = 1,
     readOnly = false,
     size = 'medium',
-    value: valueProp,
+    value: valueProp = null,
     ...other
   } = props;
 

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -112,14 +112,13 @@ IconContainer.propTypes = {
 const defaultIcon = <Star fontSize="inherit" />;
 
 function defaultLabelText(value) {
-  return `${value} star${value !== 1 ? 's' : ''}`;
+  return `${value} Star${value !== 1 ? 's' : ''}`;
 }
 
 const Rating = React.forwardRef(function Rating(props, ref) {
   const {
     classes,
     className,
-    component: Component = 'div',
     disabled = false,
     emptyIcon,
     getLabelText = defaultLabelText,
@@ -295,7 +294,7 @@ const Rating = React.forwardRef(function Rating(props, ref) {
   };
 
   return (
-    <Component
+    <div
       ref={handleRef}
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
@@ -309,6 +308,8 @@ const Rating = React.forwardRef(function Rating(props, ref) {
         },
         className,
       )}
+      role={readOnly ? 'img' : null}
+      aria-label={readOnly ? getLabelText(value) : null}
       {...other}
     >
       {!readOnly && !disabled && value == null && (
@@ -383,7 +384,7 @@ const Rating = React.forwardRef(function Rating(props, ref) {
           },
         );
       })}
-    </Component>
+    </div>
   );
 });
 
@@ -397,11 +398,6 @@ Rating.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
-  /**
-   * The component used for the root node.
-   * Either a string to use a DOM element or a component.
-   */
-  component: PropTypes.elementType,
   /**
    * If `true`, the rating will be disabled.
    */

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { expect } from 'chai';
+import { createMount, getClasses } from '@material-ui/core/test-utils';
+import describeConformance from '@material-ui/core/test-utils/describeConformance';
+import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import Rating from './Rating';
+
+describe('<Rating />', () => {
+  let mount;
+  const render = createClientRender({ strict: true });
+  let classes;
+  const props = {
+    value: 2,
+  };
+
+  before(() => {
+    mount = createMount({ strict: true });
+    classes = getClasses(<Rating {...props} />);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  describeConformance(<Rating {...props} />, () => ({
+    classes,
+    inheritComponent: 'div',
+    mount,
+    refInstanceof: window.HTMLDivElement,
+  }));
+
+  it('should render', () => {
+    const { container } = render(<Rating {...props} />);
+
+    expect(container.firstChild).to.have.class(classes.root);
+  });
+});

--- a/packages/material-ui-lab/src/Rating/Rating.test.js
+++ b/packages/material-ui-lab/src/Rating/Rating.test.js
@@ -31,6 +31,7 @@ describe('<Rating />', () => {
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
+    skip: ['componentProp'],
   }));
 
   it('should render', () => {

--- a/packages/material-ui-lab/src/Rating/index.d.ts
+++ b/packages/material-ui-lab/src/Rating/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './Rating';
+export * from './Rating';

--- a/packages/material-ui-lab/src/Rating/index.js
+++ b/packages/material-ui-lab/src/Rating/index.js
@@ -1,0 +1,1 @@
+export { default } from './Rating';

--- a/packages/material-ui-lab/src/index.d.ts
+++ b/packages/material-ui-lab/src/index.d.ts
@@ -1,3 +1,4 @@
+export { default as Rating } from './Rating';
 export { default as SpeedDial } from './SpeedDial';
 export { default as SpeedDialAction } from './SpeedDialAction';
 export { default as SpeedDialIcon } from './SpeedDialIcon';

--- a/packages/material-ui-lab/src/index.js
+++ b/packages/material-ui-lab/src/index.js
@@ -1,3 +1,4 @@
+export { default as Rating } from './Rating';
 export { default as Slider } from './Slider';
 export { default as SpeedDial } from './SpeedDial';
 export { default as SpeedDialAction } from './SpeedDialAction';

--- a/packages/material-ui-lab/src/internal/svg-icons/Add.js
+++ b/packages/material-ui-lab/src/internal/svg-icons/Add.js
@@ -1,17 +1,7 @@
 import React from 'react';
-import SvgIcon from '@material-ui/core/SvgIcon';
+import createSvgIcon from './createSvgIcon';
 
 /**
  * @ignore - internal component.
  */
-const Add = React.memo(function Add(props) {
-  return (
-    <SvgIcon {...props}>
-      <path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-    </SvgIcon>
-  );
-});
-
-Add.muiName = 'SvgIcon';
-
-export default Add;
+export default createSvgIcon(<path d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />, 'Add');

--- a/packages/material-ui-lab/src/internal/svg-icons/Star.js
+++ b/packages/material-ui-lab/src/internal/svg-icons/Star.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import createSvgIcon from './createSvgIcon';
+
+/**
+ * @ignore - internal component.
+ */
+export default createSvgIcon(
+  <path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />,
+  'Star',
+);

--- a/packages/material-ui-lab/src/internal/svg-icons/createSvgIcon.js
+++ b/packages/material-ui-lab/src/internal/svg-icons/createSvgIcon.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import SvgIcon from '@material-ui/core/SvgIcon';
+
+export default function createSvgIcon(path, displayName) {
+  const Component = React.memo(
+    React.forwardRef((props, ref) => (
+      <SvgIcon data-mui-test={`${displayName}Icon`} ref={ref} {...props}>
+        {path}
+      </SvgIcon>
+    )),
+  );
+
+  if (process.env.NODE_ENV !== 'production') {
+    Component.displayName = `${displayName}Icon`;
+  }
+
+  Component.muiName = SvgIcon.muiName;
+
+  return Component;
+}

--- a/packages/material-ui/src/Slider/Slider.d.ts
+++ b/packages/material-ui/src/Slider/Slider.d.ts
@@ -21,6 +21,7 @@ export interface SliderProps
   'aria-label'?: string;
   'aria-labelledby'?: string;
   'aria-valuetext'?: string;
+  component?: React.ElementType<React.HTMLAttributes<HTMLSpanElement>>;
   defaultValue?: number | number[];
   disabled?: boolean;
   getAriaValueText?: (value: number, index: number) => string;

--- a/pages/api/rating.js
+++ b/pages/api/rating.js
@@ -1,0 +1,11 @@
+import 'docs/src/modules/components/bootstrap';
+// --- Post bootstrap -----
+import React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './rating.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default Page;

--- a/pages/api/rating.md
+++ b/pages/api/rating.md
@@ -1,0 +1,76 @@
+---
+filename: /packages/material-ui-lab/src/Rating/Rating.js
+---
+
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# Rating API
+
+<p class="description">The API documentation of the Rating React component. Learn more about the properties and the CSS customization points.</p>
+
+```js
+import Rating from '@material-ui/lab/Rating';
+```
+
+
+
+## Props
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the rating will be disabled. |
+| <span class="prop-name">emptyIcon</span> | <span class="prop-type">node</span> |  | The icon to display when empty. |
+| <span class="prop-name">getLabelText</span> | <span class="prop-type">func</span> | <span class="prop-default">function defaultLabelText(value) {  return `${value} star${value !== 1 ? 's' : ''}`;}</span> | Accepts a function which returns a string value that provides a user-friendly name for the current value of the rating.<br><br>**Signature:**<br>`function(value: number) => void`<br>*value:* The rating label's value to format |
+| <span class="prop-name">icon</span> | <span class="prop-type">node</span> | <span class="prop-default">&lt;Star fontSize="inherit" /></span> | The icon to display. |
+| <span class="prop-name">IconContainerComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">function IconContainer(props) {  const { value, ...other } = props;  return &lt;div {...other} />;}</span> | The component containing the icon. |
+| <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | Maximum rating. |
+| <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | Name attribute of the radio `input` elements. |
+| <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: number) => void`<br>*event:* The event source of the callback<br>*value:* The new value |
+| <span class="prop-name">onChangeHover</span> | <span class="prop-type">func</span> |  | Callback function that is fired when the hover state changes.<br><br>**Signature:**<br>`function(event: object, value: any) => void`<br>*event:* The event source of the callback<br>*value:* The new value |
+| <span class="prop-name">precision</span> | <span class="prop-type">number</span> | <span class="prop-default">1</span> | The minimum increment value change allowed. |
+| <span class="prop-name">readOnly</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Removes all hover effects and pointer events. |
+| <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span> | <span class="prop-default">'medium'</span> | The size of the rating. |
+| <span class="prop-name">value</span> | <span class="prop-type">number</span> |  | The rating value. |
+
+The `ref` is forwarded to the root element.
+
+Any other properties supplied will be provided to the root element (native element).
+
+## CSS
+
+You can override all the class names injected by Material-UI thanks to the `classes` property.
+This property accepts the following keys:
+
+
+| Name | Description |
+|:-----|:------------|
+| <span class="prop-name">root</span> | Styles applied to the root element.
+| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.
+| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">readOnly</span> | Pseudo-class applied to the root element if `readOnly={true}`.
+| <span class="prop-name">visuallyhidden</span> | 
+| <span class="prop-name">icon</span> | Pseudo-class applied to the icon wrapping elements.
+| <span class="prop-name">iconEmpty</span> | Pseudo-class applied to the icon wrapping elements when empty.
+| <span class="prop-name">iconFilled</span> | Pseudo-class applied to the icon wrapping elements when filled.
+| <span class="prop-name">iconHover</span> | Pseudo-class applied to the icon wrapping elements when hover.
+| <span class="prop-name">iconActive</span> | Pseudo-class applied to the icon wrapping elements when active.
+| <span class="prop-name">decimal</span> | Pseudo-class applied to the icon wrapping elements when decimals are necessary.
+
+Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
+and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Rating/Rating.js)
+for more detail.
+
+If using the `overrides` [key of the theme](/customization/themes/#css),
+you need to use the following style sheet name: `MuiRating`.
+
+## Notes
+
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+
+## Demos
+
+- [Rating](/components/rating/)
+

--- a/pages/api/rating.md
+++ b/pages/api/rating.md
@@ -28,7 +28,7 @@ import Rating from '@material-ui/lab/Rating';
 | <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | Maximum rating. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | Name attribute of the radio `input` elements. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: number) => void`<br>*event:* The event source of the callback<br>*value:* The new value |
-| <span class="prop-name">onChangeHover</span> | <span class="prop-type">func</span> |  | Callback function that is fired when the hover state changes.<br><br>**Signature:**<br>`function(event: object, value: any) => void`<br>*event:* The event source of the callback<br>*value:* The new value |
+| <span class="prop-name">onChangeActive</span> | <span class="prop-type">func</span> |  | Callback function that is fired when the hover state changes.<br><br>**Signature:**<br>`function(event: object, value: any) => void`<br>*event:* The event source of the callback<br>*value:* The new value |
 | <span class="prop-name">precision</span> | <span class="prop-type">number</span> | <span class="prop-default">1</span> | The minimum increment value change allowed. |
 | <span class="prop-name">readOnly</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Removes all hover effects and pointer events. |
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span> | <span class="prop-default">'medium'</span> | The size of the rating. |
@@ -49,15 +49,19 @@ This property accepts the following keys:
 | <span class="prop-name">root</span> | Styles applied to the root element.
 | <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.
+| <span class="prop-name">readOnly</span> | Styles applied to the root element if `readOnly={true}`.
 | <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">readOnly</span> | Pseudo-class applied to the root element if `readOnly={true}`.
-| <span class="prop-name">visuallyhidden</span> | 
-| <span class="prop-name">icon</span> | Pseudo-class applied to the icon wrapping elements.
-| <span class="prop-name">iconEmpty</span> | Pseudo-class applied to the icon wrapping elements when empty.
-| <span class="prop-name">iconFilled</span> | Pseudo-class applied to the icon wrapping elements when filled.
-| <span class="prop-name">iconHover</span> | Pseudo-class applied to the icon wrapping elements when hover.
-| <span class="prop-name">iconActive</span> | Pseudo-class applied to the icon wrapping elements when active.
-| <span class="prop-name">decimal</span> | Pseudo-class applied to the icon wrapping elements when decimals are necessary.
+| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the root element if keyboard focused.
+| <span class="prop-name">visuallyhidden</span> | Visually hide an element.
+| <span class="prop-name">pristine</span> | Styles applied to the pristine label.
+| <span class="prop-name">label</span> | Styles applied to the label elements.
+| <span class="prop-name">icon</span> | Styles applied to the icon wrapping elements.
+| <span class="prop-name">iconEmpty</span> | Styles applied to the icon wrapping elements when empty.
+| <span class="prop-name">iconFilled</span> | Styles applied to the icon wrapping elements when filled.
+| <span class="prop-name">iconHover</span> | Styles applied to the icon wrapping elements when hover.
+| <span class="prop-name">iconFocus</span> | Styles applied to the icon wrapping elements when focus.
+| <span class="prop-name">iconActive</span> | Styles applied to the icon wrapping elements when active.
+| <span class="prop-name">decimal</span> | Styles applied to the icon wrapping elements when decimals are necessary.
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Rating/Rating.js)

--- a/pages/api/rating.md
+++ b/pages/api/rating.md
@@ -31,7 +31,7 @@ import Rating from '@material-ui/lab/Rating';
 | <span class="prop-name">precision</span> | <span class="prop-type">number</span> | <span class="prop-default">1</span> | The minimum increment value change allowed. |
 | <span class="prop-name">readOnly</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Removes all hover effects and pointer events. |
 | <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'&nbsp;&#124;<br>&nbsp;'large'<br></span> | <span class="prop-default">'medium'</span> | The size of the rating. |
-| <span class="prop-name">value</span> | <span class="prop-type">number</span> |  | The rating value. |
+| <span class="prop-name">value</span> | <span class="prop-type">number</span> | <span class="prop-default">null</span> | The rating value. |
 
 The `ref` is forwarded to the root element.
 

--- a/pages/api/rating.md
+++ b/pages/api/rating.md
@@ -19,10 +19,9 @@ import Rating from '@material-ui/lab/Rating';
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the rating will be disabled. |
 | <span class="prop-name">emptyIcon</span> | <span class="prop-type">node</span> |  | The icon to display when empty. |
-| <span class="prop-name">getLabelText</span> | <span class="prop-type">func</span> | <span class="prop-default">function defaultLabelText(value) {  return `${value} star${value !== 1 ? 's' : ''}`;}</span> | Accepts a function which returns a string value that provides a user-friendly name for the current value of the rating.<br><br>**Signature:**<br>`function(value: number) => void`<br>*value:* The rating label's value to format |
+| <span class="prop-name">getLabelText</span> | <span class="prop-type">func</span> | <span class="prop-default">function defaultLabelText(value) {  return `${value} Star${value !== 1 ? 's' : ''}`;}</span> | Accepts a function which returns a string value that provides a user-friendly name for the current value of the rating.<br><br>**Signature:**<br>`function(value: number) => void`<br>*value:* The rating label's value to format |
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> | <span class="prop-default">&lt;Star fontSize="inherit" /></span> | The icon to display. |
 | <span class="prop-name">IconContainerComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">function IconContainer(props) {  const { value, ...other } = props;  return &lt;div {...other} />;}</span> | The component containing the icon. |
 | <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | Maximum rating. |

--- a/pages/components/rating.js
+++ b/pages/components/rating.js
@@ -1,16 +1,18 @@
+import 'docs/src/modules/components/bootstrap';
+// --- Post bootstrap -----
 import React from 'react';
-import Rating from '@material-ui/lab/Rating';
-import Typography from '@material-ui/core/Typography';
-import Box from '@material-ui/core/Box';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
 
-export default function HalfRating() {
-  return (
-    <div>
-      <Typography gutterBottom>value=2.5</Typography>
-      <Rating name="half-rating" value={2.5} />
-      <Box mt={3} />
-      <Typography gutterBottom>precision=0.5</Typography>
-      <Rating name="half-rating-precision" value={2.5} precision={0.5} />
-    </div>
-  );
+const req = require.context('docs/src/pages/components/rating', false, /\.(md|js|tsx)$/);
+const reqSource = require.context(
+  '!raw-loader!../../docs/src/pages/components/rating',
+  false,
+  /\.(js|tsx)$/,
+);
+const reqPrefix = 'pages/components/rating';
+
+function Page() {
+  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
 }
+
+export default Page;

--- a/pages/components/rating.js
+++ b/pages/components/rating.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import Rating from '@material-ui/lab/Rating';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+
+export default function HalfRating() {
+  return (
+    <div>
+      <Typography gutterBottom>value=2.5</Typography>
+      <Rating name="half-rating" value={2.5} />
+      <Box mt={3} />
+      <Typography gutterBottom>precision=0.5</Typography>
+      <Rating name="half-rating-precision" value={2.5} precision={0.5} />
+    </div>
+  );
+}

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -103,6 +103,11 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui/build/esm/Slider/index.js',
     },
     {
+      name: 'Rating',
+      webpack: true,
+      path: 'packages/material-ui-lab/build/esm/Rating/index.js',
+    },
+    {
       // vs https://bundlephobia.com/result?p=react-portal
       name: 'Portal',
       webpack: true,


### PR DESCRIPTION
This is a low hanging fruit. Preview: https://deploy-preview-16455--material-ui.netlify.com/components/rating/.

![Capture d’écran 2019-07-02 à 18 58 52](https://user-images.githubusercontent.com/3165635/60527717-7549b580-9cfb-11e9-8a5a-496632811238.png)

The feature side was benchmarked with:
- http://voronianski.github.io/react-star-rating-component/example/
- https://developer.microsoft.com/en-us/fabric/#/controls/web/rating
- https://vuetifyjs.com/en/components/ratings
- https://ant.design/components/rate/
- https://github.com/TeamWertarbyte/material-ui-rating/blob/master/src/components/Rating/Rating.js
- https://www.jqwidgets.com/jquery-widgets-demo/demos/jqxrating/index.htm#demos/jqxrating/defaultfunctionality.htm
- https://mdbootstrap.com/plugins/jquery/rating/
- https://baseweb.design/components/rating/
- https://quasar.dev/vue-components/rating
- https://semantic-ui.com/modules/rating.html

The accessibility side was benchmarked with
- https://www.w3.org/WAI/tutorials/forms/custom-controls/
- http://ebay.github.io/mindpatterns/input/star-rating/index.html
- https://github.com/dandv/comparisons/blob/master/star-rating-widgets.md#superset-of-features cc @dandv

The next component I would like to tackle is the autocomplete /  combo box / multi-select one. It will be a large effort, not a one week gig like the rating but much more valuable too. 