### PR TITLE
[core] Add funding entry to manifests

### DIFF
--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -22,6 +22,10 @@
     "url": "https://github.com/mui-org/material-ui/issues"
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-styles",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/material-ui"
+  },
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -22,6 +22,10 @@
     "url": "https://github.com/mui-org/material-ui/issues"
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-system",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/material-ui"
+  },
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -20,6 +20,10 @@
     "url": "https://github.com/mui-org/material-ui/issues"
   },
   "homepage": "https://material-ui.com/",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/material-ui"
+  },
   "scripts": {
     "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:umd && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",


### PR DESCRIPTION
[`npm@^6.13.0`](https://github.com/npm/cli/releases/tag/v6.13.0) added the [`funding` field](https://github.com/npm/rfcs/blob/latest/accepted/0017-add-funding-support.md)

I included it in packages that don't have other mui peer dependencies with a `funding` field and are "substantial". This includes `/core`, `/system` and `/styles`.

/cc @mui-org/board-members 