### PR TITLE
[core] Batch small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ via [Patreon](https://www.patreon.com/oliviertassinari)
 via [OpenCollective](https://opencollective.com/material-ui)
 
 <p style="display: flex; justify-content: center; flex-wrap: wrap;">
-  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.call-em-all.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ff4053300-e0ea-11e7-acf0-0fa7c0509f4e.png&height=100" alt="callemall" title="The easy way to message your group"></a>
+  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.call-em-all.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ff4053300-e0ea-11e7-acf0-0fa7c0509f4e.png&height=100" alt="callemall" title="The easy way to message your group" width="100" loading="lazy"></a>
+  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.crosswordsolver.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;"><img src="https://images.opencollective.com/crosswordsolver/avatar.png" alt="crosswordsolver" title="Crossword Puzzle Solver" width="100" loading="lazy"></a>
 </p>
 
 ### There is more!

--- a/docs/pages/api/button-base.md
+++ b/docs/pages/api/button-base.md
@@ -27,7 +27,6 @@ It contains a load of style reset and some focus/ripple logic.
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">action</span> | <span class="prop-type">ref</span> |  | A ref for imperative actions. It currently only supports `focusVisible()` action. |
-| <span class="prop-name">buttonRef</span> | <span class="prop-type">ref</span> |  | Use that prop to pass a ref to the native button component. |
 | <span class="prop-name">centerRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripples will be centered. They won't start at the cursor interaction position. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |

--- a/docs/pages/blog/april-2019-update.md
+++ b/docs/pages/blog/april-2019-update.md
@@ -61,6 +61,8 @@ But this summary is just scratching the surface. We have accepted 243 commits fr
   - Timeline
 - Something big 🌈
 
+- ❓ Please upvote our [GitHub issues](https://github.com/mui-org/material-ui/issues) if you want something specific. The number of 👍 helps us to prioritize.
+
 <hr />
 
 Material-UI is an MIT-licensed open source project. It’s an independent project with ongoing development helped by the support of these awesome [backers](/discover-more/backers/). Please join them ✨.

--- a/docs/pages/blog/august-2019-update.md
+++ b/docs/pages/blog/august-2019-update.md
@@ -37,7 +37,7 @@ But this summary is just scratching the surface. We have accepted 193 commits fr
 
 - 🔍 We will keep working on providing ready to use autocomplete, combo box, and multi-select components. We announced it last month but have made little progress so far due to focusing on fixing bugs in existing components. Let's make it happen!
 
-- ❓ Do you want something in specific? Please upvote our GitHub issues, the number of 👍 matters to us.
+- ❓ Please upvote our [GitHub issues](https://github.com/mui-org/material-ui/issues) if you want something specific. The number of 👍 helps us to prioritize.
 
 <hr />
 

--- a/docs/pages/blog/july-2019-update.md
+++ b/docs/pages/blog/july-2019-update.md
@@ -41,6 +41,8 @@ But this summary is just scratching the surface. We have accepted 146 commits fr
 
   ![Skeleton](/static/blog/july-2019-update/skeleton.png)
 
+- ❓ Please upvote our [GitHub issues](https://github.com/mui-org/material-ui/issues) if you want something specific. The number of 👍 helps us to prioritize.
+
 <hr />
 
 Material-UI is an MIT-licensed open source project. It’s an independent project with ongoing development helped by the support of these awesome [backers](/discover-more/backers/). Please join them ✨.

--- a/docs/pages/blog/june-2019-update.md
+++ b/docs/pages/blog/june-2019-update.md
@@ -33,6 +33,8 @@ But this summary is just scratching the surface. We have accepted 198 commits fr
   You can already [preview it](https://deploy-preview-16455--material-ui.netlify.com/components/rating/).
   ![Rating](/static/blog/june-2019-update/rating.png)
 
+- ❓ Please upvote our [GitHub issues](https://github.com/mui-org/material-ui/issues) if you want something specific. The number of 👍 helps us to prioritize.
+
 <hr />
 
 Material-UI is an MIT-licensed open source project. It’s an independent project with ongoing development helped by the support of these awesome [backers](/discover-more/backers/). Please join them ✨.

--- a/docs/pages/blog/march-2019-update.md
+++ b/docs/pages/blog/march-2019-update.md
@@ -35,6 +35,7 @@ Don't worry, it's almost over! We will focus on providing more components once w
   - TypeScript demo variants.
   - Migration from Classes to Hooks, removal of unnecessary internal components.
   - Removal of `findDOMNode()`, support of `StrictMode`, forward of references.
+- ❓ Please upvote our [GitHub issues](https://github.com/mui-org/material-ui/issues) if you want something specific. The number of 👍 helps us to prioritize.
 
 <hr />
 

--- a/docs/pages/blog/may-2019-update.md
+++ b/docs/pages/blog/may-2019-update.md
@@ -37,6 +37,8 @@ If you are an enterprise and are looking for one of the following:
 
 You can contact us at advisory@material-ui.com.
 
+- ❓ Please upvote our [GitHub issues](https://github.com/mui-org/material-ui/issues) if you want something specific. The number of 👍 helps us to prioritize.
+
 <hr />
 
 Material-UI is an MIT-licensed open source project. It’s an independent project with ongoing development helped by the support of these awesome [backers](/discover-more/backers/). Please join them ✨.

--- a/docs/pages/blog/september-2019-update.md
+++ b/docs/pages/blog/september-2019-update.md
@@ -64,7 +64,7 @@ But this summary is just scratching the surface. We have accepted 199 commits fr
 - 🧮 We will start to work on a Data Table component.
 ⭐️ Notice that the advanced features of the data grid will be paid, behind an enterprise subscription. This is an effort part of [our roadmap](/discover-more/roadmap/) to answer enterprise needs.
 
-- ❓ Do you want something in specific? Please upvote our [GitHub issues](https://github.com/mui-org/material-ui/issues), the number of 👍 matters to us.
+- ❓ Please upvote our [GitHub issues](https://github.com/mui-org/material-ui/issues) if you want something specific. The number of 👍 helps us to prioritize.
 
 <hr />
 

--- a/docs/scripts/buildApi.js
+++ b/docs/scripts/buildApi.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import { mkdir, readFileSync, writeFileSync } from 'fs';
 import { getLineFeed } from './helpers';
 import path from 'path';

--- a/docs/scripts/buildIcons.js
+++ b/docs/scripts/buildIcons.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 const path = require('path');
 const gm = require('gm');
 

--- a/docs/scripts/buildServiceWorker.js
+++ b/docs/scripts/buildServiceWorker.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 const path = require('path');
 const fse = require('fs-extra');
 

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 /**
  * Transpiles TypeScript demos to formatted JavaScript.
  * Can be used to verify that JS and TS demos are equivalent. No introduced change

--- a/docs/scripts/i18n.js
+++ b/docs/scripts/i18n.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import path from 'path';
 import fse from 'fs-extra';
 import { pageToTitle } from 'docs/src/modules/utils/helpers';

--- a/docs/scripts/updateIconSynonyms.js
+++ b/docs/scripts/updateIconSynonyms.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import 'isomorphic-fetch';
 import fse from 'fs-extra';
 import path from 'path';

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-danger */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import marked from 'marked';

--- a/docs/src/modules/components/HomeQuickWord.js
+++ b/docs/src/modules/components/HomeQuickWord.js
@@ -33,6 +33,11 @@ const backers = [
     alt: 'blokt',
     title: 'Leading Cryptocurrency News',
   },
+  {
+    href: 'https://www.crosswordsolver.com',
+    alt: 'crosswordsolver',
+    title: 'Crossword Puzzle Solver',
+  },
 ];
 
 const styles = theme => ({

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -46,7 +46,7 @@ const externs = [
   'https://www.amazon.com/',
   'https://materialdesignicons.com/',
   'https://www.w3.org/',
-  'https://devexpress.github.io/'
+  'https://devexpress.github.io/',
 ];
 
 renderer.link = (href, title, text) => {

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -46,6 +46,7 @@ const externs = [
   'https://www.amazon.com/',
   'https://materialdesignicons.com/',
   'https://www.w3.org/',
+  'https://devexpress.github.io/'
 ];
 
 renderer.link = (href, title, text) => {

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/no-danger, react-hooks/exhaustive-deps */
-
 import 'isomorphic-fetch';
 import React from 'react';
 import { useSelector } from 'react-redux';

--- a/docs/src/modules/components/backers.md
+++ b/docs/src/modules/components/backers.md
@@ -20,9 +20,8 @@ via [Patreon](https://www.patreon.com/oliviertassinari)
 via [OpenCollective](https://opencollective.com/material-ui)
 
 <p style="display: flex; justify-content: center; flex-wrap: wrap;">
-  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.call-em-all.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;">
-    <img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ff4053300-e0ea-11e7-acf0-0fa7c0509f4e.png&height=100" alt="callemall" title="The easy way to message your group" width=100 loading="lazy">
-  </a>
+  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.call-em-all.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ff4053300-e0ea-11e7-acf0-0fa7c0509f4e.png&height=100" alt="callemall" title="The easy way to message your group" width="100" loading="lazy"></a>
+  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.crosswordsolver.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;"><img src="https://images.opencollective.com/crosswordsolver/avatar.png" alt="crosswordsolver" title="Crossword Puzzle Solver" width="100" loading="lazy"></a>
 </p>
 
 ### There are more!

--- a/docs/src/modules/components/prism.js
+++ b/docs/src/modules/components/prism.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/no-mutable-exports, global-require */
-
 import prism from 'prismjs';
 import 'prismjs/components/prism-css';
 import 'prismjs/components/prism-diff';

--- a/docs/src/modules/redux/initRedux.js
+++ b/docs/src/modules/redux/initRedux.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import optionsReducer from 'docs/src/modules/redux/optionsReducer';
 

--- a/docs/src/pages/components/breadcrumbs/CollapsedBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/CollapsedBreadcrumbs.js
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';

--- a/docs/src/pages/components/breadcrumbs/CollapsedBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/CollapsedBreadcrumbs.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-nested-ternary */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';

--- a/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/RouterBreadcrumbs.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable no-nested-ternary */
-
 import React from 'react';
 import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import List from '@material-ui/core/List';

--- a/docs/src/pages/components/links/ButtonLink.js
+++ b/docs/src/pages/components/links/ButtonLink.js
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import Link from '@material-ui/core/Link';
 

--- a/docs/src/pages/components/links/ButtonLink.tsx
+++ b/docs/src/pages/components/links/ButtonLink.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import Link from '@material-ui/core/Link';
 

--- a/docs/src/pages/components/links/Links.js
+++ b/docs/src/pages/components/links/Links.js
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Link from '@material-ui/core/Link';

--- a/docs/src/pages/components/links/Links.tsx
+++ b/docs/src/pages/components/links/Links.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-
 import React from 'react';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 import Link from '@material-ui/core/Link';

--- a/docs/src/pages/components/menus/MenuListComposition.js
+++ b/docs/src/pages/components/menus/MenuListComposition.js
@@ -69,7 +69,7 @@ export default function MenuListComposition() {
         >
           Toggle Menu Grow
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}

--- a/docs/src/pages/components/menus/MenuListComposition.js
+++ b/docs/src/pages/components/menus/MenuListComposition.js
@@ -69,7 +69,7 @@ export default function MenuListComposition() {
         >
           Toggle Menu Grow
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} keepMounted transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}

--- a/docs/src/pages/components/menus/MenuListComposition.tsx
+++ b/docs/src/pages/components/menus/MenuListComposition.tsx
@@ -71,7 +71,7 @@ export default function MenuListComposition() {
         >
           Toggle Menu Grow
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} keepMounted transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}

--- a/docs/src/pages/components/popover/SimplePopover.tsx
+++ b/docs/src/pages/components/popover/SimplePopover.tsx
@@ -16,7 +16,7 @@ export default function SimplePopover() {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(null);
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
 

--- a/docs/src/pages/components/popper/PositionedPopper.tsx
+++ b/docs/src/pages/components/popper/PositionedPopper.tsx
@@ -25,7 +25,7 @@ export default function PositionedPopper() {
   const classes = useStyles();
 
   const handleClick = (newPlacement: PopperPlacementType) => (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+    event: React.MouseEvent<HTMLButtonElement>,
   ) => {
     setAnchorEl(event.currentTarget);
     setOpen(prev => placement !== newPlacement || !prev);

--- a/docs/src/pages/components/snackbars/snackbars.md
+++ b/docs/src/pages/components/snackbars/snackbars.md
@@ -76,8 +76,8 @@ For more advanced use cases you might be able to take advantage of:
 ![stars](https://img.shields.io/github/stars/iamhosseindhv/notistack.svg?style=social&label=Stars)
 ![npm downloads](https://img.shields.io/npm/dm/notistack.svg)
 
-We demonstrate how to use [notistack](https://github.com/iamhosseindhv/notistack).
-notistack has an **imperative API** that makes it easy to display toasts (so you don't have to deal with open/close state of them).
+This example demonstrates how to use [notistack](https://github.com/iamhosseindhv/notistack).
+notistack has an **imperative API** that makes it easy to display snackbars, without having to handle their open/close state.
 It also enables you to **stack** them on top of one another (although this is discouraged by the Material Design specification).
 
 {{"demo": "pages/components/snackbars/IntegrationNotistack.js", "defaultCodeOpen": false}}

--- a/docs/src/pages/components/tables/CustomPaginationActionsTable.tsx
+++ b/docs/src/pages/components/tables/CustomPaginationActionsTable.tsx
@@ -122,10 +122,7 @@ export default function CustomPaginationActionsTable() {
 
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
 
-  const handleChangePage = (
-    event: React.MouseEvent<HTMLButtonElement> | null,
-    newPage: number,
-  ) => {
+  const handleChangePage = (event: React.MouseEvent<HTMLButtonElement> | null, newPage: number) => {
     setPage(newPage);
   };
 

--- a/docs/src/pages/components/tables/CustomPaginationActionsTable.tsx
+++ b/docs/src/pages/components/tables/CustomPaginationActionsTable.tsx
@@ -26,7 +26,7 @@ interface TablePaginationActionsProps {
   count: number;
   page: number;
   rowsPerPage: number;
-  onChangePage: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>, newPage: number) => void;
+  onChangePage: (event: React.MouseEvent<HTMLButtonElement>, newPage: number) => void;
 }
 
 function TablePaginationActions(props: TablePaginationActionsProps) {
@@ -34,19 +34,19 @@ function TablePaginationActions(props: TablePaginationActionsProps) {
   const theme = useTheme();
   const { count, page, rowsPerPage, onChangePage } = props;
 
-  const handleFirstPageButtonClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleFirstPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     onChangePage(event, 0);
   };
 
-  const handleBackButtonClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleBackButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     onChangePage(event, page - 1);
   };
 
-  const handleNextButtonClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleNextButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     onChangePage(event, page + 1);
   };
 
-  const handleLastPageButtonClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleLastPageButtonClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     onChangePage(event, Math.max(0, Math.ceil(count / rowsPerPage) - 1));
   };
 
@@ -123,7 +123,7 @@ export default function CustomPaginationActionsTable() {
   const emptyRows = rowsPerPage - Math.min(rowsPerPage, rows.length - page * rowsPerPage);
 
   const handleChangePage = (
-    event: React.MouseEvent<HTMLButtonElement, MouseEvent> | null,
+    event: React.MouseEvent<HTMLButtonElement> | null,
     newPage: number,
   ) => {
     setPage(newPage);

--- a/docs/src/pages/components/tree-view/tree-view.md
+++ b/docs/src/pages/components/tree-view/tree-view.md
@@ -25,4 +25,4 @@ Tree views can be used to represent a file system navigator displaying folders a
 
 (WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#TreeView)
 
-The component follows the WAI-ARIA best practices.
+The component follows the WAI-ARIA authoring practices.

--- a/docs/src/pages/discover-more/backers/backers.md
+++ b/docs/src/pages/discover-more/backers/backers.md
@@ -29,7 +29,8 @@ via [Patreon](https://www.patreon.com/oliviertassinari)
 via [OpenCollective](https://opencollective.com/material-ui)
 
 <p style="display: flex; justify-content: center; flex-wrap: wrap;">
-  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.call-em-all.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ff4053300-e0ea-11e7-acf0-0fa7c0509f4e.png&height=100" alt="callemall" title="The easy way to message your group"></a>
+  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.call-em-all.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;"><img src="https://images.opencollective.com/proxy/images?src=https%3A%2F%2Fopencollective-production.s3-us-west-1.amazonaws.com%2Ff4053300-e0ea-11e7-acf0-0fa7c0509f4e.png&height=100" alt="callemall" title="The easy way to message your group" width="100" loading="lazy"></a>
+  <a data-ga-event-category="sponsors" data-ga-event-action="logo" data-ga-event-label="callemall" href="https://www.crosswordsolver.com" rel="noopener nofollow" target="_blank" style="margin-right: 16px;"><img src="https://images.opencollective.com/crosswordsolver/avatar.png" alt="crosswordsolver" title="Crossword Puzzle Solver" width="100" loading="lazy"></a>
 </p>
 
 ## Silver Sponsors

--- a/docs/src/pages/getting-started/templates/dashboard/Deposits.js
+++ b/docs/src/pages/getting-started/templates/dashboard/Deposits.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-script-url */
-
 import React from 'react';
 import Link from '@material-ui/core/Link';
 import { makeStyles } from '@material-ui/core/styles';

--- a/docs/src/pages/getting-started/templates/dashboard/Orders.js
+++ b/docs/src/pages/getting-started/templates/dashboard/Orders.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-script-url */
-
 import React from 'react';
 import Link from '@material-ui/core/Link';
 import { makeStyles } from '@material-ui/core/styles';

--- a/docs/src/pages/guides/interoperability/StyledComponentsPortal.tsx
+++ b/docs/src/pages/guides/interoperability/StyledComponentsPortal.tsx
@@ -19,7 +19,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 export default function StyledComponentsPortal() {
   const [anchorEl, setAnchorEl] = React.useState<EventTarget | null>(null);
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
 

--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -175,20 +175,21 @@ If you are using Create React App, you will need to use a couple of projects tha
 
   Note: You may run into errors like these:
 
-  ```
-    Module not found: Can't resolve '@material-ui/core/makeStyles' in '/your/project'
-    Module not found: Can't resolve '@material-ui/core/createStyles' in '/your/project'
-  ```
+  > Module not found: Can't resolve '@material-ui/core/makeStyles' in '/your/project'
 
   This is because `@material-ui/styles` is re-exported through `core`, but the full import is not allowed.
 
   You have an import like this in your code:
 
-  `import {makeStyles, createStyles} from '@material-ui/core';`
+  ```js
+  import { makeStyles, createStyles } from '@material-ui/core';
+  ```
 
   The fix is simple, define the import separately:
 
-  `import {makeStyles, createStyles} from '@material-ui/core/styles';`
+  ```js
+  import { makeStyles, createStyles } from '@material-ui/core/styles';
+  ```
 
   Enjoy significantly faster start times.
 

--- a/examples/create-react-app-with-typescript/src/index.tsx
+++ b/examples/create-react-app-with-typescript/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
 import theme from './theme';
 

--- a/examples/create-react-app/src/index.js
+++ b/examples/create-react-app/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
 import theme from './theme';
 

--- a/examples/gatsby/plugins/gatsby-plugin-top-layout/TopLayout.js
+++ b/examples/gatsby/plugins/gatsby-plugin-top-layout/TopLayout.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Helmet } from 'react-helmet';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import theme from '../../src/theme';
 
 export default function TopLayout(props) {

--- a/examples/gatsby/plugins/gatsby-plugin-top-layout/gatsby-browser.js
+++ b/examples/gatsby/plugins/gatsby-plugin-top-layout/gatsby-browser.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/prefer-default-export, react/prop-types */
-
 import React from 'react';
 import TopLayout from './TopLayout';
 

--- a/examples/gatsby/plugins/gatsby-plugin-top-layout/gatsby-ssr.js
+++ b/examples/gatsby/plugins/gatsby-plugin-top-layout/gatsby-ssr.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/prefer-default-export, react/prop-types */
-
 import React from 'react';
 import TopLayout from './TopLayout';
 

--- a/examples/nextjs-with-typescript/package.json
+++ b/examples/nextjs-with-typescript/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "latest",
-    "@material-ui/styles": "latest",
     "clsx": "latest",
     "next": "latest",
     "react": "latest",

--- a/examples/nextjs-with-typescript/pages/_app.tsx
+++ b/examples/nextjs-with-typescript/pages/_app.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import App from 'next/app';
 import Head from 'next/head';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import theme from '../src/theme';
 

--- a/examples/nextjs-with-typescript/pages/_document.tsx
+++ b/examples/nextjs-with-typescript/pages/_document.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
-import { ServerStyleSheets } from '@material-ui/styles';
+import { ServerStyleSheets } from '@material-ui/core/styles';
 import theme from '../src/theme';
 
 export default class MyDocument extends Document {

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "latest",
-    "@material-ui/styles": "latest",
     "clsx": "latest",
     "next": "latest",
     "prop-types": "latest",

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import App from 'next/app';
 import Head from 'next/head';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import theme from '../src/theme';
 

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
-import { ServerStyleSheets } from '@material-ui/styles';
+import { ServerStyleSheets } from '@material-ui/core/styles';
 import theme from '../src/theme';
 
 export default class MyDocument extends Document {

--- a/examples/parcel/src/index.js
+++ b/examples/parcel/src/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import App from './App';
 import theme from './theme';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 
 ReactDOM.render(
   <ThemeProvider theme={theme}>

--- a/examples/preact/src/index.js
+++ b/examples/preact/src/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
 import theme from './theme';
 

--- a/examples/ssr/client.js
+++ b/examples/ssr/client.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
 import theme from './theme';
 

--- a/examples/ssr/package.json
+++ b/examples/ssr/package.json
@@ -9,7 +9,6 @@
     "@babel/preset-env": "latest",
     "@babel/preset-react": "latest",
     "@material-ui/core": "latest",
-    "@material-ui/styles": "latest",
     "babel-loader": "latest",
     "cross-env": "latest",
     "express": "latest",

--- a/examples/ssr/server.js
+++ b/examples/ssr/server.js
@@ -2,7 +2,7 @@ import express from 'express';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { ServerStyleSheets, ThemeProvider } from '@material-ui/styles';
+import { ServerStyleSheets, ThemeProvider } from '@material-ui/core/styles';
 import App from './App';
 import theme from './theme';
 

--- a/modules/log.js
+++ b/modules/log.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 // https://github.com/trentm/node-bunyan#levels
 const logTypes = {
   // Detail on regular operation.

--- a/packages/eslint-plugin-material-ui/src/index.js
+++ b/packages/eslint-plugin-material-ui/src/index.js
@@ -1,5 +1,4 @@
 /* eslint-disable global-require */
-
 module.exports.rules = {
   'docgen-ignore-before-comment': require('./rules/docgen-ignore-before-comment'),
   'no-hardcoded-labels': require('./rules/no-hardcoded-labels'),

--- a/packages/material-ui-benchmark/src/core.js
+++ b/packages/material-ui-benchmark/src/core.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import Benchmark from 'benchmark';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';

--- a/packages/material-ui-benchmark/src/docs.js
+++ b/packages/material-ui-benchmark/src/docs.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import Benchmark from 'benchmark';
 import fs from 'fs';
 import path from 'path';

--- a/packages/material-ui-benchmark/src/server.js
+++ b/packages/material-ui-benchmark/src/server.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import express from 'express';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';

--- a/packages/material-ui-benchmark/src/styles.js
+++ b/packages/material-ui-benchmark/src/styles.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import Benchmark from 'benchmark';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';

--- a/packages/material-ui-benchmark/src/system.js
+++ b/packages/material-ui-benchmark/src/system.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import Benchmark from 'benchmark';
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';

--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import fse from 'fs-extra';
 import yargs from 'yargs';
 import path from 'path';

--- a/packages/material-ui-icons/scripts/create-typings.js
+++ b/packages/material-ui-icons/scripts/create-typings.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import path from 'path';
 import chalk from 'chalk';
 import fse from 'fs-extra';

--- a/packages/material-ui-icons/scripts/download.js
+++ b/packages/material-ui-icons/scripts/download.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 import 'isomorphic-fetch';
 import fse from 'fs-extra';
 import path from 'path';

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -354,20 +354,20 @@ const Rating = React.forwardRef(function Rating(props, ref) {
               })}
             >
               {items.map(($, indexDecimal) => {
-                const itemDeciamlValue = roundValueToPrecision(
+                const itemDecimalValue = roundValueToPrecision(
                   itemValue - 1 + (indexDecimal + 1) * precision,
                   precision,
                 );
 
                 return item(
                   {
-                    value: itemDeciamlValue,
+                    value: itemDecimalValue,
                     style:
                       items.length - 1 === indexDecimal
                         ? {}
                         : {
                             width:
-                              itemDeciamlValue === value
+                              itemDecimalValue === value
                                 ? `${(indexDecimal + 1) * precision * 100}%`
                                 : '0%',
                             overflow: 'hidden',
@@ -376,10 +376,10 @@ const Rating = React.forwardRef(function Rating(props, ref) {
                           },
                   },
                   {
-                    filled: itemDeciamlValue <= value,
-                    hover: itemDeciamlValue <= hover,
-                    focus: itemDeciamlValue <= focus,
-                    checked: itemDeciamlValue === valueProp,
+                    filled: itemDecimalValue <= value,
+                    hover: itemDecimalValue <= hover,
+                    focus: itemDecimalValue <= focus,
+                    checked: itemDecimalValue === valueProp,
                   },
                 );
               })}

--- a/packages/material-ui-styles/src/getThemeProps/getThemeProps.js
+++ b/packages/material-ui-styles/src/getThemeProps/getThemeProps.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-restricted-syntax */
-
 function getThemeProps(params) {
   const { theme, name, props } = params;
 

--- a/packages/material-ui-styles/src/makeStyles/indexCounter.js
+++ b/packages/material-ui-styles/src/makeStyles/indexCounter.js
@@ -1,5 +1,4 @@
 /* eslint-disable import/prefer-default-export */
-
 // Global index counter to preserve source order.
 // We create the style sheet during at the creation of the component,
 // children are handled after the parents, so the order of style elements would be parent->child.

--- a/packages/material-ui/src/Avatar/Avatar.js
+++ b/packages/material-ui/src/Avatar/Avatar.js
@@ -41,7 +41,7 @@ const Avatar = React.forwardRef(function Avatar(props, ref) {
     alt,
     children: childrenProp,
     classes,
-    className: classNameProp,
+    className,
     component: Component = 'div',
     imgProps,
     sizes,
@@ -77,7 +77,7 @@ const Avatar = React.forwardRef(function Avatar(props, ref) {
         {
           [classes.colorDefault]: !img,
         },
-        classNameProp,
+        className,
       )}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -301,6 +301,8 @@ ButtonBase.propTypes = {
    */
   action: refType,
   /**
+   * @ignore
+   *
    * Use that prop to pass a ref to the native button component.
    * @deprecated Use `ref` instead.
    */

--- a/packages/material-ui/src/ButtonGroup/ButtonGroup.js
+++ b/packages/material-ui/src/ButtonGroup/ButtonGroup.js
@@ -103,7 +103,7 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(props, ref) {
   const {
     children,
     classes,
-    className: classNameProp,
+    className,
     color = 'default',
     component: Component = 'div',
     disabled = false,
@@ -133,7 +133,7 @@ const ButtonGroup = React.forwardRef(function ButtonGroup(props, ref) {
           [classes.contained]: variant === 'contained',
           [classes.fullWidth]: fullWidth,
         },
-        classNameProp,
+        className,
       )}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/CardHeader/CardHeader.js
+++ b/packages/material-ui/src/CardHeader/CardHeader.js
@@ -38,7 +38,7 @@ const CardHeader = React.forwardRef(function CardHeader(props, ref) {
     action,
     avatar,
     classes,
-    className: classNameProp,
+    className,
     component: Component = 'div',
     disableTypography = false,
     subheader: subheaderProp,
@@ -80,7 +80,7 @@ const CardHeader = React.forwardRef(function CardHeader(props, ref) {
   }
 
   return (
-    <Component className={clsx(classes.root, classNameProp)} ref={ref} {...other}>
+    <Component className={clsx(classes.root, className)} ref={ref} {...other}>
       {avatar && <div className={classes.avatar}>{avatar}</div>}
       <div className={classes.content}>
         {title}

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -57,7 +57,7 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(props, ref) 
   const {
     checked,
     classes,
-    className: classNameProp,
+    className,
     control,
     disabled: disabledProp,
     inputRef,
@@ -95,7 +95,7 @@ const FormControlLabel = React.forwardRef(function FormControlLabel(props, ref) 
           [classes[`labelPlacement${capitalize(labelPlacement)}`]]: labelPlacement !== 'end',
           [classes.disabled]: disabled,
         },
-        classNameProp,
+        className,
       )}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/FormHelperText/FormHelperText.js
+++ b/packages/material-ui/src/FormHelperText/FormHelperText.js
@@ -45,7 +45,7 @@ export const styles = theme => ({
 const FormHelperText = React.forwardRef(function FormHelperText(props, ref) {
   const {
     classes,
-    className: classNameProp,
+    className,
     component: Component = 'p',
     disabled,
     error,
@@ -77,7 +77,7 @@ const FormHelperText = React.forwardRef(function FormHelperText(props, ref) {
           [classes.focused]: fcs.focused,
           [classes.required]: fcs.required,
         },
-        classNameProp,
+        className,
       )}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/FormLabel/FormLabel.js
+++ b/packages/material-ui/src/FormLabel/FormLabel.js
@@ -44,7 +44,7 @@ const FormLabel = React.forwardRef(function FormLabel(props, ref) {
   const {
     children,
     classes,
-    className: classNameProp,
+    className,
     component: Component = 'label',
     disabled,
     error,
@@ -72,7 +72,7 @@ const FormLabel = React.forwardRef(function FormLabel(props, ref) {
           [classes.focused]: fcs.focused,
           [classes.required]: fcs.required,
         },
-        classNameProp,
+        className,
       )}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/GridList/GridList.js
+++ b/packages/material-ui/src/GridList/GridList.js
@@ -20,7 +20,7 @@ const GridList = React.forwardRef(function GridList(props, ref) {
     cellHeight = 180,
     children,
     classes,
-    className: classNameProp,
+    className,
     cols = 2,
     component: Component = 'ul',
     spacing = 4,
@@ -30,7 +30,7 @@ const GridList = React.forwardRef(function GridList(props, ref) {
 
   return (
     <Component
-      className={clsx(classes.root, classNameProp)}
+      className={clsx(classes.root, className)}
       ref={ref}
       style={{ margin: -spacing / 2, ...style }}
       {...other}

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.js
@@ -72,7 +72,7 @@ const GridListTileBar = React.forwardRef(function GridListTileBar(props, ref) {
     actionIcon,
     actionPosition = 'right',
     classes,
-    className: classNameProp,
+    className,
     subtitle,
     title,
     titlePosition = 'bottom',
@@ -80,25 +80,27 @@ const GridListTileBar = React.forwardRef(function GridListTileBar(props, ref) {
   } = props;
 
   const actionPos = actionIcon && actionPosition;
-  const className = clsx(
-    classes.root,
-    {
-      [classes.titlePositionBottom]: titlePosition === 'bottom',
-      [classes.titlePositionTop]: titlePosition === 'top',
-      [classes.rootSubtitle]: subtitle,
-    },
-    classNameProp,
-  );
-
-  // Remove the margin between the title / subtitle wrapper, and the Action Icon
-  const titleWrapClassName = clsx(classes.titleWrap, {
-    [classes.titleWrapActionPosLeft]: actionPos === 'left',
-    [classes.titleWrapActionPosRight]: actionPos === 'right',
-  });
 
   return (
-    <div className={className} ref={ref} {...other}>
-      <div className={titleWrapClassName}>
+    <div
+      className={clsx(
+        classes.root,
+        {
+          [classes.titlePositionBottom]: titlePosition === 'bottom',
+          [classes.titlePositionTop]: titlePosition === 'top',
+          [classes.rootSubtitle]: subtitle,
+        },
+        className,
+      )}
+      ref={ref}
+      {...other}
+    >
+      <div
+        className={clsx(classes.titleWrap, {
+          [classes.titleWrapActionPosLeft]: actionPos === 'left',
+          [classes.titleWrapActionPosRight]: actionPos === 'right',
+        })}
+      >
         <div className={classes.title}>{title}</div>
         {subtitle ? <div className={classes.subtitle}>{subtitle}</div> : null}
       </div>

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -169,7 +169,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     autoComplete,
     autoFocus,
     classes,
-    className: classNameProp,
+    className,
     defaultValue,
     disabled,
     endAdornment,
@@ -398,7 +398,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
           [classes.adornedStart]: startAdornment,
           [classes.adornedEnd]: endAdornment,
         },
-        classNameProp,
+        className,
       )}
       onClick={handleClick}
       ref={ref}

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -167,7 +167,7 @@ export const styles = theme => {
 const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
   const {
     classes,
-    className: classNameProp,
+    className,
     color = 'primary',
     value,
     valueBuffer,
@@ -220,7 +220,7 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
           [classes.buffer]: variant === 'buffer',
           [classes.query]: variant === 'query',
         },
-        classNameProp,
+        className,
       )}
       role="progressbar"
       {...rootProps}

--- a/packages/material-ui/src/Modal/TrapFocus.js
+++ b/packages/material-ui/src/Modal/TrapFocus.js
@@ -1,5 +1,4 @@
 /* eslint-disable consistent-return, jsx-a11y/no-noninteractive-tabindex */
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -36,9 +36,10 @@ const Paper = React.forwardRef(function Paper(props, ref) {
     elevation = 1,
     ...other
   } = props;
-  const theme = useTheme();
 
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const theme = useTheme();
     if (!theme.shadows[elevation]) {
       console.error(`Material-UI: this elevation \`${elevation}\` is not implemented.`);
     }

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -30,7 +30,7 @@ export const styles = theme => {
 const Paper = React.forwardRef(function Paper(props, ref) {
   const {
     classes,
-    className: classNameProp,
+    className,
     component: Component = 'div',
     square = false,
     elevation = 1,
@@ -45,16 +45,20 @@ const Paper = React.forwardRef(function Paper(props, ref) {
     }
   }
 
-  const className = clsx(
-    classes.root,
-    classes[`elevation${elevation}`],
-    {
-      [classes.rounded]: !square,
-    },
-    classNameProp,
+  return (
+    <Component
+      className={clsx(
+        classes.root,
+        classes[`elevation${elevation}`],
+        {
+          [classes.rounded]: !square,
+        },
+        className,
+      )}
+      ref={ref}
+      {...other}
+    />
   );
-
-  return <Component className={className} ref={ref} {...other} />;
 });
 
 Paper.propTypes = {

--- a/packages/material-ui/src/Portal/Portal.test.js
+++ b/packages/material-ui/src/Portal/Portal.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/prop-types */
-
 import React from 'react';
 import { assert } from 'chai';
 import { spy } from 'sinon';

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -28,7 +28,7 @@ const Step = React.forwardRef(function Step(props, ref) {
     alternativeLabel,
     children,
     classes,
-    className: classNameProp,
+    className,
     completed = false,
     connector,
     disabled = false,
@@ -38,18 +38,20 @@ const Step = React.forwardRef(function Step(props, ref) {
     ...other
   } = props;
 
-  const className = clsx(
-    classes.root,
-    classes[orientation],
-    {
-      [classes.alternativeLabel]: alternativeLabel,
-      [classes.completed]: completed,
-    },
-    classNameProp,
-  );
-
   return (
-    <div className={className} ref={ref} {...other}>
+    <div
+      className={clsx(
+        classes.root,
+        classes[orientation],
+        {
+          [classes.alternativeLabel]: alternativeLabel,
+          [classes.completed]: completed,
+        },
+        className,
+      )}
+      ref={ref}
+      {...other}
+    >
       {connector &&
         alternativeLabel &&
         index !== 0 &&

--- a/packages/material-ui/src/StepButton/StepButton.js
+++ b/packages/material-ui/src/StepButton/StepButton.js
@@ -34,7 +34,7 @@ const StepButton = React.forwardRef(function StepButton(props, ref) {
     alternativeLabel,
     children,
     classes,
-    className: classNameProp,
+    className,
     completed,
     disabled,
     icon,
@@ -63,7 +63,7 @@ const StepButton = React.forwardRef(function StepButton(props, ref) {
     <ButtonBase
       disabled={disabled}
       TouchRippleProps={{ className: classes.touchRipple }}
-      className={clsx(classes.root, classes[orientation], classNameProp)}
+      className={clsx(classes.root, classes[orientation], className)}
       ref={ref}
       {...other}
     >

--- a/packages/material-ui/src/StepConnector/StepConnector.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.js
@@ -51,7 +51,7 @@ const StepConnector = React.forwardRef(function StepConnector(props, ref) {
     active,
     alternativeLabel = false,
     classes,
-    className: classNameProp,
+    className,
     completed,
     disabled,
     index,
@@ -70,7 +70,7 @@ const StepConnector = React.forwardRef(function StepConnector(props, ref) {
           [classes.completed]: completed,
           [classes.disabled]: disabled,
         },
-        classNameProp,
+        className,
       )}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/StepLabel/StepLabel.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.js
@@ -71,7 +71,7 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
     alternativeLabel = false,
     children,
     classes,
-    className: classNameProp,
+    className,
     completed = false,
     disabled = false,
     error = false,
@@ -100,7 +100,7 @@ const StepLabel = React.forwardRef(function StepLabel(props, ref) {
           [classes.alternativeLabel]: alternativeLabel,
           [classes.error]: error,
         },
-        classNameProp,
+        className,
       )}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/Stepper/Stepper.js
+++ b/packages/material-ui/src/Stepper/Stepper.js
@@ -34,21 +34,12 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
     alternativeLabel = false,
     children,
     classes,
-    className: classNameProp,
+    className,
     connector: connectorProp = defaultConnector,
     nonLinear = false,
     orientation = 'horizontal',
     ...other
   } = props;
-
-  const className = clsx(
-    classes.root,
-    classes[orientation],
-    {
-      [classes.alternativeLabel]: alternativeLabel,
-    },
-    classNameProp,
-  );
 
   const connector = React.isValidElement(connectorProp)
     ? React.cloneElement(connectorProp, { orientation })
@@ -90,7 +81,20 @@ const Stepper = React.forwardRef(function Stepper(props, ref) {
   });
 
   return (
-    <Paper square elevation={0} className={className} ref={ref} {...other}>
+    <Paper
+      square
+      elevation={0}
+      className={clsx(
+        classes.root,
+        classes[orientation],
+        {
+          [classes.alternativeLabel]: alternativeLabel,
+        },
+        className,
+      )}
+      ref={ref}
+      {...other}
+    >
       {steps}
     </Paper>
   );

--- a/packages/material-ui/src/Tabs/TabScrollButton.js
+++ b/packages/material-ui/src/Tabs/TabScrollButton.js
@@ -1,5 +1,4 @@
 /* eslint-disable jsx-a11y/aria-role */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -61,7 +61,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
     autoFocus,
     children,
     classes,
-    className: classNameProp,
+    className,
     defaultValue,
     error,
     FormHelperTextProps,
@@ -154,7 +154,7 @@ const TextField = React.forwardRef(function TextField(props, ref) {
 
   return (
     <FormControl
-      className={clsx(classes.root, classNameProp)}
+      className={clsx(classes.root, className)}
       error={error}
       fullWidth={fullWidth}
       hiddenLabel={hiddenLabel}

--- a/packages/material-ui/src/Toolbar/Toolbar.js
+++ b/packages/material-ui/src/Toolbar/Toolbar.js
@@ -30,23 +30,27 @@ export const styles = theme => ({
 const Toolbar = React.forwardRef(function Toolbar(props, ref) {
   const {
     classes,
-    className: classNameProp,
+    className,
     component: Component = 'div',
     disableGutters = false,
     variant = 'regular',
     ...other
   } = props;
 
-  const className = clsx(
-    classes.root,
-    classes[variant],
-    {
-      [classes.gutters]: !disableGutters,
-    },
-    classNameProp,
+  return (
+    <Component
+      className={clsx(
+        classes.root,
+        classes[variant],
+        {
+          [classes.gutters]: !disableGutters,
+        },
+        className,
+      )}
+      ref={ref}
+      {...other}
+    />
   );
-
-  return <Component className={className} ref={ref} {...other} />;
 });
 
 Toolbar.propTypes = {

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -35,7 +35,7 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
     checked: checkedProp,
     checkedIcon,
     classes,
-    className: classNameProp,
+    className,
     defaultChecked,
     disabled: disabledProp,
     icon,
@@ -110,7 +110,7 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
           [classes.checked]: checked,
           [classes.disabled]: disabled,
         },
-        classNameProp,
+        className,
       )}
       disabled={disabled}
       tabIndex={null}

--- a/packages/material-ui/src/styles/MuiThemeProvider.js
+++ b/packages/material-ui/src/styles/MuiThemeProvider.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { ThemeProvider } from '@material-ui/styles';
 
+/**
+ * @ignore - internal component.
+ *
+ * TODO v5: remove
+ */
 export default function MuiThemeProvider(props) {
   if (process.env.NODE_ENV !== 'production') {
     console.error(

--- a/packages/material-ui/src/styles/MuiThemeProvider.js
+++ b/packages/material-ui/src/styles/MuiThemeProvider.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ThemeProvider } from '@material-ui/styles';
+
+export default function MuiThemeProvider(props) {
+  if (process.env.NODE_ENV !== 'production') {
+    console.error(
+      [
+        'Material-UI: you have imported a private module.',
+        '',
+        "Please replace the '@material-ui/core/styles/MuiThemeProvider' import with:",
+        "`import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles';`",
+        '',
+        'See https://github.com/mui-org/material-ui/issues/17900 for more detail.',
+      ].join('\n'),
+    );
+  }
+
+  return <ThemeProvider {...props} />;
+}

--- a/packages/material-ui/src/styles/zIndex.d.ts
+++ b/packages/material-ui/src/styles/zIndex.d.ts
@@ -1,5 +1,6 @@
 export interface ZIndex {
   mobileStepper: number;
+  speedDial: number;
   appBar: number;
   drawer: number;
   modal: number;

--- a/scripts/deduplicate.js
+++ b/scripts/deduplicate.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 const { spawn } = require('child_process');
 const path = require('path');
 const fs = require('fs');

--- a/scripts/prettier.js
+++ b/scripts/prettier.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 // Based on similar script in React
 // https://github.com/facebook/react/blob/b87aabdfe1b7461e7331abb3601d9e6bb27544bc/scripts/prettier/index.js
 

--- a/test/utils/consoleError.js
+++ b/test/utils/consoleError.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-
 // Makes sure the tests fails when a PropType validation fails.
 function consoleError() {
   console.error = (...args) => {


### PR DESCRIPTION
16 commits for this time (spotted answering issues the last 7 days). I hope there is nothing really important. I have noticed a few other possible quick wins, but they require standalone pull requests.

- [docs] Fix markdown format b016e55: I was concerned with the contrast. The error message wasn't readable
- Remove default default TypeScript argument f0ed07b: We were using the two approaches at 50%, looking at the React TypeScript definitions, I think that we can save the default TypeScript argument.
- [Rating] Fix typo in variable name 15a4538: Thanks @jmaloon for the report https://github.com/mui-org/material-ui/issues/17921#issue-508667291
- [docs] Better wording for the accessibility section d8ec0e3: Handle @esp1lon feedback
- [blog] Better upvote wording 0d5d0e7: Handle @mbrookes feedback
- [Paper] Reduce overhead in production 1b4f786: I have found this by change looking at a outlined Paper implementation
- [core] Avoid className rename d25d3e9: The prop rename is unnecessary most of the time.
- [ButtonBase] Hide the buttonRef prop 8451317: The `@deprecated` mention is no visible. I think that we hide the prop from the documentation (yes, it's a bit unfair for people that uses it) and use `deprecatedPropType` once we prepare v4 deprecations for v5.
- [theme] Add missing speed dial typescript key cd7ac5a: I suspect nobody uses it, buy anyway.
- [docs] rel nofollow devexpress f863c2d
- [core] Remove blank line after eslint disable 04ac4a7: we might as well use a single "way".
- [examples] Replace the /styles package with /core 7c59822: This is a leftover from #17447.
- [Snackbar] Handle Matt review 75cd925: https://github.com/mui-org/material-ui/pull/17910#pullrequestreview-304019486
- [Menu] Fix demo jump 8c8c77e: Reported by @AliYmn in #17923
- [core] Improve upgrade experience 9757b73: Handle #17900 and prepare the deprecation of MuiThemeProvider for ThemeProvider instead.
- [docs] Add crosswordsolver as sponsor bc05f8f: requested in #18028.
