### PR TITLE
[styles] Make theme optional for `styled` components (#16379)

### DIFF
--- a/packages/material-ui-styles/src/styled/styled.d.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.d.spec.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { styled } from '@material-ui/styles';
+
+function styledTest() {
+  function styleFunction(props: {
+    someStyleValue: number;
+    theme: { palette: { primary: 'limegreen' } };
+  }) {
+    return {};
+  }
+
+  const StyledComponent = styled('div')(styleFunction);
+
+  // prop 'theme' must not be required
+  <StyledComponent someStyleValue={2} />;
+
+  // Property 'palette' is missing in type '{}'
+  <StyledComponent someStyleValue={2} theme={{}} />; // $ExpectError
+}

--- a/packages/material-ui-styles/src/styled/styled.d.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.d.spec.tsx
@@ -2,18 +2,47 @@ import * as React from 'react';
 import { styled } from '@material-ui/styles';
 
 function styledTest() {
-  function styleFunction(props: {
-    someStyleValue: number;
-    theme: { palette: { primary: 'limegreen' } };
-  }) {
-    return {};
-  }
+  const style = (props: { value: number }) => ({});
+  const styleWithTheme = (props: {
+    value: number;
+    theme: { palette: { primary: string } };
+  }) => ({});
+  const Component: React.FC = () => null;
+  const ComponentWithTheme: React.FC<{ theme: { zIndex: { [k: string]: number } } }> = () => null;
 
-  const StyledComponent = styled('div')(styleFunction);
+  const ComponentStyled = styled(Component)(style);
+  const ComponentStyledWithTheme = styled(Component)(styleWithTheme);
+  const ComponentWithThemeStyled = styled(ComponentWithTheme)(style);
+  const ComponentWithThemeStyledWithTheme = styled(ComponentWithTheme)(styleWithTheme);
 
   // prop 'theme' must not be required
-  <StyledComponent someStyleValue={2} />;
+  <ComponentStyled value={1} />;
+  <ComponentStyledWithTheme value={1} />;
+  // error: property 'palette' is missing in type {}
+  <ComponentStyledWithTheme value={1} theme={{}} />; // $ExpectError
+  // error: property 'theme' is missing in type ... (because the component requires it)
+  <ComponentWithThemeStyled value={1} />; // $ExpectError
+  <ComponentWithThemeStyledWithTheme value={1} />; // $ExpectError
+  // error: property 'zIndex' is missing in type ...
+  <ComponentWithThemeStyledWithTheme value={1} theme={{ palette: { primary: '#333' } }} />; // $ExpectError
+  // error: property 'palette' is missing in type ...
+  <ComponentWithThemeStyledWithTheme value={1} theme={{ zIndex: { appBar: 500 } }} />; // $ExpectError
+  <ComponentWithThemeStyledWithTheme
+    value={1}
+    theme={{ zIndex: { appBar: 500 }, palette: { primary: '#333' } }}
+  />;
 
-  // Property 'palette' is missing in type '{}'
-  <StyledComponent someStyleValue={2} theme={{}} />; // $ExpectError
+  const ComponentWithOptionalTheme: React.FC<{
+    theme?: { zIndex: { [k: string]: number } };
+  }> = () => null;
+  const ComponentWithOptionalThemeStyledWithTheme = styled(ComponentWithOptionalTheme)(
+    styleWithTheme,
+  );
+
+  // prop 'theme' must not be required
+  <ComponentWithOptionalThemeStyledWithTheme value={1} />;
+  // error: property 'palette' is missing in type {}
+  <ComponentWithOptionalThemeStyledWithTheme value={1} theme={{}} />; // $ExpectError
+  // error: property 'zIndex' is missing in type ...
+  <ComponentWithOptionalThemeStyledWithTheme value={1} theme={{ palette: { primary: '#333' } }} />; // $ExpectError
 }

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -12,7 +12,7 @@ import * as React from 'react';
 export type ComponentCreator<Component extends React.ElementType> = <Theme, Props extends {} = any>(
   styles:
     | CreateCSSProperties<Props>
-    | (({ theme, ...props }: { theme: Theme } & Props) => CreateCSSProperties<Props>),
+    | ((props: { theme: Theme } & CoerceEmptyInterface<Props>) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
   Omit<

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -12,14 +12,16 @@ import * as React from 'react';
 export type ComponentCreator<Component extends React.ElementType> = <Theme, Props extends {} = any>(
   styles:
     | CreateCSSProperties<Props>
-    | ((props: { theme: Theme } & CoerceEmptyInterface<Props>) => CreateCSSProperties<Props>),
+    | (({ theme, ...props }: { theme: Theme } & Props) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
   Omit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
     'classes' | 'className'
   > &
-    StyledComponentProps<'root'> & { className?: string } & CoerceEmptyInterface<Props>
+    StyledComponentProps<'root'> & { className?: string } & CoerceEmptyInterface<
+      Props extends { theme: Theme } ? Omit<Props, 'theme'> & { theme?: Theme } : Props
+    >
 >;
 
 export interface StyledProps {

--- a/packages/material-ui/src/styles/styled.d.ts
+++ b/packages/material-ui/src/styles/styled.d.ts
@@ -27,7 +27,9 @@ export type ComponentCreator<Component extends React.ElementType> = <
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
     'classes' | 'className'
   > &
-    StyledComponentProps<'root'> & { className?: string } & CoerceEmptyInterface<Props>
+    StyledComponentProps<'root'> & { className?: string } & CoerceEmptyInterface<
+      Props extends { theme: Theme } ? Omit<Props, 'theme'> & { theme?: Theme } : Props
+    >
 >;
 
 export interface StyledProps {

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -563,6 +563,47 @@ withStyles(theme =>
 }
 
 {
+  // Make theme property on styled components optional
+  // https://github.com/mui-org/material-ui/issues/16379#issuecomment-507209971
+  const style = (props: { value: number }) => ({});
+  const styleWithTheme = (props: { value: number; theme: Theme }) => ({});
+  const Component: React.FC = () => null;
+  const ComponentWithTheme: React.FC<{ theme: { zIndex: { [k: string]: number } } }> = () => null;
+
+  const ComponentStyled = styled(Component)(style);
+  const ComponentStyledWithTheme = styled(Component)(styleWithTheme);
+  const ComponentWithThemeStyled = styled(ComponentWithTheme)(style);
+  const ComponentWithThemeStyledWithTheme = styled(ComponentWithTheme)(styleWithTheme);
+
+  // prop 'theme' must not be required
+  <ComponentStyled value={1} />;
+  <ComponentStyledWithTheme value={1} />;
+  // error: type {} is missing properties from 'Theme' ...
+  <ComponentStyledWithTheme value={1} theme={{}} />; // $ExpectError
+  // error: property 'theme' is missing in type ... (because the component requires it)
+  <ComponentWithThemeStyled value={1} />; // $ExpectError
+  <ComponentWithThemeStyledWithTheme value={1} />; // $ExpectError
+  // error: type {} is not assignable to type ...
+  <ComponentWithThemeStyledWithTheme value={1} theme={{}} />; // $ExpectError
+  // error: missing properties from type 'ZIndex' ...
+  <ComponentWithThemeStyledWithTheme value={1} theme={{ zIndex: { appBar: 100 } }} />; // $ExpectError
+
+  const ComponentWithOptionalTheme: React.FC<{
+    theme?: { zIndex: { [k: string]: number } };
+  }> = () => null;
+  const ComponentWithOptionalThemeStyledWithTheme = styled(ComponentWithOptionalTheme)(
+    styleWithTheme,
+  );
+
+  // prop 'theme' must not be required
+  <ComponentWithOptionalThemeStyledWithTheme value={1} />;
+  // error: property 'zIndex' is missing in type {}
+  <ComponentWithOptionalThemeStyledWithTheme value={1} theme={{}} />; // $ExpectError
+  // error: missing properties from type 'Theme' ...
+  <ComponentWithOptionalThemeStyledWithTheme value={1} theme={{ zIndex: { appBar: 100 } }} />; // $ExpectError
+}
+
+{
   // Make sure theme and props have the correct types
   // https://github.com/mui-org/material-ui/issues/16351
 


### PR DESCRIPTION
- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Theme can be passed via context, so `styled` components should not require theme property.

Example of the problem: https://codesandbox.io/s/stoic-yonath-3ukmk
