### PR TITLE
[Portal] Fix circular PortalProps Types

### DIFF
--- a/packages/material-ui/src/Portal/Portal.d.ts
+++ b/packages/material-ui/src/Portal/Portal.d.ts
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { PortalProps } from '../Portal';
 
 export interface PortalProps {
   children: React.ReactElement<any>;


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/18601 per https://github.com/mui-org/material-ui/issues/18601#issuecomment-559261644

Just back ports #17676 

Wasn't 100% sure if this is the proper target for a back port PR, please let me know if not.


