### PR TITLE
[ButtonGroup] Separate button colors

### DIFF
--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -130,7 +130,7 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(props, ref) {
         return React.cloneElement(child, {
           className: clsx(buttonClassName, child.props.className),
           disabled: child.props.disabled || disabled,
-          color,
+          color: child.props.color || color,
           disableFocusRipple,
           disableRipple,
           fullWidth,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Allow children buttons inside a ButtonGroup component to have a separate `color` prop (like already `disabled`, etc.)