### PR TITLE
[test] Fix tests polluting DOM

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -8,10 +8,15 @@ import TreeItem from './TreeItem';
 import TreeView from '../TreeView';
 
 describe('<TreeItem />', () => {
-  // StrictModeViolation: uses Collapse
+  let classes;
+  let mount;
   const render = createClientRender({ strict: false });
-  const mount = createMount({ strict: false });
-  const classes = getClasses(<TreeItem nodeId="one" label="one" />);
+
+  before(() => {
+    // StrictModeViolation: uses Collapse
+    mount = createMount({ strict: false });
+    classes = getClasses(<TreeItem nodeId="one" label="one" />);
+  });
 
   describeConformance(<TreeItem nodeId="one" label="one" />, () => ({
     classes,

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -8,9 +8,15 @@ import TreeView from './TreeView';
 import TreeItem from '../TreeItem';
 
 describe('<TreeView />', () => {
+  let classes;
+  let mount;
+  // StrictModeViolation: test uses TreeItem
   const render = createClientRender({ strict: false });
-  const mount = createMount({ strict: false });
-  const classes = getClasses(<TreeView />);
+
+  before(() => {
+    mount = createMount({ strict: true });
+    classes = getClasses(<TreeView />);
+  });
 
   describeConformance(<TreeView />, () => ({
     classes,


### PR DESCRIPTION
Since cleanup runs in a `afterAll` hook setup has to run in a beforeAll hook. The hooks need to be symmetric. It was only a minor inconvenience when debuggin (the containers from createMount got printed in the console).

Aside:
* TreeView conformance suite is run in StrictMode (only TreeItem is problematic)
