### PR TITLE
[styles] Share the context between package versions

### DIFF
--- a/packages/material-ui-styles/src/useTheme/ThemeContext.js
+++ b/packages/material-ui-styles/src/useTheme/ThemeContext.js
@@ -1,5 +1,10 @@
 import React from 'react';
+import { ponyfillGlobal } from '@material-ui/utils';
 
-const ThemeContext = React.createContext(null);
+// Share the theme context object with a global so theme propagation can work
+// in case of style package duplication.
+if (!ponyfillGlobal['__@material-ui/theme-context__']) {
+  ponyfillGlobal['__@material-ui/theme-context__'] = React.createContext(null);
+}
 
-export default ThemeContext;
+export default ponyfillGlobal['__@material-ui/theme-context__'];


### PR DESCRIPTION
This is an attempt to mitigate #18105. I believe the change is safe to deploy, but it won't solve 100% of the duplication problem. I didn't want to share the style provider context object, as changes are likely not backward compatible.