### PR TITLE
[CardMedia] Use propTypes for "at least one"-check

### DIFF
--- a/packages/material-ui/src/CardMedia/CardMedia.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
+import { chainPropTypes } from '@material-ui/utils';
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -36,12 +37,6 @@ const CardMedia = React.forwardRef(function CardMedia(props, ref) {
     ...other
   } = props;
 
-  if (process.env.NODE_ENV !== 'production') {
-    if (!children && !image && !src) {
-      console.error('Material-UI: either `children`, `image` or `src` prop must be specified.');
-    }
-  }
-
   const isMediaComponent = MEDIA_COMPONENTS.indexOf(Component) !== -1;
   const composedStyle =
     !isMediaComponent && image ? { backgroundImage: `url("${image}")`, ...style } : style;
@@ -70,7 +65,12 @@ CardMedia.propTypes = {
   /**
    * The content of the component.
    */
-  children: PropTypes.node,
+  children: chainPropTypes(PropTypes.node, props => {
+    if (!props.children && !props.image && !props.src) {
+      return new Error('Material-UI: either `children`, `image` or `src` prop must be specified.');
+    }
+    return null;
+  }),
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import CardMedia from './CardMedia';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
 
 describe('<CardMedia />', () => {
   let mount;
@@ -76,6 +77,26 @@ describe('<CardMedia />', () => {
     it('should not have `src` prop if not media component specified', () => {
       const wrapper = mount(<CardMedia image="/foo.jpg" component="table" />);
       assert.strictEqual(findOutermostIntrinsic(wrapper).props().src, undefined);
+    });
+  });
+
+  describe('warnings', () => {
+    before(() => {
+      consoleErrorMock.spy();
+    });
+
+    after(() => {
+      consoleErrorMock.reset();
+    });
+
+    it('warns when neither `children`, nor `image`, nor `src` are provided', () => {
+      mount(<CardMedia />);
+
+      assert.strictEqual(consoleErrorMock.callCount(), 1);
+      assert.include(
+        consoleErrorMock.args()[0][0],
+        'Material-UI: either `children`, `image` or `src` prop must be specified.',
+      );
     });
   });
 });

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -4,6 +4,7 @@ import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/co
 import describeConformance from '../test-utils/describeConformance';
 import CardMedia from './CardMedia';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
+import PropTypes from 'prop-types';
 
 describe('<CardMedia />', () => {
   let mount;
@@ -87,6 +88,7 @@ describe('<CardMedia />', () => {
 
     after(() => {
       consoleErrorMock.reset();
+      PropTypes.resetWarningCache();
     });
 
     it('warns when neither `children`, nor `image`, nor `src` are provided', () => {


### PR DESCRIPTION
`propTypes` is currently the superior solution to runtime warnings in render methods since it includes component stacks when in ssr (no devtools available) and automatically deduplicates<sup>1</sup> messages (something I want to work on in react-devtools regardless).

<sup>1</sup> We can't polyfill deduplication since propTypes messages are deduplicated based on there component stack. Two warnings with different stacks are not deduplicated. We could only deduplicate every warning regardless of component stack.

