### PR TITLE
[Stepper] Improve the description of the icon prop

### DIFF
--- a/docs/pages/api/step-icon.md
+++ b/docs/pages/api/step-icon.md
@@ -22,7 +22,7 @@ import { StepIcon } from '@material-ui/core';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">completed</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as completed. Is passed to child components. |
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as failed. |
-| <span class="prop-name required">icon&nbsp;*</span> | <span class="prop-type">node</span> |  | The icon displayed by the step label. |
+| <span class="prop-name required">icon&nbsp;*</span> | <span class="prop-type">node</span> |  | The label displayed in the step icon. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api/step-label.md
+++ b/docs/pages/api/step-label.md
@@ -22,7 +22,7 @@ import { StepLabel } from '@material-ui/core';
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as disabled, will also disable the button if `StepLabelButton` is a child of `StepLabel`. Is passed to child components. |
 | <span class="prop-name">error</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Mark the step as failed. |
-| <span class="prop-name">icon</span> | <span class="prop-type">node</span> |  | Override the default icon. |
+| <span class="prop-name">icon</span> | <span class="prop-type">node</span> |  | Override the default label of the step icon. |
 | <span class="prop-name">optional</span> | <span class="prop-type">node</span> |  | The optional node to display. |
 | <span class="prop-name">StepIconComponent</span> | <span class="prop-type">elementType</span> |  | The component to render in place of the [`StepIcon`](/api/step-icon/). |
 | <span class="prop-name">StepIconProps</span> | <span class="prop-type">object</span> |  | Props applied to the [`StepIcon`](/api/step-icon/) element. |

--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -82,7 +82,7 @@ StepIcon.propTypes = {
    */
   error: PropTypes.bool,
   /**
-   * The icon displayed by the step label.
+   * The label displayed in the step icon.
    */
   icon: PropTypes.node.isRequired,
 };

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -179,7 +179,7 @@ StepLabel.propTypes = {
    */
   error: PropTypes.bool,
   /**
-   * Override the default icon.
+   * Override the default label of the step icon.
    */
   icon: PropTypes.node,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

The comment here https://github.com/mui-org/material-ui/issues/12262 made me realize the wording of the icon prop descriptions could be improved. Feel free to suggest better alternatives.

Arguably the prop name is misleading, but that's a breaking change for another day. (Does it warrant a placeholder issue? I suspect stepper is not a particularly widely used component.)