### PR TITLE
[ButtonBase] Test keyboard events of child elements

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -687,9 +687,9 @@ describe('<ButtonBase />', () => {
             Hello
           </ButtonBase>,
         );
-
         const button = getByRole('button');
         button.focus();
+
         fireEvent.keyDown(document.activeElement || document.body, {
           key: ' ',
         });
@@ -697,6 +697,55 @@ describe('<ButtonBase />', () => {
         expect(onClickSpy.calledOnce).to.equal(true);
         // defaultPrevented?
         expect(onClickSpy.returnValues[0]).to.equal(true);
+      });
+
+      it('calls onClick when Enter is pressed on the element', () => {
+        const onClickSpy = spy(event => event.defaultPrevented);
+        const { getByRole } = render(
+          <ButtonBase onClick={onClickSpy} component="div">
+            Hello
+          </ButtonBase>,
+        );
+        const button = getByRole('button');
+        button.focus();
+
+        fireEvent.keyDown(document.activeElement || document.body, {
+          key: 'Enter',
+        });
+
+        expect(onClickSpy.calledOnce).to.equal(true);
+        // defaultPrevented?
+        expect(onClickSpy.returnValues[0]).to.equal(true);
+      });
+
+      it('does not call onClick if Enter was pressed on a child', () => {
+        const onClickSpy = spy(event => event.defaultPrevented);
+        render(
+          <ButtonBase onClick={onClickSpy} component="div">
+            <input autoFocus type="text" />
+          </ButtonBase>,
+        );
+
+        fireEvent.keyDown(document.activeElement, {
+          key: 'Enter',
+        });
+
+        expect(onClickSpy.callCount).to.equal(0);
+      });
+
+      it('does not call onClick if Space was pressed on a child', () => {
+        const onClickSpy = spy(event => event.defaultPrevented);
+        render(
+          <ButtonBase onClick={onClickSpy} component="div">
+            <input autoFocus type="text" />
+          </ButtonBase>,
+        );
+
+        fireEvent.keyDown(document.activeElement, {
+          key: ' ',
+        });
+
+        expect(onClickSpy.callCount).to.equal(0);
       });
 
       it('prevents default with an anchor and empty href', () => {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -720,8 +720,9 @@ describe('<ButtonBase />', () => {
 
       it('does not call onClick if Enter was pressed on a child', () => {
         const onClickSpy = spy(event => event.defaultPrevented);
+        const onKeyDownSpy = spy();
         render(
-          <ButtonBase onClick={onClickSpy} component="div">
+          <ButtonBase onClick={onClickSpy} onKeyDown={onKeyDownSpy} component="div">
             <input autoFocus type="text" />
           </ButtonBase>,
         );
@@ -730,13 +731,15 @@ describe('<ButtonBase />', () => {
           key: 'Enter',
         });
 
+        expect(onKeyDownSpy.callCount).to.equal(1);
         expect(onClickSpy.callCount).to.equal(0);
       });
 
       it('does not call onClick if Space was pressed on a child', () => {
         const onClickSpy = spy(event => event.defaultPrevented);
+        const onKeyDownSpy = spy();
         render(
-          <ButtonBase onClick={onClickSpy} component="div">
+          <ButtonBase onClick={onClickSpy} onKeyDown={onKeyDownSpy} component="div">
             <input autoFocus type="text" />
           </ButtonBase>,
         );
@@ -745,6 +748,7 @@ describe('<ButtonBase />', () => {
           key: ' ',
         });
 
+        expect(onKeyDownSpy.callCount).to.equal(1);
         expect(onClickSpy.callCount).to.equal(0);
       });
 


### PR DESCRIPTION
This is a test extracted from #18271

We currently don't expect `event.stopPropagation` but manually check if the event is explicitly dispatched on the button i.e. are we currently focusing the button?

I think this makes for this example specifically more sense. I guess keyboard events are fundamentally different than pointer events in this regard. With cursor events we can't possibly expect that the user knows exactly what elements they want to target (since the DOM is hidden). For keyboard events we can since focused elements are perceivable.