### PR TITLE
[theme] Fix wrong ResponsiveFontSizesOptions type

### DIFF
--- a/packages/material-ui/src/styles/responsiveFontSizes.d.ts
+++ b/packages/material-ui/src/styles/responsiveFontSizes.d.ts
@@ -6,7 +6,7 @@ export interface ResponsiveFontSizesOptions {
   breakpoints?: Breakpoint[];
   disableAlign?: boolean;
   factor?: number;
-  variants?: ThemeStyle;
+  variants?: ThemeStyle[];
 }
 
 export default function responsiveFontSizes(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Before this fix, the following code would complain about `variants` not being compatible with `ResponsiveFontSizesOptions`, although this property must be passed as an array in any case:

```ts
responsiveFontSizes(theme, { factor: 1.5, breakpoints: ['sm'], variants: ['h1', 'h2'] })
```

Docs are correct: https://material-ui.com/customization/theming/#responsivefontsizes-theme-options-theme
