### PR TITLE
[docs] Fix RTL-toggle tooltip bug in app bar

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -182,8 +182,19 @@ function AppFrame(props) {
 
     changeTheme({ paletteType });
   };
+
+  // these handlers used to fix issue with RTL tooltip staying open after click
+  const [directionTooltipOpen, setDirectionTooltipOpen] = React.useState(false);
+  const handleDirectionTooltipClose = () => {
+    setDirectionTooltipOpen(false);
+  };
+  const handleDirectionTooltipOpen = () => {
+    setDirectionTooltipOpen(true);
+  };
+
   const handleToggleDirection = () => {
     changeTheme({ direction: theme.direction === 'ltr' ? 'rtl' : 'ltr' });
+    setDirectionTooltipOpen(false);
   };
 
   const router = useRouter();
@@ -311,7 +322,13 @@ function AppFrame(props) {
               {theme.palette.type === 'light' ? <Brightness4Icon /> : <Brightness7Icon />}
             </IconButton>
           </Tooltip>
-          <Tooltip title={t('toggleRTL')} enterDelay={300}>
+          <Tooltip
+            title={t('toggleRTL')}
+            enterDelay={300}
+            open={directionTooltipOpen}
+            onOpen={handleDirectionTooltipOpen}
+            onClose={handleDirectionTooltipClose}
+          >
             <IconButton
               color="inherit"
               onClick={handleToggleDirection}

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -182,19 +182,8 @@ function AppFrame(props) {
 
     changeTheme({ paletteType });
   };
-
-  // these handlers used to fix issue with RTL tooltip staying open after click
-  const [directionTooltipOpen, setDirectionTooltipOpen] = React.useState(false);
-  const handleDirectionTooltipClose = () => {
-    setDirectionTooltipOpen(false);
-  };
-  const handleDirectionTooltipOpen = () => {
-    setDirectionTooltipOpen(true);
-  };
-
   const handleToggleDirection = () => {
     changeTheme({ direction: theme.direction === 'ltr' ? 'rtl' : 'ltr' });
-    setDirectionTooltipOpen(false);
   };
 
   const router = useRouter();
@@ -322,13 +311,7 @@ function AppFrame(props) {
               {theme.palette.type === 'light' ? <Brightness4Icon /> : <Brightness7Icon />}
             </IconButton>
           </Tooltip>
-          <Tooltip
-            title={t('toggleRTL')}
-            enterDelay={300}
-            open={directionTooltipOpen}
-            onOpen={handleDirectionTooltipOpen}
-            onClose={handleDirectionTooltipClose}
-          >
+          <Tooltip title={t('toggleRTL')} key={theme.direction} enterDelay={300}>
             <IconButton
               color="inherit"
               onClick={handleToggleDirection}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This fixes an issue related to #13203 in the documentation site's appbar. Currently when you click the button to toggle right-to-left, the tooltip message persists after clicking. This change manually controls the state of the tooltip and closes it when clicked.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Closes #13203