### PR TITLE
[docs] Fixed typo in Components/Modal

### DIFF
--- a/docs/src/pages/components/modal/TransitionsModal.js
+++ b/docs/src/pages/components/modal/TransitionsModal.js
@@ -50,7 +50,7 @@ export default function TransitionsModal() {
         <Fade in={open}>
           <div className={classes.paper}>
             <h2 id="transition-modal-title">Transition modal</h2>
-            <p id="transition-modal-description">react-transiton-group animates me.</p>
+            <p id="transition-modal-description">react-transition-group animates me.</p>
           </div>
         </Fade>
       </Modal>

--- a/docs/src/pages/components/modal/TransitionsModal.tsx
+++ b/docs/src/pages/components/modal/TransitionsModal.tsx
@@ -52,7 +52,7 @@ export default function TransitionsModal() {
         <Fade in={open}>
           <div className={classes.paper}>
             <h2 id="transition-modal-title">Transition modal</h2>
-            <p id="transition-modal-description">react-transiton-group animates me.</p>
+            <p id="transition-modal-description">react-transition-group animates me.</p>
           </div>
         </Fade>
       </Modal>


### PR DESCRIPTION
- react-transitin-group is supposed to be react-transition-group

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Resolves #17703 