### PR TITLE
[TreeView] Add customization demo

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -78,6 +78,7 @@
     "react-router": "^5.0.0",
     "react-router-dom": "^5.0.1",
     "react-select": "^3.0.4",
+    "react-spring": "^8.0.27",
     "react-swipeable-views": "^0.13.3",
     "react-test-renderer": "^16.8.5",
     "react-text-mask": "^5.0.2",

--- a/docs/pages/api/tree-item.md
+++ b/docs/pages/api/tree-item.md
@@ -21,10 +21,12 @@ import { TreeItem } from '@material-ui/lab';
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">collapseIcon</span> | <span class="prop-type">node</span> |  | The icon used to collapse the node. |
+| <span class="prop-name">endIcon</span> | <span class="prop-type">node</span> |  | The icon displayed next to a end node. |
 | <span class="prop-name">expandIcon</span> | <span class="prop-type">node</span> |  | The icon used to expand the node. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> |  | The icon to display next to the tree node's label. |
 | <span class="prop-name">label</span> | <span class="prop-type">node</span> |  | The tree node label. |
 | <span class="prop-name required">nodeId&nbsp;*</span> | <span class="prop-type">string</span> |  | The id of the node. |
+| <span class="prop-name">TransitionComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">Collapse</span> | The component used for the transition. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/src/pages/components/tree-view/CustomizedTreeView.js
+++ b/docs/src/pages/components/tree-view/CustomizedTreeView.js
@@ -1,0 +1,94 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import SvgIcon from '@material-ui/core/SvgIcon';
+import { fade, withStyles } from '@material-ui/core/styles';
+import TreeView from '@material-ui/lab/TreeView';
+import TreeItem from '@material-ui/lab/TreeItem';
+import Collapse from '@material-ui/core/Collapse';
+import { useSpring, animated } from 'react-spring';
+
+function MinusSquare(props) {
+  return (
+    <SvgIcon fontSize="inherit" {...props}>
+      {/* tslint:disable-next-line: max-line-length */}
+      <path d="M22.047 22.074v0 0-20.147 0h-20.12v0 20.147 0h20.12zM22.047 24h-20.12q-.803 0-1.365-.562t-.562-1.365v-20.147q0-.776.562-1.351t1.365-.575h20.147q.776 0 1.351.575t.575 1.351v20.147q0 .803-.575 1.365t-1.378.562v0zM17.873 11.023h-11.826q-.375 0-.669.281t-.294.682v0q0 .401.294 .682t.669.281h11.826q.375 0 .669-.281t.294-.682v0q0-.401-.294-.682t-.669-.281z" />
+    </SvgIcon>
+  );
+}
+
+function PlusSquare(props) {
+  return (
+    <SvgIcon fontSize="inherit" {...props}>
+      {/* tslint:disable-next-line: max-line-length */}
+      <path d="M22.047 22.074v0 0-20.147 0h-20.12v0 20.147 0h20.12zM22.047 24h-20.12q-.803 0-1.365-.562t-.562-1.365v-20.147q0-.776.562-1.351t1.365-.575h20.147q.776 0 1.351.575t.575 1.351v20.147q0 .803-.575 1.365t-1.378.562v0zM17.873 12.977h-4.923v4.896q0 .401-.281.682t-.682.281v0q-.375 0-.669-.281t-.294-.682v-4.896h-4.923q-.401 0-.682-.294t-.281-.669v0q0-.401.281-.682t.682-.281h4.923v-4.896q0-.401.294-.682t.669-.281v0q.401 0 .682.281t.281.682v4.896h4.923q.401 0 .682.281t.281.682v0q0 .375-.281.669t-.682.294z" />
+    </SvgIcon>
+  );
+}
+
+function CloseSquare(props) {
+  return (
+    <SvgIcon className="close" fontSize="inherit" {...props}>
+      {/* tslint:disable-next-line: max-line-length */}
+      <path d="M17.485 17.512q-.281.281-.682.281t-.696-.268l-4.12-4.147-4.12 4.147q-.294.268-.696.268t-.682-.281-.281-.682.294-.669l4.12-4.147-4.12-4.147q-.294-.268-.294-.669t.281-.682.682-.281.696 .268l4.12 4.147 4.12-4.147q.294-.268.696-.268t.682.281 .281.669-.294.682l-4.12 4.147 4.12 4.147q.294.268 .294.669t-.281.682zM22.047 22.074v0 0-20.147 0h-20.12v0 20.147 0h20.12zM22.047 24h-20.12q-.803 0-1.365-.562t-.562-1.365v-20.147q0-.776.562-1.351t1.365-.575h20.147q.776 0 1.351.575t.575 1.351v20.147q0 .803-.575 1.365t-1.378.562v0z" />
+    </SvgIcon>
+  );
+}
+
+function TransitionComponent(props) {
+  const style = useSpring({
+    from: { opacity: 0, transform: 'translate3d(20px,0,0)' },
+    to: { opacity: props.in ? 1 : 0, transform: `translate3d(${props.in ? 0 : 20}px,0,0)` },
+  });
+
+  return (
+    <animated.div style={style}>
+      <Collapse {...props} />
+    </animated.div>
+  );
+}
+
+TransitionComponent.propTypes = {
+  /**
+   * Show the component; triggers the enter or exit states
+   */
+  in: PropTypes.bool,
+};
+
+const StyledTreeItem = withStyles(theme => ({
+  iconContainer: {
+    '& .close': {
+      opacity: 0.3,
+    },
+  },
+  group: {
+    marginLeft: 12,
+    paddingLeft: 12,
+    borderLeft: `1px dashed ${fade(theme.palette.text.primary, 0.4)}`,
+  },
+}))(props => <TreeItem {...props} TransitionComponent={TransitionComponent} />);
+
+export default function CustomizedTreeView() {
+  return (
+    <TreeView
+      defaultExpanded={['1']}
+      defaultCollapseIcon={<MinusSquare />}
+      defaultExpandIcon={<PlusSquare />}
+      defaultEndIcon={<CloseSquare />}
+    >
+      <StyledTreeItem nodeId="1" label="main">
+        <StyledTreeItem nodeId="2" label="hello" />
+        <StyledTreeItem nodeId="3" label="subtree with children">
+          <StyledTreeItem nodeId="6" label="hello" />
+          <StyledTreeItem nodeId="7" label="sub-subtree with children">
+            <StyledTreeItem nodeId="9" label="child 1" />
+            <StyledTreeItem nodeId="10" label="child 2" />
+            <StyledTreeItem nodeId="11" label="child 3" />
+          </StyledTreeItem>
+          <StyledTreeItem nodeId="8" label="hello" />
+        </StyledTreeItem>
+        <StyledTreeItem nodeId="4" label="world" />
+        <StyledTreeItem nodeId="5" label="🙀 something something" />
+      </StyledTreeItem>
+    </TreeView>
+  );
+}

