### PR TITLE
[benchmark] Fix not running

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -101,5 +101,17 @@ module.exports = {
         ],
       ],
     },
+    benchmark: {
+      plugins: [
+        ...productionPlugins,
+        [
+          'babel-plugin-module-resolver',
+          {
+            root: ['./'],
+            alias: defaultAlias,
+          },
+        ],
+      ],
+    },
   },
 };

--- a/packages/material-ui-benchmark/package.json
+++ b/packages/material-ui-benchmark/package.json
@@ -12,11 +12,11 @@
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-benchmark",
   "scripts": {
-    "core": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/core.js --inspect=0.0.0.0:9229",
-    "docs": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/docs.js --inspect=0.0.0.0:9229",
-    "server": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/server.js --inspect=0.0.0.0:9229",
-    "styles": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/styles.js --inspect=0.0.0.0:9229",
-    "system": "cd ../../ && NODE_ENV=production BABEL_ENV=docs-production babel-node packages/material-ui-benchmark/src/system.js --inspect=0.0.0.0:9229",
+    "core": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/core.js --inspect=0.0.0.0:9229",
+    "docs": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/docs.js --inspect=0.0.0.0:9229",
+    "server": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/server.js --inspect=0.0.0.0:9229",
+    "styles": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/styles.js --inspect=0.0.0.0:9229",
+    "system": "cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/system.js --inspect=0.0.0.0:9229",
     "test": "exit 0"
   },
   "engines": {

--- a/packages/material-ui-benchmark/src/docs.js
+++ b/packages/material-ui-benchmark/src/docs.js
@@ -7,6 +7,8 @@ import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import Markdown from 'docs/src/pages/getting-started/templates/blog/Markdown';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 
 const suite = new Benchmark.Suite('core', {
   onError: event => {
@@ -20,12 +22,22 @@ const markdown = fs.readFileSync(
   'UTF-8',
 );
 
+const store = createStore(state => state, {
+  options: {
+    userLanguage: 'en',
+  },
+});
+
 suite
   .add('Markdown', () => {
     ReactDOMServer.renderToString(<Markdown>{markdown}</Markdown>);
   })
   .add('MarkdownElement', () => {
-    ReactDOMServer.renderToString(<MarkdownElement text={markdown} />);
+    ReactDOMServer.renderToString(
+      <Provider store={store}>
+        <MarkdownElement text={markdown} />
+      </Provider>,
+    );
   })
   .on('cycle', event => {
     console.log(String(event.target));


### PR DESCRIPTION
- In #16640 `BABEL_ENV=docs-production` was removed.
- MarkdownElement now requires redux store.

```
~/github/material-ui/packages/material-ui-benchmark fix-benchmark* ⇣⇡ 11s
❯ yarn core
yarn run v1.17.3
$ cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/core.js --inspect=0.0.0.0:9229
Debugger listening on ws://0.0.0.0:9229/52f1bb14-809e-4501-9880-df82379a766f
For help, see: https://nodejs.org/en/docs/inspector
ButtonBase x 23,318 ops/sec ±4.24% (182 runs sampled)
HocButton x 327,217 ops/sec ±1.51% (186 runs sampled)
NakedButton x 365,454 ops/sec ±2.09% (178 runs sampled)
ButtonBase enable ripple x 138,361 ops/sec ±1.88% (185 runs sampled)
ButtonBase disable ripple x 144,882 ops/sec ±2.60% (180 runs sampled)
✨  Done in 58.54s.

~/github/material-ui/packages/material-ui-benchmark fix-benchmark* 58s
❯ yarn docs
yarn run v1.17.3
$ cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/docs.js --inspect=0.0.0.0:9229
Debugger listening on ws://0.0.0.0:9229/64232561-9747-412a-85d1-86200e217ecd
For help, see: https://nodejs.org/en/docs/inspector
Markdown x 2,021 ops/sec ±0.76% (189 runs sampled)
MarkdownElement x 11,085 ops/sec ±0.82% (191 runs sampled)
✨  Done in 24.68s.

~/github/material-ui/packages/material-ui-benchmark fix-benchmark* 25s
❯ yarn styles
yarn run v1.17.3
$ cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/styles.js --inspect=0.0.0.0:9229
Debugger listening on ws://0.0.0.0:9229/1e31d934-182b-4c19-8d3a-6c874d3c4f2f
For help, see: https://nodejs.org/en/docs/inspector
StyledMuiButton x 33,268 ops/sec ±1.87% (186 runs sampled)
Box x 8,208 ops/sec ±1.06% (188 runs sampled)
JSS naked x 72,211 ops/sec ±2.83% (188 runs sampled)
JSSButton x 26,094 ops/sec ±1.91% (185 runs sampled)
WithStylesButton x 26,140 ops/sec ±1.20% (187 runs sampled)
HookButton x 32,356 ops/sec ±1.33% (188 runs sampled)
StyledComponentsButton x 13,659 ops/sec ±1.35% (189 runs sampled)
EmotionButton x 19,945 ops/sec ±1.31% (188 runs sampled)
EmotionCssButton x 101,195 ops/sec ±0.60% (192 runs sampled)
EmotionServerCssButton x 81,554 ops/sec ±0.97% (192 runs sampled)
Naked x 117,799 ops/sec ±0.99% (192 runs sampled)
✨  Done in 123.60s.

~/github/material-ui/packages/material-ui-benchmark fix-benchmark* 2m 4s
❯ yarn system
yarn run v1.17.3
$ cd ../../ && NODE_ENV=production BABEL_ENV=benchmark babel-node packages/material-ui-benchmark/src/system.js --inspect=0.0.0.0:9229
Debugger listening on ws://0.0.0.0:9229/45f38fd8-3904-411f-99c1-41f3e764bd5c
For help, see: https://nodejs.org/en/docs/inspector
colors @material-ui/system  x 398,591 ops/sec ±0.44% (180 runs sampled)
colors styled-system x 1,155,442 ops/sec ±0.99% (189 runs sampled)
spaces @material-ui/system x 449,603 ops/sec ±0.94% (189 runs sampled)
spaces styled-system x 986,864 ops/sec ±2.36% (176 runs sampled)
compose @material-ui/system x 54,185 ops/sec ±0.90% (188 runs sampled)
compose styled-system x 248,660 ops/sec ±0.73% (191 runs sampled)
@material-ui/core all-inclusive x 44,269 ops/sec ±0.87% (191 runs sampled)
styled-components Box + @material-ui/system x 21,953 ops/sec ±1.04% (187 runs sampled)
styled-components Box + styled-system x 32,964 ops/sec ±2.03% (189 runs sampled)
Box emotion x 24,530 ops/sec ±2.19% (177 runs sampled)
Box @material-ui/styles x 12,426 ops/sec ±2.68% (175 runs sampled)
Box styled-components x 18,259 ops/sec ±1.88% (187 runs sampled)
Naked styled-components x 40,426 ops/sec ±1.26% (188 runs sampled)
✨  Done in 147.77s.

❯ bombardier  -c 100 \
  -l \
  -d 30s \
  -m GET \
  '0.0.0.0:3001/avatar'
Bombarding http://0.0.0.0:3001/avatar for 30s using 100 connection(s)
[==========================================================================================================================================================================================================================================================================] 30s
Done!
Statistics        Avg      Stdev        Max
  Reqs/sec      9803.60    1442.34   11577.80
  Latency       10.19ms     2.27ms   113.95ms
  Latency Distribution
     50%     9.76ms
     75%    10.43ms
     90%    11.33ms
     95%    12.37ms
     99%    18.57ms
  HTTP codes:
    1xx - 0, 2xx - 294278, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     9.46MB/s
```

MBP (15-inch, 2019) Core i7 model