### PR TITLE
[Modal] Prevent backdrop to stay open

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -85,8 +85,7 @@ const Modal = React.forwardRef(function Modal(props, ref) {
   } = props;
 
   const theme = useTheme();
-  const [exited, setExited] = React.useState(!open);
-  const [hasEnteredTransition, setEnteredTransition] = React.useState(false);
+  const [exited, setExited] = React.useState(true);
   const modal = React.useRef({});
   const mountNodeRef = React.useRef(null);
   const modalRef = React.useRef(null);
@@ -154,13 +153,12 @@ const Modal = React.forwardRef(function Modal(props, ref) {
     [manager],
   );
 
-  if (!keepMounted && !open && (!hasTransition || exited || !hasEnteredTransition)) {
+  if (!keepMounted && !open && (!hasTransition || exited)) {
     return null;
   }
 
   const handleEnter = () => {
     setExited(false);
-    setEnteredTransition(true);
   };
 
   const handleExited = () => {

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -86,6 +86,7 @@ const Modal = React.forwardRef(function Modal(props, ref) {
 
   const theme = useTheme();
   const [exited, setExited] = React.useState(!open);
+  const [hasEnteredTransition, setEnteredTransition] = React.useState(false);
   const modal = React.useRef({});
   const mountNodeRef = React.useRef(null);
   const modalRef = React.useRef(null);
@@ -153,12 +154,13 @@ const Modal = React.forwardRef(function Modal(props, ref) {
     [manager],
   );
 
-  if (!keepMounted && !open && (!hasTransition || exited)) {
+  if (!keepMounted && !open && (!hasTransition || exited || !hasEnteredTransition)) {
     return null;
   }
 
   const handleEnter = () => {
     setExited(false);
+    setEnteredTransition(true);
   };
 
   const handleExited = () => {

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -144,6 +144,27 @@ describe('<Modal />', () => {
       backdropSpan.simulate('click');
       assert.strictEqual(onBackdropClick.callCount, 0);
     });
+
+    // Test case for https://github.com/mui-org/material-ui/issues/12831
+    it('should unmount the children when starting open and closing immediately', () => {
+      function TestCase() {
+        const [open, setOpen] = React.useState(true);
+
+        React.useEffect(() => {
+          setOpen(false);
+        }, []);
+
+        return (
+          <Modal open={open}>
+            <Fade in={open}>
+              <div id="modal-body">hello</div>
+            </Fade>
+          </Modal>
+        );
+      }
+      render(<TestCase />);
+      expect(document.querySelector('#modal-body')).to.equal(null);
+    });
   });
 
   describe('render', () => {

--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -68,7 +68,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
   }, [handlePopperRef]);
   React.useImperativeHandle(popperRefProp, () => popperRef.current, []);
 
-  const [exited, setExited] = React.useState(!open);
+  const [exited, setExited] = React.useState(true);
 
   const rtlPlacement = flipPlacement(initialPlacement);
   /**

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -126,7 +126,7 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
   } = props;
 
   const timerAutoHide = React.useRef();
-  const [exited, setExited] = React.useState(!open);
+  const [exited, setExited] = React.useState(true);
 
   // Timer that controls delay before snackbar auto hides
   const setAutoHideTimer = React.useCallback(


### PR DESCRIPTION
Closes #12831.

After following the comments in the above issue, I indeed noticed that `onExited` was not called. However, I've also noticed that `onEntered` was not called either. This is because the transition is not even rendered.

To solve this, I have added a flag that tells if the transition was entered. If this is not the case, we can remove the modal from the DOM when open is false.

Another simpler solution would be to always set the `exited` state to `true` on mount:
```js
  const [exited, setExited] = React.useState(true);
```
but I wasn't sure of what all the implications could be.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
