### PR TITLE
[IconButton] Make sure sizeSmall padding doesn't get overwritten by the root

### DIFF
--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.js
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.js
@@ -91,10 +91,11 @@ export default function TransferList() {
             checked={numberOfChecked(items) === items.length && items.length !== 0}
             indeterminate={numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0}
             disabled={items.length === 0}
-            inputProps={{ 'aria-label': 'all items selected' }}
+            inputProps={{ 'aria-labelledby': 'transfer-list-all-label' }}
           />
         </ListItemIcon>
         <ListItemText
+          id="transfer-list-all-label"
           primary={title}
           secondary={`${numberOfChecked(items)}/${items.length} selected`}
         />

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.js
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.js
@@ -3,7 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -14,9 +13,6 @@ import Divider from '@material-ui/core/Divider';
 const useStyles = makeStyles(theme => ({
   root: {
     margin: 'auto',
-  },
-  cardHeader: {
-    padding: theme.spacing(1, 2),
   },
   list: {
     width: 200,
@@ -49,7 +45,7 @@ export default function TransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
-  const dense = false;
+  const dense = true;
 
   const handleToggle = value => () => {
     const currentIndex = checked.indexOf(value);
@@ -88,22 +84,21 @@ export default function TransferList() {
 
   const customList = (title, items) => (
     <Card>
-      <CardHeader
-        className={classes.cardHeader}
-        avatar={
+      <ListItem dense={dense} button onClick={handleToggleAll(items)}>
+        <ListItemIcon>
           <Checkbox
             size={dense ? 'small' : 'medium'}
-            edge="start"
-            onClick={handleToggleAll(items)}
             checked={numberOfChecked(items) === items.length && items.length !== 0}
             indeterminate={numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0}
             disabled={items.length === 0}
             inputProps={{ 'aria-label': 'all items selected' }}
           />
-        }
-        title={title}
-        subheader={`${numberOfChecked(items)}/${items.length} selected`}
-      />
+        </ListItemIcon>
+        <ListItemText
+          primary={title}
+          secondary={`${numberOfChecked(items)}/${items.length} selected`}
+        />
+      </ListItem>
       <Divider />
       <List className={classes.list} dense={dense} component="div" role="list">
         {items.map(value => {
@@ -114,7 +109,6 @@ export default function TransferList() {
               <ListItemIcon>
                 <Checkbox
                   size={dense ? 'small' : 'medium'}
-                  edge="start"
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.js
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.js
@@ -49,6 +49,7 @@ export default function TransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
+  const dense = false;
 
   const handleToggle = value => () => {
     const currentIndex = checked.indexOf(value);
@@ -91,6 +92,8 @@ export default function TransferList() {
         className={classes.cardHeader}
         avatar={
           <Checkbox
+            size={dense ? 'small' : 'medium'}
+            edge="start"
             onClick={handleToggleAll(items)}
             checked={numberOfChecked(items) === items.length && items.length !== 0}
             indeterminate={numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0}
@@ -102,7 +105,7 @@ export default function TransferList() {
         subheader={`${numberOfChecked(items)}/${items.length} selected`}
       />
       <Divider />
-      <List className={classes.list} dense component="div" role="list">
+      <List className={classes.list} dense={dense} component="div" role="list">
         {items.map(value => {
           const labelId = `transfer-list-all-item-${value}-label`;
 
@@ -110,6 +113,8 @@ export default function TransferList() {
             <ListItem key={value} role="listitem" button onClick={handleToggle(value)}>
               <ListItemIcon>
                 <Checkbox
+                  size={dense ? 'small' : 'medium'}
+                  edge="start"
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
@@ -93,10 +93,10 @@ export default function TransferList() {
               checked={numberOfChecked(items) === items.length && items.length !== 0}
               indeterminate={numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0}
               disabled={items.length === 0}
-              inputProps={{ 'aria-label': 'all items selected' }}
+              inputProps={{ 'aria-labelledby': 'transfer-list-all-label' }}
             />
         </ListItemIcon>
-        <ListItemText primary={title} secondary={`${numberOfChecked(items)}/${items.length} selected`} />
+        <ListItemText id="transfer-list-all-label" primary={title} secondary={`${numberOfChecked(items)}/${items.length} selected`} />
       </ListItem>
       <Divider />
       <List className={classes.list} dense={dense} component="div" role="list">

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
@@ -3,7 +3,6 @@ import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
 import Grid from '@material-ui/core/Grid';
 import List from '@material-ui/core/List';
 import Card from '@material-ui/core/Card';
-import CardHeader from '@material-ui/core/CardHeader';
 import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
@@ -15,9 +14,6 @@ const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       margin: 'auto',
-    },
-    cardHeader: {
-      padding: theme.spacing(1, 2),
     },
     list: {
       width: 200,
@@ -51,7 +47,7 @@ export default function TransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
-  const dense = false;
+  const dense = true;
 
   const handleToggle = (value: number) => () => {
     const currentIndex = checked.indexOf(value);
@@ -90,22 +86,18 @@ export default function TransferList() {
 
   const customList = (title: React.ReactNode, items: number[]) => (
     <Card>
-      <CardHeader
-        className={classes.cardHeader}
-        avatar={
+      <ListItem dense={dense} button onClick={handleToggleAll(items)}>
+        <ListItemIcon>
           <Checkbox
-            size={dense ? 'small' : 'medium'}
-            edge='start'
-            onClick={handleToggleAll(items)}
-            checked={numberOfChecked(items) === items.length && items.length !== 0}
-            indeterminate={numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0}
-            disabled={items.length === 0}
-            inputProps={{ 'aria-label': 'all items selected' }}
-          />
-        }
-        title={title}
-        subheader={`${numberOfChecked(items)}/${items.length} selected`}
-      />
+              size={dense ? 'small' : 'medium'}
+              checked={numberOfChecked(items) === items.length && items.length !== 0}
+              indeterminate={numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0}
+              disabled={items.length === 0}
+              inputProps={{ 'aria-label': 'all items selected' }}
+            />
+        </ListItemIcon>
+        <ListItemText primary={title} secondary={`${numberOfChecked(items)}/${items.length} selected`} />
+      </ListItem>
       <Divider />
       <List className={classes.list} dense={dense} component="div" role="list">
         {items.map((value: number) => {
@@ -116,7 +108,6 @@ export default function TransferList() {
               <ListItemIcon>
                 <Checkbox
                   size={dense ? 'small' : 'medium'}
-                  edge='start'
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
+++ b/docs/src/pages/components/transfer-list/SelectAllTransferList.tsx
@@ -51,6 +51,7 @@ export default function TransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
+  const dense = false;
 
   const handleToggle = (value: number) => () => {
     const currentIndex = checked.indexOf(value);
@@ -93,6 +94,8 @@ export default function TransferList() {
         className={classes.cardHeader}
         avatar={
           <Checkbox
+            size={dense ? 'small' : 'medium'}
+            edge='start'
             onClick={handleToggleAll(items)}
             checked={numberOfChecked(items) === items.length && items.length !== 0}
             indeterminate={numberOfChecked(items) !== items.length && numberOfChecked(items) !== 0}
@@ -104,7 +107,7 @@ export default function TransferList() {
         subheader={`${numberOfChecked(items)}/${items.length} selected`}
       />
       <Divider />
-      <List className={classes.list} dense component="div" role="list">
+      <List className={classes.list} dense={dense} component="div" role="list">
         {items.map((value: number) => {
           const labelId = `transfer-list-all-item-${value}-label`;
 
@@ -112,6 +115,8 @@ export default function TransferList() {
             <ListItem key={value} role="listitem" button onClick={handleToggle(value)}>
               <ListItemIcon>
                 <Checkbox
+                  size={dense ? 'small' : 'medium'}
+                  edge='start'
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/docs/src/pages/components/transfer-list/TransferList.js
+++ b/docs/src/pages/components/transfer-list/TransferList.js
@@ -39,6 +39,7 @@ export default function TransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
+  const dense = true;
 
   const handleToggle = value => () => {
     const currentIndex = checked.indexOf(value);
@@ -77,7 +78,7 @@ export default function TransferList() {
 
   const customList = items => (
     <Paper className={classes.paper}>
-      <List dense component="div" role="list">
+      <List dense={dense} component="div" role="list">
         {items.map(value => {
           const labelId = `transfer-list-item-${value}-label`;
 
@@ -85,6 +86,8 @@ export default function TransferList() {
             <ListItem key={value} role="listitem" button onClick={handleToggle(value)}>
               <ListItemIcon>
                 <Checkbox
+                  size={dense ? 'small' : 'medium'}
+                  edge='start'
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/docs/src/pages/components/transfer-list/TransferList.js
+++ b/docs/src/pages/components/transfer-list/TransferList.js
@@ -87,7 +87,6 @@ export default function TransferList() {
               <ListItemIcon>
                 <Checkbox
                   size={dense ? 'small' : 'medium'}
-                  edge="start"
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/docs/src/pages/components/transfer-list/TransferList.js
+++ b/docs/src/pages/components/transfer-list/TransferList.js
@@ -87,7 +87,7 @@ export default function TransferList() {
               <ListItemIcon>
                 <Checkbox
                   size={dense ? 'small' : 'medium'}
-                  edge='start'
+                  edge="start"
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/docs/src/pages/components/transfer-list/TransferList.tsx
+++ b/docs/src/pages/components/transfer-list/TransferList.tsx
@@ -41,6 +41,7 @@ export default function TransferList() {
 
   const leftChecked = intersection(checked, left);
   const rightChecked = intersection(checked, right);
+  const dense = true;
 
   const handleToggle = (value: number) => () => {
     const currentIndex = checked.indexOf(value);
@@ -79,7 +80,7 @@ export default function TransferList() {
 
   const customList = (items: number[]) => (
     <Paper className={classes.paper}>
-      <List dense component="div" role="list">
+      <List dense={dense} component="div" role="list">
         {items.map((value: number) => {
           const labelId = `transfer-list-item-${value}-label`;
 
@@ -87,6 +88,8 @@ export default function TransferList() {
             <ListItem key={value} role="listitem" button onClick={handleToggle(value)}>
               <ListItemIcon>
                 <Checkbox
+                  size={dense ? 'small' : 'medium'}
+                  edge='start'
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/docs/src/pages/components/transfer-list/TransferList.tsx
+++ b/docs/src/pages/components/transfer-list/TransferList.tsx
@@ -89,7 +89,6 @@ export default function TransferList() {
               <ListItemIcon>
                 <Checkbox
                   size={dense ? 'small' : 'medium'}
-                  edge='start'
                   checked={checked.indexOf(value) !== -1}
                   tabIndex={-1}
                   disableRipple

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -31,6 +31,10 @@ export const styles = theme => ({
       backgroundColor: 'transparent',
       color: theme.palette.action.disabled,
     },
+    '&$sizeSmall': {
+      padding: 3,
+      fontSize: theme.typography.pxToRem(18),
+    }
   },
   /* Styles applied to the root element if `edge="start"`. */
   edgeStart: {
@@ -75,10 +79,7 @@ export const styles = theme => ({
   /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the root element if `size="small"`. */
-  sizeSmall: {
-    padding: 3,
-    fontSize: theme.typography.pxToRem(18),
-  },
+  sizeSmall: {},
   /* Styles applied to the children container element. */
   label: {
     width: '100%',


### PR DESCRIPTION
Found this while looking into building a dense list with checkboxes. It seems like that behavior was the intention with the TransferList but it didn't work. I also slightly updated that component to make it dense (if that is still the intention?).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
