### PR TITLE
[test] Simpler createClientRender

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -29,10 +29,7 @@ function simulatePointerDevice() {
 }
 
 describe('<ButtonBase />', () => {
-  /**
-   * @type {ReturnType<typeof createClientRender>}
-   */
-  let render;
+  const render = createClientRender({ strict: false });
   /**
    * @type {ReturnType<typeof createMount>}
    */
@@ -45,7 +42,6 @@ describe('<ButtonBase />', () => {
   let canFireDragEvents = true;
 
   before(() => {
-    render = createClientRender({ strict: false });
     /**
      * StrictModeViolation: Uses TouchRipple
      */

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -8,11 +8,11 @@ import Ripple from './Ripple';
 
 describe('<Ripple />', () => {
   let classes;
-  let mount;
+  // StrictModeViolation: uses react-transition-group
+  const mount = createClientRender({ strict: false });
 
   before(() => {
     classes = getClasses(<TouchRipple />);
-    mount = createClientRender({ strict: undefined });
   });
 
   after(() => {

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -64,18 +64,14 @@ function expectFocusVisible(element, focusVisibleClass) {
 }
 
 describe('<MenuList> integration', () => {
-  let render;
+  // StrictModeViolation: Uses MenuItem
+  const render = createClientRender({ strict: false });
 
   if (/Chrome\/49\.0/.test(window.navigator.userAgent)) {
     // fails repeatedly on chrome 49 in karma but works when manually testing
     // the same component tree (-TrackCommitCountMenuItem) in isolation in browserstack
     return;
   }
-
-  before(() => {
-    // StrictModeViolation: Uses MenuItem
-    render = createClientRender({ strict: false });
-  });
 
   after(() => {
     cleanup();

--- a/test/utils/createClientRender.js
+++ b/test/utils/createClientRender.js
@@ -1,3 +1,4 @@
+/* eslint-env mocha */
 import React from 'react';
 import {
   act,
@@ -40,10 +41,18 @@ function clientRender(element, options = {}) {
 
 export function createClientRender(globalOptions = {}) {
   const { strict: globalStrict } = globalOptions;
+  let baseElement;
 
-  const baseElement = document.createElement('div');
-  baseElement.className = 'rtl--baseElement';
-  document.body.appendChild(baseElement);
+  before(() => {
+    baseElement = document.createElement('div');
+    baseElement.className = 'rtl--baseElement';
+    document.body.appendChild(baseElement);
+  });
+
+  after(() => {
+    baseElement.parentNode.removeChild(baseElement);
+    baseElement = null;
+  });
 
   return function configuredClientRender(element, options = {}) {
     const { strict = globalStrict, ...localOptions } = options;


### PR DESCRIPTION
Improves dev ergonomics for `createClientRender` (createMount should work the same but let's follow unix philosophy here:

- no more `let render;` + `before`
- no more `@type` required
- clean-up `baseElements` properly