### PR TITLE
[useMediaQuery] Workaround Safari wrong implementation of matchMedia

### DIFF
--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -51,6 +51,7 @@ function useMediaQuery(queryInput, options = {}) {
   });
 
   React.useEffect(() => {
+    let ignore = false;
     hydrationCompleted = true;
 
     if (!supportMatchMedia) {
@@ -59,11 +60,14 @@ function useMediaQuery(queryInput, options = {}) {
 
     const queryList = window.matchMedia(query);
     const updateMatch = () => {
-      setMatch(queryList.matches);
+      if (!ignore) {
+        setMatch(queryList.matches);
+      }
     };
     updateMatch();
     queryList.addListener(updateMatch);
     return () => {
+      ignore = true;
       queryList.removeListener(updateMatch);
     };
   }, [query, supportMatchMedia]);

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -51,7 +51,7 @@ function useMediaQuery(queryInput, options = {}) {
   });
 
   React.useEffect(() => {
-    let ignore = false;
+    let active = true;
     hydrationCompleted = true;
 
     if (!supportMatchMedia) {
@@ -60,14 +60,17 @@ function useMediaQuery(queryInput, options = {}) {
 
     const queryList = window.matchMedia(query);
     const updateMatch = () => {
-      if (!ignore) {
+      // Workaround Safari wrong implementation of matchMedia
+      // TODO can we remove it?
+      // https://github.com/mui-org/material-ui/pull/17315#issuecomment-528286677
+      if (active) {
         setMatch(queryList.matches);
       }
     };
     updateMatch();
     queryList.addListener(updateMatch);
     return () => {
-      ignore = true;
+      active = false;
       queryList.removeListener(updateMatch);
     };
   }, [query, supportMatchMedia]);


### PR DESCRIPTION
For useMediaQuery(), don't call setState() once unmounting begins. This may have happened in cases such as if a component unmounts when a window resizes.