### PR TITLE
[docs] Add TS demos for SplitButton in components/buttons

### DIFF
--- a/docs/src/pages/components/buttons/SplitButton.tsx
+++ b/docs/src/pages/components/buttons/SplitButton.tsx
@@ -14,14 +14,14 @@ const options = ['Create a merge commit', 'Squash and merge', 'Rebase and merge'
 
 export default function SplitButton() {
   const [open, setOpen] = React.useState(false);
-  const anchorRef = React.useRef(null);
+  const anchorRef = React.useRef<HTMLDivElement>(null);
   const [selectedIndex, setSelectedIndex] = React.useState(1);
 
   const handleClick = () => {
     alert(`You clicked ${options[selectedIndex]}`);
   };
 
-  const handleMenuItemClick = (event, index) => {
+  const handleMenuItemClick = (event: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => {
     setSelectedIndex(index);
     setOpen(false);
   };
@@ -30,8 +30,8 @@ export default function SplitButton() {
     setOpen(prevOpen => !prevOpen);
   };
 
-  const handleClose = event => {
-    if (anchorRef.current && anchorRef.current.contains(event.target)) {
+  const handleClose = (event: React.MouseEvent<Document, MouseEvent>) => {
+    if (anchorRef.current && anchorRef.current.contains(event.target as HTMLElement)) {
       return;
     }
 

--- a/docs/src/pages/components/buttons/SplitButton.tsx
+++ b/docs/src/pages/components/buttons/SplitButton.tsx
@@ -21,7 +21,10 @@ export default function SplitButton() {
     alert(`You clicked ${options[selectedIndex]}`);
   };
 
-  const handleMenuItemClick = (event: React.MouseEvent<HTMLLIElement, MouseEvent>, index: number) => {
+  const handleMenuItemClick = (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>,
+    index: number,
+  ) => {
     setSelectedIndex(index);
     setOpen(false);
   };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

For https://github.com/mui-org/material-ui/issues/14897

I changed the Grid component usage in the demo because of an error in typescript (`No overload matches this call`) when using `align="center". I took a peek from https://github.com/mui-org/material-ui/pull/15744/commits/eee5762506fe27ea604f6d73d0a93f510e866c06#diff-0c763912c8abc6c58d319fd816c7260dL21-R10 as well for these changes.