### PR TITLE
[docs] Fix links in popover.md to work in both Github and mui websites

### DIFF
--- a/docs/src/pages/components/popover/popover.md
+++ b/docs/src/pages/components/popover/popover.md
@@ -9,8 +9,8 @@ components: Grow, Popover
 
 Things to know when using the `Popover` component:
 
-- The component is built on top of the [`Modal`](/components/modal/) component.
-- The scroll and click away are blocked unlike with the [`Popper`](/components/popper/) component.
+- The component is built on top of the [`Modal`](../modal/) component.
+- The scroll and click away are blocked unlike with the [`Popper`](../popper/) component.
 
 ## Simple Popover
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Markdown links of the form `/components/Popover/` get 404 when browsing in Github web. This way they work both on the docs website and on Github. 