### PR TITLE
[TextareaAutosize] Fix infinite rendering loop

### DIFF
--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -19,6 +19,7 @@ const styles = {
     // Ignore the scrollbar width
     overflow: 'hidden',
     height: '0',
+    top: 0,
   },
 };
 

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -18,7 +18,7 @@ const styles = {
     position: 'absolute',
     // Ignore the scrollbar width
     overflow: 'hidden',
-    height: '0',
+    height: 0,
     top: 0,
   },
 };


### PR DESCRIPTION
In Firefox, the value of `scrollHeight` is unstable. In the `<TextareAutosize>` component, the `scrollHeight` of the hidden `<textarea>` sometimes changes depending on the height of the parent element. This can cause an infinite rendering loop inside the `syncHeight` handler.

Adding a `top: 0` style to the hidden `<textarea>` fixes this problem in Firefox, and the component continues to work in Chrome, IE and Safari.

Closes #16685

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] Ran prettier
- [x] Ran linter
- [x] Ran `<TextareaAutosize />` tests
- [x] Manually tested a previously failing example in Chrome, Firefox, IE and Safari