### PR TITLE
[ToggleButton] Update TypeScript class keys

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -13,6 +13,12 @@ declare const ToggleButton: ExtendButtonBase<{
 
 export type ToggleButtonProps = SimplifiedPropsOf<typeof ToggleButton>;
 
-export type ToggleButtonClassKey = ButtonBaseClassKey | 'label' | 'selected';
+export type ToggleButtonClassKey =
+  | 'root'
+  | 'disabled'
+  | 'selected'
+  | 'label'
+  | 'sizeSmall'
+  | 'sizeLarge';
 
 export default ToggleButton;

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -16,7 +16,11 @@ export interface ToggleButtonGroupProps
   value?: any;
 }
 
-export type ToggleButtonGroupClassKey = 'root' | 'grouped' | 'groupedSizeSmall' | 'groupedSizeLarge';
+export type ToggleButtonGroupClassKey =
+  | 'root'
+  | 'grouped'
+  | 'groupedSizeSmall'
+  | 'groupedSizeLarge';
 
 declare const ToggleButtonGroup: React.ComponentType<ToggleButtonGroupProps>;
 

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -16,7 +16,7 @@ export interface ToggleButtonGroupProps
   value?: any;
 }
 
-export type ToggleButtonGroupClassKey = 'root' | 'selected';
+export type ToggleButtonGroupClassKey = 'root' | 'grouped' | 'groupedSizeSmall' | 'groupedSizeLarge';
 
 declare const ToggleButtonGroup: React.ComponentType<ToggleButtonGroupProps>;
 


### PR DESCRIPTION
Some classes were added to `ToggleButtonGroup` recently (#17187); this PR updates the typescript class key definitions accordingly.

Also removed `selected` class key as it looks like it isn't used anymore.