--- a/docs/src/pages/components/tree-view/CustomizedTreeView.tsx
+++ b/docs/src/pages/components/tree-view/CustomizedTreeView.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import SvgIcon, { SvgIconProps } from '@material-ui/core/SvgIcon';
+import { fade, withStyles, Theme, createStyles } from '@material-ui/core/styles';
+import TreeView from '@material-ui/lab/TreeView';
+import TreeItem, { TreeItemProps } from '@material-ui/lab/TreeItem';
+import Collapse from '@material-ui/core/Collapse';
+import { useSpring, animated } from 'react-spring';
+import { TransitionProps } from '@material-ui/core/transitions/transition';
+
+function MinusSquare(props: SvgIconProps) {
+  return (
+    <SvgIcon fontSize="inherit" {...props}>
+      {/* tslint:disable-next-line: max-line-length */}
+      <path d="M22.047 22.074v0 0-20.147 0h-20.12v0 20.147 0h20.12zM22.047 24h-20.12q-.803 0-1.365-.562t-.562-1.365v-20.147q0-.776.562-1.351t1.365-.575h20.147q.776 0 1.351.575t.575 1.351v20.147q0 .803-.575 1.365t-1.378.562v0zM17.873 11.023h-11.826q-.375 0-.669.281t-.294.682v0q0 .401.294 .682t.669.281h11.826q.375 0 .669-.281t.294-.682v0q0-.401-.294-.682t-.669-.281z" />
+    </SvgIcon>
+  );
+}
+
+function PlusSquare(props: SvgIconProps) {
+  return (
+    <SvgIcon fontSize="inherit" {...props}>
+      {/* tslint:disable-next-line: max-line-length */}
+      <path d="M22.047 22.074v0 0-20.147 0h-20.12v0 20.147 0h20.12zM22.047 24h-20.12q-.803 0-1.365-.562t-.562-1.365v-20.147q0-.776.562-1.351t1.365-.575h20.147q.776 0 1.351.575t.575 1.351v20.147q0 .803-.575 1.365t-1.378.562v0zM17.873 12.977h-4.923v4.896q0 .401-.281.682t-.682.281v0q-.375 0-.669-.281t-.294-.682v-4.896h-4.923q-.401 0-.682-.294t-.281-.669v0q0-.401.281-.682t.682-.281h4.923v-4.896q0-.401.294-.682t.669-.281v0q.401 0 .682.281t.281.682v4.896h4.923q.401 0 .682.281t.281.682v0q0 .375-.281.669t-.682.294z" />
+    </SvgIcon>
+  );
+}
+
+function CloseSquare(props: SvgIconProps) {
+  return (
+    <SvgIcon className="close" fontSize="inherit" {...props}>
+      {/* tslint:disable-next-line: max-line-length */}
+      <path d="M17.485 17.512q-.281.281-.682.281t-.696-.268l-4.12-4.147-4.12 4.147q-.294.268-.696.268t-.682-.281-.281-.682.294-.669l4.12-4.147-4.12-4.147q-.294-.268-.294-.669t.281-.682.682-.281.696 .268l4.12 4.147 4.12-4.147q.294-.268.696-.268t.682.281 .281.669-.294.682l-4.12 4.147 4.12 4.147q.294.268 .294.669t-.281.682zM22.047 22.074v0 0-20.147 0h-20.12v0 20.147 0h20.12zM22.047 24h-20.12q-.803 0-1.365-.562t-.562-1.365v-20.147q0-.776.562-1.351t1.365-.575h20.147q.776 0 1.351.575t.575 1.351v20.147q0 .803-.575 1.365t-1.378.562v0z" />
+    </SvgIcon>
+  );
+}
+
+function TransitionComponent(props: TransitionProps) {
+  const style = useSpring({
+    from: { opacity: 0, transform: 'translate3d(20px,0,0)' },
+    to: { opacity: props.in ? 1 : 0, transform: `translate3d(${props.in ? 0 : 20}px,0,0)` },
+  });
+
+  return (
+    <animated.div style={style}>
+      <Collapse {...props} />
+    </animated.div>
+  );
+}
+
+const StyledTreeItem = withStyles((theme: Theme) =>
+  createStyles({
+    iconContainer: {
+      '& .close': {
+        opacity: 0.3,
+      },
+    },
+    group: {
+      marginLeft: 12,
+      paddingLeft: 12,
+      borderLeft: `1px dashed ${fade(theme.palette.text.primary, 0.4)}`,
+    },
+  }),
+)((props: TreeItemProps) => <TreeItem {...props} TransitionComponent={TransitionComponent} />);
+
+export default function CustomizedTreeView() {
+  return (
+    <TreeView
+      defaultExpanded={['1']}
+      defaultCollapseIcon={<MinusSquare />}
+      defaultExpandIcon={<PlusSquare />}
+      defaultEndIcon={<CloseSquare />}
+    >
+      <StyledTreeItem nodeId="1" label="main">
+        <StyledTreeItem nodeId="2" label="hello" />
+        <StyledTreeItem nodeId="3" label="subtree with children">
+          <StyledTreeItem nodeId="6" label="hello" />
+          <StyledTreeItem nodeId="7" label="sub-subtree with children">
+            <StyledTreeItem nodeId="9" label="child 1" />
+            <StyledTreeItem nodeId="10" label="child 2" />
+            <StyledTreeItem nodeId="11" label="child 3" />
+          </StyledTreeItem>
+          <StyledTreeItem nodeId="8" label="hello" />
+        </StyledTreeItem>
+        <StyledTreeItem nodeId="4" label="world" />
+        <StyledTreeItem nodeId="5" label="🙀 something something" />
+      </StyledTreeItem>
+    </TreeView>
+  );
+}

