### PR TITLE
[Button] Add startIcon / endIcon props

### DIFF
--- a/docs/pages/api/button.md
+++ b/docs/pages/api/button.md
@@ -74,6 +74,9 @@ Any other props supplied will be provided to the root element ([ButtonBase](/api
 | <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiButton-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
 | <span class="prop-name">startIcon</span> | <span class="prop-name">MuiButton-startIcon</span> | Styles applied to the startIcon element if supplied.
 | <span class="prop-name">endIcon</span> | <span class="prop-name">MuiButton-endIcon</span> | Styles applied to the endIcon element if supplied.
+| <span class="prop-name">iconSizeSmall</span> | <span class="prop-name">MuiButton-iconSizeSmall</span> | Styles applied to the icon element if supplied and `size="small"`.
+| <span class="prop-name">iconSizeMedium</span> | <span class="prop-name">MuiButton-iconSizeMedium</span> | Styles applied to the icon element if supplied and `size="medium"`.
+| <span class="prop-name">iconSizeLarge</span> | <span class="prop-name">MuiButton-iconSizeLarge</span> | Styles applied to the icon element if supplied and `size="large"`.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/pages/api/button.md
+++ b/docs/pages/api/button.md
@@ -31,9 +31,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
 | <span class="prop-name">disableFocusRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled.<br>⚠️ Without a ripple there is no styling for :focus-visible by default. Be sure to highlight the element by applying separate styles with the `focusVisibleClassName`. |
+| <span class="prop-name">endIcon</span> | <span class="prop-type">node</span> |  |  |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will take up the full width of its container. |
 | <span class="prop-name">href</span> | <span class="prop-type">string</span> |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | <span class="prop-name">size</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'</span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
+| <span class="prop-name">startIcon</span> | <span class="prop-type">node</span> |  |  |
 | <span class="prop-name">variant</span> | <span class="prop-type">'text'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'contained'</span> | <span class="prop-default">'text'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
@@ -70,6 +72,8 @@ Any other props supplied will be provided to the root element ([ButtonBase](/api
 | <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiButton-sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">sizeLarge</span> | <span class="prop-name">MuiButton-sizeLarge</span> | Styles applied to the root element if `size="large"`.
 | <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiButton-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
+| <span class="prop-name">startIcon</span> | <span class="prop-name">MuiButton-startIcon</span> | Element placed after the children.
+| <span class="prop-name">endIcon</span> | <span class="prop-name">MuiButton-endIcon</span> | Element placed after the children.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/pages/api/button.md
+++ b/docs/pages/api/button.md
@@ -31,11 +31,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
 | <span class="prop-name">disableFocusRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled.<br>⚠️ Without a ripple there is no styling for :focus-visible by default. Be sure to highlight the element by applying separate styles with the `focusVisibleClassName`. |
-| <span class="prop-name">endIcon</span> | <span class="prop-type">node</span> |  |  |
+| <span class="prop-name">endIcon</span> | <span class="prop-type">node</span> |  | Element placed after the children. |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will take up the full width of its container. |
 | <span class="prop-name">href</span> | <span class="prop-type">string</span> |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
 | <span class="prop-name">size</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'</span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
-| <span class="prop-name">startIcon</span> | <span class="prop-type">node</span> |  |  |
+| <span class="prop-name">startIcon</span> | <span class="prop-type">node</span> |  | Element placed before the children. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'text'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'contained'</span> | <span class="prop-default">'text'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
@@ -72,8 +72,8 @@ Any other props supplied will be provided to the root element ([ButtonBase](/api
 | <span class="prop-name">sizeSmall</span> | <span class="prop-name">MuiButton-sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">sizeLarge</span> | <span class="prop-name">MuiButton-sizeLarge</span> | Styles applied to the root element if `size="large"`.
 | <span class="prop-name">fullWidth</span> | <span class="prop-name">MuiButton-fullWidth</span> | Styles applied to the root element if `fullWidth={true}`.
-| <span class="prop-name">startIcon</span> | <span class="prop-name">MuiButton-startIcon</span> | Element placed after the children.
-| <span class="prop-name">endIcon</span> | <span class="prop-name">MuiButton-endIcon</span> | Element placed after the children.
+| <span class="prop-name">startIcon</span> | <span class="prop-name">MuiButton-startIcon</span> | Styles applied to the startIcon element if supplied.
+| <span class="prop-name">endIcon</span> | <span class="prop-name">MuiButton-endIcon</span> | Styles applied to the endIcon element if supplied.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -255,7 +255,7 @@ function AppFrame(props) {
                   selected={userLanguage === language.code}
                   onClick={handleLanguageMenuClose}
                   lang={language.code}
-                  hreflang={language.code}
+                  hrefLang={language.code}
                 >
                   {language.text}
                 </MenuItem>
@@ -273,7 +273,7 @@ function AppFrame(props) {
                 target="_blank"
                 key={userLanguage}
                 lang={userLanguage}
-                hreflang="en"
+                hrefLang="en"
                 onClick={handleLanguageMenuClose}
               >
                 {`${t('helpToTranslate')}`}

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -121,9 +121,6 @@ const styles = theme => ({
   appBarHome: {
     boxShadow: 'none',
   },
-  language: {
-    margin: theme.spacing(0, 0.5, 0, 1),
-  },
   appBarShift: {
     [theme.breakpoints.up('lg')]: {
       width: 'calc(100% - 240px)',
@@ -232,16 +229,14 @@ function AppFrame(props) {
               onClick={handleLanguageIconClick}
               data-ga-event-category="AppBar"
               data-ga-event-action="language"
+              startIcon={<LanguageIcon fontSize="small" />}
+              endIcon={<ExpandMoreIcon fontSize="small" />}
             >
-              <LanguageIcon />
               <Hidden xsDown implementation="css">
-                <span className={classes.language}>
-                  {userLanguage === 'aa'
-                    ? 'Translating'
-                    : LANGUAGES_LABEL.filter(language => language.code === userLanguage)[0].text}
-                </span>
+                {userLanguage === 'aa'
+                  ? 'Translating'
+                  : LANGUAGES_LABEL.filter(language => language.code === userLanguage)[0].text}
               </Hidden>
-              <ExpandMoreIcon />
             </Button>
           </Tooltip>
           <NoSsr>

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -14,7 +14,7 @@ import IconButton from '@material-ui/core/IconButton';
 import MenuIcon from '@material-ui/icons/Menu';
 import Tooltip from '@material-ui/core/Tooltip';
 import Button from '@material-ui/core/Button';
-import Hidden from '@material-ui/core/Hidden';
+import Box from '@material-ui/core/Box';
 import NoSsr from '@material-ui/core/NoSsr';
 import LanguageIcon from '@material-ui/icons/Translate';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -116,6 +116,13 @@ const styles = theme => ({
     transition: theme.transitions.create('width'),
     '@media print': {
       position: 'absolute',
+    },
+  },
+  language: {
+    margin: theme.spacing(0, 0.5, 0, 1),
+    display: 'none',
+    [theme.breakpoints.up('md')]: {
+      display: 'block',
     },
   },
   appBarHome: {
@@ -229,14 +236,14 @@ function AppFrame(props) {
               onClick={handleLanguageIconClick}
               data-ga-event-category="AppBar"
               data-ga-event-action="language"
-              startIcon={<LanguageIcon fontSize="small" />}
-              endIcon={<ExpandMoreIcon fontSize="small" />}
             >
-              <Hidden xsDown implementation="css">
+              <LanguageIcon />
+              <span className={classes.language}>
                 {userLanguage === 'aa'
                   ? 'Translating'
                   : LANGUAGES_LABEL.filter(language => language.code === userLanguage)[0].text}
-              </Hidden>
+              </span>
+              <ExpandMoreIcon fontSize="small" />
             </Button>
           </Tooltip>
           <NoSsr>
@@ -260,7 +267,9 @@ function AppFrame(props) {
                   {language.text}
                 </MenuItem>
               ))}
-              <Divider />
+              <Box my={1}>
+                <Divider />
+              </Box>
               <MenuItem
                 component="a"
                 data-no-link="true"

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -250,7 +250,7 @@ function MarkdownDocs(props) {
                     href={prevPage.pathname}
                     size="large"
                     className={classes.pageLinkButton}
-                    startIcon={<ChevronLeftIcon fontSize="small" />}
+                    startIcon={<ChevronLeftIcon />}
                   >
                     {pageToTitleI18n(prevPage, t)}
                   </Button>
@@ -264,7 +264,7 @@ function MarkdownDocs(props) {
                     href={nextPage.pathname}
                     size="large"
                     className={classes.pageLinkButton}
-                    endIcon={<ChevronRightIcon fontSize="small" />}
+                    endIcon={<ChevronRightIcon />}
                   >
                     {pageToTitleI18n(nextPage, t)}
                   </Button>

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -75,12 +75,6 @@ const styles = theme => ({
     textTransform: 'none',
     fontWeight: theme.typography.fontWeightRegular,
   },
-  chevronLeftIcon: {
-    marginRight: theme.spacing(1),
-  },
-  chevronRightIcon: {
-    marginLeft: theme.spacing(1),
-  },
 });
 
 const SOURCE_CODE_ROOT_URL = 'https://github.com/mui-org/material-ui/blob/master/docs/src';
@@ -256,8 +250,8 @@ function MarkdownDocs(props) {
                     href={prevPage.pathname}
                     size="large"
                     className={classes.pageLinkButton}
+                    startIcon={<ChevronLeftIcon fontSize="small" />}
                   >
-                    <ChevronLeftIcon fontSize="small" className={classes.chevronLeftIcon} />
                     {pageToTitleI18n(prevPage, t)}
                   </Button>
                 ) : (
@@ -270,9 +264,9 @@ function MarkdownDocs(props) {
                     href={nextPage.pathname}
                     size="large"
                     className={classes.pageLinkButton}
+                    endIcon={<ChevronRightIcon fontSize="small" />}
                   >
                     {pageToTitleI18n(nextPage, t)}
-                    <ChevronRightIcon fontSize="small" className={classes.chevronRightIcon} />
                   </Button>
                 )}
               </div>

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -22,7 +22,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="secondary"
         className={classes.button}
-        startIcon={<DeleteIcon fontSize="small" />}
+        startIcon={<DeleteIcon />}
       >
         Delete
       </Button>
@@ -31,7 +31,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="primary"
         className={classes.button}
-        endIcon={<Icon fontSize="small">send</Icon>}
+        endIcon={<Icon>send</Icon>}
       >
         Send
       </Button>
@@ -39,7 +39,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="default"
         className={classes.button}
-        startIcon={<CloudUploadIcon fontSize="small" />}
+        startIcon={<CloudUploadIcon />}
       >
         Upload
       </Button>
@@ -48,16 +48,14 @@ export default function IconLabelButtons() {
         disabled
         color="secondary"
         className={classes.button}
-        startIcon={<KeyboardVoiceIcon fontSize="small" />}
+        startIcon={<KeyboardVoiceIcon />}
       >
         Talk
       </Button>
-      <Button
-        variant="contained"
-        size="small"
-        className={classes.button}
-        startIcon={<SaveIcon fontSize="small" />}
-      >
+      <Button variant="contained" size="small" className={classes.button} startIcon={<SaveIcon />}>
+        Save
+      </Button>
+      <Button variant="contained" size="large" className={classes.button} startIcon={<SaveIcon />}>
         Save
       </Button>
     </div>

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -6,7 +6,6 @@ import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import KeyboardVoiceIcon from '@material-ui/icons/KeyboardVoice';
 import Icon from '@material-ui/core/Icon';
 import SaveIcon from '@material-ui/icons/Save';
-import CircularProgress from '@material-ui/core/CircularProgress';
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -23,7 +22,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="secondary"
         className={classes.button}
-        endIcon={<DeleteIcon fontSize="small" />}
+        startIcon={<DeleteIcon fontSize="small" />}
       >
         Delete
       </Button>
@@ -40,7 +39,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="default"
         className={classes.button}
-        endIcon={<CloudUploadIcon fontSize="small" />}
+        startIcon={<CloudUploadIcon fontSize="small" />}
       >
         Upload
       </Button>
@@ -60,14 +59,6 @@ export default function IconLabelButtons() {
         startIcon={<SaveIcon fontSize="small" />}
       >
         Save
-      </Button>
-      <Button
-        variant="contained"
-        color="primary"
-        className={classes.button}
-        startIcon={<CircularProgress color="inherit" size={20} />}
-      >
-        Loading
       </Button>
     </div>
   );

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import clsx from 'clsx';
 import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
@@ -12,15 +11,6 @@ const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(1),
   },
-  leftIcon: {
-    marginRight: theme.spacing(1),
-  },
-  rightIcon: {
-    marginLeft: theme.spacing(1),
-  },
-  iconSmall: {
-    fontSize: 20,
-  },
 }));
 
 export default function IconLabelButtons() {
@@ -28,25 +18,46 @@ export default function IconLabelButtons() {
 
   return (
     <div>
-      <Button variant="contained" color="secondary" className={classes.button}>
+      <Button
+        variant="contained"
+        color="secondary"
+        className={classes.button}
+        endIcon={<DeleteIcon fontSize="small" />}
+      >
         Delete
-        <DeleteIcon className={classes.rightIcon} />
       </Button>
-      <Button variant="contained" color="primary" className={classes.button}>
+      {/* This Button uses a Font Icon, see the installation instructions in the Icon component docs. */}
+      <Button
+        variant="contained"
+        color="primary"
+        className={classes.button}
+        endIcon={<Icon fontSize="small">send</Icon>}
+      >
         Send
-        {/* This Button uses a Font Icon, see the installation instructions in the docs. */}
-        <Icon className={classes.rightIcon}>send</Icon>
       </Button>
-      <Button variant="contained" color="default" className={classes.button}>
+      <Button
+        variant="contained"
+        color="default"
+        className={classes.button}
+        endIcon={<CloudUploadIcon fontSize="small" />}
+      >
         Upload
-        <CloudUploadIcon className={classes.rightIcon} />
       </Button>
-      <Button variant="contained" disabled color="secondary" className={classes.button}>
-        <KeyboardVoiceIcon className={classes.leftIcon} />
+      <Button
+        variant="contained"
+        disabled
+        color="secondary"
+        className={classes.button}
+        startIcon={<KeyboardVoiceIcon fontSize="small" />}
+      >
         Talk
       </Button>
-      <Button variant="contained" size="small" className={classes.button}>
-        <SaveIcon className={clsx(classes.leftIcon, classes.iconSmall)} />
+      <Button
+        variant="contained"
+        size="small"
+        className={classes.button}
+        startIcon={<SaveIcon fontSize="small" />}
+      >
         Save
       </Button>
     </div>

--- a/docs/src/pages/components/buttons/IconLabelButtons.js
+++ b/docs/src/pages/components/buttons/IconLabelButtons.js
@@ -6,6 +6,7 @@ import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import KeyboardVoiceIcon from '@material-ui/icons/KeyboardVoice';
 import Icon from '@material-ui/core/Icon';
 import SaveIcon from '@material-ui/icons/Save';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -59,6 +60,14 @@ export default function IconLabelButtons() {
         startIcon={<SaveIcon fontSize="small" />}
       >
         Save
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        className={classes.button}
+        startIcon={<CircularProgress color="inherit" size={20} />}
+      >
+        Loading
       </Button>
     </div>
   );

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -24,7 +24,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="secondary"
         className={classes.button}
-        startIcon={<DeleteIcon fontSize="small" />}
+        startIcon={<DeleteIcon />}
       >
         Delete
       </Button>
@@ -33,7 +33,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="primary"
         className={classes.button}
-        endIcon={<Icon fontSize="small">send</Icon>}
+        endIcon={<Icon>send</Icon>}
       >
         Send
       </Button>
@@ -41,7 +41,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="default"
         className={classes.button}
-        startIcon={<CloudUploadIcon fontSize="small" />}
+        startIcon={<CloudUploadIcon />}
       >
         Upload
       </Button>
@@ -50,16 +50,14 @@ export default function IconLabelButtons() {
         disabled
         color="secondary"
         className={classes.button}
-        startIcon={<KeyboardVoiceIcon fontSize="small" />}
+        startIcon={<KeyboardVoiceIcon />}
       >
         Talk
       </Button>
-      <Button
-        variant="contained"
-        size="small"
-        className={classes.button}
-        startIcon={<SaveIcon fontSize="small" />}
-      >
+      <Button variant="contained" size="small" className={classes.button} startIcon={<SaveIcon />}>
+        Save
+      </Button>
+      <Button variant="contained" size="large" className={classes.button} startIcon={<SaveIcon />}>
         Save
       </Button>
     </div>

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -6,6 +6,7 @@ import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import KeyboardVoiceIcon from '@material-ui/icons/KeyboardVoice';
 import Icon from '@material-ui/core/Icon';
 import SaveIcon from '@material-ui/icons/Save';
+import CircularProgress from '@material-ui/core/CircularProgress';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -62,6 +63,15 @@ export default function IconLabelButtons() {
       >
         Save
       </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        className={classes.button}
+        startIcon={<CircularProgress color="inherit" size={20} />}
+      >
+        Loading
+      </Button>
+
     </div>
   );
 }

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -6,7 +6,6 @@ import CloudUploadIcon from '@material-ui/icons/CloudUpload';
 import KeyboardVoiceIcon from '@material-ui/icons/KeyboardVoice';
 import Icon from '@material-ui/core/Icon';
 import SaveIcon from '@material-ui/icons/Save';
-import CircularProgress from '@material-ui/core/CircularProgress';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -25,7 +24,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="secondary"
         className={classes.button}
-        endIcon={<DeleteIcon fontSize="small" />}
+        startIcon={<DeleteIcon fontSize="small" />}
       >
         Delete
       </Button>
@@ -42,7 +41,7 @@ export default function IconLabelButtons() {
         variant="contained"
         color="default"
         className={classes.button}
-        endIcon={<CloudUploadIcon fontSize="small" />}
+        startIcon={<CloudUploadIcon fontSize="small" />}
       >
         Upload
       </Button>
@@ -62,14 +61,6 @@ export default function IconLabelButtons() {
         startIcon={<SaveIcon fontSize="small" />}
       >
         Save
-      </Button>
-      <Button
-        variant="contained"
-        color="primary"
-        className={classes.button}
-        startIcon={<CircularProgress color="inherit" size={20} />}
-      >
-        Loading
       </Button>
     </div>
   );

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import clsx from 'clsx';
 import Button from '@material-ui/core/Button';
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import DeleteIcon from '@material-ui/icons/Delete';
@@ -13,15 +12,6 @@ const useStyles = makeStyles((theme: Theme) =>
     button: {
       margin: theme.spacing(1),
     },
-    leftIcon: {
-      marginRight: theme.spacing(1),
-    },
-    rightIcon: {
-      marginLeft: theme.spacing(1),
-    },
-    iconSmall: {
-      fontSize: 20,
-    },
   }),
 );
 
@@ -30,25 +20,46 @@ export default function IconLabelButtons() {
 
   return (
     <div>
-      <Button variant="contained" color="secondary" className={classes.button}>
+      <Button
+        variant="contained"
+        color="secondary"
+        className={classes.button}
+        endIcon={<DeleteIcon fontSize="small" />}
+      >
         Delete
-        <DeleteIcon className={classes.rightIcon} />
       </Button>
-      <Button variant="contained" color="primary" className={classes.button}>
+      {/* This Button uses a Font Icon, see the installation instructions in the Icon component docs. */}
+      <Button
+        variant="contained"
+        color="primary"
+        className={classes.button}
+        endIcon={<Icon fontSize="small">send</Icon>}
+      >
         Send
-        {/* This Button uses a Font Icon, see the installation instructions in the docs. */}
-        <Icon className={classes.rightIcon}>send</Icon>
       </Button>
-      <Button variant="contained" color="default" className={classes.button}>
+      <Button
+        variant="contained"
+        color="default"
+        className={classes.button}
+        endIcon={<CloudUploadIcon fontSize="small" />}
+      >
         Upload
-        <CloudUploadIcon className={classes.rightIcon} />
       </Button>
-      <Button variant="contained" disabled color="secondary" className={classes.button}>
-        <KeyboardVoiceIcon className={classes.leftIcon} />
+      <Button
+        variant="contained"
+        disabled
+        color="secondary"
+        className={classes.button}
+        startIcon={<KeyboardVoiceIcon fontSize="small" />}
+      >
         Talk
       </Button>
-      <Button variant="contained" size="small" className={classes.button}>
-        <SaveIcon className={clsx(classes.leftIcon, classes.iconSmall)} />
+      <Button
+        variant="contained"
+        size="small"
+        className={classes.button}
+        startIcon={<SaveIcon fontSize="small" />}
+      >
         Save
       </Button>
     </div>

--- a/docs/src/pages/components/buttons/IconLabelButtons.tsx
+++ b/docs/src/pages/components/buttons/IconLabelButtons.tsx
@@ -71,7 +71,6 @@ export default function IconLabelButtons() {
       >
         Loading
       </Button>
-
     </div>
   );
 }

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -9,9 +9,11 @@ export type ButtonTypeMap<
   props: P & {
     color?: PropTypes.Color;
     disableFocusRipple?: boolean;
+    endIcon?: React.ReactElement;
     fullWidth?: boolean;
     href?: string;
     size?: 'small' | 'medium' | 'large';
+    startIcon?: React.ReactElement;
     variant?: 'text' | 'outlined' | 'contained';
   };
   defaultComponent: D;
@@ -48,6 +50,8 @@ export type ButtonClassKey =
   | 'containedSizeLarge'
   | 'sizeSmall'
   | 'sizeLarge'
-  | 'fullWidth';
+  | 'fullWidth'
+  | 'startIcon'
+  | 'endIcon';
 
 export default Button;

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -9,11 +9,11 @@ export type ButtonTypeMap<
   props: P & {
     color?: PropTypes.Color;
     disableFocusRipple?: boolean;
-    endIcon?: React.ReactElement;
+    endIcon?: React.ReactNode;
     fullWidth?: boolean;
     href?: string;
     size?: 'small' | 'medium' | 'large';
-    startIcon?: React.ReactElement;
+    startIcon?: React.ReactNode;
     variant?: 'text' | 'outlined' | 'contained';
   };
   defaultComponent: D;

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -264,9 +264,11 @@ const Button = React.forwardRef(function Button(props, ref) {
       type={type}
       {...other}
     >
-      {startIcon}
-      <span className={classes.label}>{children}</span>
-      {endIcon}
+      <span className={classes.label}>
+        {startIcon}
+        {children}
+        {endIcon}
+      </span>
     </ButtonBase>
   );
 });

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -205,6 +205,18 @@ export const styles = theme => ({
   fullWidth: {
     width: '100%',
   },
+  /* Styles applied to the startIcon element if supplied. */
+  startIcon: {
+    display: 'inherit',
+    marginRight: 8,
+    marginLeft: -4,
+  },
+  /* Styles applied to the endIcon element if supplied. */
+  endIcon: {
+    display: 'inherit',
+    marginRight: -4,
+    marginLeft: 8,
+  },
 });
 
 const Button = React.forwardRef(function Button(props, ref) {
@@ -216,13 +228,18 @@ const Button = React.forwardRef(function Button(props, ref) {
     component = 'button',
     disabled = false,
     disableFocusRipple = false,
+    endIcon: endIconProp,
     focusVisibleClassName,
     fullWidth = false,
     size = 'medium',
+    startIcon: startIconProp,
     type = 'button',
     variant = 'text',
     ...other
   } = props;
+
+  const startIcon = startIconProp && <span className={classes.startIcon}>{startIconProp}</span>;
+  const endIcon = endIconProp && <span className={classes.endIcon}>{endIconProp}</span>;
 
   return (
     <ButtonBase
@@ -247,7 +264,9 @@ const Button = React.forwardRef(function Button(props, ref) {
       type={type}
       {...other}
     >
+      {startIcon}
       <span className={classes.label}>{children}</span>
+      {endIcon}
     </ButtonBase>
   );
 });
@@ -291,6 +310,8 @@ Button.propTypes = {
    * to highlight the element by applying separate styles with the `focusVisibleClassName`.
    */
   disableRipple: PropTypes.bool,
+  /* Element placed after the children. */
+  endIcon: PropTypes.node,
   /**
    * @ignore
    */
@@ -309,6 +330,8 @@ Button.propTypes = {
    * `small` is equivalent to the dense button styling.
    */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
+  /* Element placed after the children. */
+  startIcon: PropTypes.node,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -310,7 +310,9 @@ Button.propTypes = {
    * to highlight the element by applying separate styles with the `focusVisibleClassName`.
    */
   disableRipple: PropTypes.bool,
-  /* Element placed after the children. */
+  /**
+   * Element placed after the children.
+   */
   endIcon: PropTypes.node,
   /**
    * @ignore
@@ -330,7 +332,9 @@ Button.propTypes = {
    * `small` is equivalent to the dense button styling.
    */
   size: PropTypes.oneOf(['small', 'medium', 'large']),
-  /* Element placed after the children. */
+  /**
+   * Element placed before the children.
+   */
   startIcon: PropTypes.node,
   /**
    * @ignore

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -217,6 +217,24 @@ export const styles = theme => ({
     marginRight: -4,
     marginLeft: 8,
   },
+  /* Styles applied to the icon element if supplied and `size="small"`. */
+  iconSizeSmall: {
+    '& > *:first-child': {
+      fontSize: 18,
+    },
+  },
+  /* Styles applied to the icon element if supplied and `size="medium"`. */
+  iconSizeMedium: {
+    '& > *:first-child': {
+      fontSize: 20,
+    },
+  },
+  /* Styles applied to the icon element if supplied and `size="large"`. */
+  iconSizeLarge: {
+    '& > *:first-child': {
+      fontSize: 22,
+    },
+  },
 });
 
 const Button = React.forwardRef(function Button(props, ref) {
@@ -238,8 +256,16 @@ const Button = React.forwardRef(function Button(props, ref) {
     ...other
   } = props;
 
-  const startIcon = startIconProp && <span className={classes.startIcon}>{startIconProp}</span>;
-  const endIcon = endIconProp && <span className={classes.endIcon}>{endIconProp}</span>;
+  const startIcon = startIconProp && (
+    <span className={clsx(classes.startIcon, classes[`iconSize${capitalize(size)}`])}>
+      {startIconProp}
+    </span>
+  );
+  const endIcon = endIconProp && (
+    <span className={clsx(classes.endIcon, classes[`iconSize${capitalize(size)}`])}>
+      {endIconProp}
+    </span>
+  );
 
   return (
     <ButtonBase

--- a/packages/material-ui/src/Button/Button.spec.tsx
+++ b/packages/material-ui/src/Button/Button.spec.tsx
@@ -8,6 +8,8 @@ const TestOverride = React.forwardRef<HTMLDivElement, { x?: number }>((props, re
   <div ref={ref} />
 ));
 
+const FakeIcon = () => <div>Icon</div>;
+
 const ButtonTest = () => (
   <div>
     <Button>I am a button!</Button>
@@ -77,6 +79,8 @@ const ButtonTest = () => (
         TestOverride
       </Button>
     }
+  <Button startIcon={FakeIcon}>Start Icon</Button>
+  <Button endIcon={FakeIcon}>endIcon</Button>
   </div>
 );
 

--- a/packages/material-ui/src/Button/Button.spec.tsx
+++ b/packages/material-ui/src/Button/Button.spec.tsx
@@ -79,8 +79,8 @@ const ButtonTest = () => (
         TestOverride
       </Button>
     }
-  <Button startIcon={FakeIcon}>Start Icon</Button>
-  <Button endIcon={FakeIcon}>endIcon</Button>
+    <Button startIcon={FakeIcon}>Start Icon</Button>
+    <Button endIcon={FakeIcon}>endIcon</Button>
   </div>
 );
 

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -270,25 +270,23 @@ describe('<Button />', () => {
   it('should render a button with startIcon', () => {
     const { getByRole } = render(<Button startIcon={<span>icon</span>}>Hello World</Button>);
     const button = getByRole('button');
+    const label = button.querySelector(`.${classes.label}`);
 
     expect(button).to.have.class(classes.root);
     expect(button).to.have.class(classes.text);
-    expect(button.firstChild).not.to.have.class(classes.endIcon);
-    expect(button.firstChild).to.have.class(classes.startIcon);
+    expect(label.firstChild).not.to.have.class(classes.endIcon);
+    expect(label.firstChild).to.have.class(classes.startIcon);
   });
 
   it('should render a button with endIcon', () => {
-    const { getByRole } = render(
-      <Button disableRipple endIcon={<span>icon</span>}>
-        Hello World
-      </Button>,
-    );
+    const { getByRole } = render(<Button endIcon={<span>icon</span>}>Hello World</Button>);
     const button = getByRole('button');
+    const label = button.querySelector(`.${classes.label}`);
 
     expect(button).to.have.class(classes.root);
     expect(button).to.have.class(classes.text);
-    expect(button.lastChild).not.to.have.class(classes.startIcon);
-    expect(button.lastChild).to.have.class(classes.endIcon);
+    expect(label.lastChild).not.to.have.class(classes.startIcon);
+    expect(label.lastChild).to.have.class(classes.endIcon);
   });
 
   it('should have a ripple by default', () => {

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -278,7 +278,11 @@ describe('<Button />', () => {
   });
 
   it('should render a button with endIcon', () => {
-    const { getByRole } = render(<Button endIcon={<span>icon</span>}>Hello World</Button>);
+    const { getByRole } = render(
+      <Button disableRipple endIcon={<span>icon</span>}>
+        Hello World
+      </Button>,
+    );
     const button = getByRole('button');
 
     expect(button).to.have.class(classes.root);

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -267,6 +267,26 @@ describe('<Button />', () => {
     expect(button).to.have.class(classes.containedSizeLarge);
   });
 
+  it('should render a button with startIcon', () => {
+    const { getByRole } = render(<Button startIcon={<span>icon</span>}>Hello World</Button>);
+    const button = getByRole('button');
+
+    expect(button).to.have.class(classes.root);
+    expect(button).to.have.class(classes.text);
+    expect(button.firstChild).not.to.have.class(classes.endIcon);
+    expect(button.firstChild).to.have.class(classes.startIcon);
+  });
+
+  it('should render a button with endIcon', () => {
+    const { getByRole } = render(<Button endIcon={<span>icon</span>}>Hello World</Button>);
+    const button = getByRole('button');
+
+    expect(button).to.have.class(classes.root);
+    expect(button).to.have.class(classes.text);
+    expect(button.lastChild).not.to.have.class(classes.startIcon);
+    expect(button.lastChild).to.have.class(classes.endIcon);
+  });
+
   it('should have a ripple by default', () => {
     const { getByRole } = render(
       <Button TouchRippleProps={{ className: 'touch-ripple' }}>Hello World</Button>,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #17494 

I have gone with `startIcon` / `endIcon` for now. 

![Capture d’écran 2019-09-30 à 11 37 49](https://user-images.githubusercontent.com/3165635/65867463-c149dc00-e376-11e9-84a6-c0811b3d2c9d.png)

```jsx
<Button
  variant="contained"
  color="secondary"
  startIcon={<DeleteIcon fontSize="small" />}
>
  Delete
</Button>
```