### PR TITLE
Update PersistentDrawerLeft.tsx

### DIFF
--- a/docs/src/pages/components/drawers/PersistentDrawerLeft.tsx
+++ b/docs/src/pages/components/drawers/PersistentDrawerLeft.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import { makeStyles, useTheme, Theme, createStyles } from '@material-ui/core/styles';
+import { makeStyles, useTheme, Theme, createStyles } from '@material-ui/styles';
 import Drawer from '@material-ui/core/Drawer';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import AppBar from '@material-ui/core/AppBar';


### PR DESCRIPTION
makeStyles comes from @material-ui/styles and not from the core/styles

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
