### PR TITLE
[Dialog] Add support for a Dialog without a DialogTitle

### DIFF
--- a/packages/material-ui/src/DialogContent/DialogContent.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.js
@@ -10,6 +10,9 @@ export const styles = theme => ({
     padding: '8px 24px',
     WebkitOverflowScrolling: 'touch', // Add iOS momentum scrolling.
     overflowY: 'auto',
+    '&:first-child': {	
+      paddingTop: 20,	
+    },
   },
   /* Styles applied to the root element if `dividers={true}`. */
   dividers: {

--- a/packages/material-ui/src/DialogContent/DialogContent.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.js
@@ -7,15 +7,17 @@ export const styles = theme => ({
   /* Styles applied to the root element. */
   root: {
     flex: '1 1 auto',
-    padding: '8px 24px',
     WebkitOverflowScrolling: 'touch', // Add iOS momentum scrolling.
     overflowY: 'auto',
-    '&:first-child': {	
-      paddingTop: 20,	
+    padding: '8px 24px',
+    '&:first-child': {
+      // dialog without title
+      paddingTop: 20,
     },
   },
   /* Styles applied to the root element if `dividers={true}`. */
   dividers: {
+    padding: '16px 24px',
     borderTop: `1px solid ${theme.palette.divider}`,
     borderBottom: `1px solid ${theme.palette.divider}`,
   },

--- a/packages/material-ui/src/DialogContentText/DialogContentText.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.js
@@ -6,7 +6,7 @@ import Typography from '../Typography';
 export const styles = {
   /* Styles applied to the root element. */
   root: {
-    marginBottom: 16,
+    marginBottom: 12,
   },
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Spacing is narrow when use dialog without title. 

https://material.io/design/components/dialogs.html

|before|after|
|-|-|
|![before](https://user-images.githubusercontent.com/5723074/62921044-7c77df00-bde2-11e9-84d0-eb2e407974f0.png)|![after](https://user-images.githubusercontent.com/5723074/62921051-81d52980-bde2-11e9-8846-d3ffed4724f9.png)|

Has no effect when with title.

![with-title](https://user-images.githubusercontent.com/5723074/62921167-df697600-bde2-11e9-9c8b-535d1a402fd4.png)
