### PR TITLE
[test] Isolate each test case using testing-library

### DIFF
--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -4,7 +4,7 @@ import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Breadcrumbs from './Breadcrumbs';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 
 describe('<Breadcrumbs />', () => {
   let mount;
@@ -18,10 +18,6 @@ describe('<Breadcrumbs />', () => {
         <span>Hello World</span>
       </Breadcrumbs>,
     );
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<Breadcrumbs>Conformance?</Breadcrumbs>, () => ({

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { assert, expect } from 'chai';
 import { createMount, createRender, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Button from './Button';
 import ButtonBase from '../ButtonBase';
 
@@ -15,10 +15,6 @@ describe('<Button />', () => {
   before(() => {
     mount = createMount({ strict: false });
     classes = getClasses(<Button>Hello World</Button>);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<Button>Conformance?</Button>, () => ({

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -8,7 +8,7 @@ import describeConformance from '../test-utils/describeConformance';
 import TouchRipple from './TouchRipple';
 import ButtonBase from './ButtonBase';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import * as PropTypes from 'prop-types';
 
 /**
@@ -52,10 +52,6 @@ describe('<ButtonBase />', () => {
     } catch (err) {
       canFireDragEvents = false;
     }
-  });
-
-  after(() => {
-    cleanup();
   });
 
   describeConformance(<ButtonBase />, () => ({

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -396,6 +396,13 @@ describe('<ButtonBase />', () => {
   });
 
   describe('focusRipple', () => {
+    before(function beforeHook() {
+      if (/Version\/10\.\d+\.\d+ Safari/.test(window.navigator.userAgent)) {
+        // browserstack quirk
+        this.skip();
+      }
+    });
+
     it('should pulsate the ripple when focusVisible', () => {
       const { getByRole } = render(
         <ButtonBase

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -192,46 +192,38 @@ describe('<ButtonBase />', () => {
 
   describe('ripple', () => {
     describe('interactions', () => {
-      /**
-       * @type {HTMLElement}
-       */
-      let button;
-
-      /**
-       * Each test in here relies on the previous one. Each one has a single
-       * act and a single assertion. The state of the Ripple is tracked by the number of ripples
-       * that are active i.e. not leaving and the number of ripples that are inactive (child-leaving)
-       */
-
-      before(() => {
-        const { getByText } = render(
+      it('should not have a focus ripple by default', () => {
+        const { getByRole } = render(
           <ButtonBase
             TouchRippleProps={{
               classes: {
-                root: 'touch-ripple',
-                ripple: 'ripple',
                 ripplePulsate: 'ripple-pulsate',
-                rippleVisible: 'ripple-visible',
-                child: 'child',
-                childLeaving: 'child-leaving',
               },
             }}
-          >
-            Hello
-          </ButtonBase>,
+          />,
         );
-        button = getByText('Hello');
-
+        const button = getByRole('button');
         simulatePointerDevice();
-      });
 
-      it('should not have a focus ripple by default', () => {
         focusVisible(button);
 
         expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(0);
       });
 
-      it('should start the ripple when the mouse is pressed 1', () => {
+      it('should start the ripple when the mouse is pressed', () => {
+        const { getByRole } = render(
+          <ButtonBase
+            TouchRippleProps={{
+              classes: {
+                rippleVisible: 'ripple-visible',
+                child: 'child',
+                childLeaving: 'child-leaving',
+              },
+            }}
+          />,
+        );
+        const button = getByRole('button');
+
         fireEvent.mouseDown(button);
 
         expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(0);
@@ -241,6 +233,20 @@ describe('<ButtonBase />', () => {
       });
 
       it('should stop the ripple when the mouse is released', () => {
+        const { getByRole } = render(
+          <ButtonBase
+            TouchRippleProps={{
+              classes: {
+                rippleVisible: 'ripple-visible',
+                child: 'child',
+                childLeaving: 'child-leaving',
+              },
+            }}
+          />,
+        );
+        const button = getByRole('button');
+        fireEvent.mouseDown(button);
+
         fireEvent.mouseUp(button);
 
         expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(1);
@@ -250,6 +256,21 @@ describe('<ButtonBase />', () => {
       });
 
       it('should start the ripple when the mouse is pressed 2', () => {
+        const { getByRole } = render(
+          <ButtonBase
+            TouchRippleProps={{
+              classes: {
+                rippleVisible: 'ripple-visible',
+                child: 'child',
+                childLeaving: 'child-leaving',
+              },
+            }}
+          />,
+        );
+        const button = getByRole('button');
+        fireEvent.mouseDown(button);
+        fireEvent.mouseUp(button);
+
         fireEvent.mouseDown(button);
 
         expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(1);
@@ -259,48 +280,102 @@ describe('<ButtonBase />', () => {
       });
 
       it('should stop the ripple when the button blurs', () => {
-        button.blur();
-
-        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(2);
-        expect(
-          button.querySelectorAll('.ripple-visible .child:not(.child-leaving)'),
-        ).to.have.lengthOf(0);
-      });
-
-      it('should start the ripple when the mouse is pressed 3', () => {
+        const { getByRole } = render(
+          <ButtonBase
+            TouchRippleProps={{
+              classes: {
+                rippleVisible: 'ripple-visible',
+                child: 'child',
+                childLeaving: 'child-leaving',
+              },
+            }}
+          />,
+        );
+        const button = getByRole('button');
         fireEvent.mouseDown(button);
 
-        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(2);
+        button.blur();
+
+        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(0);
+        expect(
+          button.querySelectorAll('.ripple-visible .child:not(.child-leaving)'),
+        ).to.have.lengthOf(1);
+      });
+
+      it('should restart the ripple when the mouse is pressed again', () => {
+        const { getByRole } = render(
+          <ButtonBase
+            TouchRippleProps={{
+              classes: {
+                rippleVisible: 'ripple-visible',
+                child: 'child',
+                childLeaving: 'child-leaving',
+              },
+            }}
+          />,
+        );
+        const button = getByRole('button');
+
+        fireEvent.mouseDown(button);
+
+        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(0);
+        expect(
+          button.querySelectorAll('.ripple-visible .child:not(.child-leaving)'),
+        ).to.have.lengthOf(1);
+
+        fireEvent.mouseUp(button);
+        fireEvent.mouseDown(button);
+
+        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(1);
         expect(
           button.querySelectorAll('.ripple-visible .child:not(.child-leaving)'),
         ).to.have.lengthOf(1);
       });
 
       it('should stop the ripple when the mouse leaves', () => {
+        const { getByRole } = render(
+          <ButtonBase
+            TouchRippleProps={{
+              classes: {
+                rippleVisible: 'ripple-visible',
+                child: 'child',
+                childLeaving: 'child-leaving',
+              },
+            }}
+          />,
+        );
+        const button = getByRole('button');
+        fireEvent.mouseDown(button);
+
         fireEvent.mouseLeave(button);
 
-        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(3);
+        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(1);
         expect(
           button.querySelectorAll('.ripple-visible .child:not(.child-leaving)'),
         ).to.have.lengthOf(0);
-      });
-
-      it('should start the ripple when the mouse is pressed 4', () => {
-        fireEvent.mouseDown(button);
-
-        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(3);
-        expect(
-          button.querySelectorAll('.ripple-visible .child:not(.child-leaving)'),
-        ).to.have.lengthOf(1);
       });
 
       it('should stop the ripple when dragging has finished', function test() {
         if (!canFireDragEvents) {
           this.skip();
         }
+        const { getByRole } = render(
+          <ButtonBase
+            TouchRippleProps={{
+              classes: {
+                rippleVisible: 'ripple-visible',
+                child: 'child',
+                childLeaving: 'child-leaving',
+              },
+            }}
+          />,
+        );
+        const button = getByRole('button');
+        fireEvent.mouseDown(button);
+
         fireEvent.dragLeave(button);
 
-        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(4);
+        expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(1);
         expect(
           button.querySelectorAll('.ripple-visible .child:not(.child-leaving)'),
         ).to.have.lengthOf(0);
@@ -321,55 +396,86 @@ describe('<ButtonBase />', () => {
   });
 
   describe('focusRipple', () => {
-    /**
-     * @type {HTMLElement}
-     */
-    let button;
-
-    before(() => {
-      const { getByText } = render(
+    it('should pulsate the ripple when focusVisible', () => {
+      const { getByRole } = render(
         <ButtonBase
           focusRipple
-          focusVisibleClassName="focus-visible"
           TouchRippleProps={{
             classes: {
-              root: 'touch-ripple',
-              ripple: 'ripple',
               ripplePulsate: 'ripple-pulsate',
-              rippleVisible: 'ripple-visible',
-              childLeaving: 'child-leaving',
             },
           }}
-        >
-          Hello
-        </ButtonBase>,
+        />,
       );
-
-      button = getByText('Hello');
+      const button = getByRole('button');
 
       simulatePointerDevice();
-    });
-
-    it('should pulsate the ripple when focusVisible', () => {
       focusVisible(button);
 
       expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
     });
 
     it('should not stop the ripple when the mouse leaves', () => {
+      const { getByRole } = render(
+        <ButtonBase
+          focusRipple
+          TouchRippleProps={{
+            classes: {
+              ripplePulsate: 'ripple-pulsate',
+            },
+          }}
+        />,
+      );
+      const button = getByRole('button');
+
+      simulatePointerDevice();
+      focusVisible(button);
       fireEvent.mouseLeave(button);
 
       expect(button.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
     });
 
     it('should stop pulsate and start a ripple when the space button is pressed', () => {
+      const { getByRole } = render(
+        <ButtonBase
+          focusRipple
+          TouchRippleProps={{
+            classes: {
+              childLeaving: 'child-leaving',
+              ripplePulsate: 'ripple-pulsate',
+              rippleVisible: 'rippled-visible',
+            },
+          }}
+        />,
+      );
+      const button = getByRole('button');
+
+      simulatePointerDevice();
+      focusVisible(button);
       fireEvent.keyDown(button, { key: ' ' });
 
       expect(button.querySelectorAll('.ripple-pulsate .child-leaving')).to.have.lengthOf(1);
-      expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(2);
+      expect(button.querySelectorAll('.ripple-visible')).to.have.lengthOf(0);
     });
 
     it('should stop and re-pulsate when space bar is released', () => {
+      const { getByRole } = render(
+        <ButtonBase
+          focusRipple
+          TouchRippleProps={{
+            classes: {
+              childLeaving: 'child-leaving',
+              ripplePulsate: 'ripple-pulsate',
+              rippleVisible: 'ripple-visible',
+            },
+          }}
+        />,
+      );
+      const button = getByRole('button');
+
+      simulatePointerDevice();
+      focusVisible(button);
+      fireEvent.keyDown(button, { key: ' ' });
       fireEvent.keyUp(button, { key: ' ' });
 
       expect(button.querySelectorAll('.ripple-pulsate .child-leaving')).to.have.lengthOf(1);
@@ -378,12 +484,26 @@ describe('<ButtonBase />', () => {
     });
 
     it('should stop on blur and set focusVisible to false', () => {
-      expect(button).to.match('.focus-visible');
+      const { getByRole } = render(
+        <ButtonBase
+          focusRipple
+          TouchRippleProps={{
+            classes: {
+              childLeaving: 'child-leaving',
+              rippleVisible: 'ripple-visible',
+            },
+          }}
+        />,
+      );
+      const button = getByRole('button');
+      simulatePointerDevice();
+      focusVisible(button);
+
       act(() => {
         button.blur();
       });
 
-      expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(3);
+      expect(button.querySelectorAll('.ripple-visible .child-leaving')).to.have.lengthOf(1);
     });
   });
 

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { assert, expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import TouchRipple from './TouchRipple';
 import Ripple from './Ripple';
 
@@ -12,10 +12,6 @@ describe('<Ripple />', () => {
 
   before(() => {
     classes = getClasses(<TouchRipple />);
-  });
-
-  after(() => {
-    cleanup();
   });
 
   it('should have the ripple className', () => {

--- a/packages/material-ui/src/ButtonBase/TouchRipple.test.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { useFakeTimers } from 'sinon';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import TouchRipple, { DELAY_RIPPLE } from './TouchRipple';
 
@@ -51,7 +51,6 @@ describe('<TouchRipple />', () => {
   });
 
   after(() => {
-    cleanup();
     mount.cleanUp();
   });
 

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Modal from '../Modal';
 import Dialog from './Dialog';
 
@@ -48,7 +48,6 @@ describe('<Dialog />', () => {
 
   afterEach(() => {
     clock.restore();
-    cleanup();
   });
 
   describeConformance(<Dialog open>foo</Dialog>, () => ({

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, createRender, getClasses } from '../test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import Fab from './Fab';
 import ButtonBase from '../ButtonBase';
 import Icon from '../Icon';
@@ -15,10 +15,6 @@ describe('<Fab />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<Fab>Fab</Fab>);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<Fab>Conformance?</Fab>, () => ({

--- a/packages/material-ui/src/FilledInput/FilledInput.test.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import FilledInput from './FilledInput';
 import InputBase from '../InputBase';
 
@@ -14,10 +14,6 @@ describe('<FilledInput />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<FilledInput />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<FilledInput open />, () => ({

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import Input from '../Input';
 import Select from '../Select';
 import FormControl from './FormControl';
@@ -23,10 +23,6 @@ describe('<FormControl />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<FormControl />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   after(() => {

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import Checkbox from '../Checkbox';
 import FormControlLabel from './FormControlLabel';
 import FormControl from '../FormControl';
@@ -15,10 +15,6 @@ describe('<FormControlLabel />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<FormControlLabel label="Pizza" control={<div />} />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<FormControlLabel label="Pizza" control={<Checkbox />} />, () => ({

--- a/packages/material-ui/src/FormHelperText/FormHelperText.test.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import FormHelperText from './FormHelperText';
 import FormControl from '../FormControl';
 
@@ -14,10 +14,6 @@ describe('<FormHelperText />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<FormHelperText />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<FormHelperText />, () => ({

--- a/packages/material-ui/src/FormLabel/FormLabel.test.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.test.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import FormLabel from './FormLabel';
 import FormControl, { useFormControl } from '../FormControl';
 
@@ -15,10 +15,6 @@ describe('<FormLabel />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<FormLabel />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<FormLabel />, () => ({

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import Icon from '../Icon';
 import ButtonBase from '../ButtonBase';
 import IconButton from './IconButton';
@@ -17,10 +17,6 @@ describe('<IconButton />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<IconButton />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<IconButton>book</IconButton>, () => ({

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import Typography from '../Typography';
 import InputAdornment from './InputAdornment';
 import TextField from '../TextField';
@@ -18,10 +18,6 @@ describe('<InputAdornment />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<InputAdornment position="start">foo</InputAdornment>);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<InputAdornment position="start">foo</InputAdornment>, () => ({

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import FormControl, { useFormControl } from '../FormControl';
 import InputAdornment from '../InputAdornment';
@@ -21,10 +21,6 @@ describe('<InputBase />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<InputBase />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<InputBase />, () => ({

--- a/packages/material-ui/src/InputLabel/InputLabel.test.js
+++ b/packages/material-ui/src/InputLabel/InputLabel.test.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import FormControl from '../FormControl';
 import Input from '../Input';
 import InputLabel from './InputLabel';
@@ -17,10 +17,6 @@ describe('<InputLabel />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<InputLabel />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<InputLabel>Foo</InputLabel>, () => ({

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -4,13 +4,7 @@ import PropTypes from 'prop-types';
 import { getClasses, createMount } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import {
-  act,
-  cleanup,
-  createClientRender,
-  fireEvent,
-  queries,
-} from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent, queries } from 'test/utils/createClientRender';
 import ListItemText from '../ListItemText';
 import ListItemSecondaryAction from '../ListItemSecondaryAction';
 import ListItem from './ListItem';
@@ -28,10 +22,6 @@ describe('<ListItem />', () => {
   before(() => {
     classes = getClasses(<ListItem />);
     mount = createMount({ strict: true });
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<ListItem />, () => ({

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -3,7 +3,7 @@ import { assert, expect } from 'chai';
 import { useFakeTimers, spy } from 'sinon';
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import { createMuiTheme } from '@material-ui/core/styles';
 import { createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import { ThemeProvider } from '@material-ui/styles';
@@ -25,10 +25,6 @@ describe('<Modal />', () => {
 
   beforeEach(() => {
     document.body.setAttribute('style', savedBodyStyle);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   after(() => {

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { getClasses } from '@material-ui/core/test-utils';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import NotchedOutline from './NotchedOutline';
 
@@ -16,10 +16,6 @@ describe('<NotchedOutline />', () => {
 
   before(() => {
     classes = getClasses(<NotchedOutline {...defaultProps} />);
-  });
-
-  after(() => {
-    cleanup();
   });
 
   it('should pass props', () => {

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import OutlinedInput from './OutlinedInput';
 import InputBase from '../InputBase';
 
@@ -14,10 +14,6 @@ describe('<OutlinedInput />', () => {
   before(() => {
     classes = getClasses(<OutlinedInput />);
     mount = createMount({ strict: true });
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<OutlinedInput labelWidth={0} />, () => ({

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { getClasses, createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
-import { act, cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { act, createClientRender, fireEvent } from 'test/utils/createClientRender';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import MenuItem from '../MenuItem';
 import Input from '../Input';
@@ -18,10 +18,6 @@ describe('<Select />', () => {
     classes = getClasses(<Select />);
     // StrictModeViolation: test uses MenuItem
     mount = createMount({ strict: false });
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<Select value="none" />, () => ({

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
-import { cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Slider from './Slider';
 
@@ -34,10 +34,6 @@ describe('<Slider />', () => {
   before(() => {
     classes = getClasses(<Slider value={0} />);
     mount = createMount({ strict: true });
-  });
-
-  after(() => {
-    cleanup();
   });
 
   describeConformance(<Slider value={0} />, () => ({

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import Table from './Table';
 import TableContext from './TableContext';
 
@@ -14,10 +14,6 @@ describe('<Table />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<Table>foo</Table>);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -4,7 +4,7 @@ import { spy, useFakeTimers } from 'sinon';
 import * as PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createMount, createRender, getClasses } from '@material-ui/core/test-utils';
-import { cleanup, createClientRender, fireEvent } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import describeConformance from '../test-utils/describeConformance';
 import Tab from '../Tab';
 import Tabs from './Tabs';
@@ -42,10 +42,6 @@ describe('<Tabs />', () => {
     classes = getClasses(<Tabs value={0} />);
     mount = createMount({ strict: true });
     serverRender = createRender();
-  });
-
-  after(() => {
-    cleanup();
   });
 
   describeConformance(<Tabs value={0} />, () => ({

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import FormControl from '../FormControl';
 import Input from '../Input';
 import OutlinedInput from '../OutlinedInput';
@@ -16,10 +16,6 @@ describe('<TextField />', () => {
   before(() => {
     classes = getClasses(<TextField />);
     mount = createMount({ strict: true });
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<TextField />, () => ({

--- a/packages/material-ui/src/Toolbar/Toolbar.test.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import Toolbar from './Toolbar';
 
 describe('<Toolbar />', () => {
@@ -13,10 +13,6 @@ describe('<Toolbar />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<Toolbar>foo</Toolbar>);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(<Toolbar />, () => ({

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -4,7 +4,7 @@ import { spy } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { cleanup, createClientRender } from 'test/utils/createClientRender';
+import { createClientRender } from 'test/utils/createClientRender';
 import SwitchBase from './SwitchBase';
 import FormControl, { useFormControl } from '../FormControl';
 import IconButton from '../IconButton';
@@ -26,10 +26,6 @@ describe('<SwitchBase />', () => {
   before(() => {
     mount = createMount({ strict: true });
     classes = getClasses(<SwitchBase icon="unchecked" checkedIcon="checked" type="checkbox" />);
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describeConformance(

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider } from '@material-ui/styles';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { act, cleanup, createClientRender } from 'test/utils/createClientRender';
+import { act, createClientRender } from 'test/utils/createClientRender';
 import { createRender } from '@material-ui/core/test-utils';
 import mediaQuery from 'css-mediaquery';
 import { expect } from 'chai';
@@ -47,10 +47,6 @@ describe('useMediaQuery', () => {
   beforeEach(() => {
     testReset();
     values = spy();
-  });
-
-  afterEach(() => {
-    cleanup();
   });
 
   describe('without feature', () => {

--- a/test/utils/createClientRender.js
+++ b/test/utils/createClientRender.js
@@ -78,6 +78,10 @@ function clientRender(element, options = {}) {
 export function createClientRender(globalOptions = {}) {
   const { strict: globalStrict } = globalOptions;
 
+  afterEach(() => {
+    cleanup();
+  });
+
   return function configuredClientRender(element, options = {}) {
     const { strict = globalStrict, ...localOptions } = options;
 

--- a/test/utils/createClientRender.js
+++ b/test/utils/createClientRender.js
@@ -39,11 +39,6 @@ const customQueries = { queryDescriptionOf, getDescriptionOf, findDescriptionOf 
 function clientRender(element, options = {}) {
   const { baseElement, strict = false, wrapper: InnerWrapper = React.Fragment } = options;
 
-  // TODO: remove before merge
-  if (options.disableUnnmount !== undefined) {
-    throw new Error('not implemented anymore');
-  }
-
   const Mode = strict ? React.StrictMode : React.Fragment;
   function Wrapper({ children }) {
     return (

--- a/test/utils/createClientRender.js
+++ b/test/utils/createClientRender.js
@@ -8,7 +8,7 @@ import {
   createEvent,
   fireEvent as rtlFireEvent,
   queries,
-  render,
+  render as testingLibraryRender,
 } from '@testing-library/react/pure';
 
 // holes are *All* selectors which aren't necessary for id selectors
@@ -37,15 +37,11 @@ const customQueries = { queryDescriptionOf, getDescriptionOf, findDescriptionOf 
  * TODO: type return RenderResult in setProps
  */
 function clientRender(element, options = {}) {
-  const {
-    baseElement,
-    disableUnnmount = false,
-    strict = false,
-    wrapper: InnerWrapper = React.Fragment,
-  } = options;
+  const { baseElement, strict = false, wrapper: InnerWrapper = React.Fragment } = options;
 
-  if (!disableUnnmount) {
-    cleanup();
+  // TODO: remove before merge
+  if (options.disableUnnmount !== undefined) {
+    throw new Error('not implemented anymore');
   }
 
   const Mode = strict ? React.StrictMode : React.Fragment;
@@ -58,7 +54,7 @@ function clientRender(element, options = {}) {
   }
   Wrapper.propTypes = { children: PropTypes.node };
 
-  const result = render(element, {
+  const result = testingLibraryRender(element, {
     baseElement,
     queries: { ...queries, ...customQueries },
     wrapper: Wrapper,
@@ -79,7 +75,9 @@ export function createClientRender(globalOptions = {}) {
   const { strict: globalStrict } = globalOptions;
 
   afterEach(() => {
-    cleanup();
+    act(() => {
+      cleanup();
+    });
   });
 
   return function configuredClientRender(element, options = {}) {
@@ -116,5 +114,10 @@ const fireEvent = Object.assign(rtlFireEvent, {
 });
 
 export * from '@testing-library/react';
-// in case someone accidentally imports `render`. we want to use a single API
-export { act, cleanup, clientRender as render, fireEvent };
+export { act, cleanup, fireEvent };
+
+export function render() {
+  throw new Error(
+    "Don't use `render` directly. Instead use the return value from `createClientRender`",
+  );
+}


### PR DESCRIPTION
Tests with `test/utils/createClientRender` are now cleaned up automatically between each test. Mount in another PR. Let's make the new test proper and rather port old ones instead of refactoring them.

Improving test readability and tracking down "tests did a full page reload".

* [x] Force cleanup between each test for tests using `createClientRender`
* ~[ ] Force cleanup between each test for tests using `createMount`~