### PR TITLE
[TreeView] Iterate on the component

### DIFF
--- a/docs/pages/api/tree-view.md
+++ b/docs/pages/api/tree-view.md
@@ -38,7 +38,7 @@ Any other props supplied will be provided to the root element (native element).
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|
-| <span class="prop-name">root</span> | <span class="prop-name">MuiTreeView-root</span> | Styles applied to the root component.
+| <span class="prop-name">root</span> | <span class="prop-name">MuiTreeView-root</span> | Styles applied to the root element.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.js
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.js
@@ -11,11 +11,6 @@ const useStyles = makeStyles({
   },
 });
 
-function handleClick(event) {
-  event.preventDefault();
-  alert('You clicked a leaf node.');
-}
-
 export default function FileSystemNavigator() {
   const classes = useStyles();
 
@@ -26,15 +21,15 @@ export default function FileSystemNavigator() {
       defaultExpandIcon={<ChevronRightIcon />}
     >
       <TreeItem nodeId="1" label="Applications">
-        <TreeItem nodeId="2" label="Calendar" onClick={handleClick} />
-        <TreeItem nodeId="3" label="Chrome" onClick={handleClick} />
-        <TreeItem nodeId="4" label="Webstorm" onClick={handleClick} />
+        <TreeItem nodeId="2" label="Calendar" />
+        <TreeItem nodeId="3" label="Chrome" />
+        <TreeItem nodeId="4" label="Webstorm" />
       </TreeItem>
       <TreeItem nodeId="5" label="Documents">
         <TreeItem nodeId="6" label="Material-UI">
-          <TreeItem nodeId="7" label="src" >
-            <TreeItem nodeId="8" label="index.js" onClick={handleClick} />
-            <TreeItem nodeId="9" label="tree-view.js" onClick={handleClick} />
+          <TreeItem nodeId="7" label="src">
+            <TreeItem nodeId="8" label="index.js" />
+            <TreeItem nodeId="9" label="tree-view.js" />
           </TreeItem>
         </TreeItem>
       </TreeItem>

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.js
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.js
@@ -32,7 +32,7 @@ export default function FileSystemNavigator() {
       </TreeItem>
       <TreeItem nodeId="5" label="Documents">
         <TreeItem nodeId="6" label="Material-UI">
-          <TreeItem nodeId="7" label="src">
+          <TreeItem nodeId="7" label="src" >
             <TreeItem nodeId="8" label="index.js" onClick={handleClick} />
             <TreeItem nodeId="9" label="tree-view.js" onClick={handleClick} />
           </TreeItem>

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.js
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.js
@@ -1,22 +1,40 @@
 import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import TreeItem from '@material-ui/lab/TreeItem';
 
+const useStyles = makeStyles({
+  root: {
+    height: 216,
+  },
+});
+
+function handleClick(event) {
+  event.preventDefault();
+  alert('You clicked a leaf node.');
+}
+
 export default function FileSystemNavigator() {
+  const classes = useStyles();
+
   return (
-    <TreeView defaultCollapseIcon={<ExpandMoreIcon />} defaultExpandIcon={<ChevronRightIcon />}>
-      <TreeItem nodeId="1" label="Applications: ">
-        <TreeItem nodeId="2" label="Calendar : app" />
-        <TreeItem nodeId="3" label="Chrome : app" />
-        <TreeItem nodeId="4" label="Webstorm : app" />
+    <TreeView
+      className={classes.root}
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpandIcon={<ChevronRightIcon />}
+    >
+      <TreeItem nodeId="1" label="Applications">
+        <TreeItem nodeId="2" label="Calendar" onClick={handleClick} />
+        <TreeItem nodeId="3" label="Chrome" onClick={handleClick} />
+        <TreeItem nodeId="4" label="Webstorm" onClick={handleClick} />
       </TreeItem>
-      <TreeItem nodeId="5" label="Documents: ">
-        <TreeItem nodeId="6" label="Material-UI : app">
-          <TreeItem nodeId="7" label="src : ">
-            <TreeItem nodeId="8" label="index : js" />
-            <TreeItem nodeId="9" label="tree-view : js" />
+      <TreeItem nodeId="5" label="Documents">
+        <TreeItem nodeId="6" label="Material-UI">
+          <TreeItem nodeId="7" label="src" >
+            <TreeItem nodeId="8" label="index.js" onClick={handleClick} />
+            <TreeItem nodeId="9" label="tree-view.js" onClick={handleClick} />
           </TreeItem>
         </TreeItem>
       </TreeItem>

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.js
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.js
@@ -32,7 +32,7 @@ export default function FileSystemNavigator() {
       </TreeItem>
       <TreeItem nodeId="5" label="Documents">
         <TreeItem nodeId="6" label="Material-UI">
-          <TreeItem nodeId="7" label="src" >
+          <TreeItem nodeId="7" label="src">
             <TreeItem nodeId="8" label="index.js" onClick={handleClick} />
             <TreeItem nodeId="9" label="tree-view.js" onClick={handleClick} />
           </TreeItem>

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
@@ -13,11 +13,6 @@ const useStyles = makeStyles(
   }),
 );
 
-function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
-  event.preventDefault();
-  alert('You clicked a leaf node.');
-}
-
 export default function FileSystemNavigator() {
   const classes = useStyles();
 
@@ -28,15 +23,15 @@ export default function FileSystemNavigator() {
       defaultExpandIcon={<ChevronRightIcon />}
     >
       <TreeItem nodeId="1" label="Applications">
-        <TreeItem nodeId="2" label="Calendar" onClick={handleClick} />
-        <TreeItem nodeId="3" label="Chrome" onClick={handleClick} />
-        <TreeItem nodeId="4" label="Webstorm" onClick={handleClick} />
+        <TreeItem nodeId="2" label="Calendar" />
+        <TreeItem nodeId="3" label="Chrome" />
+        <TreeItem nodeId="4" label="Webstorm" />
       </TreeItem>
       <TreeItem nodeId="5" label="Documents">
         <TreeItem nodeId="6" label="Material-UI">
           <TreeItem nodeId="7" label="src">
-            <TreeItem nodeId="8" label="index.js" onClick={handleClick} />
-            <TreeItem nodeId="9" label="tree-view.js" onClick={handleClick} />
+            <TreeItem nodeId="8" label="index.js" />
+            <TreeItem nodeId="9" label="tree-view.js" />
           </TreeItem>
         </TreeItem>
       </TreeItem>

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
@@ -1,22 +1,42 @@
 import React from 'react';
+import { makeStyles, createStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import TreeItem from '@material-ui/lab/TreeItem';
 
+const useStyles = makeStyles(
+  createStyles({
+    root: {
+      height: 216,
+    },
+  }),
+);
+
+function handleClick(event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) {
+  event.preventDefault();
+  alert('You clicked a leaf node.');
+}
+
 export default function FileSystemNavigator() {
+  const classes = useStyles();
+
   return (
-    <TreeView defaultCollapseIcon={<ExpandMoreIcon />} defaultExpandIcon={<ChevronRightIcon />}>
-      <TreeItem nodeId="1" label="Applications: ">
-        <TreeItem nodeId="2" label="Calendar : app" />
-        <TreeItem nodeId="3" label="Chrome : app" />
-        <TreeItem nodeId="4" label="Webstorm : app" />
+    <TreeView
+      className={classes.root}
+      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultExpandIcon={<ChevronRightIcon />}
+    >
+      <TreeItem nodeId="1" label="Applications">
+        <TreeItem nodeId="2" label="Calendar" onClick={handleClick} />
+        <TreeItem nodeId="3" label="Chrome" onClick={handleClick} />
+        <TreeItem nodeId="4" label="Webstorm" onClick={handleClick} />
       </TreeItem>
-      <TreeItem nodeId="5" label="Documents: ">
-        <TreeItem nodeId="6" label="Material-UI : app">
-          <TreeItem nodeId="7" label="src : ">
-            <TreeItem nodeId="8" label="index : js" />
-            <TreeItem nodeId="9" label="tree-view : js" />
+      <TreeItem nodeId="5" label="Documents">
+        <TreeItem nodeId="6" label="Material-UI">
+          <TreeItem nodeId="7" label="src">
+            <TreeItem nodeId="8" label="index.js" onClick={handleClick} />
+            <TreeItem nodeId="9" label="tree-view.js" onClick={handleClick} />
           </TreeItem>
         </TreeItem>
       </TreeItem>

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -36,7 +36,7 @@ export const styles = function styles(theme) {
         backgroundColor: theme.palette.grey[200],
       },
       '&:hover': {
-        backgroundColor: theme.palette.grey[200],
+        backgroundColor: theme.palette.action.hover,
       },
     },
     /* Styles applied to the tree node icon and collapse/expand icon. */

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -10,7 +10,7 @@ import TreeViewContext from '../TreeView/TreeViewContext';
 
 export const styles = function styles(theme) {
   return {
-  /* Styles applied to the root element. */
+    /* Styles applied to the root element. */
     root: {
       listStyle: 'none',
       margin: 0,
@@ -49,7 +49,7 @@ export const styles = function styles(theme) {
     },
     /* Styles applied to the label element. */
     label: {},
-  }
+  };
 };
 
 const isPrintableCharacter = str => {
@@ -71,7 +71,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     onKeyDown,
     ...other
   } = props;
-  
+
   const {
     icons: contextIcons,
     toggle,

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -8,49 +8,43 @@ import { withStyles } from '@material-ui/core/styles';
 import { useForkRef } from '@material-ui/core/utils';
 import TreeViewContext from '../TreeView/TreeViewContext';
 
-export const styles = theme => {
-  return {
-    /* Styles applied to the root element. */
-    root: {
-      listStyle: 'none',
-      margin: 0,
-      padding: 0,
-      '&:focus': {
-        outline: 'none',
-      },
-      '&:focus > $content': {
-        outline: 'none',
-        backgroundColor: theme.palette.grey[400],
-      },
+export const styles = theme => ({
+  /* Styles applied to the root element. */
+  root: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    outline: 'none',
+    '&:focus > $content': {
+      backgroundColor: theme.palette.grey[400],
     },
-    /* Styles applied to the `role="group"` element. */
-    group: {
-      margin: 0,
-      padding: 0,
-      marginLeft: 26,
+  },
+  /* Styles applied to the `role="group"` element. */
+  group: {
+    margin: 0,
+    padding: 0,
+    marginLeft: 26,
+  },
+  /* Styles applied to the tree node content. */
+  content: {
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+    '&:hover': {
+      backgroundColor: theme.palette.action.hover,
     },
-    /* Styles applied to the tree node content. */
-    content: {
-      width: '100%',
-      display: 'flex',
-      alignItems: 'center',
-      cursor: 'pointer',
-      '&:hover': {
-        backgroundColor: theme.palette.action.hover,
-      },
-    },
-    /* Styles applied to the tree node icon and collapse/expand icon. */
-    iconContainer: {
-      marginRight: 2,
-      width: 24,
-      minWidth: 24,
-      display: 'flex',
-      justifyContent: 'center',
-    },
-    /* Styles applied to the label element. */
-    label: {},
-  };
-};
+  },
+  /* Styles applied to the tree node icon and collapse/expand icon. */
+  iconContainer: {
+    marginRight: 2,
+    width: 24,
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  /* Styles applied to the label element. */
+  label: {},
+});
 
 const isPrintableCharacter = str => {
   return str && str.length === 1 && str.match(/\S/);
@@ -58,9 +52,9 @@ const isPrintableCharacter = str => {
 
 const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   const {
+    children,
     classes,
     className,
-    children,
     collapseIcon,
     expandIcon,
     icon,
@@ -73,21 +67,21 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   } = props;
 
   const {
-    icons: contextIcons,
-    toggle,
-    isExpanded,
-    isTabable,
+    expandAllSiblings,
     focus,
-    focusNextNode,
-    focusPreviousNode,
     focusFirstNode,
     focusLastNode,
-    isFocused,
-    handleLeftArrow,
-    expandAllSiblings,
-    setFocusByFirstCharacter,
-    handleNodeMap,
+    focusNextNode,
+    focusPreviousNode,
     handleFirstChars,
+    handleLeftArrow,
+    handleNodeMap,
+    icons: contextIcons,
+    isExpanded,
+    isFocused,
+    isTabable,
+    setFocusByFirstCharacter,
+    toggle,
   } = React.useContext(TreeViewContext);
 
   const nodeRef = React.useRef(null);

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -15,6 +15,7 @@ export const styles = {
     margin: 0,
     padding: 0,
     outline: 0,
+    cursor: 'pointer',
     '&:focus > $content': {
       outline: 'auto 1px',
     },
@@ -62,6 +63,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     onKeyDown,
     ...other
   } = props;
+  
   const {
     icons: contextIcons,
     toggle,

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -15,9 +15,12 @@ export const styles = function styles(theme) {
       listStyle: 'none',
       margin: 0,
       padding: 0,
-      outline: 0,
+      '&:focus': {
+        outline: 'none',
+      },
       '&:focus > $content': {
-        outline: 'auto 1px',
+        outline: 'none',
+        backgroundColor: theme.palette.grey[400],
       },
     },
     /* Styles applied to the `role="group"` element. */

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -8,40 +8,45 @@ import { withStyles } from '@material-ui/core/styles';
 import { useForkRef } from '@material-ui/core/utils';
 import TreeViewContext from '../TreeView/TreeViewContext';
 
-export const styles = {
+export const styles = function styles(theme) {
+  return {
   /* Styles applied to the root element. */
-  root: {
-    listStyle: 'none',
-    margin: 0,
-    padding: 0,
-    outline: 0,
-    cursor: 'pointer',
-    '&:focus > $content': {
-      outline: 'auto 1px',
+    root: {
+      listStyle: 'none',
+      margin: 0,
+      padding: 0,
+      outline: 0,
+      cursor: 'pointer',
+      '&:focus > $content': {
+        outline: 'auto 1px',
+      },
     },
-  },
-  /* Styles applied to the `role="group"` element. */
-  group: {
-    margin: 0,
-    padding: 0,
-    marginLeft: 26,
-  },
-  /* Styles applied to the tree node content. */
-  content: {
-    width: '100%',
-    display: 'flex',
-    alignItems: 'center',
-  },
-  /* Styles applied to the tree node icon and collapse/expand icon. */
-  iconContainer: {
-    marginRight: 2,
-    width: 24,
-    minWidth: 24,
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  /* Styles applied to the label element. */
-  label: {},
+    /* Styles applied to the `role="group"` element. */
+    group: {
+      margin: 0,
+      padding: 0,
+      marginLeft: 26,
+    },
+    /* Styles applied to the tree node content. */
+    content: {
+      width: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      '&:hover': {
+        backgroundColor: theme.palette.grey[200]
+      },
+    },
+    /* Styles applied to the tree node icon and collapse/expand icon. */
+    iconContainer: {
+      marginRight: 2,
+      width: 24,
+      minWidth: 24,
+      display: 'flex',
+      justifyContent: 'center',
+    },
+    /* Styles applied to the label element. */
+    label: {},
+  }
 };
 
 const isPrintableCharacter = str => {

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -16,7 +16,6 @@ export const styles = function styles(theme) {
       margin: 0,
       padding: 0,
       outline: 0,
-      cursor: 'pointer',
       '&:focus > $content': {
         outline: 'auto 1px',
       },
@@ -32,6 +31,7 @@ export const styles = function styles(theme) {
       width: '100%',
       display: 'flex',
       alignItems: 'center',
+      cursor: 'pointer',
       '&:hover': {
         backgroundColor: theme.palette.action.hover,
       },

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -5,8 +5,7 @@ import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Collapse from '@material-ui/core/Collapse';
 import { withStyles } from '@material-ui/core/styles';
-import { useForkRef } from '@material-ui/core/utils';
-import { useIsFocusVisible } from '../../../material-ui/src/utils/focusVisible';
+import { useForkRef, useIsFocusVisible } from '@material-ui/core/utils';
 import TreeViewContext from '../TreeView/TreeViewContext';
 
 export const styles = function styles(theme) {
@@ -99,7 +98,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
 
   const nodeRef = React.useRef(null);
   const contentRef = React.useRef(null);
-  const handleRef = useForkRef(focusVisibleRef, nodeRef, ref);
+  const handleRef = useForkRef(focusVisibleRef, useForkRef(nodeRef, ref));
 
   let stateIcon = null;
 

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -6,18 +6,20 @@ import Typography from '@material-ui/core/Typography';
 import Collapse from '@material-ui/core/Collapse';
 import { withStyles } from '@material-ui/core/styles';
 import { useForkRef } from '@material-ui/core/utils';
-import { useIsFocusVisible } from '../../../material-ui/src/utils/focusVisible';
 import TreeViewContext from '../TreeView/TreeViewContext';
 
 export const styles = function styles(theme) {
   return {
-    /* Styles applied to the root element. */
+  /* Styles applied to the root element. */
     root: {
       listStyle: 'none',
       margin: 0,
       padding: 0,
       outline: 0,
       cursor: 'pointer',
+      '&:focus > $content': {
+        outline: 'auto 1px',
+      },
     },
     /* Styles applied to the `role="group"` element. */
     group: {
@@ -30,12 +32,6 @@ export const styles = function styles(theme) {
       width: '100%',
       display: 'flex',
       alignItems: 'center',
-      '&:focus': {
-        outline: 'none',
-      },
-      '&$focusVisible': {
-        backgroundColor: theme.palette.grey[200],
-      },
       '&:hover': {
         backgroundColor: theme.palette.action.hover,
       },
@@ -50,9 +46,7 @@ export const styles = function styles(theme) {
     },
     /* Styles applied to the label element. */
     label: {},
-    /* Pseudo-class applied to the content element if the link is keyboard focused. */
-    focusVisible: {},
-  };
+  }
 };
 
 const isPrintableCharacter = str => {
@@ -69,13 +63,12 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     icon,
     label,
     nodeId,
-    onBlur,
     onClick,
     onFocus,
     onKeyDown,
     ...other
   } = props;
-
+  
   const {
     icons: contextIcons,
     toggle,
@@ -94,12 +87,9 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     handleFirstChars,
   } = React.useContext(TreeViewContext);
 
-  const { isFocusVisible, onBlurVisible, ref: focusVisibleRef } = useIsFocusVisible();
-  const [focusVisible, setFocusVisible] = React.useState(false);
-
   const nodeRef = React.useRef(null);
   const contentRef = React.useRef(null);
-  const handleRef = useForkRef(focusVisibleRef, nodeRef, ref);
+  const handleRef = useForkRef(nodeRef, ref);
 
   let stateIcon = null;
 
@@ -233,21 +223,9 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     if (!focused && tabable) {
       focus(nodeId);
     }
-    if (isFocusVisible(event)) {
-      setFocusVisible(true);
-    }
+
     if (onFocus) {
       onFocus(event);
-    }
-  };
-
-  const handleBlur = event => {
-    if (focusVisible) {
-      onBlurVisible();
-      setFocusVisible(false);
-    }
-    if (onBlur) {
-      onBlur(event);
     }
   };
 
@@ -275,20 +253,13 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
       className={clsx(classes.root, className)}
       role="treeitem"
       onKeyDown={handleKeyDown}
-      onBlur={handleBlur}
       onFocus={handleFocus}
       aria-expanded={expandable ? expanded : null}
       ref={handleRef}
       tabIndex={tabable ? 0 : -1}
       {...other}
     >
-      <div
-        className={clsx(classes.content, {
-          [classes.focusVisible]: focusVisible,
-        })}
-        onClick={handleClick}
-        ref={contentRef}
-      >
+      <div className={classes.content} onClick={handleClick} ref={contentRef}>
         {stateIconsProvided ? <div className={classes.iconContainer}>{stateIcon}</div> : null}
         {startAdornment ? <div className={classes.iconContainer}>{startAdornment}</div> : null}
         <Typography className={classes.label}>{label}</Typography>
@@ -336,10 +307,6 @@ TreeItem.propTypes = {
    * The id of the node.
    */
   nodeId: PropTypes.string.isRequired,
-  /**
-   * @ignore
-   */
-  onBlur: PropTypes.func,
   /**
    * @ignore
    */

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -8,7 +8,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { useForkRef } from '@material-ui/core/utils';
 import TreeViewContext from '../TreeView/TreeViewContext';
 
-export const styles = function styles(theme) {
+export const styles = theme => {
   return {
     /* Styles applied to the root element. */
     root: {

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -5,7 +5,8 @@ import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Collapse from '@material-ui/core/Collapse';
 import { withStyles } from '@material-ui/core/styles';
-import { useForkRef, useIsFocusVisible } from '@material-ui/core/utils';
+import { useForkRef } from '@material-ui/core/utils';
+import { useIsFocusVisible } from '../../../material-ui/src/utils/focusVisible';
 import TreeViewContext from '../TreeView/TreeViewContext';
 
 export const styles = function styles(theme) {
@@ -98,7 +99,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
 
   const nodeRef = React.useRef(null);
   const contentRef = React.useRef(null);
-  const handleRef = useForkRef(focusVisibleRef, useForkRef(nodeRef, ref));
+  const handleRef = useForkRef(focusVisibleRef, nodeRef, ref);
 
   let stateIcon = null;
 

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -5,7 +5,7 @@ import TreeViewContext from './TreeViewContext';
 import { withStyles } from '@material-ui/core/styles';
 
 export const styles = {
-  /* Styles applied to the root component. */
+  /* Styles applied to the root element. */
   root: {
     padding: 0,
     margin: 0,
@@ -17,14 +17,14 @@ const defaultExpandedDefault = [];
 
 const TreeView = React.forwardRef(function TreeView(props, ref) {
   const {
+    children,
     classes,
     className,
-    children,
     defaultCollapseIcon,
     defaultEndIcon,
+    defaultExpanded = defaultExpandedDefault,
     defaultExpandIcon,
     defaultParentIcon,
-    defaultExpanded = defaultExpandedDefault,
     onNodeToggle,
     ...other
   } = props;
@@ -264,21 +264,21 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
   return (
     <TreeViewContext.Provider
       value={{
-        icons: { defaultCollapseIcon, defaultExpandIcon, defaultParentIcon, defaultEndIcon },
-        toggle,
-        isExpanded,
-        isTabable,
+        expandAllSiblings,
         focus,
-        focusNextNode,
-        focusPreviousNode,
         focusFirstNode,
         focusLastNode,
-        isFocused,
-        handleLeftArrow,
-        expandAllSiblings,
-        setFocusByFirstCharacter,
-        handleNodeMap,
+        focusNextNode,
+        focusPreviousNode,
         handleFirstChars,
+        handleLeftArrow,
+        handleNodeMap,
+        icons: { defaultCollapseIcon, defaultExpandIcon, defaultParentIcon, defaultEndIcon },
+        isExpanded,
+        isFocused,
+        isTabable,
+        setFocusByFirstCharacter,
+        toggle,
       }}
     >
       <ul role="tree" className={clsx(classes.root, className)} ref={ref} {...other}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

A handful of commits iterating on the TreeView component

 - Tidy up the demo tree labels, and make the edge nodes clickable, fix the demo height so that the page doesn't resize.
 - Use the cursor pointer on hover
 - More material-like hover style
 - ~[WIP] Focus-visible support~

There's a small issue with the latter, where the container node is also receiving focus visible. Any ideas?

I did also wonder if we should be using ButtonBase so the nodes ripple when clicked.