### PR TITLE
[core] Add react-is dependency

### DIFF
--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -42,7 +42,8 @@
     "@babel/runtime": "^7.4.4",
     "@material-ui/utils": "^4.5.2",
     "clsx": "^1.0.4",
-    "prop-types": "^15.7.2"
+    "prop-types": "^15.7.2",
+    "react-is": "^16.8.0"
   },
   "devDependencies": {},
   "sideEffects": false,

--- a/packages/material-ui-utils/package.json
+++ b/packages/material-ui-utils/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "prop-types": "^15.7.2",
-    "react-is": "^16.8.6"
+    "react-is": "^16.8.0"
   },
   "devDependencies": {},
   "sideEffects": false,

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -53,6 +53,7 @@
     "normalize-scroll-left": "^0.2.0",
     "popper.js": "^1.14.1",
     "prop-types": "^15.7.2",
+    "react-is": "^16.8.0",
     "react-transition-group": "^4.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12184,7 +12184,7 @@ react-is@16.8.6:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-is@^16.10.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.10.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==


### PR DESCRIPTION
This dependency is called in Menu.js but is not listed in package.json

I detected this problem when I runned a project with yarn berry (v2) using pnp.
The Menu.js component is using 'isFragment' function from the react-is library.
The only package.json that have react-is is in @material-ui/utils.

This change is also related to the #17317
