### PR TITLE
[LinearProgress] maxValue prop and appropiate scaling

### DIFF
--- a/docs/pages/api/linear-progress.md
+++ b/docs/pages/api/linear-progress.md
@@ -24,8 +24,9 @@ attribute to `true` on that region until it has finished loading.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'primary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
-| <span class="prop-name">value</span> | <span class="prop-type">number</span> |  | The value of the progress indicator for the determinate and buffer variants. Value between 0 and 100. |
-| <span class="prop-name">valueBuffer</span> | <span class="prop-type">number</span> |  | The value for the buffer variant. Value between 0 and 100. |
+| <span class="prop-name">maxValue</span> | <span class="prop-type">number</span> | <span class="prop-default">100</span> | The max value of the progress indicator. Default value 100. |
+| <span class="prop-name">value</span> | <span class="prop-type">number</span> |  | The value of the progress indicator for the determinate and buffer variants. Value between 0 and maxValue. |
+| <span class="prop-name">valueBuffer</span> | <span class="prop-type">number</span> |  | The value for the buffer variant. Value between 0 and maxValue. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'determinate'<br>&#124;&nbsp;'indeterminate'<br>&#124;&nbsp;'buffer'<br>&#124;&nbsp;'query'</span> | <span class="prop-default">'indeterminate'</span> | The variant to use. Use indeterminate or query when there is no progress value. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api/linear-progress.md
+++ b/docs/pages/api/linear-progress.md
@@ -24,7 +24,7 @@ attribute to `true` on that region until it has finished loading.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">color</span> | <span class="prop-type">'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'primary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
-| <span class="prop-name">maxValue</span> | <span class="prop-type">number</span> | <span class="prop-default">100</span> | The max value of the progress indicator. Default value 100. |
+| <span class="prop-name">maxValue</span> | <span class="prop-type">number</span> | <span class="prop-default">100</span> | The max value of the progress indicator. |
 | <span class="prop-name">value</span> | <span class="prop-type">number</span> |  | The value of the progress indicator for the determinate and buffer variants. Value between 0 and maxValue. |
 | <span class="prop-name">valueBuffer</span> | <span class="prop-type">number</span> |  | The value for the buffer variant. Value between 0 and maxValue. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'determinate'<br>&#124;&nbsp;'indeterminate'<br>&#124;&nbsp;'buffer'<br>&#124;&nbsp;'query'</span> | <span class="prop-default">'indeterminate'</span> | The variant to use. Use indeterminate or query when there is no progress value. |

--- a/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
@@ -6,6 +6,7 @@ export interface LinearProgressProps
   color?: 'primary' | 'secondary';
   value?: number;
   valueBuffer?: number;
+  maxValue?: number;
   variant?: 'determinate' | 'indeterminate' | 'buffer' | 'query';
 }
 

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -275,7 +275,7 @@ LinearProgress.propTypes = {
    */
   color: PropTypes.oneOf(['primary', 'secondary']),
   /**
-   * The max value of the progress indicatior.
+   * The max value of the progress indicator.
    * Default value 100.
    */
   maxValue: PropTypes.number,

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -169,6 +169,7 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
     theme,
     value,
     valueBuffer,
+    maxValue,
     variant = 'indeterminate',
     ...other
   } = props;
@@ -207,10 +208,18 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
   const rootProps = {};
   const inlineStyles = { bar1: {}, bar2: {} };
 
