### PR TITLE
[Autocomplete] Improve focus logic

### DIFF
--- a/docs/src/pages/components/autocomplete/CustomizedHook.js
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.js
@@ -124,7 +124,7 @@ const Listbox = styled('ul')`
 
 export default function CustomizedHook() {
   const {
-    getComboboxProps,
+    getRootProps,
     getInputLabelProps,
     getInputProps,
     getTagProps,
@@ -143,7 +143,7 @@ export default function CustomizedHook() {
 
   return (
     <div>
-      <div {...getComboboxProps()}>
+      <div {...getRootProps()}>
         <Label {...getInputLabelProps()}>Customized hook</Label>
         <InputWrapper ref={setAnchorEl} className={focused ? 'focused' : ''}>
           {value.map((option, index) => (

--- a/docs/src/pages/components/autocomplete/CustomizedHook.tsx
+++ b/docs/src/pages/components/autocomplete/CustomizedHook.tsx
@@ -124,7 +124,7 @@ const Listbox = styled('ul')`
 
 export default function CustomizedHook() {
   const {
-    getComboboxProps,
+    getRootProps,
     getInputLabelProps,
     getInputProps,
     getTagProps,
@@ -143,7 +143,7 @@ export default function CustomizedHook() {
 
   return (
     <div>
-      <div {...getComboboxProps()}>
+      <div {...getRootProps()}>
         <Label {...getInputLabelProps()}>Customized hook</Label>
         <InputWrapper ref={setAnchorEl} className={focused ? 'focused' : ''}>
           {value.map((option: FilmOptionType, index: number) => (

--- a/docs/src/pages/components/autocomplete/UseAutocomplete.js
+++ b/docs/src/pages/components/autocomplete/UseAutocomplete.js
@@ -36,7 +36,7 @@ const useStyles = makeStyles(theme => ({
 export default function UseAutocomplete() {
   const classes = useStyles();
   const {
-    getComboboxProps,
+    getRootProps,
     getInputLabelProps,
     getInputProps,
     getListboxProps,
@@ -49,7 +49,7 @@ export default function UseAutocomplete() {
 
   return (
     <div>
-      <div {...getComboboxProps()}>
+      <div {...getRootProps()}>
         <label className={classes.label} {...getInputLabelProps()}>
           useAutocomplete
         </label>

--- a/docs/src/pages/components/autocomplete/UseAutocomplete.tsx
+++ b/docs/src/pages/components/autocomplete/UseAutocomplete.tsx
@@ -38,7 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
 export default function UseAutocomplete() {
   const classes = useStyles();
   const {
-    getComboboxProps,
+    getRootProps,
     getInputLabelProps,
     getInputProps,
     getListboxProps,
@@ -51,7 +51,7 @@ export default function UseAutocomplete() {
 
   return (
     <div>
-      <div {...getComboboxProps()}>
+      <div {...getRootProps()}>
         <label className={classes.label} {...getInputLabelProps()}>
           useAutocomplete
         </label>

--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -55,7 +55,7 @@ The Autocomplete component uses this hook internally.
 import useAutocomplete from '@material-ui/lab/useAutocomplete';
 ```
 
-- 📦 [4 kB gzipped](/size-snapshot).
+- 📦 [4.5 kB gzipped](/size-snapshot).
 
 {{"demo": "pages/components/autocomplete/UseAutocomplete.js", "defaultCodeOpen": false}}
 

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -210,7 +210,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
   const PopperComponent = disablePortal ? DisablePortal : PopperComponentProp;
 
   const {
-    getComboboxProps,
+    getRootProps,
     getInputProps,
     getInputLabelProps,
     getPopupIndicatorProps,
@@ -282,7 +282,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
           },
           className,
         )}
-        {...getComboboxProps()}
+        {...getRootProps()}
         {...other}
       >
         {renderInput({

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -497,4 +497,56 @@ describe('<Autocomplete />', () => {
       expect(handleChange.callCount).to.equal(1);
     });
   });
+
+  describe('prop: autoComplete', () => {
+    it('add a completion string', () => {
+      const { getByRole } = render(
+        <Autocomplete
+          autoComplete
+          options={['one', 'two']}
+          renderInput={params => <TextField autoFocus {...params} />}
+        />,
+      );
+      const textbox = getByRole('textbox');
+      fireEvent.change(textbox, { target: { value: 'O' } });
+      expect(textbox.value).to.equal('O');
+      fireEvent.keyDown(textbox, { key: 'ArrowDown' });
+      expect(textbox.value).to.equal('one');
+      expect(textbox.selectionStart).to.equal(1);
+      expect(textbox.selectionEnd).to.equal(3);
+      fireEvent.keyDown(textbox, { key: 'Enter' });
+      expect(textbox.value).to.equal('one');
+      expect(textbox.selectionStart).to.equal(3);
+      expect(textbox.selectionEnd).to.equal(3);
+    });
+  });
+
+  describe('click input', () => {
+    it('toggles if empty', () => {
+      const { getByRole } = render(
+        <Autocomplete options={['one', 'two']} renderInput={params => <TextField {...params} />} />,
+      );
+      const textbox = getByRole('textbox');
+      const combobox = getByRole('combobox');
+      expect(combobox).to.have.attribute('aria-expanded', 'false');
+      fireEvent.mouseDown(textbox);
+      expect(combobox).to.have.attribute('aria-expanded', 'true');
+      fireEvent.mouseDown(textbox);
+      expect(combobox).to.have.attribute('aria-expanded', 'false');
+    });
+
+    it('selects all the first time', () => {
+      const { getByRole } = render(
+        <Autocomplete
+          value="one"
+          options={['one', 'two']}
+          renderInput={params => <TextField {...params} />}
+        />,
+      );
+      const textbox = getByRole('textbox');
+      fireEvent.click(textbox);
+      expect(textbox.selectionStart).to.equal(0);
+      expect(textbox.selectionEnd).to.equal(3);
+    });
+  });
 });

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -153,7 +153,7 @@ export interface UseAutocompleteProps {
 export default function useAutocomplete(
   props: UseAutocompleteProps,
 ): {
-  getComboboxProps: () => {};
+  getRootProps: () => {};
   getInputProps: () => {};
   getInputLabelProps: () => {};
   getClearProps: () => {};


### PR DESCRIPTION
- Fix bug with autoComplete + Enter
- Closes #18280 cc @lyftian
- Closes #18101 cc @eps1lon 
- Closes #18203 cc @FlorisWarmenhoven
- Revert `getRootProps` change to avoid breaking change

Preview: https://deploy-preview-18286--material-ui.netlify.com/components/autocomplete/