### PR TITLE
editable 'container' and 'secondaryAction' classes

### DIFF
--- a/packages/material-ui/src/MenuItem/MenuItem.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.js
@@ -55,7 +55,11 @@ const MenuItem = React.forwardRef(function MenuItem(props, ref) {
       component={component}
       selected={selected}
       disableGutters={disableGutters}
-      classes={{ dense: classes.dense }}
+      classes={{
+        dense: classes.dense,
+        container: classes.container,
+        secondaryAction: classes.secondaryAction,
+      }}
       className={clsx(
         classes.root,
         {


### PR DESCRIPTION
We need to be able to add classes to ListItem's 'container' and 'secondaryAction' in MenuItem

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
