### PR TITLE
[TreeView] Support empty array

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -97,7 +97,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
 
   let icon = iconProp;
 
-  const expandable = Boolean(children);
+  const expandable = Boolean(Array.isArray(children) ? children.length : children);
   const expanded = isExpanded ? isExpanded(nodeId) : false;
   const focused = isFocused ? isFocused(nodeId) : false;
   const tabable = isTabable ? isTabable(nodeId) : false;

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -66,7 +66,7 @@ describe('<TreeItem />', () => {
           <TreeItem nodeId="4" label="4" data-testid="4" />
         </TreeItem>
         <TreeItem nodeId="7" label="7" data-testid="7">
-            {[]}
+          {[]}
         </TreeItem>
       </TreeView>,
     );

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -65,6 +65,9 @@ describe('<TreeItem />', () => {
         <TreeItem nodeId="3" label="3" data-testid="3">
           <TreeItem nodeId="4" label="4" data-testid="4" />
         </TreeItem>
+        <TreeItem nodeId="7" label="7" data-testid="7">
+            {[]}
+        </TreeItem>
       </TreeView>,
     );
 
@@ -85,6 +88,9 @@ describe('<TreeItem />', () => {
     expect(getIcon('6'))
       .attribute('data-test')
       .to.equal('endIcon');
+    expect(getIcon('7'))
+      .attribute('data-test')
+      .to.equal('defaultEndIcon');
   });
 
   it('should not call onClick when children are clicked', () => {

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -49,7 +49,7 @@ describe('<TreeItem />', () => {
     const icon = <div data-test="icon" />;
     const endIcon = <div data-test="endIcon" />;
 
-    const { getByTestId } = render(
+    const { getByTestId, getByRole, getByText } = render(
       <TreeView
         defaultEndIcon={defaultEndIcon}
         defaultExpandIcon={defaultExpandIcon}
@@ -88,9 +88,7 @@ describe('<TreeItem />', () => {
     expect(getIcon('6'))
       .attribute('data-test')
       .to.equal('endIcon');
-    expect(getIcon('7'))
-      .attribute('data-test')
-      .to.equal('defaultEndIcon');
+    expect(getByTestId('7')).to.not.have.attribute('aria-expanded');
   });
 
   it('should not call onClick when children are clicked', () => {

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -49,7 +49,7 @@ describe('<TreeItem />', () => {
     const icon = <div data-test="icon" />;
     const endIcon = <div data-test="endIcon" />;
 
-    const { getByTestId, getByRole, getByText } = render(
+    const { getByTestId } = render(
       <TreeView
         defaultEndIcon={defaultEndIcon}
         defaultExpandIcon={defaultExpandIcon}

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -65,9 +65,6 @@ describe('<TreeItem />', () => {
         <TreeItem nodeId="3" label="3" data-testid="3">
           <TreeItem nodeId="4" label="4" data-testid="4" />
         </TreeItem>
-        <TreeItem nodeId="7" label="7" data-testid="7">
-          {[]}
-        </TreeItem>
       </TreeView>,
     );
 
@@ -88,7 +85,20 @@ describe('<TreeItem />', () => {
     expect(getIcon('6'))
       .attribute('data-test')
       .to.equal('endIcon');
-    expect(getByTestId('7')).to.not.have.attribute('aria-expanded');
+  });
+
+  it('should treat an empty array equally to no children', () => {
+    const { getByTestId } = render(
+      <TreeView defaultExpanded={['1']}>
+        <TreeItem nodeId="1" label="1" data-testid="1">
+          <TreeItem nodeId="2" label="2" data-testid="2">
+            {[]}
+          </TreeItem>
+        </TreeItem>
+      </TreeView>,
+    );
+
+    expect(getByTestId('2')).to.not.have.attribute('aria-expanded');
   });
 
   it('should not call onClick when children are clicked', () => {


### PR DESCRIPTION
When you pass empty array as a children of TreeItem, it should not be able to expand it.
