### PR TITLE
[docs] Revert hits per page change

### DIFF
--- a/docs/src/modules/components/AppSearch.js
+++ b/docs/src/modules/components/AppSearch.js
@@ -51,7 +51,6 @@ function initDocsearch(userLanguage) {
       inputSelector: '#docsearch-input',
       algoliaOptions: {
         facetFilters: ['version:master', `language:${userLanguage}`],
-        hitsPerPage: 40,
       },
       autocompleteOptions: {
         openOnFocus: true,


### PR DESCRIPTION
The change of `hitsPerPage` in #17450 had some unintended side-effects. The goal was to make large resultsets pageable but it also changed how these resultsets are created. It is the documented, recommended approach for [pagination of algolia results](https://www.algolia.com/doc/api-reference/api-parameters/hitsPerPage/#how-to-use) but I would never expect pagination to change  what results are displayed or in which order. It should only add more i.e. if I had 5 before and extend it to 10 the first 5 should stay the same.

For example all results for `icons` linked to https://material-ui.netlify.com/components/icons/. Extending to `hitsPerPage` should've made it possible to scroll past a single page. Unfortunately it changed the resultset of e.g. `input` which now links to https://material-ui.netlify.com/api/input/ in the first 6 results where it only displayed 2 previously.

Looks like the default is 2 which would've made it clear that this is no pure pagination option.