### PR TITLE
[SelectInput] Fix layout issue with displayEmpty

### DIFF
--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -14,6 +14,10 @@ function areEqualValues(a, b) {
   return String(a) === String(b);
 }
 
+function isEmptyString(val) {
+  return typeof val === 'string' && !val.match(/\S/);
+}
+
 /**
  * @ignore - internal component.
  */
@@ -278,8 +282,12 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         {...SelectDisplayProps}
       >
         {/* So the vertical align positioning algorithm kicks in. */}
-        {/* eslint-disable-next-line react/no-danger */}
-        {display != null ? display : <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />}
+        {display != null && !isEmptyString(display) ? (
+          display
+        ) : (
+          // eslint-disable-next-line react/no-danger
+          <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
+        )}
       </div>
       <input
         value={Array.isArray(value) ? value.join(',') : value}

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -14,8 +14,8 @@ function areEqualValues(a, b) {
   return String(a) === String(b);
 }
 
-function isEmptyString(val) {
-  return typeof val === 'string' && !val.match(/\S/);
+function isEmpty(display) {
+  return display == null || (typeof display === 'string' && !display.trim());
 }
 
 /**
@@ -282,11 +282,11 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         {...SelectDisplayProps}
       >
         {/* So the vertical align positioning algorithm kicks in. */}
-        {display != null && !isEmptyString(display) ? (
-          display
-        ) : (
+        {isEmpty(display) ? (
           // eslint-disable-next-line react/no-danger
           <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
+        ) : (
+          display
         )}
       </div>
       <input

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -1,12 +1,15 @@
 import React from 'react';
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
+import { cleanup, createClientRender } from 'test/utils/createClientRender';
 import Menu from '../Menu';
 import MenuItem from '../MenuItem';
 import SelectInput from './SelectInput';
 
 describe('<SelectInput />', () => {
+  const render = createClientRender({ strict: true });
+
   let shallow;
   let mount;
   const defaultProps = {
@@ -37,6 +40,7 @@ describe('<SelectInput />', () => {
 
   after(() => {
     mount.cleanUp();
+    cleanup();
   });
 
   it('should render a correct top element', () => {
@@ -140,9 +144,14 @@ describe('<SelectInput />', () => {
     });
   });
 
+  it('should render a placeholder if there is no value to display', () => {
+    const { getByRole } = render(<SelectInput {...defaultProps} renderValue={() => '   '} />);
+    expect(getByRole('button').querySelector('span')).to.be.ok;
+  });
+
   describe('prop: displayEmpty', () => {
     it('should display the selected item even if its value is empty', () => {
-      const wrapper = shallow(
+      const wrapper = mount(
         <SelectInput {...defaultProps} value="" displayEmpty>
           <MenuItem value="">Ten</MenuItem>
           <MenuItem value={20}>Twenty</MenuItem>
@@ -156,7 +165,7 @@ describe('<SelectInput />', () => {
   describe('prop: renderValue', () => {
     it('should use the prop to render the value', () => {
       const renderValue = x => String(-x);
-      const wrapper = shallow(<SelectInput {...defaultProps} renderValue={renderValue} />);
+      const wrapper = mount(<SelectInput {...defaultProps} renderValue={renderValue} />);
       assert.strictEqual(wrapper.find(`.${defaultProps.classes.select}`).text(), '-10');
     });
   });
@@ -453,12 +462,12 @@ describe('<SelectInput />', () => {
 
   describe('prop: name', () => {
     it('should have no id when name is not provided', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} />);
+      const wrapper = mount(<SelectInput {...defaultProps} />);
       assert.strictEqual(wrapper.find('.select').props().id, undefined);
     });
 
     it('should have select-`name` id when name is provided', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} name="foo" />);
+      const wrapper = mount(<SelectInput {...defaultProps} name="foo" />);
       assert.strictEqual(wrapper.find('.select').props().id, 'select-foo');
     });
   });


### PR DESCRIPTION
When certain condition with displayEmpty is enabled, SelectInput skips zero-width space hack, leads to layout issue like below:

<img width="744" alt="screenshot" src="https://user-images.githubusercontent.com/400558/61844201-8e4c1d80-aed9-11e9-9283-c614de2720d6.png">

Conditions:
- renderValue function returns blank string (like `''`, `'   '`, `'\n'` or `'\t'`).
- `multiple === true && value === []`

Reproduction:

```diff
diff --git a/docs/src/pages/components/selects/MultipleSelect.js b/docs/src/pages/components/selects/MultipleSelect.js
index 4333b82f8..931c1da6c 100644
--- a/docs/src/pages/components/selects/MultipleSelect.js
+++ b/docs/src/pages/components/selects/MultipleSelect.js
@@ -151,13 +151,6 @@ function handleChangeMultiple(event) {
           value={personName}
           onChange={handleChange}
           input={<Input id="select-multiple-placeholder" />}
-          renderValue={selected => {
-            if (selected.length === 0) {
-              return <em>Placeholder</em>;
-            }
-
-            return selected.join(', ');
-          }}
           MenuProps={MenuProps}
         >
           <MenuItem disabled value="">
diff --git a/docs/src/pages/components/selects/SimpleSelect.js b/docs/src/pages/components/selects/SimpleSelect.js
index 8d0e971c3..49c6f877e 100644
--- a/docs/src/pages/components/selects/SimpleSelect.js
+++ b/docs/src/pages/components/selects/SimpleSelect.js
@@ -81,6 +81,7 @@ function handleChange(event) {
           value={values.age}
           onChange={handleChange}
           displayEmpty
+          renderValue={() => '   '}
           name="age"
           className={classes.selectEmpty}
         >
```