### PR TITLE
[core] Optimise destructuring for useState, useReducer

### DIFF
--- a/docs/src/pages/components/portal/portal.md
+++ b/docs/src/pages/components/portal/portal.md
@@ -7,7 +7,7 @@ components: Portal
 
 <p class="description">The portal component renders its children into a new "subtree" outside of current component hierarchy.</p>
 
-- 📦 [1.5 kB gzipped](/size-snapshot)
+- 📦 [1.3 kB gzipped](/size-snapshot)
 
 The children of the portal component will be appended to the `container` specified.
 

--- a/docs/src/pages/components/textarea-autosize/textarea-autosize.md
+++ b/docs/src/pages/components/textarea-autosize/textarea-autosize.md
@@ -7,7 +7,7 @@ components: TextareaAutosize
 
 <p class="description">A textarea component for React which grows with content.</p>
 
-- 📦 [2.3 kB gzipped](/size-snapshot)
+- 📦 [2.1 kB gzipped](/size-snapshot)
 
 ## Empty
 

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "**/@babel/core": "^7.5.5",
     "**/@babel/plugin-proposal-class-properties": "^7.5.5",
     "**/@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+    "**/@babel/plugin-transform-destructuring": "npm:@minh.nguyen/plugin-transform-destructuring@^7.5.2",
     "**/@babel/plugin-transform-runtime": "~7.5.5",
     "**/@babel/preset-env": "^7.5.5",
     "**/@babel/preset-react": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -447,10 +447,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-transform-destructuring@^7.5.0":
-  version "7.5.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.0.tgz#f6c09fdfe3f94516ff074fe877db7bc9ef05855a"
-  integrity sha512-YbYgbd3TryYYLGyC7ZR+Tq8H/+bCmwoaxHfJHupom5ECstzbRLTch6gOQbhEY9Z4hiCNHEURgq06ykFv9JZ/QQ==
+"@babel/plugin-transform-destructuring@^7.5.0", "@babel/plugin-transform-destructuring@npm:@minh.nguyen/plugin-transform-destructuring@^7.5.2":
+  version "7.5.2"
+  resolved "https://registry.yarnpkg.com/@minh.nguyen/plugin-transform-destructuring/-/plugin-transform-destructuring-7.5.2.tgz#49de3e25c373fadd11471a2fc99ec0ce07d92f19"
+  integrity sha512-DIzWFKl5nzSk9Hj9ZsEXAvvgHiyuAsw52queJMuKqfZOk1BOr9u1i2h0tc6tPF3rQieubP+eX4DPLTKSMpbyMg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Update

GitHub repo now available at https://github.com/NMinhNguyen/babel-plugin-transform-destructuring

---

I used https://github.com/babel/babel/pull/9486 as an inspiration which was originally intended for Create React App (https://github.com/facebook/create-react-app/issues/5602#issuecomment-434689307). You can actually see `selectiveLoose` option used in CRA's [Babel config](https://github.com/facebook/create-react-app/blob/bffc296a2c8967d46bed40d3120d82f2752496dc/packages/babel-preset-react-app/create.js#L129-L140) although I don't think it does anything as the Babel PR isn't merged. ~~This PR uses [patch-package](https://github.com/ds300/patch-package) which you may not like as maintainers, but I'm mostly just raising this PR to look at the bundle size diff 😅.~~ When I built packages using #16072 (as well as in my own project at work), I observed that it doesn't seem to handle array destructuring, thus this PR.

