### PR TITLE
[ButtonGroup] Fix missing divider if background color is set

### DIFF
--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -55,8 +55,10 @@ export const styles = theme => ({
   /* Styles applied to the children if variant="outlined". */
   groupedOutlined: {
     '&:not(:first-child)': {
-      borderLeftColor: 'transparent',
       marginLeft: -1,
+    },
+    '&:not(:last-child)': {
+      borderRightColor: 'transparent',
     },
   },
   /* Styles applied to the children if variant="outlined" & color="primary". */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
 
fixes #17495 