### PR TITLE
[slider] Improve UX for pointing device with limited accuracy

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -154,6 +154,14 @@ export const styles = theme => ({
       height: '100%',
       padding: '0 11px',
     },
+    // The primary input mechanism of the device includes a pointing device of limited accuracy.
+    '@media (pointer: coarse)': {
+      // Reach 42px touch target, about ~8mm on screen.
+      padding: '20px 0',
+      '&$vertical': {
+        padding: '0 20px',
+      },
+    },
   },
   /* Styles applied to the root element if `color="primary"`. */
   colorPrimary: {


### PR DESCRIPTION
**The problem**: from time to time when we try to interact with the slider on mobile, we have to give multiple tries, until our finger actually touches the rail DOM node.

The changes aim to find a tradeoff between:

- Provide a tall enough interaction zone (e.g. to account for the size of a finger)
- Provide a small enough interaction zone (e.g. to avoid unintended interactions with a too tall interaction zone or not to "waste" space on the screen)
- Avoid overlapping other interactive elements (predictability)
- Override simplicity