### PR TITLE
[test] Run tests periodically with `react@next`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ defaults: &defaults
       type: string
       default: stable
   environment:
+    # expose it globally otherwise we have to thread it from each job to the install command
     REACT_DIST_TAG: << parameters.react-dist-tag >>
   working_directory: /tmp/material-ui
   docker:
@@ -22,15 +23,10 @@ defaults: &defaults
 
 commands:
   install_js:
-    parameters:
-      react-dist-tag:
-        description: The dist-tag of react to be used
-        type: string
-        default: stable
     steps:
       - run:
           name: Resolve react version
-          command: node scripts/use-react-dist-tag $REACT_DIST_TAG
+          command: node scripts/use-react-dist-tag
       - restore_cache:
           keys:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,11 @@
 version: 2.1
 
 defaults: &defaults
+  parameters:
+    react-dist-tag:
+      description: The dist-tag of react to be used
+      type: string
+      default: stable
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:8.15
@@ -17,13 +22,13 @@ commands:
   install_js:
     parameters:
       react-dist-tag:
-        description: 'The dist-tag of react to be used'
+        description: The dist-tag of react to be used
         type: string
-        default: 'stable'
+        default: stable
     steps:
       - run:
-        name: Resolve react version
-        command: node scripts/use-react-dist-tag << parameters.react-dist-tag >>
+          name: Resolve react version
+          command: node scripts/use-react-dist-tag << parameters.react-dist-tag >>
       - restore_cache:
           keys:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}
@@ -187,7 +192,8 @@ workflows:
             - test_types
             - test_browser
   react-next:
-    - test_unit:
-      react-version: next
-    - test_browser:
-      react-version: next
+    jobs:
+      - test_unit:
+          react-dist-tag: next
+      - test_browser:
+          react-dist-tag: next

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,6 +193,13 @@ workflows:
             - test_types
             - test_browser
   react-next:
+    triggers:
+      - schedule:
+          cron: '0 0 * * *'
+          filters:
+            branches:
+              only:
+                - master
     jobs:
       - test_unit:
           react-dist-tag: next

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,10 @@ commands:
     steps:
       - run:
           name: Resolve react version
-          command: node scripts/use-react-dist-tag
+          command: |
+            node scripts/use-react-dist-tag
+            # log a patch for maintainers who want to check out this change
+            git diff --patch
       - restore_cache:
           keys:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}
@@ -194,4 +197,9 @@ workflows:
       - test_unit:
           react-dist-tag: next
       - test_browser:
+          react-dist-tag: next
+      - test_regressions:
+          requires:
+            - test_unit
+            - test_browser
           react-dist-tag: next

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,8 @@ defaults: &defaults
       description: The dist-tag of react to be used
       type: string
       default: stable
+  environment:
+    REACT_DIST_TAG: << parameters.react-dist-tag >>
   working_directory: /tmp/material-ui
   docker:
     - image: circleci/node:8.15
@@ -28,7 +30,7 @@ commands:
     steps:
       - run:
           name: Resolve react version
-          command: node scripts/use-react-dist-tag << parameters.react-dist-tag >>
+          command: node scripts/use-react-dist-tag $REACT_DIST_TAG
       - restore_cache:
           keys:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,15 @@ defaults: &defaults
 
 commands:
   install_js:
+    parameters:
+      react-dist-tag:
+        description: 'The dist-tag of react to be used'
+        type: string
+        default: 'stable'
     steps:
+      - run:
+        name: Resolve react version
+        command: node scripts/use-react-dist-tag << parameters.react-dist-tag >>
       - restore_cache:
           keys:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}
@@ -157,7 +165,7 @@ workflows:
       - checkout:
           filters:
             branches:
-              ignore: 
+              ignore:
                 - l10n
                 - /dependabot\//
       - test_unit:
@@ -178,3 +186,8 @@ workflows:
             - test_static
             - test_types
             - test_browser
+  react-next:
+    - test_unit:
+      react-version: next
+    - test_browser:
+      react-version: next

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ commands:
           command: |
             node scripts/use-react-dist-tag
             # log a patch for maintainers who want to check out this change
