### PR TITLE
[Portal] Remove redundant circular PortalProps import

### DIFF
--- a/packages/material-ui/src/Portal/Portal.d.ts
+++ b/packages/material-ui/src/Portal/Portal.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { PortalProps } from '../Portal';
 
 export interface PortalProps {
   /**


### PR DESCRIPTION
Looks like this import was left there by mistake and typescript 3.7+ throws on it because of name conflict.

```
node_modules/@material-ui/core/Portal/Portal.d.ts:2:10 - error TS2440: Import declaration conflicts with local declaration of 'PortalProps'.

2 import { PortalProps } from '../Portal';
```

see more: https://devblogs.microsoft.com/typescript/announcing-typescript-3-7-beta/
in section: "Local and Imported Type Declarations Now Conflict"

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
