### PR TITLE
[Container] Add MuiContainer to ComponentNameToClassKey overrides

### DIFF
--- a/packages/material-ui/src/styles/overrides.d.ts
+++ b/packages/material-ui/src/styles/overrides.d.ts
@@ -20,6 +20,7 @@ import { CheckboxClassKey } from '../Checkbox';
 import { ChipClassKey } from '../Chip';
 import { CircularProgressClassKey } from '../CircularProgress';
 import { CollapseClassKey } from '../Collapse';
+import { ContainerClassKey } from '../Container';
 import { CssBaselineClassKey } from '../CssBaseline';
 import { DialogActionsClassKey } from '../DialogActions';
 import { DialogClassKey } from '../Dialog';
@@ -121,6 +122,7 @@ export interface ComponentNameToClassKey {
   MuiChip: ChipClassKey;
   MuiCircularProgress: CircularProgressClassKey;
   MuiCollapse: CollapseClassKey;
+  MuiContainer: ContainerClassKey;
   MuiCssBaseline: CssBaselineClassKey;
   MuiDialog: DialogClassKey;
   MuiDialogActions: DialogActionsClassKey;


### PR DESCRIPTION
Add MuiContainer to ComponentNameToClassKey interface in overrides, resolves #16768

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
