### PR TITLE
[slider] Increase interaction area

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -136,7 +136,7 @@ export const styles = theme => ({
     height: 2,
     width: '100%',
     boxSizing: 'content-box',
-    padding: '11px 0',
+    padding: '13px 0',
     display: 'inline-block',
     position: 'relative',
     cursor: 'pointer',
@@ -152,7 +152,7 @@ export const styles = theme => ({
     '&$vertical': {
       width: 2,
       height: '100%',
-      padding: '0 11px',
+      padding: '0 13px',
     },
     // The primary input mechanism of the device includes a pointing device of limited accuracy.
     '@media (pointer: coarse)': {
@@ -247,11 +247,12 @@ export const styles = theme => ({
     '&::after': {
       position: 'absolute',
       content: '""',
-      // reach 48px touch target (2 * 18 + thumb circumference)
-      left: -18,
-      top: -18,
-      right: -18,
-      bottom: -18,
+      borderRadius: '50%',
+      // x10 thumb surface (from 12px^2 to 40px^2).
+      left: -14,
+      top: -14,
+      right: -14,
+      bottom: -14,
     },
     '&$focusVisible,&:hover': {
       boxShadow: `0px 0px 0px 8px ${fade(theme.palette.primary.main, 0.16)}`,
@@ -317,12 +318,12 @@ export const styles = theme => ({
     ...theme.typography.body2,
     color: theme.palette.text.secondary,
     position: 'absolute',
-    top: 22,
+    top: 26,
     transform: 'translateX(-50%)',
     whiteSpace: 'nowrap',
     '$vertical &': {
       top: 'auto',
-      left: 22,
+      left: 26,
       transform: 'translateY(50%)',
     },
     '@media (pointer: coarse)': {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -248,11 +248,11 @@ export const styles = theme => ({
       position: 'absolute',
       content: '""',
       borderRadius: '50%',
-      // x10 thumb surface (from 12px^2 to 40px^2).
-      left: -14,
-      top: -14,
-      right: -14,
-      bottom: -14,
+      // reach 42px hit target (2 * 15 + thumb diameter)
+      left: -15,
+      top: -15,
+      right: -15,
+      bottom: -15,
     },
     '&$focusVisible,&:hover': {
       boxShadow: `0px 0px 0px 8px ${fade(theme.palette.primary.main, 0.16)}`,


### PR DESCRIPTION
... and keep the thumb in parent boundaries

Reverted from #18395 and continued in a standalone effort.

Looking more closely at design systems like Elastic UI, Garden, Blueprint, BaseUI, you can notice that the slider height is larget than us. This change gets us closer to what the Material Design specification recommends: https://material.io/design/usability/accessibility.html#layout-typography: 44px when the main modality is a pointer device. We go from 24px to 28px (still /4).

I have reduced the touch area of the thumb so it almost doesn't "leak" outside its container. This is subjective, but I don't think that the slider should prevent the interaction on the element above it. We have 42px vs the recommended 44px minimum.

**Before**
![Capture d’écran 2019-11-18 à 13 28 13](https://user-images.githubusercontent.com/3165635/69052431-49f40880-0a07-11ea-94e2-87d81edc8ce9.png)

**After**
![Capture d’écran 2019-11-18 à 14 57 13](https://user-images.githubusercontent.com/3165635/69058317-bbd24f00-0a13-11ea-8385-ab9e9fb9117f.png)

