### PR TITLE
Fix missing classes from TextField to FormControl

### DIFF
--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -60,8 +60,6 @@ const TextField = React.forwardRef(function TextField(props, ref) {
     autoComplete,
     autoFocus = false,
     children,
-    classes,
-    className,
     color = 'primary',
     defaultValue,
     disabled = false,
@@ -158,7 +156,6 @@ const TextField = React.forwardRef(function TextField(props, ref) {
 
   return (
     <FormControl
-      className={clsx(classes.root, className)}
       disabled={disabled}
       error={error}
       fullWidth={fullWidth}

--- a/packages/material-ui/src/TextField/TextField.js
+++ b/packages/material-ui/src/TextField/TextField.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
-import clsx from 'clsx';
 import { refType } from '@material-ui/utils';
 import Input from '../Input';
 import FilledInput from '../FilledInput';


### PR DESCRIPTION
Here is the initial issue: https://github.com/mui-org/material-ui/issues/18593

Missing: typescript's types changes for TextField's classes but I'm not confident enough to apply those modifications.