### PR TITLE
Allow to pass mixins as a function to createMuiTheme()

### DIFF
--- a/packages/material-ui/src/styles/createMixins.d.ts
+++ b/packages/material-ui/src/styles/createMixins.d.ts
@@ -15,5 +15,5 @@ export interface MixinsOptions extends Partial<Mixins> {
 export default function createMixins(
   breakpoints: Breakpoints,
   spacing: Spacing,
-  mixins: MixinsOptions,
+  mixins: MixinsOptions | ((breakpoints: Breakpoints, spacing: Spacing) => MixinsOptions),
 ): Mixins;

--- a/packages/material-ui/src/styles/createMixins.js
+++ b/packages/material-ui/src/styles/createMixins.js
@@ -38,6 +38,6 @@ export default function createMixins(breakpoints, spacing, mixins) {
         minHeight: 64,
       },
     },
-    ...mixins,
+    ...(typeof mixins === 'function' ? mixins(breakpoints, spacing) : mixins),
   };
 }

--- a/packages/material-ui/src/styles/createMixins.test.js
+++ b/packages/material-ui/src/styles/createMixins.test.js
@@ -23,4 +23,29 @@ describe('createMixins', () => {
       paddingRight: 16,
     });
   });
+
+  it('should accept a function', () => {
+    const theme = createMuiTheme();
+    const mixins = createMixins(theme.breakpoints, theme.spacing, (breakpoints, spacing) => {
+      assert.strictEqual(breakpoints, theme.breakpoints);
+      assert.strictEqual(spacing, theme.spacing);
+      return {
+        element: {
+          padding: spacing(1),
+          [breakpoints.up('sm')]: {
+            padding: spacing(2),
+          },
+        },
+      };
+    });
+
+    assert.deepEqual(mixins.element, {
+      element: {
+        padding: theme.spacing(1),
+        [breakpoints.up('sm')]: {
+          padding: spacing(2),
+        },
+      },
+    });
+  });
 });


### PR DESCRIPTION
#### Usage Example

```js
createMuiTheme({
  mixins: (breakpoints, spacing) => ({
    element: {
      padding: spacing(1),
      [breakpoints.up('sm')]: {
        padding: spacing(2)
      }
    }
  })
})
```