### PR TITLE
[docs] Improve demo clarity by using form elements

### DIFF
--- a/docs/src/pages/components/text-fields/CustomizedInputBase.js
+++ b/docs/src/pages/components/text-fields/CustomizedInputBase.js
@@ -32,7 +32,7 @@ export default function CustomizedInputBase() {
   const classes = useStyles();
 
   return (
-    <Paper className={classes.root}>
+    <Paper component="form" className={classes.root}>
       <IconButton className={classes.iconButton} aria-label="menu">
         <MenuIcon />
       </IconButton>
@@ -41,7 +41,7 @@ export default function CustomizedInputBase() {
         placeholder="Search Google Maps"
         inputProps={{ 'aria-label': 'search google maps' }}
       />
-      <IconButton className={classes.iconButton} aria-label="search">
+      <IconButton type="submit" className={classes.iconButton} aria-label="search">
         <SearchIcon />
       </IconButton>
       <Divider className={classes.divider} orientation="vertical" />

--- a/docs/src/pages/components/text-fields/CustomizedInputBase.tsx
+++ b/docs/src/pages/components/text-fields/CustomizedInputBase.tsx
@@ -34,7 +34,7 @@ export default function CustomizedInputBase() {
   const classes = useStyles();
 
   return (
-    <Paper className={classes.root}>
+    <Paper component="form" className={classes.root}>
       <IconButton className={classes.iconButton} aria-label="menu">
         <MenuIcon />
       </IconButton>
@@ -43,7 +43,7 @@ export default function CustomizedInputBase() {
         placeholder="Search Google Maps"
         inputProps={{ 'aria-label': 'search google maps' }}
       />
-      <IconButton className={classes.iconButton} aria-label="search">
+      <IconButton type="submit" className={classes.iconButton} aria-label="search">
         <SearchIcon />
       </IconButton>
       <Divider className={classes.divider} orientation="vertical" />

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 
 export interface PaperProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, PaperClassKey> {
-  component?: React.ElementType<React.HTMLAttributes<HTMLDivElement>>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
   elevation?: number;
   square?: boolean;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

The `Paper` element is now rendered with a `form` and the `IconButton` uses `submit`. This makes submitting the `InputBase` element much clearer and wires in the `IconButton`.

Fixes #18240