### PR TITLE
[Rating] Add Custom prop-type to prop name

### DIFF
--- a/docs/pages/api/rating.md
+++ b/docs/pages/api/rating.md
@@ -31,7 +31,7 @@ You can learn more about the difference by [reading our guide](/guides/minimizin
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> | <span class="prop-default">&lt;Star fontSize="inherit" /></span> | The icon to display. |
 | <span class="prop-name">IconContainerComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">function IconContainer(props) {  const { value, ...other } = props;  return &lt;div {...other} />;}</span> | The component containing the icon. |
 | <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | Maximum rating. |
-| <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | Name attribute of the radio `input` elements. |
+| <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | The name attribute of the radio `input` elements. If `readOnly` is false, the prop is required, this input name`should be unique within the parent form. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value changes.<br><br>**Signature:**<br>`function(event: object, value: number) => void`<br>*event:* The event source of the callback<br>*value:* The new value |
 | <span class="prop-name">onChangeActive</span> | <span class="prop-type">func</span> |  | Callback function that is fired when the hover state changes.<br><br>**Signature:**<br>`function(event: object, value: any) => void`<br>*event:* The event source of the callback<br>*value:* The new value |
 | <span class="prop-name">precision</span> | <span class="prop-type">number</span> | <span class="prop-default">1</span> | The minimum increment value change allowed. |

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -455,12 +455,14 @@ Rating.propTypes = {
     }
     return null;
   }),
-  /**
+
+  /** name
    * Callback fired when the value changes.
    *
    * @param {object} event The event source of the callback
    * @param {number} value The new value
    */
+
   onChange: PropTypes.func,
   /**
    * Callback function that is fired when the hover state changes.

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -440,29 +440,27 @@ Rating.propTypes = {
    */
   max: PropTypes.number,
   /**
-   * Name attribute of the radio `input` elements.
-   * When `readOnly` is false the prop is required
-   * The name value should be unique.
+   * The name attribute of the radio `input` elements.
+   * If `readOnly` is false, the prop is required,
+   * this input name`should be unique within the parent form.
    */
   name: chainPropTypes(PropTypes.string, props => {
     if (!props.readOnly && !props.name) {
       return new Error(
         [
-          'Material-UI: When `readOnly` is false the prop `name` is required.',
-          'Also check if the name value is unique.',
+          'Material-UI: the prop `name` is required (when `readOnly` is false).',
+          'Additionally, the input name should be unique within the parent form.',
         ].join('\n'),
       );
     }
     return null;
   }),
-
-  /** name
+  /**
    * Callback fired when the value changes.
    *
    * @param {object} event The event source of the callback
    * @param {number} value The new value
    */
-
   onChange: PropTypes.func,
   /**
    * Callback function that is fired when the hover state changes.

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
+import { chainPropTypes } from '@material-ui/utils';
 import { useTheme, withStyles } from '@material-ui/core/styles';
 import { capitalize, useForkRef, ownerWindow, useIsFocusVisible } from '@material-ui/core/utils';
 import Star from '../internal/svg-icons/Star';
@@ -440,8 +441,20 @@ Rating.propTypes = {
   max: PropTypes.number,
   /**
    * Name attribute of the radio `input` elements.
+   * When `readOnly` is false the prop is required
+   * The name value should be unique.
    */
-  name: PropTypes.string,
+  name: chainPropTypes(PropTypes.string, props => {
+    if (!props.readOnly && !props.name) {
+      return new Error(
+        [
+          'Material-UI: When `readOnly` is false the prop `name` is required.',
+          'Also check if the name value is unique.',
+        ].join('\n'),
+      );
+    }
+    return null;
+  }),
   /**
    * Callback fired when the value changes.
    *

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -739,7 +739,6 @@ Slider.propTypes = {
 
     return null;
   }),
-
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #17075

Add a custom prop-type on prop `name` to avoid erros when `readOnly`is false 
