### PR TITLE
[Grid] Infer `displayName`

### DIFF
--- a/packages/material-ui/src/Grid/Grid.js
+++ b/packages/material-ui/src/Grid/Grid.js
@@ -199,7 +199,7 @@ export const styles = theme => ({
   }, {}),
 });
 
-const Grid = React.forwardRef((props, ref) => {
+const Grid = React.forwardRef(function Grid(props, ref) {
   const {
     alignContent = 'stretch',
     alignItems = 'stretch',
@@ -244,12 +244,6 @@ const Grid = React.forwardRef((props, ref) => {
 
   return <Component className={className} ref={ref} {...other} />;
 });
-
-if (process.env.NODE_ENV !== 'production') {
-  // can't use named function expression since the function body references `Grid`
-  // which would point to the render function instead of the actual component
-  Grid.displayName = 'ForwardRef(Grid)';
-}
 
 Grid.propTypes = {
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

`Grid` no longer has references to `Grid` in the component body (it used to access `Grid.defaultProps`) so we can simplify it now.