### PR TITLE
[docs] Redirects old v1.5.0 url to v1 subdomain

### DIFF
--- a/docs/cdn/_redirects
+++ b/docs/cdn/_redirects
@@ -43,6 +43,9 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /r/pseudo-classes-guide /customization/components/#pseudo-classes 302
 /r/input-component-ref-interface /components/text-fields/#integration-with-3rd-party-input-libraries 302
 
+# v1
+https://v1-5-0.material-ui.com/* https://v1.material-ui.com/:splat 301!
+
 # Legacy
 /v0.20.0 https://v0.material-ui.com/v0.20.0
 /v0.19.4 https://v0.material-ui.com/v0.19.4


### PR DESCRIPTION
This small change will help out anyone who has linked to the v1.5.0 site by redirecting them to a functional docs site.

Fixed as suggested in #16541 by @oliviertassinari.