### PR TITLE
[Autocomplete] Rename autoHightlight prop to autoHighlight

### DIFF
--- a/docs/pages/api/autocomplete.md
+++ b/docs/pages/api/autocomplete.md
@@ -25,7 +25,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">autoComplete</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the portion of the selected suggestion that has not been typed by the user, known as the completion string, appears inline after the input cursor in the textbox. The inline completion string is visually highlighted and has a selected state. |
-| <span class="prop-name">autoHightlight</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the first option is automatically highlighted. |
+| <span class="prop-name">autoHighlight</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the first option is automatically highlighted. |
 | <span class="prop-name">autoSelect</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the selected option becomes the value of the input when the Autocomplete loses focus unless the user chooses a different option or changes the character string in the input. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">clearOnEscape</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, clear all values when the user presses escape and the popup is closed. |

--- a/docs/src/pages/components/autocomplete/CountrySelect.js
+++ b/docs/src/pages/components/autocomplete/CountrySelect.js
@@ -32,7 +32,7 @@ export default function CountrySelect() {
       classes={{
         option: classes.option,
       }}
-      autoHightlight
+      autoHighlight
       getOptionLabel={option => option.label}
       renderOption={option => (
         <React.Fragment>

--- a/docs/src/pages/components/autocomplete/CountrySelect.tsx
+++ b/docs/src/pages/components/autocomplete/CountrySelect.tsx
@@ -32,7 +32,7 @@ export default function CountrySelect() {
       classes={{
         option: classes.option,
       }}
-      autoHightlight
+      autoHighlight
       getOptionLabel={(option: CountryType) => option.label}
       renderOption={(option: CountryType) => (
         <React.Fragment>

--- a/docs/src/pages/components/autocomplete/Playground.js
+++ b/docs/src/pages/components/autocomplete/Playground.js
@@ -88,9 +88,9 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        autoHightlight
+        autoHighlight
         renderInput={params => (
-          <TextField {...params} label="autoHightlight" margin="normal" fullWidth />
+          <TextField {...params} label="autoHighlight" margin="normal" fullWidth />
         )}
       />
       <Autocomplete

--- a/docs/src/pages/components/autocomplete/Playground.tsx
+++ b/docs/src/pages/components/autocomplete/Playground.tsx
@@ -86,9 +86,9 @@ export default function Playground() {
       />
       <Autocomplete
         {...defaultProps}
-        autoHightlight
+        autoHighlight
         renderInput={params => (
-          <TextField {...params} label="autoHightlight" margin="normal" fullWidth />
+          <TextField {...params} label="autoHighlight" margin="normal" fullWidth />
         )}
       />
       <Autocomplete

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -149,7 +149,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
   /* eslint-disable no-unused-vars */
   const {
     autoComplete = false,
-    autoHightlight = false,
+    autoHighlight = false,
     autoSelect = false,
     classes,
     className,
@@ -372,7 +372,7 @@ Autocomplete.propTypes = {
   /**
    * If `true`, the first option is automatically highlighted.
    */
-  autoHightlight: PropTypes.bool,
+  autoHighlight: PropTypes.bool,
   /**
    * If `true`, the selected option becomes the value of the input
    * when the Autocomplete loses focus unless the user chooses

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -28,7 +28,7 @@ export interface UseAutocompleteProps {
   /**
    * If `true`, the first option is automatically highlighted.
    */
-  autoHightlight?: boolean;
+  autoHighlight?: boolean;
   /**
    * If `true`, the selected option becomes the value of the input
    * when the Autocomplete loses focus unless the user chooses

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -51,7 +51,7 @@ const pageSize = 5;
 export default function useAutocomplete(props) {
   const {
     autoComplete = false,
-    autoHightlight = false,
+    autoHighlight = false,
     autoSelect = false,
     clearOnEscape = false,
     debug = false,
@@ -98,7 +98,7 @@ export default function useAutocomplete(props) {
   const [anchorEl, setAnchorEl] = React.useState(null);
 
   const [focusedTag, setFocusedTag] = React.useState(-1);
-  const defaultHighlighted = autoHightlight ? 0 : -1;
+  const defaultHighlighted = autoHighlight ? 0 : -1;
   const highlightedIndexRef = React.useRef(defaultHighlighted);
   const selectedIndexRef = React.useRef(-1);
 
@@ -727,7 +727,7 @@ useAutocomplete.propTypes = {
   /**
    * If `true`, the first option is automatically highlighted.
    */
-  autoHightlight: PropTypes.bool,
+  autoHighlight: PropTypes.bool,
   /**
    * If `true`, the selected option becomes the value of the input
    * when the Autocomplete loses focus unless the user chooses


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Fix #18134 

### Breaking change

```diff
diff --git a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
index 7f28ddca2..531ab7bb8 100644
--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -727,7 +727,7 @@ useAutocomplete.propTypes = {
   /**
    * If `true`, the first option is automatically highlighted.
    */
-  autoHightlight: PropTypes.bool,
+  autoHighlight: PropTypes.bool,
   /**
    * If `true`, the selected option becomes the value of the input
    * when the Autocomplete loses focus unless the user chooses
```