### PR TITLE
[Ripple] Use custom transition logic

### DIFF
--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -30,7 +30,7 @@ describe('<SpeedDial />', () => {
   }
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
+    // StrictModeViolation: unknown
     mount = createMount({ strict: false });
     classes = getClasses(
       <SpeedDial {...props} icon={icon}>

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -17,7 +17,7 @@ describe('<SpeedDialAction />', () => {
   };
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
+    // StrictModeViolation: unknown
     mount = createMount({ strict: false });
     classes = getClasses(<SpeedDialAction {...props} />);
   });

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.test.js
@@ -17,7 +17,7 @@ describe('<ToggleButton />', () => {
   let classes;
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
+    // StrictModeViolation: uses simulate
     mount = createMount({ strict: false });
     render = createRender();
     classes = getClasses(<ToggleButton value="classes">Hello World</ToggleButton>);

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.test.js
@@ -11,8 +11,7 @@ describe('<ToggleButtonGroup />', () => {
   let classes;
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
     classes = getClasses(
       <ToggleButtonGroup>
         <ToggleButton value="hello" />

--- a/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
+++ b/packages/material-ui/src/BottomNavigation/BottomNavigation.test.js
@@ -20,8 +20,7 @@ describe('<BottomNavigation />', () => {
         <BottomNavigationAction icon={icon} />
       </BottomNavigation>,
     );
-    // StrictModeViolation: uses BottomNavigationAction
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -13,7 +13,7 @@ describe('<BottomNavigationAction />', () => {
   const icon = <Icon>restore</Icon>;
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
+    // StrictModeViolation: uses simulate
     mount = createMount({ strict: false });
     classes = getClasses(<BottomNavigationAction />);
   });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -29,7 +29,7 @@ function simulatePointerDevice() {
 }
 
 describe('<ButtonBase />', () => {
-  const render = createClientRender({ strict: false });
+  const render = createClientRender({ strict: true });
   /**
    * @type {ReturnType<typeof createMount>}
    */
@@ -42,10 +42,7 @@ describe('<ButtonBase />', () => {
   let canFireDragEvents = true;
 
   before(() => {
-    /**
-     * StrictModeViolation: Uses TouchRipple
-     */
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
     classes = getClasses(<ButtonBase />);
     // browser testing config
     try {

--- a/packages/material-ui/src/ButtonBase/Ripple.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.js
@@ -7,7 +7,7 @@ import { Transition } from 'react-transition-group';
  * @ignore - internal component.
  */
 function Ripple(props) {
-  const { classes, className, pulsate = false, rippleX, rippleY, rippleSize, ...other } = props;
+  const { classes, pulsate = false, rippleX, rippleY, rippleSize, ...other } = props;
   const [visible, setVisible] = React.useState(false);
   const [leaving, setLeaving] = React.useState(false);
 
@@ -25,7 +25,6 @@ function Ripple(props) {
       [classes.rippleVisible]: visible,
       [classes.ripplePulsate]: pulsate,
     },
-    className,
   );
 
   const rippleStyles = {
@@ -55,10 +54,6 @@ Ripple.propTypes = {
    * See [CSS API](#css) below for more details.
    */
   classes: PropTypes.object.isRequired,
-  /**
-   * @ignore
-   */
-  className: PropTypes.string,
   /**
    * If `true`, the ripple pulsates, typically indicating the keyboard focus state of an element.
    */

--- a/packages/material-ui/src/ButtonBase/Ripple.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.js
@@ -8,12 +8,7 @@ import { Transition } from 'react-transition-group';
  */
 function Ripple(props) {
   const { classes, pulsate = false, rippleX, rippleY, rippleSize, ...other } = props;
-  const [visible, setVisible] = React.useState(false);
   const [leaving, setLeaving] = React.useState(false);
-
-  const handleEnter = () => {
-    setVisible(true);
-  };
 
   const handleExit = () => {
     setLeaving(true);
@@ -21,8 +16,8 @@ function Ripple(props) {
 
   const rippleClassName = clsx(
     classes.ripple,
+    classes.rippleVisible,
     {
-      [classes.rippleVisible]: visible,
       [classes.ripplePulsate]: pulsate,
     },
   );
@@ -40,7 +35,7 @@ function Ripple(props) {
   });
 
   return (
-    <Transition onEnter={handleEnter} onExit={handleExit} {...other}>
+    <Transition onExit={handleExit} {...other}>
       <span className={rippleClassName} style={rippleStyles}>
         <span className={childClassName} />
       </span>

--- a/packages/material-ui/src/ButtonBase/Ripple.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.js
@@ -46,7 +46,9 @@ function Ripple(props) {
 
       // react-transition-group#onExited
       const timeoutId = setTimeout(handleExited, timeout);
-      return () => clearTimeout(timeoutId);
+      return () => {
+        clearTimeout(timeoutId);
+      };
     }
     return undefined;
   }, [handleExited, inProp, timeout]);

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -8,8 +8,7 @@ import Ripple from './Ripple';
 
 describe('<Ripple />', () => {
   let classes;
-  // StrictModeViolation: uses react-transition-group
-  const mount = createClientRender({ strict: false });
+  const mount = createClientRender({ strict: true });
 
   before(() => {
     classes = getClasses(<TouchRipple />);

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -21,7 +21,7 @@ describe('<Ripple />', () => {
 
   it('should have the ripple className', () => {
     const { container } = mount(
-      <Ripple classes={classes} timeout={{}} rippleX={0} rippleY={0} rippleSize={11} />,
+      <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} />,
     );
     const ripple = container.querySelector('span');
     expect(ripple).to.have.class(classes.ripple);
@@ -33,13 +33,7 @@ describe('<Ripple />', () => {
 
     before(() => {
       wrapper = mount(
-        <Ripple
-          classes={classes}
-          timeout={{ exit: 0, enter: 0 }}
-          rippleX={0}
-          rippleY={0}
-          rippleSize={11}
-        />,
+        <Ripple classes={classes} timeout={0} rippleX={0} rippleY={0} rippleSize={11} />,
       );
     });
 
@@ -64,7 +58,7 @@ describe('<Ripple />', () => {
       wrapper = mount(
         <Ripple
           classes={classes}
-          timeout={{ enter: 0, exit: 0 }}
+          timeout={0}
           in={false}
           rippleX={0}
           rippleY={0}
@@ -108,7 +102,7 @@ describe('<Ripple />', () => {
       wrapper = mount(
         <Ripple
           classes={classes}
-          timeout={{ exit: 550 }}
+          timeout={550}
           in
           onExited={callbackSpy}
           rippleX={0}

--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -258,7 +258,7 @@ class TouchRipple extends React.PureComponent {
 
     return (
       <span className={clsx(classes.root, className)} ref={this.container} {...other}>
-        <TransitionGroup component={null} enter exit>
+        <TransitionGroup component={null} exit>
           {this.state.ripples}
         </TransitionGroup>
       </span>

--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -213,10 +213,7 @@ class TouchRipple extends React.PureComponent {
           <Ripple
             key={state.nextKey}
             classes={this.props.classes}
-            timeout={{
-              exit: DURATION,
-              enter: DURATION,
-            }}
+            timeout={DURATION}
             pulsate={pulsate}
             rippleX={rippleX}
             rippleY={rippleY}

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useFakeTimers } from 'sinon';
 import { assert } from 'chai';
-import { createShallow, createMount, getClasses, unwrap } from '@material-ui/core/test-utils';
+import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Ripple from './Ripple';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
@@ -12,11 +12,10 @@ describe('<TouchRipple />', () => {
   let shallow;
   let mount;
   let classes;
-  const TouchRippleNaked = unwrap(TouchRipple);
 
   before(() => {
     shallow = createShallow({ dive: true });
-    mount = createMount({ strict: undefined });
+    mount = createMount({ strict: true });
     classes = getClasses(<TouchRipple />);
   });
 
@@ -55,28 +54,28 @@ describe('<TouchRipple />', () => {
   });
 
   it('should create individual ripples', () => {
-    const wrapper = mount(<TouchRippleNaked classes={{}} />);
-    const instance = wrapper.instance();
+    const wrapper = mount(<TouchRipple />);
+    const instance = wrapper.find('TouchRipple').instance();
 
-    assert.strictEqual(wrapper.state().ripples.length, 0);
-
-    instance.start({ clientX: 0, clientY: 0 }, cb);
-    assert.strictEqual(wrapper.state().ripples.length, 1);
+    assert.strictEqual(instance.state.ripples.length, 0);
 
     instance.start({ clientX: 0, clientY: 0 }, cb);
-    assert.strictEqual(wrapper.state().ripples.length, 2);
+    assert.strictEqual(instance.state.ripples.length, 1);
 
     instance.start({ clientX: 0, clientY: 0 }, cb);
-    assert.strictEqual(wrapper.state().ripples.length, 3);
+    assert.strictEqual(instance.state.ripples.length, 2);
+
+    instance.start({ clientX: 0, clientY: 0 }, cb);
+    assert.strictEqual(instance.state.ripples.length, 3);
 
     instance.stop({ type: 'mouseup' });
-    assert.strictEqual(wrapper.state().ripples.length, 2);
+    assert.strictEqual(instance.state.ripples.length, 2);
 
     instance.stop({ type: 'mouseup' });
-    assert.strictEqual(wrapper.state().ripples.length, 1);
+    assert.strictEqual(instance.state.ripples.length, 1);
 
     instance.stop({ type: 'mouseup' });
-    assert.strictEqual(wrapper.state().ripples.length, 0);
+    assert.strictEqual(instance.state.ripples.length, 0);
   });
 
   describe('creating unique ripples', () => {

--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -11,8 +11,7 @@ describe('<Checkbox />', () => {
 
   before(() => {
     classes = getClasses(<Checkbox />);
-    // StrictModeViolation: uses IconButton
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -15,7 +15,7 @@ describe('<ExpansionPanelSummary />', () => {
   }
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
+    // StrictModeViolation: uses simulate
     mount = createMount({ strict: false });
     classes = getClasses(<ExpansionPanelSummary />);
   });

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -13,8 +13,7 @@ describe('<Fab />', () => {
   let classes;
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
     classes = getClasses(<Fab>Fab</Fab>);
   });
 

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -13,8 +13,7 @@ describe('<FormControlLabel />', () => {
   let classes;
 
   before(() => {
-    // StrictModeViolation: uses Checkbox in test
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
     classes = getClasses(<FormControlLabel label="Pizza" control={<div />} />);
   });
 

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -15,8 +15,7 @@ describe('<IconButton />', () => {
   const render = createClientRender({ strict: false });
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
     classes = getClasses(<IconButton />);
   });
 

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -27,8 +27,7 @@ describe('<ListItem />', () => {
 
   before(() => {
     classes = getClasses(<ListItem />);
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
   });
 
   afterEach(() => {

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -15,8 +15,7 @@ describe('<MenuItem />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<MenuItem />);
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -11,8 +11,7 @@ describe('<Radio />', () => {
 
   before(() => {
     classes = getClasses(<Radio />);
-    // StrictModeViolation: uses Switchbase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -16,8 +16,7 @@ describe('<StepButton />', () => {
   before(() => {
     classes = getClasses(<StepButton />);
     shallow = createShallow({ dive: true });
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -20,7 +20,7 @@ describe('<Tab />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    // StrictModeViolation: uses ButtonBase
+    // StrictModeViolation: uses text()
     mount = createMount({ strict: false });
     classes = getClasses(<Tab textColor="inherit" />);
   });

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -32,7 +32,7 @@ describe('<TablePagination />', () => {
     classes = getClasses(
       <TablePagination count={1} onChangePage={() => {}} page={0} rowsPerPage={1} />,
     );
-    // StrictModeViolation: uses  ButtonBase
+    // StrictModeViolation: uses #html()
     mount = createMount({ strict: false });
   });
 

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -13,8 +13,7 @@ describe('<TableSortLabel />', () => {
 
   before(() => {
     shallow = createShallow({ dive: true });
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
     classes = getClasses(<TableSortLabel />);
   });
 

--- a/packages/material-ui/src/Tabs/TabScrollButton.test.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.test.js
@@ -15,8 +15,7 @@ describe('<TabScrollButton />', () => {
   before(() => {
     shallow = createShallow({ dive: true });
     classes = getClasses(<TabScrollButton {...props} />);
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
   });
 
   after(() => {

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -35,13 +35,12 @@ describe('<Tabs />', () => {
 
   let mount;
   let classes;
-  const render = createClientRender({ strict: false });
+  const render = createClientRender({ strict: true });
   let serverRender;
 
   before(() => {
     classes = getClasses(<Tabs value={0} />);
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
     serverRender = createRender();
   });
 

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -19,13 +19,12 @@ const shouldSuccessOnce = name => func => () => {
 };
 
 describe('<SwitchBase />', () => {
-  const render = createClientRender({ strict: false });
+  const render = createClientRender({ strict: true });
   let mount;
   let classes;
 
   before(() => {
-    // StrictModeViolation: uses ButtonBase
-    mount = createMount({ strict: false });
+    mount = createMount({ strict: true });
     classes = getClasses(<SwitchBase icon="unchecked" checkedIcon="checked" type="checkbox" />);
   });
 

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -64,8 +64,7 @@ function expectFocusVisible(element, focusVisibleClass) {
 }
 
 describe('<MenuList> integration', () => {
-  // StrictModeViolation: Uses MenuItem
-  const render = createClientRender({ strict: false });
+  const render = createClientRender({ strict: true });
 
   if (/Chrome\/49\.0/.test(window.navigator.userAgent)) {
     // fails repeatedly on chrome 49 in karma but works when manually testing

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -7,7 +7,7 @@ describe('<Select> integration', () => {
   let mount;
 
   before(() => {
-    // StrictModeViolation: uses MenuItem
+    // StrictModeViolation: unknown
     mount = createMount({ strict: false });
   });
 

--- a/pages/api/bottom-navigation.md
+++ b/pages/api/bottom-navigation.md
@@ -48,7 +48,7 @@ you need to use the following style sheet name: `MuiBottomNavigation`.
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/button-base.md
+++ b/pages/api/button-base.md
@@ -60,7 +60,7 @@ you need to use the following style sheet name: `MuiButtonBase`.
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/checkbox.md
+++ b/pages/api/checkbox.md
@@ -67,7 +67,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/fab.md
+++ b/pages/api/fab.md
@@ -66,7 +66,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/form-control-label.md
+++ b/pages/api/form-control-label.md
@@ -58,7 +58,7 @@ you need to use the following style sheet name: `MuiFormControlLabel`.
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/icon-button.md
+++ b/pages/api/icon-button.md
@@ -64,7 +64,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/list-item.md
+++ b/pages/api/list-item.md
@@ -65,7 +65,7 @@ you need to use the following style sheet name: `MuiListItem`.
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/menu-item.md
+++ b/pages/api/menu-item.md
@@ -53,7 +53,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/radio.md
+++ b/pages/api/radio.md
@@ -65,7 +65,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/step-button.md
+++ b/pages/api/step-button.md
@@ -54,7 +54,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/table-sort-label.md
+++ b/pages/api/table-sort-label.md
@@ -57,7 +57,7 @@ You can take advantage of this behavior to [target nested components](/guides/ap
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/tabs.md
+++ b/pages/api/tabs.md
@@ -63,7 +63,7 @@ you need to use the following style sheet name: `MuiTabs`.
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 
 ## Demos
 

--- a/pages/api/touch-ripple.md
+++ b/pages/api/touch-ripple.md
@@ -50,5 +50,5 @@ you need to use the following style sheet name: `MuiTouchRipple`.
 
 ## Notes
 
-The component can cause issues in [StrictMode](https://reactjs.org/docs/strict-mode.html).
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
 


### PR DESCRIPTION
Review per-commit is advised.

Reduces implementation logic (remove unused `className` and enter delay). We only ever needed the exit transition for which we don't need a complete Transition component. This makes `Ripple` StrictMode compatible which cascades to a lot of components since ButtonBase only uses `TransitionGroup` which is StrictMode compatible as of `react-transition-group@^4.0.0`.

Also reduces the number of commits (no more `enter` transition which was never needed as far as I can tell).