### PR TITLE
[Dialog] fix the modal tabindex

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -225,6 +225,7 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
         onExit={onExit}
         onExiting={onExiting}
         onExited={onExited}
+        tabIndex={children.props.tabIndex}                        
         role="none presentation"
         {...TransitionProps}
       >


### PR DESCRIPTION
related to #17937 issue, Modal need to know the children tabindex if present
