### PR TITLE
[slider] Increase hover target size

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -236,6 +236,15 @@ export const styles = theme => ({
     transition: theme.transitions.create(['box-shadow'], {
       duration: theme.transitions.duration.shortest,
     }),
+    '&::after': {
+      position: 'absolute',
+      content: '""',
+      // reach 48px touch target (2 * 18 + thumb circumference)
+      left: -18,
+      top: -18,
+      right: -18,
+      bottom: -18,
+    },
     '&$focusVisible,&:hover': {
       boxShadow: `0px 0px 0px 8px ${fade(theme.palette.primary.main, 0.16)}`,
       '@media (hover: none)': {


### PR DESCRIPTION
Use touch target size of 48px from Material guidelines (https://material.io/design/usability/accessibility.html#layout-typography)

The actual touch target size was already good since we use the full rail. But we could get some toggle flicker when hovering from label to thumb

`master`
![slider-master-hitbox](https://user-images.githubusercontent.com/12292047/67676910-e8e69100-f982-11e9-80dc-9b74803bbc8c.gif)

vs.

branch
![slider-pr-hitbox](https://user-images.githubusercontent.com/12292047/67676913-ed12ae80-f982-11e9-9403-8ee6623b8ee8.gif)
