### PR TITLE
[CircularProgress] Fix centering

### DIFF
--- a/packages/material-ui/src/CircularProgress/CircularProgress.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.js
@@ -27,7 +27,6 @@ export const styles = theme => ({
   /* Styles applied to the root element. */
   root: {
     display: 'inline-block',
-    lineHeight: 1, // Keep the progress centered
   },
   /* Styles applied to the root element if `variant="static"`. */
   static: {
@@ -46,7 +45,9 @@ export const styles = theme => ({
     color: theme.palette.secondary.main,
   },
   /* Styles applied to the `svg` element. */
-  svg: {},
+  svg: {
+    display: 'block', // Keeps the progress centered
+  },
   /* Styles applied to the `circle` svg path. */
   circle: {
     stroke: 'currentColor',


### PR DESCRIPTION
caused by non default font-size. I tested this with the local documentation (increased font-size for testing)

i basically just applied the diff in [this comment](https://github.com/mui-org/material-ui/issues/17464#issuecomment-532357247)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #17464