### PR TITLE
[docs] Replace react-inspector with custom TreeView implementation

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -98,7 +98,6 @@
     "react-draggable": "^4.0.3",
     "react-final-form": "^6.3.0",
     "react-frame-component": "^4.1.1",
-    "react-inspector": "^3.0.2",
     "react-number-format": "^4.0.8",
     "react-redux": "^7.1.1",
     "react-router": "^5.0.0",

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -7,7 +7,7 @@ import CollapseIcon from '@material-ui/icons/ChevronRight';
 import TreeView from '@material-ui/lab/TreeView';
 import TreeItem from '@material-ui/lab/TreeItem';
 import clsx from 'clsx';
-import { makeStyles, withStyles, createMuiTheme, useTheme } from '@material-ui/core/styles';
+import { withStyles, createMuiTheme } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 
@@ -54,38 +54,24 @@ function useLabel(value, type) {
   }
 }
 
-const useTreeLabelStyles = makeStyles(theme => {
-  const darkMode = theme.palette.type === 'dark';
-
-  return {
-    objectKey: {
-      color: darkMode ? 'rgb(227, 110, 236)' : 'rgb(136, 19, 145)',
-    },
-    objectValue: {},
-    'type-function': {
-      fontStyle: 'italic',
-    },
-    'type-string': {
-      color: darkMode ? 'rgb(233, 63, 59)' : 'rgb(196, 26, 22)',
-    },
-    'type-boolean': {
-      color: darkMode ? 'rgb(153, 128, 255)' : 'rgb(28, 0, 207)',
-    },
-    'type-number': {
-      color: darkMode ? 'rgb(153, 128, 255)' : 'rgb(136, 19, 145)',
-    },
-  };
-});
+function useTokenType(type) {
+  switch (type) {
+    case 'object':
+    case 'array':
+      return 'comment';
+    default:
+      return type;
+  }
+}
 
 function ObjectEntryLabel({ objectKey, objectValue }) {
   const type = useType(objectValue);
   const label = useLabel(objectValue, type);
-  const classes = useTreeLabelStyles();
+  const tokenType = useTokenType(type);
 
   return (
     <React.Fragment>
-      <span className={classes.objectKey}>{objectKey}: </span>
-      <span className={clsx(classes.objectValue, classes[`type-${type}`])}>{label}</span>
+      {objectKey}: <span className={clsx('token', tokenType)}>{label}</span>
     </React.Fragment>
   );
 }
@@ -171,10 +157,12 @@ Inspector.propTypes = {
 
 const styles = theme => ({
   root: {
+    backgroundColor: '#333',
+    borderRadius: 4,
+    color: '#fff',
+    display: 'block',
     padding: theme.spacing(2),
     paddingTop: 0,
-    // Match <Inspector /> default theme.
-    backgroundColor: theme.palette.type === 'light' ? theme.palette.common.white : '#242424',
     minHeight: theme.spacing(40),
     width: '100%',
   },
@@ -230,7 +218,6 @@ function DefaultTheme(props) {
     );
   }, []);
 
-  const theme = useTheme();
   const data = React.useMemo(createMuiTheme, []);
 
   const allNodeIds = useNodeIdsLazy(data);
@@ -261,12 +248,7 @@ function DefaultTheme(props) {
         }
         label={t('expandAll')}
       />
-      <Inspector
-        theme={theme.palette.type === 'light' ? 'chromeLight' : 'chromeDark'}
-        data={data}
-        expandPaths={expandPaths}
-        expandLevel={checked ? 100 : 1}
-      />
+      <Inspector data={data} expandPaths={expandPaths} expandLevel={checked ? 100 : 1} />
     </div>
   );
 }

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -7,7 +7,7 @@ import CollapseIcon from '@material-ui/icons/ChevronRight';
 import TreeView from '@material-ui/lab/TreeView';
 import TreeItem from '@material-ui/lab/TreeItem';
 import clsx from 'clsx';
-import { withStyles, createMuiTheme } from '@material-ui/core/styles';
+import { makeStyles, withStyles, createMuiTheme, lighten } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
 
