### PR TITLE
Update ResponsiveDrawer.js

### DIFF
--- a/docs/src/pages/components/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.js
@@ -53,8 +53,8 @@ const useStyles = makeStyles(theme => ({
 
 export default function ResponsiveDrawer(props) {
   const { container } = props;
-  const classes = useStyles();
   const theme = useTheme();
+  const classes = useStyles(theme);
   const [mobileOpen, setMobileOpen] = React.useState(false);
 
   function handleDrawerToggle() {


### PR DESCRIPTION
Should provide `theme` props in `useStyles`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
