### PR TITLE
[docs] Extend size-snapshot

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,11 +57,6 @@ steps:
       yarn size:snapshot
     displayName: 'create a size snapshot'
 
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: 'size-snapshot'
-      targetPath: 'scripts/sizeSnapshot/build/stats.json'
-
   - task: AmazonWebServices.aws-vsts-tools.S3Upload.S3Upload@1
     displayName: 'persist size snapshot'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -95,9 +95,9 @@ function computeBundleLabel(bundleId) {
     return '@material-ui/core[umd]';
   }
   if (bundleId === '@material-ui/core/Textarea') {
-    return '/core/TextareaAutosize';
+    return 'TextareaAutosize';
   }
-  return bundleId.replace(/^@material-ui\/core\//, '/core/').replace(/\.esm$/, '');
+  return bundleId.replace(/^@material-ui\/core\//, '').replace(/\.esm$/, '');
 }
 
 /**

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -169,10 +169,12 @@ async function run() {
       ],
       results
         .map(([bundleId, size]) => [computeBundleLabel(bundleId), size])
-        // orderBy(parsedDiff DESC, gzipDiff DESC, name ASC)
+        // orderBy(|parsedDiff| DESC, |gzipDiff| DESC, name ASC)
         .sort(([labelA, statsA], [labelB, statsB]) => {
-          const compareParsedDiff = statsB.parsed.absoluteDiff - statsA.parsed.absoluteDiff;
-          const compareGzipDiff = statsB.gzip.absoluteDiff - statsA.gzip.absoluteDiff;
+          const compareParsedDiff = Math.abs(
+            statsB.parsed.absoluteDiff - statsA.parsed.absoluteDiff,
+          );
+          const compareGzipDiff = Math.abs(statsB.gzip.absoluteDiff - statsA.gzip.absoluteDiff);
           const compareName = labelA.localeCompare(labelB);
 
           if (compareParsedDiff === 0 && compareGzipDiff === 0) {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -94,6 +94,9 @@ function computeBundleLabel(bundleId) {
   if (bundleId === 'packages/material-ui/build/umd/material-ui.production.min.js') {
     return '@material-ui/core[umd]';
   }
+  if (bundleId === '@material-ui/core/Textarea') {
+    return '/core/TextareaAutosize';
+  }
   return bundleId.replace(/^@material-ui\/core\//, '/core/').replace(/\.esm$/, '');
 }
 

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "mocha": "^6.2.0",
     "nyc": "^14.1.1",
     "prettier": "1.17.0",
+    "pretty-bytes": "^5.3.0",
     "prop-types": "^15.7.2",
     "puppeteer": "^1.20.0",
     "react": "^16.10.1",

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -28,7 +28,9 @@ async function getSizeLimitBundles() {
     let entryName = componentName;
     if (componentName === 'Paper') {
       entryName = '@material-ui/core/Paper.esm';
-    } else if (['Popper', 'TextArea'].indexOf(componentName) !== -1) {
+    } else if (componentName === 'TextareaAutosize') {
+      entryName = '@material-ui/core/Textarea';
+    } else if (['Popper'].indexOf(componentName) !== -1) {
       entryName = `@material-ui/core/${componentName}`;
     }
 

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -23,8 +23,15 @@ async function getSizeLimitBundles() {
 
   const corePackagePath = path.join(workspaceRoot, 'packages/material-ui/build/esm');
   const coreComponents = (await glob(path.join(corePackagePath, '[A-Z]*'))).map(componentPath => {
+    const componentName = path.basename(componentPath);
+    // adjust for legacy names
+    let entryName = componentName;
+    if (componentName === 'Paper') {
+      entryName = '@material-ui/core/Paper.esm';
+    }
+
     return {
-      name: `@material-ui/core/${path.basename(componentPath)}.esm`,
+      name: entryName,
       webpack: true,
       path: path.relative(workspaceRoot, componentPath),
     };
@@ -32,8 +39,10 @@ async function getSizeLimitBundles() {
 
   const labPackagePath = path.join(workspaceRoot, 'packages/material-ui-lab/build/esm');
   const labComponents = (await glob(path.join(labPackagePath, '[A-Z]*'))).map(componentPath => {
+    const componentName = path.basename(componentPath);
+
     return {
-      name: `@material-ui/lab/${path.basename(componentPath)}.esm`,
+      name: componentName,
       webpack: true,
       path: path.relative(workspaceRoot, componentPath),
     };

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -24,8 +24,8 @@ async function getSizeLimitBundles() {
   const corePackagePath = path.join(workspaceRoot, 'packages/material-ui/build/esm');
   const coreComponents = (await glob(path.join(corePackagePath, '[A-Z]*'))).map(componentPath => {
     const componentName = path.basename(componentPath);
-    // adjust for legacy names
     let entryName = componentName;
+    // adjust for legacy names
     if (componentName === 'Paper') {
       entryName = '@material-ui/core/Paper.esm';
     } else if (componentName === 'TextareaAutosize') {

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -1,6 +1,10 @@
 const fse = require('fs-extra');
+const globCallback = require('glob');
 const path = require('path');
 const CompressionPlugin = require('compression-webpack-plugin');
+const { promisify } = require('util');
+
+const glob = promisify(globCallback);
 
 const workspaceRoot = path.join(__dirname, '..', '..');
 
@@ -17,31 +21,34 @@ async function getSizeLimitBundles() {
     return result;
   }, []);
 
+  const corePackagePath = path.join(workspaceRoot, 'packages/material-ui/build/esm');
+  const coreComponents = (await glob(path.join(corePackagePath, '[A-Z]*'))).map(componentPath => {
+    return {
+      name: `@material-ui/core/${path.basename(componentPath)}.esm`,
+      webpack: true,
+      path: path.relative(workspaceRoot, componentPath),
+    };
+  });
+
+  const labPackagePath = path.join(workspaceRoot, 'packages/material-ui-lab/build/esm');
+  const labComponents = (await glob(path.join(labPackagePath, '[A-Z]*'))).map(componentPath => {
+    return {
+      name: `@material-ui/lab/${path.basename(componentPath)}.esm`,
+      webpack: true,
+      path: path.relative(workspaceRoot, componentPath),
+    };
+  });
+
   return [
-    {
-      name: '@material-ui/core/Paper',
-      webpack: true,
-      path: 'packages/material-ui/build/Paper/index.js',
-    },
-    {
-      name: '@material-ui/core/Paper.esm',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/Paper/index.js',
-    },
     {
       name: '@material-ui/core',
       webpack: true,
-      path: 'packages/material-ui/build/esm/index.js',
-    },
-    {
-      name: '@material-ui/core/styles/createMuiTheme',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/styles/createMuiTheme.js',
+      path: path.join(path.relative(workspaceRoot, corePackagePath), 'index.js'),
     },
     {
       name: '@material-ui/lab',
       webpack: true,
-      path: 'packages/material-ui-lab/build/esm/index.js',
+      path: path.join(path.relative(workspaceRoot, labPackagePath), 'index.js'),
     },
     {
       name: '@material-ui/styles',
@@ -53,66 +60,24 @@ async function getSizeLimitBundles() {
       webpack: true,
       path: 'packages/material-ui-system/build/esm/index.js',
     },
+    ...coreComponents,
+    {
+      name: '@material-ui/core/styles/createMuiTheme',
+      webpack: true,
+      path: 'packages/material-ui/build/esm/styles/createMuiTheme.js',
+    },
     {
       name: 'colorManipulator',
       webpack: true,
       path: 'packages/material-ui/build/esm/styles/colorManipulator.js',
     },
+    ...labComponents,
     {
-      // why we use esm here: https://github.com/mui-org/material-ui/pull/13391#issuecomment-459692816
-      name: 'Button',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/Button/index.js',
-    },
-    {
-      // vs https://bundlephobia.com/result?p=react-modal
-      // vs https://bundlephobia.com/result?p=@reach/dialog
-      name: 'Modal',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/Modal/index.js',
-    },
-    {
-      // vs https://bundlephobia.com/result?p=react-popper
-      name: '@material-ui/core/Popper',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/Popper/index.js',
-    },
-    {
-      // vs https://bundlephobia.com/result?p=react-responsive
-      // vs https://bundlephobia.com/result?p=react-media
-      name: '@material-ui/core/useMediaQuery',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/useMediaQuery/index.js',
-    },
-    {
+      // TODO: Is this even a public module?
       // vs https://bundlephobia.com/result?p=react-focus-lock
       name: '@material-ui/core/TrapFocus',
       webpack: true,
       path: 'packages/material-ui/build/esm/Modal/TrapFocus.js',
-    },
-    {
-      // vs https://bundlephobia.com/result?p=react-textarea-autosize
-      // vs https://bundlephobia.com/result?p=react-autosize-textarea
-      name: '@material-ui/core/Textarea',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/TextareaAutosize/index.js',
-    },
-    {
-      // vs https://bundlephobia.com/result?p=rc-slider
-      name: 'Slider',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/Slider/index.js',
-    },
-    {
-      name: 'Rating',
-      webpack: true,
-      path: 'packages/material-ui-lab/build/esm/Rating/index.js',
-    },
-    {
-      // vs https://bundlephobia.com/result?p=react-portal
-      name: 'Portal',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/Portal/index.js',
     },
     {
       name: 'docs.main',

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -73,11 +73,6 @@ async function getSizeLimitBundles() {
     },
     ...coreComponents,
     {
-      name: '@material-ui/core/useMediaQuery',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/useMediaQuery.js',
-    },
-    {
       name: '@material-ui/core/styles/createMuiTheme',
       webpack: true,
       path: 'packages/material-ui/build/esm/styles/createMuiTheme.js',
@@ -88,6 +83,11 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui/build/esm/styles/colorManipulator.js',
     },
     ...labComponents,
+    {
+      name: '@material-ui/core/useMediaQuery',
+      webpack: true,
+      path: 'packages/material-ui/build/esm/useMediaQuery/index.js',
+    },
     {
       // TODO: Is this even a public module?
       // vs https://bundlephobia.com/result?p=react-focus-lock

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -28,6 +28,8 @@ async function getSizeLimitBundles() {
     let entryName = componentName;
     if (componentName === 'Paper') {
       entryName = '@material-ui/core/Paper.esm';
+    } else if (['Popper', 'TextArea'].indexOf(componentName) !== -1) {
+      entryName = `@material-ui/core/${componentName}`;
     }
 
     return {
@@ -70,6 +72,11 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui-system/build/esm/index.js',
     },
     ...coreComponents,
+    {
+      name: '@material-ui/core/useMediaQuery',
+      webpack: true,
+      path: 'packages/material-ui/build/esm/useMediaQuery.js',
+    },
     {
       name: '@material-ui/core/styles/createMuiTheme',
       webpack: true,

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -91,13 +91,6 @@ async function getSizeLimitBundles() {
       path: 'packages/material-ui/build/esm/useMediaQuery/index.js',
     },
     {
-      // TODO: Is this even a public module?
-      // vs https://bundlephobia.com/result?p=react-focus-lock
-      name: '@material-ui/core/TrapFocus',
-      webpack: true,
-      path: 'packages/material-ui/build/esm/Modal/TrapFocus.js',
-    },
-    {
       name: 'docs.main',
       webpack: false,
       path: path.relative(workspaceRoot, main.path),

--- a/yarn.lock
+++ b/yarn.lock
@@ -11714,6 +11714,11 @@ prettier@1.17.0:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.17.0.tgz#53b303676eed22cc14a9f0cec09b477b3026c008"
   integrity sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==
 
+pretty-bytes@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.3.0.tgz#f2849e27db79fb4d6cfe24764fc4134f165989f2"
+  integrity sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==
+
 pretty-format@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.6.0.tgz#5eaac8eeb6b33b987b7fe6097ea6a8a146ab5760"


### PR DESCRIPTION
New comparison table sorts by absolute diff making it easier to scan for changes

Track all components in core and lab. This should make their size snapshots a bit more stable with regards to chunks (we had some issues previously when a change in one dependency caused fluctuations for every tracked asset). 

Running webpack separately on every bundle instead of declaring every bundle as an entry would be the most stable solution but increases time and is less representative of the change one sees when adding a given component to their app.

Labelled as docs since we link to it from some docs sites and I want to automate that process.

Future work:
* Display size of component in material-ui/com/api/* (probably easier to do with mdx)
* Explore if we can leverage lambda functions to calculate bundle size of a given demo