### PR TITLE
[ToggleButton] Fix horizontal shift

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -69,6 +69,7 @@ export const styles = theme => ({
   /* Styles applied to the root element if `size="small"`. */
   sizeSmall: {
     height: 40,
+    padding: '0px 7px 0px 8px',
     fontSize: theme.typography.pxToRem(13),
   },
   /* Styles applied to the root element if `size="large"`. */

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -13,7 +13,6 @@ export const styles = theme => ({
     ...theme.typography.button,
     boxSizing: 'border-box',
     height: 48,
-    minWidth: 49,
     padding: '0px 11px 0px 12px',
     border: `1px solid ${fade(theme.palette.action.active, 0.12)}`,
     color: fade(theme.palette.action.active, 0.38),
@@ -30,7 +29,6 @@ export const styles = theme => ({
       '& + &': {
         borderLeft: 0,
         marginLeft: 0,
-        minWidth: 48
       },
     },
     '&$disabled': {
@@ -71,13 +69,12 @@ export const styles = theme => ({
   /* Styles applied to the root element if `size="small"`. */
   sizeSmall: {
     height: 40,
-    minWidth: 41,
     fontSize: theme.typography.pxToRem(13),
   },
   /* Styles applied to the root element if `size="large"`. */
   sizeLarge: {
     height: 56,
-    minWidth: 57,
+    padding: '0px 15px 0px 16px',
     fontSize: theme.typography.pxToRem(15),
   },
 });

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -30,6 +30,7 @@ export const styles = theme => ({
       '& + &': {
         borderLeft: 0,
         marginLeft: 0,
+        minWidth: 48
       },
     },
     '&$disabled': {


### PR DESCRIPTION
Without this when selecting sibling toggle buttons then all later siblings are shifted one pixel to the right.

If you go to https://material-ui.com/components/toggle-button/#toggle-buttons and in the "Multiple selection" example click on the "I" (Italic) button then the two remaining buttons are shifted one pixel to the right.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
