### PR TITLE
[l10n] Fix German translation

### DIFF
--- a/packages/material-ui/src/locale/index.js
+++ b/packages/material-ui/src/locale/index.js
@@ -7,7 +7,7 @@ export const deDE = {
       nextIconButtonText: 'Nächste Seite',
     },
     MuiRating: {
-      getLabelText: value => `${value} ${value !== 1 ? 'Sterne' : 'Star'}`,
+      getLabelText: value => `${value} ${value !== 1 ? 'Sterne' : 'Stern'}`,
     },
     MuiAutocomplete: {
       clearText: 'Leeren',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

It appears that the English word "Star" slipped through instead of the correct German singular "Stern".

Edit: It seems like CircleCI failed due to a network issue. It would be great if someone could re-run the check. :100: 