### PR TITLE
Update PermanentDrawerLeft.jsx with correct location of makeStyles

### DIFF
--- a/docs/src/pages/components/drawers/PermanentDrawerLeft.js
+++ b/docs/src/pages/components/drawers/PermanentDrawerLeft.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 import Drawer from '@material-ui/core/Drawer';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';


### PR DESCRIPTION
Previously, the import of makeStyles came from @material-ui/styles but it should be 
`import { makeStyles } from '@material-ui/styles' ` instead.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
