### PR TITLE
[docs] Use scheduler where useful

### DIFF
--- a/docs/src/modules/constants.js
+++ b/docs/src/modules/constants.js
@@ -52,7 +52,10 @@ const LANGUAGES_LABEL = [
   },
 ];
 
+const ENABLE_SCHEDULER_API = true;
+
 module.exports = {
+  ENABLE_SCHEDULER_API,
   CODE_VARIANTS,
   ACTION_TYPES,
   LANGUAGES,


### PR DESCRIPTION
Scroll position in the page TOC is now updated with a low priority instead of a throttled 10 fps. For most users (we got 97% desktop usage or so) this should result in more fps. For low-end devices we give react more time to render the more important parts of the docs.

This is a continuation of #15306 with a few adjustments:
* don't rely on import resolvers (debounce and throttle do have a certain semantic guarentee that might be desired (see icon search))
* not tied to concurrent/sync mode (scheduler is not specifically tied to react anyway)

I would ship this as-is. If get reports about these issues we can just disable the flag.