### PR TITLE
Update PermanentDrawerLeft.js with updated location of makeStyles

### DIFF
--- a/docs/src/pages/components/drawers/PermanentDrawerLeft.js
+++ b/docs/src/pages/components/drawers/PermanentDrawerLeft.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/styles';
 import Drawer from '@material-ui/core/Drawer';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';


### PR DESCRIPTION
Previously this component would error on the location of makeStyles. The location is not at core/styles but at styles
import { makeStyles } from '@material-ui/styles'; This edit allows this component to work.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
