### PR TITLE
[Table] Adjust table styles to the latest specs

### DIFF
--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -238,46 +238,24 @@ const styles = theme => ({
         borderBottom: `1px dotted ${theme.palette.text.hint}`,
       },
     },
-    '& thead': {
-      fontSize: 14,
-      fontWeight: theme.typography.fontWeightMedium,
-      color: theme.palette.text.secondary,
-    },
-    '& tbody': {
-      fontSize: 14,
-      lineHeight: 1.5,
-      color: theme.palette.text.primary,
-    },
     '& td': {
+      ...theme.typography.body2,
       borderBottom: `1px solid ${theme.palette.divider}`,
-      padding: '8px 16px 8px 8px',
-      textAlign: 'left',
-    },
-    '& td:last-child': {
-      paddingRight: 24,
-    },
-    '& td compact': {
-      paddingRight: 24,
+      padding: 16,
+      color: theme.palette.text.primary,
     },
     '& td code': {
       fontSize: 13,
       lineHeight: 1.6,
     },
     '& th': {
+      fontSize: 14,
+      lineHeight: theme.typography.pxToRem(24),
+      fontWeight: theme.typography.fontWeightMedium,
+      color: theme.palette.text.primary,
       whiteSpace: 'pre',
       borderBottom: `1px solid ${theme.palette.divider}`,
-      fontWeight: theme.typography.fontWeightMedium,
-      padding: '0 16px 0 8px',
-      textAlign: 'left',
-    },
-    '& th:last-child': {
-      paddingRight: 24,
-    },
-    '& tr': {
-      height: 48,
-    },
-    '& thead tr': {
-      height: 64,
+      padding: 16,
     },
     '& blockquote': {
       borderLeft: '5px solid #ffe564',

--- a/docs/src/pages/components/tables/CustomPaginationActionsTable.js
+++ b/docs/src/pages/components/tables/CustomPaginationActionsTable.js
@@ -17,7 +17,6 @@ import LastPageIcon from '@material-ui/icons/LastPage';
 const useStyles1 = makeStyles(theme => ({
   root: {
     flexShrink: 0,
-    color: theme.palette.text.secondary,
     marginLeft: theme.spacing(2.5),
   },
 }));

--- a/docs/src/pages/components/tables/CustomPaginationActionsTable.tsx
+++ b/docs/src/pages/components/tables/CustomPaginationActionsTable.tsx
@@ -17,7 +17,6 @@ const useStyles1 = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       flexShrink: 0,
-      color: theme.palette.text.secondary,
       marginLeft: theme.spacing(2.5),
     },
   }),

--- a/docs/src/pages/components/tables/StickyHeadTable.js
+++ b/docs/src/pages/components/tables/StickyHeadTable.js
@@ -9,26 +9,26 @@ import TablePagination from '@material-ui/core/TablePagination';
 import TableRow from '@material-ui/core/TableRow';
 
 const columns = [
-  { id: 'name', label: 'Name', minWidth: 200 },
+  { id: 'name', label: 'Name', minWidth: 170 },
   { id: 'code', label: 'ISO\u00a0Code', minWidth: 100 },
   {
     id: 'population',
     label: 'Population',
-    minWidth: 120,
+    minWidth: 170,
     align: 'right',
     format: value => value.toLocaleString(),
   },
   {
     id: 'size',
     label: 'Size\u00a0(km\u00b2)',
-    minWidth: 120,
+    minWidth: 170,
     align: 'right',
     format: value => value.toLocaleString(),
   },
   {
     id: 'density',
     label: 'Density',
-    minWidth: 120,
+    minWidth: 170,
     align: 'right',
     format: value => value.toFixed(2),
   },
@@ -62,7 +62,7 @@ const useStyles = makeStyles({
     width: '100%',
   },
   tableWrapper: {
-    maxHeight: 407,
+    maxHeight: 440,
     overflow: 'auto',
   },
 });

