### PR TITLE
[Fab] Add FabProps to the customizable theme's default props

### DIFF
--- a/packages/material-ui/src/styles/props.d.ts
+++ b/packages/material-ui/src/styles/props.d.ts
@@ -30,6 +30,7 @@ import { ExpansionPanelActionsProps } from '../ExpansionPanelActions';
 import { ExpansionPanelDetailsProps } from '../ExpansionPanelDetails';
 import { ExpansionPanelProps } from '../ExpansionPanel';
 import { ExpansionPanelSummaryProps } from '../ExpansionPanelSummary';
+import { FabProps } from '../Fab';
 import { FilledInputProps } from '../FilledInput';
 import { FormControlLabelProps } from '../FormControlLabel';
 import { FormControlProps } from '../FormControl';
@@ -132,6 +133,7 @@ export interface ComponentsPropsList {
   MuiExpansionPanelActions: ExpansionPanelActionsProps;
   MuiExpansionPanelDetails: ExpansionPanelDetailsProps;
   MuiExpansionPanelSummary: ExpansionPanelSummaryProps;
+  MuiFab: FabProps;
   MuiFilledInput: FilledInputProps;
   MuiFormControl: FormControlProps;
   MuiFormControlLabel: FormControlLabelProps;


### PR DESCRIPTION
This will allow the Fab component to be customisation.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
