### PR TITLE
[RootRef] Remove use of findDOMNode and replace with Forward Ref

### DIFF
--- a/packages/material-ui/src/RootRef/RootRef.d.ts
+++ b/packages/material-ui/src/RootRef/RootRef.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 export interface RootRefProps<T = any> {
   rootRef?: ((instance: T | null) => void) | React.RefObject<T>;
+  forwardedRef?: ((instance: T | null) => void) | React.RefObject<T>;
 }
 
 declare const RootRef: React.ComponentType<RootRefProps>;

--- a/packages/material-ui/src/RootRef/RootRef.js
+++ b/packages/material-ui/src/RootRef/RootRef.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { exactProp, refType } from '@material-ui/utils';
 import setRef from '../utils/setRef';
@@ -38,12 +37,12 @@ import setRef from '../utils/setRef';
  */
 class RootRef extends React.Component {
   componentDidMount() {
-    this.ref = ReactDOM.findDOMNode(this);
-    setRef(this.props.rootRef, this.ref);
+    this.ref = this.props.forwardedRed;
+    setRef(this.props.rootRef, this.props.forwardedRed);
   }
 
   componentDidUpdate(prevProps) {
-    const ref = ReactDOM.findDOMNode(this);
+    const ref = this.props.forwardedRed;
 
     if (prevProps.rootRef !== this.props.rootRef || this.ref !== ref) {
       if (prevProps.rootRef !== this.props.rootRef) {
@@ -73,6 +72,10 @@ RootRef.propTypes = {
   /**
    * A ref that points to the first DOM node of the wrapped element.
    */
+  forwardedRed: refType.isRequired,
+  /**
+   * A ref that points to the first DOM node of the wrapped element.
+   */
   rootRef: refType.isRequired,
 };
 
@@ -80,4 +83,9 @@ if (process.env.NODE_ENV !== 'production') {
   RootRef.propTypes = exactProp(RootRef.propTypes);
 }
 
-export default RootRef;
+export default React.forwardRef((props, ref) => (
+  <RootRef
+    {...props}
+    forwardedRed={ref}
+  />
+));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

This Pull Request replaces the `React.findDOMNode` with `React.forwardRef` of the `RootRef` component. Based on "[Caveat with StrictMode](https://github.com/mui-org/material-ui/blob/6a61fee852634e223986c5608165d242c247eabe/docs/src/pages/guides/composition/composition.md#caveat-with-strictmode)".
