### PR TITLE
[docs] Add turtle icon to slow top-level import option

### DIFF
--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -40,6 +40,7 @@ import TextField from '@material-ui/core/TextField';
 instead of top level imports (without a Babel plugin):
 
 ```js
+// 🐢 Slow
 import { Button, TextField } from '@material-ui/core';
 ```
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#submitting-a-pull-request).

I had to read this twice to figure out which option I was supposed to choose. I think this icon would help and it would balance out the 🚀on the other option.