### PR TITLE
[core] Prevent empty useEffect in production

### DIFF
--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -33,8 +33,9 @@ const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
     [],
   );
 
-  React.useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
       if (isControlled !== (valueProp != null)) {
         console.error(
           [
@@ -48,8 +49,8 @@ const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
           ].join('\n'),
         );
       }
-    }
-  }, [valueProp, isControlled]);
+    }, [valueProp, isControlled]);
+  }
 
   const value = isControlled ? valueProp : valueState;
 

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -120,8 +120,9 @@ function Tooltip(props) {
   const leaveTimer = React.useRef();
   const touchTimer = React.useRef();
 
-  React.useEffect(() => {
-    if (process.env.NODE_ENV !== 'production') {
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
       if (
         childNode &&
         childNode.disabled &&
@@ -139,8 +140,8 @@ function Tooltip(props) {
           ].join('\n'),
         );
       }
-    }
-  }, [isControlled, title, childNode]);
+    }, [isControlled, title, childNode]);
+  }
 
   React.useEffect(() => {
     // Fallback to this default id when possible.


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Wrapped the `useEffect` hook checking if the user is changing between controlled and uncontrolled state with `process.env.NODE_ENV !== 'production'` to prevent empty `useEffect` in production code