### PR TITLE
[docs] Switched copy in divider documentation to match context in which it is used

### DIFF
--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -45,8 +45,8 @@ export default function MiddleDividers() {
           </Grid>
         </Grid>
         <Typography color="textSecondary" variant="body2">
-          Pinstriped cornflower blue cotton blouse takes you on a walk to the park or just down the
-          hall.
+          Handmade, artisinal toothbrush with natural fibers will keeps your teeth clean while
+          keeping plastic out of landfills.
         </Typography>
       </div>
       <Divider variant="middle" />

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -45,7 +45,7 @@ export default function MiddleDividers() {
           </Grid>
         </Grid>
         <Typography color="textSecondary" variant="body2">
-          Handmade, artisinal toothbrush with natural fibers will keep your teeth clean while
+          Handmade, artisanal toothbrush with natural fibers will keep your teeth clean while
           keeping plastic out of landfills.
         </Typography>
       </div>

--- a/docs/src/pages/components/dividers/MiddleDividers.js
+++ b/docs/src/pages/components/dividers/MiddleDividers.js
@@ -45,7 +45,7 @@ export default function MiddleDividers() {
           </Grid>
         </Grid>
         <Typography color="textSecondary" variant="body2">
-          Handmade, artisinal toothbrush with natural fibers will keeps your teeth clean while
+          Handmade, artisinal toothbrush with natural fibers will keep your teeth clean while
           keeping plastic out of landfills.
         </Typography>
       </div>

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -47,7 +47,7 @@ export default function MiddleDividers() {
           </Grid>
         </Grid>
         <Typography color="textSecondary" variant="body2">
-          Handmade, artisinal toothbrush with natural fibers will keeps your teeth clean while 
+          Handmade, artisinal toothbrush with natural fibers will keep your teeth clean while 
           keeping plastic out of landfills.
         </Typography>
       </div>

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -47,7 +47,7 @@ export default function MiddleDividers() {
           </Grid>
         </Grid>
         <Typography color="textSecondary" variant="body2">
-          Handmade, artisinal toothbrush with natural fibers will keep your teeth clean while 
+          Handmade, artisanal toothbrush with natural fibers will keep your teeth clean while 
           keeping plastic out of landfills.
         </Typography>
       </div>

--- a/docs/src/pages/components/dividers/MiddleDividers.tsx
+++ b/docs/src/pages/components/dividers/MiddleDividers.tsx
@@ -47,8 +47,8 @@ export default function MiddleDividers() {
           </Grid>
         </Grid>
         <Typography color="textSecondary" variant="body2">
-          Pinstriped cornflower blue cotton blouse takes you on a walk to the park or just down the
-          hall.
+          Handmade, artisinal toothbrush with natural fibers will keeps your teeth clean while 
+          keeping plastic out of landfills.
         </Typography>
       </div>
       <Divider variant="middle" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Existing example was a toothbrush item, but the description in the example was for a blouse. I've replaced the text to reflect the example of a toothbrush.


