### PR TITLE
Bump @testing-library/react from 9.3.0 to 9.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.6.2",
     "@testing-library/dom": "^6.8.1",
-    "@testing-library/react": "^9.2.0",
+    "@testing-library/react": "^9.3.2",
     "@types/chai": "^4.2.3",
     "@types/chai-dom": "^0.0.8",
     "@types/enzyme": "^3.10.3",

--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiDom from 'chai-dom';
 import { isInaccessible } from '@testing-library/dom';
-import { prettyDOM } from '@testing-library/react';
+import { prettyDOM } from '@testing-library/react/pure';
 
 chai.use(chaiDom);
 chai.use((chaiAPI, utils) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1980,10 +1980,10 @@
     pretty-format "^24.9.0"
     wait-for-expect "^3.0.0"
 
-"@testing-library/react@^9.2.0":
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.3.0.tgz#1dabf46d1ea018a1c89acecc0e7b86859b34c0f8"
-  integrity sha512-FTPCwmLo0tLtP50Au2uGz4/N1BcJTnBx4StDVHZ47zPMEj1/+J2rk/RTj8SLoHRKWCtcmhN4wRmudOXQNP29/w==
+"@testing-library/react@^9.3.2":
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-9.3.2.tgz#418000daa980dafd2d9420cc733d661daece9aa0"
+  integrity sha512-J6ftWtm218tOLS175MF9eWCxGp+X+cUXCpkPIin8KAXWtyZbr9CbqJ8M8QNd6spZxJDAGlw+leLG4MJWLlqVgg==
   dependencies:
     "@babel/runtime" "^7.6.0"
     "@testing-library/dom" "^6.3.0"


### PR DESCRIPTION
#18183 + https://github.com/testing-library/react-testing-library/releases/tag/v9.3.2
