### PR TITLE
[docs] Add Typescript demos for MenuPopupState

### DIFF
--- a/docs/src/pages/components/menus/MenuPopupState.tsx
+++ b/docs/src/pages/components/menus/MenuPopupState.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Button from '@material-ui/core/Button';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import PopupState, { bindTrigger, bindMenu } from 'material-ui-popup-state';
+
+function MenuPopupState() {
+  return (
+    <PopupState variant="popover" popupId="demo-popup-menu">
+      {popupState => (
+        <React.Fragment>
+          <Button variant="contained" {...bindTrigger(popupState)}>
+            Open Menu
+          </Button>
+          <Menu {...bindMenu(popupState)}>
+            <MenuItem onClick={popupState.close}>Cake</MenuItem>
+            <MenuItem onClick={popupState.close}>Death</MenuItem>
+          </Menu>
+        </React.Fragment>
+      )}
+    </PopupState>
+  );
+}
+
+export default MenuPopupState;

--- a/docs/types/material-ui-popup-state.d.ts
+++ b/docs/types/material-ui-popup-state.d.ts
@@ -1,0 +1,1 @@
+declare module '@material-ui-popup-state';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
I wasn't able to run successfully yarn docs:typescript:check as it was told that it can be pushed anyway. Please let me know if I did it right or wrong.

Related to #14897