### PR TITLE
[Docs] Update server-rendering.md docs

### DIFF
--- a/docs/src/pages/guides/server-rendering/server-rendering.md
+++ b/docs/src/pages/guides/server-rendering/server-rendering.md
@@ -171,7 +171,7 @@ function Main() {
   React.useEffect(() => {
     const jssStyles = document.querySelector('#jss-server-side');
     if (jssStyles) {
-      jssStyles.parentElement.removeChild(jssStyles);
+      jssStyles.parentNode.removeChild(jssStyles);
     }
   }, []);
 


### PR DESCRIPTION
Adds fix in guide to reference parentNode instead of parentElement for SSR when modifying CSR CSS.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
