### PR TITLE
[system] Fix props being required from `style` function

### DIFF
--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -161,7 +161,7 @@ export interface StyleOptions<PropKey, Theme extends object> {
 }
 export function style<PropKey extends string, Theme extends object>(
   options: StyleOptions<PropKey, Theme>,
-): StyleFunction<{ [K in PropKey]: unknown } & { theme: Theme }>;
+): StyleFunction<{ [K in PropKey]?: unknown } & { theme: Theme }>;
 
 // typography.js
 export const fontFamily: SimpleStyleFunction<'fontFamily'>;

--- a/packages/material-ui-system/src/index.spec.tsx
+++ b/packages/material-ui-system/src/index.spec.tsx
@@ -1,4 +1,4 @@
-import { compose, css, palette, StyleFunction, spacing } from '@material-ui/system';
+import { compose, css, palette, StyleFunction, spacing, style } from '@material-ui/system';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -61,9 +61,11 @@ function cssRequiredTest() {
  * Testing inference of TypeScript + styled-components + @material-ui/system
  */
 function interopTest() {
+  const mixin = style({ prop: 'color' });
   // built-in style function
   const SystemSpacingBox = styled.div`
     ${spacing}
+    ${mixin}
   `;
   <SystemSpacingBox m={2} />;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

According to https://github.com/mui-org/material-ui/blob/master/packages/material-ui-system/src/style.js#L16 mixins props should be optional