### PR TITLE
[ci] Merge test_browser and test_production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,18 +116,6 @@ jobs:
       - run:
           name: Tests TypeScript definitions
           command: yarn typescript
-  test_production:
-    <<: *defaults
-    steps:
-      - checkout
-      - install_js
-      - run:
-          name: Can we generate the @material-ui/core umd build?
-          command: yarn workspace @material-ui/core build:umd
-      - prepare_chrome_headless
-      - run:
-          name: Test umd release
-          command: yarn test:umd
   test_browser:
     <<: *defaults
     steps:
@@ -137,6 +125,12 @@ jobs:
       - run:
           name: Tests real browsers
           command: yarn test:karma
+      - run:
+          name: Can we generate the @material-ui/core umd build?
+          command: yarn workspace @material-ui/core build:umd
+      - run:
+          name: Test umd release
+          command: yarn test:umd
   test_regressions:
     <<: *defaults
     docker:
@@ -170,13 +164,9 @@ workflows:
       - test_browser:
           requires:
             - checkout
-      - test_production:
-          requires:
-            - checkout
       - test_regressions:
           requires:
             - test_unit
             - test_static
             - test_types
             - test_browser
-            - test_production


### PR DESCRIPTION
Was originally introduced with the assumption we have at least 5 parallel jobs. Since we only have 4 we will already starve CI with a single build. 

Microjobs are not worth it since every job has a fixed duration of around 1 minute (restore/save cache, install deps). Only ~30% of the time of `test_production` was actually spent in the test.

Merging it with `test_browser` makes sense because it requires the same dependencies.

@oliviertassinari could you remove `test_production` from the required GitHub checks please? 