### PR TITLE
[docs] Remove unused imports

### DIFF
--- a/docs/src/pages/components/buttons/FloatingActionButtonZoom.tsx
+++ b/docs/src/pages/components/buttons/FloatingActionButtonZoom.tsx
@@ -6,7 +6,7 @@ import { makeStyles, useTheme, Theme, createStyles } from '@material-ui/core/sty
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
-import Typography, { TypographyProps } from '@material-ui/core/Typography';
+import Typography from '@material-ui/core/Typography';
 import Zoom from '@material-ui/core/Zoom';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';

--- a/docs/src/pages/components/slider/CustomizedSlider.tsx
+++ b/docs/src/pages/components/slider/CustomizedSlider.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { fade, withStyles, makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { withStyles, makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import Slider from '@material-ui/core/Slider';
 import Typography from '@material-ui/core/Typography';

--- a/docs/src/pages/components/slider/RangeSlider.tsx
+++ b/docs/src/pages/components/slider/RangeSlider.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Typography from '@material-ui/core/Typography';
 import Slider from '@material-ui/core/Slider';
-import Tooltip from '@material-ui/core/Tooltip';
 
 const useStyles = makeStyles({
   root: {

--- a/docs/src/pages/customization/palette/DarkTheme.tsx
+++ b/docs/src/pages/customization/palette/DarkTheme.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Typography from '@material-ui/core/Typography';
-import { useTheme, Theme, createMuiTheme } from '@material-ui/core/styles';
+import { useTheme, createMuiTheme } from '@material-ui/core/styles';
 import { ThemeProvider } from '@material-ui/styles';
 
 function WithTheme() {

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig.json",
   "include": ["types", "src/pages/**/*"],
   "compilerOptions": {
-    "allowJs": false
+    "allowJs": false,
+    "noUnusedLocals": true
   }
 }


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

- Set `noUnusedLocals` to true in `docs/tsconfig.json`
- Removed unused imports

This should prevent unused things showing up in the docs (except parameters)