### PR TITLE
[docs] Better strict mode switch

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -11,7 +11,7 @@ const workspaceRoot = path.join(__dirname, '../');
 /**
  * @type {'legacy' | 'sync' | 'concurrent'}
  */
-const reactMode = 'concurrent';
+const reactMode = 'legacy';
 
 module.exports = withTypescript({
   webpack: (config, options) => {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -8,6 +8,11 @@ const { LANGUAGES_SSR } = require('./src/modules/constants');
 
 const workspaceRoot = path.join(__dirname, '../');
 
+/**
+ * @type {'legacy' | 'sync' | 'concurrent'}
+ */
+const reactMode = 'concurrent';
+
 module.exports = withTypescript({
   webpack: (config, options) => {
     const plugins = config.plugins.concat([
@@ -15,6 +20,7 @@ module.exports = withTypescript({
         'process.env': {
           LIB_VERSION: JSON.stringify(pkg.version),
           ENABLE_AD: JSON.stringify(process.env.ENABLE_AD),
+          REACT_MODE: JSON.stringify(reactMode),
         },
       }),
     ]);
@@ -33,6 +39,10 @@ module.exports = withTypescript({
 
     config.resolve.alias['react-dom$'] = 'react-dom/profiling';
     config.resolve.alias['scheduler/tracing'] = 'scheduler/tracing-profiling';
+
+    if (reactMode !== 'legacy') {
+      config.resolve.alias['react-transition-group'] = '@material-ui/react-transition-group';
+    }
 
     // next includes node_modules in webpack externals. Some of those have dependencies
     // on the aliases defined above. If a module is an external those aliases won't be used.

--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,7 @@
     "@material-ui/icons": "^4.2.1",
     "@material-ui/lab": "^4.0.0-alpha.18",
     "@material-ui/pickers": "^3.2.5",
+    "@material-ui/react-transition-group": "^4.2.0",
     "@material-ui/styles": "^4.1.2",
     "@material-ui/system": "^4.3.0",
     "@material-ui/types": "^4.1.1",

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -200,8 +200,13 @@ async function registerServiceWorker() {
 
 // Add the strict mode back once the number of warnings is manageable.
 // We might miss important warnings by keeping the strict mode 🌊🌊🌊.
-const USE_STRICT_MODE = false;
-const ReactMode = USE_STRICT_MODE ? React.StrictMode : React.Fragment;
+const ReactMode =
+  {
+    // createSyncRoot compatible
+    sync: React.StrictMode,
+    // partial createRoot, ConcurrentMode is deprecated
+    concurrent: React.unstable_ConcurrentMode,
+  }[process.env.REACT_MODE] || React.Fragment;
 
 let dependenciesLoaded = false;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,6 +1767,16 @@
     rifm "^0.7.0"
     tslib "^1.9.3"
 
+"@material-ui/react-transition-group@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/react-transition-group/-/react-transition-group-4.2.0.tgz#afec833bbcc79f05a9b4d4828b3e07965cc7e321"
+  integrity sha512-4zapZ0gW1ZTws5aH9OGy3IMvtTV/olc7YrVSkM1WFu1FsrEhL+qarEniRjx7LjHt0gukFqoINfElI8v2boVMQA==
+  dependencies:
+    "@babel/runtime" "^7.4.5"
+    dom-helpers "^3.4.0"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
Adds a better strict mode switch (for devs only). With our fork of `react-transition-group` at least in our docs `/core` will be strict mode compatible. Should help weeding out the 3rd party libraries that are not strict mode compatible.

Pushed in concurrent mode to get a prod version to play around. Use `legacy` before merge.