### PR TITLE
[test] Fix failing test_browser

### DIFF
--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -5,8 +5,7 @@ import { expect } from 'chai';
 import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
-import { useFakeTimers } from 'sinon';
-import { cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { cleanup, createClientRender, fireEvent, wait } from 'test/utils/createClientRender';
 
 const options = [
   'Show some love to Material-UI',
@@ -61,15 +60,9 @@ function SimpleMenu({ selectedIndex: selectedIndexProp, ...props }) {
 SimpleMenu.propTypes = { selectedIndex: PropTypes.number };
 
 describe('<Menu /> integration', () => {
-  let clock;
   const render = createClientRender({ strict: false });
 
-  beforeEach(() => {
-    clock = useFakeTimers();
-  });
-
   afterEach(() => {
-    clock.restore();
     cleanup();
   });
 
@@ -267,7 +260,7 @@ describe('<Menu /> integration', () => {
     });
   });
 
-  it.skip('closes the menu when Tabbing while the list is active', () => {
+  it('closes the menu when Tabbing while the list is active', async () => {
     const { queryByRole, getByLabelText } = render(<SimpleMenu transitionDuration={0} />);
     const button = getByLabelText('Open menu');
 
@@ -278,12 +271,12 @@ describe('<Menu /> integration', () => {
     expect(queryByRole('menu')).to.be.focused;
 
     fireEvent.keyDown(document.activeElement, { key: 'Tab' });
-    clock.tick(10);
 
-    expect(queryByRole('menu')).to.be.null;
+    // react-transition-group uses one commit per state transition so we need to wait a bit
+    await wait(() => expect(queryByRole('menu')).to.be.null, { timeout: 10 });
   });
 
-  it('closes the menu when the backdrop is clicked', () => {
+  it('closes the menu when the backdrop is clicked', async () => {
     const { queryByRole, getByLabelText } = render(<SimpleMenu transitionDuration={0} />);
     const button = getByLabelText('Open menu');
 
@@ -294,8 +287,7 @@ describe('<Menu /> integration', () => {
     expect(queryByRole('menu')).to.be.focused;
 
     fireEvent.click(document.querySelector('[data-mui-test="Backdrop"]'));
-    clock.tick(10);
 
-    expect(queryByRole('menu')).to.be.null;
+    await wait(() => expect(queryByRole('menu')).to.be.null, { timeout: 10 });
   });
 });

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -6,7 +6,7 @@ import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import { useFakeTimers } from 'sinon';
-import { cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
 
 const options = [
   'Show some love to Material-UI',
@@ -67,15 +67,17 @@ describe('<Menu /> integration', () => {
   function waitForExited(transitionDuration) {
     // transitions can't disappear instantly because of react-transition-group
     // exited is only reached on the next commit
-    //clock.tick(transitionDuration + 1);
+    act(() => {
+      clock.tick(transitionDuration + 1);
+    });
   }
 
   beforeEach(() => {
-    //clock = useFakeTimers();
+    clock = useFakeTimers();
   });
 
   afterEach(() => {
-    //clock.restore();
+    clock.restore();
     cleanup();
   });
 

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -6,7 +6,7 @@ import Button from '@material-ui/core/Button';
 import MenuItem from '@material-ui/core/MenuItem';
 import Menu from '@material-ui/core/Menu';
 import { useFakeTimers } from 'sinon';
-import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
 
 const options = [
   'Show some love to Material-UI',
@@ -63,14 +63,6 @@ SimpleMenu.propTypes = { selectedIndex: PropTypes.number };
 describe('<Menu /> integration', () => {
   let clock;
   const render = createClientRender({ strict: false });
-
-  function waitForExited(transitionDuration) {
-    // transitions can't disappear instantly because of react-transition-group
-    // exited is only reached on the next commit
-    act(() => {
-      clock.tick(transitionDuration + 1);
-    });
-  }
 
   beforeEach(() => {
     clock = useFakeTimers();
@@ -286,11 +278,12 @@ describe('<Menu /> integration', () => {
     expect(queryByRole('menu')).to.be.focused;
 
     fireEvent.keyDown(document.activeElement, { key: 'Tab' });
-    waitForExited(0);
+    clock.tick(10);
+
     expect(queryByRole('menu')).to.be.null;
   });
 
-  it('closes the menu when the backdrop is clicked', () => {
+  it.skip('closes the menu when the backdrop is clicked', () => {
     const { queryByRole, getByLabelText } = render(<SimpleMenu transitionDuration={0} />);
     const button = getByLabelText('Open menu');
 
@@ -301,7 +294,7 @@ describe('<Menu /> integration', () => {
     expect(queryByRole('menu')).to.be.focused;
 
     fireEvent.click(document.querySelector('[data-mui-test="Backdrop"]'));
-    waitForExited(0);
+    clock.tick(10);
 
     expect(queryByRole('menu')).to.be.null;
   });

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -67,7 +67,7 @@ describe('<Menu /> integration', () => {
   function waitForExited(transitionDuration) {
     // transitions can't disappear instantly because of react-transition-group
     // exited is only reached on the next commit
-    clock.tick(transitionDuration);
+    clock.tick(transitionDuration + 1);
   }
 
   beforeEach(() => {

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -67,15 +67,15 @@ describe('<Menu /> integration', () => {
   function waitForExited(transitionDuration) {
     // transitions can't disappear instantly because of react-transition-group
     // exited is only reached on the next commit
-    clock.tick(transitionDuration + 1);
+    //clock.tick(transitionDuration + 1);
   }
 
   beforeEach(() => {
-    clock = useFakeTimers();
+    //clock = useFakeTimers();
   });
 
   afterEach(() => {
-    clock.restore();
+    //clock.restore();
     cleanup();
   });
 

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -267,7 +267,7 @@ describe('<Menu /> integration', () => {
     });
   });
 
-  it('closes the menu when Tabbing while the list is active', () => {
+  it.skip('closes the menu when Tabbing while the list is active', () => {
     const { queryByRole, getByLabelText } = render(<SimpleMenu transitionDuration={0} />);
     const button = getByLabelText('Open menu');
 
@@ -283,7 +283,7 @@ describe('<Menu /> integration', () => {
     expect(queryByRole('menu')).to.be.null;
   });
 
-  it.skip('closes the menu when the backdrop is clicked', () => {
+  it('closes the menu when the backdrop is clicked', () => {
     const { queryByRole, getByLabelText } = render(<SimpleMenu transitionDuration={0} />);
     const button = getByLabelText('Open menu');
 


### PR DESCRIPTION
Closes #16683

Replaces `sinon#useFakeTimers` with [async utilities from `@testing-library/react`](https://testing-library.com/docs/dom-testing-library/api-async).

It already timed out just by calling `useFakeTimers` in beforeEach and restoring it in afterEach.

I suspect it has to do with `performance.now` usage in `Menu`. It's not as a meaningful of a test as before but it's better than not testing at all. We can't guarentee exact timings in actual applications anyway.