### PR TITLE
[docs] Improve testing readme

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -7,13 +7,42 @@ Thanks for writing tests! Here's a quick run-down on our current setup.
 Please familiarise yourself with these if you plan on contributing! :+1:
 
 - [mocha](https://github.com/mochajs/mocha)
-- [enzyme](https://github.com/airbnb/enzyme)
+- [@testing-library/react](https://github.com/testing-library/react)
 - [jsdom](https://github.com/tmpvar/jsdom)
 - [karma](https://github.com/karma-runner/karma)
 - [chai](https://github.com/chaijs/chai)
 - [sinon](https://github.com/sinonjs/sinon)
 - [docker](https://github.com/docker/docker)
 - [vrtest](https://github.com/nathanmarks/vrtest)
+- [enzyme](https://github.com/airbnb/enzyme) (old tests only)
+
+## Writing Tests
+
+For all unit tests, please use the return value from `test/utils/createClientRender`.
+It prepares the test suite and returns a function with the same interface as
+[`render` from `@testing-library/react`](https://testing-library.com/docs/react-testing-library/api#render).
+
+For new test please use `expect` from the BDD testing approach. Prefer to use as expressive [matchers](https://www.chaijs.com/api/bdd/) as possible. This keeps
+the tests and more importantly the message if they fail as expressive as possible.
+
+In addition to the core matchers from `chai` we also use matchers from [`chai-dom`](https://github.com/nathanboktae/chai-dom#readme).
+
+Deciding where to put a test is (like naming things) a hard problem:
+* when in doubt put the new test case directly in the unit test for that component e.g. `material-ui/src/Button/Button.test.js`
+* if you test interaction requiring multiple components from the library create a
+new integration test
+* If you find yourself using a lot of `data-testid` attributes or you're accessing
+a lot of styles consider adding a component (that doesn't require any interaction)
+into `test/regressions/tests/` e.g. `test/regressions/tests/List/ListWithSomeStyleProp` 
+
+#### Visual regression tests
+
+We should try to use as many demos from the documentation as possible;
+however, we can't replace one with the other as they address different needs.
+With the regression tests:
+
+- You might need to test a more complex situation, e.g. a stress test of the grid
+- You might need to test a simpler situation, e.g. a static progress bar
 
 ## Commands
 
@@ -24,7 +53,7 @@ trade-off, mainly completeness vs. speed.
 
 #### Run the core mocha unit/integration test suite.
 
-To run all of the unit tests just run  `yarn test:unit`
+To run all of the unit tests just run `yarn test:unit`
 
 If you want to `grep` for certain tests just add `-- -g STRING_TO_GREP` and change STRING_TO_GREP.
 
@@ -33,18 +62,15 @@ If you want to `grep` for certain tests just add `-- -g STRING_TO_GREP` and chan
 `yarn test:watch`
 
 First, we have the **unit test** suite.
-It uses [mocha](https://mochajs.org) and the *shallow* API of [enzyme](https://github.com/airbnb/enzyme) to allow testing the components in isolation.
-It's the fastest approach, and is best suited for testing many combinations.
-Here is an [example](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Menu/Menu.test.js#L27) with the `Menu` component.
+It uses [mocha](https://mochajs.org) and a thin wrapper around `@testing-library/react`.
+Here is an [example](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Dialog/Dialog.test.js#L87) with the `Dialog` component.
 
-Next, we have the **integration** tests.
-We are using the *mount* API of [enzyme](https://github.com/airbnb/enzyme).
-It allows testing the integration of different components using a virtual DOM.
-This virtual DOM is provided by [jsdom](https://github.com/tmpvar/jsdom).
-It's here to make sure components work together.
+Next, we have the **integration** tests. They are mostly used for components that
+act as composite widgets like `Select` or `Menu`.
 Here is an [example](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/test/integration/Menu.test.js#L28) with the `Menu` component.
 
 #### Create HTML coverage reports
+
 `yarn test:coverage:html`
 
 When running this command you should get under `coverage/index.html` a full coverage report in HTML format. This is created using [Istanbul](https://istanbul-js.org)'s HTML reporter and gives good data such as line, branch and function coverage.
@@ -110,20 +136,3 @@ testUrl: process.env.DOCKER_TEST_URL || 'http://10.200.10.1:3090',
 In addition to docker, the visual regression tests depend on either
 [ImageMagick](https://www.imagemagick.org/)
 or [GraphicsMagick](https://www.graphicsmagick.org/) being installed.
-
-## Writing Tests
-
-For all unit tests, please use the [shallow renderer](https://github.com/airbnb/enzyme/blob/master/docs/api/shallow.md) from `enzyme` unless the Component being tested requires a DOM. [Here's](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Avatar/Avatar.test.js) a small shallow rendered test to get you started.
-
-If the Component being unit tested requires a DOM, you can use the [mount api](https://github.com/airbnb/enzyme/blob/master/docs/api/mount.md) from `enzyme`. For some operations, you may still need to use the React test utils, but try to use the `enzyme` API as much as possible.
-
-Stick to test assertions such as `assert.strictEqual` and `assert.ok`. This helps keep tests simple and readable.
-
-#### Visual regression tests
-
-We should try to use as many demos from the documentation as possible;
-however, we can't replace one with the other as they address different needs.
-With the regression tests:
-
-- You might need to test a more complex situation, e.g. a stress test of the grid
-- You might need to test a simpler situation, e.g. a static progress bar

--- a/test/README.md
+++ b/test/README.md
@@ -60,7 +60,7 @@ trade-off, mainly completeness vs. speed.
 
 To run all of the unit and integration tests run `yarn test:unit`
 
-If you want to `grep` for certain tests add `-- -g STRING_TO_GREP` and change STRING_TO_GREP.
+If you want to `grep` for certain tests add `-g STRING_TO_GREP` and change STRING_TO_GREP.
 
 #### Watch the core mocha unit/integration test suite.
 

--- a/test/README.md
+++ b/test/README.md
@@ -58,9 +58,9 @@ trade-off, mainly completeness vs. speed.
 
 #### Run the core mocha unit/integration test suite.
 
-To run all of the unit and integration tests just run `yarn test:unit`
+To run all of the unit and integration tests run `yarn test:unit`
 
-If you want to `grep` for certain tests just add `-- -g STRING_TO_GREP` and change STRING_TO_GREP.
+If you want to `grep` for certain tests add `-- -g STRING_TO_GREP` and change STRING_TO_GREP.
 
 #### Watch the core mocha unit/integration test suite.
 

--- a/test/README.md
+++ b/test/README.md
@@ -28,7 +28,7 @@ It prepares the test suite and returns a function with the same interface as
 [`render` from `@testing-library/react`](https://testing-library.com/docs/react-testing-library/api#render).
 
 For new test please use `expect` from the BDD testing approach. Prefer to use as expressive [matchers](https://www.chaijs.com/api/bdd/) as possible. This keeps
-the tests and more importantly the message if they fail as expressive as possible.
+the tests readable and more importantly the message if they fail as descriptive as possible.
 
 In addition to the core matchers from `chai` we also use matchers from [`chai-dom`](https://github.com/nathanboktae/chai-dom#readme).
 

--- a/test/README.md
+++ b/test/README.md
@@ -2,19 +2,24 @@
 
 Thanks for writing tests! Here's a quick run-down on our current setup.
 
+## Getting started
+
+1. add a test to `packages/*/src/TheUnitInQuestion/TheUnitInQuestion.test.js` or `packages/*/test/`
+2. run `yarn test:watch`
+3. Implement the tested behavior
+4. Open a PR once the test passes or you want somebody to review your work
+
 ## Tools we use
 
-Please familiarise yourself with these if you plan on contributing! :+1:
-
-- [mocha](https://github.com/mochajs/mocha)
-- [@testing-library/react](https://github.com/testing-library/react)
-- [jsdom](https://github.com/tmpvar/jsdom)
-- [karma](https://github.com/karma-runner/karma)
-- [chai](https://github.com/chaijs/chai)
-- [sinon](https://github.com/sinonjs/sinon)
-- [docker](https://github.com/docker/docker)
+- [@testing-library/react](https://testing-library.com/docs/react-testing-library/intro)
+- [chai](https://www.chaijs.com/)
+- [sinon](https://sinonjs.org/)
+- [mocha](https://mochajs.org/)
+- [karma](https://karma-runner.github.io/latest/index.html)
+- [enzyme](https://airbnb.io/enzyme/) (old tests only)
 - [vrtest](https://github.com/nathanmarks/vrtest)
-- [enzyme](https://github.com/airbnb/enzyme) (old tests only)
+- [docker](https://docs.docker.com/)
+- [jsdom](https://github.com/jsdom/jsdom)
 
 ## Writing Tests
 
@@ -53,7 +58,7 @@ trade-off, mainly completeness vs. speed.
 
 #### Run the core mocha unit/integration test suite.
 
-To run all of the unit tests just run `yarn test:unit`
+To run all of the unit and integration tests just run `yarn test:unit`
 
 If you want to `grep` for certain tests just add `-- -g STRING_TO_GREP` and change STRING_TO_GREP.
 

--- a/test/README.md
+++ b/test/README.md
@@ -38,7 +38,7 @@ Deciding where to put a test is (like naming things) a hard problem:
 - If your test requires multiple components from the library create a new integration test.
 - If you find yourself using a lot of `data-testid` attributes or you're accessing
   a lot of styles consider adding a component (that doesn't require any interaction)
-  into `test/regressions/tests/` e.g. `test/regressions/tests/List/ListWithSomeStyleProp`
+  to `test/regressions/tests/` e.g. `test/regressions/tests/List/ListWithSomeStyleProp`
 
 #### Visual regression tests
 

--- a/test/README.md
+++ b/test/README.md
@@ -33,12 +33,12 @@ the tests readable, and, more importantly, the message if they fail as descripti
 In addition to the core matchers from `chai` we also use matchers from [`chai-dom`](https://github.com/nathanboktae/chai-dom#readme).
 
 Deciding where to put a test is (like naming things) a hard problem:
-* When in doubt put the new test case directly in the unit test file for that component e.g. `material-ui/src/Button/Button.test.js`.
-* If you test interaction requiring multiple components from the library create a
-new integration test.
-* If you find yourself using a lot of `data-testid` attributes or you're accessing
-a lot of styles consider adding a component (that doesn't require any interaction)
-into `test/regressions/tests/` e.g. `test/regressions/tests/List/ListWithSomeStyleProp` 
+
+- When in doubt put the new test case directly in the unit test file for that component e.g. `material-ui/src/Button/Button.test.js`.
+- If your test requires multiple components from the library create a new integration test.
+- If you find yourself using a lot of `data-testid` attributes or you're accessing
+  a lot of styles consider adding a component (that doesn't require any interaction)
+  into `test/regressions/tests/` e.g. `test/regressions/tests/List/ListWithSomeStyleProp`
 
 #### Visual regression tests
 

--- a/test/README.md
+++ b/test/README.md
@@ -4,8 +4,8 @@ Thanks for writing tests! Here's a quick run-down on our current setup.
 
 ## Getting started
 
-1. add a test to `packages/*/src/TheUnitInQuestion/TheUnitInQuestion.test.js` or `packages/*/test/`
-2. run `yarn test:watch`
+1. Add a unit test to `packages/*/src/TheUnitInQuestion/TheUnitInQuestion.test.js` or an integration test `packages/*/test/`.
+2. Run `yarn test:watch`.
 3. Implement the tested behavior
 4. Open a PR once the test passes or you want somebody to review your work
 
@@ -27,27 +27,27 @@ For all unit tests, please use the return value from `test/utils/createClientRen
 It prepares the test suite and returns a function with the same interface as
 [`render` from `@testing-library/react`](https://testing-library.com/docs/react-testing-library/api#render).
 
-For new test please use `expect` from the BDD testing approach. Prefer to use as expressive [matchers](https://www.chaijs.com/api/bdd/) as possible. This keeps
-the tests readable and more importantly the message if they fail as descriptive as possible.
+For new tests please use `expect` from the BDD testing approach. Prefer to use as expressive [matchers](https://www.chaijs.com/api/bdd/) as possible. This keeps
+the tests readable, and, more importantly, the message if they fail as descriptive as possible.
 
 In addition to the core matchers from `chai` we also use matchers from [`chai-dom`](https://github.com/nathanboktae/chai-dom#readme).
 
 Deciding where to put a test is (like naming things) a hard problem:
-* when in doubt put the new test case directly in the unit test for that component e.g. `material-ui/src/Button/Button.test.js`
-* if you test interaction requiring multiple components from the library create a
-new integration test
+* When in doubt put the new test case directly in the unit test file for that component e.g. `material-ui/src/Button/Button.test.js`.
+* If you test interaction requiring multiple components from the library create a
+new integration test.
 * If you find yourself using a lot of `data-testid` attributes or you're accessing
 a lot of styles consider adding a component (that doesn't require any interaction)
 into `test/regressions/tests/` e.g. `test/regressions/tests/List/ListWithSomeStyleProp` 
 
 #### Visual regression tests
 
-We should try to use as many demos from the documentation as possible;
+We try to use as many demos from the documentation as possible;
 however, we can't replace one with the other as they address different needs.
 With the regression tests:
 
-- You might need to test a more complex situation, e.g. a stress test of the grid
-- You might need to test a simpler situation, e.g. a static progress bar
+- You might need to test a more complex situation, e.g. a stress test of the grid.
+- You might need to test a simpler situation, e.g. a static progress bar.
 
 ## Commands
 
@@ -60,7 +60,7 @@ trade-off, mainly completeness vs. speed.
 
 To run all of the unit and integration tests run `yarn test:unit`
 
-If you want to `grep` for certain tests add `-g STRING_TO_GREP` and change STRING_TO_GREP.
+If you want to `grep` for certain tests add `-g STRING_TO_GREP`.
 
 #### Watch the core mocha unit/integration test suite.
 


### PR DESCRIPTION
With the upcoming hacktoberfest this should be up-to-date

* update readme with latest tech
* emphasize writing tests
* add a little starter guide
* link to documentation websites instead of repositories 
* order "tools we use" by relevance (e.g. `jsdom` is a very specific implementation detail about our environment while `@testing-library/react` is way more relevant because you directly interact with their API)