### PR TITLE
[styles] Fix props based styles callback not including defaultProps

### DIFF
--- a/packages/material-ui-styles/src/withStyles/withStyles.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.js
@@ -91,6 +91,11 @@ const withStyles = (stylesOrCreator, options = {}) => Component => {
     }),
   };
 
+  // The wrapper receives only user supplied props, which could be a subset of
+  // the actual props Component might receive due to merging with defaultProps.
+  // So copying it here would give us the same result in the wrapper as well.
+  WithStyles.defaultProps = Component.defaultProps;
+
   if (process.env.NODE_ENV !== 'production') {
     WithStyles.displayName = `WithStyles(${getDisplayName(Component)})`;
   }

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -1,6 +1,7 @@
 import { assert } from 'chai';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { stub } from 'sinon';
 import { SheetsRegistry } from 'jss';
 import { Input } from '@material-ui/core';
 import { createMount } from '@material-ui/core/test-utils';
@@ -146,6 +147,26 @@ describe('withStyles', () => {
 
       wrapper.unmount();
       assert.strictEqual(sheetsRegistry.registry.length, 0);
+    });
+
+    it('should supply correct props to jss callbacks', () => {
+      const MyComp = () => <div />;
+      MyComp.defaultProps = {
+        myDefaultProp: 111,
+      };
+
+      const jssCallbackStub = stub().returns({});
+      const styles = { root: jssCallbackStub };
+      const StyledComponent = withStyles(styles)(MyComp);
+      mount(<StyledComponent mySuppliedProp={222} />);
+
+      assert.strictEqual(
+        jssCallbackStub.calledWith({
+          myDefaultProp: 111,
+          mySuppliedProp: 222,
+        }),
+        true,
+      );
     });
 
     it('should support theme.props', () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes https://github.com/mui-org/material-ui/issues/18124

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
