### PR TITLE
[Switch] Support small size

### DIFF
--- a/docs/pages/api/switch.md
+++ b/docs/pages/api/switch.md
@@ -52,12 +52,12 @@ This prop accepts the following keys:
 | <span class="prop-name">switchBase</span> | Styles applied to the internal `SwitchBase` component's `root` class.
 | <span class="prop-name">colorPrimary</span> | Styles applied to the internal SwitchBase component's root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | Styles applied to the internal SwitchBase component's root element if `color="secondary"`.
+| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">checked</span> | Pseudo-class applied to the internal `SwitchBase` component's `checked` class.
 | <span class="prop-name">disabled</span> | Pseudo-class applied to the internal SwitchBase component's disabled class.
 | <span class="prop-name">input</span> | Styles applied to the internal SwitchBase component's input element.
 | <span class="prop-name">thumb</span> | Styles used to create the thumb passed to the internal `SwitchBase` component `icon` prop.
 | <span class="prop-name">track</span> | Styles applied to the track element.
-| <span class="prop-name">sizeSmall</span> | Small size
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Switch/Switch.js)

--- a/docs/pages/api/switch.md
+++ b/docs/pages/api/switch.md
@@ -30,6 +30,7 @@ import Switch from '@material-ui/core/Switch';
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object</span> |  | [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element. |
 | <span class="prop-name">inputRef</span> | <span class="prop-type">union:&nbsp;func&nbsp;&#124;<br>&nbsp;object<br></span> |  | This prop can be used to pass a ref callback to the `input` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object, checked: boolean) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.checked`.<br>*checked:* The `checked` value of the switch |
+| <span class="prop-name">size</span> | <span class="prop-type">enum:&nbsp;'small'&nbsp;&#124;<br>&nbsp;'medium'<br></span> | <span class="prop-default">'medium'</span> | The size of the switch. `small` is equivalent to the dense switch styling. |
 | <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component prop `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the component. |
 
@@ -56,6 +57,7 @@ This prop accepts the following keys:
 | <span class="prop-name">input</span> | Styles applied to the internal SwitchBase component's input element.
 | <span class="prop-name">thumb</span> | Styles used to create the thumb passed to the internal `SwitchBase` component `icon` prop.
 | <span class="prop-name">track</span> | Styles applied to the track element.
+| <span class="prop-name">sizeSmall</span> | Small size
 
 Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
 and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Switch/Switch.js)

--- a/docs/src/pages/components/switches/CustomizedSwitches.js
+++ b/docs/src/pages/components/switches/CustomizedSwitches.js
@@ -31,7 +31,6 @@ const IOSSwitch = withStyles(theme => ({
   switchBase: {
     padding: 1,
     '&$checked': {
-      transform: 'translateX(16px)',
       color: theme.palette.common.white,
       '& + $track': {
         backgroundColor: '#52d869',
@@ -85,7 +84,6 @@ const AntSwitch = withStyles(theme => ({
     padding: 2,
     color: theme.palette.grey[500],
     '&$checked': {
-      transform: 'translateX(12px)',
       color: theme.palette.common.white,
       '& + $track': {
         opacity: 1,

--- a/docs/src/pages/components/switches/CustomizedSwitches.tsx
+++ b/docs/src/pages/components/switches/CustomizedSwitches.tsx
@@ -39,7 +39,6 @@ const IOSSwitch = withStyles(theme => ({
   switchBase: {
     padding: 1,
     '&$checked': {
-      transform: 'translateX(16px)',
       color: theme.palette.common.white,
       '& + $track': {
         backgroundColor: '#52d869',
@@ -93,7 +92,6 @@ const AntSwitch = withStyles(theme => ({
     padding: 2,
     color: theme.palette.grey[500],
     '&$checked': {
-      transform: 'translateX(12px)',
       color: theme.palette.common.white,
       '& + $track': {
         opacity: 1,

--- a/docs/src/pages/components/switches/SwitchesSize.js
+++ b/docs/src/pages/components/switches/SwitchesSize.js
@@ -3,7 +3,7 @@ import Switch from '@material-ui/core/Switch';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-export default function Switches() {
+export default function SwitchesSize() {
   const [checked, setChecked] = React.useState(false);
 
   const toggleChecked = () => {

--- a/docs/src/pages/components/switches/SwitchesSize.js
+++ b/docs/src/pages/components/switches/SwitchesSize.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import Switch from '@material-ui/core/Switch';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+
+export default function Switches() {
+  const [checked, setChecked] = React.useState(false);
+
+  const toggleChecked = () => {
+    setChecked(prev => !prev);
+  };
+
+  return (
+    <FormGroup>
+      <FormControlLabel
+        control={<Switch size="small" checked={checked} onChange={toggleChecked} />}
+        label="Small"
+      />
+      <FormControlLabel
+        control={<Switch checked={checked} onChange={toggleChecked} />}
+        label="Normal"
+      />
+    </FormGroup>
+  );
+}

--- a/docs/src/pages/components/switches/SwitchesSize.tsx
+++ b/docs/src/pages/components/switches/SwitchesSize.tsx
@@ -3,7 +3,7 @@ import Switch from '@material-ui/core/Switch';
 import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 
-export default function Switches() {
+export default function SwitchesSize() {
   const [checked, setChecked] = React.useState(false);
 
   const toggleChecked = () => {

--- a/docs/src/pages/components/switches/SwitchesSize.tsx
+++ b/docs/src/pages/components/switches/SwitchesSize.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Switch from '@material-ui/core/Switch';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+
+export default function Switches() {
+  const [checked, setChecked] = React.useState(false);
+
+  const toggleChecked = () => {
+    setChecked(prev => !prev);
+  };
+
+  return (
+    <FormGroup>
+      <FormControlLabel
+        control={<Switch size="small" checked={checked} onChange={toggleChecked} />}
+        label="Small"
+      />
+      <FormControlLabel
+        control={<Switch checked={checked} onChange={toggleChecked} />}
+        label="Normal"
+      />
+    </FormGroup>
+  );
+}

--- a/docs/src/pages/components/switches/switches.md
+++ b/docs/src/pages/components/switches/switches.md
@@ -33,6 +33,12 @@ Here are some examples of customizing the component. You can learn more about th
 
 {{"demo": "pages/components/switches/CustomizedSwitches.js"}}
 
+## Sizes
+
+Use the `size` property.
+
+{{"demo": "pages/components/switches/SwitchesSize.js"}}
+
 ## Label placement
 
 You can change the placement of the label:

--- a/docs/src/pages/components/switches/switches.md
+++ b/docs/src/pages/components/switches/switches.md
@@ -35,7 +35,7 @@ Here are some examples of customizing the component. You can learn more about th
 
 ## Sizes
 
-Use the `size` property.
+Fancy smaller switches? Use the `size` property.
 
 {{"demo": "pages/components/switches/SwitchesSize.js"}}
 

--- a/packages/material-ui/src/Switch/Switch.d.ts
+++ b/packages/material-ui/src/Switch/Switch.d.ts
@@ -7,6 +7,7 @@ export interface SwitchProps
   checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
   icon?: React.ReactNode;
+  size?: 'small' | 'medium';
 }
 
 export type SwitchClassKey =
@@ -14,6 +15,7 @@ export type SwitchClassKey =
   | 'switchBase'
   | 'colorPrimary'
   | 'colorSecondary'
+  | 'sizeSmall'
   | 'thumb'
   | 'track';
 

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -93,6 +93,19 @@ export const styles = theme => ({
         theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
     },
   },
+  /* Styles applied to the root element if `size="small"`. */
+  sizeSmall: {
+    width: 40,
+    height: 24,
+    padding: 7,
+    '& $thumb': {
+      width: 16,
+      height: 16,
+    },
+    '& $switchBase': {
+      padding: 4,
+    },
+  },
   /* Pseudo-class applied to the internal `SwitchBase` component's `checked` class. */
   checked: {},
   /* Pseudo-class applied to the internal SwitchBase component's disabled class. */
@@ -122,19 +135,6 @@ export const styles = theme => ({
     backgroundColor:
       theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
     opacity: theme.palette.type === 'light' ? 0.38 : 0.3,
-  },
-  /* Small size */
-  sizeSmall: {
-    width: 30 + 10 * 2,
-    height: 10 + 10 * 2,
-    padding: 10,
-    '& $thumb': {
-      width: 18,
-      height: 18,
-    },
-    '& $switchBase': {
-      padding: 6,
-    },
   },
 });
 
@@ -173,7 +173,6 @@ const Switch = React.forwardRef(function Switch(props, ref) {
           disabled: classes.disabled,
         }}
         ref={ref}
-        size={size}
         {...other}
       />
       <span className={classes.track} />

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -37,11 +37,13 @@ export const styles = theme => ({
     left: 0,
     zIndex: 1, // Render above the focus ripple.
     color: theme.palette.type === 'light' ? theme.palette.grey[50] : theme.palette.grey[400],
-    transition: theme.transitions.create('transform', {
+    transition: theme.transitions.create(['left', 'transform'], {
       duration: theme.transitions.duration.shortest,
     }),
+    willChange: 'left, transform',
     '&$checked': {
-      transform: 'translateX(50%)',
+      left: '100%',
+      transform: 'translateX(-100%)',
     },
     '&$disabled': {
       color: theme.palette.type === 'light' ? theme.palette.grey[400] : theme.palette.grey[800],
@@ -121,10 +123,31 @@ export const styles = theme => ({
       theme.palette.type === 'light' ? theme.palette.common.black : theme.palette.common.white,
     opacity: theme.palette.type === 'light' ? 0.38 : 0.3,
   },
+  /* Small size */
+  sizeSmall: {
+    width: 30 + 10 * 2,
+    height: 10 + 10 * 2,
+    padding: 10,
+    '& $thumb': {
+      width: 18,
+      height: 18,
+    },
+    '& $switchBase': {
+      padding: 6,
+    },
+  },
 });
 
 const Switch = React.forwardRef(function Switch(props, ref) {
-  const { classes, className, color = 'secondary', edge = false, ...other } = props;
+  const {
+    classes,
+    className,
+    color = 'secondary',
+    edge = false,
+    size = 'medium',
+    ...other
+  } = props;
+
   const icon = <span className={classes.thumb} />;
 
   return (
@@ -134,6 +157,7 @@ const Switch = React.forwardRef(function Switch(props, ref) {
         {
           [classes.edgeStart]: edge === 'start',
           [classes.edgeEnd]: edge === 'end',
+          [classes[`size${capitalize(size)}`]]: size !== 'medium',
         },
         className,
       )}
@@ -149,6 +173,7 @@ const Switch = React.forwardRef(function Switch(props, ref) {
           disabled: classes.disabled,
         }}
         ref={ref}
+        size={size}
         {...other}
       />
       <span className={classes.track} />
@@ -221,6 +246,11 @@ Switch.propTypes = {
    * @param {boolean} checked The `checked` value of the switch
    */
   onChange: PropTypes.func,
+  /**
+   * The size of the switch.
+   * `small` is equivalent to the dense switch styling.
+   */
+  size: PropTypes.oneOf(['small', 'medium']),
   /**
    * The input component prop `type`.
    */

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -1,12 +1,7 @@
 import React from 'react';
 import { assert } from 'chai';
 import clsx from 'clsx';
-import {
-  createMount,
-  createShallow,
-  getClasses,
-  findOutermostIntrinsic,
-} from '@material-ui/core/test-utils';
+import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import SwitchBase from '../internal/SwitchBase';
 import Switch from './Switch';
@@ -72,15 +67,6 @@ describe('<Switch />', () => {
       const track = wrapper.childAt(1);
       assert.strictEqual(track.name(), 'span');
       assert.strictEqual(track.hasClass(classes.track), true);
-    });
-  });
-
-  describe('prop: size', () => {
-    it('should render the right class in root element', () => {
-      let wrapper = mount(<Switch size="small" />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.sizeSmall), true);
-      wrapper = mount(<Switch />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.sizeSmall), false);
     });
   });
 });

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -1,7 +1,12 @@
 import React from 'react';
 import { assert } from 'chai';
 import clsx from 'clsx';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import {
+  createMount,
+  createShallow,
+  getClasses,
+  findOutermostIntrinsic,
+} from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import SwitchBase from '../internal/SwitchBase';
 import Switch from './Switch';
@@ -67,6 +72,15 @@ describe('<Switch />', () => {
       const track = wrapper.childAt(1);
       assert.strictEqual(track.name(), 'span');
       assert.strictEqual(track.hasClass(classes.track), true);
+    });
+  });
+
+  describe('prop: size', () => {
+    it('should render the right class in root element', () => {
+      let wrapper = mount(<Switch size="small" />);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.sizeSmall), true);
+      wrapper = mount(<Switch />);
+      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.sizeSmall), false);
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

I have added support for switch small size (Closes #16152).

- [x] Add docs and demo
- [x] fix tests

This is how it looks like:
![switch](https://user-images.githubusercontent.com/11510581/61364240-ba3a2400-a885-11e9-9243-3c02be328614.png)


I need help with tests.
- How to run a single test with watch mode? `yarn test:watch Switch` is not working...
- Finding classes is not working as expected - see test `should render the right class`


What else should I do to merge this feature?