### PR TITLE
[Skeleton] New component

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "rimraf .next && cross-env NODE_ENV=production next build",
     "build-sw": "node ./scripts/buildServiceWorker.js",
-    "dev": "rimraf ../node_modules/.cache/babel-loader && cross-env NODE_ENV=development node src/server.js",
+    "dev": "rimraf ./node_modules/.cache/babel-loader && cross-env NODE_ENV=development node src/server.js",
     "deploy": "git push material-ui-docs master:latest",
     "export": "rimraf docs/export && next export -o export && yarn build-sw && cp -r cdn/. export",
     "icons": "rimraf static/icons/* && node ./scripts/buildIcons.js",

--- a/docs/pages/api/skeleton.js
+++ b/docs/pages/api/skeleton.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import markdown from './skeleton.md';
+
+function Page() {
+  return <MarkdownDocs markdown={markdown} />;
+}
+
+export default Page;

--- a/docs/pages/api/skeleton.md
+++ b/docs/pages/api/skeleton.md
@@ -1,0 +1,60 @@
+---
+filename: /packages/material-ui-lab/src/Skeleton/Skeleton.js
+---
+
+<!--- This documentation is automatically generated, do not try to edit it. -->
+
+# Skeleton API
+
+<p class="description">The API documentation of the Skeleton React component. Learn more about the props and the CSS customization points.</p>
+
+```js
+import { Skeleton } from '@material-ui/lab';
+```
+
+
+
+## Props
+
+| Name | Type | Default | Description |
+|:-----|:-----|:--------|:------------|
+| <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
+| <span class="prop-name">disableAnimate</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the animation effect. |
+| <span class="prop-name">height</span> | <span class="prop-type">any</span> |  | Height of the skeleton. Useful when you don't want to adapt the skeleton to a text element but for instance a card. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'text'<br>&#124;&nbsp;'rect'<br>&#124;&nbsp;'circle'</span> | <span class="prop-default">'text'</span> | The type of content that will be rendered. |
+| <span class="prop-name">width</span> | <span class="prop-type">any</span> |  | Width of the skeleton. Useful when the skeleton is inside an inline element with no width of its own. |
+
+The `ref` is forwarded to the root element.
+
+Any other props supplied will be provided to the root element (native element).
+
+## CSS
+
+- Style sheet name: `MuiSkeleton`.
+- Style sheet details:
+
+| Rule name | Global class | Description |
+|:-----|:-------------|:------------|
+| <span class="prop-name">root</span> | <span class="prop-name">MuiSkeleton-root</span> | Styles applied to the root element.
+| <span class="prop-name">text</span> | <span class="prop-name">MuiSkeleton-text</span> | Styles applied to the root element if `variant="text"`.
+| <span class="prop-name">rect</span> | <span class="prop-name">MuiSkeleton-rect</span> | Styles applied to the root element if `variant="rect"`.
+| <span class="prop-name">circle</span> | <span class="prop-name">MuiSkeleton-circle</span> | Styles applied to the root element if `variant="circle"`.
+| <span class="prop-name">animate</span> | <span class="prop-name">MuiSkeleton-animate</span> | Styles applied to the root element if `disabledAnimate={false}`.
+
+You can override the style of the component thanks to one of these customization points:
+
+- With a rule name of the [`classes` object prop](/customization/components/#overriding-styles-with-classes).
+- With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
+- With a theme and an [`overrides` property](/customization/globals/#css).
+
+If that's not sufficient, you can check the [implementation of the component](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/Skeleton/Skeleton.js) for more detail.
+
+## Notes
+
+The component is fully [StrictMode](https://reactjs.org/docs/strict-mode.html) compatible.
+
+## Demos
+
+- [Skeleton](/components/skeleton/)
+

--- a/docs/pages/api/skeleton.md
+++ b/docs/pages/api/skeleton.md
@@ -20,7 +20,7 @@ import { Skeleton } from '@material-ui/lab';
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">disableAnimate</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the animation effect. |
+| <span class="prop-name">disableAnimate</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true` the animation effect is disabled. |
 | <span class="prop-name">height</span> | <span class="prop-type">any</span> |  | Height of the skeleton. Useful when you don't want to adapt the skeleton to a text element but for instance a card. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'text'<br>&#124;&nbsp;'rect'<br>&#124;&nbsp;'circle'</span> | <span class="prop-default">'text'</span> | The type of content that will be rendered. |
 | <span class="prop-name">width</span> | <span class="prop-type">any</span> |  | Width of the skeleton. Useful when the skeleton is inside an inline element with no width of its own. |

--- a/docs/pages/components/skeleton.js
+++ b/docs/pages/components/skeleton.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+
+const req = require.context('docs/src/pages/components/skeleton', false, /\.(md|js|tsx)$/);
+const reqSource = require.context(
+  '!raw-loader!../../src/pages/components/skeleton',
+  false,
+  /\.(js|tsx)$/,
+);
+const reqPrefix = 'pages/components/skeleton';
+
+function Page() {
+  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+}
+
+export default Page;

--- a/docs/src/pages.js
+++ b/docs/src/pages.js
@@ -113,6 +113,7 @@ const pages = [
         children: [
           { pathname: '/components/about-the-lab' },
           { pathname: '/components/rating' },
+          { pathname: '/components/skeleton' },
           { pathname: '/components/speed-dial' },
           { pathname: '/components/toggle-button' },
           { pathname: '/components/tree-view' },

--- a/docs/src/pages/components/skeleton/Facebook.js
+++ b/docs/src/pages/components/skeleton/Facebook.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { makeStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Avatar from '@material-ui/core/Avatar';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import Skeleton from '@material-ui/lab/Skeleton';
+
+const useStyles = makeStyles(theme => ({
+  card: {
+    maxWidth: 345,
+    margin: theme.spacing(2),
+  },
+  media: {
+    height: 190,
+  },
+}));
+
+function Media(props) {
+  const { loading = false } = props;
+  const classes = useStyles();
+
+  return (
+    <Card className={classes.card}>
+      <CardHeader
+        avatar={
+          loading ? (
+            <Skeleton variant="circle" width={40} height={40} />
+          ) : (
+            <Avatar
+              alt="Ted talk"
+              src="https://pbs.twimg.com/profile_images/877631054525472768/Xp5FAPD5_reasonably_small.jpg"
+            />
+          )
+        }
+        action={
+          loading ? null : (
+            <IconButton aria-label="settings">
+              <MoreVertIcon />
+            </IconButton>
+          )
+        }
+        title={loading ? <Skeleton height={6} width="80%" /> : 'Ted'}
+        subheader={loading ? <Skeleton height={6} width="40%" /> : '5 hours ago'}
+      />
+      {loading ? (
+        <Skeleton variant="rect" className={classes.media} />
+      ) : (
+        <CardMedia
+          className={classes.media}
+          image="https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/72bda89f-9bbf-4685-910a-2f151c4f3a8a/NicolaSturgeon_2019T-embed.jpg?w=512"
+          title="Ted talk"
+        />
+      )}
+
+      <CardContent>
+        {loading ? (
+          <React.Fragment>
+            <Skeleton height={6} />
+            <Skeleton height={6} width="80%" />
+          </React.Fragment>
+        ) : (
+          <Typography variant="body2" color="textSecondary" component="p">
+            {
+              "Why First Minister of Scotland Nicola Sturgeon thinks GDP is the wrong measure of a country's success:"
+            }
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+Media.propTypes = {
+  loading: PropTypes.bool,
+};
+
+export default function Facebook() {
+  return (
+    <div>
+      <Media loading />
+      <Media />
+    </div>
+  );
+}

--- a/docs/src/pages/components/skeleton/Facebook.tsx
+++ b/docs/src/pages/components/skeleton/Facebook.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Avatar from '@material-ui/core/Avatar';
+import Typography from '@material-ui/core/Typography';
+import IconButton from '@material-ui/core/IconButton';
+import MoreVertIcon from '@material-ui/icons/MoreVert';
+import Skeleton from '@material-ui/lab/Skeleton';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    card: {
+      maxWidth: 345,
+      margin: theme.spacing(2),
+    },
+    media: {
+      height: 190,
+    },
+  }),
+);
+
+interface MediaProps {
+  loading?: boolean;
+}
+
+function Media(props: MediaProps) {
+  const { loading = false } = props;
+  const classes = useStyles();
+
+  return (
+    <Card className={classes.card}>
+      <CardHeader
+        avatar={
+          loading ? (
+            <Skeleton variant="circle" width={40} height={40} />
+          ) : (
+            <Avatar
+              alt="Ted talk"
+              src="https://pbs.twimg.com/profile_images/877631054525472768/Xp5FAPD5_reasonably_small.jpg"
+            />
+          )
+        }
+        action={
+          loading ? null : (
+            <IconButton aria-label="settings">
+              <MoreVertIcon />
+            </IconButton>
+          )
+        }
+        title={loading ? <Skeleton height={6} width="80%" /> : 'Ted'}
+        subheader={loading ? <Skeleton height={6} width="40%" /> : '5 hours ago'}
+      />
+      {loading ? (
+        <Skeleton variant="rect" className={classes.media} />
+      ) : (
+        <CardMedia
+          className={classes.media}
+          image="https://pi.tedcdn.com/r/talkstar-photos.s3.amazonaws.com/uploads/72bda89f-9bbf-4685-910a-2f151c4f3a8a/NicolaSturgeon_2019T-embed.jpg?w=512"
+          title="Ted talk"
+        />
+      )}
+      <CardContent>
+        {loading ? (
+          <React.Fragment>
+            <Skeleton height={6} />
+            <Skeleton height={6} width="80%" />
+          </React.Fragment>
+        ) : (
+          <Typography variant="body2" color="textSecondary" component="p">
+            {
+              "Why First Minister of Scotland Nicola Sturgeon thinks GDP is the wrong measure of a country's success:"
+            }
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function Facebook() {
+  return (
+    <div>
+      <Media loading />
+      <Media />
+    </div>
+  );
+}

--- a/docs/src/pages/components/skeleton/YouTube.js
+++ b/docs/src/pages/components/skeleton/YouTube.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Skeleton from '@material-ui/lab/Skeleton';
+
+const data = [
+  {
+    src:
+      'https://i.ytimg.com/vi/pLqipJNItIo/hqdefault.jpg?sqp=-oaymwEYCNIBEHZIVfKriqkDCwgBFQAAiEIYAXAB&rs=AOn4CLBkklsyaw9FxDmMKapyBYCn9tbPNQ',
+    title: 'Don Diablo @ Tomorrowland Main Stage 2019 | Official…',
+    channel: 'Don Diablo',
+    views: '396 k views',
+    createdAt: 'a week ago',
+  },
+  {
+    src:
+      'https://i.ytimg.com/vi/ycHr1G0Gffg/hqdefault.jpg?sqp=-oaymwEYCNIBEHZIVfKriqkDCwgBFQAAiEIYAXAB&rs=AOn4CLAS6ZJ5RYa2R3Ksp9d8cLzY_8DMOA',
+    title: 'Top Latino Songs 2019 - Luis Fonsi, Ozuna, Nicky Jam…',
+    channel: 'Dj Yanky Plus',
+    views: '2.1 M views',
+    createdAt: '4 months ago',
+  },
+  {
+    src:
+      'https://i.ytimg.com/vi/kkLk2XWMBf8/hqdefault.jpg?sqp=-oaymwEYCNIBEHZIVfKriqkDCwgBFQAAiEIYAXAB&rs=AOn4CLB4GZTFu1Ju2EPPPXnhMZtFVvYBaw',
+    title: 'Calvin Harris, Sam Smith - Promises (Official Video)',
+    channel: 'Calvin Harris',
+    views: '130 M views',
+    createdAt: '10 months ago',
+  },
+];
+
+function Media(props) {
+  const { loading = false } = props;
+
+  return (
+    <Grid container wrap="nowrap">
+      {(loading ? Array.from(new Array(3)) : data).map((item, index) => (
+        <Box key={index} width={210} marginRight={0.5} my={5}>
+          {item ? (
+            <img style={{ width: 210, height: 118 }} alt={item.title} src={item.src} />
+          ) : (
+            <Skeleton variant="rect" width={210} height={118} />
+          )}
+
+          {item ? (
+            <Box paddingRight={2}>
+              <Typography gutterBottom variant="body2">
+                {item.title}
+              </Typography>
+              <Typography display="block" variant="caption" color="textSecondary">
+                {item.channel}
+              </Typography>
+              <Typography variant="caption" color="textSecondary">{`${item.views} • ${
+                item.createdAt
+              }`}</Typography>
+            </Box>
+          ) : (
+            <React.Fragment>
+              <Skeleton />
+              <Skeleton width="60%" />
+            </React.Fragment>
+          )}
+        </Box>
+      ))}
+    </Grid>
+  );
+}
+
+Media.propTypes = {
+  loading: PropTypes.bool,
+};
+
+export default function YouTube() {
+  return (
+    <Box overflow="hidden" clone>
+      <Paper>
+        <Box px={3}>
+          <Media loading />
+          <Media />
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/skeleton/YouTube.tsx
+++ b/docs/src/pages/components/skeleton/YouTube.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import Paper from '@material-ui/core/Paper';
+import Grid from '@material-ui/core/Grid';
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+import Skeleton from '@material-ui/lab/Skeleton';
+
+const data = [
+  {
+    src:
+      'https://i.ytimg.com/vi/pLqipJNItIo/hqdefault.jpg?sqp=-oaymwEYCNIBEHZIVfKriqkDCwgBFQAAiEIYAXAB&rs=AOn4CLBkklsyaw9FxDmMKapyBYCn9tbPNQ',
+    title: 'Don Diablo @ Tomorrowland Main Stage 2019 | Official…',
+    channel: 'Don Diablo',
+    views: '396 k views',
+    createdAt: 'a week ago',
+  },
+  {
+    src:
+      'https://i.ytimg.com/vi/ycHr1G0Gffg/hqdefault.jpg?sqp=-oaymwEYCNIBEHZIVfKriqkDCwgBFQAAiEIYAXAB&rs=AOn4CLAS6ZJ5RYa2R3Ksp9d8cLzY_8DMOA',
+    title: 'Top Latino Songs 2019 - Luis Fonsi, Ozuna, Nicky Jam…',
+    channel: 'Dj Yanky Plus',
+    views: '2.1 M views',
+    createdAt: '4 months ago',
+  },
+  {
+    src:
+      'https://i.ytimg.com/vi/kkLk2XWMBf8/hqdefault.jpg?sqp=-oaymwEYCNIBEHZIVfKriqkDCwgBFQAAiEIYAXAB&rs=AOn4CLB4GZTFu1Ju2EPPPXnhMZtFVvYBaw',
+    title: 'Calvin Harris, Sam Smith - Promises (Official Video)',
+    channel: 'Calvin Harris',
+    views: '130 M views',
+    createdAt: '10 months ago',
+  },
+];
+
+interface MediaProps {
+  loading?: boolean;
+}
+
+function Media(props: MediaProps) {
+  const { loading = false } = props;
+
+  return (
+    <Grid container wrap="nowrap">
+      {(loading ? Array.from(new Array(3)) : data).map((item, index) => (
+        <Box key={index} width={210} marginRight={0.5} my={5}>
+          {item ? (
+            <img style={{ width: 210, height: 118 }} alt={item.title} src={item.src} />
+          ) : (
+            <Skeleton variant="rect" width={210} height={118} />
+          )}
+          {item ? (
+            <Box paddingRight={2}>
+              <Typography gutterBottom variant="body2">
+                {item.title}
+              </Typography>
+              <Typography display="block" variant="caption" color="textSecondary">
+                {item.channel}
+              </Typography>
+              <Typography variant="caption" color="textSecondary">{`${item.views} • ${
+                item.createdAt
+              }`}</Typography>
+            </Box>
+          ) : (
+            <React.Fragment>
+              <Skeleton />
+              <Skeleton width="60%" />
+            </React.Fragment>
+          )}
+        </Box>
+      ))}
+    </Grid>
+  );
+}
+
+export default function YouTube() {
+  return (
+    <Box overflow="hidden" clone>
+      <Paper>
+        <Box px={3}>
+          <Media loading />
+          <Media />
+        </Box>
+      </Paper>
+    </Box>
+  );
+}

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -7,7 +7,7 @@ components: Skeleton
 
 <p class="description">Display a placeholder preview of your content before the data gets loaded to reduce load-time frustration.</p>
 
-The data for your components might not be immediately available. You can increase the perceived performance for users by using skeletons. It feels like things are happening immediately, the information is incrementally displayed on the screen (Cf. [Avoid The Spinner](https://www.lukew.com/ff/entry.asp?1797)).
+The data for your components might not be immediately available. You can increase the perceived performance for users by using skeletons. It feels like things are happening immediately, then the information is incrementally displayed on the screen (Cf. [Avoid The Spinner](https://www.lukew.com/ff/entry.asp?1797)).
 
 The component is designed to be used **directly in your components**.
 For instance:

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -7,7 +7,7 @@ components: Skeleton
 
 <p class="description">Display a placeholder preview of your content before the data get loaded. A skeleton can reduce load time frustration.</p>
 
-The data of your components might not be available. You can increase the user’s perceived performance by using skeletons. It feels like things are happening immediately, the information is incrementally displayed on the screen (Cf. [Avoid The Spinner](https://www.lukew.com/ff/entry.asp?1797)).
+The data for your components might not be immediately available. You can increase the perceived performance for users by using skeletons. It feels like things are happening immediately, the information is incrementally displayed on the screen (Cf. [Avoid The Spinner](https://www.lukew.com/ff/entry.asp?1797)).
 
 The component is designed to be used **directly in your components**.
 For instance:

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -1,0 +1,29 @@
+---
+title: Skeleton React component
+components: Skeleton
+---
+
+# Skeleton
+
+<p class="description">Display a placeholder preview of your content before the data get loaded. A skeleton can reduce load time frustration.</p>
+
+The data of your components might not be available. You can increase the user’s perceived performance by using skeletons. It feels like things are happening immediately, the information is incrementally displayed on the screen (Cf. [Avoid The Spinner](https://www.lukew.com/ff/entry.asp?1797)).
+
+The component is designed to be used **directly in your components**.
+For instance:
+
+```jsx
+{item ? (
+  <img style={{ width: 210, height: 118 }} alt={item.title} src={item.src} />
+) : (
+  <Skeleton variant="rect" width={210} height={118} />
+)}
+```
+
+## YouTube example
+
+{{"demo": "pages/components/skeleton/YouTube.js"}}
+
+## Facebook example
+
+{{"demo": "pages/components/skeleton/Facebook.js"}}

--- a/docs/src/pages/components/skeleton/skeleton.md
+++ b/docs/src/pages/components/skeleton/skeleton.md
@@ -5,7 +5,7 @@ components: Skeleton
 
 # Skeleton
 
-<p class="description">Display a placeholder preview of your content before the data get loaded. A skeleton can reduce load time frustration.</p>
+<p class="description">Display a placeholder preview of your content before the data gets loaded to reduce load-time frustration.</p>
 
 The data for your components might not be immediately available. You can increase the perceived performance for users by using skeletons. It feels like things are happening immediately, the information is incrementally displayed on the screen (Cf. [Avoid The Spinner](https://www.lukew.com/ff/entry.asp?1797)).
 

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.d.ts
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.d.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { OverridableComponent, SimplifiedPropsOf } from '@material-ui/core/OverridableComponent';
+
+declare const Skeleton: OverridableComponent<{
+  props: {
+    disableAnimate?: boolean;
+    height?: any;
+    variant?: 'text' | 'rect' | 'circle';
+    width?: any;
+  };
+  defaultComponent: 'div';
+  classKey: SkeletonClassKey;
+}>;
+
+export type SkeletonClassKey = 'root' | 'text' | 'rect' | 'circle' | 'animate';
+
+export type SkeletonProps = SimplifiedPropsOf<typeof Skeleton>;
+
+export default Skeleton;

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -87,7 +87,7 @@ Skeleton.propTypes = {
    */
   component: PropTypes.elementType,
   /**
-   * Disable the animation effect.
+   * If `true` the animation effect is disabled.
    */
   disableAnimate: PropTypes.bool,
   /**

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import { withStyles } from '@material-ui/core/styles';
+
+export const styles = theme => ({
+  /* Styles applied to the root element. */
+  root: {
+    backgroundColor: theme.palette.action.hover,
+    height: '1.2em',
+  },
+  /* Styles applied to the root element if `variant="text"`. */
+  text: {
+    marginTop: '0.8em',
+    marginBottom: '0.8em',
+    borderRadius: theme.shape.borderRadius,
+  },
+  /* Styles applied to the root element if `variant="rect"`. */
+  rect: {},
+  /* Styles applied to the root element if `variant="circle"`. */
+  circle: {
+    borderRadius: '50%',
+  },
+  /* Styles applied to the root element if `disabledAnimate={false}`. */
+  animate: {
+    animation: '$mui-skeleton 1.5s ease-in-out infinite',
+  },
+  '@keyframes mui-skeleton': {
+    '0%': {
+      opacity: 1,
+    },
+    '50%': {
+      opacity: 0.4,
+    },
+    '100%': {
+      opacity: 1,
+    },
+  },
+});
+
+const Skeleton = React.forwardRef(function Skeleton(props, ref) {
+  const {
+    classes,
+    className,
+    component: Component = 'div',
+    disableAnimate = false,
+    height,
+    variant = 'text',
+    width,
+    ...other
+  } = props;
+
+  return (
+    <Component
+      ref={ref}
+      className={clsx(
+        classes.root,
+        classes[variant],
+        {
+          [classes.animate]: !disableAnimate,
+        },
+        className,
+      )}
+      {...other}
+      style={{
+        width,
+        height,
+        ...other.style,
+      }}
+    />
+  );
+});
+
+Skeleton.propTypes = {
+  /**
+   * Override or extend the styles applied to the component.
+   * See [CSS API](#css) below for more details.
+   */
+  classes: PropTypes.object.isRequired,
+  /**
+   * @ignore
+   */
+  className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
+   * Disable the animation effect.
+   */
+  disableAnimate: PropTypes.bool,
+  /**
+   * Height of the skeleton.
+   * Useful when you don't want to adapt the skeleton to a text element but for instance a card.
+   */
+  height: PropTypes.any,
+  /**
+   * The type of content that will be rendered.
+   */
+  variant: PropTypes.oneOf(['text', 'rect', 'circle']),
+  /**
+   * Width of the skeleton.
+   * Useful when the skeleton is inside an inline element with no width of its own.
+   */
+  width: PropTypes.any,
+};
+
+export default withStyles(styles, { name: 'MuiSkeleton' })(Skeleton);

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { expect } from 'chai';
+import { createMount, getClasses } from '@material-ui/core/test-utils';
+import describeConformance from '@material-ui/core/test-utils/describeConformance';
+import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import Skeleton from './Skeleton';
+
+describe('<Skeleton />', () => {
+  let mount;
+  const render = createClientRender({ strict: true });
+  let classes;
+
+  before(() => {
+    mount = createMount({ strict: true });
+    classes = getClasses(<Skeleton />);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  after(() => {
+    mount.cleanUp();
+  });
+
+  describeConformance(<Skeleton />, () => ({
+    classes,
+    inheritComponent: 'div',
+    mount,
+    refInstanceof: window.HTMLDivElement,
+  }));
+
+  it('should render', () => {
+    const { container } = render(<Skeleton />);
+
+    expect(container.firstChild).to.have.class(classes.root);
+  });
+});

--- a/packages/material-ui-lab/src/Skeleton/index.d.ts
+++ b/packages/material-ui-lab/src/Skeleton/index.d.ts
@@ -1,0 +1,2 @@
+export { default } from './Skeleton';
+export * from './Skeleton';

--- a/packages/material-ui-lab/src/Skeleton/index.js
+++ b/packages/material-ui-lab/src/Skeleton/index.js
@@ -1,0 +1,1 @@
+export { default } from './Skeleton';


### PR DESCRIPTION
Preview: https://deploy-preview-16786--material-ui.netlify.com/components/skeleton/

~A one hour POC, would it make sense to complete it?~ It should be mostly done.

Benchmarked with:
- http://react.carbondesignsystem.com/?path=/story/skeletontext--default
- https://workday.github.io/canvas-kit/?path=/story/skeleton--text
- https://github.com/danilowoz/react-content-loader
- https://ant.design/components/skeleton/
- https://github.com/dvtng/react-loading-skeleton
- https://github.com/henrykuzmick/react-skeleton-loader
- https://sancho-ui.com/components/skeleton/
- https://blueprintjs.com/docs/#core/components/skeleton
- https://ionicthemes.com/tutorials/about/improved-ux-for-ionic-apps-with-skeleton-loading-screens

I have seen 3 different APIs looking at prior arts:

1. The SVG approach. I think that it's the worse of all. It makes you draw the skeleton with hardcoded layout values. I think that it's much better to rely on the existing layout algo people know. For instance:
```jsx
  <Skeleton>
    <rect x="0" y="0" rx="5" ry="5" width="70" height="70" />
    <rect x="80" y="17" rx="4" ry="4" width="300" height="13" />
  </Skeleton>
```
2. The component approach. **This is the approach implemented here**. For instance:
```jsx
<Skeleton width="80%" />
```
3. The class name/component boolean approach. Basically, you have a skeleton prop in your system or a Mui-Skeleton class name. You can enable it on any component. This is lower level than approach n°2. It can be simpler. However, when using it, you have to make sure that you make the **elements not focusable** (tab index, or disabled). I would propose that we explore it, in the future. For instance:
```jsx
<Button skeleton />
<Button className="MuiSkeleton-root" />
```