### PR TITLE
[core] Add ref type to every component

### DIFF
--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.d.ts
@@ -7,9 +7,7 @@ import { TransitionHandlerProps } from '@material-ui/core/transitions';
 export interface SpeedDialProps
   extends StandardProps<
     React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>,
-    SpeedDialClassKey,
-    never,
-    false
+    SpeedDialClassKey
   > {
   ariaLabel: string;
   ButtonProps?: Partial<ButtonProps>;

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.d.ts
@@ -4,7 +4,7 @@ import { ButtonProps } from '@material-ui/core/Button';
 import { TooltipProps } from '@material-ui/core/Tooltip';
 
 export interface SpeedDialActionProps
-  extends StandardProps<Partial<TooltipProps>, SpeedDialActionClassKey, never, false> {
+  extends StandardProps<Partial<TooltipProps>, SpeedDialActionClassKey> {
   ButtonProps?: Partial<ButtonProps>;
   delay?: number;
   icon: React.ReactNode;

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.d.ts
@@ -2,12 +2,7 @@ import * as React from 'react';
 import { StandardProps } from '@material-ui/core';
 
 export interface SpeedDialIconProps
-  extends StandardProps<
-    React.HTMLAttributes<HTMLSpanElement>,
-    SpeedDialIconClassKey,
-    never,
-    false
-  > {
+  extends StandardProps<React.HTMLAttributes<HTMLSpanElement>, SpeedDialIconClassKey> {
   icon?: React.ReactNode;
   openIcon?: React.ReactNode;
 }

--- a/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/ToggleButtonGroup.d.ts
@@ -6,8 +6,7 @@ export interface ToggleButtonGroupProps
   extends StandardProps<
     React.HTMLAttributes<HTMLDivElement>,
     ToggleButtonGroupClassKey,
-    'onChange',
-    false
+    'onChange'
   > {
   selected?: boolean;
   exclusive?: boolean;

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
@@ -1,7 +1,6 @@
 import { StandardProps } from '..';
 
-export interface ListItemAvatarProps
-  extends StandardProps<{}, ListItemAvatarClassKey, never, false> {}
+export interface ListItemAvatarProps extends StandardProps<{}, ListItemAvatarClassKey> {}
 
 export type ListItemAvatarClassKey = 'root' | 'icon';
 

--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -4,7 +4,7 @@ import { TransitionProps } from '../transitions/transition';
 import { PopperProps } from '../Popper/Popper';
 
 export interface TooltipProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title', false> {
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, TooltipClassKey, 'title'> {
   children: React.ReactElement;
   disableFocusListener?: boolean;
   disableHoverListener?: boolean;

--- a/packages/material-ui/src/index.d.ts
+++ b/packages/material-ui/src/index.d.ts
@@ -14,21 +14,14 @@ export { Omit };
  * certain `classes`, on which one can also set a top-level `className` and inline
  * `style`.
  */
-export type StandardProps<
+export type StandardProps<C, ClassKey extends string, Removals extends keyof C = never> = Omit<
   C,
-  ClassKey extends string,
-  Removals extends keyof C = never,
-  AcceptsRef = true
-> = Omit<C, 'classes' | Removals> &
+  'classes' | Removals
+> &
   StyledComponentProps<ClassKey> & {
     className?: string;
+    ref?: C extends { ref?: infer RefType } ? RefType : React.Ref<unknown>;
     style?: React.CSSProperties;
-  } & {
-    ref?: AcceptsRef extends true
-      ? C extends { ref?: infer RefType }
-        ? RefType
-        : React.Ref<unknown>
-      : never;
   };
 
 export type PaletteType = 'light' | 'dark';


### PR DESCRIPTION
Adds `ref` type to 
* `ListItemAvatar`
* `Tooltop`
* `SpeedDial`
* `SpeedDialAction`
* `ToggleButtonGroup`


Removing `AcceptRef` parameter in `StandardProps` refs are now forwarded in every component so we no longer need it. Gets rid of one conditional in an attempt to isolate #17275