### PR TITLE
[core] Fix missing type peer deps

### DIFF
--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -33,8 +33,14 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.0.1",
+    "@types/react": "^16.8.6",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -39,8 +39,14 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.0.0",
+    "@types/react": "^16.8.6",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4"

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -35,8 +35,14 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.7.0",
+    "@types/react": "^16.8.6",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -38,8 +38,14 @@
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
+    "@types/react": "^16.8.6",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -38,8 +38,14 @@
     "typescript": "tslint -p tsconfig.json \"src/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
+    "@types/react": "^16.8.6",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",

--- a/packages/material-ui-types/package.json
+++ b/packages/material-ui-types/package.json
@@ -34,7 +34,12 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@types/react": "*"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   }
 }

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -37,8 +37,14 @@
     "typescript": "tslint -p tsconfig.json \"{src,test}/**/*.{ts,tsx}\" && tsc -p tsconfig.test.json"
   },
   "peerDependencies": {
+    "@types/react": "^16.8.6",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@babel/runtime": "^7.4.4",


### PR DESCRIPTION
Only merge if either node 8 has reached end of life (end of 2019) or npm was bumped in node 8 to 6.11

Closes #17121

[`peerDependenciesMeta`](https://github.com/yarnpkg/rfcs/blob/master/accepted/0000-optional-peer-dependencies.md) is implemented in `yarn@1.13`, `npm@6.11` and `pnpm@?`.

Rule of thumb: If a type package has side effects it is a peer that has to be installed at app level. Otherwise you get type mismatches if different versions are installed. A side-effect is module augmentation which is most often used to make a type globally available (in react this happens by adding the JSX namespace). Packages without side-effects are usually safe to list as direct dependencies since multiple versions don't necessarily create clashes (here `@types/react-transition-group`).