### PR TITLE
[core] Import esm babel helpers

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -133,16 +133,16 @@ module.exports = {
       ],
     },
     esm: {
-      plugins: productionPlugins,
+      plugins: [...productionPlugins, ['@babel/plugin-transform-runtime', { useESModules: true }]],
     },
     es: {
-      plugins: productionPlugins,
+      plugins: [...productionPlugins, ['@babel/plugin-transform-runtime', { useESModules: true }]],
     },
     production: {
-      plugins: productionPlugins,
+      plugins: [...productionPlugins, ['@babel/plugin-transform-runtime', { useESModules: true }]],
     },
     'production-umd': {
-      plugins: productionPlugins,
+      plugins: [...productionPlugins, ['@babel/plugin-transform-runtime', { useESModules: true }]],
     },
     test: {
       sourceMaps: 'both',


### PR DESCRIPTION
In this diff I changed babel helpers imports to esm versions for
esm/es/umd bundles. For example

```
@babel/runtime/helpers/extends -> @babel/runtime/helpers/esm/extends
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
