### PR TITLE
[system] Add longhand borderColor props to borders

### DIFF
--- a/docs/src/pages/system/borders/BorderColor.js
+++ b/docs/src/pages/system/borders/BorderColor.js
@@ -16,6 +16,13 @@ export default function BorderColor() {
       <Box borderColor="error.main" {...defaultProps} />
       <Box borderColor="grey.500" {...defaultProps} />
       <Box borderColor="text.primary" {...defaultProps} />
+      <Box
+        borderTopColor="primary.main"
+        borderRightColor="secondary.main"
+        borderBottomColor="error.main"
+        borderLeftColor="grey.500"
+        {...defaultProps}
+      />
     </Box>
   );
 }

--- a/docs/src/pages/system/borders/BorderColor.tsx
+++ b/docs/src/pages/system/borders/BorderColor.tsx
@@ -16,6 +16,13 @@ export default function BorderColor() {
       <Box borderColor="error.main" {...defaultProps} />
       <Box borderColor="grey.500" {...defaultProps} />
       <Box borderColor="text.primary" {...defaultProps} />
+      <Box
+        borderTopColor="primary.main"
+        borderRightColor="secondary.main"
+        borderBottomColor="error.main"
+        borderLeftColor="grey.500"
+        {...defaultProps}
+      />
     </Box>
   );
 }

--- a/docs/src/pages/system/borders/borders.md
+++ b/docs/src/pages/system/borders/borders.md
@@ -38,6 +38,12 @@ Use border utilities to add or remove an element’s borders. Choose from all bo
 <Box borderColor="error.main">…
 <Box borderColor="grey.500">…
 <Box borderColor="text.primary">…
+<Box borderColor="text.primary">…
+<Box borderTopColor="primary.main" 
+  borderRightColor="secondary.main" 
+  borderBottomColor="error.main"
+  borderLeftColor="grey.500"
+/>
 ```
 
 {{"demo": "pages/system/borders/BorderColor.js"}}
@@ -61,9 +67,13 @@ import { borders } from '@material-ui/system';
 | Import name | Prop | CSS property | Theme key |
 |:------------|:-----|:-------------|:----------|
 | `border` | `border` | `border` | `borders` |
-| `borderTop` | `borderTop` | `border-top` | `borders` |
-| `borderLeft` | `borderLeft` | `border-left` | `borders` |
-| `borderRight` | `borderRight` | `border-right` | `borders` |
-| `borderBottom` | `borderBottom` | `border-bottom` | `borders` |
 | `borderColor` | `borderColor` | `border-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
+| `borderTop` | `borderTop` | `border-top` | `borders` |
+| `borderTopColor` | `borderTopColor` | `border-top-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
+| `borderRight` | `borderRight` | `border-right` | `borders` |
+| `borderRightColor` | `borderRightColor` | `border-right-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
+| `borderBottom` | `borderBottom` | `border-bottom` | `borders` |
+| `borderBottomColor` | `borderBottomColor` | `border-bottom-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
+| `borderLeft` | `borderLeft` | `border-left` | `borders` |
+| `borderLeftColor` | `borderLeftColor` | `border-left-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
 | `borderRadius` | `borderRadius` | `border-radius` | [`shape`](/customization/default-theme/?expend-path=$.shape) |

--- a/packages/material-ui-system/src/borders.js
+++ b/packages/material-ui-system/src/borders.js
@@ -44,6 +44,26 @@ export const borderColor = style({
   themeKey: 'palette',
 });
 
+export const borderTopColor = style({
+  prop: 'borderTopColor',
+  themeKey: 'palette',
+});
+
+export const borderRightColor = style({
+  prop: 'borderRightColor',
+  themeKey: 'palette',
+});
+
+export const borderBottomColor = style({
+  prop: 'borderBottomColor',
+  themeKey: 'palette',
+});
+
+export const borderLeftColor = style({
+  prop: 'borderLeftColor',
+  themeKey: 'palette',
+});
+
 export const borderRadius = style({
   prop: 'borderRadius',
   themeKey: 'shape',
@@ -56,6 +76,10 @@ const borders = compose(
   borderBottom,
   borderLeft,
   borderColor,
+  borderTopColor,
+  borderRightColor,
+  borderBottomColor,
+  borderLeftColor,
   borderRadius,
 );
 

--- a/packages/material-ui-system/src/borders.test.js
+++ b/packages/material-ui-system/src/borders.test.js
@@ -1,0 +1,50 @@
+import { assert } from 'chai';
+import borders from './borders';
+
+describe('borders', () => {
+  it('should be able to customize the border size and style', () => {
+    const borderProps = borders({
+      theme: {},
+      border: 1,
+      borderTop: 2,
+      borderRight: 3,
+      borderBottom: 4,
+      borderLeft: 5,
+    });
+    assert.deepEqual(borderProps, {
+      border: '1px solid',
+      borderTop: '2px solid',
+      borderRight: '3px solid',
+      borderBottom: '4px solid',
+      borderLeft: '5px solid',
+    });
+  });
+
+  it('should be able to customize the border color', () => {
+    const borderProps = borders({
+      theme: {
+        palette: {
+          testColor: {
+            myBorderColor: 'myBorderColor',
+            mBorderTopColor: 'mBorderTopColor',
+            myBorderRightColor: 'myBorderRightColor',
+            myBorderBottomColor: 'myBorderBottomColor',
+            myBorderLeftColor: 'myBorderLeftColor',
+          },
+        },
+      },
+      borderColor: 'testColor.myBorderColor',
+      borderTopColor: 'testColor.mBorderTopColor',
+      borderRightColor: 'testColor.myBorderRightColor',
+      borderBottomColor: 'testColor.myBorderBottomColor',
+      borderLeftColor: 'testColor.myBorderLeftColor',
+    });
+    assert.deepEqual(borderProps, {
+      borderColor: 'myBorderColor',
+      borderTopColor: 'mBorderTopColor',
+      borderRightColor: 'myBorderRightColor',
+      borderBottomColor: 'myBorderBottomColor',
+      borderLeftColor: 'myBorderLeftColor',
+    });
+  });
+});

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -12,17 +12,25 @@ type SimpleStyleFunction<PropKey extends keyof any> = StyleFunction<Partial<Reco
 // borders.js
 export const border: SimpleStyleFunction<'border'>;
 export const borderTop: SimpleStyleFunction<'borderTop'>;
+export const borderTopColor: SimpleStyleFunction<'borderTopColor'>;
 export const borderRight: SimpleStyleFunction<'borderRight'>;
+export const borderRightColor: SimpleStyleFunction<'borderRightColor'>;
 export const borderBottom: SimpleStyleFunction<'borderBottom'>;
+export const borderBottomColor: SimpleStyleFunction<'borderBottomColor'>;
 export const borderLeft: SimpleStyleFunction<'borderLeft'>;
+export const borderLeftColor: SimpleStyleFunction<'borderLeftColor'>;
 export const borderColor: SimpleStyleFunction<'borderColor'>;
 export const borderRadius: SimpleStyleFunction<'borderRadius'>;
 export const borders: SimpleStyleFunction<
   | 'border'
   | 'borderTop'
+  | 'borderTopColor'
   | 'borderRight'
+  | 'borderRightColor'
   | 'borderBottom'
+  | 'borderBottomColor'
   | 'borderLeft'
+  | 'borderLeftColor'
   | 'borderColor'
   | 'borderRadius'
 >;


### PR DESCRIPTION
Add borderColorTop, borderColorRight, borderColorBottom, borderColorLeft
props, for fine control of the border color

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fixes #16995 