### PR TITLE
[docs] Fix useMediaQuery ssr implementation example

### DIFF
--- a/docs/src/pages/components/use-media-query/use-media-query.md
+++ b/docs/src/pages/components/use-media-query/use-media-query.md
@@ -121,7 +121,7 @@ function handleRender(req, res) {
   const ssrMatchMedia = query => ({
     matches: mediaQuery.match(query, {
       // The estimated CSS width of the browser.
-      width: deviceType === 'mobile' ? 0 : 1024,
+      width: deviceType === 'mobile' ? '0px' : '1024px',
     }),
   });
 


### PR DESCRIPTION
Hello! 👋 

A colleague (@marlonbs) and me we've been struggling our heads a few days on the `useMediaQuery` SSR implementation for a Next.js project that we're building on. 

After reading [`css-mediaquery`](https://github.com/ericf/css-mediaquery#readme) docs and [examples](https://github.com/ericf/css-mediaquery#matching) we figured it out that our SSR `useMediaQuery` implementation was not working because the `px` string was not included into the match. 🙈

I'm making a PR to update the docs just in case it could help anyone ❤️ 

Related issues: #15187 and #16132

### Demo

When you use [breakpoint helpers with useMediaQuery](https://material-ui.com/components/use-media-query/#using-material-uis-breakpoint-helpers)

```js
import { useTheme } from '@material-ui/core/styles';
import useMediaQuery from '@material-ui/core/useMediaQuery';

function MyComponent() {
  const theme = useTheme();
  const matches = useMediaQuery(theme.breakpoints.up('sm'));

  return <span>{`theme.breakpoints.up('sm') matches: ${matches}`}</span>;
}
```

This statement `theme.breakpoints.down('xs')` returns something like this:

```
'(max-width:767.95px)'
```

Then the `css-mediaquery` won't match the value if the `px` string is not present:

![Screenshot 2019-11-12 at 12 55 28](https://user-images.githubusercontent.com/7629661/68669820-c55b4300-054b-11ea-9fcb-a5a259d1b5ad.png)

![Screenshot 2019-11-12 at 12 55 47](https://user-images.githubusercontent.com/7629661/68669825-c7bd9d00-054b-11ea-8725-30aa3725a811.png)


<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
