### PR TITLE
fix(Box Component): Box clone not overriding child component styles

### DIFF
--- a/packages/material-ui/src/Box/Box.js
+++ b/packages/material-ui/src/Box/Box.js
@@ -30,6 +30,6 @@ export const styleFunction = css(
 /**
  * @ignore - do not document.
  */
-const Box = styled('div')(styleFunction, { name: 'MuiBox' });
+const Box = styled('div')(styleFunction, { name: 'MuiBox', index: 1 });
 
 export default Box;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fix `Box` clone not overriding child component styles #15993 , by setting higher `index`(default 0) to insert `Box` style after.

ref https://cssinjs.org/jss-api/?v=v10.0.0-alpha.22#create-style-sheet

---

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).