### PR TITLE
[docs] Add rjsf-material-ui to the TextField complementary projects

### DIFF
--- a/docs/src/pages/components/text-fields/text-fields.md
+++ b/docs/src/pages/components/text-fields/text-fields.md
@@ -150,3 +150,4 @@ For more advanced use cases you might be able to take advantage of:
 - [redux-form-material-ui](https://github.com/erikras/redux-form-material-ui) A set of wrapper components to facilitate using Material UI with Redux Form.
 - [formik-material-ui](https://github.com/stackworx/formik-material-ui) Bindings for using Material-UI with formik.
 - [final-form-material-ui](https://github.com/Deadly0/final-form-material-ui) A set of wrapper components to facilitate using Material UI with Final Form.
+- [rjsf-material-ui](https://github.com/cybertec-postgresql/rjsf-material-ui) A Material UI theme for react-jsonschema-form.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

As [`react-jsonschema-form` supports themes](https://github.com/mozilla-services/react-jsonschema-form/pull/1226) since [v1.6.0](https://github.com/mozilla-services/react-jsonschema-form/releases/tag/v1.6.0), it was time to create a Material UI theme.

Check the theme out at https://github.com/cybertec-postgresql/rjsf-material-ui!

Here is the *live playground*: https://cybertec-postgresql.github.io/rjsf-material-ui/

This change adds our `react-jsonschema-form material-ui theme` implementation to the list of complementary projects in the `TextField` example documentation page.