### PR TITLE
[Hidden] Reduce component size

### DIFF
--- a/docs/pages/api/hidden.md
+++ b/docs/pages/api/hidden.md
@@ -21,17 +21,17 @@ Responsively hides children based on the selected implementation.
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">implementation</span> | <span class="prop-type">'js'<br>&#124;&nbsp;'css'</span> | <span class="prop-default">'js'</span> | Specify which implementation to use.  'js' is the default, 'css' works better for server-side rendering. |
 | <span class="prop-name">initialWidth</span> | <span class="prop-type">'xs'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'lg'<br>&#124;&nbsp;'xl'</span> |  | You can use this prop when choosing the `js` implementation with server-side rendering.<br>As `window.innerWidth` is unavailable on the server, we default to rendering an empty component during the first mount. You might want to use an heuristic to approximate the screen width of the client browser screen width.<br>For instance, you could be using the user-agent or the client-hints. https://caniuse.com/#search=client%20hint |
-| <span class="prop-name">lgDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and down will be hidden. |
-| <span class="prop-name">lgUp</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and up will be hidden. |
-| <span class="prop-name">mdDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and down will be hidden. |
-| <span class="prop-name">mdUp</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and up will be hidden. |
+| <span class="prop-name">lgDown</span> | <span class="prop-type">bool</span> |  | If true, screens this size and down will be hidden. |
+| <span class="prop-name">lgUp</span> | <span class="prop-type">bool</span> |  | If true, screens this size and up will be hidden. |
+| <span class="prop-name">mdDown</span> | <span class="prop-type">bool</span> |  | If true, screens this size and down will be hidden. |
+| <span class="prop-name">mdUp</span> | <span class="prop-type">bool</span> |  | If true, screens this size and up will be hidden. |
 | <span class="prop-name">only</span> | <span class="prop-type">'xs'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'lg'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;Array<'xs'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'lg'<br>&#124;&nbsp;'xl'></span> |  | Hide the given breakpoint(s). |
-| <span class="prop-name">smDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and down will be hidden. |
-| <span class="prop-name">smUp</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and up will be hidden. |
-| <span class="prop-name">xlDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and down will be hidden. |
-| <span class="prop-name">xlUp</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and up will be hidden. |
-| <span class="prop-name">xsDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and down will be hidden. |
-| <span class="prop-name">xsUp</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If true, screens this size and up will be hidden. |
+| <span class="prop-name">smDown</span> | <span class="prop-type">bool</span> |  | If true, screens this size and down will be hidden. |
+| <span class="prop-name">smUp</span> | <span class="prop-type">bool</span> |  | If true, screens this size and up will be hidden. |
+| <span class="prop-name">xlDown</span> | <span class="prop-type">bool</span> |  | If true, screens this size and down will be hidden. |
+| <span class="prop-name">xlUp</span> | <span class="prop-type">bool</span> |  | If true, screens this size and up will be hidden. |
+| <span class="prop-name">xsDown</span> | <span class="prop-type">bool</span> |  | If true, screens this size and down will be hidden. |
+| <span class="prop-name">xsUp</span> | <span class="prop-type">bool</span> |  | If true, screens this size and up will be hidden. |
 
 The component cannot hold a ref.
 

--- a/packages/material-ui/src/Hidden/Hidden.js
+++ b/packages/material-ui/src/Hidden/Hidden.js
@@ -7,54 +7,10 @@ import HiddenCss from './HiddenCss';
  * Responsively hides children based on the selected implementation.
  */
 function Hidden(props) {
-  const {
-    implementation = 'js',
-    lgDown = false,
-    lgUp = false,
-    mdDown = false,
-    mdUp = false,
-    smDown = false,
-    smUp = false,
-    xlDown = false,
-    xlUp = false,
-    xsDown = false,
-    xsUp = false,
-    ...other
-  } = props;
+  const { implementation = 'js', ...other } = props;
 
-  if (implementation === 'js') {
-    return (
-      <HiddenJs
-        lgDown={lgDown}
-        lgUp={lgUp}
-        mdDown={mdDown}
-        mdUp={mdUp}
-        smDown={smDown}
-        smUp={smUp}
-        xlDown={xlDown}
-        xlUp={xlUp}
-        xsDown={xsDown}
-        xsUp={xsUp}
-        {...other}
-      />
-    );
-  }
-
-  return (
-    <HiddenCss
-      lgDown={lgDown}
-      lgUp={lgUp}
-      mdDown={mdDown}
-      mdUp={mdUp}
-      smDown={smDown}
-      smUp={smUp}
-      xlDown={xlDown}
-      xlUp={xlUp}
-      xsDown={xsDown}
-      xsUp={xsUp}
-      {...other}
-    />
-  );
+  const Component = implementation === 'js' ? HiddenJs : HiddenCss;
+  return <Component {...other} />;
 }
 
 Hidden.propTypes = {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Reduced the size of the `Hidden` component by not setting a default value for all the props and avoid repeating the same code for `HiddenCss` and `HiddenJs`. The implementation checks for a truthy value so having the value be `undefined` instead of `false` makes no difference.