### PR TITLE
[Tabs] Fix issue where scrollable tabs auto move to selected tab

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -170,28 +170,30 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
 
     if (tabMeta && tabsMeta) {
       if (vertical) {
-        startValue = Math.round(tabMeta.top - tabsMeta.top + tabsMeta.scrollTop);
+        startValue = tabMeta.top - tabsMeta.top + tabsMeta.scrollTop;
       } else {
         const correction = isRtl
           ? tabsMeta.scrollLeftNormalized + tabsMeta.clientWidth - tabsMeta.scrollWidth
           : tabsMeta.scrollLeft;
-        startValue = Math.round(tabMeta.left - tabsMeta.left + correction);
+        startValue = tabMeta.left - tabsMeta.left + correction;
       }
     }
 
     const newIndicatorStyle = {
       [start]: startValue,
       // May be wrong until the font is loaded.
-      [size]: tabMeta ? Math.round(tabMeta[size]) : 0,
+      [size]: tabMeta ? tabMeta[size] : 0,
     };
 
-    if (
-      (newIndicatorStyle[start] !== indicatorStyle[start] ||
-        newIndicatorStyle[size] !== indicatorStyle[size]) &&
-      !isNaN(newIndicatorStyle[start]) &&
-      !isNaN(newIndicatorStyle[size])
-    ) {
+    if (isNaN(indicatorStyle[start]) || isNaN(indicatorStyle[size])) {
       setIndicatorStyle(newIndicatorStyle);
+    } else {
+      const dStart = Math.abs(indicatorStyle[start] - newIndicatorStyle[start]);
+      const dSize = Math.abs(indicatorStyle[size] - newIndicatorStyle[size]);
+
+      if (dStart >= 1 || dSize >= 1) {
+        setIndicatorStyle(newIndicatorStyle);
+      }
     }
   });
 


### PR DESCRIPTION
Fixes #10826

The diff is based on the suggestion by @oliviertassinari, though the Tabs code has changed somewhat in the meantime (due to the change to use React hooks and the addition of vertical Tabs).

The original issue was reported against Firefox, but I was able to reproduce it on Edge as well. I currently don't have access to Edge, but can test it later.

Is it possible to write a test for something like that?

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
