### PR TITLE
[docs] Reduce confusion in picker link

### DIFF
--- a/docs/src/pages/components/pickers/pickers.md
+++ b/docs/src/pages/components/pickers/pickers.md
@@ -22,7 +22,7 @@ components: TextField
 ## Native pickers
 
 ⚠️ Native input controls support by browsers [isn't perfect](https://caniuse.com/#feat=input-datetime).
-Have a look at [@material-ui/pickers](#material-ui-pickers) for a richer solution.
+Have a look at [@material-ui/pickers](https://material-ui-pickers.dev/) for a richer solution.
 
 ### Datepickers
 


### PR DESCRIPTION
While i guess the link  intentionally pointed to the paragraph above, it was misleading depending on the current scroll position.

When you enter the page via the search, it is already scrolled to #material-ui-pickers. The Link i edited is then in the center of the page (and therefore grabs visual attention). When clicked, it feels defunct, because nothing happens, because the page is already scrolled to the target position.

The Link text represents a git repository name, so i would expect it to link to this repository. So i think the easiest solution is to actually do so.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
