### PR TITLE
[Skeleton] Add missing exports from the barrel

### DIFF
--- a/packages/material-ui-lab/src/index.d.ts
+++ b/packages/material-ui-lab/src/index.d.ts
@@ -1,4 +1,5 @@
 export { default as Rating } from './Rating';
+export { default as Skeleton } from './Skeleton';
 export { default as SpeedDial } from './SpeedDial';
 export { default as SpeedDialAction } from './SpeedDialAction';
 export { default as SpeedDialIcon } from './SpeedDialIcon';

--- a/packages/material-ui-lab/src/index.js
+++ b/packages/material-ui-lab/src/index.js
@@ -1,4 +1,5 @@
 export { default as Rating } from './Rating';
+export { default as Skeleton } from './Skeleton';
 export { default as Slider } from './Slider';
 export { default as SpeedDial } from './SpeedDial';
 export { default as SpeedDialAction } from './SpeedDialAction';


### PR DESCRIPTION
…keleton is correct

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Excited to see #16786 drop. But in the documentation it recommends importing `Skeleton` like: 

```js
import { Skeleton } from '@material-ui/lab';
```

This PR adds the exports (similar to other Labs components) so that the docs are correct.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
