### PR TITLE
[Box][styled] Cache makeStyles() per JSON of props for style functions

### DIFF
--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -16,6 +16,7 @@
     "docs": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/docs.js --inspect=0.0.0.0:9229",
     "server": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/server.js --inspect=0.0.0.0:9229",
     "styles": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/styles.js --inspect=0.0.0.0:9229",
+    "box": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/box.js --inspect=0.0.0.0:9229",
     "system": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/system.js --inspect=0.0.0.0:9229",
     "test": "exit 0"
   },

--- a/packages/material-ui-benchmark/src/box.js
+++ b/packages/material-ui-benchmark/src/box.js
@@ -1,0 +1,86 @@
+/* eslint-disable no-console */
+
+import Benchmark from 'benchmark';
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import { SheetsRegistry } from 'react-jss';
+import { makeStyles, StylesProvider, styled } from '@material-ui/styles';
+import Box, { styleFunction } from '@material-ui/core/Box';
+
+const suite = new Benchmark.Suite('box', {
+  onError: event => {
+    console.log(event.target.error);
+  },
+});
+Benchmark.options.minSamples = 100;
+
+const cssObject = {
+  root: {
+    padding: 2,
+    margin: 2,
+  },
+};
+
+const useStyles = makeStyles(cssObject);
+function HookBox(props) {
+  const classes = useStyles();
+  return <div className={classes.root} {...props} />;
+}
+
+const NoCacheBox = styled('div')(styleFunction, { name: 'MuiBox', _useStylesCache: null });
+
+suite
+  .add('Box', () => {
+    const sheetsRegistry = new SheetsRegistry();
+    ReactDOMServer.renderToString(
+      <StylesProvider sheetsManager={new Map()} sheetsRegistry={sheetsRegistry}>
+        {Array.from(new Array(100)).map((_, index) => (
+          <Box key={String(index)} padding={2} margin={2}>
+            Material-UI
+          </Box>
+        ))}
+      </StylesProvider>,
+    );
+    sheetsRegistry.toString();
+  })
+  .add('Box with disable props cache', () => {
+    const sheetsRegistry = new SheetsRegistry();
+    ReactDOMServer.renderToString(
+      <StylesProvider sheetsManager={new Map()} sheetsRegistry={sheetsRegistry}>
+        {Array.from(new Array(100)).map((_, index) => (
+          <NoCacheBox key={String(index)} padding={2} margin={2}>
+            Material-UI
+          </NoCacheBox>
+        ))}
+      </StylesProvider>,
+    );
+    sheetsRegistry.toString();
+  })
+  .add('useStyles', () => {
+    const sheetsRegistry = new SheetsRegistry();
+    ReactDOMServer.renderToString(
+      <StylesProvider sheetsManager={new Map()} sheetsRegistry={sheetsRegistry}>
+        {Array.from(new Array(100)).map((_, index) => (
+          <HookBox key={String(index)}>Material-UI</HookBox>
+        ))}
+      </StylesProvider>,
+    );
+    sheetsRegistry.toString();
+  })
+  .add('Inline style', () => {
+    const sheetsRegistry = new SheetsRegistry();
+    ReactDOMServer.renderToString(
+      <StylesProvider sheetsManager={new Map()} sheetsRegistry={sheetsRegistry}>
+        {Array.from(new Array(100)).map((_, index) => (
+          <div key={String(index)} style={cssObject.root}>
+            Material-UI
+          </div>
+        ))}
+      </StylesProvider>,
+    );
+    sheetsRegistry.toString();
+  })
+  .on('cycle', event => {
+    console.log(String(event.target));
+  })
+  .run();

--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.js
@@ -39,13 +39,19 @@ export default function createGenerateClassName(options = {}) {
       [
         'Material-UI: you might have a memory leak.',
         'The ruleCounter is not supposed to grow that much.',
-      ].join(''),
+      ].join('\n'),
     );
 
     const name = styleSheet.options.name;
 
     // Is a global static MUI style?
