### PR TITLE
[docs] Migrate Palette demo to TypeScript  

### DIFF
--- a/docs/src/pages/customization/palette/Palette.tsx
+++ b/docs/src/pages/customization/palette/Palette.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { createMuiTheme } from '@material-ui/core/styles';
+import { ThemeProvider } from '@material-ui/styles';
+import { purple } from '@material-ui/core/colors';
+import Button from '@material-ui/core/Button';
+
+const theme = createMuiTheme({
+  palette: {
+    primary: { main: purple[500] }, // Purple and green play nicely together.
+    secondary: { main: '#11cb5f' }, // This is just green.A700 as hex.
+  },
+});
+
+export default function Palette() {
+  return (
+    <ThemeProvider theme={theme}>
+      <Button color="primary">Primary</Button>
+      <Button color="secondary">Secondary</Button>
+    </ThemeProvider>
+  );
+}

--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -150,6 +150,7 @@ Note that `contrastThreshold` follows a non-linear curve.
 ## Example
 
 {{"demo": "pages/customization/palette/Palette.js"}}
+{{"demo": "pages/customization/palette/Palette.tsx"}}
 
 ## Color tool
 

--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -150,7 +150,6 @@ Note that `contrastThreshold` follows a non-linear curve.
 ## Example
 
 {{"demo": "pages/customization/palette/Palette.js"}}
-{{"demo": "pages/customization/palette/Palette.tsx"}}
 
 ## Color tool
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This PR contains typescript version for the example [Palette.js](docs/src/pages/customization/palette/Palette.js)

## Test Passed
- yarn docs:typescript:formatted

![image](https://user-images.githubusercontent.com/30215516/66129716-181d1300-e60e-11e9-943f-a478130f53c5.png)
