### PR TITLE
fix: component prop definition on TypeScript

### DIFF
--- a/packages/material-ui-lab/src/Skeleton/Skeleton.d.ts
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.d.ts
@@ -8,7 +8,7 @@ export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'hr'> {
     variant?: 'text' | 'rect' | 'circle';
     width?: number | string;
   };
-  defaultComponent: 'div';
+  component: 'div';
   classKey: SkeletonClassKey;
 }
 
@@ -17,7 +17,7 @@ declare const Skeleton: OverridableComponent<SkeletonTypeMap>;
 export type SkeletonClassKey = 'root' | 'text' | 'rect' | 'circle' | 'animate';
 
 export type SkeletonProps<
-  D extends React.ElementType = SkeletonTypeMap['defaultComponent'],
+  D extends React.ElementType = SkeletonTypeMap['component'],
   P = {}
 > = OverrideProps<SkeletonTypeMap<P, D>, D>;
 

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -14,14 +14,14 @@ export type ToggleButtonTypeMap<
     selected?: boolean;
     value?: any;
   };
-  defaultComponent: D;
+  component: D;
   classKey: ToggleButtonClassKey;
 }>;
 
 declare const ToggleButton: ExtendButtonBase<ToggleButtonTypeMap>;
 
 export type ToggleButtonProps<
-  D extends React.ElementType = ToggleButtonTypeMap['defaultComponent'],
+  D extends React.ElementType = ToggleButtonTypeMap['component'],
   P = {}
 > = OverrideProps<ToggleButtonTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -9,7 +9,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
     src?: string;
     srcSet?: string;
   };
-  defaultComponent: D;
+  component: D;
   classKey: AvatarClassKey;
 }
 
@@ -18,7 +18,7 @@ declare const Avatar: OverridableComponent<AvatarTypeMap>;
 export type AvatarClassKey = 'root' | 'colorDefault' | 'img';
 
 export type AvatarProps<
-  D extends React.ElementType = AvatarTypeMap['defaultComponent'],
+  D extends React.ElementType = AvatarTypeMap['component'],
   P = {}
 > = OverrideProps<AvatarTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.d.ts
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.d.ts
@@ -15,18 +15,18 @@ export type BottomNavigationActionTypeMap<
     showLabel?: boolean;
     value?: any;
   };
-  defaultComponent: D;
+  component: D;
   classKey: BottomNavigationActionClassKey;
 }>;
 
 declare const BottomNavigationAction: ExtendButtonBase<
-  BottomNavigationActionTypeMap<{}, ButtonBaseTypeMap['defaultComponent']>
+  BottomNavigationActionTypeMap<{}, ButtonBaseTypeMap['component']>
 >;
 
 export type BottomNavigationActionClassKey = 'root' | 'selected' | 'iconOnly' | 'wrapper' | 'label';
 
 export type BottomNavigationActionProps<
-  D extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
+  D extends React.ElementType = ButtonBaseTypeMap['component'],
   P = {}
 > = OverrideProps<BottomNavigationActionTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.d.ts
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.d.ts
@@ -8,7 +8,7 @@ export interface BreadcrumbsTypeMap<P = {}, D extends React.ElementType = 'nav'>
     maxItems?: number;
     separator?: React.ReactNode;
   };
-  defaultComponent: D;
+  component: D;
   classKey: BreadcrumbsClassKey;
 }
 
@@ -17,7 +17,7 @@ declare const Breadcrumbs: OverridableComponent<BreadcrumbsTypeMap>;
 export type BreadcrumbsClassKey = 'root' | 'ol' | 'li' | 'separator';
 
 export type BreadcrumbsProps<
-  D extends React.ElementType = BreadcrumbsTypeMap['defaultComponent'],
+  D extends React.ElementType = BreadcrumbsTypeMap['component'],
   P = {}
 > = OverrideProps<BreadcrumbsTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Button/Button.d.ts
+++ b/packages/material-ui/src/Button/Button.d.ts
@@ -16,14 +16,14 @@ export type ButtonTypeMap<
     startIcon?: React.ReactNode;
     variant?: 'text' | 'outlined' | 'contained';
   };
-  defaultComponent: D;
+  component: D;
   classKey: ButtonClassKey;
 }>;
 
 declare const Button: ExtendButtonBase<ButtonTypeMap>;
 
 export type ButtonProps<
-  D extends React.ElementType = ButtonTypeMap['defaultComponent'],
+  D extends React.ElementType = ButtonTypeMap['component'],
   P = {}
 > = OverrideProps<ButtonTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.d.ts
