### PR TITLE
[Popper] Fix handlePopperRefRef.current is not a function

### DIFF
--- a/packages/material-ui/src/Popper/Popper.js
+++ b/packages/material-ui/src/Popper/Popper.js
@@ -61,8 +61,8 @@ const Popper = React.forwardRef(function Popper(props, ref) {
   const ownRef = useForkRef(tooltipRef, ref);
 
   const popperRef = React.useRef(null);
-  const handlePopperRefRef = React.useRef();
   const handlePopperRef = useForkRef(popperRef, popperRefProp);
+  const handlePopperRefRef = React.useRef(handlePopperRef);
   useEnhancedEffect(() => {
     handlePopperRefRef.current = handlePopperRef;
   }, [handlePopperRef]);

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -222,6 +222,32 @@ describe('<Popper />', () => {
     });
   });
 
+  describe('prop: disablePortal', () => {
+    it('should work', () => {
+      const popperRef = React.createRef();
+      const wrapper = mount(<Popper {...defaultProps} disablePortal popperRef={popperRef} />);
+      // renders
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      // correctly sets modifiers
+      assert.strictEqual(
+        popperRef.current.options.modifiers.preventOverflow.boundariesElement,
+        'scrollParent',
+      );
+    });
+
+    it('sets preventOverflow to window when disablePortal is false', () => {
+      const popperRef = React.createRef();
+      const wrapper = mount(<Popper {...defaultProps} popperRef={popperRef} />);
+      // renders
+      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      // correctly sets modifiers
+      assert.strictEqual(
+        popperRef.current.options.modifiers.preventOverflow.boundariesElement,
+        'window',
+      );
+    });
+  });
+
   describe('warnings', () => {
     beforeEach(() => {
       consoleErrorMock.spy();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #16800

I am not 100% sure about the tests. Those tests have reproduced the issue before I fixed it.

cc @oliviertassinari 