### PR TITLE
[docs] Rename obsoleted `ExpandMoreIcon` to `ExpandMore`

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -15,7 +15,7 @@ import Button from '@material-ui/core/Button';
 import Box from '@material-ui/core/Box';
 import NoSsr from '@material-ui/core/NoSsr';
 import LanguageIcon from '@material-ui/icons/Translate';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import Divider from '@material-ui/core/Divider';
@@ -239,7 +239,7 @@ function AppFrame(props) {
                   ? 'Translating'
                   : LANGUAGES_LABEL.filter(language => language.code === userLanguage)[0].text}
               </span>
-              <ExpandMoreIcon fontSize="small" />
+              <ExpandMore fontSize="small" />
             </Button>
           </Tooltip>
           <NoSsr>

--- a/docs/src/pages/components/breadcrumbs/CustomizedBreadcrumbs.js
+++ b/docs/src/pages/components/breadcrumbs/CustomizedBreadcrumbs.js
@@ -4,7 +4,7 @@ import Paper from '@material-ui/core/Paper';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
 import Chip from '@material-ui/core/Chip';
 import HomeIcon from '@material-ui/icons/Home';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const StyledBreadcrumb = withStyles(theme => ({
   root: {
@@ -53,7 +53,7 @@ export default function CustomizedBreadcrumbs() {
         <StyledBreadcrumb component="a" href="#" label="Catalog" onClick={handleClick} />
         <StyledBreadcrumb
           label="Accessories"
-          deleteIcon={<ExpandMoreIcon />}
+          deleteIcon={<ExpandMore />}
           onClick={handleClick}
           onDelete={handleClick}
         />

--- a/docs/src/pages/components/breadcrumbs/CustomizedBreadcrumbs.tsx
+++ b/docs/src/pages/components/breadcrumbs/CustomizedBreadcrumbs.tsx
@@ -4,7 +4,7 @@ import Paper from '@material-ui/core/Paper';
 import Breadcrumbs from '@material-ui/core/Breadcrumbs';
 import Chip from '@material-ui/core/Chip';
 import HomeIcon from '@material-ui/icons/Home';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const StyledBreadcrumb = withStyles((theme: Theme) => ({
   root: {
@@ -55,7 +55,7 @@ export default function CustomizedBreadcrumbs() {
         <StyledBreadcrumb component="a" href="#" label="Catalog" onClick={handleClick} />
         <StyledBreadcrumb
           label="Accessories"
-          deleteIcon={<ExpandMoreIcon />}
+          deleteIcon={<ExpandMore />}
           onClick={handleClick}
           onDelete={handleClick}
         />

--- a/docs/src/pages/components/cards/RecipeReviewCard.js
+++ b/docs/src/pages/components/cards/RecipeReviewCard.js
@@ -13,7 +13,7 @@ import Typography from '@material-ui/core/Typography';
 import { red } from '@material-ui/core/colors';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import ShareIcon from '@material-ui/icons/Share';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 
 const useStyles = makeStyles(theme => ({
@@ -89,7 +89,7 @@ export default function RecipeReviewCard() {
           aria-expanded={expanded}
           aria-label="show more"
         >
-          <ExpandMoreIcon />
+          <ExpandMore />
         </IconButton>
       </CardActions>
       <Collapse in={expanded} timeout="auto" unmountOnExit>

--- a/docs/src/pages/components/cards/RecipeReviewCard.tsx
+++ b/docs/src/pages/components/cards/RecipeReviewCard.tsx
@@ -13,7 +13,7 @@ import Typography from '@material-ui/core/Typography';
 import { red } from '@material-ui/core/colors';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import ShareIcon from '@material-ui/icons/Share';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -91,7 +91,7 @@ export default function RecipeReviewCard() {
           aria-expanded={expanded}
           aria-label="show more"
         >
-          <ExpandMoreIcon />
+          <ExpandMore />
         </IconButton>
       </CardActions>
       <Collapse in={expanded} timeout="auto" unmountOnExit>

--- a/docs/src/pages/components/expansion-panels/ActionsInExpansionPanelSummary.js
+++ b/docs/src/pages/components/expansion-panels/ActionsInExpansionPanelSummary.js
@@ -6,7 +6,7 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const useStyles = makeStyles({
   root: {
@@ -21,7 +21,7 @@ export default function ActionsInExpansionPanelSummary() {
     <div className={classes.root}>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-label="Expand"
           aria-controls="additional-actions1-content"
           id="additional-actions1-header"
@@ -43,7 +43,7 @@ export default function ActionsInExpansionPanelSummary() {
       </ExpansionPanel>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-label="Expand"
           aria-controls="additional-actions2-content"
           id="additional-actions2-header"
@@ -65,7 +65,7 @@ export default function ActionsInExpansionPanelSummary() {
       </ExpansionPanel>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-label="Expand"
           aria-controls="additional-actions3-content"
           id="additional-actions3-header"

--- a/docs/src/pages/components/expansion-panels/ActionsInExpansionPanelSummary.tsx
+++ b/docs/src/pages/components/expansion-panels/ActionsInExpansionPanelSummary.tsx
@@ -6,7 +6,7 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import Checkbox from '@material-ui/core/Checkbox';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const useStyles = makeStyles({
   root: {
@@ -21,7 +21,7 @@ export default function ActionsInExpansionPanelSummary() {
     <div className={classes.root}>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-label="Expand"
           aria-controls="additional-actions1-content"
           id="additional-actions1-header"
@@ -43,7 +43,7 @@ export default function ActionsInExpansionPanelSummary() {
       </ExpansionPanel>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-label="Expand"
           aria-controls="additional-actions2-content"
           id="additional-actions2-header"
@@ -65,7 +65,7 @@ export default function ActionsInExpansionPanelSummary() {
       </ExpansionPanel>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-label="Expand"
           aria-controls="additional-actions3-content"
           id="additional-actions3-header"

--- a/docs/src/pages/components/expansion-panels/ControlledExpansionPanels.js
+++ b/docs/src/pages/components/expansion-panels/ControlledExpansionPanels.js
@@ -4,7 +4,7 @@ import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -33,7 +33,7 @@ export default function ControlledExpansionPanels() {
     <div className={classes.root}>
       <ExpansionPanel expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel1bh-content"
           id="panel1bh-header"
         >
@@ -49,7 +49,7 @@ export default function ControlledExpansionPanels() {
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel2bh-content"
           id="panel2bh-header"
         >
@@ -67,7 +67,7 @@ export default function ControlledExpansionPanels() {
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel3'} onChange={handleChange('panel3')}>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel3bh-content"
           id="panel3bh-header"
         >
@@ -85,7 +85,7 @@ export default function ControlledExpansionPanels() {
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel4'} onChange={handleChange('panel4')}>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel4bh-content"
           id="panel4bh-header"
         >

--- a/docs/src/pages/components/expansion-panels/ControlledExpansionPanels.tsx
+++ b/docs/src/pages/components/expansion-panels/ControlledExpansionPanels.tsx
@@ -4,7 +4,7 @@ import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -35,7 +35,7 @@ export default function ControlledExpansionPanels() {
     <div className={classes.root}>
       <ExpansionPanel expanded={expanded === 'panel1'} onChange={handleChange('panel1')}>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel1bh-content"
           id="panel1bh-header"
         >
@@ -51,7 +51,7 @@ export default function ControlledExpansionPanels() {
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel2'} onChange={handleChange('panel2')}>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel2bh-content"
           id="panel2bh-header"
         >
@@ -69,7 +69,7 @@ export default function ControlledExpansionPanels() {
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel3'} onChange={handleChange('panel3')}>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel3bh-content"
           id="panel3bh-header"
         >
@@ -87,7 +87,7 @@ export default function ControlledExpansionPanels() {
       </ExpansionPanel>
       <ExpansionPanel expanded={expanded === 'panel4'} onChange={handleChange('panel4')}>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel4bh-content"
           id="panel4bh-header"
         >

--- a/docs/src/pages/components/expansion-panels/DetailedExpansionPanel.js
+++ b/docs/src/pages/components/expansion-panels/DetailedExpansionPanel.js
@@ -6,7 +6,7 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
 import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import Chip from '@material-ui/core/Chip';
 import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
@@ -53,7 +53,7 @@ export default function DetailedExpansionPanel() {
     <div className={classes.root}>
       <ExpansionPanel defaultExpanded>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel1c-content"
           id="panel1c-header"
         >

--- a/docs/src/pages/components/expansion-panels/DetailedExpansionPanel.tsx
+++ b/docs/src/pages/components/expansion-panels/DetailedExpansionPanel.tsx
@@ -6,7 +6,7 @@ import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelActions from '@material-ui/core/ExpansionPanelActions';
 import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import Chip from '@material-ui/core/Chip';
 import Button from '@material-ui/core/Button';
 import Divider from '@material-ui/core/Divider';
@@ -55,7 +55,7 @@ export default function DetailedExpansionPanel() {
     <div className={classes.root}>
       <ExpansionPanel defaultExpanded>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel1c-content"
           id="panel1c-header"
         >

--- a/docs/src/pages/components/expansion-panels/SimpleExpansionPanel.js
+++ b/docs/src/pages/components/expansion-panels/SimpleExpansionPanel.js
@@ -4,7 +4,7 @@ import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -23,7 +23,7 @@ export default function SimpleExpansionPanel() {
     <div className={classes.root}>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel1a-content"
           id="panel1a-header"
         >
@@ -38,7 +38,7 @@ export default function SimpleExpansionPanel() {
       </ExpansionPanel>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel2a-content"
           id="panel2a-header"
         >
@@ -53,7 +53,7 @@ export default function SimpleExpansionPanel() {
       </ExpansionPanel>
       <ExpansionPanel disabled>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel3a-content"
           id="panel3a-header"
         >

--- a/docs/src/pages/components/expansion-panels/SimpleExpansionPanel.tsx
+++ b/docs/src/pages/components/expansion-panels/SimpleExpansionPanel.tsx
@@ -4,7 +4,7 @@ import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import Typography from '@material-ui/core/Typography';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -25,7 +25,7 @@ export default function SimpleExpansionPanel() {
     <div className={classes.root}>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel1a-content"
           id="panel1a-header"
         >
@@ -40,7 +40,7 @@ export default function SimpleExpansionPanel() {
       </ExpansionPanel>
       <ExpansionPanel>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel2a-content"
           id="panel2a-header"
         >
@@ -55,7 +55,7 @@ export default function SimpleExpansionPanel() {
       </ExpansionPanel>
       <ExpansionPanel disabled>
         <ExpansionPanelSummary
-          expandIcon={<ExpandMoreIcon />}
+          expandIcon={<ExpandMore />}
           aria-controls="panel3a-content"
           id="panel3a-header"
         >

--- a/docs/src/pages/components/tree-view/ControlledTreeView.js
+++ b/docs/src/pages/components/tree-view/ControlledTreeView.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import TreeItem from '@material-ui/lab/TreeItem';
 
@@ -24,7 +24,7 @@ export default function ControlledTreeView() {
   return (
     <TreeView
       className={classes.root}
-      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultCollapseIcon={<ExpandMore />}
       defaultExpandIcon={<ChevronRightIcon />}
       expanded={expanded}
       onNodeToggle={handleChange}

--- a/docs/src/pages/components/tree-view/ControlledTreeView.tsx
+++ b/docs/src/pages/components/tree-view/ControlledTreeView.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import TreeItem from '@material-ui/lab/TreeItem';
 
@@ -24,7 +24,7 @@ export default function ControlledTreeView() {
   return (
     <TreeView
       className={classes.root}
-      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultCollapseIcon={<ExpandMore />}
       defaultExpandIcon={<ChevronRightIcon />}
       expanded={expanded}
       onNodeToggle={handleChange}

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.js
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import TreeItem from '@material-ui/lab/TreeItem';
 
@@ -19,7 +19,7 @@ export default function FileSystemNavigator() {
   return (
     <TreeView
       className={classes.root}
-      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultCollapseIcon={<ExpandMore />}
       defaultExpandIcon={<ChevronRightIcon />}
     >
       <TreeItem nodeId="1" label="Applications">

--- a/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
+++ b/docs/src/pages/components/tree-view/FileSystemNavigator.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import TreeView from '@material-ui/lab/TreeView';
-import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import ExpandMore from '@material-ui/icons/ExpandMore';
 import ChevronRightIcon from '@material-ui/icons/ChevronRight';
 import TreeItem from '@material-ui/lab/TreeItem';
 
@@ -19,7 +19,7 @@ export default function FileSystemNavigator() {
   return (
     <TreeView
       className={classes.root}
-      defaultCollapseIcon={<ExpandMoreIcon />}
+      defaultCollapseIcon={<ExpandMore />}
       defaultExpandIcon={<ChevronRightIcon />}
     >
       <TreeItem nodeId="1" label="Applications">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

`ExpandMoreIcon` is now `ExpandMore` (https://github.com/mui-org/material-ui/blob/master/packages/material-ui-icons/src/ExpandMore.js).