### PR TITLE
[docs] Remove fixed InputLabel missalignement issue from docs

### DIFF
--- a/docs/src/pages/components/text-fields/text-fields.md
+++ b/docs/src/pages/components/text-fields/text-fields.md
@@ -94,23 +94,6 @@ other styles to meet the specification.
 
 ## Limitations
 
-### Shrink
-
-The input label "shrink" state isn't always correct.
-The input label is supposed to shrink as soon as the input is displaying something.
-In some circumstances, we can't determine the "shrink" state (number input, datetime input, Stripe input). You might notice an overlap.
-
-![shrink](/static/images/text-fields/shrink.png)
-
-To workaround the issue, you can force the "shrink" state of the label.
-```jsx
-<TextField InputLabelProps={{ shrink: true }} />
-```
-or
-```jsx
-<InputLabel shrink>Count</InputLabel>
-```
-
 ### Floating label
 
 The floating label is absolutely positioned, it won't impact the layout of the page.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Is this described limitation in the docs same as this issue: https://github.com/mui-org/material-ui/issues/14427

If so, it can be removed from the docs as the issue was fixed.