### PR TITLE
[SvgIcon] Remove component prop

### DIFF
--- a/docs/src/pages/components/icons/SvgIcons.js
+++ b/docs/src/pages/components/icons/SvgIcons.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { blue, red } from '@material-ui/core/colors';
 import SvgIcon from '@material-ui/core/SvgIcon';
@@ -17,12 +18,19 @@ const useStyles = makeStyles(theme => ({
 }));
 
 function HomeIcon(props) {
+  const { children, pathProps, ...other } = props;
   return (
-    <SvgIcon {...props}>
-      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+    <SvgIcon {...other}>
+      {children}
+      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" {...pathProps} />
     </SvgIcon>
   );
 }
+
+HomeIcon.propTypes = {
+  children: PropTypes.node,
+  pathProps: PropTypes.object,
+};
 
 export default function SvgIcons() {
   const classes = useStyles();
@@ -35,25 +43,14 @@ export default function SvgIcons() {
       <HomeIcon color="action" />
       <HomeIcon className={classes.iconHover} color="error" style={{ fontSize: 30 }} />
       <HomeIcon color="disabled" fontSize="large" />
-      <HomeIcon
-        color="primary"
-        fontSize="large"
-        component={svgProps => {
-          return (
-            <svg {...svgProps}>
-              <defs>
-                <linearGradient id="gradient1">
-                  <stop offset="30%" stopColor={blue[400]} />
-                  <stop offset="70%" stopColor={red[400]} />
-                </linearGradient>
-              </defs>
-              {React.cloneElement(svgProps.children[0], {
-                fill: 'url(#gradient1)',
-              })}
-            </svg>
-          );
-        }}
-      />
+      <HomeIcon color="primary" fontSize="large" pathProps={{ fill: 'url(#gradient1)' }}>
+        <defs>
+          <linearGradient id="gradient1">
+            <stop offset="30%" stopColor={blue[400]} />
+            <stop offset="70%" stopColor={red[400]} />
+          </linearGradient>
+        </defs>
+      </HomeIcon>
     </div>
   );
 }

--- a/docs/src/pages/components/icons/SvgIcons.tsx
+++ b/docs/src/pages/components/icons/SvgIcons.tsx
@@ -18,10 +18,14 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-function HomeIcon(props: SvgIconProps) {
+function HomeIcon(
+  props: SvgIconProps & { children?: React.ReactNode; pathProps?: React.SVGProps<SVGPathElement> },
+) {
+  const { children, pathProps, ...other } = props;
   return (
-    <SvgIcon {...props}>
-      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+    <SvgIcon {...other}>
+      {children}
+      <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" {...pathProps} />
     </SvgIcon>
   );
 }
@@ -37,28 +41,14 @@ export default function SvgIcons() {
       <HomeIcon color="action" />
       <HomeIcon className={classes.iconHover} color="error" style={{ fontSize: 30 }} />
       <HomeIcon color="disabled" fontSize="large" />
-      <HomeIcon
-        color="primary"
-        fontSize="large"
-        component={(svgProps: SvgIconProps) => {
-          return (
-            <svg {...svgProps}>
-              <defs>
-                <linearGradient id="gradient1">
-                  <stop offset="30%" stopColor={blue[400]} />
-                  <stop offset="70%" stopColor={red[400]} />
-                </linearGradient>
-              </defs>
-              {React.cloneElement(
-                (svgProps.children as React.ReactNodeArray)[0] as React.ReactElement,
-                {
-                  fill: 'url(#gradient1)',
-                },
-              )}
-            </svg>
-          );
-        }}
-      />
+      <HomeIcon color="primary" fontSize="large" pathProps={{ fill: 'url(#gradient1)' }}>
+        <defs>
+          <linearGradient id="gradient1">
+            <stop offset="30%" stopColor={blue[400]} />
+            <stop offset="70%" stopColor={red[400]} />
+          </linearGradient>
+        </defs>
+      </HomeIcon>
     </div>
   );
 }

--- a/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.d.ts
@@ -4,12 +4,9 @@ import { StandardProps, PropTypes } from '..';
 export interface SvgIconProps
   extends StandardProps<React.SVGProps<SVGSVGElement>, SvgIconClassKey> {
   color?: PropTypes.Color | 'action' | 'disabled' | 'error';
-  component?: React.ElementType<React.SVGProps<SVGSVGElement>>;
   fontSize?: 'inherit' | 'default' | 'small' | 'large';
   htmlColor?: string;
-  shapeRendering?: string;
   titleAccess?: string;
-  viewBox?: string;
 }
 
 export type SvgIconClassKey =

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -58,7 +58,6 @@ const SvgIcon = React.forwardRef(function SvgIcon(props, ref) {
     classes,
     className,
     color = 'inherit',
-    component: Component = 'svg',
     fontSize = 'default',
     htmlColor,
     titleAccess,
@@ -67,7 +66,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(props, ref) {
   } = props;
 
   return (
-    <Component
+    <svg
       className={clsx(
         classes.root,
         {
@@ -86,7 +85,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(props, ref) {
     >
       {children}
       {titleAccess ? <title>{titleAccess}</title> : null}
-    </Component>
+    </svg>
   );
 });
 
@@ -109,11 +108,6 @@ SvgIcon.propTypes = {
    * You can use the `htmlColor` prop to apply a color attribute to the SVG element.
    */
   color: PropTypes.oneOf(['inherit', 'primary', 'secondary', 'action', 'error', 'disabled']),
-  /**
-   * The component used for the root node.
-   * Either a string to use a DOM element or a component.
-   */
-  component: PropTypes.elementType,
   /**
    * The fontSize applied to the icon. Defaults to 24px, but can be configure to inherit font size.
    */


### PR DESCRIPTION
`component` prop makes a component more complicated. We do have it documented but I can't see how this makes the component easier to customize. I would even argue that the change improved customization.

In any case this change is queued for v5