### PR TITLE
[TreeItem] add expandOnReceiveChildren prop

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.d.ts
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.d.ts
@@ -17,6 +17,10 @@ export interface TreeItemProps
    */
   expandIcon?: React.ReactNode;
   /**
+   * If true, when empty the node will expand automatically on receiving child nodes.
+   */
+  expandOnReceiveChildren?: boolean;
+  /**
    * The icon to display next to the tree node's label.
    */
   icon?: React.ReactNode;

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -62,6 +62,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     collapseIcon,
     endIcon,
     expandIcon,
+    expandOnReceiveChildren = false,
     icon: iconProp,
     label,
     nodeId,
@@ -93,6 +94,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   const nodeRef = React.useRef(null);
   const contentRef = React.useRef(null);
   const handleRef = useForkRef(nodeRef, ref);
+  const childrenRef = React.useRef(children);
 
   let icon = iconProp;
 
@@ -240,6 +242,14 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     }
   }, [focused]);
 
+  React.useEffect(() => {
+    if (children && !childrenRef.current.length && !expanded && expandOnReceiveChildren) {
+      toggle(nodeId)
+    }
+    childrenRef.current = children;
+
+  }, [children, expandOnReceiveChildren, expanded, nodeId, toggle]);
+
   return (
     <li
       className={clsx(classes.root, className, {
@@ -304,6 +314,10 @@ TreeItem.propTypes = {
    * The icon used to expand the node.
    */
   expandIcon: PropTypes.node,
+  /**
+   * If true, when empty the node will expand automatically on receiving child nodes.
+   */
+  expandOnReceiveChildren: PropTypes.bool,
   /**
    * The icon to display next to the tree node's label.
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
My attempt at a simple solution to #17705. Provides a new prop for the TreeItem component, expandOnReceiveChildren, so that it expands automatically when transitioning from having zero children to having some. The person who opened that issue wanted manual control over TreeItems, which would require a more sophisticated solution. This solution handles the use case described in the issue while keeping the job of managing which nodes are expanded internal to the TreeView component.

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #17705.