### PR TITLE
[system] Support style.transform return React.CSSProperties

### DIFF
--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -157,7 +157,7 @@ export interface StyleOptions<PropKey, Theme extends object> {
    * dot access in `Theme`
    */
   themeKey?: string;
-  transform?: (cssValue: unknown) => number | string;
+  transform?: (cssValue: unknown) => number | string | React.CSSProperties;
 }
 export function style<PropKey extends string, Theme extends object>(
   options: StyleOptions<PropKey, Theme>,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

transform should support map one to many css

```js
import { style } from '@material-ui/system';

export default style({
  prop: 'flexCenter',
  cssProperty: false,
  transform: flexCenter => {
    return flexCenter
      ? {
          display: 'flex',
          justifyContent: 'center',
          alignItems: 'center',
        }
      : {};
  },
});

```

use : 
```jsx
<Box flexCenter>center</Box>
```
