### PR TITLE
[chip] Support text-overflow ellipsis by default

### DIFF
--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -28,8 +28,6 @@ export const styles = theme => {
       borderRadius: 32 / 2,
       whiteSpace: 'nowrap',
       transition: theme.transitions.create(['background-color', 'box-shadow']),
-      // setting max-width to support `text-overflow: "ellipsis"`
-      maxWidth: 220,
       // label will inherit this from root, then `clickable` class overrides this for both
       cursor: 'default',
       // We disable the focus ring for mouse, touch and keyboard users.

--- a/packages/material-ui/src/Chip/Chip.js
+++ b/packages/material-ui/src/Chip/Chip.js
@@ -28,6 +28,8 @@ export const styles = theme => {
       borderRadius: 32 / 2,
       whiteSpace: 'nowrap',
       transition: theme.transitions.create(['background-color', 'box-shadow']),
+      // setting max-width to support `text-overflow: "ellipsis"`
+      maxWidth: 220,
       // label will inherit this from root, then `clickable` class overrides this for both
       cursor: 'default',
       // We disable the focus ring for mouse, touch and keyboard users.
@@ -199,8 +201,8 @@ export const styles = theme => {
     },
     /* Styles applied to the label `span` element`. */
     label: {
-      display: 'flex',
-      alignItems: 'center',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
       paddingLeft: 12,
       paddingRight: 12,
       whiteSpace: 'nowrap',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes [#18587](https://github.com/mui-org/material-ui/issues/18587)

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Setting the `root`'s `maxWidth=220` to support `text-overflow: ellipsis`

![PR_CHIP](https://user-images.githubusercontent.com/24476578/70351915-8d21f880-189c-11ea-8d6b-6cd145644082.png)


