### PR TITLE
[Typescript] Adding `component` to the ListTypeMap interface

### DIFF
--- a/packages/material-ui/src/List/List.d.ts
+++ b/packages/material-ui/src/List/List.d.ts
@@ -6,6 +6,7 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
     dense?: boolean;
     disablePadding?: boolean;
     subheader?: React.ReactElement;
+    component?: React.ElementType;
   };
   defaultComponent: D;
   classKey: ListClassKey;


### PR DESCRIPTION
Fixes #17579.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
