### PR TITLE
[SwipeableDrawer] Only trigger a swipe when appropriate

### DIFF
--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -37,7 +37,7 @@ function getTranslate(currentTranslate, startLocation, open, maxTranslate) {
 }
 
 function getDomTreeShapes(element, rootNode) {
-  // adapted from https://github.com/oliviertassinari/react-swipeable-views/blob/7666de1dba253b896911adf2790ce51467670856/packages/react-swipeable-views/src/SwipeableViews.js#L129
+  // Adapted from https://github.com/oliviertassinari/react-swipeable-views/blob/7666de1dba253b896911adf2790ce51467670856/packages/react-swipeable-views/src/SwipeableViews.js#L129
   let domTreeShapes = [];
 
   while (element && element !== rootNode) {
@@ -56,15 +56,7 @@ function getDomTreeShapes(element, rootNode) {
     ) {
       // Ignore the nodes that have no width.
       // Keep elements with a scroll
-      domTreeShapes.push({
-        element,
-        scrollWidth: element.scrollWidth,
-        scrollHeight: element.scrollHeight,
-        clientWidth: element.clientWidth,
-        clientHeight: element.clientHeight,
-        scrollLeft: element.scrollLeft,
-        scrollTop: element.scrollTop,
-      });
+      domTreeShapes.push(element);
     }
 
     element = element.parentNode;
@@ -74,8 +66,7 @@ function getDomTreeShapes(element, rootNode) {
 }
 
 function findNativeHandler({ domTreeShapes, start, current, anchor }) {
-  // adapted from https://github.com/oliviertassinari/react-swipeable-views/blob/7666de1dba253b896911adf2790ce51467670856/packages/react-swipeable-views/src/SwipeableViews.js#L175
-
+  // Adapted from https://github.com/oliviertassinari/react-swipeable-views/blob/7666de1dba253b896911adf2790ce51467670856/packages/react-swipeable-views/src/SwipeableViews.js#L175
   const axisProperties = {
     scrollPosition: {
       x: 'scrollLeft',

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.js
@@ -313,6 +313,15 @@ const SwipeableDrawer = React.forwardRef(function SwipeableDrawer(props, ref) {
       return;
     }
 
+    // At least one element clogs the drawer interaction zone.
+    if (
+      open &&
+      !backdropRef.current.contains(event.target) &&
+      !paperRef.current.contains(event.target)
+    ) {
+      return;
+    }
+
     const anchorRtl = getAnchor(theme, anchor);
     const horizontalSwipe = isHorizontal(anchor);
 

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -6,18 +6,26 @@ import describeConformance from '@material-ui/core/test-utils/describeConformanc
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import Drawer from '../Drawer';
-import SwipeableDrawer from './SwipeableDrawer';
+import SwipeableDrawer, { reset } from './SwipeableDrawer';
 import SwipeArea from './SwipeArea';
 import useForkRef from '../utils/useForkRef';
 
-function fireBodyMouseEvent(name, properties = {}) {
+function fireMouseEvent(name, element, properties = {}) {
   const event = document.createEvent('MouseEvents');
   event.initEvent(name, true, true);
   Object.keys(properties).forEach(key => {
     event[key] = properties[key];
   });
-  document.body.dispatchEvent(event);
+  if (element.dispatchEvent) {
+    element.dispatchEvent(event);
+  } else {
+    element.getDOMNode().dispatchEvent(event);
+  }
   return event;
+}
+
+function fireBodyMouseEvent(name, properties = {}) {
+  return fireMouseEvent(name, document.body, properties);
 }
 
 function fireSwipeAreaMouseEvent(wrapper, name, properties = {}) {
@@ -79,7 +87,7 @@ const NullPaper = React.forwardRef(function NullPaper(props, ref) {
   return <div tabIndex={-1} ref={ref} />;
 });
 
-describe('<SwipeableDrawer />', () => {
+describe.only('<SwipeableDrawer />', () => {
   let mount;
 
   before(() => {
@@ -147,6 +155,7 @@ describe('<SwipeableDrawer />', () => {
     });
 
     afterEach(() => {
+      reset();
       if (wrapper.length > 0) {
         wrapper.unmount();
       }
@@ -236,7 +245,9 @@ describe('<SwipeableDrawer />', () => {
 
           const handleClose = spy();
           wrapper.setProps({ open: true, onClose: handleClose });
-          fireSwipeAreaMouseEvent(wrapper, 'touchstart', { touches: [params.closeTouches[0]] });
+          fireMouseEvent('touchstart', wrapper.find(FakePaper), {
+            touches: [params.closeTouches[0]],
+          });
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[2]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[2]] });
@@ -257,7 +268,9 @@ describe('<SwipeableDrawer />', () => {
           // simulate close swipe that doesn't swipe far enough
           const handleClose = spy();
           wrapper.setProps({ open: true, onClose: handleClose });
-          fireSwipeAreaMouseEvent(wrapper, 'touchstart', { touches: [params.closeTouches[0]] });
+          fireMouseEvent('touchstart', wrapper.find(FakePaper), {
+            touches: [params.closeTouches[0]],
+          });
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[1]] });
           assert.strictEqual(handleClose.callCount, 0);
@@ -338,7 +351,9 @@ describe('<SwipeableDrawer />', () => {
         open: true,
         onClose: handleClose,
       });
-      fireSwipeAreaMouseEvent(wrapper, 'touchstart', { touches: [{ pageX: 250, clientY: 0 }] });
+      fireMouseEvent('touchstart', wrapper.find(FakePaper), {
+        touches: [{ pageX: 250, clientY: 0 }],
+      });
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 180, clientY: 0 }] });
       wrapper.setProps({
         open: false,
@@ -410,7 +425,9 @@ describe('<SwipeableDrawer />', () => {
       // simulate close swipe
       wrapper.setProps({ disableSwipeToOpen: true });
       assert.strictEqual(wrapper.find('[role="presentation"]').exists(), true);
-      fireBodyMouseEvent('touchstart', { touches: [{ pageX: 250, clientY: 0 }] });
+      fireMouseEvent('touchstart', wrapper.find(FakePaper), {
+        touches: [{ pageX: 250, clientY: 0 }],
+      });
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 150, clientY: 0 }] });
       fireBodyMouseEvent('touchend', { changedTouches: [{ pageX: 10, clientY: 0 }] });
       assert.strictEqual(handleClose.callCount, 1);

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -87,7 +87,7 @@ const NullPaper = React.forwardRef(function NullPaper(props, ref) {
   return <div tabIndex={-1} ref={ref} />;
 });
 
-describe.only('<SwipeableDrawer />', () => {
+describe('<SwipeableDrawer />', () => {
   let mount;
 
   before(() => {
@@ -268,6 +268,7 @@ describe.only('<SwipeableDrawer />', () => {
           // simulate close swipe that doesn't swipe far enough
           const handleClose = spy();
           wrapper.setProps({ open: true, onClose: handleClose });
+          wrapper.update();
           fireMouseEvent('touchstart', wrapper.find(FakePaper), {
             touches: [params.closeTouches[0]],
           });
@@ -351,6 +352,7 @@ describe.only('<SwipeableDrawer />', () => {
         open: true,
         onClose: handleClose,
       });
+      wrapper.update();
       fireMouseEvent('touchstart', wrapper.find(FakePaper), {
         touches: [{ pageX: 250, clientY: 0 }],
       });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #17408, using @oliviertassinari's [proposed solution](https://github.com/mui-org/material-ui/issues/17408#issuecomment-544137327).

Also, this fixes #16942, using the approach suggested [here](https://github.com/mui-org/material-ui/issues/16942#issuecomment-519871941), taken from react-swipeable-views and simplified/adapted for the swipeable drawer.

I changed the temporary swipeable drawer demo to show [the reproduction content](https://github.com/mui-org/material-ui/issues/16565#issuecomment-542105521) on all sides, here's a video (Github doesn't let me upload webm files and the gif was way too big): [demo.webm.zip](https://github.com/mui-org/material-ui/files/3758335/demo.webm.zip)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
