### PR TITLE
[docs] Fix react-number-format example for FormattedInputs

### DIFF
--- a/docs/src/pages/components/text-fields/FormattedInputs.js
+++ b/docs/src/pages/components/text-fields/FormattedInputs.js
@@ -53,6 +53,7 @@ function NumberFormatCustom(props) {
         });
       }}
       thousandSeparator
+      isNumericString
       prefix="$"
     />
   );

--- a/docs/src/pages/components/text-fields/FormattedInputs.tsx
+++ b/docs/src/pages/components/text-fields/FormattedInputs.tsx
@@ -59,6 +59,7 @@ function NumberFormatCustom(props: NumberFormatCustomProps) {
         });
       }}
       thousandSeparator
+      isNumericString
       prefix="$"
     />
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fix: 
Fix the current example of react-number-format uses. When `values.value` is used from the values object, we should pass `isNumericString` prop to the `NumberFormat`. 
https://github.com/s-yadav/react-number-format#values-object

I will also update the doc of react-number-format to make this information more prominent.  
