### PR TITLE
[core] Classes to hooks

### DIFF
--- a/docs/pages/api/root-ref.md
+++ b/docs/pages/api/root-ref.md
@@ -34,23 +34,18 @@ For example:
 import React from 'react';
 import RootRef from '@material-ui/core/RootRef';
 
-class MyComponent extends React.Component {
-  constructor() {
-    super();
-    this.domRef = React.createRef();
-  }
+function MyComponent() {
+  const domRef = React.useRef();
 
-  componentDidMount() {
-    console.log(this.domRef.current); // DOM node
-  }
+  React.useEffect(() => {
+    console.log(domRef.current); // DOM node
+  }, []);
 
-  render() {
-    return (
-      <RootRef rootRef={this.domRef}>
-        <SomeChildComponent />
-      </RootRef>
-    );
-  }
+  return (
+    <RootRef rootRef={domRef}>
+      <SomeChildComponent />
+    </RootRef>
+  );
 }
 ```
 

--- a/docs/pages/getting-started/templates/checkout.js
+++ b/docs/pages/getting-started/templates/checkout.js
@@ -1,22 +1,11 @@
 import React from 'react';
-import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
 import AppTheme from 'docs/src/modules/components/AppTheme';
 import Checkout from 'docs/src/pages/getting-started/templates/checkout/Checkout';
 
-function Page(props) {
+export default function Page() {
   return (
-    <AppTheme
-      title="Checkout page layout example - Material-UI"
-      description={props.t('checkoutDescr')}
-    >
+    <AppTheme>
       <Checkout />
     </AppTheme>
   );
 }
-
-Page.propTypes = {
-  t: PropTypes.func.isRequired,
-};
-
-export default connect(state => ({ t: state.options.t }))(Page);

--- a/docs/src/modules/components/AdCarbon.js
+++ b/docs/src/modules/components/AdCarbon.js
@@ -36,8 +36,8 @@ const styles = theme => ({
   },
 });
 
-class AdCarbon extends React.Component {
-  componentDidMount() {
+function AdCarbon() {
+  React.useEffect(() => {
     const scriptSlot = document.querySelector('#carbon-ad');
 
     // Concurrence issues
@@ -50,11 +50,9 @@ class AdCarbon extends React.Component {
       scriptSlot,
     );
     script.id = '_carbonads_js';
-  }
+  }, []);
 
-  render() {
-    return <span id="carbon-ad" />;
-  }
+  return <span id="carbon-ad" />;
 }
 
 export default withStyles(styles)(AdCarbon);

--- a/docs/src/modules/components/AdCodeFund.js
+++ b/docs/src/modules/components/AdCodeFund.js
@@ -36,8 +36,8 @@ const styles = theme => ({
   },
 });
 
-class AdCodeFund extends React.Component {
-  componentDidMount() {
+function AdCodeFund() {
+  React.useEffect(() => {
     const scriptSlot = document.querySelector('#code-fund-script-slot');
 
     // Concurrence issues
@@ -46,16 +46,14 @@ class AdCodeFund extends React.Component {
     }
 
     loadScript('https://codefund.io/properties/137/funder.js?theme=unstyled', scriptSlot);
-  }
+  }, []);
 
-  render() {
-    return (
-      <React.Fragment>
-        <span id="code-fund-script-slot" />
-        <span id="codefund" />
-      </React.Fragment>
-    );
-  }
+  return (
+    <React.Fragment>
+      <span id="code-fund-script-slot" />
+      <span id="codefund" />
+    </React.Fragment>
+  );
 }
 
 export default withStyles(styles)(AdCodeFund);

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import url from 'url';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import { loadCSS } from 'fg-loadcss/src/loadCSS';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { fade, useTheme, makeStyles } from '@material-ui/core/styles';
@@ -156,11 +155,14 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function AppSearch(props) {
-  const { userLanguage } = props;
+export default function AppSearch() {
   const classes = useStyles();
   const inputRef = React.useRef(null);
   const theme = useTheme();
+
+  const { userLanguage } = useSelector(state => ({
+    userLanguage: state.options.userLanguage,
+  }));
 
   React.useEffect(() => {
     const handleKeyDown = event => {
@@ -214,11 +216,3 @@ function AppSearch(props) {
     </div>
   );
 }
-
-AppSearch.propTypes = {
-  userLanguage: PropTypes.string.isRequired,
-};
-
-export default connect(state => ({
-  userLanguage: state.options.userLanguage,
-}))(AppSearch);

--- a/docs/src/modules/components/EditPage.js
+++ b/docs/src/modules/components/EditPage.js
@@ -1,14 +1,18 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import { useSelector } from 'react-redux';
 import Button from '@material-ui/core/Button';
 
 const LOCALES = { zh: 'zh-CN', pt: 'pt-BR', es: 'es-ES' };
 const CROWDIN_ROOT_URL = 'https://translate.material-ui.com/project/material-ui-docs/';
 const SOURCE_CODE_ROOT_URL = 'https://github.com/mui-org/material-ui/edit/master';
 
-function EditPage(props) {
-  const { markdownLocation, t, userLanguage } = props;
+export default function EditPage(props) {
+  const { markdownLocation } = props;
+  const { t, userLanguage } = useSelector(state => ({
+    t: state.options.t,
+    userLanguage: state.options.userLanguage,
+  }));
   const crowdInLocale = LOCALES[userLanguage] || userLanguage;
   const crowdInPath = markdownLocation.substring(0, markdownLocation.lastIndexOf('/'));
 
@@ -34,11 +38,4 @@ function EditPage(props) {
 
 EditPage.propTypes = {
   markdownLocation: PropTypes.string.isRequired,
-  t: PropTypes.func.isRequired,
-  userLanguage: PropTypes.string.isRequired,
 };
-
-export default connect(state => ({
-  t: state.options.t,
-  userLanguage: state.options.userLanguage,
-}))(EditPage);

--- a/docs/src/modules/components/GoogleAnalytics.js
+++ b/docs/src/modules/components/GoogleAnalytics.js
@@ -33,8 +33,8 @@ function handleClick(event) {
 
 let bound = false;
 
-class GoogleAnalytics extends React.Component {
-  componentDidMount() {
+export default function GoogleAnalytics() {
+  React.useEffect(() => {
     // Wait for the title to be updated.
     setTimeout(() => {
       const { canonical } = pathnameToLanguage(window.location.pathname);
@@ -47,11 +47,7 @@ class GoogleAnalytics extends React.Component {
     }
     bound = true;
     document.addEventListener('click', handleClick);
-  }
+  }, []);
 
-  render() {
-    return null;
-  }
+  return null;
 }
-
-export default GoogleAnalytics;

--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -53,18 +53,14 @@ function handleClick(event) {
 
 let bound = false;
 
-class MarkdownLinks extends React.Component {
-  componentDidMount() {
+export default function MarkdownLinks() {
+  React.useEffect(() => {
     if (bound) {
       return;
     }
     bound = true;
     document.addEventListener('click', handleClick);
-  }
+  }, []);
 
-  render() {
-    return null;
-  }
+  return null;
 }
-
-export default MarkdownLinks;

--- a/docs/src/pages/components/chips/ChipsPlayground.js
+++ b/docs/src/pages/components/chips/ChipsPlayground.js
@@ -27,218 +27,215 @@ const styles = theme => ({
   },
 });
 
-class ChipsPlayground extends React.Component {
-  state = {
+function ChipsPlayground(props) {
+  const { classes } = props;
+  const [{ color, onDelete, avatar, icon, variant, size }, setState] = React.useState({
     color: 'default',
     onDelete: 'none',
     avatar: 'none',
     icon: 'none',
     variant: 'default',
     size: 'medium',
-  };
+  });
 
-  handleChange = key => (event, value) => {
-    this.setState({
+  const handleChange = key => (event, value) => {
+    setState(state => ({
+      ...state,
       [key]: value,
-    });
+    }));
   };
 
-  handleDeleteExample = () => {
+  const handleDeleteExample = () => {
     alert('You clicked the delete icon.');
   };
 
-  render() {
-    const { classes } = this.props;
-    const { color, onDelete, avatar, icon, variant, size } = this.state;
+  const colorToCode = color !== 'default' ? `color="${color}" ` : '';
+  const sizeToCode = size === 'small' ? `size="small" ` : '';
+  const variantToCode = variant !== 'default' ? `variant="${variant}" ` : '';
 
-    const colorToCode = color !== 'default' ? `color="${color}" ` : '';
-    const sizeToCode = size === 'small' ? `size="small" ` : '';
-    const variantToCode = variant !== 'default' ? `variant="${variant}" ` : '';
+  let onDeleteToCode;
+  switch (onDelete) {
+    case 'none':
+      onDeleteToCode = '';
+      break;
+    case 'custom':
+      onDeleteToCode = 'deleteIcon={<DoneIcon />} onDelete={handleDelete} ';
+      break;
+    default:
+      onDeleteToCode = 'onDelete={handleDelete} ';
+      break;
+  }
 
-    let onDeleteToCode;
-    switch (onDelete) {
-      case 'none':
-        onDeleteToCode = '';
-        break;
-      case 'custom':
-        onDeleteToCode = 'deleteIcon={<DoneIcon />} onDelete={handleDelete} ';
-        break;
-      default:
-        onDeleteToCode = 'onDelete={handleDelete} ';
-        break;
-    }
-
-    let iconToCode;
-    let iconToPlayground;
-    switch (icon) {
-      case 'none':
-        iconToCode = '';
-        break;
-      default:
-        iconToCode = 'icon={<FaceIcon />} ';
-        iconToPlayground = <FaceIcon />;
-        break;
-    }
-
-    let avatarToCode;
-    let avatarToPlayground;
-    switch (avatar) {
-      case 'none':
-        avatarToCode = '';
-        break;
-      case 'img':
-        avatarToCode = 'avatar={<Avatar src="/static/images/avatar/1.jpg" />} ';
-        avatarToPlayground = <Avatar src="/static/images/avatar/1.jpg" />;
-        break;
-      case 'letter':
-        avatarToCode = 'avatar={<Avatar>FH</Avatar>} ';
-        avatarToPlayground = <Avatar>FH</Avatar>;
-        break;
-      default:
-        avatarToCode = 'avatar={<Avatar><FaceIcon /></Avatar>} ';
-        avatarToPlayground = (
-          <Avatar>
-            <FaceIcon />
-          </Avatar>
-        );
-        break;
-    }
-
-    if (avatar !== 'none') {
+  let iconToCode;
+  let iconToPlayground;
+  switch (icon) {
+    case 'none':
       iconToCode = '';
-      iconToPlayground = null;
-    }
+      break;
+    default:
+      iconToCode = 'icon={<FaceIcon />} ';
+      iconToPlayground = <FaceIcon />;
+      break;
+  }
 
-    const code = `
+  let avatarToCode;
+  let avatarToPlayground;
+  switch (avatar) {
+    case 'none':
+      avatarToCode = '';
+      break;
+    case 'img':
+      avatarToCode = 'avatar={<Avatar src="/static/images/avatar/1.jpg" />} ';
+      avatarToPlayground = <Avatar src="/static/images/avatar/1.jpg" />;
+      break;
+    case 'letter':
+      avatarToCode = 'avatar={<Avatar>FH</Avatar>} ';
+      avatarToPlayground = <Avatar>FH</Avatar>;
+      break;
+    default:
+      avatarToCode = 'avatar={<Avatar><FaceIcon /></Avatar>} ';
+      avatarToPlayground = (
+        <Avatar>
+          <FaceIcon />
+        </Avatar>
+      );
+      break;
+  }
+
+  if (avatar !== 'none') {
+    iconToCode = '';
+    iconToPlayground = null;
+  }
+
+  const code = `
 \`\`\`jsx
 <Chip ${variantToCode}${colorToCode}${sizeToCode}${onDeleteToCode}${avatarToCode}${iconToCode}/>
 \`\`\`
 `;
 
-    return (
-      <Grid container className={classes.root}>
-        <Grid item xs={12}>
-          <Grid container justify="center" alignItems="center" spacing={5}>
-            <Grid item className={classes.chipWrapper}>
-              <Chip
-                label="Chip Component"
-                color={color}
-                deleteIcon={onDelete === 'custom' ? <DoneIcon /> : undefined}
-                onDelete={onDelete !== 'none' ? this.handleDeleteExample : undefined}
-                avatar={avatarToPlayground}
-                icon={iconToPlayground}
-                variant={variant}
-                size={size}
-              />
-            </Grid>
+  return (
+    <Grid container className={classes.root}>
+      <Grid item xs={12}>
+        <Grid container justify="center" alignItems="center" spacing={5}>
+          <Grid item className={classes.chipWrapper}>
+            <Chip
+              label="Chip Component"
+              color={color}
+              deleteIcon={onDelete === 'custom' ? <DoneIcon /> : undefined}
+              onDelete={onDelete !== 'none' ? handleDeleteExample : undefined}
+              avatar={avatarToPlayground}
+              icon={iconToPlayground}
+              variant={variant}
+              size={size}
+            />
           </Grid>
         </Grid>
-        <Grid item xs={12}>
-          <Paper className={classes.control}>
-            <Grid container spacing={3}>
-              <Grid item xs={12}>
-                <FormControl component="fieldset">
-                  <FormLabel>variant</FormLabel>
-                  <RadioGroup
-                    row
-                    name="variant"
-                    aria-label="variant"
-                    value={variant}
-                    onChange={this.handleChange('variant')}
-                  >
-                    <FormControlLabel value="default" control={<Radio />} label="default" />
-                    <FormControlLabel value="outlined" control={<Radio />} label="outlined" />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-              <Grid item xs={12}>
-                <FormControl component="fieldset">
-                  <FormLabel>color</FormLabel>
-                  <RadioGroup
-                    row
-                    name="color"
-                    aria-label="color"
-                    value={color}
-                    onChange={this.handleChange('color')}
-                  >
-                    <FormControlLabel value="default" control={<Radio />} label="default" />
-                    <FormControlLabel value="primary" control={<Radio />} label="primary" />
-                    <FormControlLabel value="secondary" control={<Radio />} label="secondary" />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-              <Grid item xs={12}>
-                <FormControl component="fieldset">
-                  <FormLabel>size</FormLabel>
-                  <RadioGroup
-                    row
-                    name="sizet"
-                    aria-label="size"
-                    value={size}
-                    onChange={this.handleChange('size')}
-                  >
-                    <FormControlLabel value="medium" control={<Radio />} label="medium" />
-                    <FormControlLabel value="small" control={<Radio />} label="small" />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-              <Grid item xs={12}>
-                <FormControl component="fieldset">
-                  <FormLabel>icon</FormLabel>
-                  <RadioGroup
-                    row
-                    name="icon"
-                    aria-label="icon"
-                    value={icon}
-                    onChange={this.handleChange('icon')}
-                  >
-                    <FormControlLabel value="none" control={<Radio />} label="none" />
-                    <FormControlLabel value="icon" control={<Radio />} label="icon" />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-              <Grid item xs={12}>
-                <FormControl component="fieldset">
-                  <FormLabel>avatar</FormLabel>
-                  <RadioGroup
-                    row
-                    name="avatar"
-                    aria-label="avatar"
-                    value={avatar}
-                    onChange={this.handleChange('avatar')}
-                  >
-                    <FormControlLabel value="none" control={<Radio />} label="none" />
-                    <FormControlLabel value="letter" control={<Radio />} label="letter" />
-                    <FormControlLabel value="img" control={<Radio />} label="img" />
-                    <FormControlLabel value="icon" control={<Radio />} label="icon" />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-              <Grid item xs={12}>
-                <FormControl component="fieldset">
-                  <FormLabel>onDelete</FormLabel>
-                  <RadioGroup
-                    row
-                    name="onDelete"
-                    aria-label="on delete"
-                    value={onDelete}
-                    onChange={this.handleChange('onDelete')}
-                  >
-                    <FormControlLabel value="none" control={<Radio />} label="none" />
-                    <FormControlLabel value="default" control={<Radio />} label="default" />
-                    <FormControlLabel value="custom" control={<Radio />} label="custom" />
-                  </RadioGroup>
-                </FormControl>
-              </Grid>
-            </Grid>
-          </Paper>
-        </Grid>
-        <Grid item xs={12}>
-          <MarkdownElement text={code} />
-        </Grid>
       </Grid>
-    );
-  }
+      <Grid item xs={12}>
+        <Paper className={classes.control}>
+          <Grid container spacing={3}>
+            <Grid item xs={12}>
+              <FormControl component="fieldset">
+                <FormLabel>variant</FormLabel>
+                <RadioGroup
+                  row
+                  name="variant"
+                  aria-label="variant"
+                  value={variant}
+                  onChange={handleChange('variant')}
+                >
+                  <FormControlLabel value="default" control={<Radio />} label="default" />
+                  <FormControlLabel value="outlined" control={<Radio />} label="outlined" />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12}>
+              <FormControl component="fieldset">
+                <FormLabel>color</FormLabel>
+                <RadioGroup
+                  row
+                  name="color"
+                  aria-label="color"
+                  value={color}
+                  onChange={handleChange('color')}
+                >
+                  <FormControlLabel value="default" control={<Radio />} label="default" />
+                  <FormControlLabel value="primary" control={<Radio />} label="primary" />
+                  <FormControlLabel value="secondary" control={<Radio />} label="secondary" />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12}>
+              <FormControl component="fieldset">
+                <FormLabel>size</FormLabel>
+                <RadioGroup
+                  row
+                  name="sizet"
+                  aria-label="size"
+                  value={size}
+                  onChange={handleChange('size')}
+                >
+                  <FormControlLabel value="medium" control={<Radio />} label="medium" />
+                  <FormControlLabel value="small" control={<Radio />} label="small" />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12}>
+              <FormControl component="fieldset">
+                <FormLabel>icon</FormLabel>
+                <RadioGroup
+                  row
+                  name="icon"
+                  aria-label="icon"
+                  value={icon}
+                  onChange={handleChange('icon')}
+                >
+                  <FormControlLabel value="none" control={<Radio />} label="none" />
+                  <FormControlLabel value="icon" control={<Radio />} label="icon" />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12}>
+              <FormControl component="fieldset">
+                <FormLabel>avatar</FormLabel>
+                <RadioGroup
+                  row
+                  name="avatar"
+                  aria-label="avatar"
+                  value={avatar}
+                  onChange={handleChange('avatar')}
+                >
+                  <FormControlLabel value="none" control={<Radio />} label="none" />
+                  <FormControlLabel value="letter" control={<Radio />} label="letter" />
+                  <FormControlLabel value="img" control={<Radio />} label="img" />
+                  <FormControlLabel value="icon" control={<Radio />} label="icon" />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+            <Grid item xs={12}>
+              <FormControl component="fieldset">
+                <FormLabel>onDelete</FormLabel>
+                <RadioGroup
+                  row
+                  name="onDelete"
+                  aria-label="on delete"
+                  value={onDelete}
+                  onChange={handleChange('onDelete')}
+                >
+                  <FormControlLabel value="none" control={<Radio />} label="none" />
+                  <FormControlLabel value="default" control={<Radio />} label="default" />
+                  <FormControlLabel value="custom" control={<Radio />} label="custom" />
+                </RadioGroup>
+              </FormControl>
+            </Grid>
+          </Grid>
+        </Paper>
+      </Grid>
+      <Grid item xs={12}>
+        <MarkdownElement text={code} />
+      </Grid>
+    </Grid>
+  );
 }
 
 ChipsPlayground.propTypes = {

--- a/docs/src/pages/components/popover/AnchorPlayground.js
+++ b/docs/src/pages/components/popover/AnchorPlayground.js
@@ -64,47 +64,12 @@ const inlineStyles = {
   },
 };
 
