### PR TITLE
[core] Deduplicate packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,9 @@ commands:
       - run:
           name: Install js dependencies
           command: yarn
+      - run:
+          name: Check for duplicated packages
+          command: yarn deduplicate
   prepare_chrome_headless:
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,6 @@ commands:
       - run:
           name: Install js dependencies
           command: yarn
-      - run:
-          name: Check for duplicated packages
-          command: yarn deduplicate
   prepare_chrome_headless:
     steps:
       - run:
@@ -44,6 +41,9 @@ jobs:
       - run:
           name: Should not have any git not staged
           command: git diff --exit-code
+      - run:
+          name: Check for duplicated packages
+          command: yarn deduplicate
       - save_cache:
           key: v2-yarn-sha-{{ checksum "yarn.lock" }}
           paths:

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "version": "4.2.0",
   "private": true,
   "scripts": {
+    "deduplicate": "node scripts/deduplicate.js",
     "argos": "argos upload test/regressions/screenshots/chrome --token $ARGOS_TOKEN",
     "docs:api": "rimraf ./pages/api && cross-env BABEL_ENV=test babel-node ./docs/scripts/buildApi.js ./packages/material-ui/src ./pages/api && cross-env BABEL_ENV=test babel-node ./docs/scripts/buildApi.js ./packages/material-ui-lab/src ./pages/api",
     "docs:build": "rimraf .next && cross-env NODE_ENV=production BABEL_ENV=docs-production next build",
@@ -200,7 +201,8 @@
     "webfontloader": "^1.6.28",
     "webpack": "^4.28.4",
     "webpack-bundle-analyzer": "^3.0.0",
-    "webpack-cli": "^3.2.3"
+    "webpack-cli": "^3.2.3",
+    "yarn-deduplicate": "^1.1.1"
   },
   "resolutions": {
     "**/hoist-non-react-statics": "^3.2.1"

--- a/scripts/deduplicate.js
+++ b/scripts/deduplicate.js
@@ -5,60 +5,38 @@ const path = require('path');
 const fs = require('fs');
 const deduplicate = require('yarn-deduplicate');
 
-function deduplicatePackages() {
-  return new Promise(resolve => {
-    const lockFile = path.resolve(__dirname, '../yarn.lock');
-    const yarnlock = fs.readFileSync(lockFile, 'utf8');
+const lockFile = path.resolve(__dirname, '../yarn.lock');
+const yarnlock = fs.readFileSync(lockFile, 'utf8');
 
-    const duplicates = deduplicate.listDuplicates(yarnlock);
-    if (duplicates.length === 0) {
-      console.log('No duplicated packages found');
-      resolve();
-      return;
-    }
-
-    console.log(
-      `${duplicates.length} duplicated package(s) found\n${duplicates
-        .map(x => `  ${x}`)
-        .join('\n')}`,
-    );
-
-    if (process.env.CI) {
-      console.error(
-        [
-          `Error: There are currently ${duplicates.length} duplicated package(s).`,
-          `To deduplicate run "yarn deduplicate"`,
-        ].join('\n'),
-      );
-      process.exit(1);
-    }
-
-    console.log('Deduplicating package(s)');
-    fs.writeFileSync(lockFile, deduplicate.fixDuplicates(yarnlock));
-
-    const yarn = spawn('yarn', {
-      shell: true,
-      stdio: 'inherit',
-      cwd: path.resolve(__dirname, '..'),
-      env: { NOYARNPOSTINSTALL: 1 },
-    });
-
-    yarn.on('close', code => {
-      if (code !== 0) {
-        process.exit(code);
-      }
-
-      resolve();
-    });
-  });
+const duplicates = deduplicate.listDuplicates(yarnlock);
+if (duplicates.length === 0) {
+  console.log('No duplicated packages found');
+  process.exit(0);
 }
 
-async function run() {
-  if (process.env.NOYARNPOSTINSTALL) {
-    return;
-  }
+console.log(
+  `${duplicates.length} duplicated package(s) found\n${duplicates.map(x => `  ${x}`).join('\n')}`,
+);
 
-  await deduplicatePackages();
+if (process.env.CI) {
+  console.error(
+    [
+      `Error: There are currently ${duplicates.length} duplicated package(s).`,
+      `To deduplicate run "yarn deduplicate"`,
+    ].join('\n'),
+  );
+  process.exit(1);
 }
 
-run();
+console.log('Deduplicating package(s)');
+fs.writeFileSync(lockFile, deduplicate.fixDuplicates(yarnlock));
+
+const yarn = spawn('yarn', {
+  shell: true,
+  stdio: 'inherit',
+  cwd: path.resolve(__dirname, '..'),
+});
+
+yarn.on('close', code => {
+  process.exit(code);
+});

--- a/scripts/deduplicate.js
+++ b/scripts/deduplicate.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-console */
+
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const deduplicate = require('yarn-deduplicate');
+
+function deduplicatePackages() {
+  return new Promise(resolve => {
+    const lockFile = path.resolve(__dirname, '../yarn.lock');
+    const yarnlock = fs.readFileSync(lockFile, 'utf8');
+
+    const duplicates = deduplicate.listDuplicates(yarnlock);
+    if (duplicates.length === 0) {
+      console.log('No duplicated packages found');
+      resolve();
+      return;
+    }
+
+    console.log(
+      `${duplicates.length} duplicated package(s) found\n${duplicates
+        .map(x => `  ${x}`)
+        .join('\n')}`,
+    );
+
+    if (process.env.CI) {
+      console.error(
+        [
+          `Error: There are currently ${duplicates.length} duplicated package(s).`,
+          `To deduplicate run "yarn deduplicate"`,
+        ].join('\n'),
+      );
+      process.exit(1);
+    }
+
+    console.log('Deduplicating package(s)');
+    fs.writeFileSync(lockFile, deduplicate.fixDuplicates(yarnlock));
+
+    const yarn = spawn('yarn', {
+      shell: true,
+      stdio: 'inherit',
+      cwd: path.resolve(__dirname, '..'),
+      env: { NOYARNPOSTINSTALL: 1 },
+    });
+
+    yarn.on('close', code => {
+      if (code !== 0) {
+        process.exit(code);
+      }
+
+      resolve();
+    });
+  });
+}
+
+async function run() {
+  if (process.env.NOYARNPOSTINSTALL) {
+    return;
+  }
+
+  await deduplicatePackages();
+}
+
+run();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2649,6 +2649,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
+
 "@zeit/next-typescript@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@zeit/next-typescript/-/next-typescript-1.1.1.tgz#0b0ddfbb13ca04cde52ac2718473f1b9c40ba0ee"
@@ -4323,7 +4328,7 @@ commander@2.9.0, commander@~2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
-commander@^2.11.0, commander@^2.12.1, commander@^2.18.0, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0, commander@~2.20.0:
+commander@^2.10.0, commander@^2.11.0, commander@^2.12.1, commander@^2.18.0, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -14736,6 +14741,15 @@ yargs@^12.0.0, yargs@^12.0.1, yargs@^12.0.5:
     which-module "^2.0.0"
     y18n "^3.2.1 || ^4.0.0"
     yargs-parser "^11.1.1"
+
+yarn-deduplicate@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/yarn-deduplicate/-/yarn-deduplicate-1.1.1.tgz#19b4a87654b66f55bf3a4bd6b153b4e4ab1b6e6d"
+  integrity sha512-2FDJ1dFmtvqhRmfja89ohYzpaheCYg7BFBSyaUq+kxK0y61C9oHv1XaQovCWGJtP2WU8PksQOgzMVV7oQOobzw==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    commander "^2.10.0"
+    semver "^5.3.0"
 
 yauzl@2.4.1:
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9782,12 +9782,7 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.3.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.5.0.tgz#8028c49fc1191bba56a07adc6e2a954644a48501"
-  integrity sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw==
-
-node-fetch@^2.5.0:
+node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

- Added `yarn deduplicate` which automatically deduplicates packages using [yarn-deduplicate](https://www.npmjs.com/package/yarn-deduplicate) then runs `yarn install`
- Made the CI fail if there are duplicated packages

Output:
```sh
$ yarn upgrade @babel/core && node scripts/postinstall.js
yarn upgrade v1.17.3
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.9: The platform "win32" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning " > @material-ui/pickers@3.1.1" has unmet peer dependency "@date-io/core@^1.3.6".
warning " > jss-rtl@0.2.3" has unmet peer dependency "jss@^9.0.0".
[4/4] Rebuilding all packages...
success Saved lockfile.
success Saved 9 new dependencies.
info Direct dependencies
└─ @babel/core@7.5.4
info All dependencies
├─ @babel/core@7.5.4
├─ @babel/helpers@7.5.4
├─ @babel/highlight@7.5.0
├─ ansi-styles@3.2.1
├─ chalk@2.4.2
├─ color-convert@1.9.3
├─ color-name@1.1.3
├─ js-tokens@4.0.0
└─ supports-color@5.5.0
Done in 16.74s.
22 duplicated package(s) found
  Package "@babel/core" wants ^7.1.6 and could get 7.5.4, but got 7.4.4
  Package "@babel/core" wants ^7.4.4 and could get 7.5.4, but got 7.4.4
  Package "@babel/generator" wants ^7.1.2 and could get 7.5.0, but got 7.4.4
  Package "@babel/generator" wants ^7.4.0 and could get 7.5.0, but got 7.4.4
  Package "@babel/helpers" wants ^7.1.2 and could get 7.5.4, but got 7.4.4
  Package "@babel/parser" wants ^7.0.0 and could get 7.5.0, but got 7.4.4
  Package "@babel/parser" wants ^7.1.2 and could get 7.5.0, but got 7.4.4
  Package "@babel/parser" wants ^7.1.6 and could get 7.5.0, but got 7.4.4
  Package "@babel/parser" wants ^7.4.3 and could get 7.5.0, but got 7.4.4
  Package "@babel/traverse" wants ^7.0.0 and could get 7.5.0, but got 7.4.4
  Package "@babel/traverse" wants ^7.1.0 and could get 7.5.0, but got 7.4.4
  Package "@babel/traverse" wants ^7.4.3 and could get 7.5.0, but got 7.4.4
  Package "@babel/types" wants ^7.1.2 and could get 7.5.0, but got 7.4.4
  Package "@babel/types" wants ^7.2.0 and could get 7.5.0, but got 7.4.4
  Package "@babel/types" wants ^7.3.0 and could get 7.5.0, but got 7.4.4
  Package "@babel/types" wants ^7.4.0 and could get 7.5.0, but got 7.4.4
  Package "ms" wants ^2.0.0 and could get 2.1.2, but got 2.1.1
  Package "resolve" wants ^1.10.0 and could get 1.11.1, but got 1.10.1
  Package "resolve" wants ^1.10.1 and could get 1.11.1, but got 1.10.1
  Package "resolve" wants ^1.4.0 and could get 1.11.1, but got 1.10.1
  Package "resolve" wants ^1.5.0 and could get 1.11.1, but got 1.10.1
  Package "resolve" wants ^1.8.1 and could get 1.11.1, but got 1.10.1
Deduplicating package(s)
yarn install v1.17.3
[1/4] Resolving packages...
[2/4] Fetching packages...
info fsevents@1.2.9: The platform "win32" is incompatible with this module.
info "fsevents@1.2.9" is an optional dependency and failed compatibility check. Excluding it from installation.
[3/4] Linking dependencies...
warning " > @material-ui/pickers@3.1.1" has unmet peer dependency "@date-io/core@^1.3.6".
warning " > jss-rtl@0.2.3" has unmet peer dependency "jss@^9.0.0".
[4/4] Building fresh packages...

$ node scripts/postinstall.js
Done in 12.57s.
```