### PR TITLE
[docs] Prepare the DatePicker developer survey notification

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -9,6 +9,11 @@
     "userLanguage": "zh"
   },
   {
+    "id": 43,
+    "text": "We plan to significantly improve the date picker. <a style=\"color: inherit;\" target=\"_blank\" rel=\"noopener\" href=\"https://www.surveymonkey.com/r/5XHDL76\">Share your thoughts in our survey!</a>",
+    "route": "/components/pickers"
+  },
+  {
     "id": 44,
     "text": "<a style=\"color: inherit;\" target=\"_blank\" rel=\"noopener\" href=\"https://twitter.com/MaterialUI/status/1179314080139612160\">Material-UI v4.5.0 is out 🎉</a>"
   }

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -4,6 +4,7 @@ import 'isomorphic-fetch';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import Button from '@material-ui/core/Button';
+import { useRouter } from 'next/router';
 import Snackbar from '@material-ui/core/Snackbar';
 import sleep from 'modules/waterfall/sleep';
 import { getCookie } from 'docs/src/modules/utils/helpers';
@@ -32,9 +33,9 @@ async function getMessages() {
 }
 
 export default function Notifications() {
-  const mounted = React.useRef(false);
   const [open, setOpen] = React.useState(false);
   const [message, setMessage] = React.useState({});
+  const { route } = useRouter();
   const t = useSelector(state => state.options.t);
   const userLanguage = useSelector(state => state.options.userLanguage);
 
@@ -53,10 +54,14 @@ export default function Notifications() {
         return false;
       }
 
+      if (message2.route && message2.route !== route) {
+        return false;
+      }
+
       return true;
     });
 
-    if (unseenMessages.length > 0 && mounted.current) {
+    if (unseenMessages.length > 0) {
       setMessage(unseenMessages[0]);
       setOpen(true);
     }
@@ -68,7 +73,7 @@ export default function Notifications() {
   };
 
   React.useEffect(() => {
-    mounted.current = true;
+    let active = true;
 
     // Prevent search engines from indexing the notification.
     if (/glebot/.test(navigator.userAgent)) {
@@ -77,13 +82,15 @@ export default function Notifications() {
 
     (async () => {
       await getMessages();
-      handleMessage();
+      if (active) {
+        handleMessage();
+      }
     })();
 
     return () => {
-      mounted.current = false;
+      active = false;
     };
-  }, []);
+  }, [route]);
 
   return (
     <Snackbar


### PR DESCRIPTION
I wasn't exactly sure how to approach the problem. I have gone with a tradeoff based on the assumption that: context > volume. My hope is that displaying the notification in the right context, increases the conversion rate, even if it means fewer displays.

cc @dmtrKovalenko

This effort might take us between 100 and 500 hours.