### PR TITLE
[test] Only build component packages for codesandbox 

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -3,18 +3,12 @@
   "packages": [
     "packages/material-ui",
     "packages/material-ui-icons",
-    "packages/material-ui-lab",
-    "packages/material-ui-styles",
-    "packages/material-ui-system",
-    "packages/material-ui-utils"
+    "packages/material-ui-lab"
   ],
   "publishDirectory": {
     "@material-ui/core": "packages/material-ui/build",
     "@material-ui/icons": "packages/material-ui-icons/build",
-    "@material-ui/lab": "packages/material-ui-lab/build",
-    "@material-ui/styles": "packages/material-ui-styles/build",
-    "@material-ui/system": "packages/material-ui-system/build",
-    "@material-ui/utils": "packages/material-ui-utils/build"
+    "@material-ui/lab": "packages/material-ui-lab/build"
   },
   "sandboxes": [
     "new",

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -17,7 +17,7 @@
     "@material-ui/utils": "packages/material-ui-utils/build"
   },
   "sandboxes": [
-    "react",
+    "new",
     "github/mui-org/material-ui/tree/master/examples/create-react-app",
     "github/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript"
   ],


### PR DESCRIPTION
Without `resolutions` building `styles` would be pointless `/core` would still list the latest stable as its dependency.