### PR TITLE
[docs] Add error boundary to demos

### DIFF
--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Typography from '@material-ui/core/Typography';
+import Link from '@material-ui/core/Link';
+
+export default class DemoErrorBoundary extends React.Component {
+  state = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  render() {
+    const { children } = this.props;
+    const { error } = this.state;
+
+    if (error) {
+      /* eslint-disable material-ui/no-hardcoded-labels */
+      return (
+        <div>
+          <Typography color="error" component="p" variant="h5" gutterBottom>
+            This demo had a runtime error!
+          </Typography>
+          <Typography>
+            We would appreciate it if you report this error directly to our{' '}
+            <Link href="https://github.com/mui-org/material-ui/issues/new/choose" target="_blank">
+              issue tracker
+            </Link>
+            .
+          </Typography>
+          <pre>{error.toString()}</pre>
+        </div>
+      );
+      /* eslint-enable material-ui/no-hardcoded-labels */
+    }
+
+    return children;
+  }
+}
+
+DemoErrorBoundary.propTypes = {
+  children: PropTypes.node,
+};

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -6,6 +6,7 @@ import { jssPreset, StylesProvider } from '@material-ui/styles';
 import NoSsr from '@material-ui/core/NoSsr';
 import rtl from 'jss-rtl';
 import Frame from 'react-frame-component';
+import DemoErrorBoundary from 'docs/src/modules/components/DemoErrorBoundary';
 
 const styles = theme => ({
   root: {
@@ -90,9 +91,11 @@ function DemoSandboxed(props) {
   const sandboxProps = iframe ? { title: `${name} demo`, ...other } : {};
 
   return (
-    <Sandbox {...sandboxProps}>
-      <Component />
-    </Sandbox>
+    <DemoErrorBoundary>
+      <Sandbox {...sandboxProps}>
+        <Component />
+      </Sandbox>
+    </DemoErrorBoundary>
   );
 }
 


### PR DESCRIPTION
An alternative to #16746 that let our developers fill the issue template, no assistance is provided. It saves us work.

Closes #16209
Closes #16746

![Capture d’écran 2019-08-03 à 17 02 07](https://user-images.githubusercontent.com/3165635/62413547-80e90e80-b610-11e9-8236-1357c7f303ac.png)
