### PR TITLE
[Drawer] Improve "ResponsiveDrawer" demo

### DIFF
--- a/docs/src/pages/components/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.js
@@ -30,9 +30,9 @@ const useStyles = makeStyles(theme => ({
     },
   },
   appBar: {
-    marginLeft: drawerWidth,
     [theme.breakpoints.up('sm')]: {
       width: `calc(100% - ${drawerWidth}px)`,
+      marginLeft: drawerWidth,
     },
   },
   menuButton: {

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
@@ -30,9 +30,9 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     appBar: {
-      marginLeft: drawerWidth,
       [theme.breakpoints.up('sm')]: {
         width: `calc(100% - ${drawerWidth}px)`,
+        marginLeft: drawerWidth,
       },
     },
     menuButton: {


### PR DESCRIPTION
The app bar at the top does not fit the full size of the screen when going mobile. It stays chopped at 240(drawerWidth). and you end up with half the screen empty on mobile. This PR fixes that issue.