### PR TITLE
[SelectInput] Use `@testing-library` for test

### DIFF
--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -360,9 +360,11 @@ SelectInput.propTypes = {
   /**
    * The icon that displays the arrow.
    */
-  IconComponent: PropTypes.elementType,
+  IconComponent: PropTypes.elementType.isRequired,
   /**
    * Use that prop to pass a ref to the native select element.
+   *
+   * TODO: there's no native select element here
    */
   inputRef: refType,
   /**

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -362,9 +362,8 @@ SelectInput.propTypes = {
    */
   IconComponent: PropTypes.elementType.isRequired,
   /**
-   * Use that prop to pass a ref to the native select element.
-   *
-   * TODO: there's no native select element here
+   * Imperative handle implementing `{ value: T, node: HTMLElement, focus(): void }`
+   * Equivalent to `ref`
    */
   inputRef: refType,
   /**
@@ -438,6 +437,7 @@ SelectInput.propTypes = {
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * @ignore
+   * TODO: remove in V5
    */
   type: PropTypes.string,
   /**

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -48,6 +48,8 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     required,
     SelectDisplayProps,
     tabIndex: tabIndexProp,
+    // catching `type` from Input which makes no sense for SelectInput
+    type,
     value,
     variant = 'standard',
     ...other
@@ -434,6 +436,10 @@ SelectInput.propTypes = {
    * @ignore
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  /**
+   * @ignore
+   */
+  type: PropTypes.any,
   /**
    * The input value.
    */

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -48,7 +48,6 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     required,
     SelectDisplayProps,
     tabIndex: tabIndexProp,
-    type = 'hidden',
     value,
     variant = 'standard',
     ...other
@@ -295,7 +294,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
         value={Array.isArray(value) ? value.join(',') : value}
         name={name}
         ref={inputRef}
-        type={type}
+        type="hidden"
         autoFocus={autoFocus}
         {...other}
       />
@@ -435,11 +434,6 @@ SelectInput.propTypes = {
    * @ignore
    */
   tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  /**
-   * @ignore
-   * TODO: remove in V5
-   */
-  type: PropTypes.string,
   /**
    * The input value.
    */

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -6,7 +6,7 @@ import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createCl
 import MenuItem from '../MenuItem';
 import SelectInput from './SelectInput';
 
-describe.only('<SelectInput />', () => {
+describe('<SelectInput />', () => {
   // StrictModeViolation: uses Popover
   const render = createClientRender({ strict: false });
 
@@ -380,6 +380,7 @@ describe.only('<SelectInput />', () => {
           <SelectInput
             classes={{}}
             IconComponent="div"
+            MenuProps={{ transitionDuration: 0 }}
             open={open}
             onClose={() => setOpen(false)}
             onOpen={() => setOpen(true)}
@@ -521,7 +522,13 @@ describe.only('<SelectInput />', () => {
         consoleErrorMock.reset();
       });
 
-      it('should throw if non array', () => {
+      it('should throw if non array', function test() {
+        if (!/jsdom/.test(window.navigator.userAgent)) {
+          // can't catch render errors in the browser for unknown reason
+          // tried try-catch + error boundary + window onError preventDefault
+          this.skip();
+        }
+
         expect(() => {
           render(
             <SelectInput classes={{}} IconComponent="div" multiple value="10,20">

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -6,7 +6,7 @@ import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createCl
 import MenuItem from '../MenuItem';
 import SelectInput from './SelectInput';
 
-describe('<SelectInput />', () => {
+describe.only('<SelectInput />', () => {
   // StrictModeViolation: uses Popover
   const render = createClientRender({ strict: false });
 
@@ -197,6 +197,7 @@ describe('<SelectInput />', () => {
      * TODO how do we support this? In its current state it will log a warning
      * with no way to fix it
      */
+    // eslint-disable-next-line mocha/no-skipped-tests
     it.skip('should be able to override it', () => {
       const { container } = render(
         <SelectInput classes={{}} IconComponent="div" type="text" value="10">

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -194,8 +194,9 @@ describe('<SelectInput />', () => {
     });
 
     /**
-     * TODO how do we support this? In its current state it will log a warning
-     * with no way to fix it
+     * In its current state it will log a react warning
+     * with no way to fix it. It is reachable by using `<Select inputProps={{ type: 'text' }} />`.
+     * We should not support it in v5.
      */
     // eslint-disable-next-line mocha/no-skipped-tests
     it.skip('should be able to override it', () => {
@@ -615,7 +616,7 @@ describe('<SelectInput />', () => {
         getByRole('button').click();
       });
 
-      // TODO not match WAI-ARIA authoring practices
+      // TODO not matching WAI-ARIA authoring practices. It should focus the first (or selected) item.
       expect(getByRole('listbox')).to.be.focused;
     });
   });

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -524,6 +524,9 @@ describe('<SelectInput />', () => {
 
       it('should throw if non array', function test() {
         if (!/jsdom/.test(window.navigator.userAgent)) {
+          // afterEach is not run since the only test in this block is skipped
+          // this is likely a bug in mocha
+          consoleErrorMock.reset();
           // can't catch render errors in the browser for unknown reason
           // tried try-catch + error boundary + window onError preventDefault
           this.skip();

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -1,178 +1,242 @@
 import React from 'react';
-import { expect, assert } from 'chai';
+import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
-import { createShallow, createMount } from '@material-ui/core/test-utils';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
-import Menu from '../Menu';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
+import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import MenuItem from '../MenuItem';
 import SelectInput from './SelectInput';
 
 describe('<SelectInput />', () => {
-  const render = createClientRender({ strict: true });
+  // StrictModeViolation: uses Popover
+  const render = createClientRender({ strict: false });
 
-  let shallow;
-  let mount;
-  const defaultProps = {
-    classes: { select: 'select' },
-    autoWidth: false,
-    value: 10,
-    multiple: false,
-    displayEmpty: false,
-    IconComponent: 'div',
-    children: [
-      <MenuItem key={1} value={10}>
-        Ten
-      </MenuItem>,
-      <MenuItem key={2} value={20}>
-        Twenty
-      </MenuItem>,
-      <MenuItem key={3} value={30}>
-        Thirty
-      </MenuItem>,
-    ],
-  };
-
-  before(() => {
-    shallow = createShallow();
-    // StrictModeViolation: test uses MenuItem
-    mount = createMount({ strict: false });
-  });
-
-  after(() => {
-    mount.cleanUp();
+  afterEach(() => {
     cleanup();
   });
 
-  it('should render a correct top element', () => {
-    const wrapper = shallow(<SelectInput {...defaultProps} />);
-    assert.strictEqual(wrapper.name(), 'Fragment');
-    assert.strictEqual(
-      wrapper
-        .find(MenuItem)
-        .at(0)
-        .props()['data-value'],
-      10,
+  specify('the trigger is in tab order', () => {
+    const { getByRole } = render(
+      <SelectInput classes={{}} IconComponent="div" open value="">
+        <MenuItem value="">None</MenuItem>
+      </SelectInput>,
     );
+
+    expect(getByRole('button')).to.have.property('tabIndex', 0);
   });
 
-  it('should accept invalid child', () => {
-    shallow(
-      <SelectInput {...defaultProps}>
+  it('options should have a data-value attribute', () => {
+    const { getAllByRole } = render(
+      <SelectInput classes={{}} IconComponent="div" open value={10}>
+        <MenuItem value={10}>Ten</MenuItem>
+        <MenuItem value={20}>Twenty</MenuItem>
+      </SelectInput>,
+      { baseElement: document.body },
+    );
+
+    expect(getAllByRole('option')[0]).to.have.attribute('data-value', '10');
+    expect(getAllByRole('option')[1]).to.have.attribute('data-value', '20');
+  });
+
+  it('should accept null child', () => {
+    render(
+      <SelectInput classes={{}} IconComponent="div" open value={10}>
         {null}
-        <MenuItem />
+        <MenuItem value={10}>Ten</MenuItem>
       </SelectInput>,
     );
   });
 
   describe('prop: value', () => {
     it('should select the option based on the number value', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} value={20} />);
-      assert.deepEqual(wrapper.find(MenuItem).map(m => m.props().selected), [false, true, false]);
+      const { getAllByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" open value={20}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </SelectInput>,
+        { baseElement: document.body },
+      );
+
+      expect(getAllByRole('option')[0]).not.to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[1]).to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[2]).not.to.have.attribute('aria-selected', 'true');
     });
 
     it('should select the option based on the string value', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} value="20" />);
-      assert.deepEqual(wrapper.find(MenuItem).map(m => m.props().selected), [false, true, false]);
+      const { getAllByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" open value="20">
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </SelectInput>,
+        { baseElement: document.body },
+      );
+
+      expect(getAllByRole('option')[0]).not.to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[1]).to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[2]).not.to.have.attribute('aria-selected', 'true');
     });
 
     it('should select only the option that matches the object', () => {
       const obj1 = { id: 1 };
       const obj2 = { id: 2 };
-
-      const wrapper = shallow(
-        <SelectInput {...defaultProps} value={obj1}>
-          <MenuItem key={1} value={obj1}>
-            1
-          </MenuItem>
-          <MenuItem key={2} value={obj2}>
-            2
-          </MenuItem>
+      const { getAllByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" open value={obj1}>
+          <MenuItem value={obj1}>1</MenuItem>
+          <MenuItem value={obj2}>2</MenuItem>
         </SelectInput>,
+        { baseElement: document.body },
       );
 
-      assert.deepEqual(wrapper.find(MenuItem).map(wrapper2 => wrapper2.props().selected), [
-        true,
-        false,
-      ]);
+      expect(getAllByRole('option')[0]).to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[1]).not.to.have.attribute('aria-selected', 'true');
     });
   });
 
   describe('prop: readOnly', () => {
     it('should not trigger any event with readOnly', () => {
-      const wrapper = mount(<SelectInput {...defaultProps} readOnly />);
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('keyDown', { key: 'ArrowDown' });
-      assert.strictEqual(wrapper.find(MenuItem).exists(), false);
+      const { getByRole, queryByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" readOnly value="10">
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+        </SelectInput>,
+        { baseElement: document.body },
+      );
+      getByRole('button').focus();
+
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+      expect(queryByRole('listbox')).not.to.be.ok;
     });
   });
 
   describe('prop: MenuProps', () => {
+    let clock;
+
+    beforeEach(() => {
+      clock = useFakeTimers();
+    });
+
+    afterEach(() => {
+      clock.restore();
+    });
+
     it('should apply additional props to the Menu component', () => {
-      const wrapper = shallow(
-        <SelectInput {...defaultProps} MenuProps={{ transitionDuration: 100 }} />,
+      const onEntered = spy();
+      const { getByRole } = render(
+        <SelectInput
+          classes={{}}
+          IconComponent="div"
+          MenuProps={{ onEntered, transitionDuration: 100 }}
+          value="10"
+        >
+          <MenuItem value="10">Ten</MenuItem>
+        </SelectInput>,
       );
-      assert.strictEqual(wrapper.find(Menu).props().transitionDuration, 100);
+
+      fireEvent.click(getByRole('button'));
+      act(() => {
+        clock.tick(99);
+      });
+
+      expect(onEntered.callCount).to.equal(0);
+
+      act(() => {
+        clock.tick(1);
+      });
+
+      expect(onEntered.callCount).to.equal(1);
     });
 
     it('should be able to override PaperProps minWidth', () => {
-      const wrapper = shallow(
-        <SelectInput {...defaultProps} MenuProps={{ PaperProps: { style: { minWidth: 12 } } }} />,
+      const { getByTestId } = render(
+        <SelectInput
+          classes={{}}
+          IconComponent="div"
+          MenuProps={{ PaperProps: { 'data-testid': 'paper', style: { minWidth: 12 } } }}
+          open
+          value="10"
+        >
+          <MenuItem value="10">Ten</MenuItem>
+        </SelectInput>,
       );
-      assert.strictEqual(wrapper.find(Menu).props().PaperProps.style.minWidth, 12);
+
+      expect(getByTestId('paper').style).to.have.property('minWidth', '12px');
     });
   });
 
   describe('prop: SelectDisplayProps', () => {
-    it('should apply additional props to the clickable div element', () => {
-      const wrapper = shallow(
-        <SelectInput {...defaultProps} SelectDisplayProps={{ 'data-test': 'SelectDisplay' }} />,
+    it('should apply additional props to trigger element', () => {
+      const { getByRole } = render(
+        <SelectInput
+          classes={{}}
+          IconComponent="div"
+          SelectDisplayProps={{ 'data-test': 'SelectDisplay' }}
+          value="10"
+        >
+          <MenuItem value="10">Ten</MenuItem>
+        </SelectInput>,
       );
 
-      const selectDisplay = wrapper.find('[role="button"]');
-      assert.strictEqual(selectDisplay.props()['data-test'], 'SelectDisplay');
+      expect(getByRole('button')).to.have.attribute('data-test', 'SelectDisplay');
     });
   });
 
   describe('prop: type', () => {
     it('should be hidden by default', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} />);
-      assert.strictEqual(wrapper.find('input').props().type, 'hidden');
+      const { container } = render(
+        <SelectInput classes={{}} IconComponent="div" value="10">
+          <MenuItem value="10">Ten</MenuItem>
+        </SelectInput>,
+      );
+
+      expect(container.querySelector('input')).to.have.property('type', 'hidden');
     });
 
-    it('should be able to override it', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} type="text" />);
-      assert.strictEqual(wrapper.find('input').props().type, 'text');
-    });
-  });
+    /**
+     * TODO how do we support this? In its current state it will log a warning
+     * with no way to fix it
+     */
+    it.skip('should be able to override it', () => {
+      const { container } = render(
+        <SelectInput classes={{}} IconComponent="div" type="text" value="10">
+          <MenuItem value="10">Ten</MenuItem>
+        </SelectInput>,
+      );
 
-  it('should render a placeholder if there is no value to display', () => {
-    const { getByRole } = render(<SelectInput {...defaultProps} renderValue={() => '   '} />);
-    expect(getByRole('button').querySelector('span')).to.be.ok;
+      expect(container.querySelector('input')).to.have.property('type', 'text');
+    });
   });
 
   describe('prop: displayEmpty', () => {
     it('should display the selected item even if its value is empty', () => {
-      const wrapper = mount(
-        <SelectInput {...defaultProps} value="" displayEmpty>
+      const { getByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" value="" displayEmpty>
           <MenuItem value="">Ten</MenuItem>
           <MenuItem value={20}>Twenty</MenuItem>
           <MenuItem value={30}>Thirty</MenuItem>
         </SelectInput>,
       );
-      assert.strictEqual(wrapper.find(`.${defaultProps.classes.select}`).text(), 'Ten');
+
+      expect(getByRole('button')).to.have.text('Ten');
     });
   });
 
   describe('prop: renderValue', () => {
     it('should use the prop to render the value', () => {
-      const renderValue = x => String(-x);
-      const wrapper = mount(<SelectInput {...defaultProps} renderValue={renderValue} />);
-      assert.strictEqual(wrapper.find(`.${defaultProps.classes.select}`).text(), '-10');
+      const renderValue = x => `0b${x.toString(2)}`;
+      const { getByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" renderValue={renderValue} value={4}>
+          <MenuItem value={2}>2</MenuItem>
+          <MenuItem value={4}>4</MenuItem>
+        </SelectInput>,
+      );
+
+      expect(getByRole('button')).to.have.text('0b100');
     });
   });
 
   describe('prop: onChange', () => {
-    let wrapper;
-    let handleChange;
     let clock;
 
     before(() => {
@@ -183,292 +247,429 @@ describe('<SelectInput />', () => {
       clock.restore();
     });
 
-    beforeEach(() => {
-      handleChange = spy();
-      wrapper = mount(
-        <SelectInput
-          {...defaultProps}
-          onChange={handleChange}
-          MenuProps={{ transitionDuration: 0 }}
-        />,
-      );
-    });
-
     it('should call onChange when clicking an item', () => {
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.find(MenuItem).exists(), true);
-      wrapper
-        .find('li')
-        .at(1)
-        .simulate('click');
-      clock.tick(0);
-      wrapper.update();
-      assert.strictEqual(wrapper.find(MenuItem).exists(), false);
-      assert.strictEqual(handleChange.callCount, 1);
-      assert.strictEqual(handleChange.args[0][0].target.value, 20);
+      const handleChange = stub().callsFake(event => event.target.value);
+      const { getByRole, getAllByRole, queryByRole } = render(
+        <SelectInput
+          classes={{}}
+          IconComponent="div"
+          MenuProps={{ transitionDuration: 0 }}
+          onChange={handleChange}
+          value=""
+        >
+          <MenuItem value="">none</MenuItem>
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectInput>,
+      );
+
+      fireEvent.click(getByRole('button'));
+      fireEvent.click(getAllByRole('option')[1]);
+      act(() => {
+        clock.tick(0);
+      });
+
+      expect(handleChange.calledOnce).to.be.true;
+      expect(handleChange.firstCall.returnValue).to.equal(10);
+      expect(queryByRole('listbox')).to.be.null;
     });
 
     it('should ignore onBlur the first time the menu is open', () => {
+      // mousedown calls focus while click opens moving the focus to an item
+      // this means the trigger is blurred immediately
       const handleBlur = spy();
-      wrapper.setProps({ onBlur: handleBlur });
+      const { getByRole, getAllByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" onBlur={handleBlur} value="">
+          <MenuItem value="">none</MenuItem>
+          <MenuItem value={10}>Ten</MenuItem>
+        </SelectInput>,
+      );
 
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.find(MenuItem).exists(), true);
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('blur');
-      assert.strictEqual(handleBlur.callCount, 0);
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('blur');
-      assert.strictEqual(handleBlur.callCount, 1);
+      const trigger = getByRole('button');
+      // simulating user click
+      fireEvent.mouseDown(trigger);
+      trigger.focus();
+      trigger.click();
+
+      expect(handleBlur.callCount).to.equal(0);
+      expect(getByRole('listbox')).to.be.ok;
+
+      act(() => {
+        getAllByRole('option')[0].click();
+      });
+      trigger.blur();
+
+      expect(handleBlur.callCount).to.equal(1);
     });
 
     it('should pass "name" as part of the event.target for onBlur', () => {
-      const handleBlur = spy();
-      wrapper.setProps({ onBlur: handleBlur, name: 'blur-testing' });
+      const handleBlur = stub().callsFake(event => event.target.name);
+      const { getByRole } = render(
+        <SelectInput
+          classes={{}}
+          IconComponent="div"
+          onBlur={handleBlur}
+          name="blur-testing"
+          value=""
+        >
+          <MenuItem value="">none</MenuItem>
+        </SelectInput>,
+      );
+      getByRole('button').focus();
 
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.find(MenuItem).exists(), true);
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('blur');
-      assert.strictEqual(handleBlur.callCount, 0);
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('blur');
-      assert.strictEqual(handleBlur.callCount, 1);
-      assert.strictEqual(handleBlur.args[0][0].target.name, 'blur-testing');
+      getByRole('button').blur();
+
+      expect(handleBlur.callCount).to.equal(1);
+      expect(handleBlur.firstCall.returnValue).to.equal('blur-testing');
     });
 
     [' ', 'ArrowUp', 'ArrowDown', 'Enter'].forEach(key => {
       it(`'should open menu when pressed ${key} key on select`, () => {
-        wrapper.find(`.${defaultProps.classes.select}`).simulate('keyDown', { key });
-        assert.strictEqual(wrapper.find(MenuItem).exists(), true);
+        const { getByRole } = render(
+          <SelectInput classes={{}} IconComponent="div" value="">
+            <MenuItem value="">none</MenuItem>
+          </SelectInput>,
+        );
+        getByRole('button').focus();
+
+        fireEvent.keyDown(document.activeElement, { key });
+
+        expect(getByRole('listbox')).to.be.ok;
       });
     });
 
-    it('should call handleClose', () => {
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.find(MenuItem).exists(), true);
+    it('should call onClose when the backdrop is clicked', () => {
+      const handleClose = spy();
+      const { getByTestId } = render(
+        <SelectInput
+          classes={{}}
+          IconComponent="div"
+          MenuProps={{ BackdropProps: { 'data-testid': 'backdrop' } }}
+          onClose={handleClose}
+          open
+          value=""
+        >
+          <MenuItem value="">none</MenuItem>
+        </SelectInput>,
+      );
 
-      const backdrop = wrapper.find('[data-mui-test="Backdrop"]');
-      backdrop.simulate('click');
-      clock.tick(0);
-      wrapper.update();
-      assert.strictEqual(wrapper.find(MenuItem).exists(), false);
+      act(() => {
+        getByTestId('backdrop').click();
+      });
+
+      expect(handleClose.callCount).to.equal(1);
     });
   });
 
   describe('prop: open (controlled)', () => {
-    class ControlledWrapper extends React.Component {
-      state = {
-        open: false,
-      };
+    let clock;
 
-      render() {
+    before(() => {
+      clock = useFakeTimers();
+    });
+
+    after(() => {
+      clock.restore();
+    });
+
+    it('should allow to control closing by passing onClose props', () => {
+      function ControlledWrapper() {
+        const [open, setOpen] = React.useState(false);
+
         return (
           <SelectInput
-            {...defaultProps}
-            open={this.state.open}
-            onClose={() => this.setState({ open: false })}
-            onOpen={() => this.setState({ open: true })}
+            classes={{}}
+            IconComponent="div"
+            open={open}
+            onClose={() => setOpen(false)}
+            onOpen={() => setOpen(true)}
+            value=""
           >
-            <MenuItem onClick={() => this.setState({ open: false })}>close</MenuItem>
+            <MenuItem onClick={() => setOpen(false)}>close</MenuItem>
           </SelectInput>
         );
       }
-    }
+      const { getByRole, queryByRole } = render(<ControlledWrapper />);
 
-    it('should allow to control closing by passing onClose props', () => {
-      const wrapper = mount(<ControlledWrapper />);
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.find('ControlledWrapper').state().open, true);
-      wrapper.find(MenuItem).simulate('click');
-      assert.strictEqual(wrapper.find('ControlledWrapper').state().open, false);
+      act(() => {
+        getByRole('button').click();
+      });
+
+      expect(getByRole('listbox')).to.be.ok;
+
+      act(() => {
+        getByRole('option').click();
+      });
+      // react-transition-group uses one extra commit for exit
+      // it is desired that this assertion breaks some day. Current behavior adds
+      // and unnecessary commit artifically slowing down the exit transition
+      expect(getByRole('listbox')).to.be.ok;
+      act(() => {
+        clock.tick(0);
+      });
+
+      expect(queryByRole('listbox')).to.be.null;
     });
 
-    it('should work when open is initially true', () => {
-      const element = (
-        <SelectInput {...defaultProps} open>
+    it('should be open when initially true', () => {
+      const { getByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" open value="">
           <MenuItem>Hello</MenuItem>
-        </SelectInput>
+        </SelectInput>,
       );
 
-      const wrapper1 = shallow(element, { disableLifecycleMethods: true });
-      assert.strictEqual(wrapper1.find(Menu).props().open, false);
-      const wrapper2 = mount(element);
-      assert.strictEqual(wrapper2.find(Menu).props().open, true);
+      expect(getByRole('listbox')).to.be.ok;
     });
   });
 
   describe('prop: autoWidth', () => {
-    it('should take the anchor width into account', () => {
-      const wrapper = mount(<SelectInput {...defaultProps} />);
-      const selectDisplay = wrapper.find('[role="button"]').instance();
-      stub(selectDisplay, 'clientWidth').get(() => 14);
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.find(Menu).props().PaperProps.style.minWidth, 14);
+    it('should take the trigger width into account by default', () => {
+      const { getByRole, getByTestId } = render(
+        <SelectInput
+          classes={{}}
+          IconComponent="div"
+          MenuProps={{ PaperProps: { 'data-testid': 'paper' } }}
+          value=""
+        >
+          <MenuItem>Only</MenuItem>
+        </SelectInput>,
+      );
+      stub(getByRole('button'), 'clientWidth').get(() => 14);
+
+      act(() => {
+        getByRole('button').click();
+      });
+
+      expect(getByTestId('paper').style).to.have.property('minWidth', '14px');
     });
 
-    it('should not take the anchor width into account', () => {
-      const wrapper = mount(<SelectInput {...defaultProps} autoWidth />);
-      const selectDisplay = wrapper.find('[role="button"]').instance();
-      stub(selectDisplay, 'clientWidth').get(() => 14);
-      wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-      assert.strictEqual(wrapper.find(Menu).props().PaperProps.style.minWidth, null);
+    it('should not take the triger width into account when autoWidth is true', () => {
+      const { getByRole, getByTestId } = render(
+        <SelectInput
+          autoWidth
+          classes={{}}
+          IconComponent="div"
+          MenuProps={{ PaperProps: { 'data-testid': 'paper' } }}
+          value=""
+        >
+          <MenuItem>Only</MenuItem>
+        </SelectInput>,
+      );
+      stub(getByRole('button'), 'clientWidth').get(() => 14);
+
+      act(() => {
+        getByRole('button').click();
+      });
+
+      expect(getByTestId('paper').style).to.have.property('minWidth', '');
     });
   });
 
   describe('prop: multiple', () => {
-    it('should take precedence', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} disabled tabIndex={0} />);
-      assert.strictEqual(wrapper.find('[role="button"]').props().tabIndex, 0);
-    });
-
     it('should serialize multiple select value', () => {
-      const wrapper = shallow(<SelectInput {...defaultProps} value={[10, 30]} multiple />);
-      assert.strictEqual(wrapper.find('input').props().value, '10,30');
-      assert.deepEqual(wrapper.find(MenuItem).map(wrapper2 => wrapper2.props().selected), [
-        true,
-        false,
-        true,
-      ]);
+      const { container, getAllByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" multiple open value={[10, 30]}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </SelectInput>,
+      );
+
+      expect(container.querySelector('input')).to.have.property('value', '10,30');
+      expect(getAllByRole('option')[0]).to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[1]).not.to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[2]).to.have.attribute('aria-selected', 'true');
     });
 
-    describe('when the value matches an option but they are different types', () => {
-      it('should select the options based on the value', () => {
-        const wrapper = shallow(<SelectInput {...defaultProps} value={['10', '20']} multiple />);
-        assert.deepEqual(wrapper.find(MenuItem).map(wrapper2 => wrapper2.props().selected), [
-          true,
-          true,
-          false,
-        ]);
+    it('selects value based on their stringified equality when theyre not objects', () => {
+      const { getAllByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" multiple open value={['10', '20']}>
+          <MenuItem value={10}>Ten</MenuItem>
+          <MenuItem value={20}>Twenty</MenuItem>
+          <MenuItem value={30}>Thirty</MenuItem>
+        </SelectInput>,
+      );
+
+      expect(getAllByRole('option')[0]).to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[1]).to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[2]).not.to.have.attribute('aria-selected', 'true');
+    });
+
+    it('selects values based on strict equlity if theyre objects', () => {
+      const obj1 = { id: 1 };
+      const obj2 = { id: 2 };
+      const obj3 = { id: 3 };
+      const { getAllByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" multiple open value={[obj1, obj3]}>
+          <MenuItem value={obj1}>ID: 1</MenuItem>
+          <MenuItem value={obj2}>ID: 2</MenuItem>
+          <MenuItem value={obj3}>ID: 3</MenuItem>
+        </SelectInput>,
+      );
+
+      expect(getAllByRole('option')[0]).to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[1]).not.to.have.attribute('aria-selected', 'true');
+      expect(getAllByRole('option')[2]).to.have.attribute('aria-selected', 'true');
+    });
+
+    describe('errors', () => {
+      beforeEach(() => {
+        consoleErrorMock.spy();
       });
-    });
 
-    describe('when the value is an object', () => {
-      it('should select only the options that match', () => {
-        const obj1 = { id: 1 };
-        const obj2 = { id: 2 };
-        const obj3 = { id: 3 };
-
-        const wrapper = shallow(
-          <SelectInput {...defaultProps} value={[obj1, obj3]} multiple>
-            <MenuItem key={1} value={obj1}>
-              1
-            </MenuItem>
-            <MenuItem key={2} value={obj2}>
-              2
-            </MenuItem>
-            <MenuItem key={3} value={obj3}>
-              3
-            </MenuItem>
-          </SelectInput>,
-        );
-
-        assert.deepEqual(wrapper.find(MenuItem).map(wrapper2 => wrapper2.props().selected), [
-          true,
-          false,
-          true,
-        ]);
+      afterEach(() => {
+        consoleErrorMock.reset();
       });
-    });
 
-    it('should throw if non array', () => {
-      assert.throw(() => {
-        shallow(<SelectInput {...defaultProps} multiple />);
-      }, /the `value` prop must be an array/);
+      it('should throw if non array', () => {
+        expect(() => {
+          render(
+            <SelectInput classes={{}} IconComponent="div" multiple value="10,20">
+              <MenuItem value="10">Ten</MenuItem>
+              <MenuItem value="20">Twenty</MenuItem>
+              <MenuItem value="30">Thirty</MenuItem>
+            </SelectInput>,
+          );
+        }).to.throw(/the `value` prop must be an array/);
+      });
     });
 
     describe('prop: onChange', () => {
-      let wrapper;
-      let handleChange;
-
-      beforeEach(() => {
-        handleChange = spy();
-        wrapper = mount(
-          <SelectInput
-            {...defaultProps}
-            multiple
-            value={[20, 30]}
-            name="age"
-            onChange={handleChange}
-            MenuProps={{ transitionDuration: 0 }}
-          />,
-        );
-      });
-
       it('should call onChange when clicking an item', () => {
-        wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-        assert.strictEqual(wrapper.find(MenuItem).exists(), true);
-        const portalLayer = document.querySelector('[data-mui-test="Modal"]');
+        function ControlledSelectInput(props) {
+          // eslint-disable-next-line react/prop-types
+          const { onChange } = props;
+          const [values, clickedValue] = React.useReducer((currentValues, valueClicked) => {
+            if (currentValues.indexOf(valueClicked) === -1) {
+              return currentValues.concat(valueClicked);
+            }
+            return currentValues.filter(value => {
+              return value !== valueClicked;
+            });
+          }, []);
 
-        portalLayer.querySelectorAll('li')[1].click();
-        assert.strictEqual(wrapper.find(MenuItem).exists(), true);
-        assert.strictEqual(handleChange.callCount, 1);
-        assert.deepEqual(handleChange.args[0][0].target.value, [30]);
-        assert.deepEqual(handleChange.args[0][0].target.name, 'age');
-        wrapper.setProps({ value: [30] });
+          function handleChange(event) {
+            onChange(event);
+            clickedValue(event.target.value);
+          }
 
-        portalLayer.querySelectorAll('li')[0].click();
-        assert.strictEqual(wrapper.find(MenuItem).exists(), true);
-        assert.strictEqual(handleChange.callCount, 2);
-        assert.deepEqual(handleChange.args[1][0].target.value, [30, 10]);
+          return (
+            <SelectInput
+              classes={{}}
+              IconComponent="div"
+              multiple
+              name="age"
+              onChange={handleChange}
+              value={values}
+            >
+              <MenuItem value={10}>Ten</MenuItem>
+              <MenuItem value={20}>Ten</MenuItem>
+              <MenuItem value={30}>Ten</MenuItem>
+            </SelectInput>
+          );
+        }
+        const onChange = stub().callsFake(event => {
+          return {
+            name: event.target.name,
+            value: event.target.value,
+          };
+        });
+        const { getByRole, getAllByRole } = render(<ControlledSelectInput onChange={onChange} />);
+
+        fireEvent.click(getByRole('button'));
+        fireEvent.click(getAllByRole('option')[2]);
+
+        expect(onChange.callCount).to.equal(1);
+        expect(onChange.firstCall.returnValue).to.deep.equal({ name: 'age', value: [30] });
+
+        act(() => {
+          getByRole('button').click();
+        });
+        act(() => {
+          getAllByRole('option')[0].click();
+        });
+
+        expect(onChange.callCount).to.equal(2);
+        expect(onChange.secondCall.returnValue).to.deep.equal({ name: 'age', value: [30, 10] });
       });
     });
+  });
 
-    describe('no selection', () => {
-      it('should focus list if no selection', () => {
-        const wrapper = mount(<SelectInput {...defaultProps} value="" autoFocus />);
-        wrapper.find(`.${defaultProps.classes.select}`).simulate('click');
-        assert.strictEqual(wrapper.find(MenuItem).exists(), true);
-        const portalLayer = document.querySelector('[data-mui-test="Modal"]');
-        assert.strictEqual(document.activeElement, portalLayer.querySelectorAll('ul')[0]);
+  describe('no selection', () => {
+    it('should focus list if no selection', () => {
+      const { getByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" value="" autoFocus />,
+      );
+
+      act(() => {
+        getByRole('button').click();
       });
+
+      // TODO not match WAI-ARIA authoring practices
+      expect(getByRole('listbox')).to.be.focused;
     });
+  });
 
-    describe('prop: autoFocus', () => {
-      it('should focus select after SelectInput did mount', () => {
-        mount(<SelectInput {...defaultProps} autoFocus />);
-        assert.strictEqual(document.activeElement.className, `${defaultProps.classes.select}`);
-      });
+  describe('prop: autoFocus', () => {
+    it('should focus select after SelectInput did mount', () => {
+      const { getByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" value="" autoFocus />,
+      );
+
+      expect(getByRole('button')).to.be.focused;
     });
   });
 
   it('should be able to return the input node via a ref object', () => {
     const ref = React.createRef();
-    const wrapper = mount(<SelectInput {...defaultProps} ref={ref} />);
-    assert.strictEqual(ref.current.node.tagName, 'INPUT');
-    wrapper.setProps({
+    const { setProps } = render(
+      <SelectInput classes={{}} IconComponent="div" ref={ref} value="" />,
+    );
+
+    expect(ref.current.node).to.have.property('tagName', 'INPUT');
+
+    setProps({
       value: 20,
     });
-    assert.strictEqual(ref.current.node.tagName, 'INPUT');
+    expect(ref.current.node).to.have.property('tagName', 'INPUT');
   });
 
   describe('prop: inputRef', () => {
     it('should be able to return the input node via a ref object', () => {
       const ref = React.createRef();
-      mount(<SelectInput {...defaultProps} inputRef={ref} />);
-      assert.strictEqual(ref.current.node.tagName, 'INPUT');
+      render(<SelectInput classes={{}} IconComponent="div" inputRef={ref} value="" />);
+
+      expect(ref.current.node).to.have.property('tagName', 'INPUT');
     });
 
-    it('should be able to return the input focus proxy function', () => {
+    // TODO: This might be confusing a prop called input!Ref can imperatively
+    // focus a button. This implies <input type="button" /> is still used.
+    it('should be able focus the trigger imperatively', () => {
       const ref = React.createRef();
-      mount(<SelectInput {...defaultProps} inputRef={ref} />);
-      assert.strictEqual(typeof ref.current.focus, 'function');
-    });
+      const { getByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" inputRef={ref} value="" />,
+      );
 
-    it('should be able to hit proxy function', () => {
-      const ref = React.createRef();
-      const onFocus = spy();
-      mount(<SelectInput {...defaultProps} inputRef={ref} onFocus={onFocus} />);
-      ref.current.focus();
-      assert.strictEqual(onFocus.called, true);
+      act(() => {
+        ref.current.focus();
+      });
+
+      expect(getByRole('button')).to.be.focused;
     });
   });
 
   describe('prop: name', () => {
     it('should have no id when name is not provided', () => {
-      const wrapper = mount(<SelectInput {...defaultProps} />);
-      assert.strictEqual(wrapper.find('.select').props().id, undefined);
+      const { getByRole } = render(<SelectInput classes={{}} IconComponent="div" value="" />);
+
+      expect(getByRole('button')).not.to.have.attribute('id');
     });
 
     it('should have select-`name` id when name is provided', () => {
-      const wrapper = mount(<SelectInput {...defaultProps} name="foo" />);
-      assert.strictEqual(wrapper.find('.select').props().id, 'select-foo');
+      const { getByRole } = render(
+        <SelectInput classes={{}} IconComponent="div" name="foo" value="" />,
+      );
+
+      expect(getByRole('button')).to.have.attribute('id', 'select-foo');
     });
   });
 });

--- a/packages/material-ui/src/Select/SelectInput.test.js
+++ b/packages/material-ui/src/Select/SelectInput.test.js
@@ -46,6 +46,16 @@ describe('<SelectInput />', () => {
     );
   });
 
+  it('should have a input[type="hidden"] by default', () => {
+    const { container } = render(
+      <SelectInput classes={{}} IconComponent="div" value="10">
+        <MenuItem value="10">Ten</MenuItem>
+      </SelectInput>,
+    );
+
+    expect(container.querySelector('input')).to.have.property('type', 'hidden');
+  });
+
   describe('prop: value', () => {
     it('should select the option based on the number value', () => {
       const { getAllByRole } = render(
@@ -179,34 +189,6 @@ describe('<SelectInput />', () => {
       );
 
       expect(getByRole('button')).to.have.attribute('data-test', 'SelectDisplay');
-    });
-  });
-
-  describe('prop: type', () => {
-    it('should be hidden by default', () => {
-      const { container } = render(
-        <SelectInput classes={{}} IconComponent="div" value="10">
-          <MenuItem value="10">Ten</MenuItem>
-        </SelectInput>,
-      );
-
-      expect(container.querySelector('input')).to.have.property('type', 'hidden');
-    });
-
-    /**
-     * In its current state it will log a react warning
-     * with no way to fix it. It is reachable by using `<Select inputProps={{ type: 'text' }} />`.
-     * We should not support it in v5.
-     */
-    // eslint-disable-next-line mocha/no-skipped-tests
-    it.skip('should be able to override it', () => {
-      const { container } = render(
-        <SelectInput classes={{}} IconComponent="div" type="text" value="10">
-          <MenuItem value="10">Ten</MenuItem>
-        </SelectInput>,
-      );
-
-      expect(container.querySelector('input')).to.have.property('type', 'text');
     });
   });
 


### PR DESCRIPTION
Creating code comments for open issues. Please wait for review until this leaves the DRAFT state.

Replaces shallow/mount testing with `@testing-library/react` testing while also isolating each test (cleanup between each test instead of after full test suite)<sup>1</sup>


Please leave a review comment at the specific test description (i.e. use GitHub review interface) for review. These should be separate topics and not discussed in the main PR comments.
<details>
<summary>For easier review I collected changed test messages/approach:</summary>


```diff
-should render a correct top element
+options should have a data-value attribute
# not sure what was meant by "top element" or "correct". Message now reflects the test approach

-should select only the option that matches the object
+should select only the option that strictly equals the object value
# specified what "matches" means

-should not trigger any event with readOnly
+should not open when readOnly
# it never prevented "any" event. Only prevented opening

-should apply additional props to the Menu component
+should be able to change the transitionDuration
# The nature of this API makes it virtually impossible to test (we would need to define behavior for every combination of props). Instead we're focusing on the most common use case for this prop

-should apply additional props to the clickable div element
should apply additional props to the trigger
# doesn't matter if this is a div element or if it's clickable. That is tested in other tests. This test was only concerned about additional props

-can render a placeholder if there is no value to display
+removed
# there was a value to display but the test simply overwrote whatever value was selected

-should ignore onBlur the first time the menu is open
+does not call onBlur when clicking the button

-should call handleClose
+should call onClose when the backdrop is clicked
# specified when it should be called. otherwise message would be non-descriptive.

-should take the anchor width into account
+should take the trigger width into account by default
# nitpick about vocabulary

-should not take the anchor width into account
+should not take the triger width into account when autoWidth is true
# nitpick about vocabulary and specified conditions. would otherwise contradict previous test

-should take precedence
+the trigger is in tab order
# previous message could mean anything

-should select the options based on the value
+selects value based on their stringified equality when they're not objects
# "based on value" usually means deep equality at least interpreting it as String(2) ==== String("2") is quite the stretch.

-when the value is an object > should select only the options that match
+selects values based on strict equlity if they're objects
# as above: "match" is ambigious

-should focus list if no selection
+should focus list if no selection when autoFocus is true
# specified condition

-should focus select after SelectInput did mount
+should focus the trigger after SelectInput did mount
# "select" usually implies the role="listbox" element which was never true. `autoFocus` focuses the trigger

-should be able to return the input focus proxy function
# Removed since the next test immediately tests if the function is callable
```
</details>

<sup>1</sup> We get increasing test_browsers fails due to "full page reload". Apparently this might be caused by tests not being isolated. This test basically moves us closer to being able use the implicit cleanup from `@testing-library/react`.