### PR TITLE
[icons] Update script to use latest json file

### DIFF
--- a/packages/material-ui-icons/scripts/download.js
+++ b/packages/material-ui-icons/scripts/download.js
@@ -1,34 +1,38 @@
 /* eslint-disable no-console */
 
-import fse from 'fs-extra';
-import path from 'path';
-import yargs from 'yargs';
-import Queue from 'modules/waterfall/Queue';
-import sleep from 'modules/waterfall/sleep';
-import retry from 'modules/waterfall/retry';
-import 'isomorphic-fetch';
+import fse from "fs-extra";
+import path from "path";
+import yargs from "yargs";
+import Queue from "modules/waterfall/Queue";
+import sleep from "modules/waterfall/sleep";
+import retry from "modules/waterfall/retry";
+import "isomorphic-fetch";
 
 const themeMap = {
-  baseline: '', // filled
-  outline: '_outlined',
-  round: '_rounded',
-  twotone: '_two_tone',
-  sharp: '_sharp',
+  baseline: "", // filled
+  outline: "outlined",
+  round: "round",
+  twotone: "twotone",
+  sharp: "sharp"
+};
+
+const themeFileNameMap = {
+  baseline: "", // filled
+  outline: "Outlined",
+  round: "Rounded",
+  twotone: "TwoTone",
+  sharp: "Sharp"
 };
 
 function downloadIcon(icon) {
-  console.log(`downloadIcon ${icon.index}: ${icon.id}`);
+  const { name } = icon;
+  console.log(`downloadIcon ${icon.index}: ${name}`);
 
   return Promise.all(
     Object.keys(themeMap).map(async theme => {
-      let endUrl;
-      if (icon.imageUrls && icon.imageUrls[theme]) {
-        endUrl = icon.imageUrls[theme];
-      } else {
-        endUrl = `${theme}-${icon.id}-24px.svg`;
-      }
-      const size = endUrl.match(/^.*-([0-9]+)px.svg$/)[1];
-      const response = await fetch(`https://material.io/tools/icons/static/icons/${endUrl}`);
+      const response = await fetch(
+        `https://fonts.gstatic.com/s/i/materialicons${themeMap[theme]}/${name}/v1/24px.svg`
+      );
       if (response.status !== 200) {
         throw new Error(`status ${response.status}`);
       }
@@ -36,24 +40,25 @@ function downloadIcon(icon) {
       await fse.writeFile(
         path.join(
           __dirname,
-          `../material-io-tools-icons/ic_${icon.id}${themeMap[theme]}_${size}px.svg`,
+          `../material-io-tools-icons/ic_${icon.name}${themeFileNameMap[theme]}_24px.svg`
         ),
-        SVG,
+        SVG
       );
-    }),
+    })
   );
 }
 
 async function run() {
   try {
     const argv = yargs
-      .usage('Download the SVG from material.io/tools/icons')
-      .describe('start-after', 'Resume at the following index').argv;
-    console.log('run', argv);
-    await fse.ensureDir(path.join(__dirname, '../material-io-tools-icons'));
-    const response = await fetch('https://material.io/tools/icons/static/data.json');
-    const data = await response.json();
-    let icons = data.categories.reduce((acc, item) => acc.concat(item.icons), []);
+      .usage("Download the SVG from material.io/tools/icons")
+      .describe("start-after", "Resume at the following index").argv;
+    console.log("run", argv);
+    await fse.ensureDir(path.join(__dirname, "../material-io-tools-icons"));
+    const response = await fetch("https://fonts.google.com/metadata/icons");
+    const text = await response.text();
+    const data = await JSON.parse(text.replace(")]}'", ""));
+    let icons = data.icons;
     icons = icons.map((icon, index) => ({ index, ...icon }));
     icons = icons.splice(argv.startAfter || 0);
     console.log(`${icons.length} icons to download`);
@@ -65,12 +70,12 @@ async function run() {
           await downloadIcon(icon);
         });
       },
-      { concurrency: 5 },
+      { concurrency: 5 }
     );
     queue.push(icons);
     await queue.wait({ empty: true });
   } catch (err) {
-    console.log('err', err);
+    console.log("err", err);
     throw err;
   }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

The data referenced in the download script is outdated and no longer maintained. This PR updates the script with the latest url path and data structure.

Current: https://material.io/resources/icons/static/data.json
Latest: https://fonts.google.com/metadata/icons

As referenced at https://github.com/mui-org/material-ui/issues/12251#issuecomment-526876455