### PR TITLE
[Modal] Fix focus not being contained

### DIFF
--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -504,6 +504,34 @@ describe('<Modal />', () => {
       });
       assert.strictEqual(document.activeElement.getAttribute('data-test'), 'sentinelEnd');
     });
+
+    it.only('contains the focus if the active element is removed', () => {
+      function WithRemovableElement({ open = false, hideButton = false }) {
+        return (
+          <Modal open={open}>
+            <div data-testid="modal">{!hideButton && <button>I'm going to disappear</button>}</div>
+          </Modal>
+        );
+      }
+
+      wrapper = mount(<WithRemovableElement />);
+
+      wrapper.setProps({ open: true });
+      wrapper.update();
+      assert.strictEqual(document.activeElement.nodeName, 'DIV');
+      assert.strictEqual(document.activeElement.getAttribute('data-testid'), 'modal');
+
+      wrapper
+        .find('button')
+        .instance()
+        .focus();
+      assert.strictEqual(document.activeElement.nodeName, 'BUTTON');
+
+      wrapper.setProps({ hideButton: true });
+      wrapper.update();
+      assert.strictEqual(document.activeElement.nodeName, 'DIV');
+      assert.strictEqual(document.activeElement.getAttribute('data-testid'), 'modal');
+    });
   });
 
   describe('prop: onRendered', () => {

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -3,6 +3,7 @@ import { assert, expect } from 'chai';
 import { spy } from 'sinon';
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
+import { act, cleanup, createClientRender } from 'test/utils/createClientRender';
 import { createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Fade from '../Fade';
@@ -11,6 +12,7 @@ import Modal from './Modal';
 
 describe('<Modal />', () => {
   let mount;
+  const render = createClientRender({ strict: false });
   let savedBodyStyle;
 
   before(() => {
@@ -21,6 +23,10 @@ describe('<Modal />', () => {
 
   beforeEach(() => {
     document.body.setAttribute('style', savedBodyStyle);
+  });
+
+  afterEach(() => {
+    cleanup();
   });
 
   after(() => {
@@ -506,31 +512,26 @@ describe('<Modal />', () => {
     });
 
     it.only('contains the focus if the active element is removed', () => {
-      function WithRemovableElement({ open = false, hideButton = false }) {
+      function WithRemovableElement({ hideButton = false }) {
         return (
-          <Modal open={open}>
-            <div data-testid="modal">{!hideButton && <button>I'm going to disappear</button>}</div>
+          <Modal open>
+            <div>{!hideButton && <button>I'm going to disappear</button>}</div>
           </Modal>
         );
       }
 
-      wrapper = mount(<WithRemovableElement />);
+      // remove once .only remvoved
+      wrapper = { unmount() {} };
 
-      wrapper.setProps({ open: true });
-      wrapper.update();
-      assert.strictEqual(document.activeElement.nodeName, 'DIV');
-      assert.strictEqual(document.activeElement.getAttribute('data-testid'), 'modal');
+      const { getByRole, setProps } = render(<WithRemovableElement />);
 
-      wrapper
-        .find('button')
-        .instance()
-        .focus();
-      assert.strictEqual(document.activeElement.nodeName, 'BUTTON');
+      expect(getByRole('document')).to.be.focused;
 
-      wrapper.setProps({ hideButton: true });
-      wrapper.update();
-      assert.strictEqual(document.activeElement.nodeName, 'DIV');
-      assert.strictEqual(document.activeElement.getAttribute('data-testid'), 'modal');
+      getByRole('button').focus();
+      expect(getByRole('button')).to.be.focused;
+
+      setProps({ hideButton: true });
+      expect(getByRole('document')).to.be.focused;
     });
   });
 

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -100,9 +100,14 @@ function TrapFocus(props) {
     doc.addEventListener('focus', contain, true);
     doc.addEventListener('keydown', loopFocus, true);
 
+    // With Edge, Safari and Firefox, no focus related events are fired when the focused area stops being a focused area
+    // e.g. https://bugzilla.mozilla.org/show_bug.cgi?id=559561.
+    //
+    // The whatwg spec defines how the browser should behave but does not explicitly mention any events:
+    // https://html.spec.whatwg.org/multipage/interaction.html#focus-fixup-rule.
     const interval = setInterval(() => {
       contain();
-    }, 500);
+    }, 50);
 
     return () => {
       clearInterval(interval);

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import warning from 'warning';
 import ownerDocument from '../utils/ownerDocument';
 import { useForkRef } from '../utils/reactHelpers';
-import { contains } from '../utils';
 
 /**
  * @ignore - internal component.
@@ -59,7 +58,7 @@ function TrapFocus(props) {
           [
             'Material-UI: the modal content node does not accept focus.',
             'For the benefit of assistive technologies, ' +
-            'the tabIndex of the node is being set to "-1".',
+              'the tabIndex of the node is being set to "-1".',
           ].join('\n'),
         );
         rootRef.current.setAttribute('tabIndex', -1);

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -67,13 +67,13 @@ function TrapFocus(props) {
       rootRef.current.focus();
     }
 
-    const contain = () => {
+    const contain = nativeFocusOutEvent => {
       if (disableEnforceFocus || !isEnabled() || ignoreNextEnforceFocus.current) {
         ignoreNextEnforceFocus.current = false;
         return;
       }
 
-      if (rootRef.current && !rootRef.current.contains(doc.activeElement)) {
+      if (rootRef.current && !rootRef.current.contains(nativeFocusOutEvent.relatedTarget)) {
         rootRef.current.focus();
       }
     };

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -20,7 +20,6 @@ function TrapFocus(props) {
     isEnabled,
     open,
   } = props;
-  const ignoreNextEnforceFocus = React.useRef();
   const sentinelStart = React.useRef(null);
   const sentinelEnd = React.useRef(null);
   const nodeToRestore = React.useRef();
@@ -68,8 +67,7 @@ function TrapFocus(props) {
     }
 
     const contain = nativeFocusOutEvent => {
-      if (disableEnforceFocus || !isEnabled() || ignoreNextEnforceFocus.current) {
-        ignoreNextEnforceFocus.current = false;
+      if (disableEnforceFocus || !isEnabled()) {
         return;
       }
 
@@ -86,9 +84,6 @@ function TrapFocus(props) {
 
       // Make sure the next tab starts from the right place.
       if (doc.activeElement === rootRef.current) {
-        // We need to ignore the next contain as
-        // it will try to move the focus back to the rootRef element.
-        ignoreNextEnforceFocus.current = true;
         if (event.shiftKey) {
           sentinelEnd.current.focus();
         } else {

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -97,11 +97,11 @@ function TrapFocus(props) {
       }
     };
 
-    doc.addEventListener('focus', contain, true);
+    doc.addEventListener('focusout', contain, true);
     doc.addEventListener('keydown', loopFocus, true);
 
     return () => {
-      doc.removeEventListener('focus', contain, true);
+      doc.removeEventListener('focusout', contain, true);
       doc.removeEventListener('keydown', loopFocus, true);
 
       // restoreLastFocus()

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import warning from 'warning';
 import ownerDocument from '../utils/ownerDocument';
 import { useForkRef } from '../utils/reactHelpers';
+import { contains } from '../utils';
 
 /**
  * @ignore - internal component.
@@ -58,7 +59,7 @@ function TrapFocus(props) {
           [
             'Material-UI: the modal content node does not accept focus.',
             'For the benefit of assistive technologies, ' +
-              'the tabIndex of the node is being set to "-1".',
+            'the tabIndex of the node is being set to "-1".',
           ].join('\n'),
         );
         rootRef.current.setAttribute('tabIndex', -1);
@@ -97,11 +98,12 @@ function TrapFocus(props) {
       }
     };
 
-    doc.addEventListener('focusout', contain, true);
+    const { current: trapNode } = rootRef;
+    trapNode.addEventListener('focusout', contain);
     doc.addEventListener('keydown', loopFocus, true);
 
     return () => {
-      doc.removeEventListener('focusout', contain, true);
+      trapNode.removeEventListener('focusout', contain);
       doc.removeEventListener('keydown', loopFocus, true);
 
       // restoreLastFocus()

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -609,6 +609,8 @@ describe('<Popover />', () => {
     let wrapper;
 
     before(() => {
+      clock = useFakeTimers();
+
       innerHeightContainer = window.innerHeight;
       const mockedAnchor = document.createElement('div');
       stub(mockedAnchor, 'getBoundingClientRect').callsFake(() => ({
@@ -629,8 +631,6 @@ describe('<Popover />', () => {
         </Popover>,
       );
       element = handleEntering.args[0][0];
-
-      clock = useFakeTimers();
     });
 
     after(() => {


### PR DESCRIPTION
Not sure yet if the test is properly set up but I have [codesandbox as a proof of concept](https://codesandbox.io/s/trap-focus-by-focusout-regain-x0kbx).

The issue was that DOM events were confused with React events. In React every event bubbles. In the DOM that's not necessarily the case. Specifically [focus](https://developer.mozilla.org/en-US/docs/Web/API/Element/focus_event) does not bubble. [Focusout](https://developer.mozilla.org/en-US/docs/Web/API/Element/focusout_event) does.

Should close #16584 if done