### PR TITLE
16995/add additional border color support2

### DIFF
--- a/docs/src/pages/system/borders/BorderColor.js
+++ b/docs/src/pages/system/borders/BorderColor.js
@@ -11,18 +11,13 @@ const defaultProps = {
 export default function BorderColor() {
   return (
     <Box display="flex" justifyContent="center">
-      <Box borderColor="primary.main" {...defaultProps} />
-      <Box borderColor="secondary.main" {...defaultProps} />
-      <Box borderColor="error.main" {...defaultProps} />
-      <Box borderColor="grey.500" {...defaultProps} />
-      <Box borderColor="text.primary" {...defaultProps} />
-      <Box
-        borderTopColor="primary.main"
-        borderRightColor="secondary.main"
-        borderBottomColor="error.main"
-        borderLeftColor="grey.500"
-        {...defaultProps}
-      />
+      <Box {...defaultProps} borderColor="primary.main" />
+      <Box {...defaultProps} borderColor="secondary.main" />
+      <Box {...defaultProps} borderColor="error.main" />
+      <Box {...defaultProps} borderColor="grey.500" />
+      <Box {...defaultProps} borderColor="text.primary" />
+      <Box {...defaultProps} border="2 dotted secondary.main" />
+      <Box {...defaultProps} border="2 solid secondary.main" borderRight="2 dotted primary.main" />
     </Box>
   );
 }

--- a/docs/src/pages/system/borders/BorderColor.js
+++ b/docs/src/pages/system/borders/BorderColor.js
@@ -16,6 +16,13 @@ export default function BorderColor() {
       <Box borderColor="error.main" {...defaultProps} />
       <Box borderColor="grey.500" {...defaultProps} />
       <Box borderColor="text.primary" {...defaultProps} />
+      <Box
+        borderTopColor="primary.main"
+        borderRightColor="secondary.main"
+        borderBottomColor="error.main"
+        borderLeftColor="grey.500"
+        {...defaultProps}
+      />
     </Box>
   );
 }

--- a/docs/src/pages/system/borders/BorderColor.tsx
+++ b/docs/src/pages/system/borders/BorderColor.tsx
@@ -11,18 +11,13 @@ const defaultProps = {
 export default function BorderColor() {
   return (
     <Box display="flex" justifyContent="center">
-      <Box borderColor="primary.main" {...defaultProps} />
-      <Box borderColor="secondary.main" {...defaultProps} />
-      <Box borderColor="error.main" {...defaultProps} />
-      <Box borderColor="grey.500" {...defaultProps} />
-      <Box borderColor="text.primary" {...defaultProps} />
-      <Box
-        borderTopColor="primary.main"
-        borderRightColor="secondary.main"
-        borderBottomColor="error.main"
-        borderLeftColor="grey.500"
-        {...defaultProps}
-      />
+      <Box {...defaultProps} borderColor="primary.main" />
+      <Box {...defaultProps} borderColor="secondary.main" />
+      <Box {...defaultProps} borderColor="error.main" />
+      <Box {...defaultProps} borderColor="grey.500" />
+      <Box {...defaultProps} borderColor="text.primary" />
+      <Box {...defaultProps} border="2 dotted secondary.main" />
+      <Box {...defaultProps} border="2 solid secondary.main" borderRight="2 dotted primary.main" />
     </Box>
   );
 }

--- a/docs/src/pages/system/borders/BorderColor.tsx
+++ b/docs/src/pages/system/borders/BorderColor.tsx
@@ -16,6 +16,13 @@ export default function BorderColor() {
       <Box borderColor="error.main" {...defaultProps} />
       <Box borderColor="grey.500" {...defaultProps} />
       <Box borderColor="text.primary" {...defaultProps} />
+      <Box
+        borderTopColor="primary.main"
+        borderRightColor="secondary.main"
+        borderBottomColor="error.main"
+        borderLeftColor="grey.500"
+        {...defaultProps}
+      />
     </Box>
   );
 }

