### PR TITLE
[test] Run queries on document.body

### DIFF
--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -17,10 +17,6 @@ describe('<Button />', () => {
     classes = getClasses(<Button>Hello World</Button>);
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   afterEach(() => {
     cleanup();
   });
@@ -31,6 +27,7 @@ describe('<Button />', () => {
     mount,
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   it('should render with the root & text classes but no others', () => {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -56,7 +56,6 @@ describe('<ButtonBase />', () => {
 
   after(() => {
     cleanup();
-    mount.cleanUp();
   });
 
   describeConformance(<ButtonBase />, () => ({
@@ -65,6 +64,7 @@ describe('<ButtonBase />', () => {
     mount,
     refInstanceof: window.HTMLButtonElement,
     testComponentPropWith: 'a',
+    after: () => mount.cleanUp(),
   }));
 
   describe('root node', () => {

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -21,16 +21,13 @@ describe('<Fab />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<Fab>Conformance?</Fab>, () => ({
     classes,
     inheritComponent: ButtonBase,
     mount,
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   it('should render with the root class but no others', () => {

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -20,16 +20,13 @@ describe('<FilledInput />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<FilledInput open />, () => ({
     classes,
     inheritComponent: InputBase,
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   it('should have the underline class', () => {

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -21,16 +21,13 @@ describe('<FormControlLabel />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<FormControlLabel label="Pizza" control={<Checkbox />} />, () => ({
     classes,
     inheritComponent: 'label',
     mount,
     refInstanceof: window.HTMLLabelElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   it('should render the label text inside an additional element', () => {

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -20,16 +20,13 @@ describe('<FormHelperText />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<FormHelperText />, () => ({
     classes,
     inheritComponent: 'p',
     mount,
     refInstanceof: window.HTMLParagraphElement,
     testComponentPropWith: 'div',
+    after: () => mount.cleanUp(),
   }));
 
   describe('prop: error', () => {

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -21,16 +21,13 @@ describe('<FormLabel />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<FormLabel />, () => ({
     classes,
     inheritComponent: 'label',
     mount,
     refInstanceof: window.HTMLLabelElement,
     testComponentPropWith: 'div',
+    after: () => mount.cleanUp(),
   }));
 
   describe('prop: required', () => {

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -23,16 +23,13 @@ describe('<IconButton />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<IconButton>book</IconButton>, () => ({
     classes,
     inheritComponent: ButtonBase,
     mount,
     refInstanceof: window.HTMLButtonElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   it('should render an inner label span (bloody safari)', () => {

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -24,16 +24,13 @@ describe('<InputAdornment />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<InputAdornment position="start">foo</InputAdornment>, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
     testComponentPropWith: 'span',
+    after: () => mount.cleanUp(),
   }));
 
   it('should wrap text children in a Typography', () => {

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -26,16 +26,13 @@ describe('<InputBase />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<InputBase />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   it('should render an <input /> inside the div', () => {

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -23,16 +23,13 @@ describe('<InputLabel />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<InputLabel>Foo</InputLabel>, () => ({
     classes,
     inheritComponent: FormLabel,
     mount,
     refInstanceof: window.HTMLLabelElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   it('should render a label with text', () => {

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -34,15 +34,12 @@ describe('<ListItem />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<ListItem />, () => ({
     classes,
     inheritComponent: 'li',
     mount,
     refInstanceof: window.HTMLLIElement,
+    after: () => mount.cleanUp(),
   }));
 
   it('should render with gutters classes', () => {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -20,16 +20,13 @@ describe('<OutlinedInput />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<OutlinedInput labelWidth={0} />, () => ({
     classes,
     inheritComponent: InputBase,
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   it('should render a NotchedOutline', () => {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -38,7 +38,6 @@ describe('<Slider />', () => {
 
   after(() => {
     cleanup();
-    mount.cleanUp();
   });
 
   describeConformance(<Slider value={0} />, () => ({
@@ -47,6 +46,7 @@ describe('<Slider />', () => {
     mount,
     refInstanceof: window.HTMLSpanElement,
     testComponentPropWith: 'span',
+    after: () => mount.cleanUp(),
   }));
 
   it('should call handlers', () => {

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -20,10 +20,6 @@ describe('<Table />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(
     <Table>
       <tbody />
@@ -35,6 +31,7 @@ describe('<Table />', () => {
       refInstanceof: window.HTMLTableElement,
       // can't test another component with tbody as a child
       testComponentPropWith: 'table',
+      after: () => mount.cleanUp(),
     }),
   );
 

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -45,7 +45,6 @@ describe('<Tabs />', () => {
   });
 
   after(() => {
-    mount.cleanUp();
     cleanup();
   });
 
@@ -54,6 +53,7 @@ describe('<Tabs />', () => {
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
+    after: () => mount.cleanUp(),
   }));
 
   describe('warnings', () => {

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -22,16 +22,13 @@ describe('<TextField />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<TextField />, () => ({
     classes,
     inheritComponent: FormControl,
     mount,
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
+    after: () => mount.cleanUp(),
   }));
 
   describe('structure', () => {

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -19,15 +19,12 @@ describe('<Toolbar />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(<Toolbar />, () => ({
     classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,
+    after: () => mount.cleanUp(),
   }));
 
   it('should render with gutters class', () => {

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -32,10 +32,6 @@ describe('<SwitchBase />', () => {
     cleanup();
   });
 
-  after(() => {
-    mount.cleanUp();
-  });
-
   describeConformance(
     <SwitchBase checkedIcon="checked" icon="unchecked" type="checkbox" />,
     () => ({
@@ -44,6 +40,7 @@ describe('<SwitchBase />', () => {
       mount,
       refInstanceof: window.HTMLSpanElement,
       testComponentPropWith: 'div',
+      after: () => mount.cleanUp(),
     }),
   );
 

--- a/packages/material-ui/src/test-utils/describeConformance.js
+++ b/packages/material-ui/src/test-utils/describeConformance.js
@@ -174,8 +174,10 @@ const fullSuite = {
  *
  */
 export default function describeConformance(minimalElement, getOptions) {
-  const { only = Object.keys(fullSuite), skip = [] } = getOptions();
+  const { after: runAfterHook = () => {}, only = Object.keys(fullSuite), skip = [] } = getOptions();
   describe('Material-UI component API', () => {
+    after(runAfterHook);
+
     Object.keys(fullSuite)
       .filter(testKey => only.indexOf(testKey) !== -1 && skip.indexOf(testKey) === -1)
       .forEach(testKey => {

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -10,397 +10,393 @@ import { setRef } from '../../src/utils/reactHelpers';
 import { stub } from 'sinon';
 import PropTypes from 'prop-types';
 import { createMuiTheme } from '@material-ui/core/styles';
-import { cleanup, render, fireEvent } from 'test/utils/createClientRender';
+import { cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
 
 describe('<Menu> integration', () => {
-  describe('Using mount', () => {
-    let mount;
+  let mount;
+
+  before(() => {
+    // StrictModeViolation: test uses simulate
+    mount = createMount({ strict: false });
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  describe('mounted open', () => {
+    let wrapper;
+    let portalLayer;
 
     before(() => {
-      // StrictModeViolation: test uses simulate
-      mount = createMount({ strict: false });
+      wrapper = mount(<SimpleMenu transitionDuration={0} />);
     });
 
-    after(() => {
-      mount.cleanUp();
+    it('should not be open', () => {
+      const popover = wrapper.find(Popover);
+      assert.strictEqual(popover.props().open, false, 'should have passed open=false to Popover');
+      const menuEl = document.getElementById('simple-menu');
+      assert.strictEqual(menuEl, null);
     });
 
-    describe('mounted open', () => {
-      let wrapper;
-      let portalLayer;
-
-      before(() => {
-        wrapper = mount(<SimpleMenu transitionDuration={0} />);
-      });
-
-      it('should not be open', () => {
-        const popover = wrapper.find(Popover);
-        assert.strictEqual(popover.props().open, false, 'should have passed open=false to Popover');
-        const menuEl = document.getElementById('simple-menu');
-        assert.strictEqual(menuEl, null);
-      });
-
-      it('should focus the list as nothing has been selected', () => {
-        wrapper.find('button').simulate('click');
-        portalLayer = document.querySelector('[data-mui-test="Modal"]');
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('ul')[0]);
-      });
-
-      it('should change focus to the first item when down arrow is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'ArrowDown',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
-      });
-
-      it('should change focus to the 2nd item when down arrow is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'ArrowDown',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
-      });
-
-      it('should change focus to the 3rd item when down arrow is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'ArrowDown',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
-      });
-
-      it('should switch focus from the 3rd item to the 1st item when down arrow is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'ArrowDown',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
-      });
-
-      it('should switch focus from the 1st item to the 3rd item when up arrow is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'ArrowUp',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
-      });
-
-      it('should switch focus from the 3rd item to the 1st item when home key is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'Home',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
-      });
-
-      it('should switch focus from the 1st item to the 3rd item when end key is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'End',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
-      });
-
-      it('should keep focus on the last item when a key with no associated action is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'ArrowRight',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
-      });
-
-      it('should change focus to the 2nd item when up arrow is pressed', () => {
-        TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
-          key: 'ArrowUp',
-        });
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
-      });
-
-      it('should select the 2nd item and close the menu', () => {
-        portalLayer.querySelectorAll('li')[1].click();
-        assert.strictEqual(wrapper.text(), 'selectedIndex: 1, open: false');
-      });
+    it('should focus the list as nothing has been selected', () => {
+      wrapper.find('button').simulate('click');
+      portalLayer = document.querySelector('[data-mui-test="Modal"]');
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('ul')[0]);
     });
 
-    describe('opening with a selected item', () => {
-      let wrapper;
-
-      before(() => {
-        wrapper = mount(<SimpleMenu transitionDuration={0} selectedIndex={2} />);
+    it('should change focus to the first item when down arrow is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowDown',
       });
-
-      it('should not be open', () => {
-        const popover = wrapper.find(Popover);
-        assert.strictEqual(popover.props().open, false);
-        const menuEl = document.getElementById('simple-menu');
-        assert.strictEqual(menuEl, null);
-      });
-
-      it('should focus the 3rd selected item', () => {
-        wrapper.find('button').simulate('click');
-        const portalLayer = document.querySelector('[data-mui-test="Modal"]');
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
-      });
-
-      it('should select the 2nd item and close the menu', () => {
-        const portalLayer = document.querySelector('[data-mui-test="Modal"]');
-        const item = portalLayer.querySelector('ul').children[1];
-        item.click();
-        assert.strictEqual(wrapper.text(), 'selectedIndex: 1, open: false');
-      });
-
-      it('should focus the 2nd selected item', () => {
-        wrapper.find('button').simulate('click');
-        const portalLayer = document.querySelector('[data-mui-test="Modal"]');
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
-      });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
     });
 
-    describe('Menu variant differences', () => {
-      const contentAnchorTracker = [false, false, false];
-      const focusTracker = [false, false, false];
-      let menuListFocusTracker = false;
-      const tabIndexTracker = [false, false, false];
-      const TrackingMenuItem = React.forwardRef(({ itemIndex, ...other }, ref) => {
-        return (
-          <MenuItem
-            onFocus={() => {
-              focusTracker[itemIndex] = true;
-            }}
-            ref={instance => {
-              setRef(ref, instance);
-              if (instance && !instance.stubbed) {
-                if (instance.tabIndex === 0) {
-                  tabIndexTracker[itemIndex] = true;
-                } else if (instance.tabIndex > 0) {
-                  tabIndexTracker[itemIndex] = instance.tabIndex;
-                }
-                const offsetTop = instance.offsetTop;
-                stub(instance, 'offsetTop').get(() => {
-                  contentAnchorTracker[itemIndex] = true;
-                  return offsetTop;
-                });
-                instance.stubbed = true;
-              }
-            }}
-            {...other}
-          />
-        );
+    it('should change focus to the 2nd item when down arrow is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowDown',
       });
-      TrackingMenuItem.propTypes = {
-        /**
-         * @ignore
-         */
-        itemIndex: PropTypes.number,
-      };
-      // Array.fill not supported by Chrome 41
-      const fill = (array, value) => {
-        for (let i = 0; i < array.length; i += 1) {
-          array[i] = value;
-        }
-      };
-      const mountTrackingMenu = (
-        variant,
-        {
-          selectedIndex,
-          selectedTabIndex,
-          invalidIndex,
-          autoFocusIndex,
-          disabledIndex,
-          autoFocus,
-          themeDirection,
-        } = {},
-      ) => {
-        const theme =
-          themeDirection !== undefined
-            ? createMuiTheme({
-                direction: themeDirection,
-              })
-            : undefined;
-
-        fill(contentAnchorTracker, false);
-        fill(focusTracker, false);
-        menuListFocusTracker = false;
-        fill(tabIndexTracker, false);
-        mount(
-          <Menu
-            variant={variant}
-            autoFocus={autoFocus}
-            anchorEl={document.body}
-            open
-            theme={theme}
-            MenuListProps={{
-              onFocus: () => {
-                menuListFocusTracker = true;
-              },
-            }}
-          >
-            {[0, 1, 2].map(itemIndex => {
-              if (itemIndex === invalidIndex) {
-                return null;
-              }
-              return (
-                <TrackingMenuItem
-                  key={itemIndex}
-                  disabled={itemIndex === disabledIndex ? true : undefined}
-                  itemIndex={itemIndex}
-                  selected={itemIndex === selectedIndex}
-                  tabIndex={itemIndex === selectedIndex ? selectedTabIndex : undefined}
-                  autoFocus={itemIndex === autoFocusIndex ? true : undefined}
-                >
-                  Menu Item {itemIndex}
-                </TrackingMenuItem>
-              );
-            })}
-          </Menu>,
-        );
-      };
-
-      it('[variant=menu] adds coverage for rtl and Tab with no onClose', () => {
-        // This isn't adding very meaningful coverage apart from verifying it doesn't error, but
-        // it was so close to 100% that this has value in avoiding needing to drill into coverage
-        // details to see what isn't being tested.
-        mountTrackingMenu('menu', { themeDirection: 'rtl' });
-        assert.deepEqual(contentAnchorTracker, [true, false, false]);
-        assert.deepEqual(focusTracker, [false, false, false]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, false, false]);
-
-        // Adds coverage for Tab with no onClose
-        TestUtils.Simulate.keyDown(document.activeElement, {
-          key: 'Tab',
-        });
-      });
-
-      it('[variant=menu] nothing selected', () => {
-        assert.deepEqual(contentAnchorTracker, [true, false, false]);
-        assert.deepEqual(focusTracker, [false, false, false]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, false, false]);
-      });
-
-      it('[variant=menu] nothing selected, autoFocus on third', () => {
-        mountTrackingMenu('menu', { autoFocusIndex: 2 });
-        assert.deepEqual(contentAnchorTracker, [true, false, false]);
-        assert.deepEqual(focusTracker, [false, false, true]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, false, false]);
-      });
-
-      it('[variant=selectedMenu] nothing selected', () => {
-        mountTrackingMenu('selectedMenu');
-        assert.deepEqual(contentAnchorTracker, [true, false, false]);
-        assert.deepEqual(focusTracker, [false, false, false]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, false, false]);
-      });
-
-      it('[variant=selectedMenu] nothing selected, first index invalid', () => {
-        mountTrackingMenu('selectedMenu', { invalidIndex: 0 });
-        assert.deepEqual(contentAnchorTracker, [false, true, false]);
-        assert.deepEqual(focusTracker, [false, false, false]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, false, false]);
-      });
-
-      it('[variant=menu] second item selected', () => {
-        mountTrackingMenu('menu', { selectedIndex: 1 });
-        assert.deepEqual(contentAnchorTracker, [true, false, false]);
-        assert.deepEqual(focusTracker, [false, false, false]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, false, false]);
-      });
-
-      it('[variant=selectedMenu] second item selected, explicit tabIndex', () => {
-        mountTrackingMenu('selectedMenu', { selectedIndex: 1, selectedTabIndex: 2 });
-        assert.deepEqual(contentAnchorTracker, [false, true, false]);
-        assert.deepEqual(focusTracker, [false, true, false]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, 2, false]);
-      });
-
-      it('[variant=selectedMenu] second item selected', () => {
-        mountTrackingMenu('selectedMenu', { selectedIndex: 1 });
-        assert.deepEqual(contentAnchorTracker, [false, true, false]);
-        assert.deepEqual(focusTracker, [false, true, false]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, true, false]);
-      });
-
-      it('[variant=selectedMenu] second item selected and disabled', () => {
-        mountTrackingMenu('selectedMenu', { selectedIndex: 1, disabledIndex: 1 });
-        assert.deepEqual(contentAnchorTracker, [true, false, false]);
-        assert.deepEqual(focusTracker, [false, false, false]);
-        assert.strictEqual(menuListFocusTracker, true);
-        assert.deepEqual(tabIndexTracker, [false, false, false]);
-      });
-
-      it('[variant=selectedMenu] second item selected, no autoFocus', () => {
-        mountTrackingMenu('selectedMenu', { selectedIndex: 1, autoFocus: false });
-        assert.deepEqual(contentAnchorTracker, [false, true, false]);
-        assert.deepEqual(focusTracker, [false, false, false]);
-        assert.strictEqual(menuListFocusTracker, false);
-        assert.deepEqual(tabIndexTracker, [false, true, false]);
-      });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
     });
 
-    describe('closing', () => {
-      let wrapper;
-      let portalLayer;
-
-      beforeEach(() => {
-        wrapper = mount(<SimpleMenu transitionDuration={0} />);
-        wrapper.find('button').simulate('click');
-        portalLayer = document.querySelector('[data-mui-test="Modal"]');
+    it('should change focus to the 3rd item when down arrow is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowDown',
       });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
+    });
 
-      it('should close the menu with tab', done => {
-        wrapper.setProps({
-          onExited() {
-            assert.strictEqual(document.getElementById('[data-mui-test="Menu"]'), null);
-            done();
-          },
-        });
-        assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: true');
-        const list = portalLayer.querySelector('ul');
-        TestUtils.Simulate.keyDown(list, {
-          key: 'Tab',
-        });
-        assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: false');
+    it('should switch focus from the 3rd item to the 1st item when down arrow is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowDown',
       });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
+    });
 
-      it('should close the menu using the backdrop', done => {
-        wrapper.setProps({
-          onExited() {
-            assert.strictEqual(document.getElementById('[data-mui-test="Menu"]'), null);
-            done();
-          },
-        });
-        assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: true');
-        const backdrop = portalLayer.querySelector('[data-mui-test="Backdrop"]');
-        assert.strictEqual(backdrop != null, true);
-        backdrop.click();
-        assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: false');
+    it('should switch focus from the 1st item to the 3rd item when up arrow is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowUp',
       });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
+    });
+
+    it('should switch focus from the 3rd item to the 1st item when home key is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'Home',
+      });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[0]);
+    });
+
+    it('should switch focus from the 1st item to the 3rd item when end key is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'End',
+      });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
+    });
+
+    it('should keep focus on the last item when a key with no associated action is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowRight',
+      });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
+    });
+
+    it('should change focus to the 2nd item when up arrow is pressed', () => {
+      TestUtils.Simulate.keyDown(portalLayer.querySelector('ul'), {
+        key: 'ArrowUp',
+      });
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
+    });
+
+    it('should select the 2nd item and close the menu', () => {
+      portalLayer.querySelectorAll('li')[1].click();
+      assert.strictEqual(wrapper.text(), 'selectedIndex: 1, open: false');
     });
   });
 
-  describe('Using RTL render with keepMounted', () => {
+  describe('opening with a selected item', () => {
     let wrapper;
 
     before(() => {
-      // Using render instead of createClientRender because createClientRender specifies an explicit
-      // base element that is the starting point for queries, but the menu would be rendered outside
-      // of that base element.
-      wrapper = render(<SimpleMenu transitionDuration={0} keepMounted />);
+      wrapper = mount(<SimpleMenu transitionDuration={0} selectedIndex={2} />);
     });
 
-    after(() => {
-      cleanup();
+    it('should not be open', () => {
+      const popover = wrapper.find(Popover);
+      assert.strictEqual(popover.props().open, false);
+      const menuEl = document.getElementById('simple-menu');
+      assert.strictEqual(menuEl, null);
     });
 
-    it('should focus the list on open', () => {
-      const button = wrapper.getByLabelText('When device is locked');
-      const menu = wrapper.getByRole('menu');
-      expect(menu).to.not.be.focused;
-      button.focus();
-      fireEvent.click(button);
-      expect(menu).to.be.focused;
-      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      expect(wrapper.getAllByRole('menuitem')[0]).to.be.focused;
+    it('should focus the 3rd selected item', () => {
+      wrapper.find('button').simulate('click');
+      const portalLayer = document.querySelector('[data-mui-test="Modal"]');
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[2]);
     });
+
+    it('should select the 2nd item and close the menu', () => {
+      const portalLayer = document.querySelector('[data-mui-test="Modal"]');
+      const item = portalLayer.querySelector('ul').children[1];
+      item.click();
+      assert.strictEqual(wrapper.text(), 'selectedIndex: 1, open: false');
+    });
+
+    it('should focus the 2nd selected item', () => {
+      wrapper.find('button').simulate('click');
+      const portalLayer = document.querySelector('[data-mui-test="Modal"]');
+      assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('li')[1]);
+    });
+  });
+
+  describe('Menu variant differences', () => {
+    const contentAnchorTracker = [false, false, false];
+    const focusTracker = [false, false, false];
+    let menuListFocusTracker = false;
+    const tabIndexTracker = [false, false, false];
+    const TrackingMenuItem = React.forwardRef(({ itemIndex, ...other }, ref) => {
+      return (
+        <MenuItem
+          onFocus={() => {
+            focusTracker[itemIndex] = true;
+          }}
+          ref={instance => {
+            setRef(ref, instance);
+            if (instance && !instance.stubbed) {
+              if (instance.tabIndex === 0) {
+                tabIndexTracker[itemIndex] = true;
+              } else if (instance.tabIndex > 0) {
+                tabIndexTracker[itemIndex] = instance.tabIndex;
+              }
+              const offsetTop = instance.offsetTop;
+              stub(instance, 'offsetTop').get(() => {
+                contentAnchorTracker[itemIndex] = true;
+                return offsetTop;
+              });
+              instance.stubbed = true;
+            }
+          }}
+          {...other}
+        />
+      );
+    });
+    TrackingMenuItem.propTypes = {
+      /**
+       * @ignore
+       */
+      itemIndex: PropTypes.number,
+    };
+    // Array.fill not supported by Chrome 41
+    const fill = (array, value) => {
+      for (let i = 0; i < array.length; i += 1) {
+        array[i] = value;
+      }
+    };
+    const mountTrackingMenu = (
+      variant,
+      {
+        selectedIndex,
+        selectedTabIndex,
+        invalidIndex,
+        autoFocusIndex,
+        disabledIndex,
+        autoFocus,
+        themeDirection,
+      } = {},
+    ) => {
+      const theme =
+        themeDirection !== undefined
+          ? createMuiTheme({
+              direction: themeDirection,
+            })
+          : undefined;
+
+      fill(contentAnchorTracker, false);
+      fill(focusTracker, false);
+      menuListFocusTracker = false;
+      fill(tabIndexTracker, false);
+      mount(
+        <Menu
+          variant={variant}
+          autoFocus={autoFocus}
+          anchorEl={document.body}
+          open
+          theme={theme}
+          MenuListProps={{
+            onFocus: () => {
+              menuListFocusTracker = true;
+            },
+          }}
+        >
+          {[0, 1, 2].map(itemIndex => {
+            if (itemIndex === invalidIndex) {
+              return null;
+            }
+            return (
+              <TrackingMenuItem
+                key={itemIndex}
+                disabled={itemIndex === disabledIndex ? true : undefined}
+                itemIndex={itemIndex}
+                selected={itemIndex === selectedIndex}
+                tabIndex={itemIndex === selectedIndex ? selectedTabIndex : undefined}
+                autoFocus={itemIndex === autoFocusIndex ? true : undefined}
+              >
+                Menu Item {itemIndex}
+              </TrackingMenuItem>
+            );
+          })}
+        </Menu>,
+      );
+    };
+
+    it('[variant=menu] adds coverage for rtl and Tab with no onClose', () => {
+      // This isn't adding very meaningful coverage apart from verifying it doesn't error, but
+      // it was so close to 100% that this has value in avoiding needing to drill into coverage
+      // details to see what isn't being tested.
+      mountTrackingMenu('menu', { themeDirection: 'rtl' });
+      assert.deepEqual(contentAnchorTracker, [true, false, false]);
+      assert.deepEqual(focusTracker, [false, false, false]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, false, false]);
+
+      // Adds coverage for Tab with no onClose
+      TestUtils.Simulate.keyDown(document.activeElement, {
+        key: 'Tab',
+      });
+    });
+
+    it('[variant=menu] nothing selected', () => {
+      assert.deepEqual(contentAnchorTracker, [true, false, false]);
+      assert.deepEqual(focusTracker, [false, false, false]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, false, false]);
+    });
+
+    it('[variant=menu] nothing selected, autoFocus on third', () => {
+      mountTrackingMenu('menu', { autoFocusIndex: 2 });
+      assert.deepEqual(contentAnchorTracker, [true, false, false]);
+      assert.deepEqual(focusTracker, [false, false, true]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, false, false]);
+    });
+
+    it('[variant=selectedMenu] nothing selected', () => {
+      mountTrackingMenu('selectedMenu');
+      assert.deepEqual(contentAnchorTracker, [true, false, false]);
+      assert.deepEqual(focusTracker, [false, false, false]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, false, false]);
+    });
+
+    it('[variant=selectedMenu] nothing selected, first index invalid', () => {
+      mountTrackingMenu('selectedMenu', { invalidIndex: 0 });
+      assert.deepEqual(contentAnchorTracker, [false, true, false]);
+      assert.deepEqual(focusTracker, [false, false, false]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, false, false]);
+    });
+
+    it('[variant=menu] second item selected', () => {
+      mountTrackingMenu('menu', { selectedIndex: 1 });
+      assert.deepEqual(contentAnchorTracker, [true, false, false]);
+      assert.deepEqual(focusTracker, [false, false, false]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, false, false]);
+    });
+
+    it('[variant=selectedMenu] second item selected, explicit tabIndex', () => {
+      mountTrackingMenu('selectedMenu', { selectedIndex: 1, selectedTabIndex: 2 });
+      assert.deepEqual(contentAnchorTracker, [false, true, false]);
+      assert.deepEqual(focusTracker, [false, true, false]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, 2, false]);
+    });
+
+    it('[variant=selectedMenu] second item selected', () => {
+      mountTrackingMenu('selectedMenu', { selectedIndex: 1 });
+      assert.deepEqual(contentAnchorTracker, [false, true, false]);
+      assert.deepEqual(focusTracker, [false, true, false]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, true, false]);
+    });
+
+    it('[variant=selectedMenu] second item selected and disabled', () => {
+      mountTrackingMenu('selectedMenu', { selectedIndex: 1, disabledIndex: 1 });
+      assert.deepEqual(contentAnchorTracker, [true, false, false]);
+      assert.deepEqual(focusTracker, [false, false, false]);
+      assert.strictEqual(menuListFocusTracker, true);
+      assert.deepEqual(tabIndexTracker, [false, false, false]);
+    });
+
+    it('[variant=selectedMenu] second item selected, no autoFocus', () => {
+      mountTrackingMenu('selectedMenu', { selectedIndex: 1, autoFocus: false });
+      assert.deepEqual(contentAnchorTracker, [false, true, false]);
+      assert.deepEqual(focusTracker, [false, false, false]);
+      assert.strictEqual(menuListFocusTracker, false);
+      assert.deepEqual(tabIndexTracker, [false, true, false]);
+    });
+  });
+
+  describe('closing', () => {
+    let wrapper;
+    let portalLayer;
+
+    beforeEach(() => {
+      wrapper = mount(<SimpleMenu transitionDuration={0} />);
+      wrapper.find('button').simulate('click');
+      portalLayer = document.querySelector('[data-mui-test="Modal"]');
+    });
+
+    it('should close the menu with tab', done => {
+      wrapper.setProps({
+        onExited() {
+          assert.strictEqual(document.getElementById('[data-mui-test="Menu"]'), null);
+          done();
+        },
+      });
+      assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: true');
+      const list = portalLayer.querySelector('ul');
+      TestUtils.Simulate.keyDown(list, {
+        key: 'Tab',
+      });
+      assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: false');
+    });
+
+    it('should close the menu using the backdrop', done => {
+      wrapper.setProps({
+        onExited() {
+          assert.strictEqual(document.getElementById('[data-mui-test="Menu"]'), null);
+          done();
+        },
+      });
+      assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: true');
+      const backdrop = portalLayer.querySelector('[data-mui-test="Backdrop"]');
+      assert.strictEqual(backdrop != null, true);
+      backdrop.click();
+      assert.strictEqual(wrapper.text(), 'selectedIndex: null, open: false');
+    });
+  });
+});
+
+// new tests with @testing-library/react
+describe('<Menu /> integration 2', () => {
+  const render = createClientRender({ strict: false });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('should focus the list on open', () => {
+    const { getAllByRole, getByLabelText, getByRole } = render(
+      <SimpleMenu transitionDuration={0} keepMounted />,
+    );
+    const button = getByLabelText('When device is locked');
+    const menu = getByRole('menu');
+
+    expect(menu).to.not.be.focused;
+    button.focus();
+    fireEvent.click(button);
+    expect(menu).to.be.focused;
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+    expect(getAllByRole('menuitem')[0]).to.be.focused;
   });
 });

--- a/test/utils/createClientRender.js
+++ b/test/utils/createClientRender.js
@@ -77,23 +77,11 @@ function clientRender(element, options = {}) {
 
 export function createClientRender(globalOptions = {}) {
   const { strict: globalStrict } = globalOptions;
-  let baseElement;
-
-  before(() => {
-    baseElement = document.createElement('div');
-    baseElement.className = 'rtl--baseElement';
-    document.body.appendChild(baseElement);
-  });
-
-  after(() => {
-    baseElement.parentNode.removeChild(baseElement);
-    baseElement = null;
-  });
 
   return function configuredClientRender(element, options = {}) {
     const { strict = globalStrict, ...localOptions } = options;
 
-    return clientRender(element, { ...localOptions, baseElement, strict });
+    return clientRender(element, { ...localOptions, strict });
   };
 }
 


### PR DESCRIPTION
Will be important when testing components working with portals. We use `document.body` as the base element for queries from `@testing-library/react` and clean up trees mounted with enzyme after `describeConformance` is done.

Isolation is still not perfect but we're getting there.