### PR TITLE
[Button] Add missing class keys for icon sizing

### DIFF
--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -52,6 +52,9 @@ export type ButtonClassKey =
   | 'sizeLarge'
   | 'fullWidth'
   | 'startIcon'
-  | 'endIcon';
+  | 'endIcon'
+  | 'iconSizeSmall'
+  | 'iconSizeMedium'
+  | 'iconSizeLarge';
 
 export default Button;


### PR DESCRIPTION
The class key for button did not contain the new classes for icon sizes.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
