### PR TITLE
fix typo + types

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -419,11 +419,11 @@ Autocomplete.propTypes = {
    */
   disableOpenOnFocus: PropTypes.bool,
   /**
-   * A filter function that determins the options that are eligible.
+   * A filter function that determines the options that are eligible.
    *
-   * @param {any} options The options to render.
+   * @param {any[]} options The options to render.
    * @param {object} state The state of the component.
-   * @returns {boolean}
+   * @returns {any[]}
    */
   filterOptions: PropTypes.func,
   /**


### PR DESCRIPTION
According to the typescript types:
`  filterOptions?: (options: any[], state: FilterOptionsState) => any[];`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
