### PR TITLE
[lab] Bump material-ui/core version

### DIFF
--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -34,7 +34,7 @@
     "typescript": "tslint -p tsconfig.json \"src/**/*.{ts,tsx}\""
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.5.2",
+    "@material-ui/core": "^4.6.1",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

Today, `lab` requires a minimum version of `v4.6.1` in `core`, without it, `Autocomplete` breaks. 

Because the change in `useEventCallback`, that now accepts a list of [`args` instead just event](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/utils/useEventCallback.js#L15). 

Without this change, `resetInputValue` receives `undefined` in [`newValue`](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js#L169) and set the value to [empty](https://github.com/mui-org/material-ui/blob/master/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js#L174).