### PR TITLE
[Grid] Generify props with component property

### DIFF
--- a/docs/src/pages/getting-started/page-layout-examples/sign-in-side/SignInSide.js
+++ b/docs/src/pages/getting-started/page-layout-examples/sign-in-side/SignInSide.js
@@ -61,7 +61,7 @@ export default function SignInSide() {
     <Grid container component="main" className={classes.root}>
       <CssBaseline />
       <Grid item xs={false} sm={4} md={7} className={classes.image} />
-      <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square>
+      <Grid item xs={12} sm={8} md={5} component={() => <Paper square elevation={6} />}>
         <div className={classes.paper}>
           <Avatar className={classes.avatar}>
             <LockOutlinedIcon />

--- a/docs/src/pages/getting-started/page-layout-examples/sign-in-side/SignInSide.js
+++ b/docs/src/pages/getting-started/page-layout-examples/sign-in-side/SignInSide.js
@@ -61,7 +61,7 @@ export default function SignInSide() {
     <Grid container component="main" className={classes.root}>
       <CssBaseline />
       <Grid item xs={false} sm={4} md={7} className={classes.image} />
-      <Grid item xs={12} sm={8} md={5} component={() => <Paper square elevation={6} />}>
+      <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square>
         <div className={classes.paper}>
           <Avatar className={classes.avatar}>
             <LockOutlinedIcon />

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Omit } from '@material-ui/types';
-import { StandardProps } from '..';
 import { Breakpoint } from '../styles/createBreakpoints';
+import { OverridableComponent, SimplifiedPropsOf } from '../OverridableComponent';
 
 export type GridItemsAlignment = 'flex-start' | 'center' | 'flex-end' | 'stretch' | 'baseline';
 
@@ -27,24 +26,9 @@ export type GridJustification =
 
 export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
-export type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type GridSize = false | 'auto' | true | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
-export interface GridProps
-  extends StandardProps<
-    React.HTMLAttributes<HTMLElement> & Partial<Record<Breakpoint, boolean | GridSize>>,
-    GridClassKey
-  > {
-  alignContent?: GridContentAlignment;
-  alignItems?: GridItemsAlignment;
-  component?: string | React.ComponentType<Omit<GridProps, StrippedProps>>;
-  container?: boolean;
-  direction?: GridDirection;
-  item?: boolean;
-  justify?: GridJustification;
-  spacing?: GridSpacing;
-  wrap?: GridWrap;
-  zeroMinWidth?: boolean;
-}
+export type GridProps = SimplifiedPropsOf<typeof Grid>;
 
 export type GridClassKey =
   | 'container'
@@ -92,7 +76,26 @@ export type GridClassKey =
   | 'grid-xs-11'
   | 'grid-xs-12';
 
-declare const Grid: React.ComponentType<GridProps>;
+declare const Grid: OverridableComponent<{
+  props: {
+    alignContent?: GridContentAlignment;
+    alignItems?: GridItemsAlignment;
+    container?: boolean;
+    direction?: GridDirection;
+    item?: boolean;
+    justify?: GridJustification;
+    lg?: GridSize;
+    md?: GridSize;
+    sm?: GridSize;
+    spacing?: GridSpacing;
+    wrap?: GridWrap;
+    xl?: GridSize;
+    xs?: GridSize;
+    zeroMinWidth?: boolean;
+  };
+  defaultComponent: 'div';
+  classKey: GridClassKey;
+}>;
 
 export default Grid;
 

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -26,7 +26,7 @@ export type GridJustification =
 
 export type GridWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
 
-export type GridSize = false | 'auto' | true | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
+export type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12;
 
 export type GridProps = SimplifiedPropsOf<typeof Grid>;
 
@@ -77,20 +77,15 @@ export type GridClassKey =
   | 'grid-xs-12';
 
 declare const Grid: OverridableComponent<{
-  props: {
+  props: Partial<Record<Breakpoint, boolean | GridSize>> & {
     alignContent?: GridContentAlignment;
     alignItems?: GridItemsAlignment;
     container?: boolean;
     direction?: GridDirection;
     item?: boolean;
     justify?: GridJustification;
-    lg?: GridSize;
-    md?: GridSize;
-    sm?: GridSize;
     spacing?: GridSpacing;
     wrap?: GridWrap;
-    xl?: GridSize;
-    xs?: GridSize;
     zeroMinWidth?: boolean;
   };
   defaultComponent: 'div';

--- a/packages/material-ui/src/Grid/Grid.spec.tsx
+++ b/packages/material-ui/src/Grid/Grid.spec.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+
+function responsiveTest() {
+  <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square />;
+}


### PR DESCRIPTION
fix TypeScript check error.

- Property does not exist on Grid:  'elevation'
- Property does not exist on Grid:  'square'

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
