### PR TITLE
[docs] Migrate WithTheme demo to Typescript

### DIFF
--- a/docs/src/pages/styles/advanced/WithTheme.js
+++ b/docs/src/pages/styles/advanced/WithTheme.js
@@ -7,7 +7,9 @@ function DeepChildRaw(props) {
 }
 
 DeepChildRaw.propTypes = {
-  theme: PropTypes.object.isRequired,
+  theme: PropTypes.shape({
+    spacing: PropTypes.string.isRequired,
+  }).isRequired,
 };
 
 const DeepChild = withTheme(DeepChildRaw);

--- a/docs/src/pages/styles/advanced/WithTheme.tsx
+++ b/docs/src/pages/styles/advanced/WithTheme.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ThemeProvider, WithTheme as WithThemeProps, withTheme } from '@material-ui/styles';
+
+interface Theme {
+  spacing: string;
+}
+
+interface Props extends WithThemeProps<Theme> {}
+
+function DeepChildRaw(props: Props) {
+  return <span>{`spacing ${props.theme.spacing}`}</span>;
+}
+
+const DeepChild = withTheme<Theme, typeof DeepChildRaw>(DeepChildRaw);
+
+function WithTheme() {
+  return (
+    <ThemeProvider
+      theme={{
+        spacing: '8px',
+      }}
+    >
+      <DeepChild />
+    </ThemeProvider>
+  );
+}
+
+export default WithTheme;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Migrate `WithTheme` demo to Typescript (https://github.com/mui-org/material-ui/issues/14897)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
