### PR TITLE
[ci] Create canaries

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
       cd packages/material-ui/build
       npm version 0.0.0-canary.$(Build.SourceVersion) --no-git-tag-version
       npm pack
-      mv *.tgz ../../../
+      mv *.tgz ../../../material-ui-core.tgz
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     displayName: 'create @material-ui/core canary distributable'
 
@@ -47,7 +47,7 @@ steps:
     inputs:
       pathtoPublish: '$(Build.ArtifactStagingDirectory)'
       artifactName: 'canaries'
-      targetPath: 'material-ui-core-0.0.0-canary.$(Build.SourceVersion).tgz'
+      targetPath: 'material-ui-core.tgz'
 
   - script: |
       yarn docs:build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,8 +26,7 @@ steps:
       cd packages/material-ui/build
       npm version 0.0.0-canary.$(Build.SourceVersion) --no-git-tag-version
       npm pack
-      mv *.tgz ../../../material-ui-core.tgz
-    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+      mv material-ui-core-0.0.0-canary.$(Build.SourceVersion).tgz ../../../material-ui-core.tgz
     displayName: 'create @material-ui/core canary distributable'
 
   - task: S3Upload@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,14 +23,14 @@ steps:
     displayName: 'build @material-ui packages'
 
   - script: |
-      cd packages/material-ui && tar cfv build.tar ./build/*
+      tar cfvz core.tgz -C packages/material-ui/build/ .
     displayName: 'create @material-ui/core tarball'
 
   - task: PublishPipelineArtifact@0
     inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)/node_modules/@material-ui'
-      artifactName: 'core.tar'
-      targetPath: 'packages/material-ui/build.tar'
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'packages'
+      targetPath: 'core.tgz'
 
   - script: |
       yarn docs:build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,8 +28,9 @@ steps:
 
   - task: PublishPipelineArtifact@0
     inputs:
-      artifactName: '@material-ui/core.tgz'
-      targetPath: 'packages/material-ui/build.tgz'
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)/node_modules/@material-ui'
+      artifactName: 'core.tar'
+      targetPath: 'packages/material-ui/build.tar'
 
   - script: |
       yarn docs:build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,7 +32,7 @@ steps:
   - task: S3Upload@1
     inputs:
       regionName: 'eu-central-1'
-      bucketName: 'eps1lon-material-ui'
+      bucketName: 'eps1lon-mui-scripts'
       globExpressions: '*.tgz'
       targetFolder: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)'
       filesAcl: 'public-read'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,10 +32,10 @@ steps:
     inputs:
       regionName: 'eu-central-1'
       bucketName: 'eps1lon-material-ui'
-      globExpressions: '*.tgz'
+      globExpressions: 'packages/*/build/*.tgz'
       targetFolder: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)'
       filesAcl: 'public-read'
-    displayName: "Upload @material-ui/core canary to S3"
+    displayName: "Upload distributables to S3"
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
       AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,13 +26,14 @@ steps:
       cd packages/material-ui/build
       npm version 0.0.0-canary.$(Build.SourceVersion) --no-git-tag-version
       npm pack
+      mv *.tgz ../../../
     displayName: 'create @material-ui/core canary distributable'
 
   - task: S3Upload@1
     inputs:
       regionName: 'eu-central-1'
       bucketName: 'eps1lon-material-ui'
-      globExpressions: 'packages/*/build/*.tgz'
+      globExpressions: '*.tgz'
       targetFolder: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)'
       filesAcl: 'public-read'
     displayName: "Upload distributables to S3"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
     displayName: 'build @material-ui packages'
 
   - script: |
-      cd packages/material-ui && tar cfvz build.tgz ./build
+      cd packages/material-ui && tar cfv build.tar ./build
     displayName: 'create @material-ui/core tarball'
 
   - task: PublishPipelineArtifact@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,14 +23,22 @@ steps:
     displayName: 'build @material-ui packages'
 
   - script: |
-      tar cfvz core.tgz -C packages/material-ui/build/ .
-    displayName: 'create @material-ui/core tarball'
+      cd packages/material-ui/build
+      npm version 0.0.0-canary.$(Build.SourceVersion) --no-git-tag-version
+      npm pack
+    displayName: 'create @material-ui/core canary distributable'
 
-  - task: PublishPipelineArtifact@0
+  - task: S3Upload@1
     inputs:
-      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-      artifactName: 'packages'
-      targetPath: 'core.tgz'
+      regionName: 'eu-central-1'
+      bucketName: 'eps1lon-material-ui'
+      globExpressions: '*.tgz'
+      targetFolder: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)'
+      filesAcl: 'public-read'
+    displayName: "Upload @material-ui/core canary to S3"
+    env:
+      AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
+      AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
 
   - script: |
       yarn docs:build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ steps:
     displayName: 'build @material-ui packages'
 
   - script: |
-      cd packages/material-ui && tar cfv build.tar ./build
+      cd packages/material-ui && tar cfv build.tar ./build/*
     displayName: 'create @material-ui/core tarball'
 
   - task: PublishPipelineArtifact@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,6 +43,12 @@ steps:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
       AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)
 
+  - task: PublishPipelineArtifact@0
+    inputs:
+      pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+      artifactName: 'canaries'
+      targetPath: 'material-ui-core-0.0.0-canary.$(Build.SourceVersion).tgz'
+
   - script: |
       yarn docs:build
     displayName: 'build docs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,7 +1,7 @@
 trigger:
   branches:
     include:
-    - '*' 
+    - '*'
     exclude:
     - l10n
 
@@ -21,6 +21,15 @@ steps:
   - script: |
       yarn lerna run --ignore @material-ui/icons --parallel --scope "@material-ui/*" build
     displayName: 'build @material-ui packages'
+
+  - script: |
+      cd packages/material-ui && tar cfvz build.tgz ./build
+    displayName: 'create @material-ui/core tarball'
+
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: '@material-ui/core.tgz'
+      targetPath: 'packages/material-ui/build.tgz'
 
   - script: |
       yarn docs:build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,16 +27,18 @@ steps:
       npm version 0.0.0-canary.$(Build.SourceVersion) --no-git-tag-version
       npm pack
       mv *.tgz ../../../
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     displayName: 'create @material-ui/core canary distributable'
 
   - task: S3Upload@1
     inputs:
       regionName: 'eu-central-1'
-      bucketName: 'eps1lon-mui-scripts'
+      bucketName: 'eps1lon-material-ui'
       globExpressions: '*.tgz'
       targetFolder: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)'
       filesAcl: 'public-read'
     displayName: "Upload distributables to S3"
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
       AWS_SECRET_ACCESS_KEY: $(AWS_SECRET_ACCESS_KEY)

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -1,5 +1,4 @@
 import * as colors from './colors';
-import React from 'react';
 
 export { colors };
 export {
@@ -127,7 +126,3 @@ export { default as useScrollTrigger } from './useScrollTrigger';
 export { default as withMobileDialog } from './withMobileDialog';
 export { default as withWidth } from './withWidth';
 export { default as Zoom } from './Zoom';
-
-export function Canary() {
-  return <h1>Did the canary survive?</h1>;
-}

--- a/packages/material-ui/src/index.js
+++ b/packages/material-ui/src/index.js
@@ -1,4 +1,5 @@
 import * as colors from './colors';
+import React from 'react';
 
 export { colors };
 export {
@@ -126,3 +127,7 @@ export { default as useScrollTrigger } from './useScrollTrigger';
 export { default as withMobileDialog } from './withMobileDialog';
 export { default as withWidth } from './withWidth';
 export { default as Zoom } from './Zoom';
+
+export function Canary() {
+  return <h1>Did the canary survive?</h1>;
+}


### PR DESCRIPTION
Creates a downloadable tarball for `@material-ui/core`. It's more of a maintainer gimmick to check out PR builds.

![mui-canaries](https://user-images.githubusercontent.com/12292047/61158254-bd858680-a4f8-11e9-9901-fca1ce3b75ca.gif)

Wanted to include the link in the mui-pr-bot comment but Azure has no API to get a link to an Artifact file. Only the whole Artifact is available and then only in zip format and guess what: yarn doesn't support zip.

Ultimate goal was to create a codesandbox with the latest build on a PR but that is blocked by https://github.com/codesandbox/codesandbox-client/issues/1570

Will create canaries from master available via 
`https://eps1lon-material-ui.s3.eu-central-1.amazonaws.com/artifacts/master/${commitSHA}/material-ui-core.tgz`