### PR TITLE
Replace ImgMediaCard demo to use styled-components

### DIFF
--- a/docs/src/pages/components/cards/ImgMediaCard.js
+++ b/docs/src/pages/components/cards/ImgMediaCard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import styled from 'styled-components';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
@@ -8,17 +8,13 @@ import CardMedia from '@material-ui/core/CardMedia';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles({
-  card: {
-    maxWidth: 345,
-  },
-});
+const StyledCard = styled(Card)`
+  max-width: 345px;
+`;
 
 export default function ImgMediaCard() {
-  const classes = useStyles();
-
   return (
-    <Card className={classes.card}>
+    <StyledCard>
       <CardActionArea>
         <CardMedia
           component="img"
@@ -45,6 +41,6 @@ export default function ImgMediaCard() {
           Learn More
         </Button>
       </CardActions>
-    </Card>
+    </StyledCard>
   );
 }

--- a/docs/src/pages/components/cards/ImgMediaCard.tsx
+++ b/docs/src/pages/components/cards/ImgMediaCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import styled from 'styled-components';
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
 import CardActions from '@material-ui/core/CardActions';
@@ -8,17 +8,13 @@ import CardMedia from '@material-ui/core/CardMedia';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
-const useStyles = makeStyles({
-  card: {
-    maxWidth: 345,
-  },
-});
+const StyledCard = styled(Card)`
+  max-width: 345px;
+`;
 
 export default function ImgMediaCard() {
-  const classes = useStyles();
-
   return (
-    <Card className={classes.card}>
+    <StyledCard>
       <CardActionArea>
         <CardMedia
           component="img"
@@ -45,6 +41,6 @@ export default function ImgMediaCard() {
           Learn More
         </Button>
       </CardActions>
-    </Card>
+    </StyledCard>
   );
 }


### PR DESCRIPTION
Following the issue #16947 I started to replace material-ui/styles to use styled components
