### PR TITLE
[Backdrop] Comment on z-index use case

### DIFF
--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -7,7 +7,7 @@ import Fade from '../Fade';
 export const styles = {
   /* Styles applied to the root element. */
   root: {
-    zIndex: -1,
+    zIndex: 1,
     position: 'fixed',
     display: 'flex',
     alignItems: 'center',

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -7,7 +7,8 @@ import Fade from '../Fade';
 export const styles = {
   /* Styles applied to the root element. */
   root: {
-    zIndex: 1,
+    // Improve scrollable dialog support.
+    zIndex: -1,
     position: 'fixed',
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
It seems very strange to me that you would want the zIndex of the Backdrop to be -1. I would think the backdrop zIndex should be 1 so it overrides any normally positioned or fixed positioned element on the page. I am seeing strange issues with the default backdrop where some elements on the page (also MUI components, like Paper) are shown above it.

The -1 seems to be the culprit.

If you aren't going to change to 1, can someone explain why -1 is desirable?

Thanks.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
