### PR TITLE
[docs] Fix various a11y issues reported by lighthouse

### DIFF
--- a/docs/src/pages/components/app-bar/ProminentAppBar.js
+++ b/docs/src/pages/components/app-bar/ProminentAppBar.js
@@ -45,10 +45,10 @@ export default function ProminentAppBar() {
           <Typography className={classes.title} variant="h5" noWrap>
             Material-UI
           </Typography>
-          <IconButton color="inherit">
+          <IconButton aria-label="search" color="inherit">
             <SearchIcon />
           </IconButton>
-          <IconButton edge="end" color="inherit">
+          <IconButton aria-label="display more actions" edge="end" color="inherit">
             <MoreIcon />
           </IconButton>
         </Toolbar>

--- a/docs/src/pages/components/app-bar/ProminentAppBar.tsx
+++ b/docs/src/pages/components/app-bar/ProminentAppBar.tsx
@@ -45,10 +45,10 @@ export default function ProminentAppBar() {
           <Typography className={classes.title} variant="h5" noWrap>
             Material-UI
           </Typography>
-          <IconButton color="inherit">
+          <IconButton aria-label="search" color="inherit">
             <SearchIcon />
           </IconButton>
-          <IconButton edge="end" color="inherit">
+          <IconButton aria-label="display more actions" edge="end" color="inherit">
             <MoreIcon />
           </IconButton>
         </Toolbar>

--- a/docs/src/pages/components/buttons/SplitButton.js
+++ b/docs/src/pages/components/buttons/SplitButton.js
@@ -46,14 +46,16 @@ export default function SplitButton() {
           <Button
             color="primary"
             size="small"
-            aria-owns={open ? 'menu-list-grow' : undefined}
-            aria-haspopup="true"
+            aria-controls={open ? 'split-button-menu' : undefined}
+            aria-expanded={open ? 'true' : undefined}
+            aria-label="select merge strategy"
+            aria-haspopup="menu"
             onClick={handleToggle}
           >
             <ArrowDropDownIcon />
           </Button>
         </ButtonGroup>
-        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}
@@ -61,9 +63,9 @@ export default function SplitButton() {
                 transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
               }}
             >
-              <Paper id="menu-list-grow">
+              <Paper>
                 <ClickAwayListener onClickAway={handleClose}>
-                  <MenuList>
+                  <MenuList id="split-button-menu">
                     {options.map((option, index) => (
                       <MenuItem
                         key={option}

--- a/docs/src/pages/components/buttons/SplitButton.tsx
+++ b/docs/src/pages/components/buttons/SplitButton.tsx
@@ -49,14 +49,16 @@ export default function SplitButton() {
           <Button
             color="primary"
             size="small"
-            aria-owns={open ? 'menu-list-grow' : undefined}
-            aria-haspopup="true"
+            aria-controls={open ? 'split-button-menu' : undefined}
+            aria-expanded={open ? 'true' : undefined}
+            aria-label="select merge strategy"
+            aria-haspopup="menu"
             onClick={handleToggle}
           >
             <ArrowDropDownIcon />
           </Button>
         </ButtonGroup>
-        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}
@@ -64,9 +66,9 @@ export default function SplitButton() {
                 transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom',
               }}
             >
-              <Paper id="menu-list-grow">
+              <Paper>
                 <ClickAwayListener onClickAway={handleClose}>
-                  <MenuList>
+                  <MenuList id="split-button-menu">
                     {options.map((option, index) => (
                       <MenuItem
                         key={option}

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.js
@@ -58,6 +58,7 @@ function StyledCheckbox(props) {
       color="default"
       checkedIcon={<span className={clsx(classes.icon, classes.checkedIcon)} />}
       icon={<span className={classes.icon} />}
+      inputProps={{ 'aria-label': 'decorative checkbox' }}
       {...props}
     />
   );

--- a/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
+++ b/docs/src/pages/components/checkboxes/CustomizedCheckbox.tsx
@@ -58,6 +58,7 @@ function StyledCheckbox(props: CheckboxProps) {
       color="default"
       checkedIcon={<span className={clsx(classes.icon, classes.checkedIcon)} />}
       icon={<span className={classes.icon} />}
+      inputProps={{ 'aria-label': 'decorative checkbox' }}
       {...props}
     />
   );

--- a/docs/src/pages/components/menus/MenuListComposition.js
+++ b/docs/src/pages/components/menus/MenuListComposition.js
@@ -63,21 +63,21 @@ export default function MenuListComposition() {
       <div>
         <Button
           ref={anchorRef}
-          aria-controls="menu-list-grow"
+          aria-controls={open ? 'menu-list-grow' : undefined}
           aria-haspopup="true"
           onClick={handleToggle}
         >
           Toggle Menu Grow
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}
               style={{ transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom' }}
             >
-              <Paper id="menu-list-grow">
+              <Paper>
                 <ClickAwayListener onClickAway={handleClose}>
-                  <MenuList autoFocusItem={open} onKeyDown={handleListKeyDown}>
+                  <MenuList autoFocusItem={open} id="menu-list-grow" onKeyDown={handleListKeyDown}>
                     <MenuItem onClick={handleClose}>Profile</MenuItem>
                     <MenuItem onClick={handleClose}>My account</MenuItem>
                     <MenuItem onClick={handleClose}>Logout</MenuItem>

--- a/docs/src/pages/components/menus/MenuListComposition.tsx
+++ b/docs/src/pages/components/menus/MenuListComposition.tsx
@@ -65,21 +65,21 @@ export default function MenuListComposition() {
       <div>
         <Button
           ref={anchorRef}
-          aria-controls="menu-list-grow"
+          aria-controls={open ? 'menu-list-grow' : undefined}
           aria-haspopup="true"
           onClick={handleToggle}
         >
           Toggle Menu Grow
         </Button>
-        <Popper open={open} anchorEl={anchorRef.current} transition disablePortal>
+        <Popper open={open} anchorEl={anchorRef.current} role={undefined} transition disablePortal>
           {({ TransitionProps, placement }) => (
             <Grow
               {...TransitionProps}
               style={{ transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom' }}
             >
-              <Paper id="menu-list-grow">
+              <Paper>
                 <ClickAwayListener onClickAway={handleClose}>
-                  <MenuList autoFocusItem={open} onKeyDown={handleListKeyDown}>
+                  <MenuList autoFocusItem={open} id="menu-list-grow" onKeyDown={handleListKeyDown}>
                     <MenuItem onClick={handleClose}>Profile</MenuItem>
                     <MenuItem onClick={handleClose}>My account</MenuItem>
                     <MenuItem onClick={handleClose}>Logout</MenuItem>


### PR DESCRIPTION
Common issues:
- using a Popper for something that isn't a tooltip without removing the tooltip role by using `<Popper role={undefined} />`
- pointing to generic containers in `aria-controls`
- missing accessible names (it's less about having those in the docs but more about teaching how these would be set in production)