### PR TITLE
[slider] Avoid mutating user's value prop

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -313,7 +313,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const valueDerived = isControlled ? valueProp : valueState;
   const range = Array.isArray(valueDerived);
   const instanceRef = React.useRef();
-  let values = range ? valueDerived.sort(asc) : [valueDerived];
+  let values = range ? [...valueDerived].sort(asc) : [valueDerived];
   values = values.map(value => clamp(value, min, max));
   const marks =
     marksProp === true && step !== null


### PR DESCRIPTION
Spread array before applying `sort` to avoid mutating user's value props

Closes #17082