### PR TITLE
[core] Let value properties of type "unknown" be type-inferred

### DIFF
--- a/docs/src/pages/components/selects/MultipleSelect.tsx
+++ b/docs/src/pages/components/selects/MultipleSelect.tsx
@@ -72,8 +72,8 @@ export default function MultipleSelect() {
   const theme = useTheme();
   const [personName, setPersonName] = React.useState<string[]>([]);
 
-  function handleChange(event: React.ChangeEvent<{ value: unknown }>) {
-    setPersonName(event.target.value as string[]);
+  function handleChange(event: React.ChangeEvent<{ value: string[] }>) {
+    setPersonName(event.target.value);
   }
 
   function handleChangeMultiple(event: React.ChangeEvent<{ value: unknown }>) {
@@ -112,7 +112,7 @@ export default function MultipleSelect() {
           value={personName}
           onChange={handleChange}
           input={<Input id="select-multiple-checkbox" />}
-          renderValue={selected => (selected as string[]).join(', ')}
+          renderValue={selected => selected.join(', ')}
           MenuProps={MenuProps}
         >
           {names.map(name => (
@@ -132,7 +132,7 @@ export default function MultipleSelect() {
           input={<Input id="select-multiple-chip" />}
           renderValue={selected => (
             <div className={classes.chips}>
-              {(selected as string[]).map(value => (
+              {selected.map(value => (
                 <Chip key={value} label={value} className={classes.chip} />
               ))}
             </div>
@@ -154,11 +154,11 @@ export default function MultipleSelect() {
           onChange={handleChange}
           input={<Input id="select-multiple-placeholder" />}
           renderValue={selected => {
-            if ((selected as string[]).length === 0) {
+            if (selected.length === 0) {
               return <em>Placeholder</em>;
             }
 
-            return (selected as string[]).join(', ');
+            return selected.join(', ');
           }}
           MenuProps={MenuProps}
         >

--- a/packages/material-ui/src/Checkbox/Checkbox.d.ts
+++ b/packages/material-ui/src/Checkbox/Checkbox.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 
-export interface CheckboxProps
-  extends StandardProps<SwitchBaseProps, CheckboxClassKey, 'checkedIcon' | 'color' | 'icon'> {
+export interface CheckboxProps<V = unknown>
+  extends StandardProps<SwitchBaseProps<V>, CheckboxClassKey, 'checkedIcon' | 'color' | 'icon'> {
   checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
   icon?: React.ReactNode;
@@ -17,6 +17,4 @@ export type CheckboxClassKey =
   | 'colorPrimary'
   | 'colorSecondary';
 
-declare const Checkbox: React.ComponentType<CheckboxProps>;
-
-export default Checkbox;
+export default function Checkbox<V>(props: CheckboxProps<V>): JSX.Element;

--- a/packages/material-ui/src/FilledInput/FilledInput.d.ts
+++ b/packages/material-ui/src/FilledInput/FilledInput.d.ts
@@ -2,12 +2,10 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { InputBaseProps, InputBaseClassKey } from '../InputBase';
 
-export interface FilledInputProps extends StandardProps<InputBaseProps, FilledInputClassKey> {
+export interface FilledInputProps<V = unknown> extends StandardProps<InputBaseProps<V>, FilledInputClassKey> {
   disableUnderline?: boolean;
 }
 
 export type FilledInputClassKey = InputBaseClassKey | 'underline';
 
-declare const FilledInput: React.ComponentType<FilledInputProps>;
-
-export default FilledInput;
+export default function FilledInput<V>(props: FilledInputProps<V>): JSX.Element;

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 
-export interface FormControlLabelProps
+export interface FormControlLabelProps<V = unknown>
   extends StandardProps<
     React.LabelHTMLAttributes<HTMLLabelElement>,
     FormControlLabelClassKey,
@@ -15,11 +15,9 @@ export interface FormControlLabelProps
   name?: string;
   onChange?: (event: React.ChangeEvent<{}>, checked: boolean) => void;
   labelPlacement?: 'end' | 'start' | 'top' | 'bottom';
-  value?: unknown;
+  value?: V;
 }
 
 export type FormControlLabelClassKey = 'root' | 'start' | 'disabled' | 'label';
 
-declare const FormControlLabel: React.ComponentType<FormControlLabelProps>;
-
-export default FormControlLabel;
+export default function FormControlLabel<V>(props: FormControlLabelProps<V>): JSX.Element;

--- a/packages/material-ui/src/Input/Input.d.ts
+++ b/packages/material-ui/src/Input/Input.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { InputBaseProps } from '../InputBase';
 
-export interface InputProps extends StandardProps<InputBaseProps, InputClassKey> {
+export interface InputProps<V = unknown> extends StandardProps<InputBaseProps<V>, InputClassKey> {
   disableUnderline?: boolean;
 }
 
@@ -20,6 +20,4 @@ export type InputClassKey =
   | 'inputMultiline'
   | 'inputTypeSearch';
 
-declare const Input: React.ComponentType<InputProps>;
-
-export default Input;
+export default function Input<V>(props: InputProps<V>): JSX.Element;

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { StandardProps } from '..';
 
-export interface InputBaseProps
+export interface InputBaseProps<V = unknown>
   extends StandardProps<
     React.HTMLAttributes<HTMLDivElement>,
     InputBaseClassKey,
@@ -9,7 +9,7 @@ export interface InputBaseProps
   > {
   autoComplete?: string;
   autoFocus?: boolean;
-  defaultValue?: unknown;
+  defaultValue?: V;
   disabled?: boolean;
   endAdornment?: React.ReactNode;
   error?: boolean;
@@ -37,7 +37,7 @@ export interface InputBaseProps
   rowsMax?: string | number;
   startAdornment?: React.ReactNode;
   type?: string;
-  value?: unknown;
+  value?: V;
   /**
    * `onChange`, `onKeyUp` + `onKeyDown` are applied to the inner `InputComponent`,
    * which by default is an input or textarea. Since these handlers differ from the
@@ -76,6 +76,4 @@ export type InputBaseClassKey =
   | 'inputAdornedEnd'
   | 'inputHiddenLabel';
 
-declare const InputBase: React.ComponentType<InputBaseProps>;
-
-export default InputBase;
+export default function InputBase<V>(props: InputBaseProps<V>): JSX.Element;

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -3,12 +3,12 @@ import { StandardProps } from '..';
 import { InputProps } from '../Input';
 import { NativeSelectInputProps } from './NativeSelectInput';
 
-export interface NativeSelectProps
-  extends StandardProps<InputProps, NativeSelectClassKey, 'value' | 'onChange'>,
-    Pick<NativeSelectInputProps, 'onChange'> {
+export interface NativeSelectProps<V = unknown>
+  extends StandardProps<InputProps<V>, NativeSelectClassKey, 'value' | 'onChange'>,
+    Pick<NativeSelectInputProps<V>, 'onChange'> {
   IconComponent?: React.ElementType;
   input?: React.ReactNode;
-  value?: unknown;
+  value?: V;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
@@ -21,6 +21,4 @@ export type NativeSelectClassKey =
   | 'filled'
   | 'outlined';
 
-declare const NativeSelect: React.ComponentType<NativeSelectProps>;
-
-export default NativeSelect;
+export default function NativeSelect<V>(props: NativeSelectProps<V>): JSX.Element;

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
@@ -1,17 +1,15 @@
 import * as React from 'react';
 
-export interface NativeSelectInputProps {
+export interface NativeSelectInputProps<V = unknown> {
   disabled?: boolean;
   IconComponent?: React.ElementType;
   inputRef?: (
-    ref: HTMLSelectElement | { node: HTMLInputElement; value: NativeSelectInputProps['value'] },
+    ref: HTMLSelectElement | { node: HTMLInputElement; value: NativeSelectInputProps<V>['value'] },
   ) => void;
   name?: string;
   onChange?: (event: React.ChangeEvent<HTMLSelectElement>, child: React.ReactNode) => void;
-  value?: unknown;
+  value?: V;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
-declare const NativeSelectInput: React.ComponentType<NativeSelectInputProps>;
-
-export default NativeSelectInput;
+export default function NativeSelectInput<V>(props: NativeSelectInputProps<V>): JSX.Element;

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { InputBaseProps } from '../InputBase';
 
-export interface OutlinedInputProps extends StandardProps<InputBaseProps, OutlinedInputClassKey> {
+export interface OutlinedInputProps<V = unknown> extends StandardProps<InputBaseProps<V>, OutlinedInputClassKey> {
   notched?: boolean;
   labelWidth: number;
 }
@@ -24,6 +24,4 @@ export type OutlinedInputClassKey =
   | 'inputAdornedStart'
   | 'inputAdornedEnd';
 
-declare const OutlinedInput: React.ComponentType<OutlinedInputProps>;
-
-export default OutlinedInput;
+export default function OutlinedInput<V>(props: OutlinedInputProps<V>): JSX.Element;

--- a/packages/material-ui/src/Radio/Radio.d.ts
+++ b/packages/material-ui/src/Radio/Radio.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 
-export interface RadioProps
-  extends StandardProps<SwitchBaseProps, RadioClassKey, 'checkedIcon' | 'color' | 'icon'> {
+export interface RadioProps<V = unknown>
+  extends StandardProps<SwitchBaseProps<V>, RadioClassKey, 'checkedIcon' | 'color' | 'icon'> {
   checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
   icon?: React.ReactNode;
@@ -11,6 +11,4 @@ export interface RadioProps
 
 export type RadioClassKey = SwitchBaseClassKey | 'colorPrimary' | 'colorSecondary';
 
-declare const Radio: React.ComponentType<RadioProps>;
-
-export default Radio;
+export default function Radio<V>(props: RadioProps<V>): JSX.Element;

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -4,9 +4,9 @@ import { InputProps } from '../Input';
 import { MenuProps } from '../Menu';
 import { SelectInputProps } from './SelectInput';
 
-export interface SelectProps
-  extends StandardProps<InputProps, SelectClassKey, 'value' | 'onChange'>,
-    Pick<SelectInputProps, 'onChange'> {
+export interface SelectProps<V = unknown>
+  extends StandardProps<InputProps<V>, SelectClassKey, 'value' | 'onChange'>,
+    Pick<SelectInputProps<V>, 'onChange'> {
   autoWidth?: boolean;
   displayEmpty?: boolean;
   IconComponent?: React.ElementType;
@@ -17,9 +17,9 @@ export interface SelectProps
   onClose?: (event: React.ChangeEvent<{}>) => void;
   onOpen?: (event: React.ChangeEvent<{}>) => void;
   open?: boolean;
-  renderValue?: (value: SelectProps['value']) => React.ReactNode;
+  renderValue?: (value: SelectProps<V>['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
-  value?: unknown;
+  value?: V;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
@@ -32,6 +32,4 @@ export type SelectClassKey =
   | 'filled'
   | 'outlined';
 
-declare const Select: React.ComponentType<SelectProps>;
-
-export default Select;
+export default function Select<V>(props: SelectProps<V>): JSX.Element;

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -4,22 +4,22 @@ import { InputProps } from '../Input';
 import { MenuProps } from '../Menu';
 import { SelectInputProps } from './SelectInput';
 
-export interface SelectProps<V = unknown>
+export interface SelectProps<V = unknown, M = boolean>
   extends StandardProps<InputProps<V>, SelectClassKey, 'value' | 'onChange'>,
-    Pick<SelectInputProps<V>, 'onChange'> {
+    Pick<SelectInputProps<V, M>, 'onChange'> {
   autoWidth?: boolean;
   displayEmpty?: boolean;
   IconComponent?: React.ElementType;
   input?: React.ReactNode;
   MenuProps?: Partial<MenuProps>;
-  multiple?: boolean;
+  multiple?: M;
   native?: boolean;
   onClose?: (event: React.ChangeEvent<{}>) => void;
   onOpen?: (event: React.ChangeEvent<{}>) => void;
   open?: boolean;
-  renderValue?: (value: SelectProps<V>['value']) => React.ReactNode;
+  renderValue?: (value: SelectInputProps<V, M>['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
-  value?: V;
+  value?: SelectInputProps<V, M>['value'];
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
@@ -32,4 +32,8 @@ export type SelectClassKey =
   | 'filled'
   | 'outlined';
 
-export default function Select<V>(props: SelectProps<V>): JSX.Element;
+/* tslint:disable:unified-signatures */
+declare function Select<V>(props: { multiple: true } & SelectProps<V, true>): JSX.Element;
+declare function Select<V>(props: ({ multiple: false } | { multiple?: undefined }) & SelectProps<V, false>): JSX.Element;
+
+export default Select;

--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { MenuProps } from '../Menu';
 
-export interface SelectInputProps {
+export interface SelectInputProps<V = unknown> {
   autoFocus?: boolean;
   autoWidth: boolean;
   disabled?: boolean;
   IconComponent?: React.ElementType;
   inputRef?: (
-    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps['value'] },
+    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<V>['value'] },
   ) => void;
   MenuProps?: Partial<MenuProps>;
   multiple: boolean;
@@ -15,7 +15,7 @@ export interface SelectInputProps {
   native: boolean;
   onBlur?: React.FocusEventHandler<any>;
   onChange?: (
-    event: React.ChangeEvent<{ name?: string; value: unknown }>,
+    event: React.ChangeEvent<{ name?: string; value: V | undefined }>,
     child: React.ReactNode,
   ) => void;
   onClose?: (event: React.ChangeEvent<{}>) => void;
@@ -23,13 +23,11 @@ export interface SelectInputProps {
   onOpen?: (event: React.ChangeEvent<{}>) => void;
   open?: boolean;
   readOnly?: boolean;
-  renderValue?: (value: SelectInputProps['value']) => React.ReactNode;
+  renderValue?: (value: SelectInputProps<V>['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
   tabIndex?: number;
-  value: unknown;
+  value: V;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
-declare const SelectInput: React.ComponentType<SelectInputProps>;
-
-export default SelectInput;
+export default function SelectInput<V>(props: SelectInputProps<V>): JSX.Element;

--- a/packages/material-ui/src/Select/SelectInput.d.ts
+++ b/packages/material-ui/src/Select/SelectInput.d.ts
@@ -1,21 +1,21 @@
 import * as React from 'react';
 import { MenuProps } from '../Menu';
 
-export interface SelectInputProps<V = unknown> {
+export interface SelectInputProps<V = unknown, M = boolean> {
   autoFocus?: boolean;
   autoWidth: boolean;
   disabled?: boolean;
   IconComponent?: React.ElementType;
   inputRef?: (
-    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<V>['value'] },
+    ref: HTMLSelectElement | { node: HTMLInputElement; value: SelectInputProps<V, M>['value'] },
   ) => void;
   MenuProps?: Partial<MenuProps>;
-  multiple: boolean;
+  multiple: M;
   name?: string;
   native: boolean;
   onBlur?: React.FocusEventHandler<any>;
   onChange?: (
-    event: React.ChangeEvent<{ name?: string; value: V | undefined }>,
+    event: React.ChangeEvent<{ name?: string; value: M extends true ? V[] : (V | undefined) }>,
     child: React.ReactNode,
   ) => void;
   onClose?: (event: React.ChangeEvent<{}>) => void;
@@ -23,11 +23,15 @@ export interface SelectInputProps<V = unknown> {
   onOpen?: (event: React.ChangeEvent<{}>) => void;
   open?: boolean;
   readOnly?: boolean;
-  renderValue?: (value: SelectInputProps<V>['value']) => React.ReactNode;
+  renderValue?: (value: SelectInputProps<V, M>['value']) => React.ReactNode;
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
   tabIndex?: number;
-  value: V;
+  value: M extends true ? V[] : V;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
-export default function SelectInput<V>(props: SelectInputProps<V>): JSX.Element;
+/* tslint:disable:unified-signatures */
+declare function SelectInput<V>(props: { multiple: true } & SelectInputProps<V, true>): JSX.Element;
+declare function SelectInput<V>(props: ({ multiple: false } | { multiple?: undefined }) & SelectInputProps<V, false>): JSX.Element;
+
+export default SelectInput;

--- a/packages/material-ui/src/Switch/Switch.d.ts
+++ b/packages/material-ui/src/Switch/Switch.d.ts
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 
-export interface SwitchProps
-  extends StandardProps<SwitchBaseProps, SwitchClassKey, 'checkedIcon' | 'color' | 'icon'> {
+export interface SwitchProps<V = unknown>
+  extends StandardProps<SwitchBaseProps<V>, SwitchClassKey, 'checkedIcon' | 'color' | 'icon'> {
   checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
   icon?: React.ReactNode;
@@ -19,6 +19,4 @@ export type SwitchClassKey =
   | 'thumb'
   | 'track';
 
-declare const Switch: React.ComponentType<SwitchProps>;
-
-export default Switch;
+export default function Switch<V>(props: SwitchProps<V>): JSX.Element;

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -26,7 +26,7 @@ declare const TablePagination: OverridableComponent<{
     page: number;
     rowsPerPage: number;
     rowsPerPageOptions?: number[];
-    SelectProps?: Partial<SelectProps>;
+    SelectProps?: Partial<SelectProps<number>>;
   };
   defaultComponent: React.ComponentType<TablePaginationBaseProps>;
   classKey: TablePaginationClassKey;

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -8,12 +8,12 @@ import { OutlinedInputProps } from '../OutlinedInput';
 import { InputLabelProps } from '../InputLabel';
 import { SelectProps } from '../Select';
 
-export interface BaseTextFieldProps
+export interface BaseTextFieldProps<V = unknown>
   extends StandardProps<FormControlProps, TextFieldClassKey, 'onChange' | 'defaultValue'> {
   autoComplete?: string;
   autoFocus?: boolean;
   children?: React.ReactNode;
-  defaultValue?: unknown;
+  defaultValue?: V;
   disabled?: boolean;
   error?: boolean;
   FormHelperTextProps?: Partial<FormHelperTextProps>;
@@ -32,33 +32,31 @@ export interface BaseTextFieldProps
   rows?: string | number;
   rowsMax?: string | number;
   select?: boolean;
-  SelectProps?: Partial<SelectProps>;
+  SelectProps?: Partial<SelectProps<V>>;
   type?: string;
-  value?: unknown;
+  value?: V;
 }
 
-export interface StandardTextFieldProps extends BaseTextFieldProps {
+export interface StandardTextFieldProps<V = unknown> extends BaseTextFieldProps<V> {
   variant?: 'standard';
-  InputProps?: Partial<StandardInputProps>;
-  inputProps?: StandardInputProps['inputProps'];
+  InputProps?: Partial<StandardInputProps<V>>;
+  inputProps?: StandardInputProps<V>['inputProps'];
 }
 
-export interface FilledTextFieldProps extends BaseTextFieldProps {
+export interface FilledTextFieldProps<V = unknown> extends BaseTextFieldProps<V> {
   variant: 'filled';
-  InputProps?: Partial<FilledInputProps>;
-  inputProps?: FilledInputProps['inputProps'];
+  InputProps?: Partial<FilledInputProps<V>>;
+  inputProps?: FilledInputProps<V>['inputProps'];
 }
 
-export interface OutlinedTextFieldProps extends BaseTextFieldProps {
+export interface OutlinedTextFieldProps<V = unknown> extends BaseTextFieldProps<V> {
   variant: 'outlined';
-  InputProps?: Partial<OutlinedInputProps>;
-  inputProps?: OutlinedInputProps['inputProps'];
+  InputProps?: Partial<OutlinedInputProps<V>>;
+  inputProps?: OutlinedInputProps<V>['inputProps'];
 }
 
-export type TextFieldProps = StandardTextFieldProps | FilledTextFieldProps | OutlinedTextFieldProps;
+export type TextFieldProps<V = unknown> = StandardTextFieldProps<V> | FilledTextFieldProps<V> | OutlinedTextFieldProps<V>;
 
 export type TextFieldClassKey = 'root';
 
-declare const TextField: React.ComponentType<TextFieldProps>;
-
-export default TextField;
+export default function TextField<V>(props: TextFieldProps<V>): JSX.Element;

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { IconButtonProps } from '../IconButton';
 
-export interface SwitchBaseProps
+export interface SwitchBaseProps<V = unknown>
   extends StandardProps<IconButtonProps, SwitchBaseClassKey, 'onChange' | 'value'> {
   autoFocus?: boolean;
   checked?: boolean;
@@ -18,11 +18,9 @@ export interface SwitchBaseProps
   readOnly?: boolean;
   required?: boolean;
   tabIndex?: number;
-  value?: unknown;
+  value?: V;
 }
 
 export type SwitchBaseClassKey = 'root' | 'checked' | 'disabled' | 'input';
 
-declare const SwitchBase: React.ComponentType<SwitchBaseProps>;
-
-export default SwitchBase;
+export default function SwitchBase<V>(props: SwitchBaseProps<V>): JSX.Element;

--- a/packages/material-ui/test/typescript/components.spec.tsx
+++ b/packages/material-ui/test/typescript/components.spec.tsx
@@ -949,6 +949,17 @@ const SelectTest = () => (
   </Select>
 );
 
+const MultipleSelectTest = () => (
+  <Select multiple input={<Input />} value={[10]} onChange={e => log(e.currentTarget.value)}>
+    <MenuItem value="">
+      <em>None</em>
+    </MenuItem>
+    <MenuItem value={10}>Ten</MenuItem>
+    <MenuItem value={20}>Twenty</MenuItem>
+    <MenuItem value={30}>Thirty</MenuItem>
+  </Select>
+);
+
 const InputAdornmentTest = () => <InputAdornment position="end" onClick={() => alert('Hello')} />;
 
 const TooltipComponentTest = () => (


### PR DESCRIPTION
With current typing, this Select component:

```
<Select value={10} onChange={e => log(e.currentTarget.value)} />
```
has an `onChange` property of type
```
((event: React.ChangeEvent<{
    name?: string | undefined;
    value: unknown;
}>, child: React.ReactNode) => void) | undefined
```

which means `e.currentTarget.value` cannot be passed to a function taking an
argument of type `number` without adding a run-time type check
(`typeof === "number"`) or a `@ts-ignore` comment.

However, the type of `value` can be inferred using generics components, e.g.:

```
interface SelectProps<V = unknown> {
  value?: V;
}

function Select<V>(props: SelectProps<V>): JSX.Element;
```

In the example above, the `onChange` type then turns to:
```
((event: React.ChangeEvent<{
    name?: string | undefined;
    value: number | undefined;
}>, child: React.ReactNode) => void) | undefined
```

In the cases the `Select` has some `MenuItem` with value of a different type,
as in this example (`string | number`):
```
<Select value={10} onChange={e => log(e.currentTarget.value)}>
  <MenuItem value="">
    <em>None</em>
  </MenuItem>
  <MenuItem value={10}>Ten</MenuItem>
  <MenuItem value={20}>Twenty</MenuItem>
  <MenuItem value={30}>Thirty</MenuItem>
</Select>
```
the `value` type can be enforced on the call site for more precise typing:
```
<Select<string | number> value={10} onChange={e => log(e.currentTarget.value)} />
```
leading to an `onChange` property of type:
```
((event: React.ChangeEvent<{
    name?: string | undefined;
    value: string | number | undefined;
}>, child: React.ReactNode) => void) | undefined
```

Also, multiple Select components are handled (no `undefined` value):
```
<Select multiple value={[10]} onChange={e => log(e.currentTarget.value)} />
```
has an `onChange` property of type
```
((event: React.ChangeEvent<{
    name?: string | undefined;
    value: number[];
}>, child: React.ReactNode) => void) | undefined
```

This is done using conditional type inference:
```
interface SelectProps<V = unknown, M = boolean> {
  multiple?: M;
  value?: M extends true ? V[] : V;
}

function Select<V>(props: { multiple: true } & SelectProps<V, true>): JSX.Element;
function Select<V>(props: ({ multiple: false } | { multiple?: undefined }) & SelectProps<V, false>): JSX.Element;
```

This diff makes all component with a value property of type "unknown" generics,
with a default type to "unknown" if it cannot be inferred.

It also may opens the path to further improvements such as:
  - `TextField`: enforcing the `value` property to type `number` if the `type`
    property is `"number"`
  - `Select`: using the `children` property to infer `value` property type from
    `MenuItem` child nodes properties