+  if (maxValue <= 0) {
+    warning(
+      false,
+      'Material-UI: you need to provide a maxValue greater than 0 ' +
+        'when using the maxValue of LinearProgress.',
+    );
+  }
   if (variant === 'determinate' || variant === 'buffer') {
     if (value !== undefined) {
       rootProps['aria-valuenow'] = Math.round(value);
-      let transform = value - 100;
+      const scaledValue = (value * 100) / maxValue;
+      let transform = scaledValue - 100;
       if (theme.direction === 'rtl') {
         transform = -transform;
       }
@@ -225,7 +234,8 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
   }
   if (variant === 'buffer') {
     if (valueBuffer !== undefined) {
-      let transform = (valueBuffer || 0) - 100;
+      const scaledValueBuffer = (valueBuffer * 100) / maxValue;
+      let transform = (scaledValueBuffer || 0) - 100;
       if (theme.direction === 'rtl') {
         transform = -transform;
       }
@@ -265,17 +275,22 @@ LinearProgress.propTypes = {
    */
   color: PropTypes.oneOf(['primary', 'secondary']),
   /**
+   * The max value of the progress indicatior.
+   * Default value 100.
+   */
+  maxValue: PropTypes.number,
+  /**
    * @ignore
    */
   theme: PropTypes.object,
   /**
    * The value of the progress indicator for the determinate and buffer variants.
-   * Value between 0 and 100.
+   * Value between 0 and maxValue.
    */
   value: PropTypes.number,
   /**
    * The value for the buffer variant.
-   * Value between 0 and 100.
+   * Value between 0 and maxValue.
    */
   valueBuffer: PropTypes.number,
   /**
@@ -283,6 +298,10 @@ LinearProgress.propTypes = {
    * Use indeterminate or query when there is no progress value.
    */
   variant: PropTypes.oneOf(['determinate', 'indeterminate', 'buffer', 'query']),
+};
+
+LinearProgress.defaultProps = {
+  maxValue: 100,
 };
 
 export default withStyles(styles, { name: 'MuiLinearProgress', withTheme: true })(LinearProgress);

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -209,7 +209,7 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
   const inlineStyles = { bar1: {}, bar2: {} };
 
   warning(
-    maxValue > 100,
+    maxValue > 0,
     'Material-UI: you need to provide a maxValue greater than 0 ' +
       'when using the maxValue of LinearProgress.',
   );

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -169,7 +169,7 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
     theme,
     value,
     valueBuffer,
-    maxValue,
+    maxValue = 100,
     variant = 'indeterminate',
     ...other
   } = props;
@@ -208,13 +208,12 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
   const rootProps = {};
   const inlineStyles = { bar1: {}, bar2: {} };
 
-  if (maxValue <= 0) {
-    warning(
-      false,
-      'Material-UI: you need to provide a maxValue greater than 0 ' +
-        'when using the maxValue of LinearProgress.',
-    );
-  }
+  warning(
+    maxValue > 100,
+    'Material-UI: you need to provide a maxValue greater than 0 ' +
+      'when using the maxValue of LinearProgress.',
+  );
+
   if (variant === 'determinate' || variant === 'buffer') {
     if (value !== undefined) {
       rootProps['aria-valuenow'] = Math.round(value);
@@ -276,7 +275,6 @@ LinearProgress.propTypes = {
   color: PropTypes.oneOf(['primary', 'secondary']),
   /**
    * The max value of the progress indicator.
-   * Default value 100.
    */
   maxValue: PropTypes.number,
   /**
@@ -298,10 +296,6 @@ LinearProgress.propTypes = {
    * Use indeterminate or query when there is no progress value.
    */
   variant: PropTypes.oneOf(['determinate', 'indeterminate', 'buffer', 'query']),
-};
-
-LinearProgress.defaultProps = {
-  maxValue: 100,
 };
 
 export default withStyles(styles, { name: 'MuiLinearProgress', withTheme: true })(LinearProgress);

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -88,6 +88,18 @@ describe('<LinearProgress />', () => {
     assert.strictEqual(wrapper.props()['aria-valuenow'], 77);
   });
 
+  it('should set with of bar1 on determinate variant with a max value', () => {
+    const wrapper = shallow(<LinearProgress variant="determinate" value={23} maxValue={50} />);
+    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    assert.strictEqual(wrapper.hasClass(classes.determinate), true);
+    assert.strictEqual(
+      wrapper.childAt(0).props().style.transform,
+      'translateX(-54%)',
+      'should have width set',
+    );
+    assert.strictEqual(wrapper.props()['aria-valuenow'], 23);
+  });
+
   it('should render with buffer classes for the primary color by default', () => {
     const wrapper = shallow(<LinearProgress value={1} valueBuffer={1} variant="buffer" />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
@@ -192,6 +204,12 @@ describe('<LinearProgress />', () => {
       assert.match(
         consoleErrorMock.args()[2][0],
         /Warning: Material-UI: you need to provide a valueBuffer prop/,
+      );
+      shallow(<LinearProgress variant="determinate" value={50} maxValue={-10} />);
+      assert.strictEqual(consoleErrorMock.callCount(), 4);
+      assert.match(
+        consoleErrorMock.args()[3][0],
+        /Warning: Material-UI: you need to provide a maxValue greater than 0/,
       );
     });
   });

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -88,7 +88,7 @@ describe('<LinearProgress />', () => {
     assert.strictEqual(wrapper.props()['aria-valuenow'], 77);
   });
 
-  it('should set with of bar1 on determinate variant with a max value', () => {
+  it('should set width of bar1 on determinate variant with a max value', () => {
     const wrapper = shallow(<LinearProgress variant="determinate" value={23} maxValue={50} />);
     assert.strictEqual(wrapper.hasClass(classes.root), true);
     assert.strictEqual(wrapper.hasClass(classes.determinate), true);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I felt that the loader would be more dev friendly if it can accept a maxValue prop. I came across having to scale my values into the loader manually. This makes the component handle the scaling of the value / maxValue.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