-            git diff --patch
+            git diff HEAD
       - restore_cache:
           keys:
             - v2-yarn-sha-{{ checksum "yarn.lock" }}

--- a/scripts/use-react-dist-tag.js
+++ b/scripts/use-react-dist-tag.js
@@ -1,5 +1,12 @@
 /* eslint-disable no-console */
-// WARNING: This script can only use built-in modules
+/**
+ * Given an environment variable called `REACT_DIST_TAG` fetch the corresponding
+ * version and make sure this version is used throughout the repository.
+ *
+ * If you work on this file:
+ * WARNING: This script can only use built-in modules since it has to run before
+ * `yarn install`
+ */
 const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -38,8 +45,6 @@ async function main(distTag) {
   });
 
   fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
-
-  console.log(`Applied version '${version}' via 'resolutions' field`);
 }
 
 main(process.env.REACT_DIST_TAG).catch(error => {

--- a/scripts/use-react-dist-tag.js
+++ b/scripts/use-react-dist-tag.js
@@ -1,2 +1,48 @@
-console.log('arg:' + process.argv);
-console.log('env:' + process.env.REACT_DIST_TAG)
+/* eslint-disable no-console */
+// WARNING: This script can only use built-in modules
+const childProcess = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+
+const exec = promisify(childProcess.exec);
+
+// packages published from the react monorepo using the same version
+const reactPackageNames = ['react', 'react-dom', 'react-is', 'react-test-renderer', 'scheduler'];
+
+async function main(distTag) {
+  if (typeof distTag !== 'string') {
+    throw new TypeError(`expected distTag: string but got '${distTag}'`);
+  }
+
+  if (distTag === 'stable') {
+    console.log('nothing to do with stable');
+    return;
+  }
+
+  const { stdout: versions } = await exec(`npm dist-tag ls react ${distTag}`);
+  const tagMapping = versions.split('\n').find(mapping => {
+    return mapping.startsWith(`${distTag}: `);
+  });
+  if (tagMapping === undefined) {
+    throw new Error(`Could not find '${distTag}' in "${versions}"`);
+  }
+
+  const version = tagMapping.replace(`${distTag}: `, '');
+
+  const packageJsonPath = path.resolve(__dirname, '../package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+
+  reactPackageNames.forEach(reactPackageName => {
+    packageJson.resolutions[reactPackageName] = version;
+  });
+
+  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+
+  console.log(`Applied version '${version}' via 'resolutions' field`);
+}
+
+main(process.env.REACT_DIST_TAG).catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/use-react-dist-tag.js
+++ b/scripts/use-react-dist-tag.js
@@ -1,1 +1,2 @@
-console.log(process.argc);
+console.log('arg:' + process.argv);
+console.log('env:' + process.env.REACT_DIST_TAG)

--- a/scripts/use-react-dist-tag.js
+++ b/scripts/use-react-dist-tag.js
@@ -1,0 +1,1 @@
+console.log(process.argc);

--- a/scripts/use-react-dist-tag.js
+++ b/scripts/use-react-dist-tag.js
@@ -9,6 +9,7 @@
  */
 const childProcess = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { promisify } = require('util');
 
@@ -44,7 +45,8 @@ async function main(distTag) {
     packageJson.resolutions[reactPackageName] = version;
   });
 
-  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  // CircleCI seemingly times out if it has a newline diff at the end
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}${os.EOL}`);
 }
 
 main(process.env.REACT_DIST_TAG).catch(error => {


### PR DESCRIPTION
Runs `test_unit`, `test_browser` and `test_regression` once a day with reacts `next` release channel.

More info in https://reactjs.org/blog/2019/10/22/react-release-channels.html

Why we can't just `yarn install react@next`:

1. In a monorepo it isn't trivial (with yarn v1) to bump a version
2. enzyme's adapter has a dependency on `react-test-renderer` (which has a dependency on `scheduler`) and I'd rather not find out what happens if different versions are used.


Bonus:
This also allows running the pipeline with other release channels like `experimental`. This might be more interesting once CircleCI allows builds using their 2.1 config via API.

@oliviertassinari Could you change the required status checks accordingly?

```diff
-test_unit
+test_unit-1
-test_browser
+test_browser-1
-test_regression
+test_regression-1
```