-class AnchorPlayground extends React.Component {
-  anchorRef = React.createRef();
+function AnchorPlayground(props) {
+  const { classes } = props;
+  const anchorRef = React.useRef();
 
-  state = {
-    open: false,
-    anchorOriginVertical: 'top',
-    anchorOriginHorizontal: 'left',
-    transformOriginVertical: 'top',
-    transformOriginHorizontal: 'left',
-    positionTop: 200, // Just so the popover can be spotted more easily
-    positionLeft: 400, // Same as above
-    anchorReference: 'anchorEl',
-  };
-
-  handleChange = key => (event, value) => {
-    this.setState({
-      [key]: value,
-    });
-  };
-
-  handleNumberInputChange = key => event => {
-    this.setState({
-      [key]: parseInt(event.target.value, 10),
-    });
-  };
-
-  handleClickButton = () => {
-    this.setState({
-      open: true,
-    });
-  };
-
-  handleClose = () => {
-    this.setState({
-      open: false,
-    });
-  };
-
-  render() {
-    const { classes } = this.props;
-    const {
+  const [
+    {
       open,
       anchorOriginVertical,
       anchorOriginHorizontal,
@@ -113,17 +78,56 @@ class AnchorPlayground extends React.Component {
       positionTop,
       positionLeft,
       anchorReference,
-    } = this.state;
+    },
+    setState,
+  ] = React.useState({
+    open: false,
+    anchorOriginVertical: 'top',
+    anchorOriginHorizontal: 'left',
+    transformOriginVertical: 'top',
+    transformOriginHorizontal: 'left',
+    positionTop: 200, // Just so the popover can be spotted more easily
+    positionLeft: 400, // Same as above
+    anchorReference: 'anchorEl',
+  });
 
-    let mode = '';
+  const handleChange = key => (event, value) => {
+    setState(state => ({
+      ...state,
+      [key]: value,
+    }));
+  };
 
-    if (anchorReference === 'anchorPosition') {
-      mode = `
+  const handleNumberInputChange = key => event => {
+    setState(state => ({
+      ...state,
+      [key]: parseInt(event.target.value, 10),
+    }));
+  };
+
+  const handleClickButton = () => {
+    setState(state => ({
+      ...state,
+      open: true,
+    }));
+  };
+
+  const handleClose = () => {
+    setState(state => ({
+      ...state,
+      open: false,
+    }));
+  };
+
+  let mode = '';
+
+  if (anchorReference === 'anchorPosition') {
+    mode = `
   anchorReference="${anchorReference}"
   anchorPosition={{ top: ${positionTop}, left: ${positionLeft} }}`;
-    }
+  }
 
-    const code = `
+  const code = `
 \`\`\`jsx
 <Popover ${mode}
   anchorOrigin={{
@@ -140,187 +144,170 @@ class AnchorPlayground extends React.Component {
 \`\`\`
 `;
 
-    const radioAnchorClasses = { root: classes.radioAnchor, checked: classes.checked };
+  const radioAnchorClasses = { root: classes.radioAnchor, checked: classes.checked };
 
-    return (
-      <div>
-        <Grid container justify="center">
-          <Grid item className={classes.buttonWrapper}>
-            <Button ref={this.anchorRef} variant="contained" onClick={this.handleClickButton}>
-              Open Popover
-            </Button>
-            {anchorReference === 'anchorEl' && (
-              <div
-                className={classes.anchor}
-                style={{
-                  ...inlineStyles.anchorVertical[anchorOriginVertical],
-                  ...inlineStyles.anchorHorizontal[anchorOriginHorizontal],
-                }}
-              />
-            )}
-          </Grid>
+  return (
+    <div>
+      <Grid container justify="center">
+        <Grid item className={classes.buttonWrapper}>
+          <Button ref={anchorRef} variant="contained" onClick={handleClickButton}>
+            Open Popover
+          </Button>
+          {anchorReference === 'anchorEl' && (
+            <div
+              className={classes.anchor}
+              style={{
+                ...inlineStyles.anchorVertical[anchorOriginVertical],
+                ...inlineStyles.anchorHorizontal[anchorOriginHorizontal],
+              }}
+            />
+          )}
         </Grid>
-        <Popover
-          open={open}
-          anchorEl={this.anchorRef.current}
-          anchorReference={anchorReference}
-          anchorPosition={{ top: positionTop, left: positionLeft }}
-          onClose={this.handleClose}
-          anchorOrigin={{
-            vertical: anchorOriginVertical,
-            horizontal: anchorOriginHorizontal,
-          }}
-          transformOrigin={{
-            vertical: transformOriginVertical,
-            horizontal: transformOriginHorizontal,
-          }}
-        >
-          <Typography className={classes.typography}>The content of the Popover.</Typography>
-        </Popover>
-        <Grid container spacing={2}>
-          <Grid item xs={12} sm={6}>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">anchorReference</FormLabel>
-              <RadioGroup
-                row
-                aria-label="anchor reference"
-                name="anchorReference"
-                value={anchorReference}
-                onChange={this.handleChange('anchorReference')}
-              >
-                <FormControlLabel value="anchorEl" control={<Radio />} label="anchorEl" />
-                <FormControlLabel
-                  value="anchorPosition"
-                  control={<Radio />}
-                  label="anchorPosition"
-                />
-              </RadioGroup>
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <FormControl className={classes.formControl}>
-              <InputLabel htmlFor="position-top">anchorPosition.top</InputLabel>
-              <Input
-                id="position-top"
-                type="number"
-                value={positionTop}
-                onChange={this.handleNumberInputChange('positionTop')}
-              />
-            </FormControl>
-            &nbsp;
-            <FormControl className={classes.formControl}>
-              <InputLabel htmlFor="position-left">anchorPosition.left</InputLabel>
-              <Input
-                id="position-left"
-                type="number"
-                value={positionLeft}
-                onChange={this.handleNumberInputChange('positionLeft')}
-              />
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">anchorOrigin.vertical</FormLabel>
-              <RadioGroup
-                aria-label="anchor origin vertical"
-                name="anchorOriginVertical"
-                value={anchorOriginVertical}
-                onChange={this.handleChange('anchorOriginVertical')}
-              >
-                <FormControlLabel
-                  value="top"
-                  control={<Radio classes={radioAnchorClasses} />}
-                  label="Top"
-                />
-                <FormControlLabel
-                  value="center"
-                  control={<Radio classes={radioAnchorClasses} />}
-                  label="Center"
-                />
-                <FormControlLabel
-                  value="bottom"
-                  control={<Radio classes={radioAnchorClasses} />}
-                  label="Bottom"
-                />
-              </RadioGroup>
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">transformOrigin.vertical</FormLabel>
-              <RadioGroup
-                aria-label="transform origin vertical"
-                name="transformOriginVertical"
-                value={transformOriginVertical}
-                onChange={this.handleChange('transformOriginVertical')}
-              >
-                <FormControlLabel value="top" control={<Radio color="primary" />} label="Top" />
-                <FormControlLabel
-                  value="center"
-                  control={<Radio color="primary" />}
-                  label="Center"
-                />
-                <FormControlLabel
-                  value="bottom"
-                  control={<Radio color="primary" />}
-                  label="Bottom"
-                />
-              </RadioGroup>
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">anchorOrigin.horizontal</FormLabel>
-              <RadioGroup
-                row
-                aria-label="anchor origin horizontal"
-                name="anchorOriginHorizontal"
-                value={anchorOriginHorizontal}
-                onChange={this.handleChange('anchorOriginHorizontal')}
-              >
-                <FormControlLabel
-                  value="left"
-                  control={<Radio classes={radioAnchorClasses} />}
-                  label="Left"
-                />
-                <FormControlLabel
-                  value="center"
-                  control={<Radio classes={radioAnchorClasses} />}
-                  label="Center"
-                />
-                <FormControlLabel
-                  value="right"
-                  control={<Radio classes={radioAnchorClasses} />}
-                  label="Right"
-                />
-              </RadioGroup>
-            </FormControl>
-          </Grid>
-          <Grid item xs={12} sm={6}>
-            <FormControl component="fieldset">
-              <FormLabel component="legend">transformOrigin.horizontal</FormLabel>
-              <RadioGroup
-                row
-                aria-label="transform origin horizontal"
-                name="transformOriginHorizontal"
-                value={transformOriginHorizontal}
-                onChange={this.handleChange('transformOriginHorizontal')}
-              >
-                <FormControlLabel value="left" control={<Radio color="primary" />} label="Left" />
-                <FormControlLabel
-                  value="center"
-                  control={<Radio color="primary" />}
-                  label="Center"
-                />
-                <FormControlLabel value="right" control={<Radio color="primary" />} label="Right" />
-              </RadioGroup>
-            </FormControl>
-          </Grid>
+      </Grid>
+      <Popover
+        open={open}
+        anchorEl={anchorRef.current}
+        anchorReference={anchorReference}
+        anchorPosition={{ top: positionTop, left: positionLeft }}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: anchorOriginVertical,
+          horizontal: anchorOriginHorizontal,
+        }}
+        transformOrigin={{
+          vertical: transformOriginVertical,
+          horizontal: transformOriginHorizontal,
+        }}
+      >
+        <Typography className={classes.typography}>The content of the Popover.</Typography>
+      </Popover>
+      <Grid container spacing={2}>
+        <Grid item xs={12} sm={6}>
+          <FormControl component="fieldset">
+            <FormLabel component="legend">anchorReference</FormLabel>
+            <RadioGroup
+              row
+              aria-label="anchor reference"
+              name="anchorReference"
+              value={anchorReference}
+              onChange={handleChange('anchorReference')}
+            >
+              <FormControlLabel value="anchorEl" control={<Radio />} label="anchorEl" />
+              <FormControlLabel value="anchorPosition" control={<Radio />} label="anchorPosition" />
+            </RadioGroup>
+          </FormControl>
         </Grid>
-        <MarkdownElement text={code} />
-      </div>
-    );
-  }
+        <Grid item xs={12} sm={6}>
+          <FormControl className={classes.formControl}>
+            <InputLabel htmlFor="position-top">anchorPosition.top</InputLabel>
+            <Input
+              id="position-top"
+              type="number"
+              value={positionTop}
+              onChange={handleNumberInputChange('positionTop')}
+            />
+          </FormControl>
+          &nbsp;
+          <FormControl className={classes.formControl}>
+            <InputLabel htmlFor="position-left">anchorPosition.left</InputLabel>
+            <Input
+              id="position-left"
+              type="number"
+              value={positionLeft}
+              onChange={handleNumberInputChange('positionLeft')}
+            />
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <FormControl component="fieldset">
+            <FormLabel component="legend">anchorOrigin.vertical</FormLabel>
+            <RadioGroup
+              aria-label="anchor origin vertical"
+              name="anchorOriginVertical"
+              value={anchorOriginVertical}
+              onChange={handleChange('anchorOriginVertical')}
+            >
+              <FormControlLabel
+                value="top"
+                control={<Radio classes={radioAnchorClasses} />}
+                label="Top"
+              />
+              <FormControlLabel
+                value="center"
+                control={<Radio classes={radioAnchorClasses} />}
+                label="Center"
+              />
+              <FormControlLabel
+                value="bottom"
+                control={<Radio classes={radioAnchorClasses} />}
+                label="Bottom"
+              />
+            </RadioGroup>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <FormControl component="fieldset">
+            <FormLabel component="legend">transformOrigin.vertical</FormLabel>
+            <RadioGroup
+              aria-label="transform origin vertical"
+              name="transformOriginVertical"
+              value={transformOriginVertical}
+              onChange={handleChange('transformOriginVertical')}
+            >
+              <FormControlLabel value="top" control={<Radio color="primary" />} label="Top" />
+              <FormControlLabel value="center" control={<Radio color="primary" />} label="Center" />
+              <FormControlLabel value="bottom" control={<Radio color="primary" />} label="Bottom" />
+            </RadioGroup>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <FormControl component="fieldset">
+            <FormLabel component="legend">anchorOrigin.horizontal</FormLabel>
+            <RadioGroup
+              row
+              aria-label="anchor origin horizontal"
+              name="anchorOriginHorizontal"
+              value={anchorOriginHorizontal}
+              onChange={handleChange('anchorOriginHorizontal')}
+            >
+              <FormControlLabel
+                value="left"
+                control={<Radio classes={radioAnchorClasses} />}
+                label="Left"
+              />
+              <FormControlLabel
+                value="center"
+                control={<Radio classes={radioAnchorClasses} />}
+                label="Center"
+              />
+              <FormControlLabel
+                value="right"
+                control={<Radio classes={radioAnchorClasses} />}
+                label="Right"
+              />
+            </RadioGroup>
+          </FormControl>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <FormControl component="fieldset">
+            <FormLabel component="legend">transformOrigin.horizontal</FormLabel>
+            <RadioGroup
+              row
+              aria-label="transform origin horizontal"
+              name="transformOriginHorizontal"
+              value={transformOriginHorizontal}
+              onChange={handleChange('transformOriginHorizontal')}
+            >
+              <FormControlLabel value="left" control={<Radio color="primary" />} label="Left" />
+              <FormControlLabel value="center" control={<Radio color="primary" />} label="Center" />
+              <FormControlLabel value="right" control={<Radio color="primary" />} label="Right" />
+            </RadioGroup>
+          </FormControl>
+        </Grid>
+      </Grid>
+      <MarkdownElement text={code} />
+    </div>
+  );
 }
 
 AnchorPlayground.propTypes = {

--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -251,14 +251,12 @@ const theme = createMuiTheme({
 ```jsx
 import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
 
-class MyComponent extends React.Component {
-  render () {
-    if (isWidthUp('sm', this.props.width)) {
-      return <span />
-    }
-
-    return <div />;
+function MyComponent(props) {
+  if (isWidthUp('sm', props.width)) {
+    return <span />
   }
+
+  return <div />;
 }
 
 export default withWidth()(MyComponent);

--- a/docs/src/pages/customization/color/Color.js
+++ b/docs/src/pages/customization/color/Color.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, useTheme } from '@material-ui/core/styles';
 import * as colors from '@material-ui/core/colors';
 
 const mainColors = [
@@ -114,7 +114,8 @@ function getColorGroup(options) {
 }
 
 function Color(props) {
-  const { classes, theme } = props;
+  const { classes } = props;
+  const theme = useTheme();
 
   return (
     <div className={classes.root}>
@@ -140,7 +141,6 @@ function Color(props) {
 
 Color.propTypes = {
   classes: PropTypes.object.isRequired,
-  theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles, { withTheme: true })(Color);
+export default withStyles(styles)(Color);

--- a/docs/src/pages/customization/color/ColorDemo.js
+++ b/docs/src/pages/customization/color/ColorDemo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, useTheme } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import Fab from '@material-ui/core/Fab';
@@ -38,7 +38,8 @@ const styles = theme => ({
 });
 
 function ColorDemo(props) {
-  const { classes, data, theme } = props;
+  const { classes, data } = props;
+  const theme = useTheme();
   const primary = theme.palette.augmentColor({
     main: data.primary,
     output:
@@ -73,7 +74,7 @@ function ColorDemo(props) {
               <MenuIcon />
             </IconButton>
             <Typography variant="h6" color="inherit">
-              Color sample
+              Color
             </Typography>
           </Toolbar>
         </AppBar>
@@ -96,7 +97,6 @@ function ColorDemo(props) {
 ColorDemo.propTypes = {
   classes: PropTypes.object.isRequired,
   data: PropTypes.object.isRequired,
-  theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles, { withTheme: true })(ColorDemo);
+export default withStyles(styles)(ColorDemo);

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import url from 'url';
 import Inspector from 'react-inspector';
-import { withStyles, createMuiTheme } from '@material-ui/core/styles';
+import { withStyles, createMuiTheme, useTheme } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 
@@ -22,7 +22,8 @@ const styles = theme => ({
 });
 
 function DefaultTheme(props) {
-  const { classes, theme: docsTheme } = props;
+  const { classes } = props;
+  const docsTheme = useTheme();
   const [checked, setChecked] = React.useState(false);
   const [expandPaths, setExpandPaths] = React.useState(null);
   const { t } = useSelector(state => ({ t: state.options.t }));
@@ -78,7 +79,6 @@ function DefaultTheme(props) {
 
 DefaultTheme.propTypes = {
   classes: PropTypes.object.isRequired,
-  theme: PropTypes.object.isRequired,
 };
 
-export default withStyles(styles, { withTheme: true })(DefaultTheme);
+export default withStyles(styles)(DefaultTheme);

--- a/docs/src/pages/guides/composition/composition.md
+++ b/docs/src/pages/guides/composition/composition.md
@@ -175,14 +175,13 @@ To find out if the Material-UI component you're using has this requirement, chec
 out the the props API documentation for that component. If you need to forward refs
 the description will link to this section.
 
-### Caveat with StrictMode or unstable_ConcurrentMode
+### Caveat with StrictMode
 
 If you use class components for the cases described above you will still see
-warnings in `React.StrictMode` and `React.unstable_ConcurrentMode`. We use
-`ReactDOM.findDOMNode` internally for backwards compatibility. You can use `React.forwardRef`
-and a designated prop in your class component to forward the `ref` to a DOM
-component. Doing so should not trigger any more warnings related to the deprecation
-of `ReactDOM.findDOMNode`.
+warnings in `React.StrictMode`.
+We use `ReactDOM.findDOMNode` internally for backwards compatibility.
+You can use `React.forwardRef` and a designated prop in your class component to forward the `ref` to a DOM component.
+Doing so should not trigger any more warnings related to the deprecation of `ReactDOM.findDOMNode`.
 
 ```diff
 class Component extends React.Component {

--- a/docs/src/pages/premium-themes/onepirate/modules/form/defer.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/form/defer.js
@@ -1,21 +1,15 @@
 import React from 'react';
 
-function defer(Component) {
-  class Defer extends React.Component {
-    state = {
-      mounted: false,
-    };
+export default function defer(Component) {
+  const Defer = props => {
+    const [mounted, setMounted] = React.useState(false);
 
-    componentDidMount() {
-      this.setState({ mounted: true });
-    }
+    React.useEffect(() => {
+      setMounted(true);
+    }, []);
 
-    render() {
-      return <Component mounted={this.state.mounted} {...this.props} />;
-    }
-  }
+    return <Component mounted={mounted} {...props} />;
+  };
 
   return Defer;
 }
-
-export default defer;

--- a/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
+++ b/docs/src/pages/premium-themes/onepirate/modules/views/ProductCTA.js
@@ -58,70 +58,56 @@ const styles = theme => ({
   },
 });
 
-class ProductCTA extends React.Component {
-  state = {
-    open: false,
-  };
+function ProductCTA(props) {
+  const { classes } = props;
+  const [open, setOpen] = React.useState(false);
 
-  handleSubmit = event => {
+  const handleSubmit = event => {
     event.preventDefault();
-    this.setState({
-      open: true,
-    });
+    setOpen(true);
   };
 
-  handleClose = () => {
-    this.setState({
-      open: false,
-    });
+  const handleClose = () => {
+    setOpen(false);
   };
 
-  render() {
-    const { classes } = this.props;
-
-    return (
-      <Container className={classes.root} component="section">
-        <Grid container>
-          <Grid item xs={12} md={6} className={classes.cardWrapper}>
-            <div className={classes.card}>
-              <form onSubmit={this.handleSubmit} className={classes.cardContent}>
-                <Typography variant="h2" component="h2" gutterBottom>
-                  Receive offers
-                </Typography>
-                <Typography variant="h5">
-                  Taste the holidays of the everyday close to home.
-                </Typography>
-                <TextField noBorder className={classes.textField} placeholder="Your email" />
-                <Button
-                  type="submit"
-                  color="primary"
-                  variant="contained"
-                  className={classes.button}
-                >
-                  Keep me updated
-                </Button>
-              </form>
-            </div>
-          </Grid>
-          <Grid item xs={12} md={6} className={classes.imagesWrapper}>
-            <Hidden smDown>
-              <div className={classes.imageDots} />
-              <img
-                src="https://images.unsplash.com/photo-1527853787696-f7be74f2e39a?auto=format&fit=crop&w=750&q=80"
-                alt="call to action"
-                className={classes.image}
-              />
-            </Hidden>
-          </Grid>
+  return (
+    <Container className={classes.root} component="section">
+      <Grid container>
+        <Grid item xs={12} md={6} className={classes.cardWrapper}>
+          <div className={classes.card}>
+            <form onSubmit={handleSubmit} className={classes.cardContent}>
+              <Typography variant="h2" component="h2" gutterBottom>
+                Receive offers
+              </Typography>
+              <Typography variant="h5">
+                Taste the holidays of the everyday close to home.
+              </Typography>
+              <TextField noBorder className={classes.textField} placeholder="Your email" />
+              <Button type="submit" color="primary" variant="contained" className={classes.button}>
+                Keep me updated
+              </Button>
+            </form>
+          </div>
         </Grid>
-        <Snackbar
-          open={this.state.open}
-          onClose={this.handleClose}
-          message="We will send you our best offers, once a week."
-        />
-      </Container>
-    );
-  }
+        <Grid item xs={12} md={6} className={classes.imagesWrapper}>
+          <Hidden smDown>
+            <div className={classes.imageDots} />
+            <img
+              src="https://images.unsplash.com/photo-1527853787696-f7be74f2e39a?auto=format&fit=crop&w=750&q=80"
+              alt="call to action"
+              className={classes.image}
+            />
+          </Hidden>
+        </Grid>
+      </Grid>
+      <Snackbar
+        open={open}
+        onClose={handleClose}
+        message="We will send you our best offers, once a week."
+      />
+    </Container>
+  );
 }
 
 ProductCTA.propTypes = {

--- a/docs/src/pages/premium-themes/paperbase/Header.js
+++ b/docs/src/pages/premium-themes/paperbase/Header.js
@@ -62,7 +62,7 @@ function Header(props) {
             </Hidden>
             <Grid item xs />
             <Grid item>
-              <Typography className={classes.link} component="a" href="#">
+              <Typography className={classes.link} variant="body2" component="a" href="#">
                 Go to docs
               </Typography>
             </Grid>

--- a/docs/src/pages/premium-themes/paperbase/Paperbase.js
+++ b/docs/src/pages/premium-themes/paperbase/Paperbase.js
@@ -9,13 +9,6 @@ import Content from './Content';
 import Header from './Header';
 
 let theme = createMuiTheme({
-  typography: {
-    h5: {
-      fontWeight: 500,
-      fontSize: 26,
-      letterSpacing: 0.5,
-    },
-  },
   palette: {
     primary: {
       light: '#63ccff',
@@ -23,8 +16,25 @@ let theme = createMuiTheme({
       dark: '#006db3',
     },
   },
+  typography: {
+    h5: {
+      fontWeight: 500,
+      fontSize: 26,
+      letterSpacing: 0.5,
+    },
+  },
   shape: {
     borderRadius: 8,
+  },
+  props: {
+    MuiTab: {
+      disableRipple: true,
+    },
+  },
+  mixins: {
+    toolbar: {
+      minHeight: 48,
+    },
   },
 });
 
@@ -106,17 +116,6 @@ theme = {
       },
     },
   },
-  props: {
-    MuiTab: {
-      disableRipple: true,
-    },
-  },
-  mixins: {
-    ...theme.mixins,
-    toolbar: {
-      minHeight: 48,
-    },
-  },
 };
 
 const drawerWidth = 256;
@@ -144,45 +143,40 @@ const styles = {
   },
 };
 
-class Paperbase extends React.Component {
-  state = {
-    mobileOpen: false,
+function Paperbase(props) {
+  const { classes } = props;
+  const [mobileOpen, setMobileOpen] = React.useState(false);
+
+  const handleDrawerToggle = () => {
+    setMobileOpen(!mobileOpen);
   };
 
-  handleDrawerToggle = () => {
-    this.setState(state => ({ mobileOpen: !state.mobileOpen }));
-  };
-
-  render() {
-    const { classes } = this.props;
-
-    return (
-      <ThemeProvider theme={theme}>
-        <div className={classes.root}>
-          <CssBaseline />
-          <nav className={classes.drawer}>
-            <Hidden smUp implementation="js">
-              <Navigator
-                PaperProps={{ style: { width: drawerWidth } }}
-                variant="temporary"
-                open={this.state.mobileOpen}
-                onClose={this.handleDrawerToggle}
-              />
-            </Hidden>
-            <Hidden xsDown implementation="css">
-              <Navigator PaperProps={{ style: { width: drawerWidth } }} />
-            </Hidden>
-          </nav>
-          <div className={classes.appContent}>
-            <Header onDrawerToggle={this.handleDrawerToggle} />
-            <main className={classes.mainContent}>
-              <Content />
-            </main>
-          </div>
+  return (
+    <ThemeProvider theme={theme}>
+      <div className={classes.root}>
+        <CssBaseline />
+        <nav className={classes.drawer}>
+          <Hidden smUp implementation="js">
+            <Navigator
+              PaperProps={{ style: { width: drawerWidth } }}
+              variant="temporary"
+              open={mobileOpen}
+              onClose={handleDrawerToggle}
+            />
+          </Hidden>
+          <Hidden xsDown implementation="css">
+            <Navigator PaperProps={{ style: { width: drawerWidth } }} />
+          </Hidden>
+        </nav>
+        <div className={classes.appContent}>
+          <Header onDrawerToggle={handleDrawerToggle} />
+          <main className={classes.mainContent}>
+            <Content />
+          </main>
         </div>
-      </ThemeProvider>
-    );
-  }
+      </div>
+    </ThemeProvider>
+  );
 }
 
 Paperbase.propTypes = {

--- a/docs/src/pages/styles/api/api.md
+++ b/docs/src/pages/styles/api/api.md
@@ -326,10 +326,8 @@ const styles = {
   },
 };
 
-class MyComponent extends React.Component {
-  render () {
-    return <div className={this.props.classes.root} />;
-  }
+function MyComponent(props) {
+  return <div className={props.classes.root} />;
 }
 
 export default withStyles(styles)(MyComponent);

--- a/docs/src/pages/versions/StableVersions.js
+++ b/docs/src/pages/versions/StableVersions.js
@@ -39,77 +39,73 @@ async function getBranches() {
   return cacheBranches;
 }
 
-class StableVersions extends React.Component {
-  state = {
-    docs: [],
-  };
+function StableVersions(props) {
+  const { classes } = props;
+  const [docs, setDocs] = React.useState([]);
 
-  async componentDidMount() {
-    const branches = await getBranches();
-    let docs = branches.map(n => n.name);
-    docs = docs.filter(value => FILTERED_BRANCHES.indexOf(value) === -1);
-    docs = docs.map(version => ({
-      version,
-      // Replace dot with dashes for Netlify branch subdomains
-      url: `https://${version.replace(/\./g, '-')}.material-ui.com`,
-    }));
-    // Current version.
-    docs.push({
-      version: `v${process.env.LIB_VERSION}`,
-      url: document.location.origin,
-    });
-    // Legacy documentation.
-    docs.push({
-      version: 'v0',
-      url: 'https://v0.material-ui.com',
-    });
-    docs = orderBy(docs, 'version', 'desc');
-    docs = sortedUniqBy(docs, 'version');
-    // The latest version is always using the naked domain.
-    docs[0].url = 'https://material-ui.com';
-    this.setState({ docs });
-  }
+  React.useEffect(() => {
+    (async () => {
+      const branches = await getBranches();
+      let newDocs = branches.map(n => n.name);
+      newDocs = newDocs.filter(value => FILTERED_BRANCHES.indexOf(value) === -1);
+      newDocs = newDocs.map(version => ({
+        version,
+        // Replace dot with dashes for Netlify branch subdomains
+        url: `https://${version.replace(/\./g, '-')}.material-ui.com`,
+      }));
+      // Current version.
+      newDocs.push({
+        version: `v${process.env.LIB_VERSION}`,
+        url: document.location.origin,
+      });
+      // Legacy documentation.
+      newDocs.push({
+        version: 'v0',
+        url: 'https://v0.material-ui.com',
+      });
+      newDocs = orderBy(newDocs, 'version', 'desc');
+      newDocs = sortedUniqBy(newDocs, 'version');
+      // The latest version is always using the naked domain.
+      newDocs[0].url = 'https://material-ui.com';
+      setDocs(newDocs);
+    })();
+  }, []);
 
-  render() {
-    const { classes } = this.props;
-    const { docs } = this.state;
-
-    return (
-      <Paper className={classes.root}>
-        <Table size="small">
-          <TableBody>
-            {docs.map(doc => (
-              <TableRow key={doc.version}>
-                <TableCell>
-                  <Typography variant="body2">
-                    {doc.version}
-                    {doc.version === `v${process.env.LIB_VERSION}` ? ' ✓' : ''}
-                  </Typography>
-                </TableCell>
-                <TableCell>
-                  <Link variant="body2" color="secondary" rel="nofollow" href={doc.url}>
-                    Documentation
+  return (
+    <Paper className={classes.root}>
+      <Table size="small">
+        <TableBody>
+          {docs.map(doc => (
+            <TableRow key={doc.version}>
+              <TableCell>
+                <Typography variant="body2">
+                  {doc.version}
+                  {doc.version === `v${process.env.LIB_VERSION}` ? ' ✓' : ''}
+                </Typography>
+              </TableCell>
+              <TableCell>
+                <Link variant="body2" color="secondary" rel="nofollow" href={doc.url}>
+                  Documentation
+                </Link>
+              </TableCell>
+              <TableCell>
+                {doc.version.length === 6 ? (
+                  <Link
+                    variant="body2"
+                    color="secondary"
+                    rel="nofollow"
+                    href={`${GITHUB_RELEASE_BASE_URL}${doc.version}`}
+                  >
+                    Release notes
                   </Link>
-                </TableCell>
-                <TableCell>
-                  {doc.version.length === 6 ? (
-                    <Link
-                      variant="body2"
-                      color="secondary"
-                      rel="nofollow"
-                      href={`${GITHUB_RELEASE_BASE_URL}${doc.version}`}
-                    >
-                      Release notes
-                    </Link>
-                  ) : null}
-                </TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </Paper>
-    );
-  }
+                ) : null}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
 }
 
 StableVersions.propTypes = {

--- a/packages/material-ui-benchmark/src/core.js
+++ b/packages/material-ui-benchmark/src/core.js
@@ -17,12 +17,8 @@ function NakedButton(props) {
   return <button type="button" {...props} />;
 }
 
-class HocButton extends React.Component {
-  state = {};
-
-  render() {
-    return <NakedButton {...this.props} />;
-  }
+function HocButton(props) {
+  return <NakedButton {...props} />;
 }
 
 suite

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -5,6 +5,7 @@ import { Transition } from 'react-transition-group';
 import withStyles from '../styles/withStyles';
 import { duration } from '../styles/transitions';
 import { getTransitionProps } from '../transitions/utils';
+import useTheme from '../styles/useTheme';
 
 export const styles = theme => ({
   /* Styles applied to the container element. */
@@ -52,10 +53,10 @@ const Collapse = React.forwardRef(function Collapse(props, ref) {
     onExit,
     onExiting,
     style,
-    theme,
     timeout = duration.standard,
     ...other
   } = props;
+  const theme = useTheme();
   const timer = React.useRef();
   const wrapperRef = React.useRef(null);
   const autoTransitionDuration = React.useRef();
@@ -239,10 +240,6 @@ Collapse.propTypes = {
    */
   style: PropTypes.object,
   /**
-   * @ignore
-   */
-  theme: PropTypes.object.isRequired,
-  /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    *
@@ -257,7 +254,4 @@ Collapse.propTypes = {
 
 Collapse.muiSupportAuto = true;
 
-export default withStyles(styles, {
-  withTheme: true,
-  name: 'MuiCollapse',
-})(Collapse);
+export default withStyles(styles, { name: 'MuiCollapse' })(Collapse);

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -4,7 +4,7 @@ import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Collapse from './Collapse';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import { Transition } from 'react-transition-group';
 
 describe('<Collapse />', () => {
@@ -198,19 +198,21 @@ describe('<Collapse />', () => {
     });
 
     it('should delay based on height when timeout is auto', () => {
-      const next = spy();
-
       const theme = createMuiTheme({
         transitions: {
           getAutoHeightDuration: n => n,
         },
       });
 
-      const wrapper = mount(
-        <Collapse timeout="auto" onEntered={next} theme={theme}>
-          <div />
-        </Collapse>,
+      const next1 = spy();
+      const Test = props => (
+        <MuiThemeProvider theme={theme}>
+          <Collapse timeout="auto" onEntered={next1} {...props}>
+            <div />
+          </Collapse>
+        </MuiThemeProvider>
       );
+      const wrapper = mount(<Test />);
 
       // Gets wrapper
       stub(
@@ -227,11 +229,11 @@ describe('<Collapse />', () => {
       });
 
       const autoTransitionDuration = 10;
-      assert.strictEqual(next.callCount, 0);
+      assert.strictEqual(next1.callCount, 0);
       clock.tick(0);
-      assert.strictEqual(next.callCount, 0);
+      assert.strictEqual(next1.callCount, 0);
       clock.tick(autoTransitionDuration);
-      assert.strictEqual(next.callCount, 1);
+      assert.strictEqual(next1.callCount, 1);
 
       const next2 = spy();
       const wrapper2 = mount(
@@ -239,7 +241,6 @@ describe('<Collapse />', () => {
           <div />
         </Collapse>,
       );
-
       wrapper2.setProps({ in: true });
 
       assert.strictEqual(next2.callCount, 0);

--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { withStyles } from '../styles';
+import withStyles from '../styles/withStyles';
 import { capitalize } from '../utils';
 
 export const styles = theme => ({

--- a/packages/material-ui/src/CssBaseline/CssBaseline.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { makeStyles } from '../styles';
+import makeStyles from '../styles/makeStyles';
 import { exactProp } from '@material-ui/utils';
 
 const useStyles = makeStyles(

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -8,6 +8,7 @@ import Slide from '../Slide';
 import Paper from '../Paper';
 import { capitalize } from '../utils/helpers';
 import { duration } from '../styles/transitions';
+import useTheme from '../styles/useTheme';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -114,11 +115,11 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
     open = false,
     PaperProps,
     SlideProps,
-    theme,
     transitionDuration = defaultTransitionDuration,
     variant = 'temporary',
     ...other
   } = props;
+  const theme = useTheme();
 
   // Let's assume that the Drawer will always be rendered on user space.
   // We use this state is order to skip the appear transition during the
@@ -240,10 +241,6 @@ Drawer.propTypes = {
    */
   SlideProps: PropTypes.object,
   /**
-   * @ignore
-   */
-  theme: PropTypes.object.isRequired,
-  /**
    * The duration for the transition, in milliseconds.
    * You may specify a single timeout for all transitions, or individually with an object.
    */
@@ -257,4 +254,4 @@ Drawer.propTypes = {
   variant: PropTypes.oneOf(['permanent', 'persistent', 'temporary']),
 };
 
-export default withStyles(styles, { name: 'MuiDrawer', flip: false, withTheme: true })(Drawer);
+export default withStyles(styles, { name: 'MuiDrawer', flip: false })(Drawer);

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import { assert } from 'chai';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import describeConformance from '../test-utils/describeConformance';
 import Slide from '../Slide';
-import createMuiTheme from '../styles/createMuiTheme';
 import Paper from '../Paper';
 import Modal from '../Modal';
 import Drawer, { getAnchor, isHorizontal } from './Drawer';
@@ -244,19 +244,25 @@ describe('<Drawer />', () => {
       const theme = createMuiTheme({
         direction: 'rtl',
       });
-      const wrapper = mount(
-        <Drawer open theme={theme}>
-          <div />
-        </Drawer>,
+      const wrapper1 = mount(
+        <MuiThemeProvider theme={theme}>
+          <Drawer open anchor="left">
+            <div />
+          </Drawer>
+        </MuiThemeProvider>,
       );
-
-      wrapper.setProps({ anchor: 'left' });
       // slide direction for left is right, if left is switched to right, we should get left
-      assert.strictEqual(wrapper.find(Slide).props().direction, 'left');
+      assert.strictEqual(wrapper1.find(Slide).props().direction, 'left');
 
-      wrapper.setProps({ anchor: 'right' });
+      const wrapper2 = mount(
+        <MuiThemeProvider theme={theme}>
+          <Drawer open anchor="right">
+            <div />
+          </Drawer>
+        </MuiThemeProvider>,
+      );
       // slide direction for right is left, if right is switched to left, we should get right
-      assert.strictEqual(wrapper.find(Slide).props().direction, 'right');
+      assert.strictEqual(wrapper2.find(Slide).props().direction, 'right');
     });
   });
 

--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -13,7 +13,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
-import { keys as breakpointKeys } from '../styles/createBreakpoints';
 import requirePropFactory from '../utils/requirePropFactory';
 
 const SPACINGS = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -193,7 +192,7 @@ export const styles = theme => ({
     justifyContent: 'space-evenly',
   },
   ...generateGutter(theme, 'xs'),
-  ...breakpointKeys.reduce((accumulator, key) => {
+  ...theme.breakpoints.keys.reduce((accumulator, key) => {
     // Use side effect over immutability for better performance.
     generateGrid(accumulator, theme, key);
     return accumulator;

--- a/packages/material-ui/src/Hidden/HiddenCss.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.js
@@ -1,16 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import warning from 'warning';
-import { keys as breakpointKeys } from '../styles/createBreakpoints';
 import { capitalize } from '../utils/helpers';
 import withStyles from '../styles/withStyles';
+import useTheme from '../styles/useTheme';
 
 const styles = theme => {
   const hidden = {
     display: 'none',
   };
 
-  return breakpointKeys.reduce((acc, key) => {
+  return theme.breakpoints.keys.reduce((acc, key) => {
     acc[`only${capitalize(key)}`] = {
       [theme.breakpoints.only(key)]: hidden,
     };
@@ -46,6 +46,7 @@ function HiddenCss(props) {
     xsUp,
     ...other
   } = props;
+  const theme = useTheme();
 
   warning(
     Object.keys(other).length === 0 ||
@@ -59,8 +60,8 @@ function HiddenCss(props) {
     clsx.push(className);
   }
 
-  for (let i = 0; i < breakpointKeys.length; i += 1) {
-    const breakpoint = breakpointKeys[i];
+  for (let i = 0; i < theme.breakpoints.keys.length; i += 1) {
+    const breakpoint = theme.breakpoints.keys[i];
     const breakpointUp = props[`${breakpoint}Up`];
     const breakpointDown = props[`${breakpoint}Down`];
 

--- a/packages/material-ui/src/Hidden/HiddenJs.js
+++ b/packages/material-ui/src/Hidden/HiddenJs.js
@@ -1,13 +1,14 @@
 import PropTypes from 'prop-types';
-import { keys as breakpointKeys } from '../styles/createBreakpoints';
-import withWidth, { isWidthDown, isWidthUp } from '../withWidth';
 import { exactProp } from '@material-ui/utils';
+import withWidth, { isWidthDown, isWidthUp } from '../withWidth';
+import useTheme from '../styles/useTheme';
 
 /**
  * @ignore - internal component.
  */
 function HiddenJs(props) {
   const { children, only, width } = props;
+  const theme = useTheme();
 
   let visible = true;
 
@@ -29,8 +30,8 @@ function HiddenJs(props) {
   // Allow `only` to be combined with other props. If already hidden, no need to check others.
   if (visible) {
     // determine visibility based on the smallest size up
-    for (let i = 0; i < breakpointKeys.length; i += 1) {
-      const breakpoint = breakpointKeys[i];
+    for (let i = 0; i < theme.breakpoints.keys.length; i += 1) {
+      const breakpoint = theme.breakpoints.keys[i];
       const breakpointUp = props[`${breakpoint}Up`];
       const breakpointDown = props[`${breakpoint}Down`];
       if (

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import warning from 'warning';
 import withStyles from '../styles/withStyles';
 import { lighten } from '../styles/colorManipulator';
+import useTheme from '../styles/useTheme';
 
 const TRANSITION_DURATION = 4; // seconds
 
@@ -166,12 +167,12 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
     classes,
     className: classNameProp,
     color = 'primary',
-    theme,
     value,
     valueBuffer,
     variant = 'indeterminate',
     ...other
   } = props;
+  const theme = useTheme();
 
   const className = clsx(
     classes.root,
@@ -265,10 +266,6 @@ LinearProgress.propTypes = {
    */
   color: PropTypes.oneOf(['primary', 'secondary']),
   /**
-   * @ignore
-   */
-  theme: PropTypes.object,
-  /**
    * The value of the progress indicator for the determinate and buffer variants.
    * Value between 0 and 100.
    */
@@ -285,4 +282,4 @@ LinearProgress.propTypes = {
   variant: PropTypes.oneOf(['determinate', 'indeterminate', 'buffer', 'query']),
 };
 
-export default withStyles(styles, { name: 'MuiLinearProgress', withTheme: true })(LinearProgress);
+export default withStyles(styles, { name: 'MuiLinearProgress' })(LinearProgress);

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -7,6 +7,7 @@ import MenuList from '../MenuList';
 import warning from 'warning';
 import ReactDOM from 'react-dom';
 import { setRef } from '../utils/reactHelpers';
+import useTheme from '../styles/useTheme';
 
 const RTL_ORIGIN = {
   vertical: 'top',
@@ -47,11 +48,11 @@ const Menu = React.forwardRef(function Menu(props, ref) {
     open,
     PaperProps = {},
     PopoverClasses,
-    theme,
     transitionDuration = 'auto',
     variant = 'selectedMenu',
     ...other
   } = props;
+  const theme = useTheme();
 
   const autoFocus = (autoFocusProp !== undefined ? autoFocusProp : !disableAutoFocusItem) && open;
 
@@ -239,10 +240,6 @@ Menu.propTypes = {
    */
   PopoverClasses: PropTypes.object,
   /**
-   * @ignore
-   */
-  theme: PropTypes.object.isRequired,
-  /**
    * The length of the transition in `ms`, or 'auto'
    */
   transitionDuration: PropTypes.oneOfType([
@@ -257,4 +254,4 @@ Menu.propTypes = {
   variant: PropTypes.oneOf(['menu', 'selectedMenu']),
 };
 
-export default withStyles(styles, { name: 'MuiMenu', withTheme: true })(Menu);
+export default withStyles(styles, { name: 'MuiMenu' })(Menu);

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
-import { withStyles } from '../styles';
+import withStyles from '../styles/withStyles';
+import useTheme from '../styles/useTheme';
 import { capitalize } from '../utils/helpers';
 
 export const styles = theme => {
@@ -51,10 +52,9 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
     labelWidth: labelWidthProp,
     notched,
     style,
-    theme,
     ...other
   } = props;
-
+  const theme = useTheme();
   const align = theme.direction === 'rtl' ? 'right' : 'left';
   const labelWidth = labelWidthProp > 0 ? labelWidthProp * 0.75 + 8 : 0;
 
@@ -112,12 +112,6 @@ NotchedOutline.propTypes = {
    * @ignore
    */
   style: PropTypes.object,
-  /**
-   * @ignore
-   */
-  theme: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'PrivateNotchedOutline', withTheme: true })(
-  NotchedOutline,
-);
+export default withStyles(styles, { name: 'PrivateNotchedOutline' })(NotchedOutline);

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
@@ -1,34 +1,29 @@
 import React from 'react';
-import { assert } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { expect } from 'chai';
+import { getClasses } from '@material-ui/core/test-utils';
+import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import NotchedOutline from './NotchedOutline';
 
 describe('<NotchedOutline />', () => {
-  let shallow;
+  const render = createClientRender({ strict: true });
+
   let classes;
-  const theme = {
-    direction: 'ltr',
-  };
   const defaultProps = {
     labelWidth: 36,
     notched: true,
   };
 
   before(() => {
-    shallow = createShallow({ dive: true });
     classes = getClasses(<NotchedOutline {...defaultProps} />);
   });
 
-  it('should be a fieldset', () => {
-    const wrapper = shallow(<NotchedOutline {...defaultProps} />);
-    assert.strictEqual(wrapper.name(), 'fieldset');
-    assert.strictEqual(wrapper.props()['aria-hidden'], true);
-    assert.strictEqual(wrapper.children().length, 1);
-    assert.strictEqual(wrapper.childAt(0).name(), 'legend');
+  after(() => {
+    cleanup();
   });
 
   it('should pass props', () => {
-    const wrapper = shallow(
+    const { container } = render(
       <NotchedOutline
         {...defaultProps}
         className="notched-outline"
@@ -38,28 +33,34 @@ describe('<NotchedOutline />', () => {
       />,
     );
 
-    // Ensure that these overrides are properly spread
-    assert.notStrictEqual(wrapper.props().style, 17);
-    assert.strictEqual(wrapper.hasClass('notched-outline'), true);
-    const legend = wrapper.find('legend');
-    assert.strictEqual(legend.hasClass(classes.legend), true);
+    expect(container.querySelector('fieldset')).to.have.class('notched-outline');
+    expect(container.querySelector('fieldset').style.width).to.equal('17px');
+    expect(container.querySelector('legend')).to.have.class(classes.legend);
   });
 
   it('should set alignment rtl', () => {
-    const wrapper1 = shallow(<NotchedOutline {...defaultProps} theme={theme} />);
-    assert.deepEqual(wrapper1.props().style, { paddingLeft: 8 });
-    assert.deepEqual(wrapper1.childAt(0).props().style, { width: 35 });
-
-    const wrapper2 = shallow(
-      <NotchedOutline
-        {...defaultProps}
-        theme={{
-          ...theme,
-          direction: 'rtl',
-        }}
-      />,
+    const { container: container1 } = render(
+      <MuiThemeProvider
+        theme={createMuiTheme({
+          direction: 'ltr',
+        })}
+      >
+        <NotchedOutline {...defaultProps} />
+      </MuiThemeProvider>,
     );
-    assert.deepEqual(wrapper2.props().style, { paddingRight: 8 });
-    assert.deepEqual(wrapper2.childAt(0).props().style, { width: 35 });
+    expect(container1.querySelector('fieldset').style.paddingLeft).to.equal('8px');
+    expect(container1.querySelector('legend').style.width).to.equal('35px');
+
+    const { container: container2 } = render(
+      <MuiThemeProvider
+        theme={createMuiTheme({
+          direction: 'rtl',
+        })}
+      >
+        <NotchedOutline {...defaultProps} />
+      </MuiThemeProvider>,
+    );
+    expect(container2.querySelector('fieldset').style.paddingRight).to.equal('8px');
+    expect(container2.querySelector('legend').style.width).to.equal('35px');
   });
 });

--- a/packages/material-ui/src/RootRef/RootRef.js
+++ b/packages/material-ui/src/RootRef/RootRef.js
@@ -21,23 +21,18 @@ import { setRef } from '../utils/reactHelpers';
  * import React from 'react';
  * import RootRef from '@material-ui/core/RootRef';
  *
- * class MyComponent extends React.Component {
- *   constructor() {
- *     super();
- *     this.domRef = React.createRef();
- *   }
+ * function MyComponent() {
+ *   const domRef = React.useRef();
  *
- *   componentDidMount() {
- *     console.log(this.domRef.current); // DOM node
- *   }
+ *   React.useEffect(() => {
+ *     console.log(domRef.current); // DOM node
+ *   }, []);
  *
- *   render() {
- *     return (
- *       <RootRef rootRef={this.domRef}>
- *         <SomeChildComponent />
- *       </RootRef>
- *     );
- *   }
+ *   return (
+ *     <RootRef rootRef={domRef}>
+ *       <SomeChildComponent />
+ *     </RootRef>
+ *   );
  * }
  * ```
  */

--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -13,6 +13,7 @@ import withStyles from '../styles/withStyles';
 import TabIndicator from './TabIndicator';
 import TabScrollButton from './TabScrollButton';
 import useEventCallback from '../utils/useEventCallback';
+import useTheme from '../styles/useTheme';
 
 export const styles = theme => ({
   /* Styles applied to the root element. */
@@ -86,11 +87,11 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
     scrollButtons = 'auto',
     TabIndicatorProps = {},
     textColor = 'inherit',
-    theme,
     value,
     variant = 'standard',
     ...other
   } = props;
+  const theme = useTheme();
   const scrollable = variant === 'scrollable';
   const isRtl = theme.direction === 'rtl';
   const vertical = orientation === 'vertical';
@@ -511,10 +512,6 @@ Tabs.propTypes = {
    */
   textColor: PropTypes.oneOf(['secondary', 'primary', 'inherit']),
   /**
-   * @ignore
-   */
-  theme: PropTypes.object.isRequired,
-  /**
    * The value of the currently selected `Tab`.
    * If you don't want any selected `Tab`, you can set this property to `false`.
    */
@@ -531,4 +528,4 @@ Tabs.propTypes = {
   variant: PropTypes.oneOf(['standard', 'scrollable', 'fullWidth']),
 };
 
-export default withStyles(styles, { name: 'MuiTabs', withTheme: true })(Tabs);
+export default withStyles(styles, { name: 'MuiTabs' })(Tabs);

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -11,6 +11,7 @@ import Grow from '../Grow';
 import Popper from '../Popper';
 import { useForkRef } from '../utils/reactHelpers';
 import { useIsFocusVisible } from '../utils/focusVisible';
+import useTheme from '../styles/useTheme';
 
 export const styles = theme => ({
   /* Styles applied to the Popper component. */
@@ -98,12 +99,12 @@ function Tooltip(props) {
     open: openProp,
     placement = 'bottom',
     PopperProps,
-    theme,
     title,
     TransitionComponent = Grow,
     TransitionProps,
     ...other
   } = props;
+  const theme = useTheme();
 
   const [openState, setOpenState] = React.useState(false);
   const [, forceUpdate] = React.useState(0);
@@ -491,10 +492,6 @@ Tooltip.propTypes = {
    */
   PopperProps: PropTypes.object,
   /**
-   * @ignore
-   */
-  theme: PropTypes.object.isRequired,
-  /**
    * Tooltip title. Zero-length titles string are never displayed.
    */
   title: PropTypes.node.isRequired,
@@ -508,4 +505,4 @@ Tooltip.propTypes = {
   TransitionProps: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'MuiTooltip', withTheme: true })(Tooltip);
+export default withStyles(styles, { name: 'MuiTooltip' })(Tooltip);

--- a/packages/material-ui/src/Typography/Typography.js
+++ b/packages/material-ui/src/Typography/Typography.js
@@ -130,7 +130,6 @@ const Typography = React.forwardRef(function Typography(props, ref) {
     gutterBottom = false,
     noWrap = false,
     paragraph = false,
-    theme,
     variant = 'body1',
     variantMapping = defaultVariantMapping,
     ...other
@@ -215,10 +214,6 @@ Typography.propTypes = {
    */
   paragraph: PropTypes.bool,
   /**
-   * @ignore
-   */
-  theme: PropTypes.object.isRequired,
-  /**
    * Applies the theme typography styles.
    */
   variant: PropTypes.oneOf([
@@ -247,4 +242,4 @@ Typography.propTypes = {
   variantMapping: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'MuiTypography', withTheme: true })(Typography);
+export default withStyles(styles, { name: 'MuiTypography' })(Typography);

--- a/test/regressions/tests/Input/Inputs.js
+++ b/test/regressions/tests/Input/Inputs.js
@@ -18,33 +18,26 @@ const styles = {
   },
 };
 
-class Inputs extends React.Component {
-  componentDidMount() {
-    this.focusInput.focus();
-  }
+function Inputs(props) {
+  const { classes } = props;
+  const inputRef = React.useRef();
 
-  render() {
-    const { classes } = this.props;
+  React.useEffect(() => {
+    inputRef.current.focus();
+  }, []);
 
-    return (
-      <div>
-        <div className={classes.container}>
-          <Input value="Hello world" className={classes.input} />
-          <Input placeholder="Placeholder" className={classes.input} />
-          <Input value="Disabled" className={classes.input} disabled />
-          <Input error value="Error" className={classes.input} />
-          <Input
-            value="Focused"
-            inputRef={node => {
-              this.focusInput = node;
-            }}
-            className={classes.input}
-          />
-        </div>
-        <Input value="Large input" className={clsx(classes.input, classes.large)} />
+  return (
+    <div>
+      <div className={classes.container}>
+        <Input value="Hello world" className={classes.input} />
+        <Input placeholder="Placeholder" className={classes.input} />
+        <Input value="Disabled" className={classes.input} disabled />
+        <Input error value="Error" className={classes.input} />
+        <Input value="Focused" inputRef={inputRef} className={classes.input} />
       </div>
-    );
-  }
+      <Input value="Large input" className={clsx(classes.input, classes.large)} />
+    </div>
+  );
 }
 
 Inputs.propTypes = {


### PR DESCRIPTION
Not important internal refactorization.
- Replace as many usages of `React.Component` as possible. I doubt React will remove the API before 2-3 years, if they ever do. However, better be 100% on the hooks, when possible.
- Replace all the usage of the `withTheme` option. By using useTheme, we ease the future integration with styled-components, emotions, react-jss, linaria. I had to update a few tests that were relying on the internal theme prop, better use the public API in the tests :).
- Replace static imports of breakpoint keys. It's a small step toward supporting dynamic breakpoints names.