### PR TITLE
[Grid] Add 'root' to GridClassKey typing

### DIFF
--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -31,6 +31,7 @@ export type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
 export type GridProps = SimplifiedPropsOf<typeof Grid>;
 
 export type GridClassKey =
+  | 'root'                                        
   | 'container'
   | 'item'
   | 'direction-xs-column'

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -31,7 +31,7 @@ export type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
 export type GridProps = SimplifiedPropsOf<typeof Grid>;
 
 export type GridClassKey =
-  | 'root'                                        
+  | 'root'
   | 'container'
   | 'item'
   | 'direction-xs-column'


### PR DESCRIPTION
Root was missing for type GridClassKey.

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #16796