### PR TITLE
[docs] Document the global class names

### DIFF
--- a/docs/pages/api/app-bar.md
+++ b/docs/pages/api/app-bar.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/AppBar/AppBar.js
 <p class="description">The API documentation of the AppBar React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import AppBar from '@material-ui/core/AppBar';
+import { AppBar } from '@material-ui/core';
 ```
 
 
@@ -29,28 +29,28 @@ Any other properties supplied will be provided to the root element ([Paper](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiAppBar`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiAppBar-root</span> | Styles applied to the root element.
+| <span class="prop-name">positionFixed</span> | <span class="prop-name">MuiAppBar-positionFixed</span> | Styles applied to the root element if `position="fixed"`.
+| <span class="prop-name">positionAbsolute</span> | <span class="prop-name">MuiAppBar-positionAbsolute</span> | Styles applied to the root element if `position="absolute"`.
+| <span class="prop-name">positionSticky</span> | <span class="prop-name">MuiAppBar-positionSticky</span> | Styles applied to the root element if `position="sticky"`.
+| <span class="prop-name">positionStatic</span> | <span class="prop-name">MuiAppBar-positionStatic</span> | Styles applied to the root element if `position="static"`.
+| <span class="prop-name">positionRelative</span> | <span class="prop-name">MuiAppBar-positionRelative</span> | Styles applied to the root element if `position="relative"`.
+| <span class="prop-name">colorDefault</span> | <span class="prop-name">MuiAppBar-colorDefault</span> | Styles applied to the root element if `color="default"`.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiAppBar-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiAppBar-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">positionFixed</span> | Styles applied to the root element if `position="fixed"`.
-| <span class="prop-name">positionAbsolute</span> | Styles applied to the root element if `position="absolute"`.
-| <span class="prop-name">positionSticky</span> | Styles applied to the root element if `position="sticky"`.
-| <span class="prop-name">positionStatic</span> | Styles applied to the root element if `position="static"`.
-| <span class="prop-name">positionRelative</span> | Styles applied to the root element if `position="relative"`.
-| <span class="prop-name">colorDefault</span> | Styles applied to the root element if `color="default"`.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/AppBar/AppBar.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiAppBar`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/AppBar/AppBar.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/avatar.md
+++ b/docs/pages/api/avatar.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Avatar/Avatar.js
 <p class="description">The API documentation of the Avatar React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Avatar from '@material-ui/core/Avatar';
+import { Avatar } from '@material-ui/core';
 ```
 
 
@@ -33,22 +33,22 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiAvatar`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiAvatar-root</span> | Styles applied to the root element.
+| <span class="prop-name">colorDefault</span> | <span class="prop-name">MuiAvatar-colorDefault</span> | Styles applied to the root element if there are children and not `src` or `srcSet`.
+| <span class="prop-name">img</span> | <span class="prop-name">MuiAvatar-img</span> | Styles applied to the img element if either `src` or `srcSet` is defined.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">colorDefault</span> | Styles applied to the root element if there are children and not `src` or `srcSet`.
-| <span class="prop-name">img</span> | Styles applied to the img element if either `src` or `srcSet` is defined.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Avatar/Avatar.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiAvatar`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Avatar/Avatar.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/backdrop.md
+++ b/docs/pages/api/backdrop.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Backdrop/Backdrop.js
 <p class="description">The API documentation of the Backdrop React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Backdrop from '@material-ui/core/Backdrop';