--- a/docs/src/pages/components/tables/StickyHeadTable.tsx
+++ b/docs/src/pages/components/tables/StickyHeadTable.tsx
@@ -17,26 +17,26 @@ interface Column {
 }
 
 const columns: Column[] = [
-  { id: 'name', label: 'Name', minWidth: 200 },
+  { id: 'name', label: 'Name', minWidth: 170 },
   { id: 'code', label: 'ISO\u00a0Code', minWidth: 100 },
   {
     id: 'population',
     label: 'Population',
-    minWidth: 120,
+    minWidth: 170,
     align: 'right',
     format: (value: number) => value.toLocaleString(),
   },
   {
     id: 'size',
     label: 'Size\u00a0(km\u00b2)',
-    minWidth: 120,
+    minWidth: 170,
     align: 'right',
     format: (value: number) => value.toLocaleString(),
   },
   {
     id: 'density',
     label: 'Density',
-    minWidth: 120,
+    minWidth: 170,
     align: 'right',
     format: (value: number) => value.toFixed(2),
   },
@@ -78,7 +78,7 @@ const useStyles = makeStyles({
     width: '100%',
   },
   tableWrapper: {
-    maxHeight: 407,
+    maxHeight: 440,
     overflow: 'auto',
   },
 });

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -33,7 +33,6 @@ export const styles = theme => ({
   /* Styles applied to the root element if `variant="body"` or `context.table.body`. */
   body: {
     color: theme.palette.text.primary,
-    fontWeight: theme.typography.fontWeightRegular,
   },
   /* Styles applied to the root element if `variant="footer"` or `context.table.footer`. */
   footer: {

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -22,16 +22,12 @@ export const styles = theme => ({
         : darken(fade(theme.palette.divider, 1), 0.68)
     }`,
     textAlign: 'left',
-    padding: '14px 40px 14px 16px',
-    '&:last-child': {
-      paddingRight: 16,
-    },
+    padding: 16,
   },
   /* Styles applied to the root element if `variant="head"` or `context.table.head`. */
   head: {
-    color: theme.palette.text.secondary,
-    fontSize: theme.typography.pxToRem(12),
-    lineHeight: theme.typography.pxToRem(21),
+    color: theme.palette.text.primary,
+    lineHeight: theme.typography.pxToRem(24),
     fontWeight: theme.typography.fontWeightMedium,
   },
   /* Styles applied to the root element if `variant="body"` or `context.table.body`. */

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -14,8 +14,8 @@ import TablePaginationActions from './TablePaginationActions';
 export const styles = theme => ({
   /* Styles applied to the root element. */
   root: {
-    color: theme.palette.text.secondary,
-    fontSize: theme.typography.pxToRem(12),
+    color: theme.palette.text.primary,
+    fontSize: theme.typography.pxToRem(14),
     // Increase the specificity to override TableCell.
     '&:last-child': {
       padding: 0,
@@ -106,7 +106,7 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
       <Toolbar className={classes.toolbar}>
         <div className={classes.spacer} />
         {rowsPerPageOptions.length > 1 && (
-          <Typography color="inherit" variant="caption" className={classes.caption}>
+          <Typography color="inherit" variant="body2" className={classes.caption}>
             {labelRowsPerPage}
           </Typography>
         )}
@@ -132,7 +132,7 @@ const TablePagination = React.forwardRef(function TablePagination(props, ref) {
             ))}
           </Select>
         )}
-        <Typography color="inherit" variant="caption" className={classes.caption}>
+        <Typography color="inherit" variant="body2" className={classes.caption}>
           {labelDisplayedRows({
             from: count === 0 ? 0 : page * rowsPerPage + 1,
             to: Math.min(count, (page + 1) * rowsPerPage),

--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -23,8 +23,7 @@ export const styles = theme => ({
   },
   /* Styles applied to the Toolbar component. */
   toolbar: {
-    height: 56,
-    minHeight: 56,
+    minHeight: 52,
     paddingRight: 2,
   },
   /* Styles applied to the spacer element. */

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -15,13 +15,12 @@ export const styles = theme => ({
     flexDirection: 'inherit',
     alignItems: 'center',
     '&:focus': {
-      color: theme.palette.text.primary,
+      color: theme.palette.text.secondary,
     },
     '&:hover': {
-      color: theme.palette.text.primary,
+      color: theme.palette.text.secondary,
       '& $icon': {
         opacity: 1,
-        color: theme.palette.text.secondary,
       },
     },
     '&$active': {
@@ -29,7 +28,7 @@ export const styles = theme => ({
       // && instead of & is a workaround for https://github.com/cssinjs/jss/issues/1045
       '&& $icon': {
         opacity: 1,
-        color: theme.palette.text.primary,
+        color: theme.palette.text.secondary,
       },
     },
   },

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.js
@@ -37,7 +37,6 @@ export const styles = theme => ({
   active: {},
   /* Styles applied to the icon component. */
   icon: {
-    height: 18,
     marginRight: 4,
     marginLeft: 4,
     opacity: 0,
@@ -45,7 +44,6 @@ export const styles = theme => ({
       duration: theme.transitions.duration.shorter,
     }),
     userSelect: 'none',
-    width: 18,
   },
   /* Styles applied to the icon component if `direction="desc"`. */
   iconDirectionDesc: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
On July 25, 2019 Google updated [Specs on Table component](https://material.io/components/data-tables/#specs). Padding and fonts were updated
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