@@ -18,7 +18,7 @@ export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button
     onFocusVisible?: React.FocusEventHandler<any>;
     TouchRippleProps?: Partial<TouchRippleProps>;
   };
-  defaultComponent: D;
+  component: D;
   classKey: ButtonBaseClassKey;
 }
 
@@ -29,7 +29,7 @@ export interface ButtonBaseTypeMap<P = {}, D extends React.ElementType = 'button
  */
 export interface ExtendButtonBaseTypeMap<M extends OverridableTypeMap> {
   props: ButtonBaseTypeMap['props'] & M['props'];
-  defaultComponent: M['defaultComponent'];
+  component: M['component'];
   classKey: M['classKey'];
 }
 
@@ -41,7 +41,7 @@ export type ExtendButtonBase<M extends OverridableTypeMap> = ((
 declare const ButtonBase: ExtendButtonBase<ButtonBaseTypeMap>;
 
 export type ButtonBaseProps<
-  D extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
+  D extends React.ElementType = ButtonBaseTypeMap['component'],
   P = {}
 > = OverrideProps<ButtonBaseTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.d.ts
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.d.ts
@@ -12,7 +12,7 @@ export interface ButtonGroupTypeMap<P = {}, D extends React.ElementType = 'div'>
     size?: 'small' | 'medium' | 'large';
     variant?: 'text' | 'outlined' | 'contained';
   };
-  defaultComponent: D;
+  component: D;
   classKey: ButtonGroupClassKey;
 }
 
@@ -34,7 +34,7 @@ export type ButtonGroupClassKey =
   | 'groupedContainedSecondary';
 
 export type ButtonGroupProps<
-  D extends React.ElementType = ButtonGroupTypeMap['defaultComponent'],
+  D extends React.ElementType = ButtonGroupTypeMap['component'],
   P = {}
 > = OverrideProps<ButtonGroupTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/CardActionArea/CardActionArea.d.ts
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.d.ts
@@ -5,18 +5,18 @@ export type CardActionAreaTypeMap<P, D extends React.ElementType> = ExtendButton
   props: P & {
     focusVisibleClassName?: string;
   };
-  defaultComponent: D;
+  component: D;
   classKey: CardActionAreaClassKey;
 }>;
 
 declare const CardActionArea: ExtendButtonBase<
-  CardActionAreaTypeMap<{}, ButtonBaseTypeMap['defaultComponent']>
+  CardActionAreaTypeMap<{}, ButtonBaseTypeMap['component']>
 >;
 
 export type CardActionAreaClassKey = 'root' | 'focusVisible' | 'focusHighlight';
 
 export type CardActionAreaProps<
-  D extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
+  D extends React.ElementType = ButtonBaseTypeMap['component'],
   P = {}
 > = OverrideProps<CardActionAreaTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/CardMedia/CardMedia.d.ts
+++ b/packages/material-ui/src/CardMedia/CardMedia.d.ts
@@ -6,7 +6,7 @@ export interface CardMediaTypeMap<P, D extends React.ElementType> {
     image?: string;
     src?: string;
   };
-  defaultComponent: D;
+  component: D;
   classKey: CardMediaClassKey;
 }
 

--- a/packages/material-ui/src/Chip/Chip.d.ts
+++ b/packages/material-ui/src/Chip/Chip.d.ts
@@ -15,7 +15,7 @@ export interface ChipTypeMap<P = {}, D extends React.ElementType = 'div'> {
     size?: 'small' | 'medium';
     variant?: 'default' | 'outlined';
   };
-  defaultComponent: D;
+  component: D;
   classKey: ChipClassKey;
 }
 
@@ -54,7 +54,7 @@ export type ChipClassKey =
   | 'deleteIconOutlinedColorSecondary';
 
 export type ChipProps<
-  D extends React.ElementType = ChipTypeMap['defaultComponent'],
+  D extends React.ElementType = ChipTypeMap['component'],
   P = {}
 > = OverrideProps<ChipTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Divider/Divider.d.ts
+++ b/packages/material-ui/src/Divider/Divider.d.ts
@@ -7,7 +7,7 @@ export interface DividerTypeMap<P = {}, D extends React.ElementType = 'hr'> {
     orientation?: 'horizontal' | 'vertical';
     variant?: 'fullWidth' | 'inset' | 'middle';
   };
-  defaultComponent: D;
+  component: D;
   classKey: DividerClassKey;
 }
 