This PR uses my [fork](https://www.npmjs.com/package/@minh.nguyen/plugin-transform-destructuring) ([source on unpkg.com](https://unpkg.com/@minh.nguyen/plugin-transform-destructuring@7.5.2)) of `@babel/plugin-transform-destructuring` with the following diff:

<details>
<summary>Show diff</summary>

```diff
diff --git a/node_modules/@babel/plugin-transform-destructuring/README.md b/../babel/node_modules/@babel/plugin-transform-destructuring/README.md
index 4c866eab2..92df503a1 100644
--- a/node_modules/@babel/plugin-transform-destructuring/README.md
+++ b/../babel/node_modules/@babel/plugin-transform-destructuring/README.md
@@ -1,3 +1,37 @@
+==================
+
+**This is a (hopefully temporary) fork of `@babel/plugin-transform-destructuring` that optimises array destructuring of `useState` and `useReducer` React Hooks.**
+
+**It only includes these two changes:**
+
+```diff
+@@ -1,6 +1,10 @@
+ import { declare } from '@babel/helper-plugin-utils';
+ import { types as t } from '@babel/core';
+
++const forcedLoose = ['useReducer', 'useState'].map(
++  name => new RegExp(`^_(?:React\\$)?${name}\\d*$`)
++);
++
+ export default declare((api, options) => {
+   api.assertVersion(7);
+```
+
+```diff
+@@ -129,7 +133,11 @@ export default declare((api, options) => {
+     }
+
+     toArray(node, count) {
+-      if (this.arrayOnlySpread || (t.isIdentifier(node) && this.arrays[node.name])) {
++      if (
++        this.arrayOnlySpread ||
++        (t.isIdentifier(node) &&
++          (this.arrays[node.name] || forcedLoose.some(regex => regex.test(node.name))))
++      ) {
+```
+
+==================
+
 # @babel/plugin-transform-destructuring
 
 > Compile ES2015 destructuring to ES5
diff --git a/node_modules/@babel/plugin-transform-destructuring/lib/index.js b/../babel/node_modules/@babel/plugin-transform-destructuring/lib/index.js
index 70e546780..8ef1de471 100644
--- a/node_modules/@babel/plugin-transform-destructuring/lib/index.js
+++ b/../babel/node_modules/@babel/plugin-transform-destructuring/lib/index.js
@@ -25,6 +25,10 @@ function _core() {
   return data;
 }
 
+const forcedLoose = ['useReducer', 'useState'].map(
+  name => new RegExp(`^_(?:React\\$)?${name}\\d*$`)
+);
+
 var _default = (0, _helperPluginUtils().declare)((api, options) => {
   api.assertVersion(7);
   const {
@@ -134,7 +138,11 @@ var _default = (0, _helperPluginUtils().declare)((api, options) => {
     }
 
     toArray(node, count) {
-      if (this.arrayOnlySpread || _core().types.isIdentifier(node) && this.arrays[node.name]) {
+      if (
+        this.arrayOnlySpread ||
+        (_core().types.isIdentifier(node) &&
+          (this.arrays[node.name] || forcedLoose.some(regex => regex.test(node.name))))
+      ) {
         return node;
       } else {
         return this.scope.toArray(node, count);
diff --git a/node_modules/@babel/plugin-transform-destructuring/package.json b/../babel/node_modules/@babel/plugin-transform-destructuring/package.json
index 91d8c52b3..05d4f771e 100644
--- a/node_modules/@babel/plugin-transform-destructuring/package.json
+++ b/../babel/node_modules/@babel/plugin-transform-destructuring/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@babel/plugin-transform-destructuring",
-  "version": "7.5.0",
+  "name": "@minh.nguyen/plugin-transform-destructuring",
+  "version": "7.5.2",
   "description": "Compile ES2015 destructuring to ES5",
   "repository": "https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-destructuring",
   "license": "MIT",

```

</details>

Bundle size diff can be viewed [here](https://github.com/mui-org/material-ui/commit/ba7c1fdffaf71d0517ed15799c5998dcfc79b8c3). An example is provided below for convenience:

```diff
-var _slicedToArray2 = _interopRequireDefault(require("@babel/runtime/helpers/slicedToArray"));

  var _React$useState = _react.default.useState(false),
-     _React$useState2 = (0, _slicedToArray2.default)(_React$useState, 2),
-     expanded = _React$useState2[0],
-     setExpanded = _React$useState2[1];
+     expanded = _React$useState[0],
+     setExpanded = _React$useState[1];
```

I think this PR could be merged and then if (or more like when) `babel-plugin-optimize-react` is ready at some point in the future, this can be replaced with it.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
