### PR TITLE
[TextareaAutosize] Fix missing form label

### DIFF
--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -135,6 +135,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
       />
       <textarea
         aria-hidden
+        aria-label="Shadow Input"
         className={props.className}
         readOnly
         ref={shadowRef}

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -135,7 +135,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
       />
       <textarea
         aria-hidden
-        aria-label="Shadow Input"
+        aria-label='Shadow Input'
         className={props.className}
         readOnly
         ref={shadowRef}

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -135,7 +135,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
       />
       <textarea
         aria-hidden
-        aria-label='Shadow Input'
+        aria-label="Shadow Input"
         className={props.className}
         readOnly
         ref={shadowRef}

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -134,7 +134,6 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
         {...other}
       />
       <textarea
-        aria-hidden
         aria-label="hidden input"
         className={props.className}
         readOnly

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -135,7 +135,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
       />
       <textarea
         aria-hidden
-        aria-label="Shadow Input"
+        aria-label="hidden input"
         className={props.className}
         readOnly
         ref={shadowRef}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

When using a multiline TextField, the popular WAVE Accessibility tool is throwing an error about the hidden "Shadow input" missing a form label.  This doesn't really matter as it is aria-hidden, but I suppose the logic could be that it should be there in case that visibility were to change.  It would be great to clear the error, as the tool is popular with clients testing blindly for compliance.

You can see the error here: https://hlk21.csb.app/

https://material-ui.com/components/textarea-autosize/

![2019-10-18-165303_904x614_scrot](https://user-images.githubusercontent.com/1695086/67130858-47b04b80-f1c8-11e9-83d3-58e84c14a057.png)

I was not quick to determine the best practice for how to label this invisible input, so I am hardly going to argue if you change my proposed value.