-    if (name && name.indexOf('Mui') === 0 && !styleSheet.options.link && !disableGlobal) {
+    if (
+      name &&
+      name.indexOf('Mui') === 0 &&
+      !styleSheet.options.muiDynamic &&
+      !styleSheet.options.link &&
+      !disableGlobal
+    ) {
       // We can use a shorthand class name, we never use the keys to style the components.
       if (pseudoClasses.indexOf(rule.key) !== -1) {
         return `Mui-${rule.key}`;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.js
@@ -8,6 +8,7 @@ import { StylesContext } from '../StylesProvider';
 import { increment } from './indexCounter';
 import getStylesCreator from '../getStylesCreator';
 import noopTheme from '../getStylesCreator/noopTheme';
+import useSynchronousEffect from './useSynchronousEffect';
 
 function getClasses({ state, stylesOptions }, classes, Component) {
   if (stylesOptions.disableGeneration) {
@@ -158,29 +159,6 @@ function detach({ state, theme, stylesOptions, stylesCreator }) {
       sheetsRegistry.remove(state.dynamicSheet);
     }
   }
-}
-
-function useSynchronousEffect(func, values) {
-  const key = React.useRef([]);
-  let output;
-
-  // Store "generation" key. Just returns a new object every time
-  const currentKey = React.useMemo(() => ({}), values); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // "the first render", or "memo dropped the value"
-  if (key.current !== currentKey) {
-    key.current = currentKey;
-    output = func();
-  }
-
-  React.useEffect(
-    () => () => {
-      if (output) {
-        output();
-      }
-    },
-    [currentKey], // eslint-disable-line react-hooks/exhaustive-deps
-  );
 }
 
 function makeStyles(stylesOrCreator, options = {}) {

--- a/packages/material-ui-styles/src/makeStyles/multiKeyStore.js
+++ b/packages/material-ui-styles/src/makeStyles/multiKeyStore.js
@@ -17,7 +17,11 @@ const multiKeyStore = {
   },
   delete: (cache, key1, key2) => {
     const subCache = cache.get(key1);
+    if (!subCache) return;
     subCache.delete(key2);
+    if (subCache.size === 0) {
+      cache.delete(key1);
+    }
   },
 };
 

--- a/packages/material-ui-styles/src/makeStyles/useSynchronousEffect.js
+++ b/packages/material-ui-styles/src/makeStyles/useSynchronousEffect.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+export default function useSynchronousEffect(func, values) {
+  const key = React.useRef([]);
+  let output;
+
+  // Store "generation" key. Just returns a new object every time
+  const currentKey = React.useMemo(() => ({}), values); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // "the first render", or "memo dropped the value"
+  if (key.current !== currentKey) {
+    key.current = currentKey;
+    output = func();
+  }
+
+  React.useEffect(
+    () => () => {
+      if (output) {
+        output();
+      }
+    },
+    [currentKey], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+}

--- a/packages/material-ui-styles/src/styled/createCachedUseStyles.js
+++ b/packages/material-ui-styles/src/styled/createCachedUseStyles.js
@@ -1,0 +1,65 @@
+import makeStyles from '../makeStyles';
+import multiKeyStore from '../makeStyles/multiKeyStore';
+import useSynchronousEffect from '../makeStyles/useSynchronousEffect';
+import useTheme from '../useTheme';
+import noopTheme from '../getStylesCreator/noopTheme';
+import warning from 'warning';
+
+function pick(input, fields) {
+  const output = {};
+
+  Object.keys(input).forEach(prop => {
+    if (fields.indexOf(prop) >= 0) {
+      output[prop] = input[prop];
+    }
+  });
+
+  return output;
+}
+
+export default function createCachedUseStyles({
+  styleFunction,
+  filterProps,
+  makeStylesOptions: makeStylesOptionsProp,
+  cacheStore,
+}) {
+  const makeStylesOptions = { ...makeStylesOptionsProp, muiDynamic: true };
+  return props => {
+    const theme = useTheme() || noopTheme;
+    const propsForStyle = pick(props, filterProps);
+
+    let hasFunc = false;
+    const cacheKey = JSON.stringify(propsForStyle, (_key, value) => {
+      if (typeof value !== 'function') return value;
+      if (!hasFunc) {
+        warning(false, 'Material-UI: You can not pass a function as style attribute.');
+        hasFunc = true;
+      }
+      return 'invalid';
+    });
+
+    let cacheEntry = multiKeyStore.get(cacheStore, theme, cacheKey);
+    if (!cacheEntry) {
+      cacheEntry = {
+        useStyles: makeStyles(
+          { root: styleFunction({ theme, ...propsForStyle }) },
+          makeStylesOptions,
+        ),
+        refs: 0,
+      };
+      if (!hasFunc) multiKeyStore.set(cacheStore, theme, cacheKey, cacheEntry);
+    }
+
+    useSynchronousEffect(() => {
+      cacheEntry.refs += 1;
+      return () => {
+        cacheEntry.refs -= 1;
+        if (cacheEntry.refs <= 0) {
+          multiKeyStore.delete(cacheStore, theme, cacheKey);
+        }
+      };
+    }, [cacheEntry, theme, cacheKey]);
+
+    return cacheEntry.useStyles(props);
+  };
+}


### PR DESCRIPTION
Fixes #16704

Make styled() use filterProps value to generate cache key.
You can use `_useStylesCache: null` option to disable this behavior.

```
❯ yarn box
yarn run v1.17.3
$ cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/box.js --inspect=0.0.0.0:9229
Debugger listening on ws://0.0.0.0:9229/4e1ad776-8951-4f0b-9f50-61de494bfd7f
For help, see: https://nodejs.org/en/docs/inspector
Box x 2,165 ops/sec ±1.19% (187 runs sampled)
Box with disable props cache x 413 ops/sec ±1.61% (183 runs sampled)
useStyles x 4,782 ops/sec ±1.40% (187 runs sampled)
Inline style x 9,856 ops/sec ±1.30% (190 runs sampled)
✨  Done in 45.98s.
```

It's still 2x slower than useStyles(), but 5x faster than original implementation..! (This benchmark creates 100 Boxes at once)

Limitations:
- Alias (`m={2}`) and non-alias (`margin={2}`) props will create different cache.
- Different props order will create different cache.
  - Perhaps sort is possible with small cost: https://github.com/nickyout/fast-stable-stringify
- Updating props is slower than original.
  - Maybe using `link: true` and updating existing style if `refs === 1` can solve this.