### PR TITLE
Use onValueChange instead of onChange

### DIFF
--- a/docs/src/pages/components/text-fields/FormattedInputs.js
+++ b/docs/src/pages/components/text-fields/FormattedInputs.js
@@ -92,10 +92,10 @@ export default function FormattedInputs() {
         className={classes.formControl}
         label="react-number-format"
         value={values.numberformat}
-        onValueChange={handleChange('numberformat')}
         id="formatted-numberformat-input"
         InputProps={{
           inputComponent: NumberFormatCustom,
+          other: { {onValueChange:handleChange('numberformat')} }
         }}
       />
     </div>

--- a/docs/src/pages/components/text-fields/FormattedInputs.js
+++ b/docs/src/pages/components/text-fields/FormattedInputs.js
@@ -83,7 +83,7 @@ export default function FormattedInputs() {
         <InputLabel htmlFor="formatted-text-mask-input">react-text-mask</InputLabel>
         <Input
           value={values.textmask}
-          onChange={handleChange('textmask')}
+          onValueChange={handleChange('textmask')}
           id="formatted-text-mask-input"
           inputComponent={TextMaskCustom}
         />
@@ -92,7 +92,7 @@ export default function FormattedInputs() {
         className={classes.formControl}
         label="react-number-format"
         value={values.numberformat}
-        onChange={handleChange('numberformat')}
+        onValueChange={handleChange('numberformat')}
         id="formatted-numberformat-input"
         InputProps={{
           inputComponent: NumberFormatCustom,


### PR DESCRIPTION
onChange no longer gets values object. You need to use onValueChange instead. onChange/onFocus/onBlur and other input events will be directly passed to the input.

~from react-number-format documentation.