### PR TITLE
[Select] Hide SVG icon for native multiple select

### DIFF
--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -25,7 +25,7 @@ const NativeSelectInput = React.forwardRef(function NativeSelectInput(props, ref
         ref={inputRef || ref}
         {...other}
       />
-      <IconComponent className={classes.icon} />
+      {props.multiple ? null : <IconComponent className={classes.icon} />}
     </React.Fragment>
   );
 });
@@ -58,6 +58,10 @@ NativeSelectInput.propTypes = {
    * @deprecated
    */
   inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  /**
+   * @ignore
+   */
+  multiple: PropTypes.bool,
   /**
    * Name attribute of the `select` or hidden `input` element.
    */

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -98,7 +98,7 @@ describe('<Select />', () => {
     });
   });
 
-  describe('prop: native', () => {
+  describe('SVG icon', () => {
     it('should not present an SVG icon when native and multiple are specified', () => {
       const { container } = render(
         <Select native multiple value={[0, 1]}>
@@ -109,29 +109,10 @@ describe('<Select />', () => {
       );
       expect(container.querySelector('svg')).to.be.null;
     });
-    it('should present an SVG icon when native is not specified but multiple is', () => {
-      const { container } = render(
-        <Select multiple value={[0, 1]}>
-          <option value={0}>Zero</option>
-          <option value={1}>One</option>
-          <option value={2}>Two</option>
-        </Select>,
-      );
-      expect(container.querySelector('svg')).to.be.visible;
-    });
-    it('should present an SVG icon when multiple is not specified but native is', () => {
+
+    it('should present an SVG icon', () => {
       const { container } = render(
         <Select native value={1}>
-          <option value={0}>Zero</option>
-          <option value={1}>One</option>
-          <option value={2}>Two</option>
-        </Select>,
-      );
-      expect(container.querySelector('svg')).to.be.visible;
-    });
-    it('should present an SVG icon when neither multiple nor native are specified', () => {
-      const { container } = render(
-        <Select value={1}>
           <option value={0}>Zero</option>
           <option value={1}>One</option>
           <option value={2}>Two</option>

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -98,6 +98,49 @@ describe('<Select />', () => {
     });
   });
 
+  describe('prop: native', () => {
+    it('should not present an SVG icon when native and multiple are specified', () => {
+      const { container } = render(
+        <Select native multiple value={[0, 1]}>
+          <option value={0}>Zero</option>
+          <option value={1}>One</option>
+          <option value={2}>Two</option>
+        </Select>,
+      );
+      expect(container.querySelector('svg')).to.be.null;
+    });
+    it('should present an SVG icon when native is not specified but multiple is', () => {
+      const { container } = render(
+        <Select multiple value={[0, 1]}>
+          <option value={0}>Zero</option>
+          <option value={1}>One</option>
+          <option value={2}>Two</option>
+        </Select>,
+      );
+      expect(container.querySelector('svg')).to.be.visible;
+    });
+    it('should present an SVG icon when multiple is not specified but native is', () => {
+      const { container } = render(
+        <Select native value={1}>
+          <option value={0}>Zero</option>
+          <option value={1}>One</option>
+          <option value={2}>Two</option>
+        </Select>,
+      );
+      expect(container.querySelector('svg')).to.be.visible;
+    });
+    it('should present an SVG icon when neither multiple nor native are specified', () => {
+      const { container } = render(
+        <Select value={1}>
+          <option value={0}>Zero</option>
+          <option value={1}>One</option>
+          <option value={2}>Two</option>
+        </Select>,
+      );
+      expect(container.querySelector('svg')).to.be.visible;
+    });
+  });
+
   describe('accessibility', () => {
     it('sets aria-expanded="true" when the listbox is displayed', () => {
       const { getByRole } = render(<Select open value="none" />);


### PR DESCRIPTION
Closes #16967

SVG icon is on top of the native multiple select scrollbar without this fix

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
