### PR TITLE
[ci] Ignore dependabot branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,9 @@ workflows:
       - checkout:
           filters:
             branches:
-              ignore: l10n
+              ignore: 
+                - l10n
+                - /dependabot\//
       - test_unit:
           requires:
             - checkout

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@ trigger:
     - '*'
     exclude:
     - l10n
+    - dependabot/*
 
 pool:
   vmImage: 'ubuntu-latest'


### PR DESCRIPTION
It's a bit unfortunate that dependabot doesn't have its own remote. Requires a bit more attention for CI:
- skip CI for push events from dependabot, only run on PRs