### PR TITLE
[core] Fix incorrect usage of HtmlHTMLAttributes

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -5,7 +5,7 @@ declare const Avatar: OverridableComponent<{
   props: {
     alt?: string;
     childrenClassName?: string;
-    imgProps?: React.HtmlHTMLAttributes<HTMLImageElement>;
+    imgProps?: React.ImgHTMLAttributes<HTMLImageElement>;
     sizes?: string;
     src?: string;
     srcSet?: string;

--- a/packages/material-ui/src/FormGroup/FormGroup.d.ts
+++ b/packages/material-ui/src/FormGroup/FormGroup.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface FormGroupProps
-  extends StandardProps<React.HtmlHTMLAttributes<HTMLDivElement>, FormGroupClassKey> {
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, FormGroupClassKey> {
   row?: boolean;
 }
 

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -4,7 +4,7 @@ import { BackdropProps } from '../Backdrop';
 import { PortalProps } from '../Portal';
 
 export interface ModalProps
-  extends StandardProps<React.HtmlHTMLAttributes<HTMLDivElement>, ModalClassKey, 'children'> {
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ModalClassKey, 'children'> {
   BackdropComponent?: React.ElementType<BackdropProps>;
   BackdropProps?: Partial<BackdropProps>;
   children: React.ReactElement;


### PR DESCRIPTION
In #9678 the types of various props were updated.

Unfortunately, the typings were not updated to with the appropriate interface.

This `HtmlHTMLAttributes` was used over the more general `HTMLAttributes` or in one case, the more
specific `ImgHTMLAttributes`.

This PR updates the `AvatarProps['imgProps']` to `React.ImgHTMLAttributes<HTMLImageElement>` as well
as using the general `HTMLAttributes` where appropriate.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
