### PR TITLE
[Modal] Fix Modal default open with disablePortal behavior

### DIFF
--- a/docs/pages/api/modal.md
+++ b/docs/pages/api/modal.md
@@ -39,6 +39,7 @@ This component shares many concepts with [react-overlays](https://react-bootstra
 | <span class="prop-name">disableEscapeKeyDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, hitting escape will not fire any callback. |
 | <span class="prop-name">disablePortal</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the portal behavior. The children stay within it's parent DOM hierarchy. |
 | <span class="prop-name">disableRestoreFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the modal will not restore focus to previously focused element once modal is hidden. |
+| <span class="prop-name">disableScrollLock</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the scroll lock behavior. |
 | <span class="prop-name">hideBackdrop</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the backdrop is not rendered. |
 | <span class="prop-name">keepMounted</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Always keep the children in the DOM. This prop can be useful in SEO situation or when you want to maximize the responsiveness of the Modal. |
 | <span class="prop-name">onBackdropClick</span> | <span class="prop-type">func</span> |  | Callback fired when the backdrop is clicked. |

--- a/docs/src/pages/components/modal/ServerModal.js
+++ b/docs/src/pages/components/modal/ServerModal.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Modal from '@material-ui/core/Modal';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    transform: 'translateZ(0)',
+    height: 300,
+    flexGrow: 1,
+  },
+  modal: {
+    display: 'flex',
+    padding: theme.spacing(1),
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  paper: {
+    width: 400,
+    backgroundColor: theme.palette.background.paper,
+    border: '2px solid #000',
+    boxShadow: theme.shadows[5],
+    padding: theme.spacing(2, 4, 4),
+  },
+}));
+
+export default function ServerModal() {
+  const classes = useStyles();
+  const rootRef = React.useRef(null);
+
+  return (
+    <div className={classes.root} ref={rootRef}>
+      <Modal
+        disablePortal
+        disableEnforceFocus
+        disableAutoFocus
+        open
+        aria-labelledby="server-modal-title"
+        aria-describedby="server-modal-description"
+        className={classes.modal}
+        container={() => rootRef.current}
+      >
+        <div className={classes.paper}>
+          <h2 id="server-modal-title">Server-side modal</h2>
+          <p id="server-modal-description">
+            You can disable the JavaScript, you will still see me.
+          </p>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/docs/src/pages/components/modal/ServerModal.tsx
+++ b/docs/src/pages/components/modal/ServerModal.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import Modal from '@material-ui/core/Modal';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      transform: 'translateZ(0)',
+      height: 300,
+      flexGrow: 1,
+    },
+    modal: {
+      display: 'flex',
+      padding: theme.spacing(1),
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    paper: {
+      width: 400,
+      backgroundColor: theme.palette.background.paper,
+      border: '2px solid #000',
+      boxShadow: theme.shadows[5],
+      padding: theme.spacing(2, 4, 4),
+    },
+  }),
+);
+
+export default function ServerModal() {
+  const classes = useStyles();
+  const rootRef = React.useRef<HTMLDivElement>(null);
+
+  return (
+    <div className={classes.root} ref={rootRef}>
+      <Modal
+        disablePortal
+        disableEnforceFocus
+        disableAutoFocus
+        open
+        aria-labelledby="server-modal-title"
+        aria-describedby="server-modal-description"
+        className={classes.modal}
+        container={() => rootRef.current}
+      >
+        <div className={classes.paper}>
+          <h2 id="server-modal-title">Server-side modal</h2>
+          <p id="server-modal-description">
+            You can disable the JavaScript, you will still see me.
+          </p>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/docs/src/pages/components/modal/SimpleModal.js
+++ b/docs/src/pages/components/modal/SimpleModal.js
@@ -25,7 +25,6 @@ const useStyles = makeStyles(theme => ({
     border: '2px solid #000',
     boxShadow: theme.shadows[5],
     padding: theme.spacing(2, 4, 4),
-    outline: 'none',
   },
 }));
 
@@ -56,7 +55,7 @@ export default function SimpleModal() {
         onClose={handleClose}
       >
         <div style={modalStyle} className={classes.paper}>
-          <h2 id="modal-title">Text in a modal</h2>
+          <h2 id="simple-modal-title">Text in a modal</h2>
           <p id="simple-modal-description">
             Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
           </p>

--- a/docs/src/pages/components/modal/SimpleModal.tsx
+++ b/docs/src/pages/components/modal/SimpleModal.tsx
@@ -26,7 +26,6 @@ const useStyles = makeStyles((theme: Theme) =>
       border: '2px solid #000',
       boxShadow: theme.shadows[5],
       padding: theme.spacing(2, 4, 4),
-      outline: 'none',
     },
   }),
 );
