### PR TITLE
Missing InputBaseClassKey value 'inputSelect'

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -71,6 +71,7 @@ export type InputBaseClassKey =
   | 'colorSecondary'
   | 'input'
   | 'inputMarginDense'
+  | 'inputSelect'
   | 'inputMultiline'
   | 'inputTypeSearch'
   | 'inputAdornedStart'


### PR DESCRIPTION
That's just a missing type that raises a typescript error when I try to override my theme.
