### PR TITLE
[build] Clarify transform-runtime, runtime version

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -44,7 +44,8 @@ module.exports = {
     'babel-plugin-optimize-clsx',
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
-    '@babel/plugin-transform-runtime',
+    // any package needs to declare 7.4.4 as a runtime dependency. default is ^7.0.0
+    ['@babel/plugin-transform-runtime', { version: '^7.4.4' }],
     // for IE 11 support
     '@babel/plugin-transform-object-assign',
   ],

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -1,4 +1,5 @@
 const bpmr = require('babel-plugin-module-resolver');
+const fse = require('fs-extra');
 
 function resolvePath(sourcePath, currentFile, opts) {
   if (sourcePath === 'markdown') {
@@ -22,8 +23,16 @@ const alias = {
   pages: './pages',
 };
 
+const { version: transformRuntimeVersion } = fse.readJSONSync(
+  require.resolve('@babel/runtime-corejs2/package.json'),
+);
+
 module.exports = {
-  presets: ['next/babel', '@zeit/next-typescript/babel'],
+  presets: [
+    // backport of https://github.com/zeit/next.js/pull/9511
+    ['next/babel', { 'transform-runtime': { corejs: 2, version: transformRuntimeVersion } }],
+    '@zeit/next-typescript/babel',
+  ],
   plugins: [
     'babel-plugin-optimize-clsx',
     // for IE 11 support

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@babel/core": "^7.7.4",
     "@babel/plugin-transform-object-assign": "^7.7.4",
+    "@babel/runtime-corejs2": "^7.8.3",
     "@date-io/core": "^1.3.9",
     "@date-io/date-fns": "^1.3.11",
     "@emotion/core": "^10.0.27",
@@ -70,6 +71,7 @@
     "fg-loadcss": "^2.0.1",
     "final-form": "^4.18.5",
     "flexsearch": "^0.6.30",
+    "fs-extra": "^8.1.0",
     "isomorphic-fetch": "^2.2.1",
     "json2mq": "^0.2.0",
     "jss": "^10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -830,7 +830,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime-corejs2@7.1.2", "@babel/runtime-corejs2@^7.4.4", "@babel/runtime-corejs2@^7.7.4":
+"@babel/runtime-corejs2@7.1.2", "@babel/runtime-corejs2@^7.4.4", "@babel/runtime-corejs2@^7.7.4", "@babel/runtime-corejs2@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs2/-/runtime-corejs2-7.8.3.tgz#b62a61e0c41a90d2d91181fda6de21cecd3a9734"
   integrity sha512-yxJXBKdIogkfF+wgeJrvU7Afp5ugBi92NzSgNPWWKVoQAlixH3gwMP6yYYr7SV1Dbc0HmNw7WUJkV5ksvtQuHg==


### PR DESCRIPTION
I always assumed transform-runtime and runtime version need to be related. Turns out there's actually an option to specify the `@babel/runtime` version which isn't documented but a maintainer mentioned on SO (https://stackoverflow.com/a/54066848/3406963).

I'm opening a PR to the babel docs first to see if this is still considered public. Opening here to see if this has actual bundle size implications.