### PR TITLE
[docs] Added better example for FormattedInputs

### DIFF
--- a/docs/src/pages/components/text-fields/FormattedInputs.js
+++ b/docs/src/pages/components/text-fields/FormattedInputs.js
@@ -3,10 +3,7 @@ import PropTypes from 'prop-types';
 import MaskedInput from 'react-text-mask';
 import NumberFormat from 'react-number-format';
 import { makeStyles } from '@material-ui/core/styles';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
 import TextField from '@material-ui/core/TextField';
-import FormControl from '@material-ui/core/FormControl';
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -17,26 +14,6 @@ const useStyles = makeStyles(theme => ({
     margin: theme.spacing(1),
   },
 }));
-
-function TextMaskCustom(props) {
-  const { inputRef, ...other } = props;
-
-  return (
-    <MaskedInput
-      {...other}
-      ref={ref => {
-        inputRef(ref ? ref.inputElement : null);
-      }}
-      mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
-      placeholderChar={'\u2000'}
-      showMask
-    />
-  );
-}
-
-TextMaskCustom.propTypes = {
-  inputRef: PropTypes.func.isRequired,
-};
 
 function NumberFormatCustom(props) {
   const { inputRef, onChange, ...other } = props;
@@ -80,15 +57,22 @@ export default function FormattedInputs() {
 
   return (
     <div className={classes.container}>
-      <FormControl className={classes.formControl}>
-        <InputLabel htmlFor="formatted-text-mask-input">react-text-mask</InputLabel>
-        <Input
-          value={values.textmask}
-          onChange={handleChange('textmask')}
-          id="formatted-text-mask-input"
-          inputComponent={TextMaskCustom}
-        />
-      </FormControl>
+      <MaskedInput
+        mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+        placeholderChar={'\u2000'}
+        showMask
+        value={values.textmask}
+        onChange={handleChange('textmask')}
+        render={(ref, props) => (
+          <TextField
+            label="react-text-mask"
+            inputProps={{
+              ref,
+              ...props,
+            }}
+          />
+        )}
+      />
       <TextField
         className={classes.formControl}
         label="react-number-format"

--- a/docs/src/pages/components/text-fields/FormattedInputs.tsx
+++ b/docs/src/pages/components/text-fields/FormattedInputs.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import MaskedInput from 'react-text-mask';
 import NumberFormat from 'react-number-format';
 import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
-import Input from '@material-ui/core/Input';
-import InputLabel from '@material-ui/core/InputLabel';
 import TextField from '@material-ui/core/TextField';
-import FormControl from '@material-ui/core/FormControl';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -18,26 +15,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
   }),
 );
-
-interface TextMaskCustomProps {
-  inputRef: (ref: HTMLInputElement | null) => void;
-}
-
-function TextMaskCustom(props: TextMaskCustomProps) {
-  const { inputRef, ...other } = props;
-
-  return (
-    <MaskedInput
-      {...other}
-      ref={(ref: any) => {
-        inputRef(ref ? ref.inputElement : null);
-      }}
-      mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
-      placeholderChar={'\u2000'}
-      showMask
-    />
-  );
-}
 
 interface NumberFormatCustomProps {
   inputRef: (instance: NumberFormat | null) => void;
@@ -86,15 +63,22 @@ export default function FormattedInputs() {
 
   return (
     <div className={classes.container}>
-      <FormControl className={classes.formControl}>
-        <InputLabel htmlFor="formatted-text-mask-input">react-text-mask</InputLabel>
-        <Input
-          value={values.textmask}
-          onChange={handleChange('textmask')}
-          id="formatted-text-mask-input"
-          inputComponent={TextMaskCustom as any}
-        />
-      </FormControl>
+      <MaskedInput
+        mask={['(', /[1-9]/, /\d/, /\d/, ')', ' ', /\d/, /\d/, /\d/, '-', /\d/, /\d/, /\d/, /\d/]}
+        placeholderChar={'\u2000'}
+        showMask
+        value={values.textmask}
+        onChange={handleChange('textmask')}
+        render={(ref: any, props: any) => (
+          <TextField
+            label="react-text-mask"
+            inputProps={{
+              ref,
+              ...props,
+            }}
+          />
+        )}
+      />
       <TextField
         className={classes.formControl}
         label="react-number-format"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Hi @oliviertassinari ,

I think this [code](https://material-ui.com/components/text-fields/#integration-with-3rd-party-input-libraries) (which is an example of integration with [`react-text-mask`](https://npmjs.com/package/react-text-mask) package) is a little complex.
Because it doesn't use a simple `TextField` component to show the usage of `MaskedInput`.

So, I've just removed the usage of `FormControl`, `Input`, & `InputLabel` components and used a simple `TextField`, instead.

Thanks for paying attention