### PR TITLE
[docs] Solve 301 redirections

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -114,7 +114,7 @@ module.exports = {
       }),
     });
   },
-  webpackDevMiddleware: config => config,
+  exportTrailingSlash: true,
   // Next.js provides a `defaultPathMap` argument, we could simplify the logic.
   // However, we don't in order to prevent any regression in the `findPages()` method.
   exportPathMap: () => {
@@ -149,11 +149,5 @@ module.exports = {
     }
 
     return map;
-  },
-  onDemandEntries: {
-    // Period (in ms) where the server will keep pages in the buffer
-    maxInactiveAge: 120 * 1e3, // default 25s
-    // Number of pages that should be kept simultaneously without being disposed
-    pagesBufferLength: 3, // default 2
   },
 };

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -53,7 +53,7 @@ renderer.link = (href, title, text) => {
   const userLanguage = global.__MARKED_USER_LANGUAGE__;
   let finalHref = href;
 
-  if (userLanguage !== 'en' && finalHref.indexOf('/') === 0) {
+  if (userLanguage !== 'en' && finalHref.indexOf('/') === 0 && finalHref !== '/size-snapshot') {
     finalHref = `/${userLanguage}${finalHref}`;
   }
 


### PR DESCRIPTION
Tim, from Next.js, put me on the right track, we have an option to restore the previous export behavior; https://github.com/zeit/next.js/blob/canary/UPGRADING.md#next-export-no-longer-exports-pages-as-indexhtml. It seems to solve all the problems on my local tests.

I have some doubt regarding the Ahrefs report. From what I can observe, their crawler has outdated results. The leading dash change has been live for 3 days. I have unpublished it this afternoon. I suspect that the unpublish of the redirections hasn't fully propagated to Ahrefs crawlers yet. I don't get stable results between 2 craw runs. The score increases each time I run it:

![Capture d’écran 2019-07-23 à 22 07 31](https://user-images.githubusercontent.com/3165635/61743846-54263300-ad96-11e9-817d-219f3c238367.png)
