### PR TITLE
[core] Simplify refType

### DIFF
--- a/packages/material-ui-utils/src/refType.js
+++ b/packages/material-ui-utils/src/refType.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
 
-const refType = PropTypes.oneOfType([PropTypes.func, PropTypes.PropTypes.object]);
+const refType = PropTypes.oneOfType([PropTypes.func, PropTypes.object]);
 
 export default refType;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

`PropTypes` does have a circular reference to itself via `PropTypes` property but I don't think we really want to use it?

https://github.com/facebook/prop-types/blob/1c4077b7455e037bd8f81f48e9c51d60c972f8e9/factoryWithTypeCheckers.js#L607