### PR TITLE
move types to devDependencies

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -53,7 +53,7 @@
     "react-transition-group": "^4.3.0"
   },
   "devDependencies": {
-    "@types/react-transition-group": "^4.2.0",
+    "@types/react-transition-group": "^4.2.0"
   },
   "sideEffects": false,
   "publishConfig": {

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -42,7 +42,6 @@
     "@material-ui/system": "^4.3.3",
     "@material-ui/types": "^4.1.1",
     "@material-ui/utils": "^4.4.0",
-    "@types/react-transition-group": "^4.2.0",
     "clsx": "^1.0.2",
     "convert-css-length": "^2.0.1",
     "deepmerge": "^4.0.0",
@@ -52,6 +51,9 @@
     "popper.js": "^1.14.1",
     "prop-types": "^15.7.2",
     "react-transition-group": "^4.3.0"
+  },
+  "devDependencies": {
+    "@types/react-transition-group": "^4.2.0",
   },
   "sideEffects": false,
   "publishConfig": {


### PR DESCRIPTION
Hello! Great lib, thanks for that. I try to use it wuth Preact and found one minor bug. We must store types dependencies in section "devDependencies". Otherwise, the customers (who use library) can't use specific types (like, preact types).

Please, review my solution and give me your feedback.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