--- a/docs/src/pages/components/tree-view/tree-view.md
+++ b/docs/src/pages/components/tree-view/tree-view.md
@@ -10,3 +10,7 @@ components: TreeView, TreeItem
 Tree views can be used to represent a file system navigator displaying folders and files, an item representing a folder can be expanded to reveal the contents of the folder, which may be files, folders, or both.
 
 {{"demo": "pages/components/tree-view/FileSystemNavigator.js"}}
+
+## Customized tree view
+
+{{"demo": "pages/components/tree-view/CustomizedTreeView.js"}}

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.d.ts
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.d.ts
@@ -1,13 +1,16 @@
 import * as React from 'react';
 import { StandardProps } from '@material-ui/core';
+import { TransitionProps } from '@material-ui/core/transitions/transition';
 
 export interface TreeItemProps
   extends StandardProps<React.HTMLAttributes<HTMLLIElement>, TreeItemClassKey> {
   collapseIcon?: React.ReactNode;
+  endIcon?: React.ReactNode;
   expandIcon?: React.ReactNode;
   icon?: React.ReactNode;
   label?: React.ReactNode;
   nodeId: string;
+  TransitionComponent?: React.ComponentType<TransitionProps>;
 }
 
 export type TreeItemClassKey = 'root' | 'group' | 'content' | 'iconContainer' | 'label';

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -56,13 +56,15 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     classes,
     className,
     collapseIcon,
+    endIcon,
     expandIcon,
