### PR TITLE
[types] Fix IsEmptyInterface with optional members

### DIFF
--- a/packages/material-ui-styles/test/IsEmptyInterface.spec.ts
+++ b/packages/material-ui-styles/test/IsEmptyInterface.spec.ts
@@ -27,6 +27,9 @@ type NeverIsValid = IsEmptyInterface<never>;
 // $ExpectType false
 type UnknownIsValid = IsEmptyInterface<unknown>;
 
+// $ExpectType false
+type OptionalIsValid = IsEmptyInterface<{x?: number}>;
+
 const noop = () => {};
 // $ExpectType false
 type FunctionIsValid = IsEmptyInterface<typeof noop>;

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -56,9 +56,21 @@ export type IsAny<T> = 0 extends (1 & T) ? true : false;
  */
 export type CoerceEmptyInterface<T> = IsAny<T> extends true ? {} : T;
 
-export type Or<A, B, C = false> = (A & B & C) extends true ? true : false;
+export type Or<A, B, C = false> = A extends true
+  ? true
+  : B extends true
+  ? true
+  : C extends true
+  ? true
+  : false;
 
-export type And<A, B, C = true> = (A | B | C) extends true ? true : false;
+export type And<A, B, C = true> = A extends true
+  ? B extends true
+    ? C extends true
+      ? true
+      : false
+    : false
+  : false;
 
 /**
  * @internal
@@ -71,7 +83,7 @@ export type And<A, B, C = true> = (A | B | C) extends true ? true : false;
  * 3. false if the given type is `unknown`
  */
 export type IsEmptyInterface<T> = And<
-  {} extends T ? true : false,
+  keyof T extends never ? true : false,
   string extends T ? true : false,
   unknown extends T ? false : true
 >;


### PR DESCRIPTION
This reverts commit 9d0caa5f46299a766b3fddd3aff9dd8adc41b820.

The new version of `IsEmptyInterface` accepts objects with all optional
properties and `And` and `Or` actually have negative perf impact on
their own.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
