### PR TITLE
[Select] Fix opening select requiring double enter with NVDA

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -141,11 +141,10 @@ describe('<Dialog />', () => {
   });
 
   describe('backdrop', () => {
-    it('has the document role', () => {
-      // FixMe: should have none. Revisit in React Flare
+    it('does have `role` `none presentation`', () => {
       render(<Dialog open>foo</Dialog>);
 
-      expect(findBackdrop(document.body)).to.have.attribute('role', 'document');
+      expect(findBackdrop(document.body)).to.have.attribute('role', 'none presentation');
     });
 
     it('calls onBackdropClick and onClose when clicked', () => {

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -207,10 +207,6 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
 
   const inlineStyle = styles(theme || { zIndex });
   const childProps = {};
-  // FixMe: Always apply document role. Revisit once React Flare is released
-  if (children.role === undefined) {
-    childProps.role = children.role || 'document';
-  }
   if (children.tabIndex === undefined) {
     childProps.tabIndex = children.tabIndex || '-1';
   }

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -3,7 +3,7 @@ import { assert, expect } from 'chai';
 import { useFakeTimers, spy } from 'sinon';
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createClientRender, within } from 'test/utils/createClientRender';
 import { createMuiTheme } from '@material-ui/core/styles';
 import { createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import { ThemeProvider } from '@material-ui/styles';
@@ -232,11 +232,7 @@ describe('<Modal />', () => {
         throw new Error('missing container');
       }
 
-      assert.strictEqual(
-        container2.getAttribute('role'),
-        'document',
-        'should add the document role',
-      );
+      assert.strictEqual(container2.getAttribute('role'), null, 'should not add any role');
       assert.strictEqual(container2.getAttribute('tabindex'), '-1');
     });
   });
@@ -566,7 +562,9 @@ describe('<Modal />', () => {
         function WithRemovableElement({ hideButton = false }) {
           return (
             <Modal open>
-              <div>{!hideButton && <button type="button">I am going to disappear</button>}</div>
+              <div role="dialog">
+                {!hideButton && <button type="button">I am going to disappear</button>}
+              </div>
             </Modal>
           );
         }
@@ -579,15 +577,15 @@ describe('<Modal />', () => {
         };
 
         const { getByRole, setProps } = render(<WithRemovableElement />);
-        expect(getByRole('document')).to.be.focused;
+        expect(getByRole('dialog')).to.be.focused;
 
         getByRole('button').focus();
         expect(getByRole('button')).to.be.focused;
 
         setProps({ hideButton: true });
-        expect(getByRole('document')).to.not.be.focused;
+        expect(getByRole('dialog')).to.not.be.focused;
         clock.tick(500); // wait for the interval check to kick in.
-        expect(getByRole('document')).to.be.focused;
+        expect(getByRole('dialog')).to.be.focused;
       });
     });
   });
@@ -821,12 +819,14 @@ describe('<Modal />', () => {
 
   describe('prop: disablePortal', () => {
     it('should render the content into the parent', () => {
-      const { container } = render(
-        <Modal open disablePortal>
-          <div />
-        </Modal>,
+      const { getByTestId } = render(
+        <div data-testid="parent">
+          <Modal open disablePortal>
+            <div data-testid="child" />
+          </Modal>
+        </div>,
       );
-      expect(container.querySelector('[role="document"]')).to.be.ok;
+      expect(within(getByTestId('parent')).getByTestId('child')).to.be.ok;
     });
   });
 });


### PR DESCRIPTION
Closes #11833

Only observable using nvda (using 2019.2.1). You had to enter twice to be able to have full keyboard access to the listbox. 

Affected pages:
* https://deploy-preview-17773--material-ui.netlify.com/components/selects/#selects

`role="document"` was probably only used to silence the lint warning (handlers need a role).

To be tested:
* > can't remove document role since this is the node being focused. Once we get better focus managment primitives we can revamp the a11y of the dialog

  -- https://github.com/mui-org/material-ui/pull/16780
  Edit: It doesn't help the current state anyway. This change is fine. The dialog a11y story can be improved separately.