### PR TITLE
[example] Fix "@zeit/next-typescript" dependency missing

### DIFF
--- a/examples/nextjs-with-typescript/.babelrc
+++ b/examples/nextjs-with-typescript/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["next/babel", "@zeit/next-typescript/babel"]
+  "presets": ["next/babel"]
 }


### PR DESCRIPTION
I needed to install this dependency in order to run this example. Without it babel wouldn't work.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
