### PR TITLE
[SwipeableDrawer] Change close swipe behavior and fix touch bug

### DIFF
--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -262,7 +262,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
       let startLocation = horizontalSwipe
         ? swipeInstance.current.startX
         : swipeInstance.current.startY;
-      if (open && !swipeInstance.current.paperHit) {
+      if (openRef.current && !swipeInstance.current.paperHit) {
         startLocation = Math.min(startLocation, maxTranslate);
       }
 
@@ -273,9 +273,9 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
         maxTranslate,
       );
 
-      if (open) {
-        const paperHit = horizontalSwipe ? currentX < maxTranslate : currentY < maxTranslate;
+      if (openRef.current) {
         if (!swipeInstance.current.paperHit) {
+          const paperHit = horizontalSwipe ? currentX < maxTranslate : currentY < maxTranslate;
           if (paperHit) {
             swipeInstance.current.paperHit = true;
             swipeInstance.current.startX = currentX;
@@ -312,7 +312,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
 
       setPosition(translate);
     },
-    [setPosition, handleBodyTouchEnd, anchor, disableDiscovery, swipeAreaWidth, theme, open],
+    [setPosition, handleBodyTouchEnd, anchor, disableDiscovery, swipeAreaWidth, theme],
   );
 
   const handleBodyTouchStart = React.useCallback(

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -257,10 +257,14 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
       if (!swipeInstance.current.isSwiping) {
         return;
       }
-      const startLocation = horizontalSwipe
+
+      const maxTranslate = getMaxTranslate(horizontalSwipe, paperRef.current);
+      let startLocation = horizontalSwipe
         ? swipeInstance.current.startX
         : swipeInstance.current.startY;
-      const maxTranslate = getMaxTranslate(horizontalSwipe, paperRef.current);
+      if (open) {
+        startLocation = Math.min(startLocation, maxTranslate);
+      }
 
       const translate = getTranslate(
         horizontalSwipe ? currentX : currentY,
@@ -292,7 +296,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
 
       setPosition(translate);
     },
-    [setPosition, handleBodyTouchEnd, anchor, disableDiscovery, swipeAreaWidth, theme],
+    [setPosition, handleBodyTouchEnd, anchor, disableDiscovery, swipeAreaWidth, theme, open],
   );
 
   const handleBodyTouchStart = React.useCallback(

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -262,7 +262,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
       let startLocation = horizontalSwipe
         ? swipeInstance.current.startX
         : swipeInstance.current.startY;
-      if (open) {
+      if (open && !swipeInstance.current.paperHit) {
         startLocation = Math.min(startLocation, maxTranslate);
       }
 
@@ -272,6 +272,22 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
         openRef.current,
         maxTranslate,
       );
+
+      if (open) {
+        const paperHit = horizontalSwipe ? currentX < maxTranslate : currentY < maxTranslate;
+        if (!swipeInstance.current.paperHit) {
+          if (paperHit) {
+            swipeInstance.current.paperHit = true;
+            swipeInstance.current.startX = currentX;
+            swipeInstance.current.startY = currentY;
+          } else {
+            return;
+          }
+        } else if (translate === 0) {
+          swipeInstance.current.startX = currentX;
+          swipeInstance.current.startY = currentY;
+        }
+      }
 
       if (swipeInstance.current.lastTranslate === null) {
         swipeInstance.current.lastTranslate = translate;
@@ -350,6 +366,7 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
       swipeInstance.current.velocity = 0;
       swipeInstance.current.lastTime = null;
       swipeInstance.current.lastTranslate = null;
+      swipeInstance.current.paperHit = false;
 
       touchDetected.current = true;
     },

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -14,11 +14,6 @@ import SwipeArea from './SwipeArea';
 // trigger a native scroll.
 const UNCERTAINTY_THRESHOLD = 3; // px
 
-// Exported for test purposes.
-export function reset() {
-  // TODO drop this function
-}
-
 function calculateCurrentX(anchor, touches) {
   return anchor === 'right' ? document.body.offsetWidth - touches[0].pageX : touches[0].pageX;
 }

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -6,7 +6,7 @@ import describeConformance from '@material-ui/core/test-utils/describeConformanc
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Drawer from '../Drawer';
-import SwipeableDrawer, { reset } from './SwipeableDrawer';
+import SwipeableDrawer from './SwipeableDrawer';
 import SwipeArea from './SwipeArea';
 import useForkRef from '../utils/useForkRef';
 
@@ -147,7 +147,6 @@ describe('<SwipeableDrawer />', () => {
     });
 
     afterEach(() => {
-      reset();
       if (wrapper.length > 0) {
         wrapper.unmount();
       }

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -442,12 +442,20 @@ describe('<SwipeableDrawer />', () => {
         </div>,
       );
 
-      fireSwipeAreaMouseEvent(wrapper.find(SwipeableDrawer).at(0), 'touchstart', {
-        touches: [{ pageX: 0, clientY: 0 }],
-      });
-      fireSwipeAreaMouseEvent(wrapper.find(SwipeableDrawer).at(1), 'touchstart', {
-        touches: [{ pageX: 0, clientY: 0 }],
-      });
+      // use the same event object for both touch start events, one would propagate to the other swipe area in the browser
+      const touchStartEvent = fireSwipeAreaMouseEvent(
+        wrapper.find(SwipeableDrawer).at(0),
+        'touchstart',
+        {
+          touches: [{ pageX: 0, clientY: 0 }],
+        },
+      );
+      wrapper
+        .find(SwipeableDrawer)
+        .at(1)
+        .find(SwipeArea)
+        .getDOMNode()
+        .dispatchEvent(touchStartEvent);
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 20, clientY: 0 }] });
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 180, clientY: 0 }] });
       fireBodyMouseEvent('touchend', { changedTouches: [{ pageX: 180, clientY: 0 }] });


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

This PR applies @oliviertassinari's proposed fix to #16565 and changes the close-swipe behavior [to better match Android's behavior](https://github.com/mui-org/material-ui/issues/17408#issuecomment-544178140), i.e. do nothing until the _paper_ is touched. (Note that in the gifs, the mouse is only pressed once and then moved; the button is not released until the end)

![ezgif-6-513c36ac1173](https://user-images.githubusercontent.com/5544859/67151328-ef12a880-f2c4-11e9-86f3-a1df507aac8a.gif)

The tests aren't adjusted yet and I'm not sure about the third commit. It makes the drawer easier to use by allowing to "offset" the finger while touching (I think that's why Android does it this way, if it's intended behavior), but it also introduces a bit of overhead. Without that commit, it looks like this:

![ezgif-6-46491c3cac4a](https://user-images.githubusercontent.com/5544859/67151315-b5da3880-f2c4-11e9-89c4-a4cd1d58e53b.gif)

Fixes #16565 

