### PR TITLE
[FormControlLabel] Add missing CSS class keys to TS

### DIFF
--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.d.ts
@@ -18,7 +18,13 @@ export interface FormControlLabelProps
   value?: unknown;
 }
 
-export type FormControlLabelClassKey = 'root' | 'start' | 'disabled' | 'label';
+export type FormControlLabelClassKey =
+  | 'root'
+  | 'labelPlacementStart'
+  | 'labelPlacementTop'
+  | 'labelPlacementBottom'
+  | 'disabled'
+  | 'label';
 
 declare const FormControlLabel: React.ComponentType<FormControlLabelProps>;
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

resolves #17932 