### PR TITLE
[styles] Support string templates in TypeScript

### DIFF
--- a/docs/src/pages/styles/advanced/StringTemplates.tsx
+++ b/docs/src/pages/styles/advanced/StringTemplates.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { jssPreset, StylesProvider, makeStyles } from '@material-ui/styles';
+import { create } from 'jss';
+import jssTemplate from 'jss-plugin-template';
+
+const jss = create({
+  plugins: [jssTemplate(), ...jssPreset().plugins],
+});
+
+const useStyles = makeStyles({
+  root: `
+    background: linear-gradient(45deg, #fe6b8b 30%, #ff8e53 90%);
+    border-radius: 3px;
+    font-size: 16px;
+    border: 0;
+    color: white;
+    height: 48px;
+    padding: 0 30px;
+    box-shadow: 0 3px 5px 2px rgba(255, 105, 135, 0.3);
+  `,
+});
+
+function Child() {
+  const classes = useStyles();
+  return (
+    <button type="button" className={classes.root}>
+      String templates
+    </button>
+  );
+}
+
+function StringTemplates() {
+  return (
+    <StylesProvider jss={jss}>
+      <Child />
+    </StylesProvider>
+  );
+}
+
+export default StringTemplates;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.d.ts
@@ -41,6 +41,6 @@ export default function makeStyles<
   Props extends {} = {},
   ClassKey extends string = string
 >(
-  styles: Styles<Theme, Props, ClassKey>,
+  styles: Styles<Theme, Props, ClassKey> | Record<ClassKey, string>,
   options?: Omit<WithStylesOptions<Theme>, 'withTheme'>,
 ): StylesHook<Styles<Theme, Props, ClassKey>>;

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { SheetsRegistry } from 'jss';
+import { SheetsRegistry, create } from 'jss';
 import { act } from 'react-dom/test-utils';
 import { createMount } from '@material-ui/core/test-utils';
 import { createMuiTheme } from '@material-ui/core/styles';
@@ -11,6 +11,8 @@ import makeStyles from './makeStyles';
 import useTheme from '../useTheme';
 import StylesProvider from '../StylesProvider';
 import ThemeProvider from '../ThemeProvider';
+import jssTemplate from 'jss-plugin-template';
+import { jssPreset } from '@material-ui/styles';
 
 describe('makeStyles', () => {
   let mount;
@@ -242,6 +244,33 @@ describe('makeStyles', () => {
       wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
       assert.strictEqual(sheetsRegistry.registry.length, 1);
       assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root' });
+    });
+
+    it('should apply string styles', () => {
+      const jss = create({
+        plugins: [jssTemplate(), ...jssPreset().plugins],
+      });
+      const useStyles = makeStyles({
+        root: `
+        display: flex;
+        padding: 1em;
+      `,
+      });
+      const StyledComponent = () => {
+        const classes = useStyles();
+        return <div className={classes.root} />;
+      };
+
+      mount(
+        <StylesProvider sheetsRegistry={sheetsRegistry} sheetsCache={new Map()} jss={jss}>
+          <StyledComponent />
+        </StylesProvider>,
+      );
+      assert.strictEqual(sheetsRegistry.registry.length, 1);
+      assert.deepEqual(sheetsRegistry.registry[0].rules.map.root.style, {
+        display: 'flex',
+        padding: '1em',
+      });
     });
 
     describe('overrides', () => {

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import {
   createStyles,
+  makeStyles,
+  WithStyles,
   withStyles,
   withTheme,
   WithTheme,
-  WithStyles,
-  makeStyles,
 } from '@material-ui/styles';
 import Button from '@material-ui/core/Button';
 import { Theme } from '@material-ui/core/styles';
@@ -448,6 +448,22 @@ function forwardRefTest() {
   const root = styles.root;
   // $ExpectType string
   const root2 = styles.root2;
+}
+
+{
+  // It works with string styles
+  interface testProps {
+    foo: boolean;
+  }
+
+  const useStyles = makeStyles({
+    root: `
+      display: flex;
+    `,
+  });
+  const styles = useStyles({ foo: true });
+  // $ExpectType string
+  const root = styles.root;
 }
 
 {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

* Support string templates in Typescript
* Migrate StringTemplates demo to Typescript (https://github.com/mui-org/material-ui/issues/14897)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
