### PR TITLE
[Popper] Fix scroll jump when content contains autofocus input

### DIFF
--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -183,7 +183,7 @@ const Popper = React.forwardRef(function Popper(props, ref) {
         role="tooltip"
         style={{
           // Prevents scroll issue, waiting for Popper.js to add this style once initiated.
-          position: 'absolute',
+          position: 'fixed',
         }}
         {...other}
       >


### PR DESCRIPTION
closes #16740

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