@@ -16,7 +16,7 @@ declare const Divider: OverridableComponent<DividerTypeMap>;
 export type DividerClassKey = 'root' | 'absolute' | 'inset' | 'light' | 'middle' | 'vertical';
 
 export type DividerProps<
-  D extends React.ElementType = DividerTypeMap['defaultComponent'],
+  D extends React.ElementType = DividerTypeMap['component'],
   P = {}
 > = OverrideProps<DividerTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.d.ts
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.d.ts
@@ -14,7 +14,7 @@ export type ExpansionPanelSummaryTypeMap<
     IconButtonProps?: Partial<IconButtonProps>;
     onChange?: React.ReactEventHandler<{}>;
   };
-  defaultComponent: D;
+  component: D;
   classKey: ExpansionPanelSummaryClassKey;
 }>;
 
@@ -29,7 +29,7 @@ export type ExpansionPanelSummaryClassKey =
   | 'expandIcon';
 
 export type ExpansionPanelSummaryProps<
-  D extends React.ElementType = ExpansionPanelSummaryTypeMap['defaultComponent'],
+  D extends React.ElementType = ExpansionPanelSummaryTypeMap['component'],
   P = {}
 > = OverrideProps<ExpansionPanelSummaryTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Fab/Fab.d.ts
+++ b/packages/material-ui/src/Fab/Fab.d.ts
@@ -10,16 +10,16 @@ export type FabTypeMap<P = {}, D extends React.ElementType = 'button'> = ExtendB
     size?: 'small' | 'medium' | 'large';
     variant?: 'round' | 'extended';
   };
-  defaultComponent: D;
+  component: D;
   classKey: FabClassKey;
 }>;
 
 declare const Fab: ExtendButtonBase<FabTypeMap>;
 
-export type FabProps<
-  D extends React.ElementType = FabTypeMap['defaultComponent'],
-  P = {}
-> = OverrideProps<FabTypeMap<P, D>, D>;
+export type FabProps<D extends React.ElementType = FabTypeMap['component'], P = {}> = OverrideProps<
+  FabTypeMap<P, D>,
+  D
+>;
 
 export type FabClassKey =
   | 'root'

--- a/packages/material-ui/src/FormControl/FormControl.d.ts
+++ b/packages/material-ui/src/FormControl/FormControl.d.ts
@@ -12,7 +12,7 @@ export interface FormControlTypeMap<P = {}, D extends React.ElementType = 'div'>
     required?: boolean;
     variant?: 'standard' | 'outlined' | 'filled';
   };
-  defaultComponent: D;
+  component: D;
   classKey: FormControlClassKey;
 }
 
@@ -21,7 +21,7 @@ declare const FormControl: OverridableComponent<FormControlTypeMap>;
 export type FormControlClassKey = 'root' | 'marginNormal' | 'marginDense' | 'fullWidth';
 
 export type FormControlProps<
-  D extends React.ElementType = FormControlTypeMap['defaultComponent'],
+  D extends React.ElementType = FormControlTypeMap['component'],
   P = {}
 > = OverrideProps<FormControlTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/FormLabel/FormLabel.d.ts
+++ b/packages/material-ui/src/FormLabel/FormLabel.d.ts
@@ -10,7 +10,7 @@ export interface FormLabelTypeMap<P = {}, D extends React.ElementType = 'label'>
       focused?: boolean;
       required?: boolean;
     };
-  defaultComponent: D;
+  component: D;
   classKey: FormLabelClassKey;
 }
 
@@ -28,7 +28,7 @@ export type FormLabelClassKey =
 export type FormLabelBaseProps = React.LabelHTMLAttributes<HTMLLabelElement>;
 
 export type FormLabelProps<
-  D extends React.ElementType = FormLabelTypeMap['defaultComponent'],
+  D extends React.ElementType = FormLabelTypeMap['component'],
   P = {}
 > = OverrideProps<FormLabelTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Grid/Grid.d.ts
+++ b/packages/material-ui/src/Grid/Grid.d.ts
@@ -88,14 +88,14 @@ export interface GridTypeMap<P = {}, D extends React.ElementType = 'div'> {
       wrap?: GridWrap;
       zeroMinWidth?: boolean;
     };
-  defaultComponent: D;
+  component: D;
   classKey: GridClassKey;
 }
 
 declare const Grid: OverridableComponent<GridTypeMap>;
 
 export type GridProps<
-  D extends React.ElementType = GridTypeMap['defaultComponent'],
+  D extends React.ElementType = GridTypeMap['component'],
   P = {}
 > = OverrideProps<GridTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/IconButton/IconButton.d.ts
