### PR TITLE
[styles] Fix global classnames being disabled in deserialized themes

### DIFF
--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.js
@@ -49,8 +49,8 @@ function ThemeProvider(props) {
   const theme = React.useMemo(() => {
     const output = outerTheme === null ? localTheme : mergeOuterLocalTheme(outerTheme, localTheme);
 
-    if (outerTheme !== null && output) {
-      output[nested] = true;
+    if (output != null) {
+      output[nested] = outerTheme !== null;
     }
 
     return output;

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -99,6 +99,11 @@ describe('ThemeProvider', () => {
   });
 
   it('does not allow setting mui.nested manually', () => {
+    if (typeof Symbol === 'undefined') {
+      // skip in IE11
+      return;
+    }
+
     const useStyles = makeStyles({ root: {} }, { name: 'MuiTest' });
     function Component(props) {
       const classes = useStyles();

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -6,7 +6,6 @@ import { createClientRender } from 'test/utils/createClientRender';
 import makeStyles from '../makeStyles';
 import useTheme from '../useTheme';
 import ThemeProvider from './ThemeProvider';
-import NestedSymbol from './nested';
 
 describe('ThemeProvider', () => {
   let mount;
@@ -112,7 +111,7 @@ describe('ThemeProvider', () => {
     }
 
     const { getByTestId } = render(
-      <ThemeProvider theme={{ [NestedSymbol]: true }}>
+      <ThemeProvider theme={{ [Symbol.for('mui.nested')]: true }}>
         <Component data-testid="global" />
         <ThemeProvider theme={{}}>
           <Component data-testid="nested" />

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -1,12 +1,16 @@
 import React from 'react';
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { createMount } from '@material-ui/core/test-utils';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
+import { createClientRender } from 'test/utils/createClientRender';
+import makeStyles from '../makeStyles';
 import useTheme from '../useTheme';
 import ThemeProvider from './ThemeProvider';
+import NestedSymbol from './nested';
 
 describe('ThemeProvider', () => {
   let mount;
+  const render = createClientRender({ strict: true });
 
   before(() => {
     mount = createMount({ strict: true });
@@ -93,6 +97,31 @@ describe('ThemeProvider', () => {
     wrapper.setProps({});
     assert.strictEqual(text(), 'foobar');
     assert.strictEqual(themes.length, 1);
+  });
+
+  it('does not allow setting mui.nested manually', () => {
+    const useStyles = makeStyles({ root: {} }, { name: 'MuiTest' });
+    function Component(props) {
+      const classes = useStyles();
+
+      return (
+        <div {...props} className={classes.root}>
+          Component
+        </div>
+      );
+    }
+
+    const { getByTestId } = render(
+      <ThemeProvider theme={{ [NestedSymbol]: true }}>
+        <Component data-testid="global" />
+        <ThemeProvider theme={{}}>
+          <Component data-testid="nested" />
+        </ThemeProvider>
+      </ThemeProvider>,
+    );
+
+    expect(getByTestId('global')).to.have.class('MuiTest-root');
+    expect(getByTestId('nested')).not.to.have.class('MuiTest-root');
   });
 
   describe('warnings', () => {


### PR DESCRIPTION
Just in case someone is too clever with object serialization or tries to be clever by setting private properties. Potential bugs are really obscure but better be safe than sorry i.e. only we write the property and no one else.

Ref: https://github.com/mui-org/material-ui/pull/17336/files#r321686181