@@ -58,7 +57,7 @@ export default function SimpleModal() {
         onClose={handleClose}
       >
         <div style={modalStyle} className={classes.paper}>
-          <h2 id="modal-title">Text in a modal</h2>
+          <h2 id="simple-modal-title">Text in a modal</h2>
           <p id="simple-modal-description">
             Duis mollis, est non commodo luctus, nisi erat porttitor ligula.
           </p>

--- a/docs/src/pages/components/modal/modal.md
+++ b/docs/src/pages/components/modal/modal.md
@@ -34,6 +34,8 @@ Modal is a lower-level construct that is leveraged by the following components:
 
 {{"demo": "pages/components/modal/SimpleModal.js"}}
 
+Notice that you can disable the blue outline with the `outline: 0` CSS property.
+
 ## Performance
 
 The content of the modal is **lazily mounted** into the DOM.
@@ -85,16 +87,23 @@ Additionally, you may give a description of your modal with the `aria-describedb
 
 ```jsx
 <Modal
-  aria-labelledby="simple-modal-title"
-  aria-describedby="simple-modal-description"
+  aria-labelledby="modal-title"
+  aria-describedby="modal-description"
 >
   <h2 id="modal-title">
     My Title
   </h2>
-  <p id="simple-modal-description">
+  <p id="modal-description">
     My Description
   </p>
 </Modal>
 ```
 
 - The [WAI-ARIA Authoring Practices 1.1](https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html) can help you set the initial focus on the most relevant element, based on your modal content.
+
+## Server-side modal
+
+React [doesn't support](https://github.com/facebook/react/issues/13097) the [`createPortal()`](https://reactjs.org/docs/portals.html) API on the server.
+In order to make it work, you need to disable this feature with the `disablePortal` prop:
+
+{{"demo": "pages/components/modal/ServerModal.js"}}

--- a/packages/material-ui/src/Modal/Modal.d.ts
+++ b/packages/material-ui/src/Modal/Modal.d.ts
@@ -16,6 +16,7 @@ export interface ModalProps
   disableEscapeKeyDown?: boolean;
   disablePortal?: PortalProps['disablePortal'];
   disableRestoreFocus?: boolean;
+  disableScrollLock?: boolean;
   hideBackdrop?: boolean;
   keepMounted?: boolean;
   manager?: ModalManager;

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -112,6 +112,11 @@ const Modal = React.forwardRef(function Modal(props, ref) {
     }
   });
 
+  const isTopModal = React.useCallback(
+    () => manager.isTopModal(getModal(modal, mountNodeRef, modalRef)),
+    [manager],
+  );
+
   const handlePortalRef = useEventCallback(node => {
     mountNodeRef.current = node;
 
@@ -123,7 +128,7 @@ const Modal = React.forwardRef(function Modal(props, ref) {
       onRendered();
     }
 
-    if (open) {
+    if (open && isTopModal()) {
       handleMounted();
     } else {
       ariaHidden(modalRef.current, true);
@@ -147,11 +152,6 @@ const Modal = React.forwardRef(function Modal(props, ref) {
       handleClose();
     }
   }, [open, handleClose, hasTransition, closeAfterTransition, handleOpen]);
-
-  const isTopModal = React.useCallback(
-    () => manager.isTopModal(getModal(modal, mountNodeRef, modalRef)),
-    [manager],
-  );
 
   if (!keepMounted && !open && (!hasTransition || exited)) {
     return null;

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -22,14 +22,9 @@ function getHasTransition(props) {
   return props.children ? props.children.props.hasOwnProperty('in') : false;
 }
 
+// A modal manager used to track and manage the state of open Modals.
 // Modals don't open on the server so this won't conflict with concurrent requests.
 const defaultManager = new ModalManager();
-
-function getModal(modal, mountNodeRef, modalRef) {
-  modal.current.modalRef = modalRef.current;
-  modal.current.mountNode = mountNodeRef.current;
-  return modal.current;
-}
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -73,6 +68,7 @@ const Modal = React.forwardRef(function Modal(props, ref) {
     disableEscapeKeyDown = false,
     disablePortal = false,
     disableRestoreFocus = false,
+    disableScrollLock = false,
     hideBackdrop = false,
     keepMounted = false,
     manager = defaultManager,
@@ -93,9 +89,14 @@ const Modal = React.forwardRef(function Modal(props, ref) {
   const hasTransition = getHasTransition(props);
 
   const getDoc = () => ownerDocument(mountNodeRef.current);
+  const getModal = () => {
+    modal.current.modalRef = modalRef.current;
+    modal.current.mountNode = mountNodeRef.current;
+    return modal.current;
+  };
 
   const handleMounted = () => {
-    manager.mount(getModal(modal, mountNodeRef, modalRef));
+    manager.mount(getModal(), { disableScrollLock });
 
     // Fix a bug on Chrome where the scroll isn't initially 0.
     modalRef.current.scrollTop = 0;
@@ -104,7 +105,7 @@ const Modal = React.forwardRef(function Modal(props, ref) {
   const handleOpen = useEventCallback(() => {
     const resolvedContainer = getContainer(container) || getDoc().body;
 
-    manager.add(getModal(modal, mountNodeRef, modalRef), resolvedContainer);
+    manager.add(getModal(), resolvedContainer);
 
     // The element was already mounted.
     if (modalRef.current) {
@@ -112,10 +113,7 @@ const Modal = React.forwardRef(function Modal(props, ref) {
     }
   });
 
-  const isTopModal = React.useCallback(
-    () => manager.isTopModal(getModal(modal, mountNodeRef, modalRef)),
-    [manager],
-  );
+  const isTopModal = React.useCallback(() => manager.isTopModal(getModal()), [manager]);
 
   const handlePortalRef = useEventCallback(node => {
     mountNodeRef.current = node;
@@ -136,7 +134,7 @@ const Modal = React.forwardRef(function Modal(props, ref) {
   });
 
   const handleClose = React.useCallback(() => {
-    manager.remove(getModal(modal, mountNodeRef, modalRef));
+    manager.remove(getModal());
   }, [manager]);
 
   React.useEffect(() => {
@@ -317,6 +315,10 @@ Modal.propTypes = {
    */
   disableRestoreFocus: PropTypes.bool,
   /**
+   * Disable the scroll lock behavior.
+   */
+  disableScrollLock: PropTypes.bool,
+  /**
    * If `true`, the backdrop is not rendered.
    */
   hideBackdrop: PropTypes.bool,
@@ -328,8 +330,6 @@ Modal.propTypes = {
   keepMounted: PropTypes.bool,
   /**
    * @ignore
-   *
-   * A modal manager used to track and manage the state of open Modals.
    */
   manager: PropTypes.object,
   /**

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -804,4 +804,15 @@ describe('<Modal />', () => {
       mount(<TestCase />);
     });
   });
+
+  describe('prop: disablePortal', () => {
+    it('should render the content into the parent', () => {
+      const { container } = render(
+        <Modal open disablePortal>
+          <div />
+        </Modal>,
+      );
+      expect(container.querySelector('[role="document"]')).to.be.ok;
+    });
+  });
 });

--- a/packages/material-ui/src/Modal/ModalManager.test.js
+++ b/packages/material-ui/src/Modal/ModalManager.test.js
@@ -29,7 +29,7 @@ describe('ModalManager', () => {
     const modal = {};
     const modalManager2 = new ModalManager();
     const idx = modalManager2.add(modal, container1);
-    modalManager2.mount(modal);
+    modalManager2.mount(modal, {});
     assert.strictEqual(modalManager2.add(modal, container1), idx);
     modalManager2.remove(modal);
   });
@@ -47,7 +47,7 @@ describe('ModalManager', () => {
 
     it('should add modal1', () => {
       const idx = modalManager.add(modal1, container1);
-      modalManager.mount(modal1);
+      modalManager.mount(modal1, {});
       assert.strictEqual(idx, 0, 'should be the first modal');
       assert.strictEqual(modalManager.isTopModal(modal1), true);
     });
@@ -71,7 +71,7 @@ describe('ModalManager', () => {
 
     it('should add modal2 2', () => {
       const idx = modalManager.add(modal2, container1);
-      modalManager.mount(modal2);
+      modalManager.mount(modal2, {});
       assert.strictEqual(idx, 2, 'should be the "third" modal');
       assert.strictEqual(modalManager.isTopModal(modal2), true);
       assert.strictEqual(
@@ -125,7 +125,7 @@ describe('ModalManager', () => {
 
       const modal = {};
       modalManager.add(modal, container1);
-      modalManager.mount(modal);
+      modalManager.mount(modal, {});
       assert.strictEqual(container1.style.overflow, 'hidden');
       assert.strictEqual(container1.style.paddingRight, `${20 + getScrollbarSize()}px`);
       assert.strictEqual(fixedNode.style.paddingRight, `${14 + getScrollbarSize()}px`);
@@ -138,7 +138,7 @@ describe('ModalManager', () => {
     it('should restore styles correctly if none existed before', () => {
       const modal = {};
       modalManager.add(modal, container1);
-      modalManager.mount(modal);
+      modalManager.mount(modal, {});
       assert.strictEqual(container1.style.overflow, 'hidden');
       assert.strictEqual(container1.style.paddingRight, `${20 + getScrollbarSize()}px`);
       assert.strictEqual(fixedNode.style.paddingRight, `${0 + getScrollbarSize()}px`);
@@ -168,11 +168,11 @@ describe('ModalManager', () => {
       const modal1 = {};
       const modal2 = {};
       modalManager.add(modal1, container3);
-      modalManager.mount(modal1);
+      modalManager.mount(modal1, {});
       expect(container3.children[0]).to.be.ariaHidden;
 
       modalManager.add(modal2, container4);
-      modalManager.mount(modal2);
+      modalManager.mount(modal2, {});
       expect(container4.children[0]).to.be.ariaHidden;
 
       modalManager.remove(modal2);
@@ -242,7 +242,7 @@ describe('ModalManager', () => {
       const modal = { modalRef: container2.children[0] };
 
       modalManager.add(modal, container2);
-      modalManager.mount(modal);
+      modalManager.mount(modal, {});
       expect(container2.children[0]).not.to.be.ariaHidden;
       modalManager.remove(modal, container2);
       expect(container2.children[0]).to.be.ariaHidden;
@@ -259,7 +259,7 @@ describe('ModalManager', () => {
       container2.appendChild(sibling2);
 
       modalManager.add(modal, container2);
-      modalManager.mount(modal);
+      modalManager.mount(modal, {});
       expect(container2.children[0]).not.to.be.ariaHidden;
       modalManager.remove(modal, container2);
       expect(container2.children[0]).to.be.ariaHidden;

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -36,7 +36,7 @@ function TrapFocus(props) {
   // ⚠️ You may rely on React.useMemo as a performance optimization, not as a semantic guarantee.
   // https://reactjs.org/docs/hooks-reference.html#usememo
   React.useMemo(() => {
-    if (!open) {
+    if (!open || typeof window === 'undefined') {
       return;
     }
 

--- a/packages/material-ui/src/Portal/Portal.d.ts
+++ b/packages/material-ui/src/Portal/Portal.d.ts
@@ -3,7 +3,7 @@ import { PortalProps } from '../Portal';
 
 export interface PortalProps {
   children: React.ReactElement;
-  container?: React.ReactInstance | (() => React.ReactInstance) | null;
+  container?: React.ReactInstance | (() => React.ReactInstance | null) | null;
   disablePortal?: boolean;
   onRendered?: () => void;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #16811 
Closes #16817
Closes #14285
Closes #13922

### Use Case:
```jsx
<Modal open disablePortal>
   <div>Modal Body</div>
</Modal>
```

#### Previous Behavior: 
Error Output: `TypeError: Cannot read property 'restore' of undefined`

#### New Behavior:
Component renders correctly.