### PR TITLE
[Buttons] Remove fourth IconButton size example

### DIFF
--- a/docs/src/pages/components/buttons/ButtonSizes.js
+++ b/docs/src/pages/components/buttons/ButtonSizes.js
@@ -6,7 +6,6 @@ import IconButton from '@material-ui/core/IconButton';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
 import NavigationIcon from '@material-ui/icons/Navigation';
-import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 
 const useStyles = makeStyles(theme => ({
   margin: {
@@ -93,9 +92,6 @@ export default function ButtonSizes() {
         </Fab>
       </div>
       <div>
-        <IconButton aria-label="Delete" className={classes.margin} size="small">
-          <ArrowDownwardIcon fontSize="inherit" />
-        </IconButton>
         <IconButton aria-label="Delete" className={classes.margin}>
           <DeleteIcon fontSize="small" />
         </IconButton>

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -6,7 +6,6 @@ import IconButton from '@material-ui/core/IconButton';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
 import NavigationIcon from '@material-ui/icons/Navigation';
-import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/docs/src/pages/components/buttons/ButtonSizes.tsx
+++ b/docs/src/pages/components/buttons/ButtonSizes.tsx
@@ -95,9 +95,6 @@ export default function ButtonSizes() {
         </Fab>
       </div>
       <div>
-        <IconButton aria-label="Delete" className={classes.margin} size="small">
-          <ArrowDownwardIcon fontSize="inherit" />
-        </IconButton>
         <IconButton aria-label="Delete" className={classes.margin}>
           <DeleteIcon fontSize="small" />
         </IconButton>


### PR DESCRIPTION
The sizes demo contains different types of buttons in three different sizes (small, medium, large). However, the IconButton is shown in four variations, and two different icons. This PR removes the example that does not match the row.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
