### PR TITLE
[core] Re-export missing typings

### DIFF
--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -70,6 +70,9 @@ export {
   WithStyles,
   withTheme,
   WithTheme,
+  MuiThemeProvider,
+  responsiveFontSizes,
+  styled,
 } from './styles';
 
 export { default as AppBar } from './AppBar';


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Added missing exports to `@material-ui/core` typings

- MuiThemeProvider
- responsiveFontSizes
- styled

It doesn't export all types from styles, but at least it exports the same as the JS file.

Closes #16489