### PR TITLE
[Button] Add loading prop support

### DIFF
--- a/docs/pages/api/button.md
+++ b/docs/pages/api/button.md
@@ -34,6 +34,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">endIcon</span> | <span class="prop-type">node</span> |  | Element placed after the children. |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will take up the full width of its container. |
 | <span class="prop-name">href</span> | <span class="prop-type">string</span> |  | The URL to link to when the button is clicked. If defined, an `a` element will be used as the root node. |
+| <span class="prop-name">loading</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button is in a loading state, interactions are disabled. |
 | <span class="prop-name">size</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'</span> | <span class="prop-default">'medium'</span> | The size of the button. `small` is equivalent to the dense button styling. |
 | <span class="prop-name">startIcon</span> | <span class="prop-type">node</span> |  | Element placed before the children. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'text'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'contained'</span> | <span class="prop-default">'text'</span> | The variant to use. |
@@ -62,6 +63,7 @@ Any other props supplied will be provided to the root element ([ButtonBase](/api
 | <span class="prop-name">containedSecondary</span> | <span class="prop-name">MuiButton-containedSecondary</span> | Styles applied to the root element if `variant="contained"` and `color="secondary"`.
 | <span class="prop-name">focusVisible</span> | <span class="prop-name">Mui-focusVisible</span> | Pseudo-class applied to the ButtonBase root element if the button is keyboard focused.
 | <span class="prop-name">disabled</span> | <span class="prop-name">Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
+| <span class="prop-name">loading</span> | <span class="prop-name">MuiButton-loading</span> | Styles applied to the root element if `loading={true}`.
 | <span class="prop-name">colorInherit</span> | <span class="prop-name">MuiButton-colorInherit</span> | Styles applied to the root element if `color="inherit"`.
 | <span class="prop-name">textSizeSmall</span> | <span class="prop-name">MuiButton-textSizeSmall</span> | Styles applied to the root element if `size="small"` and `variant="text"`.
 | <span class="prop-name">textSizeLarge</span> | <span class="prop-name">MuiButton-textSizeLarge</span> | Styles applied to the root element if `size="large"` and `variant="text"`.

--- a/docs/src/pages/components/buttons/LoadingButtons.js
+++ b/docs/src/pages/components/buttons/LoadingButtons.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    '& button': {
+      margin: theme.spacing(1),
+    },
+  },
+}));
+
+export default function LoadingButtons() {
+  const classes = useStyles();
+  const [loading, setLoading] = React.useState(false);
+
+  return (
+    <div className={classes.root}>
+      <Button variant="outlined" loading>
+        Loading…
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        loading
+        startIcon={<CircularProgress color="inherit" size={16} />}
+      >
+        Duplicate
+      </Button>
+      <Button
+        variant="contained"
+        color="secondary"
+        loading={loading}
+        onClick={() => {
+          setLoading(true);
+        }}
+        startIcon={loading ? <CircularProgress color="inherit" size={16} /> : null}
+      >
+        Save
+      </Button>
+    </div>
+  );
+}

--- a/docs/src/pages/components/buttons/LoadingButtons.tsx
+++ b/docs/src/pages/components/buttons/LoadingButtons.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+import Button from '@material-ui/core/Button';
+import CircularProgress from '@material-ui/core/CircularProgress';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      '& button': {
+        margin: theme.spacing(1),
+      },
+    },
+  }),
+);
+
+export default function LoadingButtons() {
+  const classes = useStyles();
+  const [loading, setLoading] = React.useState(false);
+
+  return (
+    <div className={classes.root}>
+      <Button variant="outlined" loading>
+        Loading…
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        loading
+        startIcon={<CircularProgress color="inherit" size={16} />}
+      >
+        Duplicate
+      </Button>
+      <Button
+        variant="contained"
+        color="secondary"
+        loading={loading}
+        onClick={() => {
+          setLoading(true);
+        }}
+        startIcon={loading ? <CircularProgress color="inherit" size={16} /> : null}
+      >
+        Save
+      </Button>
+    </div>
+  );
+}

