### PR TITLE
[Rating] Improve mobile support

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -141,7 +141,7 @@ export const styles = theme => ({
     cursor: 'pointer',
     paddingTop: 6,
     outline: '0',
-    // Remove grey highlight
+    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     paddingBottom: 6,
     paddingLeft: 16,

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -141,7 +141,6 @@ export const styles = theme => ({
     cursor: 'pointer',
     paddingTop: 6,
     outline: '0',
-    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     paddingBottom: 6,
     paddingLeft: 16,

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -34,7 +34,6 @@ export const styles = theme => ({
     fontSize: theme.typography.pxToRem(24),
     color: '#ffb400',
     cursor: 'pointer',
-    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     '&$disabled': {
       opacity: 0.5,

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -34,9 +34,8 @@ export const styles = theme => ({
     fontSize: theme.typography.pxToRem(24),
     color: '#ffb400',
     cursor: 'pointer',
-    [theme.breakpoints.down('xs')]: {
-      cursor: 'default',
-    },
+    // Remove blue highlight
+    WebkitTapHighlightColor: 'transparent',
     '&$disabled': {
       opacity: 0.5,
       pointerEvents: 'none',

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -35,7 +35,7 @@ export const styles = theme => ({
     color: '#ffb400',
     cursor: 'pointer',
     [theme.breakpoints.down('xs')]: {
-      cursor: 'default'
+      cursor: 'default',
     },
     '&$disabled': {
       opacity: 0.5,

--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -34,6 +34,9 @@ export const styles = theme => ({
     fontSize: theme.typography.pxToRem(24),
     color: '#ffb400',
     cursor: 'pointer',
+    [theme.breakpoints.down('xs')]: {
+      cursor: 'default'
+    },
     '&$disabled': {
       opacity: 0.5,
       pointerEvents: 'none',

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -17,7 +17,6 @@ export const styles = {
     top: 0,
     left: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     // Disable scroll capabilities.
     touchAction: 'none',

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -17,7 +17,7 @@ export const styles = {
     top: 0,
     left: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    // Remove grey highlight
+    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     // Disable scroll capabilities.
     touchAction: 'none',

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -17,7 +17,7 @@ export const styles = {
     alignItems: 'center',
     justifyContent: 'center',
     position: 'relative',
-    // Remove grey highlight
+    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     backgroundColor: 'transparent', // Reset default value
     // We disable the focus ring for mouse, touch and keyboard users.

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -17,7 +17,6 @@ export const styles = {
     alignItems: 'center',
     justifyContent: 'center',
     position: 'relative',
-    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     backgroundColor: 'transparent', // Reset default value
     // We disable the focus ring for mouse, touch and keyboard users.

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -84,7 +84,8 @@ export const styles = theme => {
     /* Styles applied to the root element if `onClick` is defined or `clickable={true}`. */
     clickable: {
       userSelect: 'none',
-      WebkitTapHighlightColor: 'transparent', // Remove grey highlight
+      // Remove blue highlight
+      WebkitTapHighlightColor: 'transparent',
       cursor: 'pointer',
       '&:hover, &:focus': {
         backgroundColor: emphasize(backgroundColor, 0.08),
@@ -211,7 +212,7 @@ export const styles = theme => {
     },
     /* Styles applied to the `deleteIcon` element. */
     deleteIcon: {
-      // Remove grey highlight
+      // Remove blue highlight
       WebkitTapHighlightColor: 'transparent',
       color: deleteIconColor,
       height: 22,

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -84,7 +84,6 @@ export const styles = theme => {
     /* Styles applied to the root element if `onClick` is defined or `clickable={true}`. */
     clickable: {
       userSelect: 'none',
-      // Remove blue highlight
       WebkitTapHighlightColor: 'transparent',
       cursor: 'pointer',
       '&:hover, &:focus': {
@@ -212,7 +211,6 @@ export const styles = theme => {
     },
     /* Styles applied to the `deleteIcon` element. */
     deleteIcon: {
-      // Remove blue highlight
       WebkitTapHighlightColor: 'transparent',
       color: deleteIconColor,
       height: 22,

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -15,7 +15,6 @@ export const styles = theme => ({
     cursor: 'pointer',
     // For correct alignment with the text.
     verticalAlign: 'middle',
-    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     marginLeft: -11,
     marginRight: 16, // used for row presentation of radio/checkbox

--- a/packages/material-ui/src/FormControlLabel/FormControlLabel.js
+++ b/packages/material-ui/src/FormControlLabel/FormControlLabel.js
@@ -15,7 +15,7 @@ export const styles = theme => ({
     cursor: 'pointer',
     // For correct alignment with the text.
     verticalAlign: 'middle',
-    // Remove grey highlight
+    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     marginLeft: -11,
     marginRight: 16, // used for row presentation of radio/checkbox

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -82,7 +82,6 @@ export const styles = theme => {
       background: 'none',
       height: '1.1875em', // Reset (19px), match the native input line-height
       margin: 0, // Reset for Safari
-      // Remove blue highlight
       WebkitTapHighlightColor: 'transparent',
       display: 'block',
       // Make the flex item shrink with Firefox

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -82,7 +82,7 @@ export const styles = theme => {
       background: 'none',
       height: '1.1875em', // Reset (19px), match the native input line-height
       margin: 0, // Reset for Safari
-      // Remove grey highlight
+      // Remove blue highlight
       WebkitTapHighlightColor: 'transparent',
       display: 'block',
       // Make the flex item shrink with Firefox

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -30,7 +30,6 @@ export const styles = {
   /* Styles applied to the root element if `component="button"`. */
   button: {
     position: 'relative',
-    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     backgroundColor: 'transparent', // Reset default value
     // We disable the focus ring for mouse, touch and keyboard users.

--- a/packages/material-ui/src/Link/Link.js
+++ b/packages/material-ui/src/Link/Link.js
@@ -30,7 +30,7 @@ export const styles = {
   /* Styles applied to the root element if `component="button"`. */
   button: {
     position: 'relative',
-    // Remove grey highlight
+    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     backgroundColor: 'transparent', // Reset default value
     // We disable the focus ring for mouse, touch and keyboard users.

--- a/packages/material-ui/src/Modal/SimpleBackdrop.js
+++ b/packages/material-ui/src/Modal/SimpleBackdrop.js
@@ -11,7 +11,6 @@ export const styles = {
     top: 0,
     left: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     // Disable scroll capabilities.
     touchAction: 'none',

--- a/packages/material-ui/src/Modal/SimpleBackdrop.js
+++ b/packages/material-ui/src/Modal/SimpleBackdrop.js
@@ -11,7 +11,7 @@ export const styles = {
     top: 0,
     left: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    // Remove grey highlight
+    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     // Disable scroll capabilities.
     touchAction: 'none',

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -142,7 +142,7 @@ export const styles = theme => ({
     cursor: 'pointer',
     touchAction: 'none',
     color: theme.palette.primary.main,
-    // Remove grey highlight
+    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     '&$disabled': {
       pointerEvents: 'none',

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -142,7 +142,6 @@ export const styles = theme => ({
     cursor: 'pointer',
     touchAction: 'none',
     color: theme.palette.primary.main,
-    // Remove blue highlight
     WebkitTapHighlightColor: 'transparent',
     '&$disabled': {
       pointerEvents: 'none',


### PR DESCRIPTION
On touch screens, the pointer cursor is causing the entire Rating span to flash a blue highlight on click, disable the "pointer" on phone screens to solve this issue.
To reproduce go to https://material-ui.com/components/rating/ and open dev tools to emulate a phone. Now "tap" on a star to change the rating, note the blue highlight effect.

- [x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
