### PR TITLE
[Button] Increase elevation on hover when contained

### DIFF
--- a/docs/src/pages/components/buttons/CustomizedButtons.js
+++ b/docs/src/pages/components/buttons/CustomizedButtons.js
@@ -29,6 +29,7 @@ const BootstrapButton = withStyles({
     '&:hover': {
       backgroundColor: '#0069d9',
       borderColor: '#0062cc',
+      boxShadow: 'none',
     },
     '&:active': {
       boxShadow: 'none',

--- a/docs/src/pages/components/buttons/CustomizedButtons.tsx
+++ b/docs/src/pages/components/buttons/CustomizedButtons.tsx
@@ -35,6 +35,7 @@ const BootstrapButton = withStyles({
     '&:hover': {
       backgroundColor: '#0069d9',
       borderColor: '#0062cc',
+      boxShadow: 'none',
     },
     '&:active': {
       boxShadow: 'none',

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -110,6 +110,16 @@ export const styles = theme => ({
     color: theme.palette.getContrastText(theme.palette.grey[300]),
     backgroundColor: theme.palette.grey[300],
     boxShadow: theme.shadows[2],
+    '&:hover': {
+      backgroundColor: theme.palette.grey.A100,
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: theme.palette.grey[300],
+      },
+      '&$disabled': {
+        backgroundColor: theme.palette.action.disabledBackground,
+      },
+    },
     '&$focusVisible': {
       boxShadow: theme.shadows[6],
     },
@@ -120,16 +130,6 @@ export const styles = theme => ({
       color: theme.palette.action.disabled,
       boxShadow: theme.shadows[0],
       backgroundColor: theme.palette.action.disabledBackground,
-    },
-    '&:hover': {
-      backgroundColor: theme.palette.grey.A100,
-      // Reset on touch devices, it doesn't add specificity
-      '@media (hover: none)': {
-        backgroundColor: theme.palette.grey[300],
-      },
-      '&$disabled': {
-        backgroundColor: theme.palette.action.disabledBackground,
-      },
     },
   },
   /* Styles applied to the root element if `variant="contained"` and `color="primary"`. */

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -112,8 +112,10 @@ export const styles = theme => ({
     boxShadow: theme.shadows[2],
     '&:hover': {
       backgroundColor: theme.palette.grey.A100,
+      boxShadow: theme.shadows[4],
       // Reset on touch devices, it doesn't add specificity
       '@media (hover: none)': {
+        boxShadow: theme.shadows[2],
         backgroundColor: theme.palette.grey[300],
       },
       '&$disabled': {


### PR DESCRIPTION
Partial fix of #17493

The color will be fixed once we figured out https://material.io/design/interaction/states.html. Previous work in #13134

I did some experiments a few weeks ago. I'll take a look how viable they are at the moment or if it makes more sense to fix the button states separately.