+++ b/packages/material-ui/src/IconButton/IconButton.d.ts
@@ -12,7 +12,7 @@ export type IconButtonTypeMap<
     edge?: 'start' | 'end' | false;
     size?: 'small' | 'medium';
   };
-  defaultComponent: D;
+  component: D;
   classKey: IconButtonClassKey;
 }>;
 
@@ -30,7 +30,7 @@ export type IconButtonClassKey =
   | 'label';
 
 export type IconButtonProps<
-  D extends React.ElementType = IconButtonTypeMap['defaultComponent'],
+  D extends React.ElementType = IconButtonTypeMap['component'],
   P = {}
 > = OverrideProps<IconButtonTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Link/Link.d.ts
+++ b/packages/material-ui/src/Link/Link.d.ts
@@ -9,7 +9,7 @@ export interface LinkTypeMap<P = {}, D extends React.ElementType = 'a'> {
       TypographyClasses?: TypographyProps['classes'];
       underline?: 'none' | 'hover' | 'always';
     };
-  defaultComponent: D;
+  component: D;
   classKey: LinkClassKey;
 }
 
@@ -27,7 +27,7 @@ export type LinkBaseProps = React.AnchorHTMLAttributes<HTMLAnchorElement> &
   Omit<TypographyProps, 'component'>;
 
 export type LinkProps<
-  D extends React.ElementType = LinkTypeMap['defaultComponent'],
+  D extends React.ElementType = LinkTypeMap['component'],
   P = {}
 > = OverrideProps<LinkTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/List/List.d.ts
+++ b/packages/material-ui/src/List/List.d.ts
@@ -7,7 +7,7 @@ export interface ListTypeMap<P = {}, D extends React.ElementType = 'ul'> {
     disablePadding?: boolean;
     subheader?: React.ReactElement;
   };
-  defaultComponent: D;
+  component: D;
   classKey: ListClassKey;
 }
 
@@ -16,7 +16,7 @@ declare const List: OverridableComponent<ListTypeMap>;
 export type ListClassKey = 'root' | 'padding' | 'dense' | 'subheader';
 
 export type ListProps<
-  D extends React.ElementType = ListTypeMap['defaultComponent'],
+  D extends React.ElementType = ListTypeMap['component'],
   P = {}
 > = OverrideProps<ListTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/ListItem/ListItem.d.ts
+++ b/packages/material-ui/src/ListItem/ListItem.d.ts
@@ -16,7 +16,7 @@ export interface ListItemTypeMap<P, D extends React.ElementType> {
     focusVisibleClassName?: string;
     selected?: boolean;
   };
-  defaultComponent: D;
+  component: D;
   classKey: ListItemClassKey;
 }
 

--- a/packages/material-ui/src/MenuItem/MenuItem.d.ts
+++ b/packages/material-ui/src/MenuItem/MenuItem.d.ts
@@ -13,12 +13,12 @@ export type MenuItemTypeMap<P = {}, D extends React.ElementType = 'li'> = Omit<
 };
 
 declare const MenuItem: OverridableComponent<
-  MenuItemTypeMap<{ button: false }, MenuItemTypeMap['defaultComponent']>
+  MenuItemTypeMap<{ button: false }, MenuItemTypeMap['component']>
 > &
-  ExtendButtonBase<MenuItemTypeMap<{ button?: true }, MenuItemTypeMap['defaultComponent']>>;
+  ExtendButtonBase<MenuItemTypeMap<{ button?: true }, MenuItemTypeMap['component']>>;
 
 export type MenuItemProps<
-  D extends React.ElementType = MenuItemTypeMap['defaultComponent'],
+  D extends React.ElementType = MenuItemTypeMap['component'],
   P = {}
 > = OverrideProps<MenuItemTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -30,7 +30,7 @@ export type OverrideProps<
 // prettier-ignore
 export type DefaultComponentProps<M extends OverridableTypeMap> =
   & BaseProps<M>
