### PR TITLE
[docs] Fix typo with &:active

### DIFF
--- a/docs/src/pages/components/slider/CustomizedSlider.js
+++ b/docs/src/pages/components/slider/CustomizedSlider.js
@@ -126,7 +126,7 @@ const PrettoSlider = withStyles({
     border: '2px solid currentColor',
     marginTop: -8,
     marginLeft: -12,
-    '&:focus,&:hover,&$active': {
+    '&:focus,&:hover,&:active': {
       boxShadow: 'inherit',
     },
   },

--- a/docs/src/pages/components/slider/CustomizedSlider.js
+++ b/docs/src/pages/components/slider/CustomizedSlider.js
@@ -78,7 +78,7 @@ const IOSSlider = withStyles({
     boxShadow: iOSBoxShadow,
     marginTop: -14,
     marginLeft: -14,
-    '&:focus,&:hover,&$active': {
+    '&:focus,&:hover,&:active': {
       boxShadow: '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.3),0 0 0 1px rgba(0,0,0,0.02)',
       // Reset on touch devices, it doesn't add specificity
       '@media (hover: none)': {
@@ -158,7 +158,7 @@ const AirbnbSlider = withStyles({
     marginTop: -12,
     marginLeft: -13,
     boxShadow: '#ebebeb 0px 2px 2px',
-    '&:focus,&:hover,&$active': {
+    '&:focus,&:hover,&:active': {
       boxShadow: '#ccc 0px 2px 3px 1px',
     },
     '& .bar': {

--- a/docs/src/pages/components/slider/CustomizedSlider.tsx
+++ b/docs/src/pages/components/slider/CustomizedSlider.tsx
@@ -87,7 +87,7 @@ const IOSSlider = withStyles({
     boxShadow: iOSBoxShadow,
     marginTop: -14,
     marginLeft: -14,
-    '&:focus,&:hover,&$active': {
+    '&:focus,&:hover,&:active': {
       boxShadow: '0 3px 1px rgba(0,0,0,0.1),0 4px 8px rgba(0,0,0,0.3),0 0 0 1px rgba(0,0,0,0.02)',
       // Reset on touch devices, it doesn't add specificity
       '@media (hover: none)': {
@@ -135,7 +135,7 @@ const PrettoSlider = withStyles({
     border: '2px solid currentColor',
     marginTop: -8,
     marginLeft: -12,
-    '&:focus,&:hover,&$active': {
+    '&:focus,&:hover,&:active': {
       boxShadow: 'inherit',
     },
   },
@@ -167,7 +167,7 @@ const AirbnbSlider = withStyles({
     marginTop: -12,
     marginLeft: -13,
     boxShadow: '#ebebeb 0px 2px 2px',
-    '&:focus,&:hover,&$active': {
+    '&:focus,&:hover,&:active': {
       boxShadow: '#ccc 0px 2px 3px 1px',
     },
     '& .bar': {


### PR DESCRIPTION
[docs] Fix typo with &:active - replace `&$active` with `&:active`

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
