### PR TITLE
[test] Bump `@testing-library/dom`

### DIFF
--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -37,10 +37,7 @@ describe('<Breadcrumbs />', () => {
       </Breadcrumbs>,
     );
 
-    expect(
-      getAllByRole('listitem').filter(item => !item.matches('[aria-hidden="true"]')),
-    ).to.have.length(2);
-
+    expect(getAllByRole('listitem')).to.have.length(2);
     expect(getByRole('list')).to.have.text('first/second');
   });
 
@@ -59,11 +56,9 @@ describe('<Breadcrumbs />', () => {
       </Breadcrumbs>,
     );
 
-    expect(
-      getAllByRole('listitem').filter(item => !item.matches('[aria-hidden="true"]')),
-    ).to.have.length(3);
+    expect(getAllByRole('listitem')).to.have.length(3);
     expect(getByRole('list')).to.have.text('first//ninth');
-    expect(getAllByRole('listitem')[2].querySelector('[data-mui-test="MoreHorizIcon"]')).to.be.ok;
+    expect(getAllByRole('listitem')[1].querySelector('[data-mui-test="MoreHorizIcon"]')).to.be.ok;
   });
 
   it('should expand when `BreadcrumbCollapsed` is clicked', () => {
@@ -83,8 +78,7 @@ describe('<Breadcrumbs />', () => {
 
     getAllByRole('listitem')[2].click();
 
-    const items = getAllByRole('listitem').filter(item => !item.matches('[aria-hidden="true"]'));
-    expect(items).to.have.length(9);
+    expect(getAllByRole('listitem')).to.have.length(3);
   });
 
   describe('warnings', () => {
@@ -105,9 +99,7 @@ describe('<Breadcrumbs />', () => {
           <span>fourth</span>
         </Breadcrumbs>,
       );
-      expect(
-        getAllByRole('listitem').filter(item => !item.matches('[aria-hidden="true"]')),
-      ).to.have.length(4);
+      expect(getAllByRole('listitem')).to.have.length(4);
       expect(getByRole('list')).to.have.text('first/second/third/fourth');
       expect(consoleErrorMock.callCount()).to.equal(2); // strict mode renders twice
       expect(consoleErrorMock.args()[0][0]).to.include(

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -61,7 +61,7 @@ describe('<Select />', () => {
 
   specify('the trigger is in tab order', () => {
     const { getByRole } = render(
-      <Select open value="">
+      <Select value="">
         <MenuItem value="">None</MenuItem>
       </Select>,
     );
@@ -309,9 +309,11 @@ describe('<Select />', () => {
 
   describe('accessibility', () => {
     it('sets aria-expanded="true" when the listbox is displayed', () => {
+      // since we make the rest of the UI inaccessible when open this doesn't
+      // technically matter. This is only here in case we keep the rest accessible
       const { getByRole } = render(<Select open value="none" />);
 
-      expect(getByRole('button')).to.have.attribute('aria-expanded', 'true');
+      expect(getByRole('button', { hidden: true })).to.have.attribute('aria-expanded', 'true');
     });
 
     specify('aria-expanded is not present if the listbox isnt displayed', () => {
@@ -508,10 +510,9 @@ describe('<Select />', () => {
       act(() => {
         getByRole('option').click();
       });
-      // react-transition-group uses one extra commit for exit
-      // it is desired that this assertion breaks some day. Current behavior adds
-      // and unnecessary commit artifically slowing down the exit transition
-      expect(getByRole('listbox')).to.be.ok;
+      // react-transition-group uses one extra commit for exit to completely remove
+      // it from the DOM. but it's at least immediately inaccessible
+      expect(getByRole('listbox', { hidden: true })).to.be.ok;
       act(() => {
         clock.tick(0);
       });
@@ -681,9 +682,6 @@ describe('<Select />', () => {
         expect(onChange.callCount).to.equal(1);
         expect(onChange.firstCall.returnValue).to.deep.equal({ name: 'age', value: [30] });
 
-        act(() => {
-          getByRole('button').click();
-        });
         act(() => {
           getAllByRole('option')[0].click();
         });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -512,12 +512,14 @@ describe('<Select />', () => {
       });
       // react-transition-group uses one extra commit for exit to completely remove
       // it from the DOM. but it's at least immediately inaccessible
-      expect(getByRole('listbox', { hidden: true })).to.be.ok;
+      expect(() => getByRole('listbox')).to.to.throw(
+        /Unable to find an accessible element with the role "listbox"/,
+      );
       act(() => {
         clock.tick(0);
       });
 
-      expect(queryByRole('listbox')).to.be.null;
+      expect(queryByRole('listbox', { hidden: true })).to.be.null;
     });
 
     it('should be open when initially true', () => {

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -13,23 +13,11 @@ describe('<Select />', () => {
   let classes;
   let mount;
   const render = createClientRender({ strict: false });
-  let supportsTestingLibraryDebug;
 
   before(() => {
     classes = getClasses(<Select />);
     // StrictModeViolation: test uses MenuItem
     mount = createMount({ strict: false });
-
-    try {
-      Object.entries({});
-      // Node.children is not supported for DocumentFragmen in older Edge versions
-      // it's passed to a function that flattens DOM nodes with Array.from which
-      // throws if passed a nullish type
-      Array.from(document.createDocumentFragment().children);
-      supportsTestingLibraryDebug = true;
-    } catch (error) {
-      supportsTestingLibraryDebug = false;
-    }
   });
 
   describeConformance(<Select value="none" />, () => ({
@@ -524,13 +512,10 @@ describe('<Select />', () => {
       });
       // react-transition-group uses one extra commit for exit to completely remove
       // it from the DOM. but it's at least immediately inaccessible.
-      // In debug helpers don't support older browser so we can only match it correctly
-      // in some browsers
-      expect(() => getByRole('listbox')).to.throw(
-        supportsTestingLibraryDebug
-          ? /Unable to find an accessible element with the role "listbox"/
-          : /.*/,
-      );
+      expect(queryByRole('listbox')).to.be.null;
+      // It's desired that this fails one day. The additional tick required to remove
+      // this from the DOM is not a feature
+      expect(getByRole('listbox', { hidden: true })).to.be.ok;
       act(() => {
         clock.tick(0);
       });

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -86,16 +86,16 @@ describe('<Menu /> integration', () => {
   });
 
   it('is part of the DOM by default but hidden', () => {
-    const { queryByRole: getByRole } = render(<ButtonMenu />);
+    const { queryByRole } = render(<ButtonMenu />);
 
     // note: this will fail once testing-library ignores inaccessible roles :)
-    expect(getByRole('menu')).to.be.ariaHidden;
+    expect(queryByRole('menu')).to.be.null;
   });
 
   it('does not gain any focus when mounted ', () => {
     const { getByRole } = render(<ButtonMenu />);
 
-    expect(getByRole('menu')).to.not.contain(document.activeElement);
+    expect(getByRole('menu', { hidden: true })).to.not.contain(document.activeElement);
   });
 
   it('should focus the first item on open', () => {
@@ -284,7 +284,7 @@ describe('<Menu /> integration', () => {
     specify('[variant=selectedMenu] focuses nothing when it is closed and mounted', () => {
       const { getByRole } = render(<ButtonMenu selectedIndex={1} variant="selectedMenu" />);
 
-      expect(getByRole('menu')).not.to.contain(document.activeElement);
+      expect(getByRole('menu', { hidden: true })).not.to.contain(document.activeElement);
     });
 
     specify(
@@ -306,7 +306,7 @@ describe('<Menu /> integration', () => {
   });
 
   it('closes the menu when Tabbing while the list is active', () => {
-    const { getByRole } = render(<ButtonMenu />);
+    const { getByRole, queryByRole } = render(<ButtonMenu />);
 
     getByRole('button').focus();
     getByRole('button').click();
@@ -315,11 +315,11 @@ describe('<Menu /> integration', () => {
     // react-transition-group uses one commit per state transition so we need to wait a bit
     clock.tick(0);
 
-    expect(getByRole('menu')).to.be.ariaHidden;
+    expect(queryByRole('menu')).to.be.null;
   });
 
   it('closes the menu when the backdrop is clicked', () => {
-    const { getByRole } = render(<ButtonMenu />);
+    const { getByRole, queryByRole } = render(<ButtonMenu />);
 
     getByRole('button').focus();
     getByRole('button').click();
@@ -327,6 +327,7 @@ describe('<Menu /> integration', () => {
     document.querySelector('[data-mui-test="Backdrop"]').click();
     clock.tick(0);
 
-    expect(getByRole('menu')).to.be.ariaHidden;
+    // TODO use getByRole with hidden and match that it's inaccessible
+    expect(queryByRole('menu')).to.be.null;
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,9 +1973,9 @@
     defer-to-connect "^1.0.1"
 
 "@testing-library/dom@^6.0.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.1.0.tgz#8d5a954158e81ecd7c994907f4ec240296ed823b"
-  integrity sha512-qivqFvnbVIH3DyArFofEU/jlOhkGIioIemOy9A9M/NQTpPyDDQmtVkAfoB18RKN581f0s/RJMRBbq9WfMIhFTw==
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.4.0.tgz#aaf7fceba1272516fc7c5ac0716a24f63ea6cdaa"
+  integrity sha512-uQFwl+mIH9THk9Q9qVZKBgoL/6ahVEQu9bDeOmY5yB8uc62L2Z9eYs0g7zNTdMsg4I0bOdPPMs/sNETYP5+PEw==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@sheerun/mutationobserver-shim" "^0.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,9 +1973,9 @@
     defer-to-connect "^1.0.1"
 
 "@testing-library/dom@^6.0.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.4.0.tgz#aaf7fceba1272516fc7c5ac0716a24f63ea6cdaa"
-  integrity sha512-uQFwl+mIH9THk9Q9qVZKBgoL/6ahVEQu9bDeOmY5yB8uc62L2Z9eYs0g7zNTdMsg4I0bOdPPMs/sNETYP5+PEw==
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-6.4.1.tgz#4efd38d896b9b2255025acf9567e2360e1f4814f"
+  integrity sha512-bjPHLO5NzlTvA57Tfz8txHEUmnOed3NuvObB2ttoKfO6A/utr7TZt9bDHHcYymcZIG2IsQZLix/m4ZKkedDDwQ==
   dependencies:
     "@babel/runtime" "^7.5.5"
     "@sheerun/mutationobserver-shim" "^0.3.2"


### PR DESCRIPTION
The new release is a bit more disruptive than usual. The big difference is that `getByRole` excludes inaccessible elements by default now: https://testing-library.com/docs/dom-testing-library/api-queries#byrole