+import { Backdrop } from '@material-ui/core';
 ```
 
 
@@ -29,21 +29,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiBackdrop`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiBackdrop-root</span> | Styles applied to the root element.
+| <span class="prop-name">invisible</span> | <span class="prop-name">MuiBackdrop-invisible</span> | Styles applied to the root element if `invisible={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">invisible</span> | Styles applied to the root element if `invisible={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Backdrop/Backdrop.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiBackdrop`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Backdrop/Backdrop.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/badge.md
+++ b/docs/pages/api/badge.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Badge/Badge.js
 <p class="description">The API documentation of the Badge React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Badge from '@material-ui/core/Badge';
+import { Badge } from '@material-ui/core';
 ```
 
 
@@ -34,26 +34,26 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiBadge`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiBadge-root</span> | Styles applied to the root element.
+| <span class="prop-name">badge</span> | <span class="prop-name">MuiBadge-badge</span> | Styles applied to the badge `span` element.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiBadge-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiBadge-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">colorError</span> | <span class="prop-name">MuiBadge-colorError</span> | Styles applied to the root element if `color="error"`.
+| <span class="prop-name">invisible</span> | <span class="prop-name">MuiBadge-invisible</span> | Styles applied to the badge `span` element if `invisible={true}`.
+| <span class="prop-name">dot</span> | <span class="prop-name">MuiBadge-dot</span> | Styles applied to the root element if `variant="dot"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">badge</span> | Styles applied to the badge `span` element.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">colorError</span> | Styles applied to the root element if `color="error"`.
-| <span class="prop-name">invisible</span> | Styles applied to the badge `span` element if `invisible={true}`.
-| <span class="prop-name">dot</span> | Styles applied to the root element if `variant="dot"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Badge/Badge.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiBadge`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Badge/Badge.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/bottom-navigation-action.md
+++ b/docs/pages/api/bottom-navigation-action.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/BottomNavigationAction/BottomNavigationActio
 <p class="description">The API documentation of the BottomNavigationAction React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import BottomNavigationAction from '@material-ui/core/BottomNavigationAction';
+import { BottomNavigationAction } from '@material-ui/core';
 ```
 
 
@@ -31,24 +31,24 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiBottomNavigationAction`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiBottomNavigationAction-root</span> | Styles applied to the root element.
+| <span class="prop-name">selected</span> | <span class="prop-name">Mui-selected</span> | Pseudo-class applied to the root element if selected.
+| <span class="prop-name">iconOnly</span> | <span class="prop-name">MuiBottomNavigationAction-iconOnly</span> | Pseudo-class applied to the root element if `showLabel={false}` and not selected.
+| <span class="prop-name">wrapper</span> | <span class="prop-name">MuiBottomNavigationAction-wrapper</span> | Styles applied to the span element that wraps the icon and label.
+| <span class="prop-name">label</span> | <span class="prop-name">MuiBottomNavigationAction-label</span> | Styles applied to the label's span element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if selected.
-| <span class="prop-name">iconOnly</span> | Pseudo-class applied to the root element if `showLabel={false}` and not selected.
-| <span class="prop-name">wrapper</span> | Styles applied to the span element that wraps the icon and label.
-| <span class="prop-name">label</span> | Styles applied to the label's span element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiBottomNavigationAction`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/bottom-navigation.md
+++ b/docs/pages/api/bottom-navigation.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/BottomNavigation/BottomNavigation.js
 <p class="description">The API documentation of the BottomNavigation React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import BottomNavigation from '@material-ui/core/BottomNavigation';
+import { BottomNavigation } from '@material-ui/core';
 ```
 
 
@@ -31,20 +31,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiBottomNavigation`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiBottomNavigation-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/BottomNavigation/BottomNavigation.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiBottomNavigation`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/BottomNavigation/BottomNavigation.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/breadcrumbs.md
+++ b/docs/pages/api/breadcrumbs.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
 <p class="description">The API documentation of the Breadcrumbs React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Breadcrumbs from '@material-ui/core/Breadcrumbs';
+import { Breadcrumbs } from '@material-ui/core';
 ```
 
 
@@ -32,23 +32,23 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiBreadcrumbs`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiBreadcrumbs-root</span> | Styles applied to the root element.
+| <span class="prop-name">ol</span> | <span class="prop-name">MuiBreadcrumbs-ol</span> | Styles applied to the ol element.
+| <span class="prop-name">li</span> | <span class="prop-name">MuiBreadcrumbs-li</span> | Styles applied to the li element.
+| <span class="prop-name">separator</span> | <span class="prop-name">MuiBreadcrumbs-separator</span> | Styles applied to the separator element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">ol</span> | Styles applied to the ol element.
-| <span class="prop-name">li</span> | Styles applied to the li element.
-| <span class="prop-name">separator</span> | Styles applied to the separator element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiBreadcrumbs`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/button-base.md
+++ b/docs/pages/api/button-base.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ButtonBase/ButtonBase.js
 <p class="description">The API documentation of the ButtonBase React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ButtonBase from '@material-ui/core/ButtonBase';
+import { ButtonBase } from '@material-ui/core';
 ```
 
 `ButtonBase` contains as few styles as possible.
@@ -41,22 +41,22 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiButtonBase`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiButtonBase-root</span> | Styles applied to the root element.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the root element if keyboard focused.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the root element if keyboard focused.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonBase/ButtonBase.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiButtonBase`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonBase/ButtonBase.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/button-group.md
+++ b/docs/pages/api/button-group.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ButtonGroup/ButtonGroup.js
 <p class="description">The API documentation of the ButtonGroup React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ButtonGroup from '@material-ui/core/ButtonGroup';
+import { ButtonGroup } from '@material-ui/core';
 ```
 
 
@@ -35,29 +35,29 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiButtonGroup`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiButtonGroup-root</span> | Styles applied to the root element.
+| <span class="prop-name">contained</span> | <span class="prop-name">MuiButtonGroup-contained</span> | Styles applied to the root element if variant="contained".
+| <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiButtonGroup-fullWidth</span> | Styles applied to the root element if fullWidth={true}.
+| <span class="prop-name">grouped</span> | <span class="prop-name">MuiButtonGroup-grouped</span> | Styles applied to the children.
+| <span class="prop-name">groupedOutlined</span> | <span class="prop-name">MuiButtonGroup-groupedOutlined</span> | Styles applied to the children if variant="outlined".
+| <span class="prop-name">groupedOutlinedPrimary</span> | <span class="prop-name">MuiButtonGroup-groupedOutlinedPrimary</span> | Styles applied to the children if variant="outlined" & color="primary".
+| <span class="prop-name">groupedOutlinedSecondary</span> | <span class="prop-name">MuiButtonGroup-groupedOutlinedSecondary</span> | Styles applied to the children if variant="outlined" & color="secondary".
+| <span class="prop-name">groupedContained</span> | <span class="prop-name">MuiButtonGroup-groupedContained</span> | Styles applied to the children if variant="contained".
+| <span class="prop-name">groupedContainedPrimary</span> | <span class="prop-name">MuiButtonGroup-groupedContainedPrimary</span> | Styles applied to the children if variant="contained" & color="primary".
+| <span class="prop-name">groupedContainedSecondary</span> | <span class="prop-name">MuiButtonGroup-groupedContainedSecondary</span> | Styles applied to the children if variant="contained" & color="secondary".
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">contained</span> | Styles applied to the root element if variant="contained".
-| <span class="prop-name">fullWidth</span> | Styles applied to the root element if fullWidth={true}.
-| <span class="prop-name">grouped</span> | Styles applied to the children.
-| <span class="prop-name">groupedOutlined</span> | Styles applied to the children if variant="outlined".
-| <span class="prop-name">groupedOutlinedPrimary</span> | Styles applied to the children if variant="outlined" & color="primary".
-| <span class="prop-name">groupedOutlinedSecondary</span> | Styles applied to the children if variant="outlined" & color="secondary".
-| <span class="prop-name">groupedContained</span> | Styles applied to the children if variant="contained".
-| <span class="prop-name">groupedContainedPrimary</span> | Styles applied to the children if variant="contained" & color="primary".
-| <span class="prop-name">groupedContainedSecondary</span> | Styles applied to the children if variant="contained" & color="secondary".
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonGroup/ButtonGroup.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiButtonGroup`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonGroup/ButtonGroup.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/button.md
+++ b/docs/pages/api/button.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Button/Button.js
 <p class="description">The API documentation of the Button React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Button from '@material-ui/core/Button';
+import { Button } from '@material-ui/core';
 ```
 
 
@@ -36,36 +36,36 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiButton`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiButton-root</span> | Styles applied to the root element.
+| <span class="prop-name">label</span> | <span class="prop-name">MuiButton-label</span> | Styles applied to the span element that wraps the children.
+| <span class="prop-name">text</span> | <span class="prop-name">MuiButton-text</span> | Styles applied to the root element if `variant="text"`.
+| <span class="prop-name">textPrimary</span> | <span class="prop-name">MuiButton-textPrimary</span> | Styles applied to the root element if `variant="text"` and `color="primary"`.
+| <span class="prop-name">textSecondary</span> | <span class="prop-name">MuiButton-textSecondary</span> | Styles applied to the root element if `variant="text"` and `color="secondary"`.
+| <span class="prop-name">outlined</span> | <span class="prop-name">MuiButton-outlined</span> | Styles applied to the root element if `variant="outlined"`.
+| <span class="prop-name">outlinedPrimary</span> | <span class="prop-name">MuiButton-outlinedPrimary</span> | Styles applied to the root element if `variant="outlined"` and `color="primary"`.
+| <span class="prop-name">outlinedSecondary</span> | <span class="prop-name">MuiButton-outlinedSecondary</span> | Styles applied to the root element if `variant="outlined"` and `color="secondary"`.
+| <span class="prop-name">contained</span> | <span class="prop-name">MuiButton-contained</span> | Styles applied to the root element if `variant="contained"`.
+| <span class="prop-name">containedPrimary</span> | <span class="prop-name">MuiButton-containedPrimary</span> | Styles applied to the root element if `variant="contained"` and `color="primary"`.
+| <span class="prop-name">containedSecondary</span> | <span class="prop-name">MuiButton-containedSecondary</span> | Styles applied to the root element if `variant="contained"` and `color="secondary"`.
+| <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the button is keyboard focused.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">colorInherit</span> | <span class="prop-name">MuiButton-colorInherit</span> | Styles applied to the root element if `color="inherit"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiButton-sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">sizeLarge</span> | <span class="prop-name">MuiButton-sizeLarge</span> | Styles applied to the root element if `size="large"`.
+| <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiButton-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">label</span> | Styles applied to the span element that wraps the children.
-| <span class="prop-name">text</span> | Styles applied to the root element if `variant="text"`.
-| <span class="prop-name">textPrimary</span> | Styles applied to the root element if `variant="text"` and `color="primary"`.
-| <span class="prop-name">textSecondary</span> | Styles applied to the root element if `variant="text"` and `color="secondary"`.
-| <span class="prop-name">outlined</span> | Styles applied to the root element if `variant="outlined"`.
-| <span class="prop-name">outlinedPrimary</span> | Styles applied to the root element if `variant="outlined"` and `color="primary"`.
-| <span class="prop-name">outlinedSecondary</span> | Styles applied to the root element if `variant="outlined"` and `color="secondary"`.
-| <span class="prop-name">contained</span> | Styles applied to the root element if `variant="contained"`.
-| <span class="prop-name">containedPrimary</span> | Styles applied to the root element if `variant="contained"` and `color="primary"`.
-| <span class="prop-name">containedSecondary</span> | Styles applied to the root element if `variant="contained"` and `color="secondary"`.
-| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the button is keyboard focused.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.
-| <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Button/Button.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiButton`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Button/Button.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/card-action-area.md
+++ b/docs/pages/api/card-action-area.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/CardActionArea/CardActionArea.js
 <p class="description">The API documentation of the CardActionArea React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import CardActionArea from '@material-ui/core/CardActionArea';
+import { CardActionArea } from '@material-ui/core';
 ```
 
 
@@ -27,22 +27,22 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCardActionArea`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiCardActionArea-root</span> | Styles applied to the root element.
+| <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the action area is keyboard focused.
+| <span class="prop-name">focusHighlight</span> | <span class="prop-name">MuiCardActionArea-focusHighlight</span> | Styles applied to the overlay that covers the action area when it is keyboard focused.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the action area is keyboard focused.
-| <span class="prop-name">focusHighlight</span> | Styles applied to the overlay that covers the action area when it is keyboard focused.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardActionArea/CardActionArea.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCardActionArea`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardActionArea/CardActionArea.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/card-actions.md
+++ b/docs/pages/api/card-actions.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/CardActions/CardActions.js
 <p class="description">The API documentation of the CardActions React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import CardActions from '@material-ui/core/CardActions';
+import { CardActions } from '@material-ui/core';
 ```
 
 
@@ -28,21 +28,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCardActions`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiCardActions-root</span> | Styles applied to the root element.
+| <span class="prop-name">spacing</span> | <span class="prop-name">MuiCardActions-spacing</span> | Styles applied to the root element if `disableSpacing={false}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">spacing</span> | Styles applied to the root element if `disableSpacing={false}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardActions/CardActions.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCardActions`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardActions/CardActions.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/card-content.md
+++ b/docs/pages/api/card-content.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/CardContent/CardContent.js
 <p class="description">The API documentation of the CardContent React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import CardContent from '@material-ui/core/CardContent';
+import { CardContent } from '@material-ui/core';
 ```
 
 
@@ -27,20 +27,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCardContent`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiCardContent-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardContent/CardContent.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCardContent`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardContent/CardContent.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/card-header.md
+++ b/docs/pages/api/card-header.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/CardHeader/CardHeader.js
 <p class="description">The API documentation of the CardHeader React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import CardHeader from '@material-ui/core/CardHeader';
+import { CardHeader } from '@material-ui/core';
 ```
 
 
@@ -34,25 +34,25 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCardHeader`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiCardHeader-root</span> | Styles applied to the root element.
+| <span class="prop-name">avatar</span> | <span class="prop-name">MuiCardHeader-avatar</span> | Styles applied to the avatar element.
+| <span class="prop-name">action</span> | <span class="prop-name">MuiCardHeader-action</span> | Styles applied to the action element.
+| <span class="prop-name">content</span> | <span class="prop-name">MuiCardHeader-content</span> | Styles applied to the content wrapper element.
+| <span class="prop-name">title</span> | <span class="prop-name">MuiCardHeader-title</span> | Styles applied to the title Typography element.
+| <span class="prop-name">subheader</span> | <span class="prop-name">MuiCardHeader-subheader</span> | Styles applied to the subheader Typography element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">avatar</span> | Styles applied to the avatar element.
-| <span class="prop-name">action</span> | Styles applied to the action element.
-| <span class="prop-name">content</span> | Styles applied to the content wrapper element.
-| <span class="prop-name">title</span> | Styles applied to the title Typography element.
-| <span class="prop-name">subheader</span> | Styles applied to the subheader Typography element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardHeader/CardHeader.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCardHeader`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardHeader/CardHeader.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/card-media.md
+++ b/docs/pages/api/card-media.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/CardMedia/CardMedia.js
 <p class="description">The API documentation of the CardMedia React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import CardMedia from '@material-ui/core/CardMedia';
+import { CardMedia } from '@material-ui/core';
 ```
 
 
@@ -29,21 +29,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCardMedia`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiCardMedia-root</span> | Styles applied to the root element.
+| <span class="prop-name">media</span> | <span class="prop-name">MuiCardMedia-media</span> | Styles applied to the root element if `component="video, audio, picture, iframe, or img"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">media</span> | Styles applied to the root element if `component="video, audio, picture, iframe, or img"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardMedia/CardMedia.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCardMedia`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CardMedia/CardMedia.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/card.md
+++ b/docs/pages/api/card.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Card/Card.js
 <p class="description">The API documentation of the Card React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Card from '@material-ui/core/Card';
+import { Card } from '@material-ui/core';
 ```
 
 
@@ -27,20 +27,20 @@ Any other properties supplied will be provided to the root element ([Paper](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCard`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiCard-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Card/Card.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCard`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Card/Card.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/checkbox.md
+++ b/docs/pages/api/checkbox.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Checkbox/Checkbox.js
 <p class="description">The API documentation of the Checkbox React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Checkbox from '@material-ui/core/Checkbox';
+import { Checkbox } from '@material-ui/core';
 ```
 
 
@@ -40,25 +40,25 @@ Any other properties supplied will be provided to the root element ([IconButton]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCheckbox`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiCheckbox-root</span> | Styles applied to the root element.
+| <span class="prop-name">checked</span> | <span class="prop-name">Mui-checked</span> | Pseudo-class applied to the root element if `checked={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">indeterminate</span> | <span class="prop-name">MuiCheckbox-indeterminate</span> | Pseudo-class applied to the root element if `indeterminate={true}`.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiCheckbox-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiCheckbox-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">checked</span> | Pseudo-class applied to the root element if `checked={true}`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">indeterminate</span> | Pseudo-class applied to the root element if `indeterminate={true}`.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Checkbox/Checkbox.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCheckbox`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Checkbox/Checkbox.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/chip.md
+++ b/docs/pages/api/chip.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Chip/Chip.js
 <p class="description">The API documentation of the Chip React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Chip from '@material-ui/core/Chip';
+import { Chip } from '@material-ui/core';
 ```
 
 Chips represent complex entities in small blocks, such as a contact.
@@ -37,49 +37,49 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiChip`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiChip-root</span> | Styles applied to the root element.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiChip-sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiChip-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiChip-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">clickable</span> | <span class="prop-name">MuiChip-clickable</span> | Styles applied to the root element if `onClick` is defined or `clickable={true}`.
+| <span class="prop-name">clickableColorPrimary</span> | <span class="prop-name">MuiChip-clickableColorPrimary</span> | Styles applied to the root element if `onClick` and `color="primary"` is defined or `clickable={true}`.
+| <span class="prop-name">clickableColorSecondary</span> | <span class="prop-name">MuiChip-clickableColorSecondary</span> | Styles applied to the root element if `onClick` and `color="secondary"` is defined or `clickable={true}`.
+| <span class="prop-name">deletable</span> | <span class="prop-name">MuiChip-deletable</span> | Styles applied to the root element if `onDelete` is defined.
+| <span class="prop-name">deletableColorPrimary</span> | <span class="prop-name">MuiChip-deletableColorPrimary</span> | Styles applied to the root element if `onDelete` and `color="primary"` is defined.
+| <span class="prop-name">deletableColorSecondary</span> | <span class="prop-name">MuiChip-deletableColorSecondary</span> | Styles applied to the root element if `onDelete` and `color="secondary"` is defined.
+| <span class="prop-name">outlined</span> | <span class="prop-name">MuiChip-outlined</span> | Styles applied to the root element if `variant="outlined"`.
+| <span class="prop-name">outlinedPrimary</span> | <span class="prop-name">MuiChip-outlinedPrimary</span> | Styles applied to the root element if `variant="outlined"` and `color="primary"`.
+| <span class="prop-name">outlinedSecondary</span> | <span class="prop-name">MuiChip-outlinedSecondary</span> | Styles applied to the root element if `variant="outlined"` and `color="secondary"`.
+| <span class="prop-name">avatar</span> | <span class="prop-name">MuiChip-avatar</span> | Styles applied to the `avatar` element.
+| <span class="prop-name">avatarSmall</span> | <span class="prop-name">MuiChip-avatarSmall</span> | 
+| <span class="prop-name">avatarColorPrimary</span> | <span class="prop-name">MuiChip-avatarColorPrimary</span> | Styles applied to the `avatar` element if `color="primary"`.
+| <span class="prop-name">avatarColorSecondary</span> | <span class="prop-name">MuiChip-avatarColorSecondary</span> | Styles applied to the `avatar` element if `color="secondary"`.
+| <span class="prop-name">avatarChildren</span> | <span class="prop-name">MuiChip-avatarChildren</span> | Styles applied to the `avatar` elements children.
+| <span class="prop-name">icon</span> | <span class="prop-name">MuiChip-icon</span> | Styles applied to the `icon` element.
+| <span class="prop-name">iconSmall</span> | <span class="prop-name">MuiChip-iconSmall</span> | 
+| <span class="prop-name">iconColorPrimary</span> | <span class="prop-name">MuiChip-iconColorPrimary</span> | Styles applied to the `icon` element if `color="primary"`.
+| <span class="prop-name">iconColorSecondary</span> | <span class="prop-name">MuiChip-iconColorSecondary</span> | Styles applied to the `icon` element if `color="secondary"`.
+| <span class="prop-name">label</span> | <span class="prop-name">MuiChip-label</span> | Styles applied to the label `span` element`.
+| <span class="prop-name">labelSmall</span> | <span class="prop-name">MuiChip-labelSmall</span> | 
+| <span class="prop-name">deleteIcon</span> | <span class="prop-name">MuiChip-deleteIcon</span> | Styles applied to the `deleteIcon` element.
+| <span class="prop-name">deleteIconSmall</span> | <span class="prop-name">MuiChip-deleteIconSmall</span> | 
+| <span class="prop-name">deleteIconColorPrimary</span> | <span class="prop-name">MuiChip-deleteIconColorPrimary</span> | Styles applied to the deleteIcon element if `color="primary"` and `variant="default"`.
+| <span class="prop-name">deleteIconColorSecondary</span> | <span class="prop-name">MuiChip-deleteIconColorSecondary</span> | Styles applied to the deleteIcon element if `color="secondary"` and `variant="default"`.
+| <span class="prop-name">deleteIconOutlinedColorPrimary</span> | <span class="prop-name">MuiChip-deleteIconOutlinedColorPrimary</span> | Styles applied to the deleteIcon element if `color="primary"` and `variant="outlined"`.
+| <span class="prop-name">deleteIconOutlinedColorSecondary</span> | <span class="prop-name">MuiChip-deleteIconOutlinedColorSecondary</span> | Styles applied to the deleteIcon element if `color="secondary"` and `variant="outlined"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">clickable</span> | Styles applied to the root element if `onClick` is defined or `clickable={true}`.
-| <span class="prop-name">clickableColorPrimary</span> | Styles applied to the root element if `onClick` and `color="primary"` is defined or `clickable={true}`.
-| <span class="prop-name">clickableColorSecondary</span> | Styles applied to the root element if `onClick` and `color="secondary"` is defined or `clickable={true}`.
-| <span class="prop-name">deletable</span> | Styles applied to the root element if `onDelete` is defined.
-| <span class="prop-name">deletableColorPrimary</span> | Styles applied to the root element if `onDelete` and `color="primary"` is defined.
-| <span class="prop-name">deletableColorSecondary</span> | Styles applied to the root element if `onDelete` and `color="secondary"` is defined.
-| <span class="prop-name">outlined</span> | Styles applied to the root element if `variant="outlined"`.
-| <span class="prop-name">outlinedPrimary</span> | Styles applied to the root element if `variant="outlined"` and `color="primary"`.
-| <span class="prop-name">outlinedSecondary</span> | Styles applied to the root element if `variant="outlined"` and `color="secondary"`.
-| <span class="prop-name">avatar</span> | Styles applied to the `avatar` element.
-| <span class="prop-name">avatarSmall</span> | 
-| <span class="prop-name">avatarColorPrimary</span> | Styles applied to the `avatar` element if `color="primary"`.
-| <span class="prop-name">avatarColorSecondary</span> | Styles applied to the `avatar` element if `color="secondary"`.
-| <span class="prop-name">avatarChildren</span> | Styles applied to the `avatar` elements children.
-| <span class="prop-name">icon</span> | Styles applied to the `icon` element.
-| <span class="prop-name">iconSmall</span> | 
-| <span class="prop-name">iconColorPrimary</span> | Styles applied to the `icon` element if `color="primary"`.
-| <span class="prop-name">iconColorSecondary</span> | Styles applied to the `icon` element if `color="secondary"`.
-| <span class="prop-name">label</span> | Styles applied to the label `span` element`.
-| <span class="prop-name">labelSmall</span> | 
-| <span class="prop-name">deleteIcon</span> | Styles applied to the `deleteIcon` element.
-| <span class="prop-name">deleteIconSmall</span> | 
-| <span class="prop-name">deleteIconColorPrimary</span> | Styles applied to the deleteIcon element if `color="primary"` and `variant="default"`.
-| <span class="prop-name">deleteIconColorSecondary</span> | Styles applied to the deleteIcon element if `color="secondary"` and `variant="default"`.
-| <span class="prop-name">deleteIconOutlinedColorPrimary</span> | Styles applied to the deleteIcon element if `color="primary"` and `variant="outlined"`.
-| <span class="prop-name">deleteIconOutlinedColorSecondary</span> | Styles applied to the deleteIcon element if `color="secondary"` and `variant="outlined"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Chip/Chip.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiChip`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Chip/Chip.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/circular-progress.md
+++ b/docs/pages/api/circular-progress.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/CircularProgress/CircularProgress.js
 <p class="description">The API documentation of the CircularProgress React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import CircularProgress from '@material-ui/core/CircularProgress';
+import { CircularProgress } from '@material-ui/core';
 ```
 
 ## ARIA
@@ -36,29 +36,29 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCircularProgress`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiCircularProgress-root</span> | Styles applied to the root element.
+| <span class="prop-name">static</span> | <span class="prop-name">MuiCircularProgress-static</span> | Styles applied to the root element if `variant="static"`.
+| <span class="prop-name">indeterminate</span> | <span class="prop-name">MuiCircularProgress-indeterminate</span> | Styles applied to the root element if `variant="indeterminate"`.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiCircularProgress-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiCircularProgress-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">svg</span> | <span class="prop-name">MuiCircularProgress-svg</span> | Styles applied to the `svg` element.
+| <span class="prop-name">circle</span> | <span class="prop-name">MuiCircularProgress-circle</span> | Styles applied to the `circle` svg path.
+| <span class="prop-name">circleStatic</span> | <span class="prop-name">MuiCircularProgress-circleStatic</span> | Styles applied to the `circle` svg path if `variant="static"`.
+| <span class="prop-name">circleIndeterminate</span> | <span class="prop-name">MuiCircularProgress-circleIndeterminate</span> | Styles applied to the `circle` svg path if `variant="indeterminate"`.
+| <span class="prop-name">circleDisableShrink</span> | <span class="prop-name">MuiCircularProgress-circleDisableShrink</span> | Styles applied to the `circle` svg path if `disableShrink={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">static</span> | Styles applied to the root element if `variant="static"`.
-| <span class="prop-name">indeterminate</span> | Styles applied to the root element if `variant="indeterminate"`.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">svg</span> | Styles applied to the `svg` element.
-| <span class="prop-name">circle</span> | Styles applied to the `circle` svg path.
-| <span class="prop-name">circleStatic</span> | Styles applied to the `circle` svg path if `variant="static"`.
-| <span class="prop-name">circleIndeterminate</span> | Styles applied to the `circle` svg path if `variant="indeterminate"`.
-| <span class="prop-name">circleDisableShrink</span> | Styles applied to the `circle` svg path if `disableShrink={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CircularProgress/CircularProgress.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCircularProgress`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/CircularProgress/CircularProgress.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/click-away-listener.md
+++ b/docs/pages/api/click-away-listener.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
 <p class="description">The API documentation of the ClickAwayListener React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import { ClickAwayListener } from '@material-ui/core';
 ```
 
 Listen for click events that occur somewhere in the document, outside of the element itself.

--- a/docs/pages/api/collapse.md
+++ b/docs/pages/api/collapse.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Collapse/Collapse.js
 <p class="description">The API documentation of the Collapse React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Collapse from '@material-ui/core/Collapse';
+import { Collapse } from '@material-ui/core';
 ```
 
 The Collapse transition is used by the
@@ -33,24 +33,24 @@ Any other properties supplied will be provided to the root element ([Transition]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiCollapse`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">container</span> | <span class="prop-name">MuiCollapse-container</span> | Styles applied to the container element.
+| <span class="prop-name">entered</span> | <span class="prop-name">MuiCollapse-entered</span> | Styles applied to the container element when the transition has entered.
+| <span class="prop-name">hidden</span> | <span class="prop-name">MuiCollapse-hidden</span> | Styles applied to the container element when the transition has exited and `collapsedHeight` != 0px.
+| <span class="prop-name">wrapper</span> | <span class="prop-name">MuiCollapse-wrapper</span> | Styles applied to the outer wrapper element.
+| <span class="prop-name">wrapperInner</span> | <span class="prop-name">MuiCollapse-wrapperInner</span> | Styles applied to the inner wrapper element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">container</span> | Styles applied to the container element.
-| <span class="prop-name">entered</span> | Styles applied to the container element when the transition has entered.
-| <span class="prop-name">hidden</span> | Styles applied to the container element when the transition has exited and `collapsedHeight` != 0px.
-| <span class="prop-name">wrapper</span> | Styles applied to the outer wrapper element.
-| <span class="prop-name">wrapperInner</span> | Styles applied to the inner wrapper element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Collapse/Collapse.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiCollapse`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Collapse/Collapse.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/container.md
+++ b/docs/pages/api/container.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Container/Container.js
 <p class="description">The API documentation of the Container React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Container from '@material-ui/core/Container';
+import { Container } from '@material-ui/core';
 ```
 
 
@@ -30,26 +30,26 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiContainer`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiContainer-root</span> | Styles applied to the root element.
+| <span class="prop-name">fixed</span> | <span class="prop-name">MuiContainer-fixed</span> | Styles applied to the root element if `fixed={true}`.
+| <span class="prop-name">maxWidthXs</span> | <span class="prop-name">MuiContainer-maxWidthXs</span> | Styles applied to the root element if `maxWidth="xs"`.
+| <span class="prop-name">maxWidthSm</span> | <span class="prop-name">MuiContainer-maxWidthSm</span> | Styles applied to the root element if `maxWidth="sm"`.
+| <span class="prop-name">maxWidthMd</span> | <span class="prop-name">MuiContainer-maxWidthMd</span> | Styles applied to the root element if `maxWidth="md"`.
+| <span class="prop-name">maxWidthLg</span> | <span class="prop-name">MuiContainer-maxWidthLg</span> | Styles applied to the root element if `maxWidth="lg"`.
+| <span class="prop-name">maxWidthXl</span> | <span class="prop-name">MuiContainer-maxWidthXl</span> | Styles applied to the root element if `maxWidth="xl"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">fixed</span> | Styles applied to the root element if `fixed={true}`.
-| <span class="prop-name">maxWidthXs</span> | Styles applied to the root element if `maxWidth="xs"`.
-| <span class="prop-name">maxWidthSm</span> | Styles applied to the root element if `maxWidth="sm"`.
-| <span class="prop-name">maxWidthMd</span> | Styles applied to the root element if `maxWidth="md"`.
-| <span class="prop-name">maxWidthLg</span> | Styles applied to the root element if `maxWidth="lg"`.
-| <span class="prop-name">maxWidthXl</span> | Styles applied to the root element if `maxWidth="xl"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Container/Container.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiContainer`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Container/Container.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/css-baseline.md
+++ b/docs/pages/api/css-baseline.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/CssBaseline/CssBaseline.js
 <p class="description">The API documentation of the CssBaseline React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import CssBaseline from '@material-ui/core/CssBaseline';
+import { CssBaseline } from '@material-ui/core';
 ```
 
 Kickstart an elegant, consistent, and simple baseline to build upon.

--- a/docs/pages/api/dialog-actions.md
+++ b/docs/pages/api/dialog-actions.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/DialogActions/DialogActions.js
 <p class="description">The API documentation of the DialogActions React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import DialogActions from '@material-ui/core/DialogActions';
+import { DialogActions } from '@material-ui/core';
 ```
 
 
@@ -28,21 +28,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiDialogActions`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiDialogActions-root</span> | Styles applied to the root element.
+| <span class="prop-name">spacing</span> | <span class="prop-name">MuiDialogActions-spacing</span> | Styles applied to the root element if `disableSpacing={false}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">spacing</span> | Styles applied to the root element if `disableSpacing={false}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogActions/DialogActions.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiDialogActions`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogActions/DialogActions.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/dialog-content-text.md
+++ b/docs/pages/api/dialog-content-text.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/DialogContentText/DialogContentText.js
 <p class="description">The API documentation of the DialogContentText React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import DialogContentText from '@material-ui/core/DialogContentText';
+import { DialogContentText } from '@material-ui/core';
 ```
 
 
@@ -27,20 +27,20 @@ Any other properties supplied will be provided to the root element ([Typography]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiDialogContentText`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiDialogContentText-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogContentText/DialogContentText.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiDialogContentText`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogContentText/DialogContentText.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/dialog-content.md
+++ b/docs/pages/api/dialog-content.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/DialogContent/DialogContent.js
 <p class="description">The API documentation of the DialogContent React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import DialogContent from '@material-ui/core/DialogContent';
+import { DialogContent } from '@material-ui/core';
 ```
 
 
@@ -28,21 +28,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiDialogContent`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiDialogContent-root</span> | Styles applied to the root element.
+| <span class="prop-name">dividers</span> | <span class="prop-name">MuiDialogContent-dividers</span> | Styles applied to the root element if `dividers={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">dividers</span> | Styles applied to the root element if `dividers={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogContent/DialogContent.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiDialogContent`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogContent/DialogContent.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/dialog-title.md
+++ b/docs/pages/api/dialog-title.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/DialogTitle/DialogTitle.js
 <p class="description">The API documentation of the DialogTitle React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import DialogTitle from '@material-ui/core/DialogTitle';
+import { DialogTitle } from '@material-ui/core';
 ```
 
 
@@ -28,20 +28,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiDialogTitle`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiDialogTitle-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogTitle/DialogTitle.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiDialogTitle`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/DialogTitle/DialogTitle.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/dialog.md
+++ b/docs/pages/api/dialog.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Dialog/Dialog.js
 <p class="description">The API documentation of the Dialog React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Dialog from '@material-ui/core/Dialog';
+import { Dialog } from '@material-ui/core';
 ```
 
 Dialogs are overlaid modal paper based components with a backdrop.
@@ -48,34 +48,34 @@ Any other properties supplied will be provided to the root element ([Modal](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiDialog`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiDialog-root</span> | Styles applied to the root element.
+| <span class="prop-name">scrollPaper</span> | <span class="prop-name">MuiDialog-scrollPaper</span> | Styles applied to the container element if `scroll="paper"`.
+| <span class="prop-name">scrollBody</span> | <span class="prop-name">MuiDialog-scrollBody</span> | Styles applied to the container element if `scroll="body"`.
+| <span class="prop-name">container</span> | <span class="prop-name">MuiDialog-container</span> | Styles applied to the container element.
+| <span class="prop-name">paper</span> | <span class="prop-name">MuiDialog-paper</span> | Styles applied to the `Paper` component.
+| <span class="prop-name">paperScrollPaper</span> | <span class="prop-name">MuiDialog-paperScrollPaper</span> | Styles applied to the `Paper` component if `scroll="paper"`.
+| <span class="prop-name">paperScrollBody</span> | <span class="prop-name">MuiDialog-paperScrollBody</span> | Styles applied to the `Paper` component if `scroll="body"`.
+| <span class="prop-name">paperWidthFalse</span> | <span class="prop-name">MuiDialog-paperWidthFalse</span> | Styles applied to the `Paper` component if `maxWidth=false`.
+| <span class="prop-name">paperWidthXs</span> | <span class="prop-name">MuiDialog-paperWidthXs</span> | Styles applied to the `Paper` component if `maxWidth="xs"`.
+| <span class="prop-name">paperWidthSm</span> | <span class="prop-name">MuiDialog-paperWidthSm</span> | Styles applied to the `Paper` component if `maxWidth="sm"`.
+| <span class="prop-name">paperWidthMd</span> | <span class="prop-name">MuiDialog-paperWidthMd</span> | Styles applied to the `Paper` component if `maxWidth="md"`.
+| <span class="prop-name">paperWidthLg</span> | <span class="prop-name">MuiDialog-paperWidthLg</span> | Styles applied to the `Paper` component if `maxWidth="lg"`.
+| <span class="prop-name">paperWidthXl</span> | <span class="prop-name">MuiDialog-paperWidthXl</span> | Styles applied to the `Paper` component if `maxWidth="xl"`.
+| <span class="prop-name">paperFullWidth</span> | <span class="prop-name">MuiDialog-paperFullWidth</span> | Styles applied to the `Paper` component if `fullWidth={true}`.
+| <span class="prop-name">paperFullScreen</span> | <span class="prop-name">MuiDialog-paperFullScreen</span> | Styles applied to the `Paper` component if `fullScreen={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">scrollPaper</span> | Styles applied to the container element if `scroll="paper"`.
-| <span class="prop-name">scrollBody</span> | Styles applied to the container element if `scroll="body"`.
-| <span class="prop-name">container</span> | Styles applied to the container element.
-| <span class="prop-name">paper</span> | Styles applied to the `Paper` component.
-| <span class="prop-name">paperScrollPaper</span> | Styles applied to the `Paper` component if `scroll="paper"`.
-| <span class="prop-name">paperScrollBody</span> | Styles applied to the `Paper` component if `scroll="body"`.
-| <span class="prop-name">paperWidthFalse</span> | Styles applied to the `Paper` component if `maxWidth=false`.
-| <span class="prop-name">paperWidthXs</span> | Styles applied to the `Paper` component if `maxWidth="xs"`.
-| <span class="prop-name">paperWidthSm</span> | Styles applied to the `Paper` component if `maxWidth="sm"`.
-| <span class="prop-name">paperWidthMd</span> | Styles applied to the `Paper` component if `maxWidth="md"`.
-| <span class="prop-name">paperWidthLg</span> | Styles applied to the `Paper` component if `maxWidth="lg"`.
-| <span class="prop-name">paperWidthXl</span> | Styles applied to the `Paper` component if `maxWidth="xl"`.
-| <span class="prop-name">paperFullWidth</span> | Styles applied to the `Paper` component if `fullWidth={true}`.
-| <span class="prop-name">paperFullScreen</span> | Styles applied to the `Paper` component if `fullScreen={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Dialog/Dialog.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiDialog`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Dialog/Dialog.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/divider.md
+++ b/docs/pages/api/divider.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Divider/Divider.js
 <p class="description">The API documentation of the Divider React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Divider from '@material-ui/core/Divider';
+import { Divider } from '@material-ui/core';
 ```
 
 
@@ -30,24 +30,24 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiDivider`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiDivider-root</span> | Styles applied to the root element.
+| <span class="prop-name">absolute</span> | <span class="prop-name">MuiDivider-absolute</span> | Styles applied to the root element if `absolute={true}`.
+| <span class="prop-name">inset</span> | <span class="prop-name">MuiDivider-inset</span> | Styles applied to the root element if `variant="inset"`.
+| <span class="prop-name">light</span> | <span class="prop-name">MuiDivider-light</span> | Styles applied to the root element if `light={true}`.
+| <span class="prop-name">middle</span> | <span class="prop-name">MuiDivider-middle</span> | Styles applied to the root element if `variant="middle"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">absolute</span> | Styles applied to the root element if `absolute={true}`.
-| <span class="prop-name">inset</span> | Styles applied to the root element if `variant="inset"`.
-| <span class="prop-name">light</span> | Styles applied to the root element if `light={true}`.
-| <span class="prop-name">middle</span> | Styles applied to the root element if `variant="middle"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Divider/Divider.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiDivider`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Divider/Divider.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/drawer.md
+++ b/docs/pages/api/drawer.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Drawer/Drawer.js
 <p class="description">The API documentation of the Drawer React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Drawer from '@material-ui/core/Drawer';
+import { Drawer } from '@material-ui/core';
 ```
 
 The properties of the [Modal](/api/modal/) component are available
@@ -37,31 +37,31 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiDrawer`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiDrawer-root</span> | Styles applied to the root element.
+| <span class="prop-name">docked</span> | <span class="prop-name">MuiDrawer-docked</span> | Styles applied to the root element if `variant="permanent or persistent"`.
+| <span class="prop-name">paper</span> | <span class="prop-name">MuiDrawer-paper</span> | Styles applied to the `Paper` component.
+| <span class="prop-name">paperAnchorLeft</span> | <span class="prop-name">MuiDrawer-paperAnchorLeft</span> | Styles applied to the `Paper` component if `anchor="left"`.
+| <span class="prop-name">paperAnchorRight</span> | <span class="prop-name">MuiDrawer-paperAnchorRight</span> | Styles applied to the `Paper` component if `anchor="right"`.
+| <span class="prop-name">paperAnchorTop</span> | <span class="prop-name">MuiDrawer-paperAnchorTop</span> | Styles applied to the `Paper` component if `anchor="top"`.
+| <span class="prop-name">paperAnchorBottom</span> | <span class="prop-name">MuiDrawer-paperAnchorBottom</span> | Styles applied to the `Paper` component if `anchor="bottom"`.
+| <span class="prop-name">paperAnchorDockedLeft</span> | <span class="prop-name">MuiDrawer-paperAnchorDockedLeft</span> | Styles applied to the `Paper` component if `anchor="left"` & `variant` is not "temporary".
+| <span class="prop-name">paperAnchorDockedTop</span> | <span class="prop-name">MuiDrawer-paperAnchorDockedTop</span> | Styles applied to the `Paper` component if `anchor="top"` & `variant` is not "temporary".
+| <span class="prop-name">paperAnchorDockedRight</span> | <span class="prop-name">MuiDrawer-paperAnchorDockedRight</span> | Styles applied to the `Paper` component if `anchor="right"` & `variant` is not "temporary".
+| <span class="prop-name">paperAnchorDockedBottom</span> | <span class="prop-name">MuiDrawer-paperAnchorDockedBottom</span> | Styles applied to the `Paper` component if `anchor="bottom"` & `variant` is not "temporary".
+| <span class="prop-name">modal</span> | <span class="prop-name">MuiDrawer-modal</span> | Styles applied to the `Modal` component.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">docked</span> | Styles applied to the root element if `variant="permanent or persistent"`.
-| <span class="prop-name">paper</span> | Styles applied to the `Paper` component.
-| <span class="prop-name">paperAnchorLeft</span> | Styles applied to the `Paper` component if `anchor="left"`.
-| <span class="prop-name">paperAnchorRight</span> | Styles applied to the `Paper` component if `anchor="right"`.
-| <span class="prop-name">paperAnchorTop</span> | Styles applied to the `Paper` component if `anchor="top"`.
-| <span class="prop-name">paperAnchorBottom</span> | Styles applied to the `Paper` component if `anchor="bottom"`.
-| <span class="prop-name">paperAnchorDockedLeft</span> | Styles applied to the `Paper` component if `anchor="left"` & `variant` is not "temporary".
-| <span class="prop-name">paperAnchorDockedTop</span> | Styles applied to the `Paper` component if `anchor="top"` & `variant` is not "temporary".
-| <span class="prop-name">paperAnchorDockedRight</span> | Styles applied to the `Paper` component if `anchor="right"` & `variant` is not "temporary".
-| <span class="prop-name">paperAnchorDockedBottom</span> | Styles applied to the `Paper` component if `anchor="bottom"` & `variant` is not "temporary".
-| <span class="prop-name">modal</span> | Styles applied to the `Modal` component.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Drawer/Drawer.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiDrawer`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Drawer/Drawer.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/expansion-panel-actions.md
+++ b/docs/pages/api/expansion-panel-actions.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.
 <p class="description">The API documentation of the ExpansionPanelActions React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
+import { ExpansionPanelActions } from '@material-ui/core';
 ```
 
 
@@ -28,21 +28,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiExpansionPanelActions`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiExpansionPanelActions-root</span> | Styles applied to the root element.
+| <span class="prop-name">spacing</span> | <span class="prop-name">MuiExpansionPanelActions-spacing</span> | Styles applied to the root element if `disableSpacing={false}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">spacing</span> | Styles applied to the root element if `disableSpacing={false}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiExpansionPanelActions`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/expansion-panel-details.md
+++ b/docs/pages/api/expansion-panel-details.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.
 <p class="description">The API documentation of the ExpansionPanelDetails React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
+import { ExpansionPanelDetails } from '@material-ui/core';
 ```
 
 
@@ -27,20 +27,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiExpansionPanelDetails`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiExpansionPanelDetails-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiExpansionPanelDetails`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/expansion-panel-summary.md
+++ b/docs/pages/api/expansion-panel-summary.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.
 <p class="description">The API documentation of the ExpansionPanelSummary React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
+import { ExpansionPanelSummary } from '@material-ui/core';
 ```
 
 
@@ -29,25 +29,25 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiExpansionPanelSummary`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiExpansionPanelSummary-root</span> | Styles applied to the root element.
+| <span class="prop-name">expanded</span> | <span class="prop-name">Mui-expanded</span> | Styles applied to the root element, children wrapper element and `IconButton` component if `expanded={true}`.
+| <span class="prop-name">focused</span> | <span class="prop-name">Mui-focused</span> | Styles applied to the root and children wrapper elements when focused.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">content</span> | <span class="prop-name">MuiExpansionPanelSummary-content</span> | Styles applied to the children wrapper element.
+| <span class="prop-name">expandIcon</span> | <span class="prop-name">MuiExpansionPanelSummary-expandIcon</span> | Styles applied to the `IconButton` component when `expandIcon` is supplied.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">expanded</span> | Styles applied to the root element, children wrapper element and `IconButton` component if `expanded={true}`.
-| <span class="prop-name">focused</span> | Styles applied to the root and children wrapper elements when focused.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">content</span> | Styles applied to the children wrapper element.
-| <span class="prop-name">expandIcon</span> | Styles applied to the `IconButton` component when `expandIcon` is supplied.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiExpansionPanelSummary`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/expansion-panel.md
+++ b/docs/pages/api/expansion-panel.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
 <p class="description">The API documentation of the ExpansionPanel React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ExpansionPanel from '@material-ui/core/ExpansionPanel';
+import { ExpansionPanel } from '@material-ui/core';
 ```
 
 
@@ -33,23 +33,23 @@ Any other properties supplied will be provided to the root element ([Paper](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiExpansionPanel`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiExpansionPanel-root</span> | Styles applied to the root element.
+| <span class="prop-name">rounded</span> | <span class="prop-name">MuiExpansionPanel-rounded</span> | Styles applied to the root element if `square={false}`.
+| <span class="prop-name">expanded</span> | <span class="prop-name">Mui-expanded</span> | Styles applied to the root element if `expanded={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Styles applied to the root element if `disabled={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">rounded</span> | Styles applied to the root element if `square={false}`.
-| <span class="prop-name">expanded</span> | Styles applied to the root element if `expanded={true}`.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiExpansionPanel`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/fab.md
+++ b/docs/pages/api/fab.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Fab/Fab.js
 <p class="description">The API documentation of the Fab React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Fab from '@material-ui/core/Fab';
+import { Fab } from '@material-ui/core';
 ```
 
 
@@ -35,29 +35,29 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiFab`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiFab-root</span> | Styles applied to the root element.
+| <span class="prop-name">label</span> | <span class="prop-name">MuiFab-label</span> | Styles applied to the span element that wraps the children.
+| <span class="prop-name">primary</span> | <span class="prop-name">MuiFab-primary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">secondary</span> | <span class="prop-name">MuiFab-secondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">extended</span> | <span class="prop-name">MuiFab-extended</span> | Styles applied to the root element if `variant="extended"`.
+| <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the button is keyboard focused.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">colorInherit</span> | <span class="prop-name">MuiFab-colorInherit</span> | Styles applied to the root element if `color="inherit"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiFab-sizeSmall</span> | Styles applied to the root element if `size="small"``.
+| <span class="prop-name">sizeMedium</span> | <span class="prop-name">MuiFab-sizeMedium</span> | Styles applied to the root element if `size="medium"``.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">label</span> | Styles applied to the span element that wraps the children.
-| <span class="prop-name">primary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">secondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">extended</span> | Styles applied to the root element if `variant="extended"`.
-| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the button is keyboard focused.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"``.
-| <span class="prop-name">sizeMedium</span> | Styles applied to the root element if `size="medium"``.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Fab/Fab.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiFab`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Fab/Fab.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/fade.md
+++ b/docs/pages/api/fade.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Fade/Fade.js
 <p class="description">The API documentation of the Fade React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Fade from '@material-ui/core/Fade';
+import { Fade } from '@material-ui/core';
 ```
 
 The Fade transition is used by the [Modal](/components/modal/) component.

--- a/docs/pages/api/filled-input.md
+++ b/docs/pages/api/filled-input.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/FilledInput/FilledInput.js
 <p class="description">The API documentation of the FilledInput React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import FilledInput from '@material-ui/core/FilledInput';
+import { FilledInput } from '@material-ui/core';
 ```
 
 
@@ -51,35 +51,35 @@ Any other properties supplied will be provided to the root element ([InputBase](
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiFilledInput`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiFilledInput-root</span> | Styles applied to the root element.
+| <span class="prop-name">underline</span> | <span class="prop-name">MuiFilledInput-underline</span> | Styles applied to the root element if `disableUnderline={false}`.
+| <span class="prop-name">focused</span> | <span class="prop-name">Mui-focused</span> | Styles applied to the root element if the component is focused.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">adornedStart</span> | <span class="prop-name">MuiFilledInput-adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
+| <span class="prop-name">adornedEnd</span> | <span class="prop-name">MuiFilledInput-adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">marginDense</span> | <span class="prop-name">MuiFilledInput-marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">multiline</span> | <span class="prop-name">MuiFilledInput-multiline</span> | Styles applied to the root element if `multiline={true}`.
+| <span class="prop-name">input</span> | <span class="prop-name">MuiFilledInput-input</span> | Styles applied to the `input` element.
+| <span class="prop-name">inputMarginDense</span> | <span class="prop-name">MuiFilledInput-inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">inputHiddenLabel</span> | <span class="prop-name">MuiFilledInput-inputHiddenLabel</span> | Styles applied to the `input` if in `<FormControl hiddenLabel />`.
+| <span class="prop-name">inputSelect</span> | <span class="prop-name">MuiFilledInput-inputSelect</span> | Styles applied to the `input` element if `select={true}`.
+| <span class="prop-name">inputMultiline</span> | <span class="prop-name">MuiFilledInput-inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
+| <span class="prop-name">inputAdornedStart</span> | <span class="prop-name">MuiFilledInput-inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
+| <span class="prop-name">inputAdornedEnd</span> | <span class="prop-name">MuiFilledInput-inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">underline</span> | Styles applied to the root element if `disableUnderline={false}`.
-| <span class="prop-name">focused</span> | Styles applied to the root element if the component is focused.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
-| <span class="prop-name">adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">multiline</span> | Styles applied to the root element if `multiline={true}`.
-| <span class="prop-name">input</span> | Styles applied to the `input` element.
-| <span class="prop-name">inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">inputHiddenLabel</span> | Styles applied to the `input` if in `<FormControl hiddenLabel />`.
-| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}`.
-| <span class="prop-name">inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
-| <span class="prop-name">inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
-| <span class="prop-name">inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FilledInput/FilledInput.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiFilledInput`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FilledInput/FilledInput.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/form-control-label.md
+++ b/docs/pages/api/form-control-label.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/FormControlLabel/FormControlLabel.js
 <p class="description">The API documentation of the FormControlLabel React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { FormControlLabel } from '@material-ui/core';
 ```
 
 Drop in replacement of the `Radio`, `Switch` and `Checkbox` component.
@@ -36,25 +36,25 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiFormControlLabel`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiFormControlLabel-root</span> | Styles applied to the root element.
+| <span class="prop-name">labelPlacementStart</span> | <span class="prop-name">MuiFormControlLabel-labelPlacementStart</span> | Styles applied to the root element if `labelPlacement="start"`.
+| <span class="prop-name">labelPlacementTop</span> | <span class="prop-name">MuiFormControlLabel-labelPlacementTop</span> | Styles applied to the root element if `labelPlacement="top"`.
+| <span class="prop-name">labelPlacementBottom</span> | <span class="prop-name">MuiFormControlLabel-labelPlacementBottom</span> | Styles applied to the root element if `labelPlacement="bottom"`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">label</span> | <span class="prop-name">MuiFormControlLabel-label</span> | Styles applied to the label's Typography component.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">labelPlacementStart</span> | Styles applied to the root element if `labelPlacement="start"`.
-| <span class="prop-name">labelPlacementTop</span> | Styles applied to the root element if `labelPlacement="top"`.
-| <span class="prop-name">labelPlacementBottom</span> | Styles applied to the root element if `labelPlacement="bottom"`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">label</span> | Styles applied to the label's Typography component.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormControlLabel/FormControlLabel.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiFormControlLabel`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormControlLabel/FormControlLabel.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/form-control.md
+++ b/docs/pages/api/form-control.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/FormControl/FormControl.js
 <p class="description">The API documentation of the FormControl React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import FormControl from '@material-ui/core/FormControl';
+import { FormControl } from '@material-ui/core';
 ```
 
 Provides context such as filled/focused/error/required for form inputs.
@@ -55,23 +55,23 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiFormControl`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiFormControl-root</span> | Styles applied to the root element.
+| <span class="prop-name">marginNormal</span> | <span class="prop-name">MuiFormControl-marginNormal</span> | Styles applied to the root element if `margin="normal"`.
+| <span class="prop-name">marginDense</span> | <span class="prop-name">MuiFormControl-marginDense</span> | Styles applied to the root element if `margin="dense"`.
+| <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiFormControl-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">marginNormal</span> | Styles applied to the root element if `margin="normal"`.
-| <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
-| <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormControl/FormControl.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiFormControl`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormControl/FormControl.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/form-group.md
+++ b/docs/pages/api/form-group.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/FormGroup/FormGroup.js
 <p class="description">The API documentation of the FormGroup React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import FormGroup from '@material-ui/core/FormGroup';
+import { FormGroup } from '@material-ui/core';
 ```
 
 `FormGroup` wraps controls such as `Checkbox` and `Switch`.
@@ -30,21 +30,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiFormGroup`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiFormGroup-root</span> | Styles applied to the root element.
+| <span class="prop-name">row</span> | <span class="prop-name">MuiFormGroup-row</span> | Styles applied to the root element if `row={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">row</span> | Styles applied to the root element if `row={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormGroup/FormGroup.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiFormGroup`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormGroup/FormGroup.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/form-helper-text.md
+++ b/docs/pages/api/form-helper-text.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/FormHelperText/FormHelperText.js
 <p class="description">The API documentation of the FormHelperText React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import FormHelperText from '@material-ui/core/FormHelperText';
+import { FormHelperText } from '@material-ui/core';
 ```
 
 
@@ -35,27 +35,27 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiFormHelperText`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiFormHelperText-root</span> | Styles applied to the root element.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">marginDense</span> | <span class="prop-name">MuiFormHelperText-marginDense</span> | Styles applied to the root element if `margin="dense"`.
+| <span class="prop-name">contained</span> | <span class="prop-name">MuiFormHelperText-contained</span> | Styles applied to the root element if `variant="filled"` or `variant="outlined"`.
+| <span class="prop-name">focused</span> | <span class="prop-name">Mui-focused</span> | Pseudo-class applied to the root element if `focused={true}`.
+| <span class="prop-name">filled</span> | <span class="prop-name">MuiFormHelperText-filled</span> | Pseudo-class applied to the root element if `filled={true}`.
+| <span class="prop-name">required</span> | <span class="prop-name">Mui-required</span> | Pseudo-class applied to the root element if `required={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">error</span> | Pseudo-class applied to the root element if `error={true}`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
-| <span class="prop-name">contained</span> | Styles applied to the root element if `variant="filled"` or `variant="outlined"`.
-| <span class="prop-name">focused</span> | Pseudo-class applied to the root element if `focused={true}`.
-| <span class="prop-name">filled</span> | Pseudo-class applied to the root element if `filled={true}`.
-| <span class="prop-name">required</span> | Pseudo-class applied to the root element if `required={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormHelperText/FormHelperText.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiFormHelperText`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormHelperText/FormHelperText.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/form-label.md
+++ b/docs/pages/api/form-label.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/FormLabel/FormLabel.js
 <p class="description">The API documentation of the FormLabel React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import FormLabel from '@material-ui/core/FormLabel';
+import { FormLabel } from '@material-ui/core';
 ```
 
 
@@ -33,26 +33,26 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiFormLabel`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiFormLabel-root</span> | Styles applied to the root element.
+| <span class="prop-name">focused</span> | <span class="prop-name">Mui-focused</span> | Pseudo-class applied to the root element if `focused={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
+| <span class="prop-name">filled</span> | <span class="prop-name">MuiFormLabel-filled</span> | Pseudo-class applied to the root element if `filled={true}`.
+| <span class="prop-name">required</span> | <span class="prop-name">Mui-required</span> | Pseudo-class applied to the root element if `required={true}`.
+| <span class="prop-name">asterisk</span> | <span class="prop-name">MuiFormLabel-asterisk</span> | Styles applied to the asterisk element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focused</span> | Pseudo-class applied to the root element if `focused={true}`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">error</span> | Pseudo-class applied to the root element if `error={true}`.
-| <span class="prop-name">filled</span> | Pseudo-class applied to the root element if `filled={true}`.
-| <span class="prop-name">required</span> | Pseudo-class applied to the root element if `required={true}`.
-| <span class="prop-name">asterisk</span> | Styles applied to the asterisk element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormLabel/FormLabel.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiFormLabel`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/FormLabel/FormLabel.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/grid-list-tile-bar.md
+++ b/docs/pages/api/grid-list-tile-bar.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/GridListTileBar/GridListTileBar.js
 <p class="description">The API documentation of the GridListTileBar React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import GridListTileBar from '@material-ui/core/GridListTileBar';
+import { GridListTileBar } from '@material-ui/core';
 ```
 
 
@@ -31,30 +31,30 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiGridListTileBar`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiGridListTileBar-root</span> | Styles applied to the root element.
+| <span class="prop-name">titlePositionBottom</span> | <span class="prop-name">MuiGridListTileBar-titlePositionBottom</span> | Styles applied to the root element if `titlePosition="bottom"`.
+| <span class="prop-name">titlePositionTop</span> | <span class="prop-name">MuiGridListTileBar-titlePositionTop</span> | Styles applied to the root element if `titlePosition="top"`.
+| <span class="prop-name">rootSubtitle</span> | <span class="prop-name">MuiGridListTileBar-rootSubtitle</span> | Styles applied to the root element if a `subtitle` is provided.
+| <span class="prop-name">titleWrap</span> | <span class="prop-name">MuiGridListTileBar-titleWrap</span> | Styles applied to the title and subtitle container element.
+| <span class="prop-name">titleWrapActionPosLeft</span> | <span class="prop-name">MuiGridListTileBar-titleWrapActionPosLeft</span> | Styles applied to the container element if `actionPosition="left"`.
+| <span class="prop-name">titleWrapActionPosRight</span> | <span class="prop-name">MuiGridListTileBar-titleWrapActionPosRight</span> | Styles applied to the container element if `actionPosition="right"`.
+| <span class="prop-name">title</span> | <span class="prop-name">MuiGridListTileBar-title</span> | Styles applied to the title container element.
+| <span class="prop-name">subtitle</span> | <span class="prop-name">MuiGridListTileBar-subtitle</span> | Styles applied to the subtitle container element.
+| <span class="prop-name">actionIcon</span> | <span class="prop-name">MuiGridListTileBar-actionIcon</span> | Styles applied to the actionIcon if supplied.
+| <span class="prop-name">actionIconActionPosLeft</span> | <span class="prop-name">MuiGridListTileBar-actionIconActionPosLeft</span> | Styles applied to the actionIcon if `actionPosition="left"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">titlePositionBottom</span> | Styles applied to the root element if `titlePosition="bottom"`.
-| <span class="prop-name">titlePositionTop</span> | Styles applied to the root element if `titlePosition="top"`.
-| <span class="prop-name">rootSubtitle</span> | Styles applied to the root element if a `subtitle` is provided.
-| <span class="prop-name">titleWrap</span> | Styles applied to the title and subtitle container element.
-| <span class="prop-name">titleWrapActionPosLeft</span> | Styles applied to the container element if `actionPosition="left"`.
-| <span class="prop-name">titleWrapActionPosRight</span> | Styles applied to the container element if `actionPosition="right"`.
-| <span class="prop-name">title</span> | Styles applied to the title container element.
-| <span class="prop-name">subtitle</span> | Styles applied to the subtitle container element.
-| <span class="prop-name">actionIcon</span> | Styles applied to the actionIcon if supplied.
-| <span class="prop-name">actionIconActionPosLeft</span> | Styles applied to the actionIcon if `actionPosition="left"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridListTileBar/GridListTileBar.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiGridListTileBar`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridListTileBar/GridListTileBar.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/grid-list-tile.md
+++ b/docs/pages/api/grid-list-tile.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/GridListTile/GridListTile.js
 <p class="description">The API documentation of the GridListTile React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import GridListTile from '@material-ui/core/GridListTile';
+import { GridListTile } from '@material-ui/core';
 ```
 
 
@@ -30,23 +30,23 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiGridListTile`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiGridListTile-root</span> | Styles applied to the root element.
+| <span class="prop-name">tile</span> | <span class="prop-name">MuiGridListTile-tile</span> | Styles applied to the `div` element that wraps the children.
+| <span class="prop-name">imgFullHeight</span> | <span class="prop-name">MuiGridListTile-imgFullHeight</span> | Styles applied to an `img` element child, if needed to ensure it covers the tile.
+| <span class="prop-name">imgFullWidth</span> | <span class="prop-name">MuiGridListTile-imgFullWidth</span> | Styles applied to an `img` element child, if needed to ensure it covers the tile.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">tile</span> | Styles applied to the `div` element that wraps the children.
-| <span class="prop-name">imgFullHeight</span> | Styles applied to an `img` element child, if needed to ensure it covers the tile.
-| <span class="prop-name">imgFullWidth</span> | Styles applied to an `img` element child, if needed to ensure it covers the tile.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridListTile/GridListTile.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiGridListTile`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridListTile/GridListTile.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/grid-list.md
+++ b/docs/pages/api/grid-list.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/GridList/GridList.js
 <p class="description">The API documentation of the GridList React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import GridList from '@material-ui/core/GridList';
+import { GridList } from '@material-ui/core';
 ```
 
 
@@ -31,20 +31,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiGridList`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiGridList-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridList/GridList.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiGridList`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/GridList/GridList.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/grid.md
+++ b/docs/pages/api/grid.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Grid/Grid.js
 <p class="description">The API documentation of the Grid React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Grid from '@material-ui/core/Grid';
+import { Grid } from '@material-ui/core';
 ```
 
 
@@ -42,66 +42,66 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiGrid`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiGrid-root</span> | Styles applied to the root element
+| <span class="prop-name">container</span> | <span class="prop-name">MuiGrid-container</span> | Styles applied to the root element if `container={true}`.
+| <span class="prop-name">item</span> | <span class="prop-name">MuiGrid-item</span> | Styles applied to the root element if `item={true}`.
+| <span class="prop-name">zeroMinWidth</span> | <span class="prop-name">MuiGrid-zeroMinWidth</span> | Styles applied to the root element if `zeroMinWidth={true}`.
+| <span class="prop-name">direction-xs-column</span> | <span class="prop-name">MuiGrid-direction-xs-column</span> | 
+| <span class="prop-name">direction-xs-column-reverse</span> | <span class="prop-name">MuiGrid-direction-xs-column-reverse</span> | 
+| <span class="prop-name">direction-xs-row-reverse</span> | <span class="prop-name">MuiGrid-direction-xs-row-reverse</span> | 
+| <span class="prop-name">wrap-xs-nowrap</span> | <span class="prop-name">MuiGrid-wrap-xs-nowrap</span> | 
+| <span class="prop-name">wrap-xs-wrap-reverse</span> | <span class="prop-name">MuiGrid-wrap-xs-wrap-reverse</span> | 
+| <span class="prop-name">align-items-xs-center</span> | <span class="prop-name">MuiGrid-align-items-xs-center</span> | 
+| <span class="prop-name">align-items-xs-flex-start</span> | <span class="prop-name">MuiGrid-align-items-xs-flex-start</span> | 
+| <span class="prop-name">align-items-xs-flex-end</span> | <span class="prop-name">MuiGrid-align-items-xs-flex-end</span> | 
+| <span class="prop-name">align-items-xs-baseline</span> | <span class="prop-name">MuiGrid-align-items-xs-baseline</span> | 
+| <span class="prop-name">align-content-xs-center</span> | <span class="prop-name">MuiGrid-align-content-xs-center</span> | 
+| <span class="prop-name">align-content-xs-flex-start</span> | <span class="prop-name">MuiGrid-align-content-xs-flex-start</span> | 
+| <span class="prop-name">align-content-xs-flex-end</span> | <span class="prop-name">MuiGrid-align-content-xs-flex-end</span> | 
+| <span class="prop-name">align-content-xs-space-between</span> | <span class="prop-name">MuiGrid-align-content-xs-space-between</span> | 
+| <span class="prop-name">align-content-xs-space-around</span> | <span class="prop-name">MuiGrid-align-content-xs-space-around</span> | 
+| <span class="prop-name">justify-xs-center</span> | <span class="prop-name">MuiGrid-justify-xs-center</span> | 
+| <span class="prop-name">justify-xs-flex-end</span> | <span class="prop-name">MuiGrid-justify-xs-flex-end</span> | 
+| <span class="prop-name">justify-xs-space-between</span> | <span class="prop-name">MuiGrid-justify-xs-space-between</span> | 
+| <span class="prop-name">justify-xs-space-around</span> | <span class="prop-name">MuiGrid-justify-xs-space-around</span> | 
+| <span class="prop-name">justify-xs-space-evenly</span> | <span class="prop-name">MuiGrid-justify-xs-space-evenly</span> | 
+| <span class="prop-name">spacing-xs-1</span> | <span class="prop-name">MuiGrid-spacing-xs-1</span> | 
+| <span class="prop-name">spacing-xs-2</span> | <span class="prop-name">MuiGrid-spacing-xs-2</span> | 
+| <span class="prop-name">spacing-xs-3</span> | <span class="prop-name">MuiGrid-spacing-xs-3</span> | 
+| <span class="prop-name">spacing-xs-4</span> | <span class="prop-name">MuiGrid-spacing-xs-4</span> | 
+| <span class="prop-name">spacing-xs-5</span> | <span class="prop-name">MuiGrid-spacing-xs-5</span> | 
+| <span class="prop-name">spacing-xs-6</span> | <span class="prop-name">MuiGrid-spacing-xs-6</span> | 
+| <span class="prop-name">spacing-xs-7</span> | <span class="prop-name">MuiGrid-spacing-xs-7</span> | 
+| <span class="prop-name">spacing-xs-8</span> | <span class="prop-name">MuiGrid-spacing-xs-8</span> | 
+| <span class="prop-name">spacing-xs-9</span> | <span class="prop-name">MuiGrid-spacing-xs-9</span> | 
+| <span class="prop-name">spacing-xs-10</span> | <span class="prop-name">MuiGrid-spacing-xs-10</span> | 
+| <span class="prop-name">grid-xs-auto</span> | <span class="prop-name">MuiGrid-grid-xs-auto</span> | 
+| <span class="prop-name">grid-xs-true</span> | <span class="prop-name">MuiGrid-grid-xs-true</span> | 
+| <span class="prop-name">grid-xs-1</span> | <span class="prop-name">MuiGrid-grid-xs-1</span> | 
+| <span class="prop-name">grid-xs-2</span> | <span class="prop-name">MuiGrid-grid-xs-2</span> | 
+| <span class="prop-name">grid-xs-3</span> | <span class="prop-name">MuiGrid-grid-xs-3</span> | 
+| <span class="prop-name">grid-xs-4</span> | <span class="prop-name">MuiGrid-grid-xs-4</span> | 
+| <span class="prop-name">grid-xs-5</span> | <span class="prop-name">MuiGrid-grid-xs-5</span> | 
+| <span class="prop-name">grid-xs-6</span> | <span class="prop-name">MuiGrid-grid-xs-6</span> | 
+| <span class="prop-name">grid-xs-7</span> | <span class="prop-name">MuiGrid-grid-xs-7</span> | 
+| <span class="prop-name">grid-xs-8</span> | <span class="prop-name">MuiGrid-grid-xs-8</span> | 
+| <span class="prop-name">grid-xs-9</span> | <span class="prop-name">MuiGrid-grid-xs-9</span> | 
+| <span class="prop-name">grid-xs-10</span> | <span class="prop-name">MuiGrid-grid-xs-10</span> | 
+| <span class="prop-name">grid-xs-11</span> | <span class="prop-name">MuiGrid-grid-xs-11</span> | 
+| <span class="prop-name">grid-xs-12</span> | <span class="prop-name">MuiGrid-grid-xs-12</span> | 
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element
-| <span class="prop-name">container</span> | Styles applied to the root element if `container={true}`.
-| <span class="prop-name">item</span> | Styles applied to the root element if `item={true}`.
-| <span class="prop-name">zeroMinWidth</span> | Styles applied to the root element if `zeroMinWidth={true}`.
-| <span class="prop-name">direction-xs-column</span> | 
-| <span class="prop-name">direction-xs-column-reverse</span> | 
-| <span class="prop-name">direction-xs-row-reverse</span> | 
-| <span class="prop-name">wrap-xs-nowrap</span> | 
-| <span class="prop-name">wrap-xs-wrap-reverse</span> | 
-| <span class="prop-name">align-items-xs-center</span> | 
-| <span class="prop-name">align-items-xs-flex-start</span> | 
-| <span class="prop-name">align-items-xs-flex-end</span> | 
-| <span class="prop-name">align-items-xs-baseline</span> | 
-| <span class="prop-name">align-content-xs-center</span> | 
-| <span class="prop-name">align-content-xs-flex-start</span> | 
-| <span class="prop-name">align-content-xs-flex-end</span> | 
-| <span class="prop-name">align-content-xs-space-between</span> | 
-| <span class="prop-name">align-content-xs-space-around</span> | 
-| <span class="prop-name">justify-xs-center</span> | 
-| <span class="prop-name">justify-xs-flex-end</span> | 
-| <span class="prop-name">justify-xs-space-between</span> | 
-| <span class="prop-name">justify-xs-space-around</span> | 
-| <span class="prop-name">justify-xs-space-evenly</span> | 
-| <span class="prop-name">spacing-xs-1</span> | 
-| <span class="prop-name">spacing-xs-2</span> | 
-| <span class="prop-name">spacing-xs-3</span> | 
-| <span class="prop-name">spacing-xs-4</span> | 
-| <span class="prop-name">spacing-xs-5</span> | 
-| <span class="prop-name">spacing-xs-6</span> | 
-| <span class="prop-name">spacing-xs-7</span> | 
-| <span class="prop-name">spacing-xs-8</span> | 
-| <span class="prop-name">spacing-xs-9</span> | 
-| <span class="prop-name">spacing-xs-10</span> | 
-| <span class="prop-name">grid-xs-auto</span> | 
-| <span class="prop-name">grid-xs-true</span> | 
-| <span class="prop-name">grid-xs-1</span> | 
-| <span class="prop-name">grid-xs-2</span> | 
-| <span class="prop-name">grid-xs-3</span> | 
-| <span class="prop-name">grid-xs-4</span> | 
-| <span class="prop-name">grid-xs-5</span> | 
-| <span class="prop-name">grid-xs-6</span> | 
-| <span class="prop-name">grid-xs-7</span> | 
-| <span class="prop-name">grid-xs-8</span> | 
-| <span class="prop-name">grid-xs-9</span> | 
-| <span class="prop-name">grid-xs-10</span> | 
-| <span class="prop-name">grid-xs-11</span> | 
-| <span class="prop-name">grid-xs-12</span> | 
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Grid/Grid.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiGrid`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Grid/Grid.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/grow.md
+++ b/docs/pages/api/grow.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Grow/Grow.js
 <p class="description">The API documentation of the Grow React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Grow from '@material-ui/core/Grow';
+import { Grow } from '@material-ui/core';
 ```
 
 The Grow transition is used by the [Tooltip](/components/tooltips/) and

--- a/docs/pages/api/hidden.md
+++ b/docs/pages/api/hidden.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Hidden/Hidden.js
 <p class="description">The API documentation of the Hidden React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Hidden from '@material-ui/core/Hidden';
+import { Hidden } from '@material-ui/core';
 ```
 
 Responsively hides children based on the selected implementation.

--- a/docs/pages/api/icon-button.md
+++ b/docs/pages/api/icon-button.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/IconButton/IconButton.js
 <p class="description">The API documentation of the IconButton React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import IconButton from '@material-ui/core/IconButton';
+import { IconButton } from '@material-ui/core';
 ```
 
 Refer to the [Icons](/components/icons/) section of the documentation
@@ -34,28 +34,28 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiIconButton`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiIconButton-root</span> | Styles applied to the root element.
+| <span class="prop-name">edgeStart</span> | <span class="prop-name">MuiIconButton-edgeStart</span> | Styles applied to the root element if `edge="start"`.
+| <span class="prop-name">edgeEnd</span> | <span class="prop-name">MuiIconButton-edgeEnd</span> | Styles applied to the root element if `edge="end"`.
+| <span class="prop-name">colorInherit</span> | <span class="prop-name">MuiIconButton-colorInherit</span> | Styles applied to the root element if `color="inherit"`.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiIconButton-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiIconButton-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiIconButton-sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">label</span> | <span class="prop-name">MuiIconButton-label</span> | Styles applied to the children container element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">edgeStart</span> | Styles applied to the root element if `edge="start"`.
-| <span class="prop-name">edgeEnd</span> | Styles applied to the root element if `edge="end"`.
-| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">label</span> | Styles applied to the children container element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/IconButton/IconButton.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiIconButton`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/IconButton/IconButton.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/icon.md
+++ b/docs/pages/api/icon.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Icon/Icon.js
 <p class="description">The API documentation of the Icon React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Icon from '@material-ui/core/Icon';
+import { Icon } from '@material-ui/core';
 ```
 
 
@@ -30,28 +30,28 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiIcon`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiIcon-root</span> | Styles applied to the root element.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiIcon-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiIcon-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">colorAction</span> | <span class="prop-name">MuiIcon-colorAction</span> | Styles applied to the root element if `color="action"`.
+| <span class="prop-name">colorError</span> | <span class="prop-name">MuiIcon-colorError</span> | Styles applied to the root element if `color="error"`.
+| <span class="prop-name">colorDisabled</span> | <span class="prop-name">MuiIcon-colorDisabled</span> | Styles applied to the root element if `color="disabled"`.
+| <span class="prop-name">fontSizeInherit</span> | <span class="prop-name">MuiIcon-fontSizeInherit</span> | 
+| <span class="prop-name">fontSizeSmall</span> | <span class="prop-name">MuiIcon-fontSizeSmall</span> | Styles applied to the root element if `fontSize="small"`.
+| <span class="prop-name">fontSizeLarge</span> | <span class="prop-name">MuiIcon-fontSizeLarge</span> | Styles applied to the root element if `fontSize="large"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">colorAction</span> | Styles applied to the root element if `color="action"`.
-| <span class="prop-name">colorError</span> | Styles applied to the root element if `color="error"`.
-| <span class="prop-name">colorDisabled</span> | Styles applied to the root element if `color="disabled"`.
-| <span class="prop-name">fontSizeInherit</span> | 
-| <span class="prop-name">fontSizeSmall</span> | Styles applied to the root element if `fontSize="small"`.
-| <span class="prop-name">fontSizeLarge</span> | Styles applied to the root element if `fontSize="large"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Icon/Icon.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiIcon`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Icon/Icon.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/input-adornment.md
+++ b/docs/pages/api/input-adornment.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/InputAdornment/InputAdornment.js
 <p class="description">The API documentation of the InputAdornment React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import InputAdornment from '@material-ui/core/InputAdornment';
+import { InputAdornment } from '@material-ui/core';
 ```
 
 
@@ -32,26 +32,26 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiInputAdornment`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiInputAdornment-root</span> | Styles applied to the root element.
+| <span class="prop-name">filled</span> | <span class="prop-name">MuiInputAdornment-filled</span> | Styles applied to the root element if `variant="filled"`.
+| <span class="prop-name">positionStart</span> | <span class="prop-name">MuiInputAdornment-positionStart</span> | Styles applied to the root element if `position="start"`.
+| <span class="prop-name">positionEnd</span> | <span class="prop-name">MuiInputAdornment-positionEnd</span> | Styles applied to the root element if `position="end"`.
+| <span class="prop-name">disablePointerEvents</span> | <span class="prop-name">MuiInputAdornment-disablePointerEvents</span> | Styles applied to the root element if `disablePointerEvents=true`.
+| <span class="prop-name">hiddenLabel</span> | <span class="prop-name">MuiInputAdornment-hiddenLabel</span> | Styles applied if the adornment is used inside &lt;FormControl hiddenLabel />.
+| <span class="prop-name">marginDense</span> | <span class="prop-name">MuiInputAdornment-marginDense</span> | Styles applied if the adornment is used inside &lt;FormControl margin="dense" />.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">filled</span> | Styles applied to the root element if `variant="filled"`.
-| <span class="prop-name">positionStart</span> | Styles applied to the root element if `position="start"`.
-| <span class="prop-name">positionEnd</span> | Styles applied to the root element if `position="end"`.
-| <span class="prop-name">disablePointerEvents</span> | Styles applied to the root element if `disablePointerEvents=true`.
-| <span class="prop-name">hiddenLabel</span> | Styles applied if the adornment is used inside &lt;FormControl hiddenLabel />.
-| <span class="prop-name">marginDense</span> | Styles applied if the adornment is used inside &lt;FormControl margin="dense" />.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputAdornment/InputAdornment.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiInputAdornment`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputAdornment/InputAdornment.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/input-base.md
+++ b/docs/pages/api/input-base.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/InputBase/InputBase.js
 <p class="description">The API documentation of the InputBase React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import InputBase from '@material-ui/core/InputBase';
+import { InputBase } from '@material-ui/core';
 ```
 
 `InputBase` contains as few styles as possible.
@@ -53,37 +53,37 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiInputBase`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiInputBase-root</span> | Styles applied to the root element.
+| <span class="prop-name">formControl</span> | <span class="prop-name">MuiInputBase-formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
+| <span class="prop-name">focused</span> | <span class="prop-name">Mui-focused</span> | Styles applied to the root element if the component is focused.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">adornedStart</span> | <span class="prop-name">MuiInputBase-adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
+| <span class="prop-name">adornedEnd</span> | <span class="prop-name">MuiInputBase-adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">marginDense</span> | <span class="prop-name">MuiInputBase-marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">multiline</span> | <span class="prop-name">MuiInputBase-multiline</span> | Styles applied to the root element if `multiline={true}`.
+| <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiInputBase-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
+| <span class="prop-name">input</span> | <span class="prop-name">MuiInputBase-input</span> | Styles applied to the `input` element.
+| <span class="prop-name">inputMarginDense</span> | <span class="prop-name">MuiInputBase-inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">inputSelect</span> | <span class="prop-name">MuiInputBase-inputSelect</span> | Styles applied to the `input` element if `select={true}`.
+| <span class="prop-name">inputMultiline</span> | <span class="prop-name">MuiInputBase-inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
+| <span class="prop-name">inputTypeSearch</span> | <span class="prop-name">MuiInputBase-inputTypeSearch</span> | Styles applied to the `input` element if `type="search"`.
+| <span class="prop-name">inputAdornedStart</span> | <span class="prop-name">MuiInputBase-inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
+| <span class="prop-name">inputAdornedEnd</span> | <span class="prop-name">MuiInputBase-inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.
+| <span class="prop-name">inputHiddenLabel</span> | <span class="prop-name">MuiInputBase-inputHiddenLabel</span> | Styles applied to the `input` element if `hiddenLabel={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
-| <span class="prop-name">focused</span> | Styles applied to the root element if the component is focused.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
-| <span class="prop-name">adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">multiline</span> | Styles applied to the root element if `multiline={true}`.
-| <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
-| <span class="prop-name">input</span> | Styles applied to the `input` element.
-| <span class="prop-name">inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}`.
-| <span class="prop-name">inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
-| <span class="prop-name">inputTypeSearch</span> | Styles applied to the `input` element if `type="search"`.
-| <span class="prop-name">inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
-| <span class="prop-name">inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.
-| <span class="prop-name">inputHiddenLabel</span> | Styles applied to the `input` element if `hiddenLabel={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputBase/InputBase.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiInputBase`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputBase/InputBase.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/input-label.md
+++ b/docs/pages/api/input-label.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/InputLabel/InputLabel.js
 <p class="description">The API documentation of the InputLabel React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import InputLabel from '@material-ui/core/InputLabel';
+import { InputLabel } from '@material-ui/core';
 ```
 
 
@@ -35,31 +35,31 @@ Any other properties supplied will be provided to the root element ([FormLabel](
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiInputLabel`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiInputLabel-root</span> | Styles applied to the root element.
+| <span class="prop-name">focused</span> | <span class="prop-name">Mui-focused</span> | Pseudo-class applied to the root element if `focused={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
+| <span class="prop-name">required</span> | <span class="prop-name">Mui-required</span> | Pseudo-class applied to the root element if `required={true}`.
+| <span class="prop-name">asterisk</span> | <span class="prop-name">MuiInputLabel-asterisk</span> | Pseudo-class applied to the asterisk element.
+| <span class="prop-name">formControl</span> | <span class="prop-name">MuiInputLabel-formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
+| <span class="prop-name">marginDense</span> | <span class="prop-name">MuiInputLabel-marginDense</span> | Styles applied to the root element if `margin="dense"`.
+| <span class="prop-name">shrink</span> | <span class="prop-name">MuiInputLabel-shrink</span> | Styles applied to the `input` element if `shrink={true}`.
+| <span class="prop-name">animated</span> | <span class="prop-name">MuiInputLabel-animated</span> | Styles applied to the `input` element if `disableAnimation={false}`.
+| <span class="prop-name">filled</span> | <span class="prop-name">MuiInputLabel-filled</span> | Styles applied to the root element if `variant="filled"`.
+| <span class="prop-name">outlined</span> | <span class="prop-name">MuiInputLabel-outlined</span> | Styles applied to the root element if `variant="outlined"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focused</span> | Pseudo-class applied to the root element if `focused={true}`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">error</span> | Pseudo-class applied to the root element if `error={true}`.
-| <span class="prop-name">required</span> | Pseudo-class applied to the root element if `required={true}`.
-| <span class="prop-name">asterisk</span> | Pseudo-class applied to the asterisk element.
-| <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
-| <span class="prop-name">marginDense</span> | Styles applied to the root element if `margin="dense"`.
-| <span class="prop-name">shrink</span> | Styles applied to the `input` element if `shrink={true}`.
-| <span class="prop-name">animated</span> | Styles applied to the `input` element if `disableAnimation={false}`.
-| <span class="prop-name">filled</span> | Styles applied to the root element if `variant="filled"`.
-| <span class="prop-name">outlined</span> | Styles applied to the root element if `variant="outlined"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputLabel/InputLabel.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiInputLabel`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputLabel/InputLabel.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/input.md
+++ b/docs/pages/api/input.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Input/Input.js
 <p class="description">The API documentation of the Input React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Input from '@material-ui/core/Input';
+import { Input } from '@material-ui/core';
 ```
 
 
@@ -51,31 +51,31 @@ Any other properties supplied will be provided to the root element ([InputBase](
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiInput`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiInput-root</span> | Styles applied to the root element.
+| <span class="prop-name">formControl</span> | <span class="prop-name">MuiInput-formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
+| <span class="prop-name">focused</span> | <span class="prop-name">Mui-focused</span> | Styles applied to the root element if the component is focused.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">underline</span> | <span class="prop-name">MuiInput-underline</span> | Styles applied to the root element if `disableUnderline={false}`.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">multiline</span> | <span class="prop-name">MuiInput-multiline</span> | Styles applied to the root element if `multiline={true}`.
+| <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiInput-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
+| <span class="prop-name">input</span> | <span class="prop-name">MuiInput-input</span> | Styles applied to the `input` element.
+| <span class="prop-name">inputMarginDense</span> | <span class="prop-name">MuiInput-inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">inputMultiline</span> | <span class="prop-name">MuiInput-inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
+| <span class="prop-name">inputTypeSearch</span> | <span class="prop-name">MuiInput-inputTypeSearch</span> | Styles applied to the `input` element if `type="search"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">formControl</span> | Styles applied to the root element if the component is a descendant of `FormControl`.
-| <span class="prop-name">focused</span> | Styles applied to the root element if the component is focused.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">underline</span> | Styles applied to the root element if `disableUnderline={false}`.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">multiline</span> | Styles applied to the root element if `multiline={true}`.
-| <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
-| <span class="prop-name">input</span> | Styles applied to the `input` element.
-| <span class="prop-name">inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
-| <span class="prop-name">inputTypeSearch</span> | Styles applied to the `input` element if `type="search"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Input/Input.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiInput`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Input/Input.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/linear-progress.md
+++ b/docs/pages/api/linear-progress.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/LinearProgress/LinearProgress.js
 <p class="description">The API documentation of the LinearProgress React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import LinearProgress from '@material-ui/core/LinearProgress';
+import { LinearProgress } from '@material-ui/core';
 ```
 
 ## ARIA
@@ -34,37 +34,37 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiLinearProgress`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiLinearProgress-root</span> | Styles applied to the root element.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiLinearProgress-colorPrimary</span> | Styles applied to the root & bar2 element if `color="primary"`; bar2 if `variant-"buffer"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiLinearProgress-colorSecondary</span> | Styles applied to the root & bar2 elements if `color="secondary"`; bar2 if `variant="buffer"`.
+| <span class="prop-name">determinate</span> | <span class="prop-name">MuiLinearProgress-determinate</span> | Styles applied to the root element if `variant="determinate"`.
+| <span class="prop-name">indeterminate</span> | <span class="prop-name">MuiLinearProgress-indeterminate</span> | Styles applied to the root element if `variant="indeterminate"`.
+| <span class="prop-name">buffer</span> | <span class="prop-name">MuiLinearProgress-buffer</span> | Styles applied to the root element if `variant="buffer"`.
+| <span class="prop-name">query</span> | <span class="prop-name">MuiLinearProgress-query</span> | Styles applied to the root element if `variant="query"`.
+| <span class="prop-name">dashed</span> | <span class="prop-name">MuiLinearProgress-dashed</span> | Styles applied to the additional bar element if `variant="buffer"`.
+| <span class="prop-name">dashedColorPrimary</span> | <span class="prop-name">MuiLinearProgress-dashedColorPrimary</span> | Styles applied to the additional bar element if `variant="buffer"` & `color="primary"`.
+| <span class="prop-name">dashedColorSecondary</span> | <span class="prop-name">MuiLinearProgress-dashedColorSecondary</span> | Styles applied to the additional bar element if `variant="buffer"` & `color="secondary"`.
+| <span class="prop-name">bar</span> | <span class="prop-name">MuiLinearProgress-bar</span> | Styles applied to the layered bar1 & bar2 elements.
+| <span class="prop-name">barColorPrimary</span> | <span class="prop-name">MuiLinearProgress-barColorPrimary</span> | Styles applied to the bar elements if `color="primary"`; bar2 if `variant` not "buffer".
+| <span class="prop-name">barColorSecondary</span> | <span class="prop-name">MuiLinearProgress-barColorSecondary</span> | Styles applied to the bar elements if `color="secondary"`; bar2 if `variant` not "buffer".
+| <span class="prop-name">bar1Indeterminate</span> | <span class="prop-name">MuiLinearProgress-bar1Indeterminate</span> | Styles applied to the bar1 element if `variant="indeterminate or query"`.
+| <span class="prop-name">bar1Determinate</span> | <span class="prop-name">MuiLinearProgress-bar1Determinate</span> | Styles applied to the bar1 element if `variant="determinate"`.
+| <span class="prop-name">bar1Buffer</span> | <span class="prop-name">MuiLinearProgress-bar1Buffer</span> | Styles applied to the bar1 element if `variant="buffer"`.
+| <span class="prop-name">bar2Indeterminate</span> | <span class="prop-name">MuiLinearProgress-bar2Indeterminate</span> | Styles applied to the bar2 element if `variant="indeterminate or query"`.
+| <span class="prop-name">bar2Buffer</span> | <span class="prop-name">MuiLinearProgress-bar2Buffer</span> | Styles applied to the bar2 element if `variant="buffer"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root & bar2 element if `color="primary"`; bar2 if `variant-"buffer"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root & bar2 elements if `color="secondary"`; bar2 if `variant="buffer"`.
-| <span class="prop-name">determinate</span> | Styles applied to the root element if `variant="determinate"`.
-| <span class="prop-name">indeterminate</span> | Styles applied to the root element if `variant="indeterminate"`.
-| <span class="prop-name">buffer</span> | Styles applied to the root element if `variant="buffer"`.
-| <span class="prop-name">query</span> | Styles applied to the root element if `variant="query"`.
-| <span class="prop-name">dashed</span> | Styles applied to the additional bar element if `variant="buffer"`.
-| <span class="prop-name">dashedColorPrimary</span> | Styles applied to the additional bar element if `variant="buffer"` & `color="primary"`.
-| <span class="prop-name">dashedColorSecondary</span> | Styles applied to the additional bar element if `variant="buffer"` & `color="secondary"`.
-| <span class="prop-name">bar</span> | Styles applied to the layered bar1 & bar2 elements.
-| <span class="prop-name">barColorPrimary</span> | Styles applied to the bar elements if `color="primary"`; bar2 if `variant` not "buffer".
-| <span class="prop-name">barColorSecondary</span> | Styles applied to the bar elements if `color="secondary"`; bar2 if `variant` not "buffer".
-| <span class="prop-name">bar1Indeterminate</span> | Styles applied to the bar1 element if `variant="indeterminate or query"`.
-| <span class="prop-name">bar1Determinate</span> | Styles applied to the bar1 element if `variant="determinate"`.
-| <span class="prop-name">bar1Buffer</span> | Styles applied to the bar1 element if `variant="buffer"`.
-| <span class="prop-name">bar2Indeterminate</span> | Styles applied to the bar2 element if `variant="indeterminate or query"`.
-| <span class="prop-name">bar2Buffer</span> | Styles applied to the bar2 element if `variant="buffer"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/LinearProgress/LinearProgress.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiLinearProgress`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/LinearProgress/LinearProgress.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/link.md
+++ b/docs/pages/api/link.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Link/Link.js
 <p class="description">The API documentation of the Link React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Link from '@material-ui/core/Link';
+import { Link } from '@material-ui/core';
 ```
 
 
@@ -32,25 +32,25 @@ Any other properties supplied will be provided to the root element ([Typography]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiLink`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiLink-root</span> | Styles applied to the root element.
+| <span class="prop-name">underlineNone</span> | <span class="prop-name">MuiLink-underlineNone</span> | Styles applied to the root element if `underline="none"`.
+| <span class="prop-name">underlineHover</span> | <span class="prop-name">MuiLink-underlineHover</span> | Styles applied to the root element if `underline="hover"`.
+| <span class="prop-name">underlineAlways</span> | <span class="prop-name">MuiLink-underlineAlways</span> | Styles applied to the root element if `underline="always"`.
+| <span class="prop-name">button</span> | <span class="prop-name">MuiLink-button</span> | Styles applied to the root element if `component="button"`.
+| <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the root element if the link is keyboard focused.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">underlineNone</span> | Styles applied to the root element if `underline="none"`.
-| <span class="prop-name">underlineHover</span> | Styles applied to the root element if `underline="hover"`.
-| <span class="prop-name">underlineAlways</span> | Styles applied to the root element if `underline="always"`.
-| <span class="prop-name">button</span> | Styles applied to the root element if `component="button"`.
-| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the root element if the link is keyboard focused.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Link/Link.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiLink`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Link/Link.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/list-item-avatar.md
+++ b/docs/pages/api/list-item-avatar.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
 <p class="description">The API documentation of the ListItemAvatar React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import { ListItemAvatar } from '@material-ui/core';
 ```
 
 A simple wrapper to apply `List` styles to an `Avatar`.
@@ -27,21 +27,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiListItemAvatar`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiListItemAvatar-root</span> | Styles applied to the root element.
+| <span class="prop-name">alignItemsFlexStart</span> | <span class="prop-name">MuiListItemAvatar-alignItemsFlexStart</span> | Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">alignItemsFlexStart</span> | Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiListItemAvatar`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/list-item-icon.md
+++ b/docs/pages/api/list-item-icon.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ListItemIcon/ListItemIcon.js
 <p class="description">The API documentation of the ListItemIcon React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ListItemIcon from '@material-ui/core/ListItemIcon';
+import { ListItemIcon } from '@material-ui/core';
 ```
 
 A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
@@ -27,21 +27,21 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiListItemIcon`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiListItemIcon-root</span> | Styles applied to the root element.
+| <span class="prop-name">alignItemsFlexStart</span> | <span class="prop-name">MuiListItemIcon-alignItemsFlexStart</span> | Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">alignItemsFlexStart</span> | Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemIcon/ListItemIcon.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiListItemIcon`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemIcon/ListItemIcon.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/list-item-secondary-action.md
+++ b/docs/pages/api/list-item-secondary-action.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAct
 <p class="description">The API documentation of the ListItemSecondaryAction React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction';
+import { ListItemSecondaryAction } from '@material-ui/core';
 ```
 
 Must be used as the last child of ListItem to function properly.
@@ -27,20 +27,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiListItemSecondaryAction`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiListItemSecondaryAction-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiListItemSecondaryAction`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/list-item-text.md
+++ b/docs/pages/api/list-item-text.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ListItemText/ListItemText.js
 <p class="description">The API documentation of the ListItemText React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ListItemText from '@material-ui/core/ListItemText';
+import { ListItemText } from '@material-ui/core';
 ```
 
 
@@ -33,25 +33,25 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiListItemText`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiListItemText-root</span> | Styles applied to the root element.
+| <span class="prop-name">multiline</span> | <span class="prop-name">MuiListItemText-multiline</span> | Styles applied to the `Typography` components if primary and secondary are set.
+| <span class="prop-name">dense</span> | <span class="prop-name">MuiListItemText-dense</span> | Styles applied to the `Typography` components if dense.
+| <span class="prop-name">inset</span> | <span class="prop-name">MuiListItemText-inset</span> | Styles applied to the root element if `inset={true}`.
+| <span class="prop-name">primary</span> | <span class="prop-name">MuiListItemText-primary</span> | Styles applied to the primary `Typography` component.
+| <span class="prop-name">secondary</span> | <span class="prop-name">MuiListItemText-secondary</span> | Styles applied to the secondary `Typography` component.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">multiline</span> | Styles applied to the `Typography` components if primary and secondary are set.
-| <span class="prop-name">dense</span> | Styles applied to the `Typography` components if dense.
-| <span class="prop-name">inset</span> | Styles applied to the root element if `inset={true}`.
-| <span class="prop-name">primary</span> | Styles applied to the primary `Typography` component.
-| <span class="prop-name">secondary</span> | Styles applied to the secondary `Typography` component.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemText/ListItemText.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiListItemText`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItemText/ListItemText.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/list-item.md
+++ b/docs/pages/api/list-item.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ListItem/ListItem.js
 <p class="description">The API documentation of the ListItem React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ListItem from '@material-ui/core/ListItem';
+import { ListItem } from '@material-ui/core';
 ```
 
 Uses an additional container component if `ListItemSecondaryAction` is the last child.
@@ -38,30 +38,30 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiListItem`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiListItem-root</span> | Styles applied to the (normally root) `component` element. May be wrapped by a `container`.
+| <span class="prop-name">container</span> | <span class="prop-name">MuiListItem-container</span> | Styles applied to the `container` element if `children` includes `ListItemSecondaryAction`.
+| <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the `component`'s `focusVisibleClassName` prop if `button={true}`.
+| <span class="prop-name">dense</span> | <span class="prop-name">MuiListItem-dense</span> | Styles applied to the `component` element if dense.
+| <span class="prop-name">alignItemsFlexStart</span> | <span class="prop-name">MuiListItem-alignItemsFlexStart</span> | Styles applied to the `component` element if `alignItems="flex-start"`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the inner `component` element if `disabled={true}`.
+| <span class="prop-name">divider</span> | <span class="prop-name">MuiListItem-divider</span> | Styles applied to the inner `component` element if `divider={true}`.
+| <span class="prop-name">gutters</span> | <span class="prop-name">MuiListItem-gutters</span> | Styles applied to the inner `component` element if `disableGutters={false}`.
+| <span class="prop-name">button</span> | <span class="prop-name">MuiListItem-button</span> | Styles applied to the inner `component` element if `button={true}`.
+| <span class="prop-name">secondaryAction</span> | <span class="prop-name">MuiListItem-secondaryAction</span> | Styles applied to the `component` element if `children` includes `ListItemSecondaryAction`.
+| <span class="prop-name">selected</span> | <span class="prop-name">Mui-selected</span> | Pseudo-class applied to the root element if `selected={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the (normally root) `component` element. May be wrapped by a `container`.
-| <span class="prop-name">container</span> | Styles applied to the `container` element if `children` includes `ListItemSecondaryAction`.
-| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the `component`'s `focusVisibleClassName` prop if `button={true}`.
-| <span class="prop-name">dense</span> | Styles applied to the `component` element if dense.
-| <span class="prop-name">alignItemsFlexStart</span> | Styles applied to the `component` element if `alignItems="flex-start"`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the inner `component` element if `disabled={true}`.
-| <span class="prop-name">divider</span> | Styles applied to the inner `component` element if `divider={true}`.
-| <span class="prop-name">gutters</span> | Styles applied to the inner `component` element if `disableGutters={false}`.
-| <span class="prop-name">button</span> | Styles applied to the inner `component` element if `button={true}`.
-| <span class="prop-name">secondaryAction</span> | Styles applied to the `component` element if `children` includes `ListItemSecondaryAction`.
-| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if `selected={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItem/ListItem.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiListItem`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListItem/ListItem.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/list-subheader.md
+++ b/docs/pages/api/list-subheader.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ListSubheader/ListSubheader.js
 <p class="description">The API documentation of the ListSubheader React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ListSubheader from '@material-ui/core/ListSubheader';
+import { ListSubheader } from '@material-ui/core';
 ```
 
 
@@ -32,25 +32,25 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiListSubheader`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiListSubheader-root</span> | Styles applied to the root element.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiListSubheader-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorInherit</span> | <span class="prop-name">MuiListSubheader-colorInherit</span> | Styles applied to the root element if `color="inherit"`.
+| <span class="prop-name">gutters</span> | <span class="prop-name">MuiListSubheader-gutters</span> | Styles applied to the inner `component` element if `disableGutters={false}`.
+| <span class="prop-name">inset</span> | <span class="prop-name">MuiListSubheader-inset</span> | Styles applied to the root element if `inset={true}`.
+| <span class="prop-name">sticky</span> | <span class="prop-name">MuiListSubheader-sticky</span> | Styles applied to the root element if `disableSticky={false}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
-| <span class="prop-name">gutters</span> | Styles applied to the inner `component` element if `disableGutters={false}`.
-| <span class="prop-name">inset</span> | Styles applied to the root element if `inset={true}`.
-| <span class="prop-name">sticky</span> | Styles applied to the root element if `disableSticky={false}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListSubheader/ListSubheader.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiListSubheader`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ListSubheader/ListSubheader.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/list.md
+++ b/docs/pages/api/list.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/List/List.js
 <p class="description">The API documentation of the List React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import List from '@material-ui/core/List';
+import { List } from '@material-ui/core';
 ```
 
 
@@ -31,23 +31,23 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiList`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiList-root</span> | Styles applied to the root element.
+| <span class="prop-name">padding</span> | <span class="prop-name">MuiList-padding</span> | Styles applied to the root element if `disablePadding={false}`.
+| <span class="prop-name">dense</span> | <span class="prop-name">MuiList-dense</span> | Styles applied to the root element if dense.
+| <span class="prop-name">subheader</span> | <span class="prop-name">MuiList-subheader</span> | Styles applied to the root element if a `subheader` is provided.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">padding</span> | Styles applied to the root element if `disablePadding={false}`.
-| <span class="prop-name">dense</span> | Styles applied to the root element if dense.
-| <span class="prop-name">subheader</span> | Styles applied to the root element if a `subheader` is provided.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/List/List.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiList`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/List/List.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/menu-item.md
+++ b/docs/pages/api/menu-item.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/MenuItem/MenuItem.js
 <p class="description">The API documentation of the MenuItem React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import MenuItem from '@material-ui/core/MenuItem';
+import { MenuItem } from '@material-ui/core';
 ```
 
 
@@ -30,23 +30,23 @@ Any other properties supplied will be provided to the root element ([ListItem](/
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiMenuItem`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiMenuItem-root</span> | Styles applied to the root element.
+| <span class="prop-name">gutters</span> | <span class="prop-name">MuiMenuItem-gutters</span> | Styles applied to the root element if `disableGutters={false}`.
+| <span class="prop-name">selected</span> | <span class="prop-name">Mui-selected</span> | Styles applied to the root element if `selected={true}`.
+| <span class="prop-name">dense</span> | <span class="prop-name">MuiMenuItem-dense</span> | Styles applied to the root element if dense.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">gutters</span> | Styles applied to the root element if `disableGutters={false}`.
-| <span class="prop-name">selected</span> | Styles applied to the root element if `selected={true}`.
-| <span class="prop-name">dense</span> | Styles applied to the root element if dense.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/MenuItem/MenuItem.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiMenuItem`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/MenuItem/MenuItem.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/menu-list.md
+++ b/docs/pages/api/menu-list.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/MenuList/MenuList.js
 <p class="description">The API documentation of the MenuList React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import MenuList from '@material-ui/core/MenuList';
+import { MenuList } from '@material-ui/core';
 ```
 
 

--- a/docs/pages/api/menu.md
+++ b/docs/pages/api/menu.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Menu/Menu.js
 <p class="description">The API documentation of the Menu React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Menu from '@material-ui/core/Menu';
+import { Menu } from '@material-ui/core';
 ```
 
 
@@ -42,21 +42,21 @@ Any other properties supplied will be provided to the root element ([Popover](/a
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiMenu`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">paper</span> | <span class="prop-name">MuiMenu-paper</span> | Styles applied to the `Paper` component.
+| <span class="prop-name">list</span> | <span class="prop-name">MuiMenu-list</span> | Styles applied to the `List` component via `MenuList`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">paper</span> | Styles applied to the `Paper` component.
-| <span class="prop-name">list</span> | Styles applied to the `List` component via `MenuList`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Menu/Menu.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiMenu`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Menu/Menu.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/mobile-stepper.md
+++ b/docs/pages/api/mobile-stepper.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/MobileStepper/MobileStepper.js
 <p class="description">The API documentation of the MobileStepper React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import MobileStepper from '@material-ui/core/MobileStepper';
+import { MobileStepper } from '@material-ui/core';
 ```
 
 
@@ -33,27 +33,27 @@ Any other properties supplied will be provided to the root element ([Paper](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiMobileStepper`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiMobileStepper-root</span> | Styles applied to the root element.
+| <span class="prop-name">positionBottom</span> | <span class="prop-name">MuiMobileStepper-positionBottom</span> | Styles applied to the root element if `position="bottom"`.
+| <span class="prop-name">positionTop</span> | <span class="prop-name">MuiMobileStepper-positionTop</span> | Styles applied to the root element if `position="top"`.
+| <span class="prop-name">positionStatic</span> | <span class="prop-name">MuiMobileStepper-positionStatic</span> | Styles applied to the root element if `position="static"`.
+| <span class="prop-name">dots</span> | <span class="prop-name">MuiMobileStepper-dots</span> | Styles applied to the dots container if `variant="dots"`.
+| <span class="prop-name">dot</span> | <span class="prop-name">MuiMobileStepper-dot</span> | Styles applied to each dot if `variant="dots"`.
+| <span class="prop-name">dotActive</span> | <span class="prop-name">MuiMobileStepper-dotActive</span> | Styles applied to a dot if `variant="dots"` and this is the active step.
+| <span class="prop-name">progress</span> | <span class="prop-name">MuiMobileStepper-progress</span> | Styles applied to the Linear Progress component if `variant="progress"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">positionBottom</span> | Styles applied to the root element if `position="bottom"`.
-| <span class="prop-name">positionTop</span> | Styles applied to the root element if `position="top"`.
-| <span class="prop-name">positionStatic</span> | Styles applied to the root element if `position="static"`.
-| <span class="prop-name">dots</span> | Styles applied to the dots container if `variant="dots"`.
-| <span class="prop-name">dot</span> | Styles applied to each dot if `variant="dots"`.
-| <span class="prop-name">dotActive</span> | Styles applied to a dot if `variant="dots"` and this is the active step.
-| <span class="prop-name">progress</span> | Styles applied to the Linear Progress component if `variant="progress"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/MobileStepper/MobileStepper.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiMobileStepper`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/MobileStepper/MobileStepper.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/modal.md
+++ b/docs/pages/api/modal.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Modal/Modal.js
 <p class="description">The API documentation of the Modal React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Modal from '@material-ui/core/Modal';
+import { Modal } from '@material-ui/core';
 ```
 
 Modal is a lower-level construct that is leveraged by the following components:

--- a/docs/pages/api/native-select.md
+++ b/docs/pages/api/native-select.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/NativeSelect/NativeSelect.js
 <p class="description">The API documentation of the NativeSelect React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import NativeSelect from '@material-ui/core/NativeSelect';
+import { NativeSelect } from '@material-ui/core';
 ```
 
 An alternative to `<Select native />` with a much smaller bundle size footprint.
@@ -33,26 +33,26 @@ Any other properties supplied will be provided to the root element ([Input](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiNativeSelect`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiNativeSelect-root</span> | Styles applied to the select component `root` class.
+| <span class="prop-name">select</span> | <span class="prop-name">MuiNativeSelect-select</span> | Styles applied to the select component `select` class.
+| <span class="prop-name">filled</span> | <span class="prop-name">MuiNativeSelect-filled</span> | Styles applied to the select component if `variant="filled"`.
+| <span class="prop-name">outlined</span> | <span class="prop-name">MuiNativeSelect-outlined</span> | Styles applied to the select component if `variant="outlined"`.
+| <span class="prop-name">selectMenu</span> | <span class="prop-name">MuiNativeSelect-selectMenu</span> | Styles applied to the select component `selectMenu` class.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the select component `disabled` class.
+| <span class="prop-name">icon</span> | <span class="prop-name">MuiNativeSelect-icon</span> | Styles applied to the select component `icon` class.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the select component `root` class.
-| <span class="prop-name">select</span> | Styles applied to the select component `select` class.
-| <span class="prop-name">filled</span> | Styles applied to the select component if `variant="filled"`.
-| <span class="prop-name">outlined</span> | Styles applied to the select component if `variant="outlined"`.
-| <span class="prop-name">selectMenu</span> | Styles applied to the select component `selectMenu` class.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the select component `disabled` class.
-| <span class="prop-name">icon</span> | Styles applied to the select component `icon` class.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/NativeSelect/NativeSelect.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiNativeSelect`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/NativeSelect/NativeSelect.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/no-ssr.md
+++ b/docs/pages/api/no-ssr.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/NoSsr/NoSsr.js
 <p class="description">The API documentation of the NoSsr React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import NoSsr from '@material-ui/core/NoSsr';
+import { NoSsr } from '@material-ui/core';
 ```
 
 NoSsr purposely removes components from the subject of Server Side Rendering (SSR).

--- a/docs/pages/api/outlined-input.md
+++ b/docs/pages/api/outlined-input.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/OutlinedInput/OutlinedInput.js
 <p class="description">The API documentation of the OutlinedInput React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import OutlinedInput from '@material-ui/core/OutlinedInput';
+import { OutlinedInput } from '@material-ui/core';
 ```
 
 
@@ -52,34 +52,34 @@ Any other properties supplied will be provided to the root element ([InputBase](
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiOutlinedInput`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiOutlinedInput-root</span> | Styles applied to the root element.
+| <span class="prop-name">focused</span> | <span class="prop-name">Mui-focused</span> | Styles applied to the root element if the component is focused.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Styles applied to the root element if `disabled={true}`.
+| <span class="prop-name">adornedStart</span> | <span class="prop-name">MuiOutlinedInput-adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
+| <span class="prop-name">adornedEnd</span> | <span class="prop-name">MuiOutlinedInput-adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Styles applied to the root element if `error={true}`.
+| <span class="prop-name">marginDense</span> | <span class="prop-name">MuiOutlinedInput-marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">multiline</span> | <span class="prop-name">MuiOutlinedInput-multiline</span> | Styles applied to the root element if `multiline={true}`.
+| <span class="prop-name">notchedOutline</span> | <span class="prop-name">MuiOutlinedInput-notchedOutline</span> | Styles applied to the `NotchedOutline` element.
+| <span class="prop-name">input</span> | <span class="prop-name">MuiOutlinedInput-input</span> | Styles applied to the `input` element.
+| <span class="prop-name">inputMarginDense</span> | <span class="prop-name">MuiOutlinedInput-inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
+| <span class="prop-name">inputSelect</span> | <span class="prop-name">MuiOutlinedInput-inputSelect</span> | Styles applied to the `input` element if `select={true}`.
+| <span class="prop-name">inputMultiline</span> | <span class="prop-name">MuiOutlinedInput-inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
+| <span class="prop-name">inputAdornedStart</span> | <span class="prop-name">MuiOutlinedInput-inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
+| <span class="prop-name">inputAdornedEnd</span> | <span class="prop-name">MuiOutlinedInput-inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">focused</span> | Styles applied to the root element if the component is focused.
-| <span class="prop-name">disabled</span> | Styles applied to the root element if `disabled={true}`.
-| <span class="prop-name">adornedStart</span> | Styles applied to the root element if `startAdornment` is provided.
-| <span class="prop-name">adornedEnd</span> | Styles applied to the root element if `endAdornment` is provided.
-| <span class="prop-name">error</span> | Styles applied to the root element if `error={true}`.
-| <span class="prop-name">marginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">multiline</span> | Styles applied to the root element if `multiline={true}`.
-| <span class="prop-name">notchedOutline</span> | Styles applied to the `NotchedOutline` element.
-| <span class="prop-name">input</span> | Styles applied to the `input` element.
-| <span class="prop-name">inputMarginDense</span> | Styles applied to the `input` element if `margin="dense"`.
-| <span class="prop-name">inputSelect</span> | Styles applied to the `input` element if `select={true}`.
-| <span class="prop-name">inputMultiline</span> | Styles applied to the `input` element if `multiline={true}`.
-| <span class="prop-name">inputAdornedStart</span> | Styles applied to the `input` element if `startAdornment` is provided.
-| <span class="prop-name">inputAdornedEnd</span> | Styles applied to the `input` element if `endAdornment` is provided.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/OutlinedInput/OutlinedInput.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiOutlinedInput`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/OutlinedInput/OutlinedInput.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/paper.md
+++ b/docs/pages/api/paper.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Paper/Paper.js
 <p class="description">The API documentation of the Paper React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Paper from '@material-ui/core/Paper';
+import { Paper } from '@material-ui/core';
 ```
 
 
@@ -30,46 +30,46 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiPaper`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiPaper-root</span> | Styles applied to the root element.
+| <span class="prop-name">rounded</span> | <span class="prop-name">MuiPaper-rounded</span> | Styles applied to the root element if `square={false}`.
+| <span class="prop-name">elevation0</span> | <span class="prop-name">MuiPaper-elevation0</span> | 
+| <span class="prop-name">elevation1</span> | <span class="prop-name">MuiPaper-elevation1</span> | 
+| <span class="prop-name">elevation2</span> | <span class="prop-name">MuiPaper-elevation2</span> | 
+| <span class="prop-name">elevation3</span> | <span class="prop-name">MuiPaper-elevation3</span> | 
+| <span class="prop-name">elevation4</span> | <span class="prop-name">MuiPaper-elevation4</span> | 
+| <span class="prop-name">elevation5</span> | <span class="prop-name">MuiPaper-elevation5</span> | 
+| <span class="prop-name">elevation6</span> | <span class="prop-name">MuiPaper-elevation6</span> | 
+| <span class="prop-name">elevation7</span> | <span class="prop-name">MuiPaper-elevation7</span> | 
+| <span class="prop-name">elevation8</span> | <span class="prop-name">MuiPaper-elevation8</span> | 
+| <span class="prop-name">elevation9</span> | <span class="prop-name">MuiPaper-elevation9</span> | 
+| <span class="prop-name">elevation10</span> | <span class="prop-name">MuiPaper-elevation10</span> | 
+| <span class="prop-name">elevation11</span> | <span class="prop-name">MuiPaper-elevation11</span> | 
+| <span class="prop-name">elevation12</span> | <span class="prop-name">MuiPaper-elevation12</span> | 
+| <span class="prop-name">elevation13</span> | <span class="prop-name">MuiPaper-elevation13</span> | 
+| <span class="prop-name">elevation14</span> | <span class="prop-name">MuiPaper-elevation14</span> | 
+| <span class="prop-name">elevation15</span> | <span class="prop-name">MuiPaper-elevation15</span> | 
+| <span class="prop-name">elevation16</span> | <span class="prop-name">MuiPaper-elevation16</span> | 
+| <span class="prop-name">elevation17</span> | <span class="prop-name">MuiPaper-elevation17</span> | 
+| <span class="prop-name">elevation18</span> | <span class="prop-name">MuiPaper-elevation18</span> | 
+| <span class="prop-name">elevation19</span> | <span class="prop-name">MuiPaper-elevation19</span> | 
+| <span class="prop-name">elevation20</span> | <span class="prop-name">MuiPaper-elevation20</span> | 
+| <span class="prop-name">elevation21</span> | <span class="prop-name">MuiPaper-elevation21</span> | 
+| <span class="prop-name">elevation22</span> | <span class="prop-name">MuiPaper-elevation22</span> | 
+| <span class="prop-name">elevation23</span> | <span class="prop-name">MuiPaper-elevation23</span> | 
+| <span class="prop-name">elevation24</span> | <span class="prop-name">MuiPaper-elevation24</span> | 
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">rounded</span> | Styles applied to the root element if `square={false}`.
-| <span class="prop-name">elevation0</span> | 
-| <span class="prop-name">elevation1</span> | 
-| <span class="prop-name">elevation2</span> | 
-| <span class="prop-name">elevation3</span> | 
-| <span class="prop-name">elevation4</span> | 
-| <span class="prop-name">elevation5</span> | 
-| <span class="prop-name">elevation6</span> | 
-| <span class="prop-name">elevation7</span> | 
-| <span class="prop-name">elevation8</span> | 
-| <span class="prop-name">elevation9</span> | 
-| <span class="prop-name">elevation10</span> | 
-| <span class="prop-name">elevation11</span> | 
-| <span class="prop-name">elevation12</span> | 
-| <span class="prop-name">elevation13</span> | 
-| <span class="prop-name">elevation14</span> | 
-| <span class="prop-name">elevation15</span> | 
-| <span class="prop-name">elevation16</span> | 
-| <span class="prop-name">elevation17</span> | 
-| <span class="prop-name">elevation18</span> | 
-| <span class="prop-name">elevation19</span> | 
-| <span class="prop-name">elevation20</span> | 
-| <span class="prop-name">elevation21</span> | 
-| <span class="prop-name">elevation22</span> | 
-| <span class="prop-name">elevation23</span> | 
-| <span class="prop-name">elevation24</span> | 
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Paper/Paper.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiPaper`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Paper/Paper.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/popover.md
+++ b/docs/pages/api/popover.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Popover/Popover.js
 <p class="description">The API documentation of the Popover React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Popover from '@material-ui/core/Popover';
+import { Popover } from '@material-ui/core';
 ```
 
 
@@ -50,20 +50,20 @@ Any other properties supplied will be provided to the root element ([Modal](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiPopover`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">paper</span> | <span class="prop-name">MuiPopover-paper</span> | Styles applied to the `Paper` component.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">paper</span> | Styles applied to the `Paper` component.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Popover/Popover.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiPopover`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Popover/Popover.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/popper.md
+++ b/docs/pages/api/popper.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Popper/Popper.js
 <p class="description">The API documentation of the Popper React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Popper from '@material-ui/core/Popper';
+import { Popper } from '@material-ui/core';
 ```
 
 Poppers rely on the 3rd party library [Popper.js](https://github.com/FezVrasta/popper.js) for positioning.

--- a/docs/pages/api/portal.md
+++ b/docs/pages/api/portal.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Portal/Portal.js
 <p class="description">The API documentation of the Portal React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Portal from '@material-ui/core/Portal';
+import { Portal } from '@material-ui/core';
 ```
 
 Portals provide a first-class way to render children into a DOM node

--- a/docs/pages/api/radio-group.md
+++ b/docs/pages/api/radio-group.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/RadioGroup/RadioGroup.js
 <p class="description">The API documentation of the RadioGroup React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import RadioGroup from '@material-ui/core/RadioGroup';
+import { RadioGroup } from '@material-ui/core';
 ```
 
 

--- a/docs/pages/api/radio.md
+++ b/docs/pages/api/radio.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Radio/Radio.js
 <p class="description">The API documentation of the Radio React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Radio from '@material-ui/core/Radio';
+import { Radio } from '@material-ui/core';
 ```
 
 
@@ -39,24 +39,24 @@ Any other properties supplied will be provided to the root element ([IconButton]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiRadio`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiRadio-root</span> | Styles applied to the root element.
+| <span class="prop-name">checked</span> | <span class="prop-name">Mui-checked</span> | Pseudo-class applied to the root element if `checked={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiRadio-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiRadio-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">checked</span> | Pseudo-class applied to the root element if `checked={true}`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Radio/Radio.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiRadio`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Radio/Radio.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/rating.md
+++ b/docs/pages/api/rating.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui-lab/src/Rating/Rating.js
 <p class="description">The API documentation of the Rating React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Rating from '@material-ui/lab/Rating';
+import { Rating } from '@material-ui/lab';
 ```
 
 
@@ -39,35 +39,35 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiRating`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiRating-root</span> | Styles applied to the root element.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiRating-sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">sizeLarge</span> | <span class="prop-name">MuiRating-sizeLarge</span> | Styles applied to the root element if `size="large"`.
+| <span class="prop-name">readOnly</span> | <span class="prop-name">MuiRating-readOnly</span> | Styles applied to the root element if `readOnly={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the root element if keyboard focused.
+| <span class="prop-name">visuallyhidden</span> | <span class="prop-name">MuiRating-visuallyhidden</span> | Visually hide an element.
+| <span class="prop-name">pristine</span> | <span class="prop-name">MuiRating-pristine</span> | Styles applied to the pristine label.
+| <span class="prop-name">label</span> | <span class="prop-name">MuiRating-label</span> | Styles applied to the label elements.
+| <span class="prop-name">icon</span> | <span class="prop-name">MuiRating-icon</span> | Styles applied to the icon wrapping elements.
+| <span class="prop-name">iconEmpty</span> | <span class="prop-name">MuiRating-iconEmpty</span> | Styles applied to the icon wrapping elements when empty.
+| <span class="prop-name">iconFilled</span> | <span class="prop-name">MuiRating-iconFilled</span> | Styles applied to the icon wrapping elements when filled.
+| <span class="prop-name">iconHover</span> | <span class="prop-name">MuiRating-iconHover</span> | Styles applied to the icon wrapping elements when hover.
+| <span class="prop-name">iconFocus</span> | <span class="prop-name">MuiRating-iconFocus</span> | Styles applied to the icon wrapping elements when focus.
+| <span class="prop-name">iconActive</span> | <span class="prop-name">MuiRating-iconActive</span> | Styles applied to the icon wrapping elements when active.
+| <span class="prop-name">decimal</span> | <span class="prop-name">MuiRating-decimal</span> | Styles applied to the icon wrapping elements when decimals are necessary.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.
-| <span class="prop-name">readOnly</span> | Styles applied to the root element if `readOnly={true}`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the root element if keyboard focused.
-| <span class="prop-name">visuallyhidden</span> | Visually hide an element.
-| <span class="prop-name">pristine</span> | Styles applied to the pristine label.
-| <span class="prop-name">label</span> | Styles applied to the label elements.
-| <span class="prop-name">icon</span> | Styles applied to the icon wrapping elements.
-| <span class="prop-name">iconEmpty</span> | Styles applied to the icon wrapping elements when empty.
-| <span class="prop-name">iconFilled</span> | Styles applied to the icon wrapping elements when filled.
-| <span class="prop-name">iconHover</span> | Styles applied to the icon wrapping elements when hover.
-| <span class="prop-name">iconFocus</span> | Styles applied to the icon wrapping elements when focus.
-| <span class="prop-name">iconActive</span> | Styles applied to the icon wrapping elements when active.
-| <span class="prop-name">decimal</span> | Styles applied to the icon wrapping elements when decimals are necessary.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Rating/Rating.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiRating`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Rating/Rating.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/root-ref.md
+++ b/docs/pages/api/root-ref.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/RootRef/RootRef.js
 <p class="description">The API documentation of the RootRef React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import RootRef from '@material-ui/core/RootRef';
+import { RootRef } from '@material-ui/core';
 ```
 
 ⚠️⚠️⚠️

--- a/docs/pages/api/select.md
+++ b/docs/pages/api/select.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Select/Select.js
 <p class="description">The API documentation of the Select React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Select from '@material-ui/core/Select';
+import { Select } from '@material-ui/core';
 ```
 
 
@@ -43,26 +43,26 @@ Any other properties supplied will be provided to the root element ([Input](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSelect`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSelect-root</span> | Styles applied to the select component `root` class.
+| <span class="prop-name">select</span> | <span class="prop-name">MuiSelect-select</span> | Styles applied to the select component `select` class.
+| <span class="prop-name">filled</span> | <span class="prop-name">MuiSelect-filled</span> | Styles applied to the select component if `variant="filled"`.
+| <span class="prop-name">outlined</span> | <span class="prop-name">MuiSelect-outlined</span> | Styles applied to the select component if `variant="outlined"`.
+| <span class="prop-name">selectMenu</span> | <span class="prop-name">MuiSelect-selectMenu</span> | Styles applied to the select component `selectMenu` class.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the select component `disabled` class.
+| <span class="prop-name">icon</span> | <span class="prop-name">MuiSelect-icon</span> | Styles applied to the select component `icon` class.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the select component `root` class.
-| <span class="prop-name">select</span> | Styles applied to the select component `select` class.
-| <span class="prop-name">filled</span> | Styles applied to the select component if `variant="filled"`.
-| <span class="prop-name">outlined</span> | Styles applied to the select component if `variant="outlined"`.
-| <span class="prop-name">selectMenu</span> | Styles applied to the select component `selectMenu` class.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the select component `disabled` class.
-| <span class="prop-name">icon</span> | Styles applied to the select component `icon` class.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Select/Select.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSelect`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Select/Select.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/slide.md
+++ b/docs/pages/api/slide.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Slide/Slide.js
 <p class="description">The API documentation of the Slide React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Slide from '@material-ui/core/Slide';
+import { Slide } from '@material-ui/core';
 ```
 
 The Slide transition is used by the [Drawer](/components/drawers/) component.

--- a/docs/pages/api/slider.md
+++ b/docs/pages/api/slider.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Slider/Slider.js
 <p class="description">The API documentation of the Slider React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Slider from '@material-ui/core/Slider';
+import { Slider } from '@material-ui/core';
 ```
 
 
@@ -46,33 +46,33 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSlider`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSlider-root</span> | Styles applied to the root element.
+| <span class="prop-name">marked</span> | <span class="prop-name">MuiSlider-marked</span> | Styles applied to the root element if `marks` is provided with at least one label.
+| <span class="prop-name">vertical</span> | <span class="prop-name">MuiSlider-vertical</span> | Pseudo-class applied to the root element if `orientation="vertical"`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">rail</span> | <span class="prop-name">MuiSlider-rail</span> | Styles applied to the rail element.
+| <span class="prop-name">track</span> | <span class="prop-name">MuiSlider-track</span> | Styles applied to the track element.
+| <span class="prop-name">thumb</span> | <span class="prop-name">MuiSlider-thumb</span> | Styles applied to the thumb element.
+| <span class="prop-name">active</span> | <span class="prop-name">MuiSlider-active</span> | Pseudo-class applied to the thumb element if it's active.
+| <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the thumb element if keyboard focused.
+| <span class="prop-name">valueLabel</span> | <span class="prop-name">MuiSlider-valueLabel</span> | Styles applied to the thumb label element.
+| <span class="prop-name">mark</span> | <span class="prop-name">MuiSlider-mark</span> | Styles applied to the mark element.
+| <span class="prop-name">markActive</span> | <span class="prop-name">MuiSlider-markActive</span> | Styles applied to the mark element if active (depending on the value).
+| <span class="prop-name">markLabel</span> | <span class="prop-name">MuiSlider-markLabel</span> | Styles applied to the mark label element.
+| <span class="prop-name">markLabelActive</span> | <span class="prop-name">MuiSlider-markLabelActive</span> | Styles applied to the mark label element if active (depending on the value).
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">marked</span> | Styles applied to the root element if `marks` is provided with at least one label.
-| <span class="prop-name">vertical</span> | Pseudo-class applied to the root element if `orientation="vertical"`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">rail</span> | Styles applied to the rail element.
-| <span class="prop-name">track</span> | Styles applied to the track element.
-| <span class="prop-name">thumb</span> | Styles applied to the thumb element.
-| <span class="prop-name">active</span> | Pseudo-class applied to the thumb element if it's active.
-| <span class="prop-name">focusVisible</span> | Pseudo-class applied to the thumb element if keyboard focused.
-| <span class="prop-name">valueLabel</span> | Styles applied to the thumb label element.
-| <span class="prop-name">mark</span> | Styles applied to the mark element.
-| <span class="prop-name">markActive</span> | Styles applied to the mark element if active (depending on the value).
-| <span class="prop-name">markLabel</span> | Styles applied to the mark label element.
-| <span class="prop-name">markLabelActive</span> | Styles applied to the mark label element if active (depending on the value).
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Slider/Slider.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSlider`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Slider/Slider.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/snackbar-content.md
+++ b/docs/pages/api/snackbar-content.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/SnackbarContent/SnackbarContent.js
 <p class="description">The API documentation of the SnackbarContent React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import SnackbarContent from '@material-ui/core/SnackbarContent';
+import { SnackbarContent } from '@material-ui/core';
 ```
 
 
@@ -28,22 +28,22 @@ Any other properties supplied will be provided to the root element ([Paper](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSnackbarContent`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSnackbarContent-root</span> | Styles applied to the root element.
+| <span class="prop-name">message</span> | <span class="prop-name">MuiSnackbarContent-message</span> | Styles applied to the message wrapper element.
+| <span class="prop-name">action</span> | <span class="prop-name">MuiSnackbarContent-action</span> | Styles applied to the action wrapper element if `action` is provided.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">message</span> | Styles applied to the message wrapper element.
-| <span class="prop-name">action</span> | Styles applied to the action wrapper element if `action` is provided.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/SnackbarContent/SnackbarContent.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSnackbarContent`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/SnackbarContent/SnackbarContent.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/snackbar.md
+++ b/docs/pages/api/snackbar.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Snackbar/Snackbar.js
 <p class="description">The API documentation of the Snackbar React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Snackbar from '@material-ui/core/Snackbar';
+import { Snackbar } from '@material-ui/core';
 ```
 
 
@@ -47,26 +47,26 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSnackbar`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSnackbar-root</span> | Styles applied to the root element.
+| <span class="prop-name">anchorOriginTopCenter</span> | <span class="prop-name">MuiSnackbar-anchorOriginTopCenter</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'center' }}`.
+| <span class="prop-name">anchorOriginBottomCenter</span> | <span class="prop-name">MuiSnackbar-anchorOriginBottomCenter</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'center' }}`.
+| <span class="prop-name">anchorOriginTopRight</span> | <span class="prop-name">MuiSnackbar-anchorOriginTopRight</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }}`.
+| <span class="prop-name">anchorOriginBottomRight</span> | <span class="prop-name">MuiSnackbar-anchorOriginBottomRight</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }}`.
+| <span class="prop-name">anchorOriginTopLeft</span> | <span class="prop-name">MuiSnackbar-anchorOriginTopLeft</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }}`.
+| <span class="prop-name">anchorOriginBottomLeft</span> | <span class="prop-name">MuiSnackbar-anchorOriginBottomLeft</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">anchorOriginTopCenter</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'center' }}`.
-| <span class="prop-name">anchorOriginBottomCenter</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'center' }}`.
-| <span class="prop-name">anchorOriginTopRight</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'right' }}`.
-| <span class="prop-name">anchorOriginBottomRight</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'right' }}`.
-| <span class="prop-name">anchorOriginTopLeft</span> | Styles applied to the root element if `anchorOrigin={{ 'top', 'left' }}`.
-| <span class="prop-name">anchorOriginBottomLeft</span> | Styles applied to the root element if `anchorOrigin={{ 'bottom', 'left' }}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Snackbar/Snackbar.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSnackbar`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Snackbar/Snackbar.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/speed-dial-action.md
+++ b/docs/pages/api/speed-dial-action.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js
 <p class="description">The API documentation of the SpeedDialAction React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import SpeedDialAction from '@material-ui/lab/SpeedDialAction';
+import { SpeedDialAction } from '@material-ui/lab';
 ```
 
 
@@ -33,21 +33,21 @@ Any other properties supplied will be provided to the root element ([Tooltip](/a
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSpeedDialAction`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">button</span> | <span class="prop-name">MuiSpeedDialAction-button</span> | Styles applied to the `Button` component.
+| <span class="prop-name">buttonClosed</span> | <span class="prop-name">MuiSpeedDialAction-buttonClosed</span> | Styles applied to the `Button` component if `open={false}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">button</span> | Styles applied to the `Button` component.
-| <span class="prop-name">buttonClosed</span> | Styles applied to the `Button` component if `open={false}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSpeedDialAction`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/speed-dial-icon.md
+++ b/docs/pages/api/speed-dial-icon.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.js
 <p class="description">The API documentation of the SpeedDialIcon React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import SpeedDialIcon from '@material-ui/lab/SpeedDialIcon';
+import { SpeedDialIcon } from '@material-ui/lab';
 ```
 
 
@@ -28,25 +28,25 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSpeedDialIcon`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSpeedDialIcon-root</span> | Styles applied to the root element.
+| <span class="prop-name">icon</span> | <span class="prop-name">MuiSpeedDialIcon-icon</span> | Styles applied to the icon component.
+| <span class="prop-name">iconOpen</span> | <span class="prop-name">MuiSpeedDialIcon-iconOpen</span> | Styles applied to the icon component if `open={true}`.
+| <span class="prop-name">iconWithOpenIconOpen</span> | <span class="prop-name">MuiSpeedDialIcon-iconWithOpenIconOpen</span> | Styles applied to the icon when and `openIcon` is provided & if `open={true}`.
+| <span class="prop-name">openIcon</span> | <span class="prop-name">MuiSpeedDialIcon-openIcon</span> | Styles applied to the `openIcon` if provided.
+| <span class="prop-name">openIconOpen</span> | <span class="prop-name">MuiSpeedDialIcon-openIconOpen</span> | Styles applied to the `openIcon` if provided & if `open={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">icon</span> | Styles applied to the icon component.
-| <span class="prop-name">iconOpen</span> | Styles applied to the icon component if `open={true}`.
-| <span class="prop-name">iconWithOpenIconOpen</span> | Styles applied to the icon when and `openIcon` is provided & if `open={true}`.
-| <span class="prop-name">openIcon</span> | Styles applied to the `openIcon` if provided.
-| <span class="prop-name">openIconOpen</span> | Styles applied to the `openIcon` if provided & if `open={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSpeedDialIcon`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/speed-dial.md
+++ b/docs/pages/api/speed-dial.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui-lab/src/SpeedDial/SpeedDial.js
 <p class="description">The API documentation of the SpeedDial React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import SpeedDial from '@material-ui/lab/SpeedDial';
+import { SpeedDial } from '@material-ui/lab';
 ```
 
 
@@ -38,27 +38,27 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSpeedDial`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSpeedDial-root</span> | Styles applied to the root element.
+| <span class="prop-name">fab</span> | <span class="prop-name">MuiSpeedDial-fab</span> | Styles applied to the Button component.
+| <span class="prop-name">directionUp</span> | <span class="prop-name">MuiSpeedDial-directionUp</span> | Styles applied to the root and action container elements when direction="up"
+| <span class="prop-name">directionDown</span> | <span class="prop-name">MuiSpeedDial-directionDown</span> | Styles applied to the root and action container elements when direction="down"
+| <span class="prop-name">directionLeft</span> | <span class="prop-name">MuiSpeedDial-directionLeft</span> | Styles applied to the root and action container elements when direction="left"
+| <span class="prop-name">directionRight</span> | <span class="prop-name">MuiSpeedDial-directionRight</span> | Styles applied to the root and action container elements when direction="right"
+| <span class="prop-name">actions</span> | <span class="prop-name">MuiSpeedDial-actions</span> | Styles applied to the actions (`children` wrapper) element.
+| <span class="prop-name">actionsClosed</span> | <span class="prop-name">MuiSpeedDial-actionsClosed</span> | Styles applied to the actions (`children` wrapper) element if `open={false}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">fab</span> | Styles applied to the Button component.
-| <span class="prop-name">directionUp</span> | Styles applied to the root and action container elements when direction="up"
-| <span class="prop-name">directionDown</span> | Styles applied to the root and action container elements when direction="down"
-| <span class="prop-name">directionLeft</span> | Styles applied to the root and action container elements when direction="left"
-| <span class="prop-name">directionRight</span> | Styles applied to the root and action container elements when direction="right"
-| <span class="prop-name">actions</span> | Styles applied to the actions (`children` wrapper) element.
-| <span class="prop-name">actionsClosed</span> | Styles applied to the actions (`children` wrapper) element if `open={false}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDial/SpeedDial.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSpeedDial`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/SpeedDial/SpeedDial.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/step-button.md
+++ b/docs/pages/api/step-button.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/StepButton/StepButton.js
 <p class="description">The API documentation of the StepButton React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import StepButton from '@material-ui/core/StepButton';
+import { StepButton } from '@material-ui/core';
 ```
 
 
@@ -29,23 +29,23 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiStepButton`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiStepButton-root</span> | Styles applied to the root element.
+| <span class="prop-name">horizontal</span> | <span class="prop-name">MuiStepButton-horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
+| <span class="prop-name">vertical</span> | <span class="prop-name">MuiStepButton-vertical</span> | Styles applied to the root element if `orientation="vertical"`.
+| <span class="prop-name">touchRipple</span> | <span class="prop-name">MuiStepButton-touchRipple</span> | Styles applied to the `ButtonBase` touch-ripple.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
-| <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical"`.
-| <span class="prop-name">touchRipple</span> | Styles applied to the `ButtonBase` touch-ripple.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepButton/StepButton.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiStepButton`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepButton/StepButton.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/step-connector.md
+++ b/docs/pages/api/step-connector.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/StepConnector/StepConnector.js
 <p class="description">The API documentation of the StepConnector React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import StepConnector from '@material-ui/core/StepConnector';
+import { StepConnector } from '@material-ui/core';
 ```
 
 
@@ -26,29 +26,29 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiStepConnector`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiStepConnector-root</span> | Styles applied to the root element.
+| <span class="prop-name">horizontal</span> | <span class="prop-name">MuiStepConnector-horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
+| <span class="prop-name">vertical</span> | <span class="prop-name">MuiStepConnector-vertical</span> | Styles applied to the root element if `orientation="vertical"`.
+| <span class="prop-name">alternativeLabel</span> | <span class="prop-name">MuiStepConnector-alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
+| <span class="prop-name">active</span> | <span class="prop-name">MuiStepConnector-active</span> | Pseudo-class applied to the root element if `active={true}`.
+| <span class="prop-name">completed</span> | <span class="prop-name">MuiStepConnector-completed</span> | Pseudo-class applied to the root element if `completed={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">line</span> | <span class="prop-name">MuiStepConnector-line</span> | Styles applied to the line element.
+| <span class="prop-name">lineHorizontal</span> | <span class="prop-name">MuiStepConnector-lineHorizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
+| <span class="prop-name">lineVertical</span> | <span class="prop-name">MuiStepConnector-lineVertical</span> | Styles applied to the root element if `orientation="vertical"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
-| <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical"`.
-| <span class="prop-name">alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
-| <span class="prop-name">active</span> | Pseudo-class applied to the root element if `active={true}`.
-| <span class="prop-name">completed</span> | Pseudo-class applied to the root element if `completed={true}`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">line</span> | Styles applied to the line element.
-| <span class="prop-name">lineHorizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
-| <span class="prop-name">lineVertical</span> | Styles applied to the root element if `orientation="vertical"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepConnector/StepConnector.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiStepConnector`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepConnector/StepConnector.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/step-content.md
+++ b/docs/pages/api/step-content.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/StepContent/StepContent.js
 <p class="description">The API documentation of the StepContent React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import StepContent from '@material-ui/core/StepContent';
+import { StepContent } from '@material-ui/core';
 ```
 
 
@@ -30,22 +30,22 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiStepContent`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiStepContent-root</span> | Styles applied to the root element.
+| <span class="prop-name">last</span> | <span class="prop-name">MuiStepContent-last</span> | Styles applied to the root element if `last={true}` (controlled by `Step`).
+| <span class="prop-name">transition</span> | <span class="prop-name">MuiStepContent-transition</span> | Styles applied to the Transition component.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">last</span> | Styles applied to the root element if `last={true}` (controlled by `Step`).
-| <span class="prop-name">transition</span> | Styles applied to the Transition component.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepContent/StepContent.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiStepContent`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepContent/StepContent.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/step-icon.md
+++ b/docs/pages/api/step-icon.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/StepIcon/StepIcon.js
 <p class="description">The API documentation of the StepIcon React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import StepIcon from '@material-ui/core/StepIcon';
+import { StepIcon } from '@material-ui/core';
 ```
 
 
@@ -30,24 +30,24 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiStepIcon`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiStepIcon-root</span> | Styles applied to the root element.
+| <span class="prop-name">text</span> | <span class="prop-name">MuiStepIcon-text</span> | Styles applied to the SVG text element.
+| <span class="prop-name">active</span> | <span class="prop-name">MuiStepIcon-active</span> | Pseudo-class applied to the root element if `active={true}`.
+| <span class="prop-name">completed</span> | <span class="prop-name">MuiStepIcon-completed</span> | Pseudo-class applied to the root element if `completed={true}`.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Pseudo-class applied to the root element if `error={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">text</span> | Styles applied to the SVG text element.
-| <span class="prop-name">active</span> | Pseudo-class applied to the root element if `active={true}`.
-| <span class="prop-name">completed</span> | Pseudo-class applied to the root element if `completed={true}`.
-| <span class="prop-name">error</span> | Pseudo-class applied to the root element if `error={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepIcon/StepIcon.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiStepIcon`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepIcon/StepIcon.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/step-label.md
+++ b/docs/pages/api/step-label.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/StepLabel/StepLabel.js
 <p class="description">The API documentation of the StepLabel React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import StepLabel from '@material-ui/core/StepLabel';
+import { StepLabel } from '@material-ui/core';
 ```
 
 
@@ -33,30 +33,30 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiStepLabel`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiStepLabel-root</span> | Styles applied to the root element.
+| <span class="prop-name">horizontal</span> | <span class="prop-name">MuiStepLabel-horizontal</span> | Styles applied to the root element if `orientation="horizontal".
+| <span class="prop-name">vertical</span> | <span class="prop-name">MuiStepLabel-vertical</span> | Styles applied to the root element if `orientation="vertical".
+| <span class="prop-name">label</span> | <span class="prop-name">MuiStepLabel-label</span> | Styles applied to the `Typography` component which wraps `children`.
+| <span class="prop-name">active</span> | <span class="prop-name">MuiStepLabel-active</span> | Pseudo-class applied to the `Typography` component if `active={true}`.
+| <span class="prop-name">completed</span> | <span class="prop-name">MuiStepLabel-completed</span> | Pseudo-class applied to the `Typography` component if `completed={true}`.
+| <span class="prop-name">error</span> | <span class="prop-name">Mui-error</span> | Pseudo-class applied to the root element and `Typography` component if `error={true}`.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element and `Typography` component if `disabled={true}`.
+| <span class="prop-name">iconContainer</span> | <span class="prop-name">MuiStepLabel-iconContainer</span> | Styles applied to the `icon` container element.
+| <span class="prop-name">alternativeLabel</span> | <span class="prop-name">MuiStepLabel-alternativeLabel</span> | Pseudo-class applied to the root & icon container and `Typography` if `alternativeLabel={true}`.
+| <span class="prop-name">labelContainer</span> | <span class="prop-name">MuiStepLabel-labelContainer</span> | Styles applied to the container element which wraps `Typography` and `optional`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal".
-| <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical".
-| <span class="prop-name">label</span> | Styles applied to the `Typography` component which wraps `children`.
-| <span class="prop-name">active</span> | Pseudo-class applied to the `Typography` component if `active={true}`.
-| <span class="prop-name">completed</span> | Pseudo-class applied to the `Typography` component if `completed={true}`.
-| <span class="prop-name">error</span> | Pseudo-class applied to the root element and `Typography` component if `error={true}`.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element and `Typography` component if `disabled={true}`.
-| <span class="prop-name">iconContainer</span> | Styles applied to the `icon` container element.
-| <span class="prop-name">alternativeLabel</span> | Pseudo-class applied to the root & icon container and `Typography` if `alternativeLabel={true}`.
-| <span class="prop-name">labelContainer</span> | Styles applied to the container element which wraps `Typography` and `optional`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepLabel/StepLabel.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiStepLabel`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/StepLabel/StepLabel.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/step.md
+++ b/docs/pages/api/step.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Step/Step.js
 <p class="description">The API documentation of the Step React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Step from '@material-ui/core/Step';
+import { Step } from '@material-ui/core';
 ```
 
 
@@ -30,24 +30,24 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiStep`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiStep-root</span> | Styles applied to the root element.
+| <span class="prop-name">horizontal</span> | <span class="prop-name">MuiStep-horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
+| <span class="prop-name">vertical</span> | <span class="prop-name">MuiStep-vertical</span> | Styles applied to the root element if `orientation="vertical"`.
+| <span class="prop-name">alternativeLabel</span> | <span class="prop-name">MuiStep-alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
+| <span class="prop-name">completed</span> | <span class="prop-name">MuiStep-completed</span> | Pseudo-class applied to the root element if `completed={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
-| <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical"`.
-| <span class="prop-name">alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
-| <span class="prop-name">completed</span> | Pseudo-class applied to the root element if `completed={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Step/Step.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiStep`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Step/Step.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/stepper.md
+++ b/docs/pages/api/stepper.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Stepper/Stepper.js
 <p class="description">The API documentation of the Stepper React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Stepper from '@material-ui/core/Stepper';
+import { Stepper } from '@material-ui/core';
 ```
 
 
@@ -32,23 +32,23 @@ Any other properties supplied will be provided to the root element ([Paper](/api
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiStepper`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiStepper-root</span> | Styles applied to the root element.
+| <span class="prop-name">horizontal</span> | <span class="prop-name">MuiStepper-horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
+| <span class="prop-name">vertical</span> | <span class="prop-name">MuiStepper-vertical</span> | Styles applied to the root element if `orientation="vertical"`.
+| <span class="prop-name">alternativeLabel</span> | <span class="prop-name">MuiStepper-alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">horizontal</span> | Styles applied to the root element if `orientation="horizontal"`.
-| <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical"`.
-| <span class="prop-name">alternativeLabel</span> | Styles applied to the root element if `alternativeLabel={true}`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Stepper/Stepper.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiStepper`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Stepper/Stepper.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/svg-icon.md
+++ b/docs/pages/api/svg-icon.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/SvgIcon/SvgIcon.js
 <p class="description">The API documentation of the SvgIcon React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import SvgIcon from '@material-ui/core/SvgIcon';
+import { SvgIcon } from '@material-ui/core';
 ```
 
 
@@ -34,28 +34,28 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSvgIcon`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSvgIcon-root</span> | Styles applied to the root element.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiSvgIcon-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiSvgIcon-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">colorAction</span> | <span class="prop-name">MuiSvgIcon-colorAction</span> | Styles applied to the root element if `color="action"`.
+| <span class="prop-name">colorError</span> | <span class="prop-name">MuiSvgIcon-colorError</span> | Styles applied to the root element if `color="error"`.
+| <span class="prop-name">colorDisabled</span> | <span class="prop-name">MuiSvgIcon-colorDisabled</span> | Styles applied to the root element if `color="disabled"`.
+| <span class="prop-name">fontSizeInherit</span> | <span class="prop-name">MuiSvgIcon-fontSizeInherit</span> | Styles applied to the root element if `fontSize="inherit"`.
+| <span class="prop-name">fontSizeSmall</span> | <span class="prop-name">MuiSvgIcon-fontSizeSmall</span> | Styles applied to the root element if `fontSize="small"`.
+| <span class="prop-name">fontSizeLarge</span> | <span class="prop-name">MuiSvgIcon-fontSizeLarge</span> | Styles applied to the root element if `fontSize="large"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">colorAction</span> | Styles applied to the root element if `color="action"`.
-| <span class="prop-name">colorError</span> | Styles applied to the root element if `color="error"`.
-| <span class="prop-name">colorDisabled</span> | Styles applied to the root element if `color="disabled"`.
-| <span class="prop-name">fontSizeInherit</span> | Styles applied to the root element if `fontSize="inherit"`.
-| <span class="prop-name">fontSizeSmall</span> | Styles applied to the root element if `fontSize="small"`.
-| <span class="prop-name">fontSizeLarge</span> | Styles applied to the root element if `fontSize="large"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/SvgIcon/SvgIcon.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSvgIcon`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/SvgIcon/SvgIcon.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/swipeable-drawer.md
+++ b/docs/pages/api/swipeable-drawer.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
 <p class="description">The API documentation of the SwipeableDrawer React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
+import { SwipeableDrawer } from '@material-ui/core';
 ```
 
 

--- a/docs/pages/api/switch.md
+++ b/docs/pages/api/switch.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Switch/Switch.js
 <p class="description">The API documentation of the Switch React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Switch from '@material-ui/core/Switch';
+import { Switch } from '@material-ui/core';
 ```
 
 
@@ -40,31 +40,31 @@ Any other properties supplied will be provided to the root element ([IconButton]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiSwitch`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSwitch-root</span> | Styles applied to the root element.
+| <span class="prop-name">edgeStart</span> | <span class="prop-name">MuiSwitch-edgeStart</span> | Styles applied to the root element if `edge="start"`.
+| <span class="prop-name">edgeEnd</span> | <span class="prop-name">MuiSwitch-edgeEnd</span> | Styles applied to the root element if `edge="end"`.
+| <span class="prop-name">switchBase</span> | <span class="prop-name">MuiSwitch-switchBase</span> | Styles applied to the internal `SwitchBase` component's `root` class.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiSwitch-colorPrimary</span> | Styles applied to the internal SwitchBase component's root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiSwitch-colorSecondary</span> | Styles applied to the internal SwitchBase component's root element if `color="secondary"`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiSwitch-sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">checked</span> | <span class="prop-name">Mui-checked</span> | Pseudo-class applied to the internal `SwitchBase` component's `checked` class.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the internal SwitchBase component's disabled class.
+| <span class="prop-name">input</span> | <span class="prop-name">MuiSwitch-input</span> | Styles applied to the internal SwitchBase component's input element.
+| <span class="prop-name">thumb</span> | <span class="prop-name">MuiSwitch-thumb</span> | Styles used to create the thumb passed to the internal `SwitchBase` component `icon` prop.
+| <span class="prop-name">track</span> | <span class="prop-name">MuiSwitch-track</span> | Styles applied to the track element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">edgeStart</span> | Styles applied to the root element if `edge="start"`.
-| <span class="prop-name">edgeEnd</span> | Styles applied to the root element if `edge="end"`.
-| <span class="prop-name">switchBase</span> | Styles applied to the internal `SwitchBase` component's `root` class.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the internal SwitchBase component's root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the internal SwitchBase component's root element if `color="secondary"`.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">checked</span> | Pseudo-class applied to the internal `SwitchBase` component's `checked` class.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the internal SwitchBase component's disabled class.
-| <span class="prop-name">input</span> | Styles applied to the internal SwitchBase component's input element.
-| <span class="prop-name">thumb</span> | Styles used to create the thumb passed to the internal `SwitchBase` component `icon` prop.
-| <span class="prop-name">track</span> | Styles applied to the track element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Switch/Switch.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiSwitch`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Switch/Switch.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/tab.md
+++ b/docs/pages/api/tab.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Tab/Tab.js
 <p class="description">The API documentation of the Tab React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Tab from '@material-ui/core/Tab';
+import { Tab } from '@material-ui/core';
 ```
 
 
@@ -34,29 +34,29 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTab`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTab-root</span> | Styles applied to the root element.
+| <span class="prop-name">labelIcon</span> | <span class="prop-name">MuiTab-labelIcon</span> | Styles applied to the root element if both `icon` and `label` are provided.
+| <span class="prop-name">textColorInherit</span> | <span class="prop-name">MuiTab-textColorInherit</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="inherit"`.
+| <span class="prop-name">textColorPrimary</span> | <span class="prop-name">MuiTab-textColorPrimary</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="primary"`.
+| <span class="prop-name">textColorSecondary</span> | <span class="prop-name">MuiTab-textColorSecondary</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="secondary"`.
+| <span class="prop-name">selected</span> | <span class="prop-name">Mui-selected</span> | Pseudo-class applied to the root element if `selected={true}` (controlled by the Tabs component).
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}` (controlled by the Tabs component).
+| <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiTab-fullWidth</span> | Styles applied to the root element if `fullWidth={true}` (controlled by the Tabs component).
+| <span class="prop-name">wrapped</span> | <span class="prop-name">MuiTab-wrapped</span> | Styles applied to the root element if `wrapped={true}`.
+| <span class="prop-name">wrapper</span> | <span class="prop-name">MuiTab-wrapper</span> | Styles applied to the `icon` and `label`'s wrapper element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">labelIcon</span> | Styles applied to the root element if both `icon` and `label` are provided.
-| <span class="prop-name">textColorInherit</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="inherit"`.
-| <span class="prop-name">textColorPrimary</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="primary"`.
-| <span class="prop-name">textColorSecondary</span> | Styles applied to the root element if the parent [`Tabs`](/api/tabs/) has `textColor="secondary"`.
-| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if `selected={true}` (controlled by the Tabs component).
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}` (controlled by the Tabs component).
-| <span class="prop-name">fullWidth</span> | Styles applied to the root element if `fullWidth={true}` (controlled by the Tabs component).
-| <span class="prop-name">wrapped</span> | Styles applied to the root element if `wrapped={true}`.
-| <span class="prop-name">wrapper</span> | Styles applied to the `icon` and `label`'s wrapper element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tab/Tab.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTab`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tab/Tab.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/table-body.md
+++ b/docs/pages/api/table-body.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TableBody/TableBody.js
 <p class="description">The API documentation of the TableBody React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TableBody from '@material-ui/core/TableBody';
+import { TableBody } from '@material-ui/core';
 ```
 
 
@@ -28,20 +28,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTableBody`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTableBody-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableBody/TableBody.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTableBody`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableBody/TableBody.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/table-cell.md
+++ b/docs/pages/api/table-cell.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TableCell/TableCell.js
 <p class="description">The API documentation of the TableCell React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TableCell from '@material-ui/core/TableCell';
+import { TableCell } from '@material-ui/core';
 ```
 
 
@@ -34,30 +34,30 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTableCell`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTableCell-root</span> | Styles applied to the root element.
+| <span class="prop-name">head</span> | <span class="prop-name">MuiTableCell-head</span> | Styles applied to the root element if `variant="head"` or `context.table.head`.
+| <span class="prop-name">body</span> | <span class="prop-name">MuiTableCell-body</span> | Styles applied to the root element if `variant="body"` or `context.table.body`.
+| <span class="prop-name">footer</span> | <span class="prop-name">MuiTableCell-footer</span> | Styles applied to the root element if `variant="footer"` or `context.table.footer`.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiTableCell-sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">paddingCheckbox</span> | <span class="prop-name">MuiTableCell-paddingCheckbox</span> | Styles applied to the root element if `padding="checkbox"`.
+| <span class="prop-name">paddingNone</span> | <span class="prop-name">MuiTableCell-paddingNone</span> | Styles applied to the root element if `padding="none"`.
+| <span class="prop-name">alignLeft</span> | <span class="prop-name">MuiTableCell-alignLeft</span> | Styles applied to the root element if `align="left"`.
+| <span class="prop-name">alignCenter</span> | <span class="prop-name">MuiTableCell-alignCenter</span> | Styles applied to the root element if `align="center"`.
+| <span class="prop-name">alignRight</span> | <span class="prop-name">MuiTableCell-alignRight</span> | Styles applied to the root element if `align="right"`.
+| <span class="prop-name">alignJustify</span> | <span class="prop-name">MuiTableCell-alignJustify</span> | Styles applied to the root element if `align="justify"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">head</span> | Styles applied to the root element if `variant="head"` or `context.table.head`.
-| <span class="prop-name">body</span> | Styles applied to the root element if `variant="body"` or `context.table.body`.
-| <span class="prop-name">footer</span> | Styles applied to the root element if `variant="footer"` or `context.table.footer`.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">paddingCheckbox</span> | Styles applied to the root element if `padding="checkbox"`.
-| <span class="prop-name">paddingNone</span> | Styles applied to the root element if `padding="none"`.
-| <span class="prop-name">alignLeft</span> | Styles applied to the root element if `align="left"`.
-| <span class="prop-name">alignCenter</span> | Styles applied to the root element if `align="center"`.
-| <span class="prop-name">alignRight</span> | Styles applied to the root element if `align="right"`.
-| <span class="prop-name">alignJustify</span> | Styles applied to the root element if `align="justify"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableCell/TableCell.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTableCell`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableCell/TableCell.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/table-footer.md
+++ b/docs/pages/api/table-footer.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TableFooter/TableFooter.js
 <p class="description">The API documentation of the TableFooter React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TableFooter from '@material-ui/core/TableFooter';
+import { TableFooter } from '@material-ui/core';
 ```
 
 
@@ -28,20 +28,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTableFooter`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTableFooter-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableFooter/TableFooter.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTableFooter`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableFooter/TableFooter.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/table-head.md
+++ b/docs/pages/api/table-head.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TableHead/TableHead.js
 <p class="description">The API documentation of the TableHead React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TableHead from '@material-ui/core/TableHead';
+import { TableHead } from '@material-ui/core';
 ```
 
 
@@ -28,20 +28,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTableHead`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTableHead-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableHead/TableHead.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTableHead`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableHead/TableHead.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/table-pagination.md
+++ b/docs/pages/api/table-pagination.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TablePagination/TablePagination.js
 <p class="description">The API documentation of the TablePagination React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TablePagination from '@material-ui/core/TablePagination';
+import { TablePagination } from '@material-ui/core';
 ```
 
 A `TableCell` based component for placing inside `TableFooter` for pagination.
@@ -39,29 +39,29 @@ Any other properties supplied will be provided to the root element ([TableCell](
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTablePagination`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTablePagination-root</span> | Styles applied to the root element.
+| <span class="prop-name">toolbar</span> | <span class="prop-name">MuiTablePagination-toolbar</span> | Styles applied to the Toolbar component.
+| <span class="prop-name">spacer</span> | <span class="prop-name">MuiTablePagination-spacer</span> | Styles applied to the spacer element.
+| <span class="prop-name">caption</span> | <span class="prop-name">MuiTablePagination-caption</span> | Styles applied to the caption Typography components if `variant="caption"`.
+| <span class="prop-name">selectRoot</span> | <span class="prop-name">MuiTablePagination-selectRoot</span> | Styles applied to the Select component root element.
+| <span class="prop-name">select</span> | <span class="prop-name">MuiTablePagination-select</span> | Styles applied to the Select component `select` class.
+| <span class="prop-name">selectIcon</span> | <span class="prop-name">MuiTablePagination-selectIcon</span> | Styles applied to the Select component `icon` class.
+| <span class="prop-name">input</span> | <span class="prop-name">MuiTablePagination-input</span> | Styles applied to the `InputBase` component.
+| <span class="prop-name">menuItem</span> | <span class="prop-name">MuiTablePagination-menuItem</span> | Styles applied to the MenuItem component.
+| <span class="prop-name">actions</span> | <span class="prop-name">MuiTablePagination-actions</span> | Styles applied to the internal `TablePaginationActions` component.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">toolbar</span> | Styles applied to the Toolbar component.
-| <span class="prop-name">spacer</span> | Styles applied to the spacer element.
-| <span class="prop-name">caption</span> | Styles applied to the caption Typography components if `variant="caption"`.
-| <span class="prop-name">selectRoot</span> | Styles applied to the Select component root element.
-| <span class="prop-name">select</span> | Styles applied to the Select component `select` class.
-| <span class="prop-name">selectIcon</span> | Styles applied to the Select component `icon` class.
-| <span class="prop-name">input</span> | Styles applied to the `InputBase` component.
-| <span class="prop-name">menuItem</span> | Styles applied to the MenuItem component.
-| <span class="prop-name">actions</span> | Styles applied to the internal `TablePaginationActions` component.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TablePagination/TablePagination.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTablePagination`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TablePagination/TablePagination.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/table-row.md
+++ b/docs/pages/api/table-row.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TableRow/TableRow.js
 <p class="description">The API documentation of the TableRow React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TableRow from '@material-ui/core/TableRow';
+import { TableRow } from '@material-ui/core';
 ```
 
 Will automatically set dynamic row height
@@ -31,24 +31,24 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTableRow`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTableRow-root</span> | Styles applied to the root element.
+| <span class="prop-name">selected</span> | <span class="prop-name">Mui-selected</span> | Pseudo-class applied to the root element if `selected={true}`.
+| <span class="prop-name">hover</span> | <span class="prop-name">MuiTableRow-hover</span> | Pseudo-class applied to the root element if `hover={true}`.
+| <span class="prop-name">head</span> | <span class="prop-name">MuiTableRow-head</span> | Styles applied to the root element if table variant="head".
+| <span class="prop-name">footer</span> | <span class="prop-name">MuiTableRow-footer</span> | Styles applied to the root element if table variant="footer".
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if `selected={true}`.
-| <span class="prop-name">hover</span> | Pseudo-class applied to the root element if `hover={true}`.
-| <span class="prop-name">head</span> | Styles applied to the root element if table variant="head".
-| <span class="prop-name">footer</span> | Styles applied to the root element if table variant="footer".
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableRow/TableRow.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTableRow`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableRow/TableRow.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/table-sort-label.md
+++ b/docs/pages/api/table-sort-label.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TableSortLabel/TableSortLabel.js
 <p class="description">The API documentation of the TableSortLabel React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TableSortLabel from '@material-ui/core/TableSortLabel';
+import { TableSortLabel } from '@material-ui/core';
 ```
 
 A button based label for placing inside `TableCell` for column sorting.
@@ -31,24 +31,24 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTableSortLabel`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTableSortLabel-root</span> | Styles applied to the root element.
+| <span class="prop-name">active</span> | <span class="prop-name">MuiTableSortLabel-active</span> | Pseudo-class applied to the root element if `active={true}`.
+| <span class="prop-name">icon</span> | <span class="prop-name">MuiTableSortLabel-icon</span> | Styles applied to the icon component.
+| <span class="prop-name">iconDirectionDesc</span> | <span class="prop-name">MuiTableSortLabel-iconDirectionDesc</span> | Styles applied to the icon component if `direction="desc"`.
+| <span class="prop-name">iconDirectionAsc</span> | <span class="prop-name">MuiTableSortLabel-iconDirectionAsc</span> | Styles applied to the icon component if `direction="asc"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">active</span> | Pseudo-class applied to the root element if `active={true}`.
-| <span class="prop-name">icon</span> | Styles applied to the icon component.
-| <span class="prop-name">iconDirectionDesc</span> | Styles applied to the icon component if `direction="desc"`.
-| <span class="prop-name">iconDirectionAsc</span> | Styles applied to the icon component if `direction="asc"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableSortLabel/TableSortLabel.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTableSortLabel`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableSortLabel/TableSortLabel.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/table.md
+++ b/docs/pages/api/table.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Table/Table.js
 <p class="description">The API documentation of the Table React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Table from '@material-ui/core/Table';
+import { Table } from '@material-ui/core';
 ```
 
 
@@ -30,20 +30,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTable`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTable-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Table/Table.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTable`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Table/Table.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/tabs.md
+++ b/docs/pages/api/tabs.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Tabs/Tabs.js
 <p class="description">The API documentation of the Tabs React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Tabs from '@material-ui/core/Tabs';
+import { Tabs } from '@material-ui/core';
 ```
 
 
@@ -39,30 +39,30 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTabs`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTabs-root</span> | Styles applied to the root element.
+| <span class="prop-name">vertical</span> | <span class="prop-name">MuiTabs-vertical</span> | Styles applied to the root element if `orientation="vertical"`.
+| <span class="prop-name">flexContainer</span> | <span class="prop-name">MuiTabs-flexContainer</span> | Styles applied to the flex container element.
+| <span class="prop-name">flexContainerVertical</span> | <span class="prop-name">MuiTabs-flexContainerVertical</span> | Styles applied to the flex container element if `orientation="vertical"`.
+| <span class="prop-name">centered</span> | <span class="prop-name">MuiTabs-centered</span> | Styles applied to the flex container element if `centered={true}` & `!variant="scrollable"`.
+| <span class="prop-name">scroller</span> | <span class="prop-name">MuiTabs-scroller</span> | Styles applied to the tablist element.
+| <span class="prop-name">fixed</span> | <span class="prop-name">MuiTabs-fixed</span> | Styles applied to the tablist element if `!variant="scrollable"`.
+| <span class="prop-name">scrollable</span> | <span class="prop-name">MuiTabs-scrollable</span> | Styles applied to the tablist element if `variant="scrollable"`.
+| <span class="prop-name">scrollButtons</span> | <span class="prop-name">MuiTabs-scrollButtons</span> | Styles applied to the `ScrollButtonComponent` component.
+| <span class="prop-name">scrollButtonsDesktop</span> | <span class="prop-name">MuiTabs-scrollButtonsDesktop</span> | Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"` or scrollButtons="desktop"`.
+| <span class="prop-name">indicator</span> | <span class="prop-name">MuiTabs-indicator</span> | Styles applied to the `TabIndicator` component.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">vertical</span> | Styles applied to the root element if `orientation="vertical"`.
-| <span class="prop-name">flexContainer</span> | Styles applied to the flex container element.
-| <span class="prop-name">flexContainerVertical</span> | Styles applied to the flex container element if `orientation="vertical"`.
-| <span class="prop-name">centered</span> | Styles applied to the flex container element if `centered={true}` & `!variant="scrollable"`.
-| <span class="prop-name">scroller</span> | Styles applied to the tablist element.
-| <span class="prop-name">fixed</span> | Styles applied to the tablist element if `!variant="scrollable"`.
-| <span class="prop-name">scrollable</span> | Styles applied to the tablist element if `variant="scrollable"`.
-| <span class="prop-name">scrollButtons</span> | Styles applied to the `ScrollButtonComponent` component.
-| <span class="prop-name">scrollButtonsDesktop</span> | Styles applied to the `ScrollButtonComponent` component if `scrollButtons="auto"` or scrollButtons="desktop"`.
-| <span class="prop-name">indicator</span> | Styles applied to the `TabIndicator` component.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tabs/Tabs.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTabs`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tabs/Tabs.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/text-field.md
+++ b/docs/pages/api/text-field.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TextField/TextField.js
 <p class="description">The API documentation of the TextField React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TextField from '@material-ui/core/TextField';
+import { TextField } from '@material-ui/core';
 ```
 
 The `TextField` is a convenience wrapper for the most common cases (80%).
@@ -82,20 +82,20 @@ Any other properties supplied will be provided to the root element ([FormControl
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTextField`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTextField-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TextField/TextField.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTextField`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TextField/TextField.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/textarea-autosize.md
+++ b/docs/pages/api/textarea-autosize.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
 <p class="description">The API documentation of the TextareaAutosize React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TextareaAutosize from '@material-ui/core/TextareaAutosize';
+import { TextareaAutosize } from '@material-ui/core';
 ```
 
 

--- a/docs/pages/api/toggle-button-group.md
+++ b/docs/pages/api/toggle-button-group.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js
 <p class="description">The API documentation of the ToggleButtonGroup React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+import { ToggleButtonGroup } from '@material-ui/lab';
 ```
 
 
@@ -31,20 +31,20 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiToggleButtonGroup`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiToggleButtonGroup-root</span> | Styles applied to the root element.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiToggleButtonGroup`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/toggle-button.md
+++ b/docs/pages/api/toggle-button.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui-lab/src/ToggleButton/ToggleButton.js
 <p class="description">The API documentation of the ToggleButton React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import ToggleButton from '@material-ui/lab/ToggleButton';
+import { ToggleButton } from '@material-ui/lab';
 ```
 
 
@@ -32,25 +32,25 @@ Any other properties supplied will be provided to the root element ([ButtonBase]
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiToggleButton`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiToggleButton-root</span> | Styles applied to the root element.
+| <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">selected</span> | <span class="prop-name">Mui-selected</span> | Pseudo-class applied to the root element if `selected={true}`.
+| <span class="prop-name">label</span> | <span class="prop-name">MuiToggleButton-label</span> | Styles applied to the `label` wrapper element.
+| <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiToggleButton-sizeSmall</span> | Styles applied to the root element if `size="small"`.
+| <span class="prop-name">sizeLarge</span> | <span class="prop-name">MuiToggleButton-sizeLarge</span> | Styles applied to the root element if `size="large"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
-| <span class="prop-name">selected</span> | Pseudo-class applied to the root element if `selected={true}`.
-| <span class="prop-name">label</span> | Styles applied to the `label` wrapper element.
-| <span class="prop-name">sizeSmall</span> | Styles applied to the root element if `size="small"`.
-| <span class="prop-name">sizeLarge</span> | Styles applied to the root element if `size="large"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/ToggleButton/ToggleButton.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiToggleButton`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/ToggleButton/ToggleButton.js) for more detail.
 
 ## Inheritance
 

--- a/docs/pages/api/toolbar.md
+++ b/docs/pages/api/toolbar.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Toolbar/Toolbar.js
 <p class="description">The API documentation of the Toolbar React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Toolbar from '@material-ui/core/Toolbar';
+import { Toolbar } from '@material-ui/core';
 ```
 
 
@@ -30,23 +30,23 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiToolbar`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiToolbar-root</span> | Styles applied to the root element.
+| <span class="prop-name">gutters</span> | <span class="prop-name">MuiToolbar-gutters</span> | Styles applied to the root element if `disableGutters={false}`.
+| <span class="prop-name">regular</span> | <span class="prop-name">MuiToolbar-regular</span> | Styles applied to the root element if `variant="regular"`.
+| <span class="prop-name">dense</span> | <span class="prop-name">MuiToolbar-dense</span> | Styles applied to the root element if `variant="dense"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">gutters</span> | Styles applied to the root element if `disableGutters={false}`.
-| <span class="prop-name">regular</span> | Styles applied to the root element if `variant="regular"`.
-| <span class="prop-name">dense</span> | Styles applied to the root element if `variant="dense"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Toolbar/Toolbar.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiToolbar`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Toolbar/Toolbar.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/tooltip.md
+++ b/docs/pages/api/tooltip.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Tooltip/Tooltip.js
 <p class="description">The API documentation of the Tooltip React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Tooltip from '@material-ui/core/Tooltip';
+import { Tooltip } from '@material-ui/core';
 ```
 
 
@@ -44,27 +44,27 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTooltip`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">popper</span> | <span class="prop-name">MuiTooltip-popper</span> | Styles applied to the Popper component.
+| <span class="prop-name">popperInteractive</span> | <span class="prop-name">MuiTooltip-popperInteractive</span> | Styles applied to the Popper component if `interactive={true}`.
+| <span class="prop-name">tooltip</span> | <span class="prop-name">MuiTooltip-tooltip</span> | Styles applied to the tooltip (label wrapper) element.
+| <span class="prop-name">touch</span> | <span class="prop-name">MuiTooltip-touch</span> | Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch.
+| <span class="prop-name">tooltipPlacementLeft</span> | <span class="prop-name">MuiTooltip-tooltipPlacementLeft</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "left".
+| <span class="prop-name">tooltipPlacementRight</span> | <span class="prop-name">MuiTooltip-tooltipPlacementRight</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "right".
+| <span class="prop-name">tooltipPlacementTop</span> | <span class="prop-name">MuiTooltip-tooltipPlacementTop</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "top".
+| <span class="prop-name">tooltipPlacementBottom</span> | <span class="prop-name">MuiTooltip-tooltipPlacementBottom</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "bottom".
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">popper</span> | Styles applied to the Popper component.
-| <span class="prop-name">popperInteractive</span> | Styles applied to the Popper component if `interactive={true}`.
-| <span class="prop-name">tooltip</span> | Styles applied to the tooltip (label wrapper) element.
-| <span class="prop-name">touch</span> | Styles applied to the tooltip (label wrapper) element if the tooltip is opened by touch.
-| <span class="prop-name">tooltipPlacementLeft</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "left".
-| <span class="prop-name">tooltipPlacementRight</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "right".
-| <span class="prop-name">tooltipPlacementTop</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "top".
-| <span class="prop-name">tooltipPlacementBottom</span> | Styles applied to the tooltip (label wrapper) element if `placement` contains "bottom".
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTooltip`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Tooltip/Tooltip.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/touch-ripple.md
+++ b/docs/pages/api/touch-ripple.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/ButtonBase/TouchRipple.js
 <p class="description">The API documentation of the TouchRipple React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import TouchRipple from '@material-ui/core/ButtonBase/TouchRipple';
+import { TouchRipple } from '@material-ui/core/ButtonBase/TouchRipple.js';
 ```
 
 
@@ -27,26 +27,26 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTouchRipple`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTouchRipple-root</span> | Styles applied to the root element.
+| <span class="prop-name">ripple</span> | <span class="prop-name">MuiTouchRipple-ripple</span> | Styles applied to the internal `Ripple` components `ripple` class.
+| <span class="prop-name">rippleVisible</span> | <span class="prop-name">MuiTouchRipple-rippleVisible</span> | Styles applied to the internal `Ripple` components `rippleVisible` class.
+| <span class="prop-name">ripplePulsate</span> | <span class="prop-name">MuiTouchRipple-ripplePulsate</span> | Styles applied to the internal `Ripple` components `ripplePulsate` class.
+| <span class="prop-name">child</span> | <span class="prop-name">MuiTouchRipple-child</span> | Styles applied to the internal `Ripple` components `child` class.
+| <span class="prop-name">childLeaving</span> | <span class="prop-name">MuiTouchRipple-childLeaving</span> | Styles applied to the internal `Ripple` components `childLeaving` class.
+| <span class="prop-name">childPulsate</span> | <span class="prop-name">MuiTouchRipple-childPulsate</span> | Styles applied to the internal `Ripple` components `childPulsate` class.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">ripple</span> | Styles applied to the internal `Ripple` components `ripple` class.
-| <span class="prop-name">rippleVisible</span> | Styles applied to the internal `Ripple` components `rippleVisible` class.
-| <span class="prop-name">ripplePulsate</span> | Styles applied to the internal `Ripple` components `ripplePulsate` class.
-| <span class="prop-name">child</span> | Styles applied to the internal `Ripple` components `child` class.
-| <span class="prop-name">childLeaving</span> | Styles applied to the internal `Ripple` components `childLeaving` class.
-| <span class="prop-name">childPulsate</span> | Styles applied to the internal `Ripple` components `childPulsate` class.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonBase/TouchRipple.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTouchRipple`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonBase/TouchRipple.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/typography.md
+++ b/docs/pages/api/typography.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Typography/Typography.js
 <p class="description">The API documentation of the Typography React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Typography from '@material-ui/core/Typography';
+import { Typography } from '@material-ui/core';
 ```
 
 
@@ -36,49 +36,49 @@ Any other properties supplied will be provided to the root element (native eleme
 
 ## CSS
 
-You can override all the class names injected by Material-UI thanks to the `classes` prop.
-This prop accepts the following keys:
+- Style sheet name: `MuiTypography`.
+- Style sheet details:
 
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTypography-root</span> | Styles applied to the root element.
+| <span class="prop-name">body2</span> | <span class="prop-name">MuiTypography-body2</span> | Styles applied to the root element if `variant="body2"`.
+| <span class="prop-name">body1</span> | <span class="prop-name">MuiTypography-body1</span> | Styles applied to the root element if `variant="body1"`.
+| <span class="prop-name">caption</span> | <span class="prop-name">MuiTypography-caption</span> | Styles applied to the root element if `variant="caption"`.
+| <span class="prop-name">button</span> | <span class="prop-name">MuiTypography-button</span> | Styles applied to the root element if `variant="button"`.
+| <span class="prop-name">h1</span> | <span class="prop-name">MuiTypography-h1</span> | Styles applied to the root element if `variant="h1"`.
+| <span class="prop-name">h2</span> | <span class="prop-name">MuiTypography-h2</span> | Styles applied to the root element if `variant="h2"`.
+| <span class="prop-name">h3</span> | <span class="prop-name">MuiTypography-h3</span> | Styles applied to the root element if `variant="h3"`.
+| <span class="prop-name">h4</span> | <span class="prop-name">MuiTypography-h4</span> | Styles applied to the root element if `variant="h4"`.
+| <span class="prop-name">h5</span> | <span class="prop-name">MuiTypography-h5</span> | Styles applied to the root element if `variant="h5"`.
+| <span class="prop-name">h6</span> | <span class="prop-name">MuiTypography-h6</span> | Styles applied to the root element if `variant="h6"`.
+| <span class="prop-name">subtitle1</span> | <span class="prop-name">MuiTypography-subtitle1</span> | Styles applied to the root element if `variant="subtitle1"`.
+| <span class="prop-name">subtitle2</span> | <span class="prop-name">MuiTypography-subtitle2</span> | Styles applied to the root element if `variant="subtitle2"`.
+| <span class="prop-name">overline</span> | <span class="prop-name">MuiTypography-overline</span> | Styles applied to the root element if `variant="overline"`.
+| <span class="prop-name">srOnly</span> | <span class="prop-name">MuiTypography-srOnly</span> | Styles applied to the root element if `variant="srOnly"`. Only accessible to screen readers.
+| <span class="prop-name">alignLeft</span> | <span class="prop-name">MuiTypography-alignLeft</span> | Styles applied to the root element if `align="left"`.
+| <span class="prop-name">alignCenter</span> | <span class="prop-name">MuiTypography-alignCenter</span> | Styles applied to the root element if `align="center"`.
+| <span class="prop-name">alignRight</span> | <span class="prop-name">MuiTypography-alignRight</span> | Styles applied to the root element if `align="right"`.
+| <span class="prop-name">alignJustify</span> | <span class="prop-name">MuiTypography-alignJustify</span> | Styles applied to the root element if `align="justify"`.
+| <span class="prop-name">noWrap</span> | <span class="prop-name">MuiTypography-noWrap</span> | Styles applied to the root element if `align="nowrap"`.
+| <span class="prop-name">gutterBottom</span> | <span class="prop-name">MuiTypography-gutterBottom</span> | Styles applied to the root element if `gutterBottom={true}`.
+| <span class="prop-name">paragraph</span> | <span class="prop-name">MuiTypography-paragraph</span> | Styles applied to the root element if `paragraph={true}`.
+| <span class="prop-name">colorInherit</span> | <span class="prop-name">MuiTypography-colorInherit</span> | Styles applied to the root element if `color="inherit"`.
+| <span class="prop-name">colorPrimary</span> | <span class="prop-name">MuiTypography-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
+| <span class="prop-name">colorSecondary</span> | <span class="prop-name">MuiTypography-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">colorTextPrimary</span> | <span class="prop-name">MuiTypography-colorTextPrimary</span> | Styles applied to the root element if `color="textPrimary"`.
+| <span class="prop-name">colorTextSecondary</span> | <span class="prop-name">MuiTypography-colorTextSecondary</span> | Styles applied to the root element if `color="textSecondary"`.
+| <span class="prop-name">colorError</span> | <span class="prop-name">MuiTypography-colorError</span> | Styles applied to the root element if `color="error"`.
+| <span class="prop-name">displayInline</span> | <span class="prop-name">MuiTypography-displayInline</span> | Styles applied to the root element if `display="inline"`.
+| <span class="prop-name">displayBlock</span> | <span class="prop-name">MuiTypography-displayBlock</span> | Styles applied to the root element if `display="block"`.
 
-| Name | Description |
-|:-----|:------------|
-| <span class="prop-name">root</span> | Styles applied to the root element.
-| <span class="prop-name">body2</span> | Styles applied to the root element if `variant="body2"`.
-| <span class="prop-name">body1</span> | Styles applied to the root element if `variant="body1"`.
-| <span class="prop-name">caption</span> | Styles applied to the root element if `variant="caption"`.
-| <span class="prop-name">button</span> | Styles applied to the root element if `variant="button"`.
-| <span class="prop-name">h1</span> | Styles applied to the root element if `variant="h1"`.
-| <span class="prop-name">h2</span> | Styles applied to the root element if `variant="h2"`.
-| <span class="prop-name">h3</span> | Styles applied to the root element if `variant="h3"`.
-| <span class="prop-name">h4</span> | Styles applied to the root element if `variant="h4"`.
-| <span class="prop-name">h5</span> | Styles applied to the root element if `variant="h5"`.
-| <span class="prop-name">h6</span> | Styles applied to the root element if `variant="h6"`.
-| <span class="prop-name">subtitle1</span> | Styles applied to the root element if `variant="subtitle1"`.
-| <span class="prop-name">subtitle2</span> | Styles applied to the root element if `variant="subtitle2"`.
-| <span class="prop-name">overline</span> | Styles applied to the root element if `variant="overline"`.
-| <span class="prop-name">srOnly</span> | Styles applied to the root element if `variant="srOnly"`. Only accessible to screen readers.
-| <span class="prop-name">alignLeft</span> | Styles applied to the root element if `align="left"`.
-| <span class="prop-name">alignCenter</span> | Styles applied to the root element if `align="center"`.
-| <span class="prop-name">alignRight</span> | Styles applied to the root element if `align="right"`.
-| <span class="prop-name">alignJustify</span> | Styles applied to the root element if `align="justify"`.
-| <span class="prop-name">noWrap</span> | Styles applied to the root element if `align="nowrap"`.
-| <span class="prop-name">gutterBottom</span> | Styles applied to the root element if `gutterBottom={true}`.
-| <span class="prop-name">paragraph</span> | Styles applied to the root element if `paragraph={true}`.
-| <span class="prop-name">colorInherit</span> | Styles applied to the root element if `color="inherit"`.
-| <span class="prop-name">colorPrimary</span> | Styles applied to the root element if `color="primary"`.
-| <span class="prop-name">colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
-| <span class="prop-name">colorTextPrimary</span> | Styles applied to the root element if `color="textPrimary"`.
-| <span class="prop-name">colorTextSecondary</span> | Styles applied to the root element if `color="textSecondary"`.
-| <span class="prop-name">colorError</span> | Styles applied to the root element if `color="error"`.
-| <span class="prop-name">displayInline</span> | Styles applied to the root element if `display="inline"`.
-| <span class="prop-name">displayBlock</span> | Styles applied to the root element if `display="block"`.
+You can override the style of the component thanks to one of these customizability points:
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Typography/Typography.js)
-for more detail.
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
 
-If using the `overrides` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: `MuiTypography`.
+If it's not enough, you can find the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Typography/Typography.js) for more detail.
 
 ## Notes
 

--- a/docs/pages/api/zoom.md
+++ b/docs/pages/api/zoom.md
@@ -9,7 +9,7 @@ filename: /packages/material-ui/src/Zoom/Zoom.js
 <p class="description">The API documentation of the Zoom React component. Learn more about the properties and the CSS customization points.</p>
 
 ```js
-import Zoom from '@material-ui/core/Zoom';
+import { Zoom } from '@material-ui/core';
 ```
 
 The Zoom transition can be used for the floating variant of the

--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -12,6 +12,9 @@ import { getHeaders } from '../src/modules/utils/parseMarkdown';
 import parseTest from '../src/modules/utils/parseTest';
 import createMuiTheme from '../../packages/material-ui/src/styles/createMuiTheme';
 import getStylesCreator from '../../packages/material-ui-styles/src/getStylesCreator';
+import createGenerateClassName from '../../packages/material-ui-styles/src/createGenerateClassName';
+
+const generateClassName = createGenerateClassName();
 
 function ensureExists(pat, mask, cb) {
   mkdir(pat, mask, err => {
@@ -111,6 +114,20 @@ async function buildDocs(options) {
       className => !className.match(/^(@media|@keyframes)/),
     );
     styles.name = component.default.options.name;
+    styles.globalClasses = styles.classes.reduce((acc, key) => {
+      acc[key] = generateClassName(
+        {
+          key,
+        },
+        {
+          options: {
+            name: styles.name,
+            theme: {},
+          },
+        },
+      );
+      return acc;
+    }, {});
 
     let styleSrc = src;
     // Exception for Select where the classes are imported from NativeSelect

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -320,38 +320,40 @@ function generateClasses(reactAPI) {
 
   let text = '';
   if (Object.keys(reactAPI.styles.descriptions).length) {
-    text = `
-| Name | Description |
-|:-----|:------------|\n`;
+    text = `| Rule name | Global class | Description |
+|:-----|:-------------|:------------|\n`;
     text += reactAPI.styles.classes
       .map(
-        className =>
-          `| <span class="prop-name">${className}</span> | ${
-            reactAPI.styles.descriptions[className]
-              ? escapeCell(reactAPI.styles.descriptions[className])
+        styleRule =>
+          `| <span class="prop-name">${styleRule}</span> | <span class="prop-name">${
+            reactAPI.styles.globalClasses[styleRule]
+          }</span> | ${
+            reactAPI.styles.descriptions[styleRule]
+              ? escapeCell(reactAPI.styles.descriptions[styleRule])
               : ''
           }`,
       )
       .join('\n');
   } else {
-    text = reactAPI.styles.classes.map(className => `- \`${className}\``).join('\n');
+    text = reactAPI.styles.classes.map(styleRule => `- \`${styleRule}\``).join('\n');
   }
 
   return `## CSS
 
-You can override all the class names injected by Material-UI thanks to the \`classes\` prop.
-This prop accepts the following keys:
+- Style sheet name: \`${reactAPI.styles.name}\`.
+- Style sheet details:
 
 ${text}
 
-Have a look at the [overriding styles with classes](/customization/components/#overriding-styles-with-classes) section
-and the [implementation of the component](${SOURCE_CODE_ROOT_URL}${normalizePath(
-    reactAPI.filename,
-  )})
-for more detail.
+You can override the style of the component thanks to one of these customizability points:
 
-If using the \`overrides\` [key of the theme](/customization/themes/#css),
-you need to use the following style sheet name: \`${reactAPI.styles.name}\`.
+- With a rule name of the [\`classes\` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [\`overrides\` property](/customization/globals/#css).
+
+If it's not enough, you can find the [implementation of the component](${SOURCE_CODE_ROOT_URL}${normalizePath(
+    reactAPI.filename,
+  )}) for more detail.
 
 `;
 }
@@ -413,12 +415,10 @@ function generateImportStatement(reactAPI) {
       /\/packages\/material-ui(-(.+?))?\/src/,
       (match, dash, pkg) => `@material-ui/${pkg || 'core'}`,
     )
-    // convert things like `Table/Table.js` to `Table`
-    .replace(/([^/]+)\/\1\.js$/, '$1')
-    // strip off trailing `.js` if any
-    .replace(/\.js$/, '');
+    // convert things like `/Table/Table.js` to ``
+    .replace(/\/([^/]+)\/\1\.js$/, '');
   return `\`\`\`js
-import ${reactAPI.name} from '${source}';
+import { ${reactAPI.name} } from '${source}';
 \`\`\``;
 }
 

--- a/docs/src/pages/customization/components/components.md
+++ b/docs/src/pages/customization/components/components.md
@@ -31,8 +31,9 @@ of the `<head />` to ensure the components always render correctly.
 ### Overriding styles with classes
 
 When the `className` property isn't enough, and you need to access deeper elements, you can take advantage of the `classes` object property to customize all the CSS injected by Material-UI for a given component.
+
 The list of  classes for each
-component is documented in the **Component API** section.
+component is documented in the component API page, you should refer to the **CSS section** and **rule name column**.
 For instance, you can have a look at the [Button CSS API](/api/button/#css).
 Alternatively, you can use the [browser dev tools](#using-the-dev-tools).
 
@@ -44,6 +45,10 @@ you wish to add or override.
 Notice that in addition to the button styling, the button label's capitalization has been changed:
 
 {{"demo": "pages/customization/components/ClassesNesting.js"}}
+
+### Overriding styles with global class names
+
+[Follow this section](/styles/advanced/#with-material-ui-core).
 
 ### Using the dev tools
 

--- a/docs/src/pages/customization/globals/GlobalCss.js
+++ b/docs/src/pages/customization/globals/GlobalCss.js
@@ -5,7 +5,7 @@ import Button from '@material-ui/core/Button';
 
 const theme = createMuiTheme({
   overrides: {
-    // Name of the component ⚛️ / style sheet
+    // Style sheet name ⚛️
     MuiButton: {
       // Name of the rule
       text: {

--- a/docs/src/pages/customization/globals/globals.md
+++ b/docs/src/pages/customization/globals/globals.md
@@ -11,9 +11,12 @@ That's a really powerful feature.
 ```js
 const theme = createMuiTheme({
   overrides: {
-    MuiButton: { // Name of the component ⚛️ / style sheet
-      text: { // Name of the rule
-        color: 'white', // Some CSS
+    // Style sheet name ⚛️
+    MuiButton: {
+      // Name of the rule
+      text: {
+        // Some CSS
+        color: 'white',
       },
     },
   },

--- a/docs/src/pages/styles/advanced/advanced.md
+++ b/docs/src/pages/styles/advanced/advanced.md
@@ -456,8 +456,8 @@ The generated class names of the `@material-ui/core` components behave different
 When the following conditions are met, the class names are **deterministic**:
 
 - Only one theme provider is used (**No theme nesting**)
-- The style sheet has a name that starts with `Mui`. (All Material-UI components)
-- The `disableGlobal` option of the [class name generator](/styles/api/#creategenerateclassname-options-class-name-generator) is `false`. (The default)
+- The style sheet has a name that starts with `Mui` (all Material-UI components).
+- The `disableGlobal` option of the [class name generator](/styles/api/#creategenerateclassname-options-class-name-generator) is `false` (the default).
 
 These conditions are met with the most common use cases of `@material-ui/core`.
 For instance, this style sheet:
@@ -504,7 +504,7 @@ const StyledTextField = styled(TextField)`
   }
   .MuiOutlinedInput-root {
     fieldset {
-      border-color: red; 🔴
+      border-color: red; 💔
     }
     &:hover fieldset {
       border-color: yellow; 💛


### PR DESCRIPTION
This is something I wanted to work on since the release of v4 and the introduction of global class names:

![Capture d’écran 2019-07-27 à 01 53 21](https://user-images.githubusercontent.com/3165635/61986704-5ba54080-b011-11e9-97e5-7c82b3abf605.png)
