### PR TITLE
[InputBase] Fix onChange event handler callback of inputProps

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -328,7 +328,7 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     }
 
     if (inputPropsProp.onChange) {
-      inputPropsProp.onChange(event);
+      inputPropsProp.onChange(event, ...args);
     }
 
     // Perform in the willUpdate

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -558,6 +558,43 @@ describe('<InputBase />', () => {
     });
   });
 
+  describe('prop: inputComponent with prop: inputProps', () => {
+    it('should call onChange inputProp callback with all params sent from custom inputComponent', () => {
+      const INPUT_VALUE = 'material';
+      const OUTPUT_VALUE = 'test';
+
+      function MyInputBase(props) {
+        const { inputRef, onChange, ...other } = props;
+
+        const handleChange = e => {
+          onChange(e.target.value, OUTPUT_VALUE);
+        };
+
+        return <input ref={inputRef} onChange={handleChange} {...other} />;
+      }
+
+      MyInputBase.propTypes = {
+        inputRef: PropTypes.func.isRequired,
+        onChange: PropTypes.func.isRequired,
+      };
+
+      let outputArguments;
+      function parentHandleChange() {
+        outputArguments = arguments;
+      }
+
+      const { getByRole } = render(
+        <InputBase inputComponent={MyInputBase} inputProps={{ onChange: parentHandleChange }} />,
+      );
+      const textbox = getByRole('textbox');
+      fireEvent.change(textbox, { target: { value: INPUT_VALUE } });
+
+      expect(outputArguments.length).to.equal(2);
+      expect(outputArguments[0]).to.equal(INPUT_VALUE);
+      expect(outputArguments[1]).to.equal(OUTPUT_VALUE);
+    });
+  });
+
   describe('prop: startAdornment, prop: endAdornment', () => {
     it('should render adornment before input', () => {
       const { getByTestId } = render(

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -579,8 +579,8 @@ describe('<InputBase />', () => {
       };
 
       let outputArguments;
-      function parentHandleChange() {
-        outputArguments = arguments;
+      function parentHandleChange(...args) {
+        outputArguments = args;
       }
 
       const { getByRole } = render(


### PR DESCRIPTION
Fixed #18130 where onChange event handler was not forwarding all params sent to it by a custom inputComponent for the InputBase component

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
