### PR TITLE
[Checkbox] Add TS demo for FormControlLabelPosition

### DIFF
--- a/docs/src/pages/components/checkboxes/FormControlLabelPosition.js
+++ b/docs/src/pages/components/checkboxes/FormControlLabelPosition.js
@@ -5,7 +5,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-function FormControlLabelPosition() {
+export default function FormControlLabelPosition() {
   return (
     <FormControl component="fieldset">
       <FormLabel component="legend">Label Placement</FormLabel>
@@ -38,5 +38,3 @@ function FormControlLabelPosition() {
     </FormControl>
   );
 }
-
-export default FormControlLabelPosition;

--- a/docs/src/pages/components/checkboxes/FormControlLabelPosition.js
+++ b/docs/src/pages/components/checkboxes/FormControlLabelPosition.js
@@ -6,16 +6,10 @@ import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
 function FormControlLabelPosition() {
-  const [value, setValue] = React.useState('female');
-
-  const handleChange = event => {
-    setValue(event.target.value);
-  };
-
   return (
     <FormControl component="fieldset">
-      <FormLabel component="legend">labelPlacement</FormLabel>
-      <FormGroup aria-label="position" name="position" value={value} onChange={handleChange} row>
+      <FormLabel component="legend">Label Placement</FormLabel>
+      <FormGroup aria-label="position" row>
         <FormControlLabel
           value="top"
           control={<Checkbox color="primary" />}

--- a/docs/src/pages/components/checkboxes/FormControlLabelPosition.tsx
+++ b/docs/src/pages/components/checkboxes/FormControlLabelPosition.tsx
@@ -5,7 +5,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
 import FormLabel from '@material-ui/core/FormLabel';
 
-function FormControlLabelPosition() {
+export default function FormControlLabelPosition() {
   return (
     <FormControl component="fieldset">
       <FormLabel component="legend">Label Placement</FormLabel>
@@ -38,5 +38,3 @@ function FormControlLabelPosition() {
     </FormControl>
   );
 }
-
-export default FormControlLabelPosition;

--- a/docs/src/pages/components/checkboxes/FormControlLabelPosition.tsx
+++ b/docs/src/pages/components/checkboxes/FormControlLabelPosition.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Checkbox from '@material-ui/core/Checkbox';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import FormControl from '@material-ui/core/FormControl';
+import FormLabel from '@material-ui/core/FormLabel';
+
+function FormControlLabelPosition() {
+  return (
+    <FormControl component="fieldset">
+      <FormLabel component="legend">Label Placement</FormLabel>
+      <FormGroup aria-label="position" row>
+        <FormControlLabel
+          value="top"
+          control={<Checkbox color="primary" />}
+          label="Top"
+          labelPlacement="top"
+        />
+        <FormControlLabel
+          value="start"
+          control={<Checkbox color="primary" />}
+          label="Start"
+          labelPlacement="start"
+        />
+        <FormControlLabel
+          value="bottom"
+          control={<Checkbox color="primary" />}
+          label="Bottom"
+          labelPlacement="bottom"
+        />
+        <FormControlLabel
+          value="end"
+          control={<Checkbox color="primary" />}
+          label="End"
+          labelPlacement="end"
+        />
+      </FormGroup>
+    </FormControl>
+  );
+}
+
+export default FormControlLabelPosition;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Typescript demo for components/checkboxes: FormControlLabelPosition

mui-org/material-ui#14897

Note: I removed the state management part
1. FormGroup API does not accept `name` and `value` props.
1. The state is not relevant for the point of the demo (which is positioning the label), potentially confusing IMO.

