### PR TITLE
Fix ExpansionPanel Performance Docs

### DIFF
--- a/docs/src/pages/components/expansion-panels/expansion-panels.md
+++ b/docs/src/pages/components/expansion-panels/expansion-panels.md
@@ -43,10 +43,10 @@ The content of ExpansionPanels is mounted by default even if the panel is not ex
 This default behavior has server-side rendering and SEO in mind.
 If you render expensive component trees inside your panels or simply render many
 panels it might be a good idea to change this default behavior by enabling the
-`unmountOnExit` in `TransitionProps`:
+`mountOnEnter` in `TransitionProps`:
 
 ```jsx
-<ExpansionPanel TransitionProps={{ unmountOnExit: true }} />
+<ExpansionPanel TransitionProps={{ mountOnEnter: true }} />
 ```
 
 As with any performance optimization this is not a silver bullet. Be sure to identify


### PR DESCRIPTION
use mountOnEnter, not unmountOnExit, to prevent ExpansionPanel details from rendering before panel is expanded.

See [this issue](https://github.com/mui-org/material-ui/issues/10569).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