--- a/docs/src/pages/components/buttons/buttons.md
+++ b/docs/src/pages/components/buttons/buttons.md
@@ -116,6 +116,10 @@ Here are some examples of customizing the component. You can learn more about th
 
 👑 If you are looking for inspiration, you can check [MUI Treasury's customization examples](https://mui-treasury.com/components/button).
 
+## Loading buttons
+
+{{"demo": "pages/components/buttons/LoadingButtons.js"}}
+
 ## Complex Buttons
 
 The Text Buttons, Contained Buttons, Floating Action Buttons and Icon Buttons are built on top of the same component: the `ButtonBase`.

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -12,6 +12,7 @@ export type ButtonTypeMap<
     endIcon?: React.ReactNode;
     fullWidth?: boolean;
     href?: string;
+    loading?: boolean;
     size?: 'small' | 'medium' | 'large';
     startIcon?: React.ReactNode;
     variant?: 'text' | 'outlined' | 'contained';

--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -162,6 +162,12 @@ export const styles = theme => ({
   focusVisible: {},
   /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
+  /* Styles applied to the root element if `loading={true}`. */
+  loading: {
+    pointerEvents: 'none', // Disable link interactions
+    cursor: 'default',
+    opacity: 0.4,
+  },
   /* Styles applied to the root element if `color="inherit"`. */
   colorInherit: {
     color: 'inherit',
@@ -249,6 +255,7 @@ const Button = React.forwardRef(function Button(props, ref) {
     endIcon: endIconProp,
     focusVisibleClassName,
     fullWidth = false,
+    loading = false,
     size = 'medium',
     startIcon: startIconProp,
     type = 'button',
@@ -277,6 +284,7 @@ const Button = React.forwardRef(function Button(props, ref) {
           [classes[`${variant}Size${capitalize(size)}`]]: size !== 'medium',
           [classes[`size${capitalize(size)}`]]: size !== 'medium',
           [classes.disabled]: disabled,
+          [classes.loading]: loading,
           [classes.fullWidth]: fullWidth,
           [classes.colorInherit]: color === 'inherit',
         },
@@ -284,6 +292,7 @@ const Button = React.forwardRef(function Button(props, ref) {
       )}
       component={component}
       disabled={disabled}
+      loading={loading}
       focusRipple={!disableFocusRipple}
       focusVisibleClassName={clsx(classes.focusVisible, focusVisibleClassName)}
       ref={ref}
@@ -355,6 +364,10 @@ Button.propTypes = {
    * If defined, an `a` element will be used as the root node.
    */
   href: PropTypes.string,
+  /**
+   * If `true`, the button is in a loading state, interactions are disabled.
+   */
+  loading: PropTypes.bool,
   /**
    * The size of the button.
    * `small` is equivalent to the dense button styling.

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -62,11 +62,12 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     classes,
     className,
     component = 'button',
-    disabled = false,
+    disabled: disabledProp = false,
     disableRipple = false,
     disableTouchRipple = false,
     focusRipple = false,
     focusVisibleClassName,
+    loading,
     onBlur,
     onClick,
     onFocus,
@@ -92,6 +93,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     return ReactDOM.findDOMNode(buttonRef.current);
   }
 
+  const disabled = disabledProp || loading;
   const rippleRef = React.useRef(null);
 
   const [focusVisible, setFocusVisible] = React.useState(false);
@@ -260,7 +262,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
       className={clsx(
         classes.root,
         {
-          [classes.disabled]: disabled,
+          [classes.disabled]: disabledProp,
           [classes.focusVisible]: focusVisible,
           [focusVisibleClassName]: focusVisible,
         },
@@ -357,6 +359,11 @@ ButtonBase.propTypes = {
    * if needed.
    */
   focusVisibleClassName: PropTypes.string,
+  /**
+   * @ignore
+   * private
+   */
+  loading: PropTypes.bool,
   /**
    * @ignore
    */


### PR DESCRIPTION
![Capture d’écran 2019-10-09 à 19 10 55](https://user-images.githubusercontent.com/3165635/66503987-8a876a80-eac8-11e9-8330-faca5eff70b5.png)

```jsx
      <Button variant="outlined" loading>
        Loading…
      </Button>
      <Button
        variant="contained"
        color="primary"
        loading
        startIcon={<CircularProgress color="inherit" size={16} />}
      >
        Duplicate
      </Button>
```

## Benchmark

The implementation was benchmarked with the following sources. I have noticed that the loading and disabled states are often styled independently.

![Capture d’écran 2019-10-09 à 17 59 21](https://user-images.githubusercontent.com/3165635/66504021-9e32d100-eac8-11e9-91d6-c3303cfafe6f.png)
evergreen

![Capture d’écran 2019-10-09 à 17 59 38](https://user-images.githubusercontent.com/3165635/66504022-9e32d100-eac8-11e9-834c-9f473f601e48.png)
blueprint

![Capture d’écran 2019-10-09 à 18 00 04](https://user-images.githubusercontent.com/3165635/66504023-9ecb6780-eac8-11e9-9143-1f6dc4fc8652.png)
vuetify

![Capture d’écran 2019-10-09 à 18 00 11](https://user-images.githubusercontent.com/3165635/66504024-9ecb6780-eac8-11e9-8bae-e9a0b5e73b41.png)
cosmos

![Capture d’écran 2019-10-09 à 18 00 24](https://user-images.githubusercontent.com/3165635/66504025-9ecb6780-eac8-11e9-8f9c-3bfb02e54830.png)
antd

![Capture d’écran 2019-10-09 à 18 00 29](https://user-images.githubusercontent.com/3165635/66504026-9f63fe00-eac8-11e9-8504-82e57b137a94.png)
element

![Capture d’écran 2019-10-09 à 18 00 41](https://user-images.githubusercontent.com/3165635/66504027-9f63fe00-eac8-11e9-9249-d6db6c3aa145.png)
sancho

![Capture d’écran 2019-10-09 à 18 00 49](https://user-images.githubusercontent.com/3165635/66504030-9f63fe00-eac8-11e9-98e4-2f4f99396dd0.png)
semantic ui

![Capture d’écran 2019-10-09 à 18 00 59](https://user-images.githubusercontent.com/3165635/66504033-9f63fe00-eac8-11e9-8ca5-9d061b75f295.png)
quasar

![Capture d’écran 2019-10-09 à 18 01 08](https://user-images.githubusercontent.com/3165635/66504034-9ffc9480-eac8-11e9-88a4-78f5841d63ab.png)
baseui

![Capture d’écran 2019-10-09 à 18 01 18](https://user-images.githubusercontent.com/3165635/66504035-9ffc9480-eac8-11e9-9ca2-b2e95262bb74.png)
atlaskit

![Capture d’écran 2019-10-09 à 18 01 29](https://user-images.githubusercontent.com/3165635/66504036-9ffc9480-eac8-11e9-9652-4d4b69e3a64c.png)
chakra

![Capture d’écran 2019-10-09 à 18 01 42](https://user-images.githubusercontent.com/3165635/66504040-9ffc9480-eac8-11e9-8d70-5ff95a200364.png)
orbit