--- a/docs/src/pages/system/borders/borders.md
+++ b/docs/src/pages/system/borders/borders.md
@@ -41,11 +41,8 @@ Use border utilities to add or remove an element’s borders. Choose from all bo
 <Box borderColor="grey.500">…
 <Box borderColor="text.primary">…
 <Box borderColor="text.primary">…
-<Box borderTopColor="primary.main" 
-  borderRightColor="secondary.main" 
-  borderBottomColor="error.main"
-  borderLeftColor="grey.500"
-/>
+<Box border="2 dotted secondary.main" />
+<Box border="2 solid secondary.main" borderRight="2 dotted primary.main" />
 ```
 
 ## Border-radius
@@ -69,11 +66,7 @@ import { borders } from '@material-ui/system';
 | `border` | `border` | `border` | `borders` |
 | `borderColor` | `borderColor` | `border-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
 | `borderTop` | `borderTop` | `border-top` | `borders` |
-| `borderTopColor` | `borderTopColor` | `border-top-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
 | `borderRight` | `borderRight` | `border-right` | `borders` |
-| `borderRightColor` | `borderRightColor` | `border-right-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
 | `borderBottom` | `borderBottom` | `border-bottom` | `borders` |
-| `borderBottomColor` | `borderBottomColor` | `border-bottom-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
 | `borderLeft` | `borderLeft` | `border-left` | `borders` |
-| `borderLeftColor` | `borderLeftColor` | `border-left-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
 | `borderRadius` | `borderRadius` | `border-radius` | [`shape`](/customization/default-theme/?expend-path=$.shape) |

--- a/docs/src/pages/system/borders/borders.md
+++ b/docs/src/pages/system/borders/borders.md
@@ -40,6 +40,12 @@ Use border utilities to add or remove an element’s borders. Choose from all bo
 <Box borderColor="error.main">…
 <Box borderColor="grey.500">…
 <Box borderColor="text.primary">…
+<Box borderColor="text.primary">…
+<Box borderTopColor="primary.main" 
+  borderRightColor="secondary.main" 
+  borderBottomColor="error.main"
+  borderLeftColor="grey.500"
+/>
 ```
 
 ## Border-radius
@@ -61,9 +67,13 @@ import { borders } from '@material-ui/system';
 | Import name | Prop | CSS property | Theme key |
 |:------------|:-----|:-------------|:----------|
 | `border` | `border` | `border` | `borders` |
-| `borderTop` | `borderTop` | `border-top` | `borders` |
-| `borderLeft` | `borderLeft` | `border-left` | `borders` |
-| `borderRight` | `borderRight` | `border-right` | `borders` |
-| `borderBottom` | `borderBottom` | `border-bottom` | `borders` |
 | `borderColor` | `borderColor` | `border-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
