### PR TITLE
[HiddenCss] Fix warning when using custom breakpoints

### DIFF
--- a/packages/material-ui/src/Hidden/HiddenCss.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.js
@@ -28,34 +28,22 @@ const styles = theme => {
  * @ignore - internal component.
  */
 function HiddenCss(props) {
-  const {
-    children,
-    classes,
-    className,
-    lgDown,
-    lgUp,
-    mdDown,
-    mdUp,
-    only,
-    smDown,
-    smUp,
-    xlDown,
-    xlUp,
-    xsDown,
-    xsUp,
-    ...other
-  } = props;
+  const { children, classes, className, only, ...other } = props;
   const theme = useTheme();
 
   if (process.env.NODE_ENV !== 'production') {
-    if (
-      Object.keys(other).length !== 0 &&
-      !(Object.keys(other).length === 1 && other.hasOwnProperty('ref'))
-    ) {
+    const unknownProps = Object.keys(other).filter(propName => {
+      const isUndeclaredBreakpoint = !theme.breakpoints.keys.some(breakpoint => {
+        return `${breakpoint}Up` === propName || `${breakpoint}Down` === propName;
+      });
+      return isUndeclaredBreakpoint;
+    });
+
+    if (unknownProps.length > 0) {
       console.error(
-        `Material-UI: unsupported props received ${Object.keys(other).join(
+        `Material-UI: Unsupported props received by \`<Hidden implementation="css" />\`: ${unknownProps.join(
           ', ',
-        )} by \`<Hidden />\`.`,
+        )}. Did you forget to wrap this component in a ThemeProvider declaring these breakpoints?`,
       );
     }
   }

--- a/packages/material-ui/src/Hidden/HiddenCss.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.js
@@ -41,7 +41,7 @@ function HiddenCss(props) {
 
     if (unknownProps.length > 0) {
       console.error(
-        `Material-UI: Unsupported props received by \`<Hidden implementation="css" />\`: ${unknownProps.join(
+        `Material-UI: unsupported props received by \`<Hidden implementation="css" />\`: ${unknownProps.join(
           ', ',
         )}. Did you forget to wrap this component in a ThemeProvider declaring these breakpoints?`,
       );

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -163,7 +163,7 @@ describe('<HiddenCss />', () => {
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
         consoleErrorMock.args()[0][0],
-        'Material-UI: Unsupported props received by `<Hidden implementation="css" />`: xxlUp.',
+        'Material-UI: unsupported props received by `<Hidden implementation="css" />`: xxlUp.',
       );
     });
   });

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -1,21 +1,32 @@
 import React from 'react';
 import { assert } from 'chai';
-import { createShallow, getClasses } from '@material-ui/core/test-utils';
+import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import HiddenCss from './HiddenCss';
+import { createMuiTheme, MuiThemeProvider } from '../styles';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 
 const Foo = () => <div>bar</div>;
 
 describe('<HiddenCss />', () => {
+  /**
+   * @type {ReturnType<typeof createMount>}
+   */
+  let mount;
   let shallow;
   let classes;
 
   before(() => {
+    mount = createMount({ strict: true });
     shallow = createShallow({ untilSelector: 'div' });
     classes = getClasses(
       <HiddenCss>
         <div />
       </HiddenCss>,
     );
+  });
+
+  after(() => {
+    mount.cleanUp();
   });
 
   describe('the generated class names', () => {
@@ -82,6 +93,19 @@ describe('<HiddenCss />', () => {
       );
       assert.strictEqual(wrapper.hasClass('custom'), true);
     });
+
+    it('allows custom breakpoints', () => {
+      const theme = createMuiTheme({ breakpoints: { keys: ['xxl'] } });
+      const wrapper = mount(
+        <MuiThemeProvider theme={theme}>
+          <HiddenCss xxlUp className="testid" classes={{ xxlUp: 'xxlUp' }}>
+            <div />
+          </HiddenCss>
+        </MuiThemeProvider>,
+      );
+
+      assert.strictEqual(wrapper.find('div.testid').hasClass('xxlUp'), true);
+    });
   });
 
   describe('prop: children', () => {
@@ -117,6 +141,30 @@ describe('<HiddenCss />', () => {
       assert.strictEqual(wrapper.childAt(0).is(Foo), true);
       assert.strictEqual(wrapper.childAt(1).is(Foo), true);
       assert.strictEqual(wrapper.childAt(2).text(), 'foo');
+    });
+  });
+
+  describe('warnings', () => {
+    beforeEach(() => {
+      consoleErrorMock.spy();
+    });
+
+    afterEach(() => {
+      consoleErrorMock.reset();
+    });
+
+    it('warns about excess props (potentially undeclared breakpoints)', () => {
+      mount(
+        <HiddenCss xxlUp>
+          <div />
+        </HiddenCss>,
+      );
+
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'Material-UI: Unsupported props received by `<Hidden implementation="css" />`: xxlUp.',
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes false positive warning when using 

```jsx
const theme = createMuiTheme({ breakpoints: { keys: ['xxl'] } });
const wrapper = mount(
  <MuiThemeProvider theme={theme}>
    <Hidden implementation="css" xxlUp>
      <div />
    </Hidden>
  </MuiThemeProvider>,
);
```

The default value story can be considered in a separate PR.