### PR TITLE
[styles] Add ref prop to withTheme

### DIFF
--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -13,6 +13,7 @@ export function withThemeCreator<Theme = DefaultTheme>(
 export interface WithTheme<Theme = DefaultTheme> {
   theme: Theme;
   innerRef?: React.Ref<any>;
+  ref?: React.Ref<any>;
 }
 
 export default function withTheme<

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -6,15 +6,23 @@ export interface WithThemeCreatorOption<Theme = DefaultTheme> {
   defaultTheme?: Theme;
 }
 
-export function withThemeCreator<Theme = DefaultTheme>(
-  option?: WithThemeCreatorOption<Theme>,
-): PropInjector<WithTheme<Theme>, Partial<WithTheme<Theme>>>;
-
 export interface WithTheme<Theme = DefaultTheme> {
   theme: Theme;
+  /**
+   * Deprecated. Will be removed in v5. Refs are now automatically forwarded to
+   * the inner component.
+   * @deprecated since version 4.0
+   */
   innerRef?: React.Ref<any>;
+}
+
+export interface ThemedComponentProps extends Partial<WithTheme> {
   ref?: React.Ref<unknown>;
 }
+
+export function withThemeCreator<Theme = DefaultTheme>(
+  option?: WithThemeCreatorOption<Theme>,
+): PropInjector<WithTheme<Theme>, ThemedComponentProps>;
 
 export default function withTheme<
   Theme,
@@ -23,5 +31,6 @@ export default function withTheme<
   component: C,
 ): React.ComponentType<
   Omit<JSX.LibraryManagedAttributes<C, React.ComponentProps<C>>, keyof WithTheme<Theme>> &
-    Partial<WithTheme<Theme>>
+    Partial<WithTheme<Theme>> &
+    ThemedComponentProps
 >;

--- a/packages/material-ui-styles/src/withTheme/withTheme.d.ts
+++ b/packages/material-ui-styles/src/withTheme/withTheme.d.ts
@@ -13,7 +13,7 @@ export function withThemeCreator<Theme = DefaultTheme>(
 export interface WithTheme<Theme = DefaultTheme> {
   theme: Theme;
   innerRef?: React.Ref<any>;
-  ref?: React.Ref<any>;
+  ref?: React.Ref<unknown>;
 }
 
 export default function withTheme<

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -72,7 +72,8 @@ const ComponentWithTheme = withTheme<Theme, React.FunctionComponent<WithTheme<Th
   ({ theme }: WithTheme<Theme>) => <div>{theme.spacing(1)}</div>,
 );
 
-<ComponentWithTheme />;
+const componentWithThemeRef = React.createRef<HTMLDivElement>();
+<ComponentWithTheme ref={componentWithThemeRef} />;
 
 // withStyles + withTheme
 type AllTheProps = WithTheme<Theme> & WithStyles<typeof styles>;

--- a/packages/material-ui/src/styles/withTheme.d.ts
+++ b/packages/material-ui/src/styles/withTheme.d.ts
@@ -6,7 +6,13 @@ export interface WithTheme {
 }
 
 export interface ThemedComponentProps extends Partial<WithTheme> {
+  /**
+   * Deprecated. Will be removed in v5. Refs are now automatically forwarded to
+   * the inner component.
+   * @deprecated since version 4.0
+   */
   innerRef?: React.Ref<any>;
+  ref?: React.Ref<unknown>;
 }
 
 declare const withTheme: PropInjector<WithTheme, ThemedComponentProps>;

--- a/packages/material-ui/test/typescript/styles.spec.tsx
+++ b/packages/material-ui/test/typescript/styles.spec.tsx
@@ -171,7 +171,8 @@ function OverridesTheme() {
 // withTheme
 const ComponentWithTheme = withTheme(({ theme }: WithTheme) => <div>{theme.spacing(1)}</div>);
 
-<ComponentWithTheme />;
+const componentWithThemeRef = React.createRef<HTMLDivElement>();
+<ComponentWithTheme ref={componentWithThemeRef} />;
 
 // withStyles + withTheme
 type AllTheProps = WithTheme & WithStyles<typeof styles>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

`withTheme` now forwards refs, but the typing for the `ref` prop is missing in the declaration file.