@@ -77,6 +77,19 @@ function ObjectEntryLabel({ objectKey, objectValue }) {
 }
 ObjectEntryLabel.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.any };
 
+const useObjectEntryStyles = makeStyles({
+  treeItem: {
+    '&:focus > $treeItemContent': {
+      backgroundColor: lighten('#333', 0.3),
+    },
+  },
+  treeItemContent: {
+    '&:hover': {
+      backgroundColor: lighten('#333', 0.1),
+    },
+  },
+});
+
 function ObjectEntry(props) {
   const { nodeId, objectKey, objectValue } = props;
 
@@ -102,8 +115,11 @@ function ObjectEntry(props) {
           });
   }
 
+  const classes = useObjectEntryStyles();
+
   return (
     <TreeItem
+      classes={{ root: classes.treeItem, content: classes.treeItemContent }}
       nodeId={nodeId}
       label={<ObjectEntryLabel objectKey={objectKey} objectValue={objectValue} />}
     >

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -54,23 +54,27 @@ function useLabel(value, type) {
   }
 }
 
-const useTreeLabelStyles = makeStyles({
-  objectKey: {
-    color: 'rgb(227, 110, 236)',
-  },
-  objectValue: {},
-  'type-function': {
-    fontStyle: 'italic',
-  },
-  'type-string': {
-    color: 'rgb(233, 63, 59)',
-  },
-  'type-boolean': {
-    color: 'rgb(153, 128, 255);',
-  },
-  'type-number': {
-    color: 'rgb(153, 128, 255);',
-  },
+const useTreeLabelStyles = makeStyles(theme => {
+  const darkMode = theme.palette.type === 'dark';
+
+  return {
+    objectKey: {
+      color: darkMode ? 'rgb(227, 110, 236)' : 'rgb(136, 19, 145)',
+    },
+    objectValue: {},
+    'type-function': {
+      fontStyle: 'italic',
+    },
+    'type-string': {
+      color: darkMode ? 'rgb(233, 63, 59)' : 'rgb(196, 26, 22)',
+    },
+    'type-boolean': {
+      color: darkMode ? 'rgb(153, 128, 255)' : 'rgb(28, 0, 207)',
+    },
+    'type-number': {
+      color: darkMode ? 'rgb(153, 128, 255)' : 'rgb(136, 19, 145)',
+    },
+  };
 });
 
 function TreeLabel({ objectKey, objectValue }) {
@@ -136,13 +140,14 @@ function Inspector(props) {
   const defaultExpanded = React.useMemo(() => {
     return Array.isArray(expandPaths)
       ? expandPaths.map(expandPath => `${keyPrefix}.${expandPath}`)
-      : undefined;
+      : [];
   }, [keyPrefix, expandPaths]);
 
   return (
     <TreeView
       /* expandPaths are only set on the client so we need to remount */
-      key={defaultExpanded}
+      /* we need "semantic equality" here since the array is returned from useMemo which does not have semantic guarantees */
+      key={defaultExpanded.join('')}
       defaultCollapseIcon={<ExpandIcon />}
       defaultExpanded={defaultExpanded}
       defaultExpandIcon={<CollapseIcon />}

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -93,7 +93,7 @@ TreeLabel.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.any };
 const ObjectContext = React.createContext('$ROOT');
 
 function ObjectTreeItem(props) {
-  const { objectKey, objectValue } = props;
+  const { nodeId, objectValue } = props;
 
   const keyPrefix = React.useContext(ObjectContext);
 
@@ -101,28 +101,33 @@ function ObjectTreeItem(props) {
     (objectValue !== null && typeof objectValue === 'object') ||
     typeof objectValue === 'function'
   ) {
+    const children =
+      Object.keys(objectValue).length === 0
+        ? undefined
+        : Object.keys(objectValue).map(key => {
+            return <ObjectTreeItem key={key} nodeId={key} objectValue={objectValue[key]} />;
+          });
+    // false hierarchy but items must be immediate children with a `nodeId` prop
     return (
-      <TreeItem
-        nodeId={`${keyPrefix}.${objectKey}`}
-        label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}
-      >
-        <ObjectContext.Provider value={`${keyPrefix}.${objectKey}`}>
-          {Object.keys(objectValue).map(key => {
-            return <ObjectTreeItem key={key} objectKey={key} objectValue={objectValue[key]} />;
-          })}
-        </ObjectContext.Provider>
-      </TreeItem>
+      <ObjectContext.Provider value={`${keyPrefix}.${nodeId}`}>
+        <TreeItem
+          nodeId={`${keyPrefix}.${nodeId}`}
+          label={<TreeLabel objectKey={nodeId} objectValue={objectValue} />}
+        >
+          {children}
+        </TreeItem>
+      </ObjectContext.Provider>
     );
   }
 
   return (
     <TreeItem
-      nodeId={`${keyPrefix}-${objectKey}`}
-      label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}
+      nodeId={`${keyPrefix}-${nodeId}`}
+      label={<TreeLabel objectKey={nodeId} objectValue={objectValue} />}
     />
   );
 }
-ObjectTreeItem.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.any };
+ObjectTreeItem.propTypes = { nodeId: PropTypes.any, objectValue: PropTypes.any };
 
 function Inspector(props) {
   const { data, expandPaths } = props;
@@ -143,7 +148,7 @@ function Inspector(props) {
       defaultExpandIcon={<CollapseIcon />}
     >
       {Object.keys(data).map(key => {
-        return <ObjectTreeItem key={key} objectKey={key} objectValue={data[key]} />;
+        return <ObjectTreeItem key={key} nodeId={key} objectValue={data[key]} />;
       })}
     </TreeView>
   );

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -80,12 +80,14 @@ ObjectEntryLabel.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.
 const useObjectEntryStyles = makeStyles({
   treeItem: {
     '&:focus > $treeItemContent': {
-      backgroundColor: lighten('#333', 0.3),
+      backgroundColor: 'inherit',
+      outline: `2px dashed ${lighten('#333', 0.3)}`,
     },
   },
   treeItemContent: {
     '&:hover': {
-      backgroundColor: lighten('#333', 0.1),
+      backgroundColor: 'inherit',
+      outline: `1px dashed ${lighten('#333', 0.3)}`,
     },
   },
 });

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -149,6 +149,7 @@ function Inspector(props) {
     <TreeView
       key={key}
       defaultCollapseIcon={<ExpandIcon />}
+      defaultEndIcon={<div style={{ width: 24 }} />}
       defaultExpanded={defaultExpanded}
       defaultExpandIcon={<CollapseIcon />}
     >

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -2,10 +2,149 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import url from 'url';
-import Inspector from 'react-inspector';
-import { withStyles, createMuiTheme, useTheme } from '@material-ui/core/styles';
+import ExpandIcon from '@material-ui/icons/ExpandMore';
+import CollapseIcon from '@material-ui/icons/ChevronRight';
+import TreeView from '@material-ui/lab/TreeView';
+import TreeItem from '@material-ui/lab/TreeItem';
+import clsx from 'clsx';
+import { makeStyles, withStyles, createMuiTheme, useTheme } from '@material-ui/core/styles';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Switch from '@material-ui/core/Switch';
+
+/**
+ * @type {React.Context<keyof object>}
+ */
+const ObjectContext = React.createContext('$ROOT');
+
+/**
+ * @param {unknown} value
+ */
+function useType(value) {
+  if (Array.isArray(value)) {
+    return 'array';
+  }
+  if (value === null) {
+    return 'null';
+  }
+
+  return typeof value;
+}
+
+/**
+ *
+ * @param {unknown} value
+ * @param {ReturnType<typeof useType>} type
+ */
+function useLabel(value, type) {
+  switch (type) {
+    case 'array':
+      return `Array(${value.length})`;
+    case 'null':
+      return 'null';
+    case 'undefined':
+      return 'undefined';
+    case 'function':
+      return `f ${value.name}()`;
+    case 'object':
+      return 'Object';
+    case 'string':
+      return `"${value}"`;
+    case 'symbol':
+      return `Symbol(${String(value)})`;
+    case 'bigint':
+    case 'boolean':
+    case 'number':
+    default:
+      return String(value);
+  }
+}
+
+const useTreeLabelStyles = makeStyles({
+  objectKey: {
+    color: 'rgb(227, 110, 236)',
+  },
+  objectValue: {},
+  'type-function': {
+    fontStyle: 'italic',
+  },
+  'type-string': {
+    color: 'rgb(233, 63, 59)',
+  },
+  'type-boolean': {
+    color: 'rgb(153, 128, 255);',
+  },
+  'type-number': {
+    color: 'rgb(153, 128, 255);',
+  },
+});
+
+function TreeLabel({ objectKey, objectValue }) {
+  const type = useType(objectValue);
+  const label = useLabel(objectValue, type);
+  const classes = useTreeLabelStyles();
+
+  return (
+    <React.Fragment>
+      <span className={classes.objectKey}>{objectKey}: </span>
+      <span className={clsx(classes.objectValue, classes[`type-${type}`])}>{label}</span>
+    </React.Fragment>
+  );
+}
+TreeLabel.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.any };
+
+function ObjectTreeItem(props) {
+  const { objectKey, objectValue } = props;
+
+  const keyPrefix = React.useContext(ObjectContext);
+
+  if (
+    (objectValue !== null && typeof objectValue === 'object') ||
+    typeof objectValue === 'function'
+  ) {
+    const children = Object.keys(objectValue).map(key => {
+      return <ObjectTreeItem key={key} objectKey={key} objectValue={objectValue[key]} />;
+    });
+
+    if (objectKey === undefined) {
+      return (
+        <TreeView defaultCollapseIcon={<ExpandIcon />} defaultExpandIcon={<CollapseIcon />}>
+          {children}
+        </TreeView>
+      );
+    }
+
+    return (
+      <TreeItem
+        nodeId={`${keyPrefix}-${objectKey}`}
+        label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}
+      >
+        <ObjectContext.Provider value={`${keyPrefix}-${objectKey}`}>
+          {children}
+        </ObjectContext.Provider>
+      </TreeItem>
+    );
+  }
+
+  return (
+    <TreeItem
+      nodeId={`${keyPrefix}-${objectKey}`}
+      label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}
+    />
+  );
+}
+ObjectTreeItem.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.any };
+
+function Inspector(props) {
+  const { data } = props;
+
+  return <ObjectTreeItem objectValue={data} />;
+}
+
+Inspector.propTypes = {
+  data: PropTypes.any,
+  /* expandLevel: PropTypes.number,
+  expandPaths: PropTypes.arrayOf(PropTypes.string), */
+};
 
 const styles = theme => ({
   root: {

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -77,7 +77,7 @@ const useTreeLabelStyles = makeStyles(theme => {
   };
 });
 
-function TreeLabel({ objectKey, objectValue }) {
+function ObjectEntryLabel({ objectKey, objectValue }) {
   const type = useType(objectValue);
   const label = useLabel(objectValue, type);
   const classes = useTreeLabelStyles();
@@ -89,9 +89,9 @@ function TreeLabel({ objectKey, objectValue }) {
     </React.Fragment>
   );
 }
-TreeLabel.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.any };
+ObjectEntryLabel.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.any };
 
-function ObjectTreeItem(props) {
+function ObjectEntry(props) {
   const { nodeId, objectKey, objectValue } = props;
 
   const keyPrefix = nodeId;
@@ -106,7 +106,7 @@ function ObjectTreeItem(props) {
         ? undefined
         : Object.keys(objectValue).map(key => {
             return (
-              <ObjectTreeItem
+              <ObjectEntry
                 key={key}
                 nodeId={`${keyPrefix}.${key}`}
                 objectKey={key}
@@ -117,12 +117,15 @@ function ObjectTreeItem(props) {
   }
 
   return (
-    <TreeItem nodeId={nodeId} label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}>
+    <TreeItem
+      nodeId={nodeId}
+      label={<ObjectEntryLabel objectKey={objectKey} objectValue={objectValue} />}
+    >
       {children}
     </TreeItem>
   );
 }
-ObjectTreeItem.propTypes = {
+ObjectEntry.propTypes = {
   nodeId: PropTypes.string.isRequired,
   objectKey: PropTypes.any.isRequired,
   objectValue: PropTypes.any,
@@ -149,7 +152,7 @@ function Inspector(props) {
     >
       {Object.keys(data).map(key => {
         return (
-          <ObjectTreeItem
+          <ObjectEntry
             key={key}
             nodeId={`${keyPrefix}.${key}`}
             objectKey={key}

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -80,14 +80,13 @@ ObjectEntryLabel.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.
 const useObjectEntryStyles = makeStyles({
   treeItem: {
     '&:focus > $treeItemContent': {
-      backgroundColor: 'inherit',
+      backgroundColor: lighten('#333', 0.08),
       outline: `2px dashed ${lighten('#333', 0.3)}`,
     },
   },
   treeItemContent: {
     '&:hover': {
-      backgroundColor: 'inherit',
-      outline: `1px dashed ${lighten('#333', 0.3)}`,
+      backgroundColor: lighten('#333', 0.08),
     },
   },
 });

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -96,11 +96,12 @@ function ObjectTreeItem(props) {
 
   const keyPrefix = nodeId;
 
+  let children = null;
   if (
     (objectValue !== null && typeof objectValue === 'object') ||
     typeof objectValue === 'function'
   ) {
-    const children =
+    children =
       Object.keys(objectValue).length === 0
         ? undefined
         : Object.keys(objectValue).map(key => {
@@ -113,22 +114,12 @@ function ObjectTreeItem(props) {
               />
             );
           });
-    // false hierarchy but items must be immediate children with a `nodeId` prop
-    return (
-      <TreeItem
-        nodeId={nodeId}
-        label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}
-      >
-        {children}
-      </TreeItem>
-    );
   }
 
   return (
-    <TreeItem
-      nodeId={nodeId}
-      label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}
-    />
+    <TreeItem nodeId={nodeId} label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}>
+      {children}
+    </TreeItem>
   );
 }
 ObjectTreeItem.propTypes = {

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -91,15 +91,10 @@ function TreeLabel({ objectKey, objectValue }) {
 }
 TreeLabel.propTypes = { objectKey: PropTypes.any, objectValue: PropTypes.any };
 
-/**
- * @type {React.Context<keyof object>}
- */
-const ObjectContext = React.createContext('$ROOT');
-
 function ObjectTreeItem(props) {
-  const { nodeId, objectValue } = props;
+  const { nodeId, objectKey, objectValue } = props;
 
-  const keyPrefix = React.useContext(ObjectContext);
+  const keyPrefix = nodeId;
 
   if (
     (objectValue !== null && typeof objectValue === 'object') ||
@@ -109,34 +104,43 @@ function ObjectTreeItem(props) {
       Object.keys(objectValue).length === 0
         ? undefined
         : Object.keys(objectValue).map(key => {
-            return <ObjectTreeItem key={key} nodeId={key} objectValue={objectValue[key]} />;
+            return (
+              <ObjectTreeItem
+                key={key}
+                nodeId={`${keyPrefix}.${key}`}
+                objectKey={key}
+                objectValue={objectValue[key]}
+              />
+            );
           });
     // false hierarchy but items must be immediate children with a `nodeId` prop
     return (
-      <ObjectContext.Provider value={`${keyPrefix}.${nodeId}`}>
-        <TreeItem
-          nodeId={`${keyPrefix}.${nodeId}`}
-          label={<TreeLabel objectKey={nodeId} objectValue={objectValue} />}
-        >
-          {children}
-        </TreeItem>
-      </ObjectContext.Provider>
+      <TreeItem
+        nodeId={nodeId}
+        label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}
+      >
+        {children}
+      </TreeItem>
     );
   }
 
   return (
     <TreeItem
-      nodeId={`${keyPrefix}-${nodeId}`}
-      label={<TreeLabel objectKey={nodeId} objectValue={objectValue} />}
+      nodeId={nodeId}
+      label={<TreeLabel objectKey={objectKey} objectValue={objectValue} />}
     />
   );
 }
-ObjectTreeItem.propTypes = { nodeId: PropTypes.any, objectValue: PropTypes.any };
+ObjectTreeItem.propTypes = {
+  nodeId: PropTypes.string.isRequired,
+  objectKey: PropTypes.any.isRequired,
+  objectValue: PropTypes.any,
+};
 
 function Inspector(props) {
   const { data, expandPaths } = props;
 
-  const keyPrefix = React.useContext(ObjectContext);
+  const keyPrefix = '$ROOT';
   const defaultExpanded = React.useMemo(() => {
     return Array.isArray(expandPaths)
       ? expandPaths.map(expandPath => `${keyPrefix}.${expandPath}`)
@@ -153,7 +157,14 @@ function Inspector(props) {
       defaultExpandIcon={<CollapseIcon />}
     >
       {Object.keys(data).map(key => {
-        return <ObjectTreeItem key={key} nodeId={key} objectValue={data[key]} />;
+        return (
+          <ObjectTreeItem
+            key={key}
+            nodeId={`${keyPrefix}.${key}`}
+            objectKey={key}
+            objectValue={data[key]}
+          />
+        );
       })}
     </TreeView>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -8186,11 +8186,6 @@ is-directory@^0.3.1:
   resolved "https://registry.yarnpkg.com/is-directory/-/is-directory-0.3.1.tgz#61339b6f2475fc772fd9c9d83f5c8575dc154ae1"
   integrity sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=
 
-is-dom@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.0.9.tgz#483832d52972073de12b9fe3f60320870da8370d"
-  integrity sha1-SDgy1SlyBz3hK5/j9gMghw2oNw0=
-
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
@@ -11798,7 +11793,7 @@ prop-types@15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12158,15 +12153,6 @@ react-input-autosize@^2.2.2:
   integrity sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==
   dependencies:
     prop-types "^15.5.8"
-
-react-inspector@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-3.0.2.tgz#c530a06101f562475537e47df428e1d7aff16ed8"
-  integrity sha512-PSR8xDoGFN8R3LKmq1NT+hBBwhxjd9Qwz8yKY+5NXY/CHpxXHm01CVabxzI7zFwFav/M3JoC/Z0Ro2kSX6Ef2Q==
-  dependencies:
-    babel-runtime "^6.26.0"
-    is-dom "^1.0.9"
-    prop-types "^15.6.1"
 
 react-is@16.8.6:
   version "16.8.6"


### PR DESCRIPTION
Use our own `TreeView` instead of `react-inspector` for https://material-ui.com/customization/default-theme/ (i.e. dogfeeding).

- [new version](https://deploy-preview-17662--material-ui.netlify.com/customization/default-theme#explore)
- [old version](https://material-ui.com/customization/default-theme/#explore)

Current bugs:
- ~keyboard navigation between items doesn't work (collapsing works but not up/down arrow). Any idea why @joshwooding ?~

TODO:
- [x] ~dark/light mode themes~ use syntax highlighting theme
- [x] expand all
- [x] expandPaths
- ~[ ] property preview for root object~ (feature cut, not that useful)
- [x] hide expand icon when object has no properties

Feedback regarding `TreeView` API:
* naming of `defaultCollapseIcon` might be confusing: Does this mean the icon that is displayed when we can collapse or is this the icon which is displayed when the item is collapse i.e. when we can expand (the latter one is the case). I would suggest swapping the names so that you don't have to write `defaultCollapseIcon={<ExpandIcon />}` which adds some cognitive overload ("I have to use the icon indicating expand for `collapseIcon`")
* `end icon` is using terminology unknown to me. While `leaf icon` is just as "jargony" it's at least Math/CS jargon.