### PR TITLE
17828 ListItemIcon alignment when secondary text is enabled

### DIFF
--- a/docs/pages/api/list-item-icon.md
+++ b/docs/pages/api/list-item-icon.md
@@ -26,6 +26,7 @@ A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The content of the component, normally `Icon`, `SvgIcon`, or a `@material-ui/icons` SVG icon element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">secondaryTextEnabled</span> | <span class="prop-type">bool</span> |  |  |
 
 The `ref` is forwarded to the root element.
 
@@ -40,6 +41,7 @@ Any other props supplied will be provided to the root element (native element).
 |:-----|:-------------|:------------|
 | <span class="prop-name">root</span> | <span class="prop-name">MuiListItemIcon-root</span> | Styles applied to the root element.
 | <span class="prop-name">alignItemsFlexStart</span> | <span class="prop-name">MuiListItemIcon-alignItemsFlexStart</span> | Styles applied to the root element when the parent `ListItem` uses `alignItems="flex-start"`.
+| <span class="prop-name">secondaryTextEnabledIconPlacement</span> | <span class="prop-name">MuiListItemIcon-secondaryTextEnabledIconPlacement</span> | Styles applied to the root element when `ListItemIcon` enables secondary text.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/src/pages/components/lists/InteractiveList.js
+++ b/docs/src/pages/components/lists/InteractiveList.js
@@ -92,7 +92,7 @@ export default function InteractiveList() {
             <List dense={dense}>
               {generate(
                 <ListItem>
-                  <ListItemIcon>
+                  <ListItemIcon secondaryTextEnabled={secondary}>
                     <FolderIcon />
                   </ListItemIcon>
                   <ListItemText

--- a/docs/src/pages/components/lists/InteractiveList.tsx
+++ b/docs/src/pages/components/lists/InteractiveList.tsx
@@ -94,7 +94,7 @@ export default function InteractiveList() {
             <List dense={dense}>
               {generate(
                 <ListItem>
-                  <ListItemIcon>
+                  <ListItemIcon secondaryTextEnabled={secondary}>
                     <FolderIcon />
                   </ListItemIcon>
                   <ListItemText

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
@@ -3,6 +3,7 @@ import { StandardProps } from '..';
 export interface ListItemIconProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ListItemIconClassKey> {
   children: React.ReactElement;
+  secondaryTextEnabled?: boolean;
 }
 
 export type ListItemIconClassKey = 'root';

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -16,13 +16,19 @@ export const styles = theme => ({
   alignItemsFlexStart: {
     marginTop: 8,
   },
+  /* Styles applied to the root element when `ListItemIcon` enables secondary text. */
+  secondaryTextEnabledIconPlacement: {
+    display: 'flex',
+    alignSelf: 'flex-start',
+    marginTop: 6,
+  },
 });
 
 /**
  * A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
  */
 const ListItemIcon = React.forwardRef(function ListItemIcon(props, ref) {
-  const { classes, className, ...other } = props;
+  const { classes, className, secondaryTextEnabled, ...other } = props;
   const context = React.useContext(ListContext);
 
   return (
@@ -30,6 +36,7 @@ const ListItemIcon = React.forwardRef(function ListItemIcon(props, ref) {
       className={clsx(
         classes.root,
         {
+          [classes.secondaryTextEnabledIconPlacement]: secondaryTextEnabled,
           [classes.alignItemsFlexStart]: context.alignItems === 'flex-start',
         },
         className,
@@ -55,6 +62,7 @@ ListItemIcon.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  secondaryTextEnabled: PropTypes.bool,
 };
 
 export default withStyles(styles, { name: 'MuiListItemIcon' })(ListItemIcon);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #17828 

- Changed alignment of `ListItemIcon` when `secondaryTextEnabled` is `true`.
- Also updated the `list-item-icon.md` with the change


![materialUIFix](https://user-images.githubusercontent.com/39945540/66620817-62ba1300-ec3e-11e9-85f1-67612d001ce0.gif)

<img width="401" alt="Screen Shot 2019-10-11 at 3 11 20 PM" src="https://user-images.githubusercontent.com/39945540/66620904-b88ebb00-ec3e-11e9-8bdd-b0e06c436848.png">

<img width="1540" alt="Screen Shot 2019-10-11 at 3 48 08 PM" src="https://user-images.githubusercontent.com/39945540/66620933-cfcda880-ec3e-11e9-8734-67477f53d2e7.png">
