### PR TITLE
[useMediaQuery] Fix hydrationCompleted true before hydrated

### DIFF
--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.js
@@ -1,9 +1,6 @@
 import React from 'react';
 import { getThemeProps, useTheme } from '@material-ui/styles';
 
-// This variable will be true once the server-side hydration is completed.
-let hydrationCompleted = false;
-
 function useMediaQuery(queryInput, options = {}) {
   const theme = useTheme();
   const props = getThemeProps({
@@ -40,7 +37,7 @@ function useMediaQuery(queryInput, options = {}) {
   };
 
   const [match, setMatch] = React.useState(() => {
-    if ((hydrationCompleted || noSsr) && supportMatchMedia) {
+    if (noSsr && supportMatchMedia) {
       return window.matchMedia(query).matches;
     }
     if (ssrMatchMedia) {
@@ -54,7 +51,6 @@ function useMediaQuery(queryInput, options = {}) {
 
   React.useEffect(() => {
     let active = true;
-    hydrationCompleted = true;
 
     if (!supportMatchMedia) {
       return undefined;
@@ -78,10 +74,6 @@ function useMediaQuery(queryInput, options = {}) {
   }, [query, supportMatchMedia]);
 
   return match;
-}
-
-export function testReset() {
-  hydrationCompleted = false;
 }
 
 export default useMediaQuery;

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -7,7 +7,7 @@ import { createRender } from '@material-ui/core/test-utils';
 import mediaQuery from 'css-mediaquery';
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
-import useMediaQuery, { testReset } from './useMediaQuery';
+import useMediaQuery from './useMediaQuery';
 
 function createMatchMedia(width, ref) {
   const listeners = [];
@@ -45,7 +45,6 @@ describe('useMediaQuery', () => {
   let values;
 
   beforeEach(() => {
-    testReset();
     values = spy();
   });
 
@@ -169,7 +168,7 @@ describe('useMediaQuery', () => {
       });
     });
 
-    it('should try to reconcile only the first time', () => {
+    it('should try to reconcile each time', () => {
       const ref = React.createRef();
       const text = () => ref.current.textContent;
       const Test = () => {
@@ -188,7 +187,7 @@ describe('useMediaQuery', () => {
 
       render(<Test />);
       expect(text()).to.equal('false');
-      expect(values.callCount).to.equal(3);
+      expect(values.callCount).to.equal(4);
     });
 
     it('should be able to change the query dynamically', () => {

--- a/packages/material-ui/src/withWidth/withWidth.test.js
+++ b/packages/material-ui/src/withWidth/withWidth.test.js
@@ -5,7 +5,6 @@ import { stub } from 'sinon';
 import { createMount, createShallow } from '@material-ui/core/test-utils';
 import mediaQuery from 'css-mediaquery';
 import withWidth, { isWidthDown, isWidthUp } from './withWidth';
-import { testReset } from '../useMediaQuery/useMediaQuery';
 import createMuiTheme from '../styles/createMuiTheme';
 
 function createMatchMedia(width, ref) {
@@ -48,7 +47,6 @@ describe('withWidth', () => {
 
   beforeEach(() => {
     matchMediaInstances = [];
-    testReset();
     const fakeMatchMedia = createMatchMedia(1200, matchMediaInstances);
     // can't stub non-existent properties with sinon
     // jsdom does not implement window.matchMedia


### PR DESCRIPTION
Fix a bug where the `hydrationCompleted` variable in `useMediaQuery()`
can be set to `true` before all components in the document are actually
hydrated.

Apply the patch suggested in #18670 that removes this optimization in
favor of more consistent rendering behavior.

Modify the test for this optimization to check for its absence, and
elsewhere, remove the use of the `testReset()` test helper function.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #18670