### PR TITLE
[icons] Improve vertical alignment

### DIFF
--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -15,7 +15,7 @@ export const styles = theme => ({
     // To remove at some point.
     overflow: 'hidden',
     flexShrink: 0,
-    verticalAlign: '-0.125em',
+    verticalAlign: 'bottom',
   },
   /* Styles applied to the root element if `color="primary"`. */
   colorPrimary: {

--- a/packages/material-ui/src/Icon/Icon.js
+++ b/packages/material-ui/src/Icon/Icon.js
@@ -15,6 +15,7 @@ export const styles = theme => ({
     // To remove at some point.
     overflow: 'hidden',
     flexShrink: 0,
+    verticalAlign: '-0.125em',
   },
   /* Styles applied to the root element if `color="primary"`. */
   colorPrimary: {

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -17,7 +17,7 @@ export const styles = theme => ({
     transition: theme.transitions.create('fill', {
       duration: theme.transitions.duration.shorter,
     }),
-    verticalAlign: '-0.125em',
+    verticalAlign: 'bottom',
   },
   /* Styles applied to the root element if `color="primary"`. */
   colorPrimary: {

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -17,6 +17,7 @@ export const styles = theme => ({
     transition: theme.transitions.create('fill', {
       duration: theme.transitions.duration.shorter,
     }),
+    verticalAlign: '-0.125em',
   },
   /* Styles applied to the root element if `color="primary"`. */
   colorPrimary: {


### PR DESCRIPTION
I have discovered this issue working on https://themes.material-ui.com. After more investigation, I have realized that FontAwesome and Ant use a similar strategy, works perfect for my use case, I suspect I'm not alone.

**Before**
![Capture d’écran 2019-09-05 à 01 27 13](https://user-images.githubusercontent.com/3165635/64300400-df413e00-cf7c-11e9-8ce6-1db688a5c8a5.png)

**After**
![Capture d’écran 2019-09-05 à 01 27 20](https://user-images.githubusercontent.com/3165635/64300401-df413e00-cf7c-11e9-86c7-18444441f944.png)



 