+| `borderTop` | `borderTop` | `border-top` | `borders` |
+| `borderTopColor` | `borderTopColor` | `border-top-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
+| `borderRight` | `borderRight` | `border-right` | `borders` |
+| `borderRightColor` | `borderRightColor` | `border-right-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
+| `borderBottom` | `borderBottom` | `border-bottom` | `borders` |
+| `borderBottomColor` | `borderBottomColor` | `border-bottom-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
+| `borderLeft` | `borderLeft` | `border-left` | `borders` |
+| `borderLeftColor` | `borderLeftColor` | `border-left-color` | [`palette`](/customization/default-theme/?expend-path=$.palette) |
 | `borderRadius` | `borderRadius` | `border-radius` | [`shape`](/customization/default-theme/?expend-path=$.shape) |

--- a/packages/material-ui-system/src/borders.js
+++ b/packages/material-ui-system/src/borders.js
@@ -44,6 +44,26 @@ export const borderColor = style({
   themeKey: 'palette',
 });
 
+export const borderTopColor = style({
+  prop: 'borderTopColor',
+  themeKey: 'palette',
+});
+
+export const borderRightColor = style({
+  prop: 'borderRightColor',
+  themeKey: 'palette',
+});
+
+export const borderBottomColor = style({
+  prop: 'borderBottomColor',
+  themeKey: 'palette',
+});
+
+export const borderLeftColor = style({
+  prop: 'borderLeftColor',
+  themeKey: 'palette',
+});
+
 export const borderRadius = style({
   prop: 'borderRadius',
   themeKey: 'shape',
@@ -56,6 +76,10 @@ const borders = compose(
   borderBottom,
   borderLeft,
   borderColor,
+  borderTopColor,
+  borderRightColor,
+  borderBottomColor,
+  borderLeftColor,
   borderRadius,
 );
 

--- a/packages/material-ui-system/src/borders.js
+++ b/packages/material-ui-system/src/borders.js
@@ -1,7 +1,7 @@
 import style from './style';
 import compose from './compose';
 
-function getBorder({ value, theme, getPath }) {
+function getBorder(value, { theme, getPath }) {
   if (typeof value === 'number') {
     return `${value}px solid`;
   }
@@ -20,32 +20,27 @@ function getBorder({ value, theme, getPath }) {
 
 export const border = style({
   prop: 'border',
-  themeKey: 'borders',
-  unstableTransform: getBorder,
+  transform: getBorder,
 });
 
 export const borderTop = style({
   prop: 'borderTop',
-  themeKey: 'borders',
-  unstableTransform: getBorder,
+  transform: getBorder,
 });
 
 export const borderRight = style({
   prop: 'borderRight',
-  themeKey: 'borders',
-  unstableTransform: getBorder,
+  transform: getBorder,
 });
 
 export const borderBottom = style({
   prop: 'borderBottom',
-  themeKey: 'borders',
-  unstableTransform: getBorder,
+  transform: getBorder,
 });
 
 export const borderLeft = style({
   prop: 'borderLeft',
-  themeKey: 'borders',
-  unstableTransform: getBorder,
+  transform: getBorder,
 });
 
 export const borderColor = style({

--- a/packages/material-ui-system/src/borders.js
+++ b/packages/material-ui-system/src/borders.js
@@ -1,66 +1,55 @@
 import style from './style';
 import compose from './compose';
 
-function getBorder(value) {
-  if (typeof value !== 'number') {
-    return value;
+function getBorder({ value, theme, getPath }) {
+  if (typeof value === 'number') {
+    return `${value}px solid`;
   }
-
-  return `${value}px solid`;
+  const [width, stroke = 'solid', themeColor] = value.split(' ');
+  let widthNum = parseInt(width, 10);
+  if (isNaN(widthNum)) {
+    widthNum = getPath(theme, `borders.${width}`);
+  }
+  let borderColor;
+  if (themeColor) {
+    borderColor = getPath(theme, `palette.${themeColor}`);
+    return [`${widthNum}px ${stroke}`, borderColor].join(' ');
+  }
+  return [`${widthNum}px ${stroke}`].join(' ');
 }
 
 export const border = style({
   prop: 'border',
   themeKey: 'borders',
-  transform: getBorder,
+  unstableTransform: getBorder,
 });
 
 export const borderTop = style({
   prop: 'borderTop',
   themeKey: 'borders',
-  transform: getBorder,
+  unstableTransform: getBorder,
 });
 
 export const borderRight = style({
   prop: 'borderRight',
   themeKey: 'borders',
-  transform: getBorder,
+  unstableTransform: getBorder,
 });
 
 export const borderBottom = style({
   prop: 'borderBottom',
   themeKey: 'borders',
-  transform: getBorder,
+  unstableTransform: getBorder,
 });
 
 export const borderLeft = style({
   prop: 'borderLeft',
   themeKey: 'borders',
-  transform: getBorder,
+  unstableTransform: getBorder,
 });
 
 export const borderColor = style({
   prop: 'borderColor',
-  themeKey: 'palette',
-});
-
-export const borderTopColor = style({
-  prop: 'borderTopColor',
-  themeKey: 'palette',
-});
-
-export const borderRightColor = style({
-  prop: 'borderRightColor',
-  themeKey: 'palette',
-});
-
-export const borderBottomColor = style({
-  prop: 'borderBottomColor',
-  themeKey: 'palette',
-});
-
-export const borderLeftColor = style({
-  prop: 'borderLeftColor',
   themeKey: 'palette',
 });
 
@@ -76,10 +65,6 @@ const borders = compose(
   borderBottom,
   borderLeft,
   borderColor,
-  borderTopColor,
-  borderRightColor,
-  borderBottomColor,
-  borderLeftColor,
   borderRadius,
 );
 

--- a/packages/material-ui-system/src/borders.test.js
+++ b/packages/material-ui-system/src/borders.test.js
@@ -2,21 +2,37 @@ import { assert } from 'chai';
 import borders from './borders';
 
 describe('borders', () => {
-  it('should be able to customize the border size and style', () => {
+  it('should be able to specify size', () => {
     const borderProps = borders({
       theme: {},
       border: 1,
-      borderTop: 2,
-      borderRight: 3,
-      borderBottom: 4,
-      borderLeft: 5,
     });
     assert.deepEqual(borderProps, {
       border: '1px solid',
-      borderTop: '2px solid',
-      borderRight: '3px solid',
-      borderBottom: '4px solid',
-      borderLeft: '5px solid',
+    });
+  });
+
+  it('should be able to specify size from the theme', () => {
+    const borderProps = borders({
+      theme: {
+        borders: {
+          small: 2,
+        },
+      },
+      border: 'small',
+    });
+    assert.deepEqual(borderProps, {
+      border: '2px solid',
+    });
+  });
+
+  it('should be able to customize the border style', () => {
+    const borderProps = borders({
+      theme: {},
+      border: '1 dotted',
+    });
+    assert.deepEqual(borderProps, {
+      border: '1px dotted',
     });
   });
 
@@ -24,27 +40,13 @@ describe('borders', () => {
     const borderProps = borders({
       theme: {
         palette: {
-          testColor: {
-            myBorderColor: 'myBorderColor',
-            mBorderTopColor: 'mBorderTopColor',
-            myBorderRightColor: 'myBorderRightColor',
-            myBorderBottomColor: 'myBorderBottomColor',
-            myBorderLeftColor: 'myBorderLeftColor',
-          },
+          testColor: 'green',
         },
       },
-      borderColor: 'testColor.myBorderColor',
-      borderTopColor: 'testColor.mBorderTopColor',
-      borderRightColor: 'testColor.myBorderRightColor',
-      borderBottomColor: 'testColor.myBorderBottomColor',
-      borderLeftColor: 'testColor.myBorderLeftColor',
+      border: '1 solid testColor',
     });
     assert.deepEqual(borderProps, {
-      borderColor: 'myBorderColor',
-      borderTopColor: 'mBorderTopColor',
-      borderRightColor: 'myBorderRightColor',
-      borderBottomColor: 'myBorderBottomColor',
-      borderLeftColor: 'myBorderLeftColor',
+      border: '1px solid green',
     });
   });
 });

--- a/packages/material-ui-system/src/borders.test.js
+++ b/packages/material-ui-system/src/borders.test.js
@@ -1,0 +1,50 @@
+import { assert } from 'chai';
+import borders from './borders';
+
+describe('borders', () => {
+  it('should be able to customize the border size and style', () => {
+    const borderProps = borders({
+      theme: {},
+      border: 1,
+      borderTop: 2,
+      borderRight: 3,
+      borderBottom: 4,
+      borderLeft: 5,
+    });
+    assert.deepEqual(borderProps, {
+      border: '1px solid',
+      borderTop: '2px solid',
+      borderRight: '3px solid',
+      borderBottom: '4px solid',
+      borderLeft: '5px solid',
+    });
+  });
+
+  it('should be able to customize the border color', () => {
+    const borderProps = borders({
+      theme: {
+        palette: {
+          testColor: {
+            myBorderColor: 'myBorderColor',
+            mBorderTopColor: 'mBorderTopColor',
+            myBorderRightColor: 'myBorderRightColor',
+            myBorderBottomColor: 'myBorderBottomColor',
+            myBorderLeftColor: 'myBorderLeftColor',
+          },
+        },
+      },
+      borderColor: 'testColor.myBorderColor',
+      borderTopColor: 'testColor.mBorderTopColor',
+      borderRightColor: 'testColor.myBorderRightColor',
+      borderBottomColor: 'testColor.myBorderBottomColor',
+      borderLeftColor: 'testColor.myBorderLeftColor',
+    });
+    assert.deepEqual(borderProps, {
+      borderColor: 'myBorderColor',
+      borderTopColor: 'mBorderTopColor',
+      borderRightColor: 'myBorderRightColor',
+      borderBottomColor: 'myBorderBottomColor',
+      borderLeftColor: 'myBorderLeftColor',
+    });
+  });
+});

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -12,17 +12,25 @@ type SimpleStyleFunction<PropKey extends keyof any> = StyleFunction<Partial<Reco
 // borders.js
 export const border: SimpleStyleFunction<'border'>;
 export const borderTop: SimpleStyleFunction<'borderTop'>;
+export const borderTopColor: SimpleStyleFunction<'borderTopColor'>;
 export const borderRight: SimpleStyleFunction<'borderRight'>;
+export const borderRightColor: SimpleStyleFunction<'borderRightColor'>;
 export const borderBottom: SimpleStyleFunction<'borderBottom'>;
+export const borderBottomColor: SimpleStyleFunction<'borderBottomColor'>;
 export const borderLeft: SimpleStyleFunction<'borderLeft'>;
+export const borderLeftColor: SimpleStyleFunction<'borderLeftColor'>;
 export const borderColor: SimpleStyleFunction<'borderColor'>;
 export const borderRadius: SimpleStyleFunction<'borderRadius'>;
 export const borders: SimpleStyleFunction<
   | 'border'
   | 'borderTop'
+  | 'borderTopColor'
   | 'borderRight'
+  | 'borderRightColor'
   | 'borderBottom'
+  | 'borderBottomColor'
   | 'borderLeft'
+  | 'borderLeftColor'
   | 'borderColor'
   | 'borderRadius'
 >;

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -12,25 +12,17 @@ type SimpleStyleFunction<PropKey extends keyof any> = StyleFunction<Partial<Reco
 // borders.js
 export const border: SimpleStyleFunction<'border'>;
 export const borderTop: SimpleStyleFunction<'borderTop'>;
-export const borderTopColor: SimpleStyleFunction<'borderTopColor'>;
 export const borderRight: SimpleStyleFunction<'borderRight'>;
-export const borderRightColor: SimpleStyleFunction<'borderRightColor'>;
 export const borderBottom: SimpleStyleFunction<'borderBottom'>;
-export const borderBottomColor: SimpleStyleFunction<'borderBottomColor'>;
 export const borderLeft: SimpleStyleFunction<'borderLeft'>;
-export const borderLeftColor: SimpleStyleFunction<'borderLeftColor'>;
 export const borderColor: SimpleStyleFunction<'borderColor'>;
 export const borderRadius: SimpleStyleFunction<'borderRadius'>;
 export const borders: SimpleStyleFunction<
   | 'border'
   | 'borderTop'
-  | 'borderTopColor'
   | 'borderRight'
-  | 'borderRightColor'
   | 'borderBottom'
-  | 'borderBottomColor'
   | 'borderLeft'
-  | 'borderLeftColor'
   | 'borderColor'
   | 'borderRadius'
 >;

--- a/packages/material-ui-system/src/style.js
+++ b/packages/material-ui-system/src/style.js
@@ -10,7 +10,7 @@ function getPath(obj, path) {
 }
 
 function style(options) {
-  const { prop, cssProperty = options.prop, themeKey, transform } = options;
+  const { prop, cssProperty = options.prop, themeKey, transform, unstableTransform } = options;
 
   const fn = props => {
     if (props[prop] == null) {
@@ -23,7 +23,9 @@ function style(options) {
     const styleFromPropValue = propValueFinal => {
       let value;
 
-      if (typeof themeMapping === 'function') {
+      if (unstableTransform) {
+        value = unstableTransform({ value: propValueFinal, theme, getPath });
+      } else if (typeof themeMapping === 'function') {
         value = themeMapping(propValueFinal);
       } else if (Array.isArray(themeMapping)) {
         value = themeMapping[propValueFinal] || propValueFinal;

--- a/packages/material-ui-system/src/style.js
+++ b/packages/material-ui-system/src/style.js
@@ -10,7 +10,7 @@ function getPath(obj, path) {
 }
 
 function style(options) {
-  const { prop, cssProperty = options.prop, themeKey, transform, unstableTransform } = options;
+  const { prop, cssProperty = options.prop, themeKey, transform } = options;
 
   const fn = props => {
     if (props[prop] == null) {
@@ -23,9 +23,7 @@ function style(options) {
     const styleFromPropValue = propValueFinal => {
       let value;
 
-      if (unstableTransform) {
-        value = unstableTransform({ value: propValueFinal, theme, getPath });
-      } else if (typeof themeMapping === 'function') {
+      if (typeof themeMapping === 'function') {
         value = themeMapping(propValueFinal);
       } else if (Array.isArray(themeMapping)) {
         value = themeMapping[propValueFinal] || propValueFinal;
@@ -33,7 +31,7 @@ function style(options) {
         value = getPath(themeMapping, propValueFinal) || propValueFinal;
 
         if (transform) {
-          value = transform(value);
+          value = transform(value, { theme, getPath });
         }
       }
 

--- a/packages/material-ui-system/src/style.test.js
+++ b/packages/material-ui-system/src/style.test.js
@@ -134,7 +134,7 @@ describe('style', () => {
 
   const unstableBorder = style({
     prop: 'border',
-    unstableTransform: ({ value, theme, getPath }) => {
+    transform: (value, { theme, getPath }) => {
       const [width, borderStyle, color] = value.split(' ');
       return `${width}px ${borderStyle} ${getPath(theme, `palette.${color}`)}`;
     },

--- a/packages/material-ui-system/src/style.test.js
+++ b/packages/material-ui-system/src/style.test.js
@@ -132,7 +132,7 @@ describe('style', () => {
     });
   });
 
-  const unstableBorder = style({
+  const borderWithColor = style({
     prop: 'border',
     transform: (value, { theme, getPath }) => {
       const [width, borderStyle, color] = value.split(' ');
@@ -140,8 +140,8 @@ describe('style', () => {
     },
   });
 
-  it('should support unstableTransforms of the prop correctly', () => {
-    const output1 = unstableBorder({
+  it('should support transform of the color correctly', () => {
+    const output1 = borderWithColor({
       theme: {
         palette: {
           testColor: 'green',

--- a/packages/material-ui-system/src/style.test.js
+++ b/packages/material-ui-system/src/style.test.js
@@ -131,4 +131,26 @@ describe('style', () => {
       border: '4px solid',
     });
   });
+
+  const unstableBorder = style({
+    prop: 'border',
+    unstableTransform: ({ value, theme, getPath }) => {
+      const [width, borderStyle, color] = value.split(' ');
+      return `${width}px ${borderStyle} ${getPath(theme, `palette.${color}`)}`;
+    },
+  });
+
+  it('should support unstableTransforms of the prop correctly', () => {
+    const output1 = unstableBorder({
+      theme: {
+        palette: {
+          testColor: 'green',
+        },
+      },
+      border: '1 dotted testColor',
+    });
+    assert.deepEqual(output1, {
+      border: '1px dotted green',
+    });
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Feel free to close (or re-work) this PR, it's somewhat experimental but might help someone understand things better.

I wanted to explore how we could get the existing API working with colors pulled from the theme.
I added additional args to the existing `transform` call (non breaking) to enable the transform to do it's own mapping.

I've written tests to show how this change supports the old and extended API.  
Now the existing `border` props can specify width, style and color.