### PR TITLE
[docs] Use Suspense for lazy loading algolia

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -65,6 +65,7 @@
     "css-mediaquery": "^0.1.2",
     "date-fns": "^2.0.1",
     "deepmerge": "^4.0.0",
+    "docsearch.js": "^2.6.3",
     "doctrine": "^3.0.0",
     "downshift": "^3.0.0",
     "emotion-theming": "^10.0.14",

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -28,7 +28,7 @@ import FormatTextdirectionLToR from '@material-ui/icons/FormatTextdirectionLToR'
 import FormatTextdirectionRToL from '@material-ui/icons/FormatTextdirectionRToL';
 import Link from 'docs/src/modules/components/Link';
 import AppDrawer from 'docs/src/modules/components/AppDrawer';
-import AppSearch from 'docs/src/modules/components/AppSearch';
+import Skeleton from '@material-ui/lab/Skeleton';
 import Notifications from 'docs/src/modules/components/Notifications';
 import MarkdownLinks from 'docs/src/modules/components/MarkdownLinks';
 import usePageTitle from 'docs/src/modules/components/usePageTitle';
@@ -50,6 +50,22 @@ Router.onRouteChangeComplete = () => {
 Router.onRouteChangeError = () => {
   NProgress.done();
 };
+
+const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
+function DeferredAppSearch() {
+  const fallback = <Skeleton height={32} variant="rect" width={220} />;
+
+  // Suspense isn't supported for SSR yet
+  if (typeof window === 'undefined') {
+    return fallback;
+  }
+
+  return (
+    <React.Suspense fallback={fallback}>
+      <AppSearch />
+    </React.Suspense>
+  );
+}
 
 const styles = theme => ({
   root: {
@@ -193,7 +209,7 @@ function AppFrame(props) {
             <MenuIcon />
           </IconButton>
           <div className={classes.grow} />
-          <AppSearch />
+          <DeferredAppSearch />
           <Tooltip title="Change language" enterDelay={300}>
             <IconButton
               color="inherit"

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -28,7 +28,6 @@ import FormatTextdirectionLToR from '@material-ui/icons/FormatTextdirectionLToR'
 import FormatTextdirectionRToL from '@material-ui/icons/FormatTextdirectionRToL';
 import Link from 'docs/src/modules/components/Link';
 import AppDrawer from 'docs/src/modules/components/AppDrawer';
-import Skeleton from '@material-ui/lab/Skeleton';
 import Notifications from 'docs/src/modules/components/Notifications';
 import MarkdownLinks from 'docs/src/modules/components/MarkdownLinks';
 import usePageTitle from 'docs/src/modules/components/usePageTitle';
@@ -53,7 +52,7 @@ Router.onRouteChangeError = () => {
 
 const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch'));
 function DeferredAppSearch() {
-  const fallback = <Skeleton height={32} variant="rect" width={220} />;
+  const fallback = null;
 
   return (
     <React.Fragment>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -55,15 +55,22 @@ const AppSearch = React.lazy(() => import('docs/src/modules/components/AppSearch
 function DeferredAppSearch() {
   const fallback = <Skeleton height={32} variant="rect" width={220} />;
 
-  // Suspense isn't supported for SSR yet
-  if (typeof window === 'undefined') {
-    return fallback;
-  }
-
   return (
-    <React.Suspense fallback={fallback}>
-      <AppSearch />
-    </React.Suspense>
+    <React.Fragment>
+      <link
+        rel="preload"
+        href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css"
+        as="style"
+      />
+      {/* Suspense isn't supported for SSR yet */}
+      {typeof window === 'undefined' ? (
+        fallback
+      ) : (
+        <React.Suspense fallback={fallback}>
+          <AppSearch />
+        </React.Suspense>
+      )}
+    </React.Fragment>
   );
 }
 

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -6,94 +6,8 @@ import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { fade, useTheme, makeStyles } from '@material-ui/core/styles';
 import Input from '@material-ui/core/Input';
 import SearchIcon from '@material-ui/icons/Search';
-import loadScript from 'docs/src/modules/utils/loadScript';
 import { handleEvent } from 'docs/src/modules/components/MarkdownLinks';
-
-let searchTimer;
-let initialized = false;
-let dependenciesLoaded = false;
-
-function loadDependencies() {
-  if (dependenciesLoaded) {
-    return;
-  }
-  dependenciesLoaded = true;
-
-  loadCSS(
-    'https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css',
-    document.querySelector('#app-search'),
-  );
-  loadScript(
-    'https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js',
-    document.querySelector('head'),
-  );
-}
-
-function initDocsearch(userLanguage) {
-  clearInterval(searchTimer);
-  searchTimer = setInterval(() => {
-    const docsearchInput = document.querySelector('#docsearch-input');
-
-    if (!window.docsearch || !docsearchInput) {
-      return;
-    }
-
-    clearInterval(searchTimer);
-
-    if (initialized === docsearchInput) {
-      return;
-    }
-
-    initialized = docsearchInput;
-    const search = window.docsearch({
-      apiKey: '1d8534f83b9b0cfea8f16498d19fbcab',
-      indexName: 'material-ui',
-      inputSelector: '#docsearch-input',
-      algoliaOptions: {
-        facetFilters: ['version:master', `language:${userLanguage}`],
-      },
-      autocompleteOptions: {
-        openOnFocus: true,
-      },
-      handleSelected: (input, event, suggestion) => {
-        event.button = 0;
-        const parseUrl = url.parse(suggestion.url);
-        handleEvent(event, parseUrl.pathname + parseUrl.hash);
-        input.close();
-      },
-      // debug: true, // Set debug to true if you want to inspect the dropdown.
-    });
-
-    search.autocomplete.on('autocomplete:cursorchanged', event => {
-      const combobox = event.target;
-      const selectedOptionNode = document.getElementById(
-        combobox.getAttribute('aria-activedescendant'),
-      );
-      const listboxNode = document.querySelector('.ds-suggestions').parentElement;
-
-      if (selectedOptionNode === null || listboxNode === null) {
-        if (process.env.NODE_ENV !== 'production') {
-          console.warn('Cant scroll to selected option.');
-        }
-        return;
-      }
-
-      // scroll active descendant into view
-      // logic copied from https://www.w3.org/TR/wai-aria-practices/examples/listbox/js/listbox.js
-      if (listboxNode.scrollHeight > listboxNode.clientHeight) {
-        const element = selectedOptionNode;
-
-        const scrollBottom = listboxNode.clientHeight + listboxNode.scrollTop;
-        const elementBottom = element.offsetTop + element.offsetHeight;
-        if (elementBottom > scrollBottom) {
-          listboxNode.scrollTop = elementBottom - listboxNode.clientHeight;
-        } else if (element.offsetTop < listboxNode.scrollTop) {
-          listboxNode.scrollTop = element.offsetTop;
-        }
-      }
-    });
-  }, 100);
-}
+import docsearch from 'docsearch.js';
 
 const useStyles = makeStyles(
   theme => ({
@@ -200,6 +114,13 @@ export default function AppSearch() {
   const userLanguage = useSelector(state => state.options.userLanguage);
 
   React.useEffect(() => {
+    loadCSS(
+      'https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css',
+      document.querySelector('#app-search'),
+    );
+  }, []);
+
+  React.useEffect(() => {
     const handleKeyDown = event => {
       // Use event.keyCode to support IE 11
       if (
@@ -225,10 +146,59 @@ export default function AppSearch() {
 
   React.useEffect(() => {
     if (desktop) {
-      loadDependencies();
-      initDocsearch(userLanguage);
+      // This assumes that by the time this effect runs the Input component is committed
+      // this holds true as long as the effect and the component are in the same
+      // suspense boundary. If you move effect and component apart be sure to check
+      // that this assumption still holds
+      const search = docsearch({
+        apiKey: '1d8534f83b9b0cfea8f16498d19fbcab',
+        indexName: 'material-ui',
+        inputSelector: '#docsearch-input',
+        algoliaOptions: {
+          facetFilters: ['version:master', `language:${userLanguage}`],
+        },
+        autocompleteOptions: {
+          openOnFocus: true,
+        },
+        handleSelected: (input, event, suggestion) => {
+          event.button = 0;
+          const parseUrl = url.parse(suggestion.url);
+          handleEvent(event, parseUrl.pathname + parseUrl.hash);
+          input.close();
+        },
+        // debug: true, // Set debug to true if you want to inspect the dropdown.
+      });
+
+      search.autocomplete.on('autocomplete:cursorchanged', event => {
+        const combobox = event.target;
+        const selectedOptionNode = document.getElementById(
+          combobox.getAttribute('aria-activedescendant'),
+        );
+        const listboxNode = document.querySelector('.ds-suggestions').parentElement;
+
+        if (selectedOptionNode === null || listboxNode === null) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn('Cant scroll to selected option.');
+          }
+          return;
+        }
+
+        // scroll active descendant into view
+        // logic copied from https://www.w3.org/TR/wai-aria-practices/examples/listbox/js/listbox.js
+        if (listboxNode.scrollHeight > listboxNode.clientHeight) {
+          const element = selectedOptionNode;
+
+          const scrollBottom = listboxNode.clientHeight + listboxNode.scrollTop;
+          const elementBottom = element.offsetTop + element.offsetHeight;
+          if (elementBottom > scrollBottom) {
+            listboxNode.scrollTop = elementBottom - listboxNode.clientHeight;
+          } else if (element.offsetTop < listboxNode.scrollTop) {
+            listboxNode.scrollTop = element.offsetTop;
+          }
+        }
+      });
     }
-  });
+  }, [desktop, userLanguage]);
 
   return (
     <div className={classes.root} style={{ display: desktop ? 'flex' : 'none' }}>

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -114,10 +114,14 @@ export default function AppSearch() {
   const userLanguage = useSelector(state => state.options.userLanguage);
 
   React.useEffect(() => {
-    loadCSS(
+    const styleNode = loadCSS(
       'https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css',
       document.querySelector('#app-search'),
     );
+
+    return () => {
+      styleNode.parentElement.removeChild(styleNode);
+    };
   }, []);
 
   React.useEffect(() => {

--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -107,6 +107,11 @@ const useStyles = makeStyles(
   { name: 'AppSearch' },
 );
 
+/**
+ * When using this component it is recommend to include a preload link
+ * `<link rel="preload" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" as="style" />`
+ * to potentially reduce load times
+ */
 export default function AppSearch() {
   const classes = useStyles();
   const inputRef = React.useRef(null);

--- a/test/utils/init.js
+++ b/test/utils/init.js
@@ -3,57 +3,7 @@ import enzyme from 'enzyme/build/index';
 import Adapter from 'enzyme-adapter-react-16';
 import consoleError from './consoleError';
 import { useIsSsr } from '@material-ui/core/test-utils/RenderMode';
-import chai from 'chai';
-import chaiDom from 'chai-dom';
-import { prettyDOM } from '@testing-library/react';
-
-chai.use(chaiDom);
-chai.use((chaiAPI, utils) => {
-  // better diff view for expect(element).to.equal(document.activeElement)
-  chai.Assertion.addProperty('focused', function elementIsFocused() {
-    const element = utils.flag(this, 'object');
-
-    this.assert(
-      element === document.activeElement,
-      'focus expected #{exp}, but #{act} was instead',
-      'unexpected focus on #{exp}',
-      element == null ? String(element) : prettyDOM(element),
-      prettyDOM(document.activeElement),
-    );
-  });
-
-  chai.Assertion.addProperty('ariaHidden', function elementIsAccessible() {
-    const element = utils.flag(this, 'object');
-
-    // used for debugging failed assertions, will either point to the top most node
-    // or the node that had aria-hidden="true"
-    let previousNode = element;
-    let currentNode = element;
-    let ariaHidden = false;
-    // "An element is considered hidden if it, or any of its ancestors are not
-    // rendered or have their aria-hidden attribute value set to true."
-    // -- https://www.w3.org/TR/wai-aria-1.1/#aria-hidden
-    while (
-      currentNode !== null &&
-      // stoping at <html /> so that failed assertion message only prints
-      // <body /> or below. use cases for aria-hidden on <html /> are unknown
-      currentNode !== document.documentElement &&
-      ariaHidden === false
-    ) {
-      ariaHidden = element.getAttribute('aria-hidden') === 'true';
-      previousNode = currentNode;
-      currentNode = currentNode.parentElement;
-    }
-
-    this.assert(
-      ariaHidden === true,
-      `expected ${utils.elToString(element)} to be aria-hidden\n${prettyDOM(previousNode)}`,
-      `expected ${utils.elToString(element)} to not be aria-hidden, but ${utils.elToString(
-        previousNode,
-      )} had aria-hidden="true" instead\n${prettyDOM(previousNode)}`,
-    );
-  });
-});
+import './initMatchers';
 
 consoleError();
 

--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -1,0 +1,51 @@
+import chai from 'chai';
+import chaiDom from 'chai-dom';
+import { prettyDOM } from '@testing-library/react';
+
+chai.use(chaiDom);
+chai.use((chaiAPI, utils) => {
+  // better diff view for expect(element).to.equal(document.activeElement)
+  chai.Assertion.addProperty('focused', function elementIsFocused() {
+    const element = utils.flag(this, 'object');
+
+    this.assert(
+      element === document.activeElement,
+      'focus expected #{exp}, but #{act} was instead',
+      'unexpected focus on #{exp}',
+      element == null ? String(element) : prettyDOM(element),
+      prettyDOM(document.activeElement),
+    );
+  });
+
+  chai.Assertion.addProperty('ariaHidden', function elementIsAccessible() {
+    const element = utils.flag(this, 'object');
+
+    // used for debugging failed assertions, will either point to the top most node
+    // or the node that had aria-hidden="true"
+    let previousNode = element;
+    let currentNode = element;
+    let ariaHidden = false;
+    // "An element is considered hidden if it, or any of its ancestors are not
+    // rendered or have their aria-hidden attribute value set to true."
+    // -- https://www.w3.org/TR/wai-aria-1.1/#aria-hidden
+    while (
+      currentNode !== null &&
+      // stoping at <html /> so that failed assertion message only prints
+      // <body /> or below. use cases for aria-hidden on <html /> are unknown
+      currentNode !== document.documentElement &&
+      ariaHidden === false
+    ) {
+      ariaHidden = element.getAttribute('aria-hidden') === 'true';
+      previousNode = currentNode;
+      currentNode = currentNode.parentElement;
+    }
+
+    this.assert(
+      ariaHidden === true,
+      `expected ${utils.elToString(element)} to be aria-hidden\n${prettyDOM(previousNode)}`,
+      `expected ${utils.elToString(element)} to not be aria-hidden, but ${utils.elToString(
+        previousNode,
+      )} had aria-hidden="true" instead\n${prettyDOM(previousNode)}`,
+    );
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2709,6 +2709,11 @@ agent-base@~4.2.1:
   dependencies:
     es6-promisify "^5.0.0"
 
+agentkeepalive@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-2.2.0.tgz#c5d1bd4b129008f1163f236f86e5faea2026e2ef"
+  integrity sha1-xdG9SxKQCPEWPyNvhuX66iAm4u8=
+
 agentkeepalive@^3.4.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-3.5.2.tgz#a113924dd3fa24a0bc3b78108c450c2abee00f67"
@@ -2751,6 +2756,27 @@ ajv@^6.1.0, ajv@^6.10.2, ajv@^6.5.5, ajv@^6.9.1:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
+
+algoliasearch@^3.24.5:
+  version "3.34.0"
+  resolved "https://registry.yarnpkg.com/algoliasearch/-/algoliasearch-3.34.0.tgz#02eb97bd6718e3a2c71121b9c3b655a35a4ba645"
+  integrity sha512-s8LDedkTWTAWR5uCWgJzGxDkCrqiej5iE4Tc2iCV+ONOO35i5qnVdieKg5gv2VDXBE7IP0YoqfAq/CC0V8PA+Q==
+  dependencies:
+    agentkeepalive "^2.2.0"
+    debug "^2.6.9"
+    envify "^4.0.0"
+    es6-promise "^4.1.0"
+    events "^1.1.0"
+    foreach "^2.0.5"
+    global "^4.3.2"
+    inherits "^2.0.1"
+    isarray "^2.0.1"
+    load-script "^1.0.0"
+    object-keys "^1.0.11"
+    querystring-es3 "^0.2.1"
+    reduce "^1.0.1"
+    semver "^5.1.0"
+    tunnel-agent "^0.6.0"
 
 alphanum-sort@^1.0.0:
   version "1.0.2"
@@ -3191,6 +3217,13 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+
+autocomplete.js@0.36.0:
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.36.0.tgz#94fe775fe64b6cd42e622d076dc7fd26bedd837b"
+  integrity sha512-jEwUXnVMeCHHutUt10i/8ZiRaCb0Wo+ZyKxeGsYwBDtw6EJHqEeDrq4UwZRD8YBSvp3g6klP678il2eeiVXN2Q==
+  dependencies:
+    immediate "^3.2.3"
 
 autodll-webpack-plugin@0.4.2:
   version "0.4.2"
@@ -5554,6 +5587,19 @@ discontinuous-range@1.0.0:
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
   integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
+docsearch.js@^2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/docsearch.js/-/docsearch.js-2.6.3.tgz#57cb4600d3b6553c677e7cbbe6a734593e38625d"
+  integrity sha512-GN+MBozuyz664ycpZY0ecdQE0ND/LSgJKhTLA0/v3arIS3S1Rpf2OJz6A35ReMsm91V5apcmzr5/kM84cvUg+A==
+  dependencies:
+    algoliasearch "^3.24.5"
+    autocomplete.js "0.36.0"
+    hogan.js "^3.0.2"
+    request "^2.87.0"
+    stack-utils "^1.0.1"
+    to-factory "^1.0.0"
+    zepto "^1.2.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -5608,6 +5654,11 @@ dom-serializer@0, dom-serializer@~0.1.0:
   dependencies:
     domelementtype "^1.3.0"
     entities "^1.1.1"
+
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
 
 domain-browser@^1.1.1:
   version "1.2.0"
@@ -5907,6 +5958,14 @@ env-paths@^1.0.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
   integrity sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA=
 
+envify@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/envify/-/envify-4.1.0.tgz#f39ad3db9d6801b4e6b478b61028d3f0b6819f7e"
+  integrity sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==
+  dependencies:
+    esprima "^4.0.0"
+    through "~2.3.4"
+
 enzyme-adapter-react-16@^1.14.0:
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.14.0.tgz#204722b769172bcf096cb250d33e6795c1f1858f"
@@ -6010,7 +6069,7 @@ es6-error@^4.0.1:
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
   integrity sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==
 
-es6-promise@^4.0.3:
+es6-promise@^4.0.3, es6-promise@^4.1.0:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
   integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
@@ -6315,7 +6374,7 @@ eventemitter3@^3.0.0, eventemitter3@^3.1.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
   integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
 
-events@1.1.1:
+events@1.1.1, events@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
@@ -6752,6 +6811,11 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+  integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
 
 foreground-child@^1.5.6:
   version "1.5.6"
@@ -7192,6 +7256,14 @@ global-prefix@^3.0.0:
     kind-of "^6.0.2"
     which "^1.3.1"
 
+global@^4.3.2:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
+  integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==
+  dependencies:
+    min-document "^2.19.0"
+    process "^0.11.10"
+
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
@@ -7483,6 +7555,14 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
+hogan.js@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/hogan.js/-/hogan.js-3.0.2.tgz#4cd9e1abd4294146e7679e41d7898732b02c7bfd"
+  integrity sha1-TNnhq9QpQUbnZ55B14mHMrAse/0=
+  dependencies:
+    mkdirp "0.3.0"
+    nopt "1.0.10"
+
 hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
@@ -7729,6 +7809,11 @@ image-diff@^1.6.3:
     gm "~1.21.1"
     mkdirp "~0.3.5"
     tmp "0.0.23"
+
+immediate@^3.2.3:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.2.3.tgz#d140fa8f614659bd6541233097ddaac25cdd991c"
+  integrity sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -8289,6 +8374,11 @@ isarray@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
   integrity sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=
+
+isarray@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isbinaryfile@^3.0.0:
   version "3.0.3"
@@ -9072,6 +9162,11 @@ load-json-file@^5.3.0:
     strip-bom "^3.0.0"
     type-fest "^0.3.0"
 
+load-script@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
+  integrity sha1-BJGTngvuVkPuSUp+PaPSuscMbKQ=
+
 loader-runner@^2.3.0, loader-runner@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
@@ -9734,6 +9829,13 @@ mimic-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
+  dependencies:
+    dom-walk "^0.1.0"
+
 min-indent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
@@ -9840,6 +9942,11 @@ mkdirp@*, mkdirp@0.5.1, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
   dependencies:
     minimist "0.0.8"
+
+mkdirp@0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
+  integrity sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=
 
 mkdirp@~0.3.5:
   version "0.3.5"
@@ -10251,6 +10358,13 @@ nomnom@^1.5.x:
     chalk "~0.4.0"
     underscore "~1.6.0"
 
+nopt@1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-1.0.10.tgz#6ddd21bd2a31417b92727dd585f8a6f37608ebee"
+  integrity sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=
+  dependencies:
+    abbrev "1"
+
 "nopt@2 || 3":
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
@@ -10478,7 +10592,7 @@ object-is@^1.0.1:
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.0.1.tgz#0aa60ec9989a0b3ed795cf4d06f62cf1ad6539b6"
   integrity sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY=
 
-object-keys@^1.0.11, object-keys@^1.0.12:
+object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -11789,7 +11903,7 @@ query-string@^6.8.1:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-querystring-es3@^0.2.0:
+querystring-es3@^0.2.0, querystring-es3@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
   integrity sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=
@@ -12497,6 +12611,13 @@ reduce-function-call@^1.0.1:
   integrity sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=
   dependencies:
     balanced-match "^0.4.2"
+
+reduce@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reduce/-/reduce-1.0.2.tgz#0cd680ad3ffe0b060e57a5c68bdfce37168d361b"
+  integrity sha512-xX7Fxke/oHO5IfZSk77lvPa/7bjMh9BuCk4OOoX5XTXrM7s0Z+MkPfSDfz0q7r91BhhGSs8gii/VEN/7zhCPpQ==
+  dependencies:
+    object-keys "^1.1.0"
 
 redux-logger@^3.0.6:
   version "3.0.6"
@@ -13561,6 +13682,11 @@ stack-trace@0.0.10:
   resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
   integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
+stack-utils@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
+  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+
 static-extend@^0.1.1:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
@@ -14096,7 +14222,7 @@ through2@~0.4.1:
     readable-stream "~1.0.17"
     xtend "~2.1.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1:
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@^2.3.8, through@~2.3, through@~2.3.1, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -14161,6 +14287,11 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
+
+to-factory@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/to-factory/-/to-factory-1.0.0.tgz#8738af8bd97120ad1d4047972ada5563bf9479b1"
+  integrity sha1-hzivi9lxIK0dQEeXKtpVY7+UebE=
 
 to-fast-properties@^1.0.3:
   version "1.0.3"
@@ -15389,3 +15520,8 @@ yn@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.0.tgz#fcbe2db63610361afcc5eb9e0ac91e976d046114"
   integrity sha512-kKfnnYkbTfrAdd0xICNFw7Atm8nKpLcLv9AZGEt+kczL/WQVai4e2V6ZN8U/O+iI6WrNuJjNNOyu4zfhl9D3Hg==
+
+zepto@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/zepto/-/zepto-1.2.0.tgz#e127bd9e66fd846be5eab48c1394882f7c0e4f98"
+  integrity sha1-4Se9nmb9hGvl6rSME5SIL3wOT5g=


### PR DESCRIPTION
Instead of eagerly loading the Input and waiting for algolia to load we bundle the input and algolia into a chunk and lazy load that one. It allows us to remove the custom retry logic. Previously we retried every 100ms to initialize the docsearch until runtime dependencies were loaded and markup was initialized. The browser takes care of this now. 

Hopefully this also means that the sever rendered landing page has no dependencies on the input component which would reduce the initial size a bit.

Not sure I like the use of the `Skeleton` component here.