### PR TITLE
[core] Guard against bad Symbol polyfills

### DIFF
--- a/packages/material-ui-styles/src/ThemeProvider/nested.js
+++ b/packages/material-ui-styles/src/ThemeProvider/nested.js
@@ -1,3 +1,3 @@
 const hasSymbol = typeof Symbol === 'function';
 
-export default (hasSymbol ? Symbol.for('mui.nested') : '__THEME_NESTED__');
+export default (hasSymbol && Symbol.for ? Symbol.for('mui.nested') : '__THEME_NESTED__');

--- a/packages/material-ui-styles/src/ThemeProvider/nested.js
+++ b/packages/material-ui-styles/src/ThemeProvider/nested.js
@@ -1,3 +1,3 @@
-const hasSymbol = typeof Symbol === 'function';
+const hasSymbol = typeof Symbol === 'function' && Symbol.for;
 
-export default (hasSymbol && Symbol.for ? Symbol.for('mui.nested') : '__THEME_NESTED__');
+export default (hasSymbol ? Symbol.for('mui.nested') : '__THEME_NESTED__');


### PR DESCRIPTION
The `typeof` check for Symbol is great but, apparently, some Symbol polyfills do not include `for()`; a further check would be preferable.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
