### PR TITLE
[docs] Improve enhanced table variable name

### DIFF
--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -64,7 +64,7 @@ function getSorting(order, orderBy) {
   return order === 'desc' ? (a, b) => desc(a, b, orderBy) : (a, b) => -desc(a, b, orderBy);
 }
 
-const headItems = [
+const headCells = [
   { id: 'name', numeric: false, disablePadding: true, label: 'Dessert (100g serving)' },
   { id: 'calories', numeric: true, disablePadding: false, label: 'Calories' },
   { id: 'fat', numeric: true, disablePadding: false, label: 'Fat (g)' },
@@ -89,20 +89,20 @@ function EnhancedTableHead(props) {
             inputProps={{ 'aria-label': 'select all desserts' }}
           />
         </TableCell>
-        {headItems.map(headItem => (
+        {headCells.map(headCell => (
           <TableCell
-            key={headItem.id}
-            align={headItem.numeric ? 'right' : 'left'}
-            padding={headItem.disablePadding ? 'none' : 'default'}
-            sortDirection={orderBy === headItems.id ? order : false}
+            key={headCell.id}
+            align={headCell.numeric ? 'right' : 'left'}
+            padding={headCell.disablePadding ? 'none' : 'default'}
+            sortDirection={orderBy === headCells.id ? order : false}
           >
             <TableSortLabel
-              active={orderBy === headItems.id}
+              active={orderBy === headCells.id}
               direction={order}
-              onClick={createSortHandler(headItems.id)}
+              onClick={createSortHandler(headCells.id)}
             >
-              {headItems.label}
-              {orderBy === headItems.id ? (
+              {headCells.label}
+              {orderBy === headCells.id ? (
                 <span className={classes.visuallyHidden}>
                   {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
                 </span>

--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -94,15 +94,15 @@ function EnhancedTableHead(props) {
             key={headCell.id}
             align={headCell.numeric ? 'right' : 'left'}
             padding={headCell.disablePadding ? 'none' : 'default'}
-            sortDirection={orderBy === headCells.id ? order : false}
+            sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel
-              active={orderBy === headCells.id}
+              active={orderBy === headCell.id}
               direction={order}
-              onClick={createSortHandler(headCells.id)}
+              onClick={createSortHandler(headCell.id)}
             >
-              {headCells.label}
-              {orderBy === headCells.id ? (
+              {headCell.label}
+              {orderBy === headCell.id ? (
                 <span className={classes.visuallyHidden}>
                   {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
                 </span>

--- a/docs/src/pages/components/tables/EnhancedTable.js
+++ b/docs/src/pages/components/tables/EnhancedTable.js
@@ -64,7 +64,7 @@ function getSorting(order, orderBy) {
   return order === 'desc' ? (a, b) => desc(a, b, orderBy) : (a, b) => -desc(a, b, orderBy);
 }
 
-const headRows = [
+const headItems = [
   { id: 'name', numeric: false, disablePadding: true, label: 'Dessert (100g serving)' },
   { id: 'calories', numeric: true, disablePadding: false, label: 'Calories' },
   { id: 'fat', numeric: true, disablePadding: false, label: 'Fat (g)' },
@@ -89,20 +89,20 @@ function EnhancedTableHead(props) {
             inputProps={{ 'aria-label': 'select all desserts' }}
           />
         </TableCell>
-        {headRows.map(row => (
+        {headItems.map(headItem => (
           <TableCell
-            key={row.id}
-            align={row.numeric ? 'right' : 'left'}
-            padding={row.disablePadding ? 'none' : 'default'}
-            sortDirection={orderBy === row.id ? order : false}
+            key={headItem.id}
+            align={headItem.numeric ? 'right' : 'left'}
+            padding={headItem.disablePadding ? 'none' : 'default'}
+            sortDirection={orderBy === headItems.id ? order : false}
           >
             <TableSortLabel
-              active={orderBy === row.id}
+              active={orderBy === headItems.id}
               direction={order}
-              onClick={createSortHandler(row.id)}
+              onClick={createSortHandler(headItems.id)}
             >
-              {row.label}
-              {orderBy === row.id ? (
+              {headItems.label}
+              {orderBy === headItems.id ? (
                 <span className={classes.visuallyHidden}>
                   {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
                 </span>

--- a/docs/src/pages/components/tables/EnhancedTable.tsx
+++ b/docs/src/pages/components/tables/EnhancedTable.tsx
@@ -82,14 +82,14 @@ function getSorting<K extends keyof any>(
   return order === 'desc' ? (a, b) => desc(a, b, orderBy) : (a, b) => -desc(a, b, orderBy);
 }
 
-interface HeadRow {
+interface headCell {
   disablePadding: boolean;
   id: keyof Data;
   label: string;
   numeric: boolean;
 }
 
-const headRows: HeadRow[] = [
+const headCells: headCell[] = [
   { id: 'name', numeric: false, disablePadding: true, label: 'Dessert (100g serving)' },
   { id: 'calories', numeric: true, disablePadding: false, label: 'Calories' },
   { id: 'fat', numeric: true, disablePadding: false, label: 'Fat (g)' },
@@ -124,20 +124,20 @@ function EnhancedTableHead(props: EnhancedTableProps) {
             inputProps={{ 'aria-label': 'select all desserts' }}
           />
         </TableCell>
-        {headRows.map(row => (
+        {headCells.map(headCell => (
           <TableCell
-            key={row.id}
-            align={row.numeric ? 'right' : 'left'}
-            padding={row.disablePadding ? 'none' : 'default'}
-            sortDirection={orderBy === row.id ? order : false}
+            key={headCell.id}
+            align={headCell.numeric ? 'right' : 'left'}
+            padding={headCell.disablePadding ? 'none' : 'default'}
+            sortDirection={orderBy === headCell.id ? order : false}
           >
             <TableSortLabel
-              active={orderBy === row.id}
+              active={orderBy === headCell.id}
               direction={order}
-              onClick={createSortHandler(row.id)}
+              onClick={createSortHandler(headCell.id)}
             >
-              {row.label}
-              {orderBy === row.id ? (
+              {headCell.label}
+              {orderBy === headCell.id ? (
                 <span className={classes.visuallyHidden}>
                   {order === 'desc' ? 'sorted descending' : 'sorted ascending'}
                 </span>


### PR DESCRIPTION
When I was looking at the demo for EnhancedTable, I thought it was a little confusing to use the name "rows" while the header does not have more than one row. I changed the name to headItems but I think headColumns or so works fine too. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
