### PR TITLE
[Modal] Prefer to lock scroll on body than html element

### DIFF
--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -632,11 +632,11 @@ describe('<Modal />', () => {
       };
 
       const wrapper = mount(<TestCase open={false} />);
-      assert.strictEqual(document.body.parentElement.style.overflow, '');
+      assert.strictEqual(document.body.style.overflow, '');
       wrapper.setProps({ open: true });
-      assert.strictEqual(document.body.parentElement.style.overflow, 'hidden');
+      assert.strictEqual(document.body.style.overflow, 'hidden');
       wrapper.setProps({ open: false });
-      assert.strictEqual(document.body.parentElement.style.overflow, '');
+      assert.strictEqual(document.body.style.overflow, '');
     });
 
     it('should open and close with Transitions', done => {
@@ -661,17 +661,17 @@ describe('<Modal />', () => {
 
       let wrapper;
       const onEntered = () => {
-        assert.strictEqual(document.body.parentElement.style.overflow, 'hidden');
+        assert.strictEqual(document.body.style.overflow, 'hidden');
         wrapper.setProps({ open: false });
       };
 
       const onExited = () => {
-        assert.strictEqual(document.body.parentElement.style.overflow, '');
+        assert.strictEqual(document.body.style.overflow, '');
         done();
       };
 
       wrapper = mount(<TestCase onEntered={onEntered} onExited={onExited} open={false} />);
-      assert.strictEqual(document.body.parentElement.style.overflow, '');
+      assert.strictEqual(document.body.style.overflow, '');
       wrapper.setProps({ open: true });
     });
   });
@@ -723,23 +723,23 @@ describe('<Modal />', () => {
 
       let wrapper;
       const onEntered = () => {
-        assert.strictEqual(document.body.parentElement.style.overflow, 'hidden');
+        assert.strictEqual(document.body.style.overflow, 'hidden');
         wrapper.setProps({ open: false });
       };
 
       const onExited = () => {
-        assert.strictEqual(document.body.parentElement.style.overflow, '');
+        assert.strictEqual(document.body.style.overflow, '');
         done();
       };
 
       const onExiting = () => {
-        assert.strictEqual(document.body.parentElement.style.overflow, 'hidden');
+        assert.strictEqual(document.body.style.overflow, 'hidden');
       };
 
       wrapper = mount(
         <TestCase onEntered={onEntered} onExiting={onExiting} onExited={onExited} open={false} />,
       );
-      assert.strictEqual(document.body.parentElement.style.overflow, '');
+      assert.strictEqual(document.body.style.overflow, '');
       wrapper.setProps({ open: true });
     });
 
@@ -766,23 +766,23 @@ describe('<Modal />', () => {
 
       let wrapper;
       const onEntered = () => {
-        assert.strictEqual(document.body.parentElement.style.overflow, 'hidden');
+        assert.strictEqual(document.body.style.overflow, 'hidden');
         wrapper.setProps({ open: false });
       };
 
       const onExited = () => {
-        assert.strictEqual(document.body.parentElement.style.overflow, '');
+        assert.strictEqual(document.body.style.overflow, '');
         done();
       };
 
       const onExiting = () => {
-        assert.strictEqual(document.body.parentElement.style.overflow, '');
+        assert.strictEqual(document.body.style.overflow, '');
       };
 
       wrapper = mount(
         <TestCase onEntered={onEntered} onExiting={onExiting} onExited={onExited} open={false} />,
       );
-      assert.strictEqual(document.body.parentElement.style.overflow, '');
+      assert.strictEqual(document.body.style.overflow, '');
       wrapper.setProps({ open: true });
     });
   });

--- a/packages/material-ui/src/Modal/ModalManager.js
+++ b/packages/material-ui/src/Modal/ModalManager.js
@@ -64,7 +64,10 @@ function handleContainer(containerInfo, props) {
     // Improve Gatsby support
     // https://css-tricks.com/snippets/css/force-vertical-scrollbar/
     const parent = container.parentElement;
-    const scrollContainer = parent.nodeName === 'HTML' ? parent : container;
+    const scrollContainer =
+      parent.nodeName === 'HTML' && window.getComputedStyle(parent)['overflow-y'] === 'scroll'
+        ? parent
+        : container;
 
     restoreStyle.push({
       value: scrollContainer.style.overflow,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Close #18336

Summary: 
Changing overflow on the html element may/will reset the page scroll position, in particular when overflow is already applied to the body element. 

This change restores behavior prior to #17972 unless overflow is already applied to the html element. 

