### PR TITLE
[StepButton] Fix overlap with StepContent

### DIFF
--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -19,6 +19,8 @@ export const styles = {
   /* Styles applied to the root element if `orientation="vertical"`. */
   vertical: {
     justifyContent: 'flex-start',
+    padding: '8px',
+    margin: '-8px',
   },
   /* Styles applied to the `ButtonBase` touch-ripple. */
   touchRipple: {


### PR DESCRIPTION
Stop StepButton overlapping with StepContent when in a vertical orientation Stepper.

Fix #11857.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