-    icon,
+    icon: iconProp,
     label,
     nodeId,
     onClick,
     onFocus,
     onKeyDown,
+    TransitionComponent = Collapse,
     ...other
   } = props;
 
@@ -88,7 +90,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   const contentRef = React.useRef(null);
   const handleRef = useForkRef(nodeRef, ref);
 
-  let stateIcon = null;
+  let icon = iconProp;
 
   const expandable = Boolean(children);
   const expanded = isExpanded ? isExpanded(nodeId) : false;
@@ -96,31 +98,20 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   const tabable = isTabable ? isTabable(nodeId) : false;
   const icons = contextIcons || {};
 
-  if (icons.defaultExpandIcon && expandable && !expanded) {
-    stateIcon = icons.defaultExpandIcon;
-  }
-  if (icons.defaultCollapseIcon && expandable && expanded) {
-    stateIcon = icons.defaultCollapseIcon;
-  }
+  if (!icon) {
+    if (expandable) {
+      if (!expanded) {
+        icon = expandIcon || icons.defaultExpandIcon;
+      } else {
+        icon = collapseIcon || icons.defaultCollapseIcon;
+      }
 
-  if (expandIcon && expandable && !expanded) {
-    stateIcon = expandIcon;
-  }
-
-  if (collapseIcon && expandable && expanded) {
-    stateIcon = collapseIcon;
-  }
-
-  const stateIconsProvided = icons && (icons.defaultCollapseIcon || icons.defaultExpandIcon);
-
-  let startAdornment = null;
-
-  if (expandable) {
-    if (icons.defaultParentIcon || icon) {
-      startAdornment = icon || icons.defaultParentIcon;
+      if (!icon) {
+        icon = icon || icons.defaultParentIcon;
+      }
+    } else {
+      icon = icons.defaultEndIcon;
     }
-  } else if (icons.defaultEndIcon || icon) {
-    startAdornment = icon || icons.defaultEndIcon;
   }
 
   const handleClick = event => {
@@ -257,14 +248,13 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
       {...other}
     >
       <div className={classes.content} onClick={handleClick} ref={contentRef}>
-        {stateIconsProvided ? <div className={classes.iconContainer}>{stateIcon}</div> : null}
-        {startAdornment ? <div className={classes.iconContainer}>{startAdornment}</div> : null}
+        {icon ? <div className={classes.iconContainer}>{icon}</div> : null}
         <Typography className={classes.label}>{label}</Typography>
       </div>
       {children && (
-        <Collapse className={classes.group} in={expanded} component="ul" role="group">
+        <TransitionComponent className={classes.group} in={expanded} component="ul" role="group">
           {children}
-        </Collapse>
+        </TransitionComponent>
       )}
     </li>
   );
@@ -288,6 +278,10 @@ TreeItem.propTypes = {
    * The icon used to collapse the node.
    */
   collapseIcon: PropTypes.node,
+  /**
+   * The icon displayed next to a end node.
+   */
+  endIcon: PropTypes.node,
   /**
    * The icon used to expand the node.
    */
@@ -316,6 +310,10 @@ TreeItem.propTypes = {
    * @ignore
    */
   onKeyDown: PropTypes.func,
+  /**
+   * The component used for the transition.
+   */
+  TransitionComponent: PropTypes.elementType,
 };
 
 export default withStyles(styles, { name: 'MuiTreeItem' })(TreeItem);

--- a/yarn.lock
+++ b/yarn.lock
@@ -12011,6 +12011,14 @@ react-smooth@^1.0.0:
     raf "^3.4.0"
     react-transition-group "^2.5.0"
 
+react-spring@^8.0.27:
+  version "8.0.27"
+  resolved "https://registry.yarnpkg.com/react-spring/-/react-spring-8.0.27.tgz#97d4dee677f41e0b2adcb696f3839680a3aa356a"
+  integrity sha512-nDpWBe3ZVezukNRandTeLSPcwwTMjNVu1IDq9qA/AMiUqHuRN4BeSWvKr3eIxxg1vtiYiOLy4FqdfCP5IoP77g==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    prop-types "^15.5.8"
+
 react-ssr-prepass@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-ssr-prepass/-/react-ssr-prepass-1.0.2.tgz#f411414cbc043a90254cddcef0793b2aaf14b086"


### PR DESCRIPTION
The new demo is **heavily** inspired by https://www.react-spring.io/docs/hooks/examples by @drcmda. The difference is that the new demo is accessible :).

Preview: https://deploy-preview-16785--material-ui.netlify.com/components/tree-view/#customized-tree-view

![Jul-28-2019 21-23-38](https://user-images.githubusercontent.com/3165635/62011828-09cdf900-b17e-11e9-8dbd-f8964e5a7b65.gif)

Closes #16784