### PR TITLE
[styles] Warn when using a missing style rule

### DIFF
--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -178,7 +178,7 @@ function MarkdownDocs(props) {
             </Portal>
           )}
 
-          <AppContent disableToc={disableToc} className={classes.root}>
+          <AppContent disableToc={disableToc}>
             {!disableEdit ? (
               <div className={classes.header}>
                 <EditPage

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -74,6 +74,10 @@ function escapeCell(value) {
     .replace(/\|/g, '\\|');
 }
 
+function isOneOfWithString(type) {
+  return type.raw.indexOf('oneOfWithString') === 0;
+}
+
 function isElementTypeAcceptingRefProp(type) {
   return type.raw === 'elementTypeAcceptingRef';
 }
@@ -169,6 +173,18 @@ function generatePropType(type) {
       }
       if (isElementAcceptingRefProp(type)) {
         return `element`;
+      }
+      if (isOneOfWithString(type)) {
+        return generatePropType({
+          name: 'enum',
+          value: type.raw
+            .replace('oneOfWithString([', '')
+            .replace('])', '')
+            .split(',')
+            .map(x => x.trim())
+            .filter(x => x)
+            .map(x => ({ value: x, computed: false })),
+        });
       }
 
       const deprecatedInfo = getDeprecatedInfo(type);

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import { capitalize } from '../utils/helpers';
+import oneOfWithString from '../utils/oneOfWithString';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -221,7 +222,7 @@ Typography.propTypes = {
   /**
    * Applies the theme typography styles.
    */
-  variant: PropTypes.oneOf([
+  variant: oneOfWithString([
     'h1',
     'h2',
     'h3',

--- a/packages/material-ui/src/utils/oneOfWithString.js
+++ b/packages/material-ui/src/utils/oneOfWithString.js
@@ -1,0 +1,5 @@
+import * as PropTypes from 'prop-types';
+
+export default function oneOfWithString() {
+  return PropTypes.string;
+}


### PR DESCRIPTION
I'm exploring one possible approach to better handle #13875, #15454, #15573.
The idea here is to soften the `PropTypes.oneOf` prop type to `PropTypes.string` while keeping the warning for dynamic values with a `classes` proxy that detects accesses to none supported values.

However, I have found two drawbacks with this approach:
1. The warning raised when it fails could be more specific. 
2. Logging `classes` return a rich object, it's less obvious that it's a simple object behind the proxy:

```js
console.log(classes);
```

![Capture d’écran 2019-07-06 à 11 40 56](https://user-images.githubusercontent.com/3165635/60754003-abc94e00-9fe3-11e9-9505-2598fdb23832.png)
