### PR TITLE
[core] Add displayName to contexts

### DIFF
--- a/docs/src/modules/components/PageContext.js
+++ b/docs/src/modules/components/PageContext.js
@@ -9,4 +9,8 @@ const PageContext = React.createContext({
   pages: [],
 });
 
+if (process.env.NODE_ENV !== 'production') {
+  PageContext.displayName = 'PageContext';
+}
+
 export default PageContext;

--- a/docs/src/modules/components/ThemeContext.js
+++ b/docs/src/modules/components/ThemeContext.js
@@ -88,8 +88,12 @@ const highDensity = {
 };
 
 export const DispatchContext = React.createContext(() => {
-  throw new Error('Forgot to wrap component in ThemeContext.Provider');
+  throw new Error('Forgot to wrap component in `ThemeProvider`');
 });
+
+if (process.env.NODE_ENV !== 'production') {
+  DispatchContext.displayName = 'ThemeDispatchContext';
+}
 
 const useEnhancedEffect = typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect;
 

--- a/packages/material-ui-lab/src/TreeView/TreeViewContext.js
+++ b/packages/material-ui-lab/src/TreeView/TreeViewContext.js
@@ -3,4 +3,10 @@ import React from 'react';
 /**
  * @ignore - internal component.
  */
-export default React.createContext({});
+const TreeViewContext = React.createContext({});
+
+if (process.env.NODE_ENV !== 'production') {
+  TreeViewContext.displayName = 'TreeViewContext';
+}
+
+export default TreeViewContext;

--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.js
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.js
@@ -28,6 +28,10 @@ const defaultOptions = {
 
 export const StylesContext = React.createContext(defaultOptions);
 
+if (process.env.NODE_ENV !== 'production') {
+  StylesContext.displayName = 'StylesContext';
+}
+
 let injectFirstNode;
 
 function StylesProvider(props) {

--- a/packages/material-ui-styles/src/useTheme/ThemeContext.js
+++ b/packages/material-ui-styles/src/useTheme/ThemeContext.js
@@ -2,4 +2,8 @@ import React from 'react';
 
 const ThemeContext = React.createContext(null);
 
+if (process.env.NODE_ENV !== 'production') {
+  ThemeContext.displayName = 'ThemeContext';
+}
+
 export default ThemeContext;

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanelContext.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanelContext.js
@@ -6,4 +6,8 @@ import React from 'react';
  */
 const ExpansionPanelContext = React.createContext({});
 
+if (process.env.NODE_ENV !== 'production') {
+  ExpansionPanelContext.displayName = 'ExpansionPanelContext';
+}
+
 export default ExpansionPanelContext;

--- a/packages/material-ui/src/FormControl/FormControlContext.js
+++ b/packages/material-ui/src/FormControl/FormControlContext.js
@@ -5,6 +5,10 @@ import React from 'react';
  */
 const FormControlContext = React.createContext();
 
+if (process.env.NODE_ENV !== 'production') {
+  FormControlContext.displayName = 'FormControlContext';
+}
+
 export function useFormControl() {
   return React.useContext(FormControlContext);
 }

--- a/packages/material-ui/src/List/ListContext.js
+++ b/packages/material-ui/src/List/ListContext.js
@@ -5,4 +5,8 @@ import React from 'react';
  */
 const ListContext = React.createContext({});
 
+if (process.env.NODE_ENV !== 'production') {
+  ListContext.displayName = 'ListContext';
+}
+
 export default ListContext;

--- a/packages/material-ui/src/RadioGroup/RadioGroupContext.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroupContext.js
@@ -5,4 +5,8 @@ import React from 'react';
  */
 const RadioGroupContext = React.createContext();
 
+if (process.env.NODE_ENV !== 'production') {
+  RadioGroupContext.displayName = 'RadioGroupContext';
+}
+
 export default RadioGroupContext;

--- a/packages/material-ui/src/Table/TableContext.js
+++ b/packages/material-ui/src/Table/TableContext.js
@@ -5,4 +5,8 @@ import React from 'react';
  */
 const TableContext = React.createContext();
 
+if (process.env.NODE_ENV !== 'production') {
+  TableContext.displayName = 'TableContext';
+}
+
 export default TableContext;

--- a/packages/material-ui/src/Table/Tablelvl2Context.js
+++ b/packages/material-ui/src/Table/Tablelvl2Context.js
@@ -5,4 +5,8 @@ import React from 'react';
  */
 const Tablelvl2Context = React.createContext();
 
+if (process.env.NODE_ENV !== 'production') {
+  Tablelvl2Context.displayName = 'Tablelvl2Context';
+}
+
 export default Tablelvl2Context;

--- a/packages/material-ui/src/test-utils/RenderMode.js
+++ b/packages/material-ui/src/test-utils/RenderMode.js
@@ -3,6 +3,10 @@ import * as PropTypes from 'prop-types';
 
 const Context = React.createContext();
 
+if (process.env.NODE_ENV !== 'production') {
+  Context.displayName = 'RenderContext';
+}
+
 /**
  * @ignore - internal component.
  */


### PR DESCRIPTION
Old (react-devtools extension):
![Screenshot from 2019-11-20 18-32-42](https://user-images.githubusercontent.com/12292047/69262694-3510a400-0bc4-11ea-8c00-e72295b4f35c.png)

New:
![Screenshot from 2019-11-20 18-31-54](https://user-images.githubusercontent.com/12292047/69262703-3772fe00-0bc4-11ea-8213-a1afb50d209d.png)


Using https://reactjs.org/docs/context.html#contextdisplayname