### PR TITLE
[l10n] Improve Russian translation

### DIFF
--- a/packages/material-ui/src/locale/index.js
+++ b/packages/material-ui/src/locale/index.js
@@ -136,7 +136,18 @@ export const ruRU = {
       nextIconButtonText: 'Следующая страница',
     },
     MuiRating: {
-      getLabelText: value => `${value} Звезд${value !== 1 ? 'ы' : 'а'}`,
+      getLabelText: value => {
+        let pluralForm = 'Звёзд';
+        const lastDigit = value % 10;
+
+        if (lastDigit > 1 && lastDigit < 5) {
+          pluralForm = 'Звезды';
+        } else if (lastDigit === 1) {
+          pluralForm = 'Звезда';
+        }
+
+        return `${value} ${pluralForm}`;
+      },
     },
     MuiAutocomplete: {
       clearText: 'Очистить',

--- a/packages/material-ui/src/locale/index.js
+++ b/packages/material-ui/src/locale/index.js
@@ -132,18 +132,18 @@ export const ruRU = {
     MuiTablePagination: {
       backIconButtonText: 'Предыдущая страница',
       labelRowsPerPage: 'Строк на страницу:',
-      labelDisplayedRows: ({ from, to, count }) => `${from}-${to === -1 ? count : to} of ${count}`,
+      labelDisplayedRows: ({ from, to, count }) => `${from}-${to === -1 ? count : to} из ${count}`,
       nextIconButtonText: 'Следующая страница',
     },
     MuiRating: {
-      getLabelText: value => `${value} ${value !== 1 ? 'Звезды' : 'звезда'}`,
+      getLabelText: value => `${value} Звезд${value !== 1 ? 'ы' : 'а'}`,
     },
     MuiAutocomplete: {
-      clearText: 'чистый',
-      closeText: 'близко',
-      loadingText: 'загрузка…',
+      clearText: 'Очистить',
+      closeText: 'Закрыть',
+      loadingText: 'Загрузка…',
       noOptionsText: 'Нет вариантов',
-      openText: 'открыто',
+      openText: 'Открыть',
     },
   },
 };

--- a/packages/material-ui/src/locale/index.js
+++ b/packages/material-ui/src/locale/index.js
@@ -131,7 +131,7 @@ export const ruRU = {
   props: {
     MuiTablePagination: {
       backIconButtonText: 'Предыдущая страница',
-      labelRowsPerPage: 'Строк на страницу:',
+      labelRowsPerPage: 'Строк на странице:',
       labelDisplayedRows: ({ from, to, count }) => `${from}-${to === -1 ? count : to} из ${count}`,
       nextIconButtonText: 'Следующая страница',
     },
@@ -153,7 +153,7 @@ export const ruRU = {
       clearText: 'Очистить',
       closeText: 'Закрыть',
       loadingText: 'Загрузка…',
-      noOptionsText: 'Нет вариантов',
+      noOptionsText: 'Нет доступных вариантов',
       openText: 'Открыть',
     },
   },


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

This is a quick fix for Russian text lines in library localization.

However, there is an issue with declination. In Russian you can't simply add an ending to noun to make it plural (as in English). There are two different endings for plural nouns (and sometimes word alters a bit).

**Example:**
2-4 stars translates as 2-4 звезд**ы**, but 5, 6, 7... 20 stars will be зв**ё**зд. Then again 21 stars translates as 21 звезд**а**.

Common solution here is to define function that takes three word forms and a number and returns suitable one.

Is it ok, if I put such function into `/utils` subfolder?

Closes #18421