### PR TITLE
[Select] Follow spec with placement of dropdown icon

### DIFF
--- a/docs/pages/api/native-select.md
+++ b/docs/pages/api/native-select.md
@@ -50,7 +50,9 @@ Any other props supplied will be provided to the root element ([Input](/api/inpu
 | <span class="prop-name">outlined</span> | <span class="prop-name">MuiNativeSelect-outlined</span> | Styles applied to the select component if `variant="outlined"`.
 | <span class="prop-name">selectMenu</span> | <span class="prop-name">MuiNativeSelect-selectMenu</span> | Styles applied to the select component `selectMenu` class.
 | <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the select component `disabled` class.
-| <span class="prop-name">icon</span> | <span class="prop-name">MuiNativeSelect-icon</span> | Styles applied to the select component `icon` class.
+| <span class="prop-name">icon</span> | <span class="prop-name">MuiNativeSelect-icon</span> | Styles applied to the icon component.
+| <span class="prop-name">iconFilled</span> | <span class="prop-name">MuiNativeSelect-iconFilled</span> | Styles applied to the icon component if `variant="filled"`.
+| <span class="prop-name">iconOutlined</span> | <span class="prop-name">MuiNativeSelect-iconOutlined</span> | Styles applied to the icon component if `variant="outlined"`.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/pages/api/select.md
+++ b/docs/pages/api/select.md
@@ -60,7 +60,9 @@ Any other props supplied will be provided to the root element ([Input](/api/inpu
 | <span class="prop-name">outlined</span> | <span class="prop-name">MuiSelect-outlined</span> | Styles applied to the select component if `variant="outlined"`.
 | <span class="prop-name">selectMenu</span> | <span class="prop-name">MuiSelect-selectMenu</span> | Styles applied to the select component `selectMenu` class.
 | <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the select component `disabled` class.
-| <span class="prop-name">icon</span> | <span class="prop-name">MuiSelect-icon</span> | Styles applied to the select component `icon` class.
+| <span class="prop-name">icon</span> | <span class="prop-name">MuiSelect-icon</span> | Styles applied to the icon component.
+| <span class="prop-name">iconFilled</span> | <span class="prop-name">MuiSelect-iconFilled</span> | Styles applied to the icon component if `variant="filled"`.
+| <span class="prop-name">iconOutlined</span> | <span class="prop-name">MuiSelect-iconOutlined</span> | Styles applied to the icon component if `variant="outlined"`.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -15,11 +15,13 @@ export interface NativeSelectProps
 export type NativeSelectClassKey =
   | 'root'
   | 'select'
+  | 'filled'
+  | 'outlined'
   | 'selectMenu'
   | 'disabled'
   | 'icon'
-  | 'filled'
-  | 'outlined';
+  | 'iconFilled'
+  | 'iconOutlined';
 
 declare const NativeSelect: React.ComponentType<NativeSelectProps>;
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -55,7 +55,7 @@ export const styles = theme => ({
   },
   /* Pseudo-class applied to the select component `disabled` class. */
   disabled: {},
-  /* Styles applied to the select component `icon` class. */
+  /* Styles applied to the icon component. */
   icon: {
     // We use a position absolute over a flexbox in order to forward the pointer events
     // to the input.
@@ -65,9 +65,11 @@ export const styles = theme => ({
     color: theme.palette.action.active,
     pointerEvents: 'none', // Don't block pointer events on the select under the icon.
   },
+  /* Styles applied to the icon component if `variant="filled"`. */
   iconFilled: {
     right: 7,
   },
+  /* Styles applied to the icon component if `variant="outlined"`. */
   iconOutlined: {
     right: 7,
   },

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -65,6 +65,12 @@ export const styles = theme => ({
     color: theme.palette.action.active,
     pointerEvents: 'none', // Don't block pointer events on the select under the icon.
   },
+  iconFilled: {
+    right: 7,
+  },
+  iconOutlined: {
+    right: 7,
+  },
 });
 
 const defaultInput = <Input />;

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -8,7 +8,15 @@ import { capitalize } from '../utils/helpers';
  * @ignore - internal component.
  */
 const NativeSelectInput = React.forwardRef(function NativeSelectInput(props, ref) {
-  const { classes, className, disabled, IconComponent, inputRef, variant, ...other } = props;
+  const {
+    classes,
+    className,
+    disabled,
+    IconComponent,
+    inputRef,
+    variant = 'standard',
+    ...other
+  } = props;
 
   return (
     <React.Fragment>
@@ -16,9 +24,8 @@ const NativeSelectInput = React.forwardRef(function NativeSelectInput(props, ref
         className={clsx(
           classes.root, // TODO v5: merge root and select
           classes.select,
+          classes[variant],
           {
-            [classes.filled]: variant === 'filled',
-            [classes.outlined]: variant === 'outlined',
             [classes.disabled]: disabled,
           },
           className,

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { refType } from '@material-ui/utils';
+import { capitalize } from '../utils/helpers';
 
 /**
  * @ignore - internal component.
@@ -26,7 +27,9 @@ const NativeSelectInput = React.forwardRef(function NativeSelectInput(props, ref
         ref={inputRef || ref}
         {...other}
       />
-      {props.multiple ? null : <IconComponent className={classes.icon} />}
+      {props.multiple ? null : (
+        <IconComponent className={clsx(classes.icon, classes[`icon${capitalize(variant)}`])} />
+      )}
     </React.Fragment>
   );
 });

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -26,11 +26,13 @@ export interface SelectProps
 export type SelectClassKey =
   | 'root'
   | 'select'
+  | 'filled'
+  | 'outlined'
   | 'selectMenu'
   | 'disabled'
   | 'icon'
-  | 'filled'
-  | 'outlined';
+  | 'iconFilled'
+  | 'iconOutlined';
 
 declare const Select: React.ComponentType<SelectProps>;
 

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -50,7 +50,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     tabIndex: tabIndexProp,
     type = 'hidden',
     value,
-    variant,
+    variant = 'standard',
     ...other
   } = props;
 
@@ -262,10 +262,9 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
           classes.root, // TODO v5: merge root and select
           classes.select,
           classes.selectMenu,
+          classes[variant],
           {
             [classes.disabled]: disabled,
-            [classes.filled]: variant === 'filled',
-            [classes.outlined]: variant === 'outlined',
           },
           className,
         )}

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import warning from 'warning';
+import { capitalize } from '../utils/helpers';
 import { refType } from '@material-ui/utils';
 import Menu from '../Menu/Menu';
 import { isFilled } from '../InputBase/utils';
@@ -299,7 +300,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         autoFocus={autoFocus}
         {...other}
       />
-      <IconComponent className={classes.icon} />
+      <IconComponent className={clsx(classes.icon, classes[`icon${capitalize(variant)}`])} />
       <Menu
         id={`menu-${name || ''}`}
         anchorEl={displayRef.current}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #17227

Unlike what was discussed in the issue, I moved the position of the dropdown icon further from the right so that the spaces A and B are equal. This closer matches the look of the specification.

![image](https://user-images.githubusercontent.com/16960005/64197923-e5a5bc00-ce8f-11e9-88fa-4a02968ee373.png)