### PR TITLE
Update grid.md

### DIFF
--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -96,7 +96,7 @@ There are 3 available workarounds:
     </div>
   </body>
 ```
-3. Adding `overflow-x: hidden;` to the parent.
+3. Adding `overflow-y: hidden;` to the parent.
 
 ### white-space: nowrap;
 


### PR DESCRIPTION
For Negative margin workaround 3, I think it should be 'overflow-y: hidden' instead of 'overflow-x: hidden'. 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
