### PR TITLE
[Dialog] Fix title being announced as clickable

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -46,6 +46,7 @@ export const styles = theme => ({
       height: 'auto',
     },
     // We disable the focus ring for mouse, touch and keyboard users.
+    pointerEvents: 'none',
     outline: 'none',
   },
   /* Styles applied to the `Paper` component. */
@@ -57,6 +58,7 @@ export const styles = theme => ({
       overflowY: 'visible',
       boxShadow: 'none',
     },
+    pointerEvents: 'auto',
   },
   /* Styles applied to the `Paper` component if `scroll="paper"`. */
   paperScrollPaper: {
@@ -172,33 +174,6 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
     ...other
   } = props;
 
-  const mouseDownTarget = React.useRef();
-  const handleMouseDown = event => {
-    mouseDownTarget.current = event.target;
-  };
-  const handleBackdropClick = event => {
-    // Ignore the events not coming from the "backdrop"
-    // We don't want to close the dialog when clicking the dialog content.
-    if (event.target !== event.currentTarget) {
-      return;
-    }
-
-    // Make sure the event starts and ends on the same DOM element.
-    if (event.target !== mouseDownTarget.current) {
-      return;
-    }
-
-    mouseDownTarget.current = null;
-
-    if (onBackdropClick) {
-      onBackdropClick(event);
-    }
-
-    if (!disableBackdropClick && onClose) {
-      onClose(event, 'backdropClick');
-    }
-  };
-
   return (
     <Modal
       className={clsx(classes.root, className)}
@@ -231,9 +206,6 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
       >
         <div
           className={clsx(classes.container, classes[`scroll${capitalize(scroll)}`])}
-          onClick={handleBackdropClick}
-          onMouseDown={handleMouseDown}
-          role="document"
           data-mui-test="FakeBackdrop"
         >
           <PaperComponent


### PR DESCRIPTION
Closes #16758

https://deploy-preview-16762--material-ui.netlify.com/components/dialogs/

[NVDA considers elements clickable if they have a click handler attached](https://github.com/nvaccess/nvda/issues/5830#issuecomment-199778283). This seems to also consider event bubbling. 

We needed to wrap our dialog content in a div to enable `scroll="body"`. This div also needed to implement backdrop logic. It seems like pointer-events: none (container) + pointer-events: auto (dialog) implements the same behavior.

Will test different browsers with the netlify build and then work fix the tests (remove FakeBackdrop).

Test plan:
- when open (SimpleDialog|ScrollDialgo):
  - click title keeps open
  - click content keeps open
  - click onClose buttons closes
  - click outside closes

Working in win 10 latest chrome, edge, ie11

- [ ] ubuntu chrome, firefox
- [ ] chrome android touch instead of click