### PR TITLE
[docs] Mentioned CSS required for disabling transitions

### DIFF
--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -66,7 +66,7 @@ const theme = createMuiTheme({
 
 ## How can I disable transitions globally?
 
-You can disable transitions globally by providing the following in your theme:
+If you are using `CssBaseline`, You can disable transitions globally by providing the following in your theme:
 
 ```js
 import { createMuiTheme } from '@material-ui/core';
@@ -79,8 +79,8 @@ const theme = createMuiTheme({
 });
 ```
 
-Sometimes you will want to enable this behavior conditionally, for instance during testing or on low-end devices,
-in these cases, you can dynamically change the theme value.
+Sometimes you will want to enable this behavior conditionally, for instance during testing or on low-end devices.
+With this method, you can dynamically change the theme value for these cases.
 
 You can go one step further by disabling all the transitions, animations and the ripple effect:
 
@@ -113,6 +113,16 @@ const theme = createMuiTheme({
   },
 });
 ```
+
+If you choose not to use `CssBaseline`, you can still disable transitions and animations by including these CSS rules:
+
+```css
+*, *::before, *::after {
+  transition: 'none !important';
+  animation: 'none !important';
+}
+```
+
 
 ## Do I have to use JSS to style my app?
 

--- a/docs/src/pages/getting-started/faq/faq.md
+++ b/docs/src/pages/getting-started/faq/faq.md
@@ -66,7 +66,8 @@ const theme = createMuiTheme({
 
 ## How can I disable transitions globally?
 
-If you are using `CssBaseline`, You can disable transitions globally by providing the following in your theme:
+Material-UI uses the same theme helper for creating all its transitions.
+So you can disable all the transitions by overriding the helper in your theme:
 
 ```js
 import { createMuiTheme } from '@material-ui/core';
@@ -79,19 +80,14 @@ const theme = createMuiTheme({
 });
 ```
 
-Sometimes you will want to enable this behavior conditionally, for instance during testing or on low-end devices.
-With this method, you can dynamically change the theme value for these cases.
+It can be useful to disable transitions during visual testing or to improve performance on low-end devices.
 
-You can go one step further by disabling all the transitions, animations and the ripple effect:
+You can go one step further by disabling all the transitions and animations effect:
 
 ```js
 import { createMuiTheme } from '@material-ui/core';
 
 const theme = createMuiTheme({
-  transitions: {
-    // So we have `transition: none;` everywhere
-    create: () => 'none',
-  },
   overrides: {
     // Name of the component ⚛️
     MuiCssBaseline: {
@@ -104,17 +100,11 @@ const theme = createMuiTheme({
       },
     },
   },
-  props: {
-    // Name of the component ⚛️
-    MuiButtonBase: {
-      // The properties to apply
-      disableRipple: true, // No more ripple, on the whole application!
-    },
-  },
 });
 ```
 
-If you choose not to use `CssBaseline`, you can still disable transitions and animations by including these CSS rules:
+Notice that the usage of `CssBaseline` is required for the above approach to work.
+If you choose not to use it, you can still disable transitions and animations by including these CSS rules:
 
 ```css
 *, *::before, *::after {
@@ -122,7 +112,6 @@ If you choose not to use `CssBaseline`, you can still disable transitions and an
   animation: 'none !important';
 }
 ```
-
 
 ## Do I have to use JSS to style my app?
 


### PR DESCRIPTION
Hopefully, this change will clarify the options available with/without using `CssBaseline`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #16483