### PR TITLE
[InputBase] Fixes Uncontrolled dirty check

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -257,6 +257,12 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     }
   }, [value, checkDirty, isControlled]);
 
+  useEnhancedEffect(() => {
+    if (!isControlled && inputRef.current) {
+      checkDirty(inputRef.current);
+    }
+  }, [checkDirty, isControlled, inputRef]);
+
   const handleFocus = event => {
     // Fix a bug with IE 11 where the focus/blur events are triggered
     // while the input is disabled.

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -10,7 +10,6 @@ import FormControl, { useFormControl } from '../FormControl';
 import InputAdornment from '../InputAdornment';
 import TextareaAutosize from '../TextareaAutosize';
 import InputBase from './InputBase';
-import InputLabel from '../InputLabel';
 import TextField from '../TextField';
 import Select from '../Select';
 
@@ -164,27 +163,35 @@ describe('<InputBase />', () => {
   // uncontrolled only fires for a full mount
   describe('uncontrolled', () => {
     it('should fire the onFilled callback when initially provided a value', () => {
+      function FilledState(props) {
+        const { filled } = useFormControl();
+        return <span {...props}>filled: {String(filled)}</span>;
+      }
+
       function TestUncontrolled() {
         const refs = React.useRef({});
 
         return (
           <FormControl>
-            <InputLabel htmlFor="my-input">Email</InputLabel>
-            <InputBase id="my-input" name='test' inputRef={(ref) => {
-              if (ref) {
-                refs.current[ref.name] = ref
-                refs.current[ref.name].value = 'test@gmail.com'
-              }
-              }}/>
+            <FilledState data-testid="filled" />
+            <InputBase
+              name="test"
+              inputRef={ref => {
+                if (ref) {
+                  refs.current[ref.name] = ref;
+                  refs.current[ref.name].value = 'test@gmail.com';
+                }
+              }}
+            />
           </FormControl>
-        )
+        );
       }
-      const { container } = render(<TestUncontrolled />);
-      const label = container.querySelector('label');
+      const { container, getByTestId } = render(<TestUncontrolled />);
 
-      expect(label.className.includes('MuiFormLabel-filled')).to.be.true;
+      expect(getByTestId('filled')).to.have.text('filled: true');
+
       fireEvent.change(container.querySelector('input'), { target: { value: '' } });
-      expect(label.className.includes('MuiFormLabel-filled')).to.be.false;
+      expect(getByTestId('filled')).to.have.text('filled: false');
     });
   });
 

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -10,6 +10,7 @@ import FormControl, { useFormControl } from '../FormControl';
 import InputAdornment from '../InputAdornment';
 import TextareaAutosize from '../TextareaAutosize';
 import InputBase from './InputBase';
+import InputLabel from '../InputLabel';
 import TextField from '../TextField';
 import Select from '../Select';
 
@@ -156,6 +157,34 @@ describe('<InputBase />', () => {
       expect(input).to.have.property('value', '');
       fireEvent.change(input, { target: { value: 'do not work' } });
       expect(input).to.have.property('value', '');
+    });
+  });
+
+  // Note the initial callback when
+  // uncontrolled only fires for a full mount
+  describe('uncontrolled', () => {
+    it('should fire the onFilled callback when initially provided a value', () => {
+      function TestUncontrolled() {
+        const refs = React.useRef({});
+
+        return (
+          <FormControl>
+            <InputLabel htmlFor="my-input">Email</InputLabel>
+            <InputBase id="my-input" name='test' inputRef={(ref) => {
+              if (ref) {
+                refs.current[ref.name] = ref
+                refs.current[ref.name].value = 'test@gmail.com'
+              }
+              }}/>
+          </FormControl>
+        )
+      }
+      const { container } = render(<TestUncontrolled />);
+      const label = container.querySelector('label');
+
+      expect(label.className.includes('MuiFormLabel-filled')).to.be.true;
+      fireEvent.change(container.querySelector('input'), { target: { value: '' } });
+      expect(label.className.includes('MuiFormLabel-filled')).to.be.false;
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This fixes #17018 where the label is not being properly moved up to do the input being uncontrolled.

I added a failing test and then reverted a small portion of #16526. (Will wait until it is confirmed on CI that the test is failing before pushing the fix)

Relates to https://github.com/react-hook-form/react-hook-form/issues/220

/cc @oliviertassinari 
