### PR TITLE
[docs] Add TS Demos for component/toggle-button

### DIFF
--- a/docs/src/pages/components/toggle-button/StandaloneToggleButton.tsx
+++ b/docs/src/pages/components/toggle-button/StandaloneToggleButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import CheckIcon from '@material-ui/icons/Check';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+
+export default function StandaloneToggleButton() {
+  const [selected, setSelected] = React.useState(false);
+
+  return (
+    <ToggleButton
+      value="check"
+      selected={selected}
+      onChange={() => {
+        setSelected(!selected);
+      }}
+    >
+      <CheckIcon />
+    </ToggleButton>
+  );
+}

--- a/docs/src/pages/components/toggle-button/ToggleButtonSizes.tsx
+++ b/docs/src/pages/components/toggle-button/ToggleButtonSizes.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft';
+import FormatAlignCenterIcon from '@material-ui/icons/FormatAlignCenter';
+import FormatAlignRightIcon from '@material-ui/icons/FormatAlignRight';
+import FormatAlignJustifyIcon from '@material-ui/icons/FormatAlignJustify';
+import Grid from '@material-ui/core/Grid';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+
+export default function ToggleButtonSizes() {
+  const [alignment, setAlignment] = React.useState('left');
+
+  const handleChange = (event: React.MouseEvent<HTMLElement>, newAlignment: string) => {
+    setAlignment(newAlignment);
+  };
+
+  const children = [
+    <ToggleButton key={1} value="left">
+      <FormatAlignLeftIcon />
+    </ToggleButton>,
+    <ToggleButton key={2} value="center">
+      <FormatAlignCenterIcon />
+    </ToggleButton>,
+    <ToggleButton key={3} value="right">
+      <FormatAlignRightIcon />
+    </ToggleButton>,
+    <ToggleButton key={4} value="justify" disabled>
+      <FormatAlignJustifyIcon />
+    </ToggleButton>,
+  ];
+
+  return (
+    <Grid container spacing={2} direction="column" alignItems="center">
+      <Grid item>
+        <ToggleButtonGroup size="small" value={alignment} exclusive onChange={handleChange}>
+          {children}
+        </ToggleButtonGroup>
+      </Grid>
+      <Grid item>
+        <ToggleButtonGroup size="medium" value={alignment} exclusive onChange={handleChange}>
+          {children}
+        </ToggleButtonGroup>
+      </Grid>
+      <Grid item>
+        <ToggleButtonGroup size="large" value={alignment} exclusive onChange={handleChange}>
+          {children}
+        </ToggleButtonGroup>
+      </Grid>
+    </Grid>
+  );
+}

--- a/docs/src/pages/components/toggle-button/ToggleButtons.tsx
+++ b/docs/src/pages/components/toggle-button/ToggleButtons.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import FormatAlignLeftIcon from '@material-ui/icons/FormatAlignLeft';
+import FormatAlignCenterIcon from '@material-ui/icons/FormatAlignCenter';
+import FormatAlignRightIcon from '@material-ui/icons/FormatAlignRight';
+import FormatAlignJustifyIcon from '@material-ui/icons/FormatAlignJustify';
+import FormatBoldIcon from '@material-ui/icons/FormatBold';
+import FormatItalicIcon from '@material-ui/icons/FormatItalic';
+import FormatUnderlinedIcon from '@material-ui/icons/FormatUnderlined';
+import FormatColorFillIcon from '@material-ui/icons/FormatColorFill';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import Typography from '@material-ui/core/Typography';
+import Grid from '@material-ui/core/Grid';
+import ToggleButton from '@material-ui/lab/ToggleButton';
+import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup';
+
+const useStyles = makeStyles(theme => ({
+  toggleContainer: {
+    margin: theme.spacing(2, 0),
+  },
+}));
+
+export default function ToggleButtons() {
+  const [alignment, setAlignment] = React.useState('left');
+  const [formats, setFormats] = React.useState(() => ['bold']);
+
+  const handleFormat = (event: React.MouseEvent<HTMLElement>, newFormats: string[]) => {
+    setFormats(newFormats);
+  };
+
+  const handleAlignment = (event: React.MouseEvent<HTMLElement>, newAlignment: string) => {
+    setAlignment(newAlignment);
+  };
+
+  const classes = useStyles();
+
+  return (
+    <Grid container spacing={2}>
+      <Grid item sm={12} md={6}>
+        <div className={classes.toggleContainer}>
+          <ToggleButtonGroup
+            value={alignment}
+            exclusive
+            onChange={handleAlignment}
+            aria-label="text alignment"
+          >
+            <ToggleButton value="left" aria-label="left aligned">
+              <FormatAlignLeftIcon />
+            </ToggleButton>
+            <ToggleButton value="center" aria-label="centered">
+              <FormatAlignCenterIcon />
+            </ToggleButton>
+            <ToggleButton value="right" aria-label="right aligned">
+              <FormatAlignRightIcon />
+            </ToggleButton>
+            <ToggleButton value="justify" aria-label="justified" disabled>
+              <FormatAlignJustifyIcon />
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </div>
+        <Typography gutterBottom>Exclusive Selection</Typography>
+        <Typography>
+          Text justification toggle buttons present options for left, right, center, full, and
+          justified text with only one item available for selection at a time. Selecting one option
+          deselects any other.
+        </Typography>
+      </Grid>
+      <Grid item sm={12} md={6}>
+        <div className={classes.toggleContainer}>
+          <ToggleButtonGroup value={formats} onChange={handleFormat} arial-label="text formatting">
+            <ToggleButton value="bold" aria-label="bold">
+              <FormatBoldIcon />
+            </ToggleButton>
+            <ToggleButton value="italic" aria-label="italic">
+              <FormatItalicIcon />
+            </ToggleButton>
+            <ToggleButton value="underlined" aria-label="underlined">
+              <FormatUnderlinedIcon />
+            </ToggleButton>
+            <ToggleButton value="color" aria-label="color" disabled>
+              <FormatColorFillIcon />
+              <ArrowDropDownIcon />
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </div>
+        <Typography gutterBottom>Multiple Selection</Typography>
+        <Typography>
+          Logically-grouped options, like Bold, Italic, and Underline, allow multiple options to be
+          selected.
+        </Typography>
+      </Grid>
+    </Grid>
+  );
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

For #14897

Contains TS Demos for 

Components
- StandaloneToggleButton
- ToggleButtons
- ToggleButtonSizes

### Tests Passed

```yarn docs:typescript:check``` and ```yarn docs:typescript:formatted```

![image](https://user-images.githubusercontent.com/30215516/66560027-27531200-eb74-11e9-9317-48d5faf86cf2.png)
