### PR TITLE
[core] Fix incorrect focus handler types for FormControl and TextField

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -9,8 +9,6 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
     fullWidth?: boolean;
     hiddenLabel?: boolean;
     margin?: PropTypes.Margin;
-    onBlur?: React.EventHandler<any>;
-    onFocus?: React.EventHandler<any>;
     required?: boolean;
     variant?: 'standard' | 'outlined' | 'filled';
   };

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -5,7 +5,7 @@ export interface InputBaseProps
   extends StandardProps<
     React.HTMLAttributes<HTMLDivElement>,
     InputBaseClassKey,
-    'onChange' | 'onKeyUp' | 'onKeyDown' | 'defaultValue'
+    'onChange' | 'onKeyUp' | 'onKeyDown' | 'onBlur' | 'onFocus' | 'defaultValue'
   > {
   autoComplete?: string;
   autoFocus?: boolean;
@@ -39,16 +39,15 @@ export interface InputBaseProps
   type?: string;
   value?: unknown;
   /**
-   * `onChange`, `onKeyUp` + `onKeyDown` are applied to the inner `InputComponent`,
+   * `onChange`, `onKeyUp`, `onKeyDown`, `onBlur`, `onFocus` are applied to the inner `InputComponent`,
    * which by default is an input or textarea. Since these handlers differ from the
    * ones inherited by `React.HTMLAttributes<HTMLDivElement>` we need to omit them.
-   *
-   * Note that  `blur` and `focus` event handler are applied to the outer `<div>`.
-   * So these can just be inherited from the native `<div>`.
    */
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onFocus?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 }
 
 export interface InputBaseComponentProps

--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -9,7 +9,12 @@ import { InputLabelProps } from '../InputLabel';
 import { SelectProps } from '../Select';
 
 export interface BaseTextFieldProps
-  extends StandardProps<FormControlProps, TextFieldClassKey, 'onChange' | 'defaultValue'> {
+  extends StandardProps<
+    FormControlProps,
+    TextFieldClassKey,
+    // event handlers are declared on derived interfaces
+    'onChange' | 'onBlur' | 'onFocus' | 'defaultValue'
+  > {
   autoComplete?: string;
   autoFocus?: boolean;
   children?: React.ReactNode;
@@ -26,7 +31,6 @@ export interface BaseTextFieldProps
   margin?: PropTypes.Margin;
   multiline?: boolean;
   name?: string;
-  onChange?: React.ChangeEventHandler<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
   placeholder?: string;
   required?: boolean;
   rows?: string | number;
@@ -38,18 +42,27 @@ export interface BaseTextFieldProps
 }
 
 export interface StandardTextFieldProps extends BaseTextFieldProps {
+  onBlur?: StandardInputProps['onBlur'];
+  onChange?: StandardInputProps['onChange'];
+  onFocus?: StandardInputProps['onFocus'];
   variant?: 'standard';
   InputProps?: Partial<StandardInputProps>;
   inputProps?: StandardInputProps['inputProps'];
 }
 
 export interface FilledTextFieldProps extends BaseTextFieldProps {
+  onBlur?: FilledInputProps['onBlur'];
+  onChange?: FilledInputProps['onChange'];
+  onFocus?: FilledInputProps['onFocus'];
   variant: 'filled';
   InputProps?: Partial<FilledInputProps>;
   inputProps?: FilledInputProps['inputProps'];
 }
 
 export interface OutlinedTextFieldProps extends BaseTextFieldProps {
+  onBlur?: OutlinedInputProps['onBlur'];
+  onChange?: OutlinedInputProps['onChange'];
+  onFocus?: OutlinedInputProps['onFocus'];
   variant: 'outlined';
   InputProps?: Partial<OutlinedInputProps>;
   inputProps?: OutlinedInputProps['inputProps'];

--- a/packages/material-ui/src/TextField/TextField.spec.tsx
+++ b/packages/material-ui/src/TextField/TextField.spec.tsx
@@ -37,3 +37,31 @@ import TextField from '@material-ui/core/TextField';
     <TextField variant="outlined" InputProps={{ classes: { notchedOutline: 'notched-outline' } }} />
   );
 }
+
+// https://github.com/mui-org/material-ui/issues/17369#issuecomment-529622304
+function FocusHandlerTest() {
+  const inputHandler = React.useCallback((event: React.FocusEvent<HTMLInputElement>) => {}, []);
+  // undesired failure but using discriminate unions or generics has bad type interop
+  // $ExpectError
+  const input = <TextField onFocus={inputHandler} />;
+
+  // this or a generic `HTMLElement` is probably closer to what we actually use.
+  const valueHandler = React.useCallback((event: React.FocusEvent<{ value: string }>) => {}, []);
+  const textfield = <TextField onFocus={valueHandler} />;
+
+  // sound narrowing with runtime overhead
+  const genericHandler = React.useCallback((event: React.FocusEvent<HTMLElement>) => {
+    if (event.currentTarget instanceof HTMLInputElement) {
+      console.assert(event.currentTarget.value === 'foo');
+    }
+  }, []);
+  const element = <TextField onFocus={genericHandler} />;
+
+  const fieldHandler = React.useCallback(
+    (ev?: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {},
+    [],
+  );
+  const field = <TextField onFocus={fieldHandler} />;
+
+  return null;
+}

--- a/packages/material-ui/src/TextField/TextField.spec.tsx
+++ b/packages/material-ui/src/TextField/TextField.spec.tsx
@@ -41,8 +41,10 @@ import TextField from '@material-ui/core/TextField';
 // https://github.com/mui-org/material-ui/issues/17369#issuecomment-529622304
 function FocusHandlerTest() {
   const inputHandler = React.useCallback((event: React.FocusEvent<HTMLInputElement>) => {}, []);
-  // undesired failure but using discriminate unions or generics has bad type interop
-  // $ExpectError
+  // Probably a decent tradeoff. React.EventHandler being bivariant does allow unsound
+  // types in this case. I should probably be consistent with the strictness stance
+  // but there are increasing issue reports demanding these unsound types to "write cleaner code"
+  // so lets see how these are received
   const input = <TextField onFocus={inputHandler} />;
 
   // this or a generic `HTMLElement` is probably closer to what we actually use.
@@ -58,7 +60,7 @@ function FocusHandlerTest() {
   const element = <TextField onFocus={genericHandler} />;
 
   const fieldHandler = React.useCallback(
-    (ev?: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {},
+    (event: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {},
     [],
   );
   const field = <TextField onFocus={fieldHandler} />;


### PR DESCRIPTION
Closes #17369

* `FormControl` does not accept focus handler for the wrapped inputs. It's just passed through
* `TextField` forwards these to `inputComponent`. The handlers being special cased at the root is a common footgun (eats handlers from `inputProps` and hard typing make this component hard to reason about. In general it's just doing too much)