### PR TITLE
Correct docs for pulling out the checkbox value

### DIFF
--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -150,7 +150,7 @@ Checkbox.propTypes = {
    * Callback fired when the state is changed.
    *
    * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.checked`.
+   * You can pull out the new value by accessing `event.target.value`.
    * @param {boolean} checked The `checked` value of the switch
    */
   onChange: PropTypes.func,


### PR DESCRIPTION
The checkbox value lives on the `value` prop, not the `checked` prop.
