### PR TITLE
Remove position sticky

### DIFF
--- a/packages/material-ui/src/ListSubheader/ListSubheader.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.js
@@ -34,7 +34,6 @@ export const styles = theme => ({
   },
   /* Styles applied to the root element if `disableSticky={false}`. */
   sticky: {
-    position: 'sticky',
     top: 0,
     zIndex: 1,
     backgroundColor: 'inherit',


### PR DESCRIPTION
I remove the sticky position because on drop down the menu get overflow

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
