### PR TITLE
[Typography] Allow strings as component prop in TS Defs

### DIFF
--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -15,7 +15,7 @@ export interface TypographyProps
     | 'textPrimary'
     | 'textSecondary'
     | 'error';
-  component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
+  component?: React.ElementType<React.HTMLAttributes<HTMLElement>> | string;
   display?: 'initial' | 'block' | 'inline';
   gutterBottom?: boolean;
   noWrap?: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

We ran into an issue where we could not reference the component prop as "div" even though the component does accept and works with string format for the component prop.