### PR TITLE
Move @types/react-transition-group to devDependencies

### DIFF
--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -42,7 +42,6 @@
     "@material-ui/system": "^4.4.3",
     "@material-ui/types": "^4.1.1",
     "@material-ui/utils": "^4.4.0",
-    "@types/react-transition-group": "^4.2.0",
     "clsx": "^1.0.2",
     "convert-css-length": "^2.0.1",
     "deepmerge": "^4.0.0",
@@ -52,6 +51,9 @@
     "popper.js": "^1.14.1",
     "prop-types": "^15.7.2",
     "react-transition-group": "^4.3.0"
+  },
+  "devDependencies": {
+    "@types/react-transition-group": "^4.2.0"
   },
   "sideEffects": false,
   "publishConfig": {


### PR DESCRIPTION
Moved the dependency on `@types/react-transition-group` from `dependencies` to `devDependencies` as it gives a lot of issues when used in typescript projects that depend on a different version of `@types/react-transition-group`
