### PR TITLE
[Dialog] Test with testing-library

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-noninteractive-element-interactions */
 
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -214,7 +213,6 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
       onClose={onClose}
       open={open}
       ref={ref}
-      role="dialog"
       {...other}
     >
       <TransitionComponent
@@ -227,17 +225,21 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
         onExit={onExit}
         onExiting={onExiting}
         onExited={onExited}
+        role="none presentation"
         {...TransitionProps}
       >
+        {/* roles are applied via cloneElement from TransitionComponent */}
+        {/* roles needs to be applied on the immediate child of Modal or it'll inject one */}
+        {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
         <div
           className={clsx(classes.container, classes[`scroll${capitalize(scroll)}`])}
           onClick={handleBackdropClick}
           onMouseDown={handleMouseDown}
-          role="document"
           data-mui-test="FakeBackdrop"
         >
           <PaperComponent
             elevation={24}
+            role="dialog"
             {...PaperProps}
             className={clsx(
               classes.paper,

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -142,10 +142,11 @@ describe('<Dialog />', () => {
   });
 
   describe('backdrop', () => {
-    it('has no accessible role', () => {
+    it('has the document role', () => {
+      // FixMe: should have none. Revisit in React Flare
       render(<Dialog open>foo</Dialog>);
 
-      expect(findBackdrop(document.body)).to.have.attribute('role', 'none presentation');
+      expect(findBackdrop(document.body)).to.have.attribute('role', 'document');
     });
 
     it('calls onBackdropClick and onClose when clicked', () => {

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -127,6 +127,12 @@ describe('<Dialog />', () => {
   });
 
   describe('backdrop', () => {
+    it('has no accessible role', () => {
+      render(<Dialog open>foo</Dialog>);
+
+      expect(findBackdrop(document.body)).to.have.attribute('role', 'none presentation');
+    });
+
     it('should call through to the user specified onBackdropClick callback', () => {
       const onBackdropClick = spy();
       render(

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -1,269 +1,243 @@
 import React from 'react';
-import { assert } from 'chai';
-import { spy } from 'sinon';
+import { expect } from 'chai';
+import { spy, useFakeTimers } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import Paper from '../Paper';
-import Fade from '../Fade';
+import { cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Modal from '../Modal';
 import Dialog from './Dialog';
 
-const findBackdrop = wrapper => wrapper.find('[data-mui-test="FakeBackdrop"]');
-const clickBackdrop = wrapper => {
-  const currentTarget = {};
-  const backdrop = findBackdrop(wrapper);
+/**
+ * more comprehensive simulation of a user click (mousedown + click)
+ * @param {HTMLElement} element
+ */
+function userClick(element) {
+  fireEvent.mouseDown(element);
+  element.click();
+}
 
-  // simulate would not allow mocking of currentTarget
-  backdrop.props().onMouseDown({ currentTarget, target: currentTarget });
-  backdrop.props().onClick({ currentTarget, target: currentTarget });
-};
+/**
+ * @param {HTMLElement} container
+ */
+function findBackdrop(container) {
+  return container.querySelector('[data-mui-test="FakeBackdrop"]');
+}
+
+/**
+ * @param {HTMLElement} container
+ */
+function clickBackdrop(container) {
+  userClick(findBackdrop(container));
+}
 
 describe('<Dialog />', () => {
+  let clock;
   let mount;
   let classes;
-  const defaultProps = {
-    open: false,
-  };
+  const render = createClientRender({ strict: false });
 
   before(() => {
     // StrictModeViolation: uses Fade
     mount = createMount({ strict: false });
-    classes = getClasses(<Dialog {...defaultProps}>foo</Dialog>);
+    classes = getClasses(<Dialog>foo</Dialog>);
   });
 
-  after(() => {
-    mount.cleanUp();
+  beforeEach(() => {
+    clock = useFakeTimers();
   });
 
-  describeConformance(
-    <Dialog {...defaultProps} open>
-      foo
-    </Dialog>,
-    () => ({
-      classes,
-      inheritComponent: Modal,
-      mount,
-      refInstanceof: window.HTMLDivElement,
-      skip: [
-        'componentProp',
-        // react-transition-group issue
-        'reactTestRenderer',
-      ],
-    }),
-  );
+  afterEach(() => {
+    clock.restore();
+    cleanup();
+  });
 
-  it('should render a Modal with TransitionComponent', () => {
-    const Transition = React.forwardRef(() => <div tabIndex={-1} />);
-    const wrapper = mount(
-      <Dialog {...defaultProps} open TransitionComponent={Transition}>
+  describeConformance(<Dialog open>foo</Dialog>, () => ({
+    classes,
+    inheritComponent: Modal,
+    mount,
+    refInstanceof: window.HTMLDivElement,
+    skip: [
+      'componentProp',
+      // react-transition-group issue
+      'reactTestRenderer',
+    ],
+    after: () => mount.cleanUp(),
+  }));
+
+  it('should render with a TransitionComponent', () => {
+    const Transition = React.forwardRef(() => <div data-testid="Transition" tabIndex={-1} />);
+    const { getAllByTestId } = render(
+      <Dialog open TransitionComponent={Transition}>
         foo
       </Dialog>,
     );
-    assert.strictEqual(wrapper.find(Transition).length, 1);
+
+    expect(getAllByTestId('Transition')).to.have.lengthOf(1);
   });
 
-  it('should put Modal specific props on the root Modal node', () => {
-    const onEscapeKeyDown = () => {};
-    const onClose = () => {};
-    const wrapper = mount(
+  it('calls onEscapeKeydown when pressing Esc followed by onClose after the specified transitionDuration', () => {
+    const onEscapeKeyDown = spy();
+    const onClose = spy();
+    const { getByRole } = render(
+      <Dialog open transitionDuration={100} onEscapeKeyDown={onEscapeKeyDown} onClose={onClose}>
+        foo
+      </Dialog>,
+    );
+    expect(getByRole('dialog')).to.be.ok;
+
+    getByRole('dialog').click();
+    fireEvent.keyDown(document.activeElement, { key: 'Esc' });
+    expect(onEscapeKeyDown.calledOnce).to.equal(true);
+
+    clock.tick(100);
+    expect(onClose.calledOnce).to.equal(true);
+  });
+
+  it('can ignore backdrop click and Esc keydown', () => {
+    const onClose = spy();
+    const { getByRole } = render(
       <Dialog
         open
-        transitionDuration={100}
-        onEscapeKeyDown={onEscapeKeyDown}
-        onClose={onClose}
         disableBackdropClick
         disableEscapeKeyDown
+        onClose={onClose}
+        transitionDuration={0}
       >
         foo
       </Dialog>,
     );
+    expect(getByRole('dialog')).to.be.ok;
 
-    const modal = wrapper.find(Modal);
-    assert.strictEqual(modal.props().open, true);
-    assert.strictEqual(modal.props().BackdropProps.transitionDuration, 100);
-    assert.strictEqual(modal.props().onEscapeKeyDown, onEscapeKeyDown);
-    assert.strictEqual(modal.props().onClose, onClose);
-    assert.strictEqual(modal.props().disableBackdropClick, true);
-    assert.strictEqual(modal.props().disableEscapeKeyDown, true);
+    getByRole('dialog').click();
+    fireEvent.keyDown(document.activeElement, { key: 'Esc' });
+    expect(onClose.callCount).to.equal(0);
+
+    clickBackdrop(document.body);
+    expect(onClose.callCount).to.equal(0);
   });
 
-  it('should spread custom props on the paper (dialog "root") node', () => {
-    const wrapper = mount(
-      <Dialog {...defaultProps} data-my-prop="woofDialog">
+  it('should spread custom props on the modal root node', () => {
+    render(
+      <Dialog data-my-prop="woofDialog" open>
         foo
       </Dialog>,
     );
-    const modal = wrapper.find(Modal);
-    assert.strictEqual(modal.props()['data-my-prop'], 'woofDialog');
-  });
-
-  it('should fade down and make the transition appear on first mount', () => {
-    const wrapper = mount(
-      <Dialog {...defaultProps} open>
-        foo
-      </Dialog>,
-    );
-    // the first one is from the Backdrop, if the Backdrop impl changes this breaks
-    assert.strictEqual(
-      wrapper
-        .find(Fade)
-        .at(1)
-        .props().appear,
-      true,
-    );
+    const modal = document.querySelector('[data-mui-test="Modal"]');
+    expect(modal).to.have.attribute('data-my-prop', 'woofDialog');
   });
 
   describe('backdrop', () => {
-    it('should attach a handler to the backdrop that fires onClose', () => {
-      const onClose = spy();
-      const wrapper = mount(
-        <Dialog onClose={onClose} open>
-          foo
-        </Dialog>,
-      );
-
-      clickBackdrop(wrapper);
-
-      assert.strictEqual(onClose.callCount, 1);
-    });
-
-    it('should let the user disable backdrop click triggering onClose', () => {
-      const onClose = spy();
-      const wrapper = mount(
-        <Dialog disableBackdropClick onClose={onClose} open>
-          foo
-        </Dialog>,
-      );
-
-      clickBackdrop(wrapper);
-
-      assert.strictEqual(onClose.callCount, 0);
-    });
-
     it('should call through to the user specified onBackdropClick callback', () => {
       const onBackdropClick = spy();
-      const wrapper = mount(
+      render(
         <Dialog onBackdropClick={onBackdropClick} open>
           foo
         </Dialog>,
       );
 
-      clickBackdrop(wrapper);
-
-      assert.strictEqual(onBackdropClick.callCount, 1);
+      clickBackdrop(document);
+      expect(onBackdropClick.callCount).to.equal(1);
     });
 
     it('should ignore the backdrop click if the event did not come from the backdrop', () => {
       const onBackdropClick = spy();
-      const wrapper = mount(
+      const { getByRole } = render(
         <Dialog onBackdropClick={onBackdropClick} open>
-          foo
+          <div tabIndex={-1}>
+            <h2>my dialog</h2>
+          </div>
         </Dialog>,
       );
 
-      const backdrop = findBackdrop(wrapper);
-      backdrop.props().onClick({
-        target: {
-          /* a dom node */
-        },
-        currentTarget: {
-          /* another dom node */
-        },
-      });
-
-      assert.strictEqual(onBackdropClick.callCount, 0);
+      userClick(getByRole('heading'));
+      expect(onBackdropClick.callCount).to.equal(0);
     });
 
     it('should not close if the target changes between the mousedown and the click', () => {
-      const onBackdropClick = spy();
-      const wrapper = mount(
-        <Dialog onBackdropClick={onBackdropClick} open>
-          foo
+      const { getByRole } = render(
+        <Dialog open>
+          <h2>my dialog</h2>
         </Dialog>,
       );
 
-      const backdrop = findBackdrop(wrapper);
-
-      // mousedown dialog, release backdrop
-      backdrop.props().onMouseDown({ target: 'dialog' });
-      backdrop.props().onClick({ target: 'backdrop', currentTarget: 'backdrop' });
-      assert.strictEqual(onBackdropClick.callCount, 0);
+      fireEvent.mouseDown(getByRole('heading'));
+      findBackdrop(document.body).click();
+      expect(getByRole('dialog')).to.be.ok;
     });
   });
 
   describe('prop: classes', () => {
     it('should add the class on the Paper element', () => {
-      const className = 'foo';
-      const wrapper = mount(
-        <Dialog {...defaultProps} open classes={{ paper: className }}>
+      const { getByTestId } = render(
+        <Dialog open classes={{ paper: 'my-paperclass' }} PaperProps={{ 'data-testid': 'paper' }}>
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(className), true);
+      expect(getByTestId('paper')).to.have.class('my-paperclass');
     });
   });
 
   describe('prop: maxWidth', () => {
     it('should use the right className', () => {
-      const wrapper = mount(
-        <Dialog {...defaultProps} open maxWidth="xs">
+      const { getByTestId } = render(
+        <Dialog open maxWidth="xs" PaperProps={{ 'data-testid': 'paper' }}>
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperWidthXs), true);
+      expect(getByTestId('paper')).to.have.class(classes.paperWidthXs);
     });
   });
 
   describe('prop: fullWidth', () => {
     it('should set `fullWidth` class if specified', () => {
-      const wrapper = mount(
-        <Dialog {...defaultProps} open fullWidth>
+      const { getByTestId } = render(
+        <Dialog open fullWidth PaperProps={{ 'data-testid': 'paper' }}>
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullWidth), true);
+      expect(getByTestId('paper')).to.have.class(classes.paperFullWidth);
     });
 
     it('should not set `fullWidth` class if not specified', () => {
-      const wrapper = mount(
-        <Dialog {...defaultProps} open>
+      const { getByTestId } = render(
+        <Dialog open PaperProps={{ 'data-testid': 'paper' }}>
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullWidth), false);
+      expect(getByTestId('paper')).not.to.have.class(classes.paperFullWidth);
     });
   });
 
   describe('prop: fullScreen', () => {
-    it('true should render fullScreen', () => {
-      const wrapper = mount(
-        <Dialog {...defaultProps} fullScreen open>
+    it('can render fullScreen if true', () => {
+      const { getByTestId } = render(
+        <Dialog open fullScreen PaperProps={{ 'data-testid': 'paper' }}>
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullScreen), true);
+      expect(getByTestId('paper')).to.have.class(classes.paperFullScreen);
     });
 
-    it('false should not render fullScreen', () => {
-      const wrapper = mount(
-        <Dialog {...defaultProps} fullScreen={false} open>
+    it('does not render fullScreen by default', () => {
+      const { getByTestId } = render(
+        <Dialog open PaperProps={{ 'data-testid': 'paper' }}>
           foo
         </Dialog>,
       );
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paperFullScreen), false);
+      expect(getByTestId('paper')).not.to.have.class(classes.paperFullScreen);
     });
   });
 
   describe('prop: PaperProps.className', () => {
     it('should merge the className', () => {
-      const wrapper = mount(
-        <Dialog open PaperProps={{ className: 'custom-paper-class' }}>
+      const { getByTestId } = render(
+        <Dialog open PaperProps={{ className: 'custom-paper-class', 'data-testid': 'paper' }}>
           foo
         </Dialog>,
       );
 
-      assert.strictEqual(wrapper.find(Paper).hasClass(classes.paper), true);
-      assert.strictEqual(wrapper.find(Paper).hasClass('custom-paper-class'), true);
+      expect(getByTestId('paper')).to.have.class(classes.paper);
+      expect(getByTestId('paper')).to.have.class('custom-paper-class');
     });
   });
 });

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -208,11 +208,12 @@ const Modal = React.forwardRef(function Modal(props, ref) {
 
   const inlineStyle = styles(theme || { zIndex });
   const childProps = {};
-  if (children.props.role === undefined) {
-    childProps.role = 'document';
+  // FixMe: Always apply document role. Revisit once React Flare is released
+  if (children.role === undefined) {
+    childProps.role = children.role || 'document';
   }
-  if (children.props.tabIndex === undefined) {
-    childProps.tabIndex = '-1';
+  if (children.tabIndex === undefined) {
+    childProps.tabIndex = children.tabIndex || '-1';
   }
 
   // It's a Transition like component

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -209,10 +209,10 @@ const Modal = React.forwardRef(function Modal(props, ref) {
   const inlineStyle = styles(theme || { zIndex });
   const childProps = {};
   if (children.props.role === undefined) {
-    childProps.role = children.role || 'document';
+    childProps.role = 'document';
   }
   if (children.props.tabIndex === undefined) {
-    childProps.tabIndex = children.tabIndex || '-1';
+    childProps.tabIndex = '-1';
   }
 
   // It's a Transition like component

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -208,10 +208,10 @@ const Modal = React.forwardRef(function Modal(props, ref) {
 
   const inlineStyle = styles(theme || { zIndex });
   const childProps = {};
-  if (children.role === undefined) {
+  if (children.props.role === undefined) {
     childProps.role = children.role || 'document';
   }
-  if (children.tabIndex === undefined) {
+  if (children.props.tabIndex === undefined) {
     childProps.tabIndex = children.tabIndex || '-1';
   }
 


### PR DESCRIPTION
- ~moves dialog role closer to the actual dialog content~
- ~replaces document role of backdrop with `none presentation` `none` being aria 2.0 and `presentation` the fallback for assistive technology not supporting `none`~
- ~fixes `Modal` overwriting roles of children~ Better not touch this because of low a11y coverage
- Can't move dialog role because that would require additional logic for forwarding aria attributes
- can't remove document role since this is the node being focused. Once we get better focus managment primitives we can revamp the a11y of the dialog
- Refactors dialog tests to use testing-library

~It should make a better case for NVDA not announcing dialog content as clickable since the click listener is attached to an element which is hidden from the a11y-tree. Need to test how children of role="presentation" are handled. Might make more sense to "null" it. [`role="document"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Document_Role) is unlikely to be appropriate in most use cases.~