### PR TITLE
[Popper] Refactor to more commonly known react patterns

### DIFF
--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -69,9 +69,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
 
   const handleOpen = React.useCallback(() => {
     const handlePopperUpdate = data => {
-      if (data.placement !== placement) {
-        setPlacement(data.placement);
-      }
+      setPlacement(data.placement);
     };
 
     const popperNode = tooltipRef.current;
@@ -106,7 +104,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
       onUpdate: createChainedFunction(handlePopperUpdate, popperOptions.onUpdate),
     });
     handlePopperRefRef.current(popper);
-  }, [anchorEl, disablePortal, modifiers, open, placement, placementProps, popperOptions]);
+  }, [anchorEl, disablePortal, modifiers, open, placementProps, popperOptions]);
 
   const handleEnter = () => {
     setExited(false);

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -6,6 +6,10 @@ import Portal from '../Portal';
 import { createChainedFunction } from '../utils/helpers';
 import { useForkRef } from '../utils/reactHelpers';
 
+/**
+ * Flips placement if in <body dir="rtl" />
+ * @param {string} placement
+ */
 function flipPlacement(placement) {
   const direction = (typeof window !== 'undefined' && document.body.getAttribute('dir')) || 'ltr';
 
@@ -47,7 +51,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
     keepMounted = false,
     modifiers,
     open,
-    placement: placementProps = 'bottom',
+    placement: initialPlacement = 'bottom',
     popperOptions = defaultPopperOptions,
     popperRef: popperRefProp,
     transition = false,
@@ -65,7 +69,16 @@ const Popper = React.forwardRef(function Popper(props, ref) {
   React.useImperativeHandle(popperRefProp, () => popperRef.current, []);
 
   const [exited, setExited] = React.useState(!open);
-  const [placement, setPlacement] = React.useState();
+
+  const rtlPlacement = flipPlacement(initialPlacement);
+  /**
+   * placement initialized from prop but can change during lifetime if modifiers.flip.
+   * modifiers.flip is essentially a flip for controlled/uncontrolled behavior
+   */
+  const [placement, setPlacement] = React.useState(rtlPlacement);
+  if (rtlPlacement !== placement) {
+    setPlacement(rtlPlacement);
+  }
 
   const handleOpen = React.useCallback(() => {
     const handlePopperUpdate = data => {
@@ -84,7 +97,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
     }
 
     const popper = new PopperJS(getAnchorEl(anchorEl), popperNode, {
-      placement: flipPlacement(placementProps),
+      placement: rtlPlacement,
       ...popperOptions,
       modifiers: {
         ...(disablePortal
@@ -100,11 +113,10 @@ const Popper = React.forwardRef(function Popper(props, ref) {
       },
       // We could have been using a custom modifier like react-popper is doing.
       // But it seems this is the best public API for this use case.
-      onCreate: createChainedFunction(handlePopperUpdate, popperOptions.onCreate),
       onUpdate: createChainedFunction(handlePopperUpdate, popperOptions.onUpdate),
     });
     handlePopperRefRef.current(popper);
-  }, [anchorEl, disablePortal, modifiers, open, placementProps, popperOptions]);
+  }, [anchorEl, disablePortal, modifiers, open, rtlPlacement, popperOptions]);
 
   const handleEnter = () => {
     setExited(false);
@@ -146,9 +158,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
     return null;
   }
 
-  const childProps = {
-    placement: placement || flipPlacement(placementProps),
-  };
+  const childProps = { placement };
 
   if (transition) {
     childProps.TransitionProps = {


### PR DESCRIPTION
Makes the controlled/uncontrolled + derived state pattern more obvious which results in one less `create` callback (wasteful popper re-creation) and `flipPlacement` call.

Videos are taken with `<Popper flip />` and we're about to scroll to a position where the placement needs to be flipped. When this happens we used to get this weird `create-update-create-update` chain that is now replaced by a continuous update.

https://material-ui.com/components/popper/#scroll-playground

![mui-popper-before-placement](https://user-images.githubusercontent.com/12292047/61316366-1ad34d80-a801-11e9-9083-fdcb5818a1c2.gif)

PR:
![mui-popper-after-placement](https://user-images.githubusercontent.com/12292047/61316371-1eff6b00-a801-11e9-8ec0-0c7e8a96d53e.gif)

And we even got less shipped code. Hope that makes the implementation more reasonable.


