### PR TITLE
[Input] Add missing class keys in TypeScript

### DIFF
--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -111,7 +111,7 @@ export const styles = theme => {
       paddingTop: 23,
       paddingBottom: 6,
     },
-    /* Styles applied to the `input` element if `select={true}. */
+    /* Styles applied to the `input` element if `select={true}`. */
     inputSelect: {
       paddingRight: 32,
     },

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -120,7 +120,7 @@ export const styles = theme => {
     inputMarginDense: {
       paddingTop: 4 - 1,
     },
-    /* Styles applied to the `input` element if `select={true}. */
+    /* Styles applied to the `input` element if `select={true}`. */
     inputSelect: {
       paddingRight: 32,
     },

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
@@ -14,10 +14,12 @@ export type OutlinedInputClassKey =
   | 'adornedStart'
   | 'adornedEnd'
   | 'error'
+  | 'marginDense'
   | 'multiline'
   | 'notchedOutline'
   | 'input'
   | 'inputMarginDense'
+  | 'inputSelect'
   | 'inputMultiline'
   | 'inputAdornedStart'
   | 'inputAdornedEnd';

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -70,7 +70,7 @@ export const styles = theme => {
       paddingTop: 10.5,
       paddingBottom: 10.5,
     },
-    /* Styles applied to the `input` element if `select={true}. */
+    /* Styles applied to the `input` element if `select={true}`. */
     inputSelect: {
       paddingRight: 32,
     },

--- a/pages/api/filled-input.md
+++ b/pages/api/filled-input.md
@@ -68,7 +68,7 @@ This property accepts the following keys:
 | <span class="prop-name">multiline</span> | Styles applied to the root element if `multiline={true}`.
 | <span class="prop-name">input</span> | Styles applied to the `input` element.
 | <span class="prop-name">inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}.
+| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}`.
 | <span class="prop-name">inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
 | <span class="prop-name">inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
 | <span class="prop-name">inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.

--- a/pages/api/input-base.md
+++ b/pages/api/input-base.md
@@ -71,7 +71,7 @@ This property accepts the following keys:
 | <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
 | <span class="prop-name">input</span> | Styles applied to the `input` element.
 | <span class="prop-name">inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}.
+| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}`.
 | <span class="prop-name">inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
 | <span class="prop-name">inputTypeSearch</span> | Styles applied to the `input` element if `type="search"`.
 | <span class="prop-name">inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.

--- a/pages/api/outlined-input.md
+++ b/pages/api/outlined-input.md
@@ -69,7 +69,7 @@ This property accepts the following keys:
 | <span class="prop-name">notchedOutline</span> | Styles applied to the `NotchedOutline` element.
 | <span class="prop-name">input</span> | Styles applied to the `input` element.
 | <span class="prop-name">inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}.
+| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}`.
 | <span class="prop-name">inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
 | <span class="prop-name">inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
 | <span class="prop-name">inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
As we can see CSS API of `OutlinedInput`, there are 2 missed class keys to provide styles.
Also, edit typo of missed 'backtick'.

And I found that `marginDense` and `inputMarginDense` do the same thing based on docs. Is it correct? 
