### PR TITLE
[ci] Use custom frozen lockfile check

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,2 +1,1 @@
---install.frozen-lockfile true
 network-timeout 150000

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-material-ui": "link:packages/eslint-plugin-material-ui",
     "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-react": "^7.4.0",
     "eslint-plugin-react-hooks": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5752,10 +5752,6 @@ eslint-plugin-jsx-a11y@^6.0.3:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
-"eslint-plugin-material-ui@link:packages/eslint-plugin-material-ui":
-  version "0.0.0"
-  uid ""
-
 eslint-plugin-mocha@^5.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-mocha/-/eslint-plugin-mocha-5.3.0.tgz#cf3eb18ae0e44e433aef7159637095a7cb19b15b"


### PR DESCRIPTION
Frozen lockfile was used to prevent yarn from regenerating some git dependency of `dtslint`. By only running it in CI we risked integrating lockfiles that change on the initial install (bad 1st contribute experience) so we added it by default.

However the working with the flag enabled is a bit cumbersome. Since we already have a check in CI against integrating outdated lockfiles (git diff after yarn) we don't need it anyway.

Since none of the active core contributers had a problem with running yarn without frozen-lockfile we can remove it. Need to properly debug the issue the next time it gets reported instead of blindly accepting fixes. It's important to boost productivity for the people that work the most on the workspace.