### PR TITLE
[docs] Clarify aria role of Switch

### DIFF
--- a/docs/src/pages/components/switches/switches.md
+++ b/docs/src/pages/components/switches/switches.md
@@ -51,13 +51,14 @@ You can change the placement of the label:
 
 ## Accessibility
 
+- It will render an element with the `checkbox` role not `switch` role since this
+  role isn't widely supported yet. Please test first if assistive technology of your
+  target audience supports this role properly. Then you can change the role with
+  `<Switch inputProps={{ role: 'switch' }}>`
 - All form controls should have labels, and this includes radio buttons, checkboxes, and switches. In most cases, this is done by using the `<label>` element ([FormControlLabel](/api/form-control-label/)).
 - When a label can't be used, it's necessary to add an attribute directly to the input component.
-In this case, you can apply the additional attribute (e.g. `aria-label`, `aria-labelledby`, `title`) via the `inputProps` property.
+  In this case, you can apply the additional attribute (e.g. `aria-label`, `aria-labelledby`, `title`) via the `inputProps` property.
 
 ```jsx
-<Switch
-  value="checkedA"
-  inputProps={{ 'aria-label': 'Switch A' }}
-/>
+<Switch value="checkedA" inputProps={{ 'aria-label': 'Switch A' }} />
 ```

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -143,6 +143,7 @@ const Switch = React.forwardRef(function Switch(props, ref) {
     className,
     color = 'secondary',
     edge = false,
+    inputProps,
     size = 'medium',
     ...other
   } = props;
@@ -170,6 +171,10 @@ const Switch = React.forwardRef(function Switch(props, ref) {
           input: classes.input,
           checked: classes.checked,
           disabled: classes.disabled,
+        }}
+        inputProps={{
+          role: 'switch',
+          ...inputProps,
         }}
         ref={ref}
         {...other}

--- a/packages/material-ui/src/Switch/Switch.js
+++ b/packages/material-ui/src/Switch/Switch.js
@@ -143,7 +143,6 @@ const Switch = React.forwardRef(function Switch(props, ref) {
     className,
     color = 'secondary',
     edge = false,
-    inputProps,
     size = 'medium',
     ...other
   } = props;
@@ -171,10 +170,6 @@ const Switch = React.forwardRef(function Switch(props, ref) {
           input: classes.input,
           checked: classes.checked,
           disabled: classes.disabled,
-        }}
-        inputProps={{
-          role: 'switch',
-          ...inputProps,
         }}
         ref={ref}
         {...other}

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -1,30 +1,25 @@
 import React from 'react';
-import { assert } from 'chai';
-import clsx from 'clsx';
-import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
+import { expect } from 'chai';
+import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import SwitchBase from '../internal/SwitchBase';
+import { createClientRender } from 'test/utils/createClientRender';
 import Switch from './Switch';
 
 describe('<Switch />', () => {
   let mount;
-  let shallow;
   let classes;
+  const render = createClientRender({ strict: true });
 
   before(() => {
     mount = createMount({ strict: true });
-    shallow = createShallow({ untilSelector: 'span' });
     classes = getClasses(<Switch />);
-  });
-
-  after(() => {
-    mount.cleanUp();
   });
 
   describeConformance(<Switch />, () => ({
     mount,
     only: ['refForwarding'],
     refInstanceof: window.HTMLSpanElement,
+    after: () => mount.cleanUp(),
   }));
 
   /* TODO Switch violates root component
@@ -38,35 +33,48 @@ describe('<Switch />', () => {
 
   describe('styleSheet', () => {
     it('should have the classes required for SwitchBase', () => {
-      assert.strictEqual(typeof classes.root, 'string');
-      assert.strictEqual(typeof classes.checked, 'string');
-      assert.strictEqual(typeof classes.disabled, 'string');
+      expect(classes).to.include.all.keys(['root', 'checked', 'disabled']);
     });
   });
 
-  describe('default Switch export', () => {
-    let wrapper;
+  specify('should render an .thumb element inside the .switchBase element', () => {
+    const { container } = render(
+      <Switch classes={{ thumb: 'thumb', switchBase: 'switch-base' }} />,
+    );
 
-    beforeEach(() => {
-      wrapper = shallow(<Switch className="foo" />);
-    });
+    expect(container.querySelector('.switch-base .thumb')).to.be.ok;
+  });
 
-    it('should render SwitchBase with a custom span icon with the thumb class', () => {
-      const switchBase = wrapper.childAt(0);
-      assert.strictEqual(switchBase.type(), SwitchBase);
-      assert.strictEqual(switchBase.props().icon.type, 'span');
-      assert.strictEqual(switchBase.props().icon.props.className, classes.thumb);
-      assert.strictEqual(switchBase.props().checkedIcon.type, 'span');
-      assert.strictEqual(
-        switchBase.props().checkedIcon.props.className,
-        clsx(classes.thumb, classes.thumbChecked),
-      );
-    });
+  it('should render the track as the 2nd child', () => {
+    const {
+      container: { firstChild: root },
+    } = render(<Switch />);
 
-    it('should render the track as the 2nd child', () => {
-      const track = wrapper.childAt(1);
-      assert.strictEqual(track.name(), 'span');
-      assert.strictEqual(track.hasClass(classes.track), true);
-    });
+    expect(root.childNodes[1]).to.have.property('tagName', 'SPAN');
+    expect(root.childNodes[1]).to.have.class(classes.track);
+  });
+
+  it('renders a `role="switch"` with the Off state by default', () => {
+    const { getByRole } = render(<Switch />);
+
+    expect(getByRole('switch')).to.have.property('checked', false);
+  });
+
+  it('renders a switch with the On state when checked', () => {
+    const { getByRole } = render(<Switch checked />);
+
+    expect(getByRole('switch')).to.have.property('checked', true);
+  });
+
+  specify('the switch can be disabled', () => {
+    const { getByRole } = render(<Switch disabled />);
+
+    expect(getByRole('switch')).to.have.property('disabled', true);
+  });
+
+  specify('the switch can be readonly', () => {
+    const { getByRole } = render(<Switch readOnly />);
+
+    expect(getByRole('switch')).to.have.property('readOnly', true);
   });
 });

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -54,27 +54,27 @@ describe('<Switch />', () => {
     expect(root.childNodes[1]).to.have.class(classes.track);
   });
 
-  it('renders a `role="switch"` with the Off state by default', () => {
+  it('renders a `role="checkbox"` with the Unechecked state by default', () => {
     const { getByRole } = render(<Switch />);
 
-    expect(getByRole('switch')).to.have.property('checked', false);
+    expect(getByRole('checkbox')).to.have.property('checked', false);
   });
 
-  it('renders a switch with the On state when checked', () => {
+  it('renders a checkbox with the Checked state when checked', () => {
     const { getByRole } = render(<Switch checked />);
 
-    expect(getByRole('switch')).to.have.property('checked', true);
+    expect(getByRole('checkbox')).to.have.property('checked', true);
   });
 
   specify('the switch can be disabled', () => {
     const { getByRole } = render(<Switch disabled />);
 
-    expect(getByRole('switch')).to.have.property('disabled', true);
+    expect(getByRole('checkbox')).to.have.property('disabled', true);
   });
 
   specify('the switch can be readonly', () => {
     const { getByRole } = render(<Switch readOnly />);
 
-    expect(getByRole('switch')).to.have.property('readOnly', true);
+    expect(getByRole('checkbox')).to.have.property('readOnly', true);
   });
 });

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
-import { createClientRender } from 'test/utils/createClientRender';
+import { createClientRender, fireEvent } from 'test/utils/createClientRender';
 import Switch from './Switch';
 
 describe('<Switch />', () => {
@@ -61,7 +61,7 @@ describe('<Switch />', () => {
   });
 
   it('renders a checkbox with the Checked state when checked', () => {
-    const { getByRole } = render(<Switch checked />);
+    const { getByRole } = render(<Switch defaultChecked />);
 
     expect(getByRole('checkbox')).to.have.property('checked', true);
   });
@@ -76,5 +76,15 @@ describe('<Switch />', () => {
     const { getByRole } = render(<Switch readOnly />);
 
     expect(getByRole('checkbox')).to.have.property('readOnly', true);
+  });
+
+  specify('the Checked state changes after change events', () => {
+    const { getByRole } = render(<Switch defaultChecked />);
+
+    // how a user would trigger it
+    getByRole('checkbox').click();
+    fireEvent.change(getByRole('checkbox'), { target: { checked: '' } });
+
+    expect(getByRole('checkbox')).to.have.property('checked', false);
   });
 });


### PR DESCRIPTION
Closes #17697

Not using `role="switch"` because apparently AT support isn't widespread<sup>1</sup>. Since we don't have control over app code it also might not be used properly (not applying changes immediately). At some point we should switch (:smile:) to the appropriate role by default and advice to change it if it is in fact used in a form and changes aren't applied immediately.

<sup>1</sup> 
> Until issues with role="switch" have been worked out, and have wide support, it may be better to use a button element, with state indicated by aria-pressed="true/false". Or stick with a input type="checkbox" if the usage of a checkbox would be an expected user experience.
-- https://scottaohara.github.io/a11y_styled_form_controls/src/checkbox--switch/#affects_on_sr

It was always a `input type="checkbox"` so it is expected.