-  & Omit<React.ComponentPropsWithRef<M['defaultComponent']>, keyof BaseProps<M>>;
+  & Omit<React.ComponentPropsWithRef<M['component']>, keyof BaseProps<M>>;
 
 /**
  * Props defined on the component (+ common material-ui props).
@@ -51,7 +51,7 @@ export interface CommonProps<M extends OverridableTypeMap>
 
 export interface OverridableTypeMap {
   props: {};
-  defaultComponent: React.ElementType;
+  component: React.ElementType;
   classKey: string;
 }
 

--- a/packages/material-ui/src/StepButton/StepButton.d.ts
+++ b/packages/material-ui/src/StepButton/StepButton.d.ts
@@ -16,18 +16,16 @@ export type StepButtonTypeMap<P, D extends React.ElementType> = ExtendButtonBase
     optional?: React.ReactNode;
     orientation?: Orientation;
   };
-  defaultComponent: D;
+  component: D;
   classKey: StepButtonClasskey;
 }>;
 
-declare const StepButton: ExtendButtonBase<
-  StepButtonTypeMap<{}, ButtonBaseTypeMap['defaultComponent']>
->;
+declare const StepButton: ExtendButtonBase<StepButtonTypeMap<{}, ButtonBaseTypeMap['component']>>;
 
 export type StepButtonClasskey = 'root' | 'vertical' | 'touchRipple';
 
 export type StepButtonProps<
-  D extends React.ElementType = ButtonBaseTypeMap['defaultComponent'],
+  D extends React.ElementType = ButtonBaseTypeMap['component'],
   P = {}
 > = OverrideProps<StepButtonTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Tab/Tab.d.ts
+++ b/packages/material-ui/src/Tab/Tab.d.ts
@@ -16,7 +16,7 @@ export type TabTypeMap<P = {}, D extends React.ElementType = 'div'> = ExtendButt
     value?: any;
     wrapped?: boolean;
   };
-  defaultComponent: D;
+  component: D;
   classKey: TabClassKey;
 }>;
 
@@ -34,9 +34,9 @@ export type TabClassKey =
   | 'wrapped'
   | 'wrapper';
 
-export type TabProps<
-  D extends React.ElementType = TabTypeMap['defaultComponent'],
-  P = {}
-> = OverrideProps<TabTypeMap<P, D>, D>;
+export type TabProps<D extends React.ElementType = TabTypeMap['component'], P = {}> = OverrideProps<
+  TabTypeMap<P, D>,
+  D
+>;
 
 export default Tab;

--- a/packages/material-ui/src/TablePagination/TablePagination.d.ts
+++ b/packages/material-ui/src/TablePagination/TablePagination.d.ts
@@ -29,7 +29,7 @@ export interface TablePaginationTypeMap<P, D extends React.ElementType> {
       rowsPerPageOptions?: number[];
       SelectProps?: Partial<SelectProps>;
     };
-  defaultComponent: D;
+  component: D;
   classKey: TablePaginationClassKey;
 }
 

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
@@ -13,7 +13,7 @@ export type TableSortLabelTypeMap<
     hideSortIcon?: boolean;
     IconComponent?: React.ComponentType<SvgIconProps>;
   };
-  defaultComponent: D;
+  component: D;
   classKey: TableSortLabelClassKey;
 }>;
 
@@ -27,7 +27,7 @@ export type TableSortLabelClassKey =
   | 'iconDirectionAsc';
 
 export type TableSortLabelProps<
-  D extends React.ElementType = TableSortLabelTypeMap['defaultComponent'],
+  D extends React.ElementType = TableSortLabelTypeMap['component'],
   P = {}
 > = OverrideProps<TableSortLabelTypeMap<P, D>, D>;
 

--- a/packages/material-ui/src/Tabs/Tabs.d.ts
+++ b/packages/material-ui/src/Tabs/Tabs.d.ts
@@ -18,7 +18,7 @@ export interface TabsTypeMap<P = {}, D extends React.ElementType = typeof Button
     variant?: 'standard' | 'scrollable' | 'fullWidth';
     width?: string;
   };
-  defaultComponent: D;
+  component: D;
   classKey: TabsClassKey;
 }
 
@@ -40,7 +40,7 @@ export interface TabsActions {
 }
 
 export type TabsProps<
-  D extends React.ElementType = TabsTypeMap['defaultComponent'],
+  D extends React.ElementType = TabsTypeMap['component'],
   P = {}
 > = OverrideProps<TabsTypeMap<P, D>, D>;
 

--- a/packages/material-ui/test/typescript/OverridableComponent.spec.tsx
+++ b/packages/material-ui/test/typescript/OverridableComponent.spec.tsx
@@ -23,7 +23,7 @@ declare const Foo: OverridableComponent<{
     callbackProp?(b: boolean): void;
     inconsistentProp?: string;
   };
-  defaultComponent: React.ComponentType<{
+  component: React.ComponentType<{
     defaultProp?: boolean;
     defaultCallbackProp?(s: string): void;
   }>;


### PR DESCRIPTION
The typescript definition still uses the old `defaultComponent` prop.
This PR fixes all definitions to use the new `component` prop instead.

@sakulstra @eps1lon could you please take a look?