### PR TITLE
[Avatar] Add missing 'fallback' AvatarClassKey

### DIFF
--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -16,7 +16,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
 
 declare const Avatar: OverridableComponent<AvatarTypeMap>;
 
-export type AvatarClassKey = 'root' | 'colorDefault' | 'circle' | 'rounded' | 'square' | 'img';
+export type AvatarClassKey = 'root' | 'colorDefault' | 'fallback' | 'circle' | 'rounded' | 'square' | 'img';
 
 export type AvatarProps<
   D extends React.ElementType = AvatarTypeMap['defaultComponent'],

--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -16,7 +16,7 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
 
 declare const Avatar: OverridableComponent<AvatarTypeMap>;
 
-export type AvatarClassKey = 'root' | 'colorDefault' | 'fallback' | 'circle' | 'rounded' | 'square' | 'img';
+export type AvatarClassKey = 'root' | 'colorDefault' | 'circle' | 'rounded' | 'square' | 'img' | 'fallback';
 
 export type AvatarProps<
   D extends React.ElementType = AvatarTypeMap['defaultComponent'],

--- a/packages/material-ui/src/Avatar/Avatar.d.ts
+++ b/packages/material-ui/src/Avatar/Avatar.d.ts
@@ -16,7 +16,14 @@ export interface AvatarTypeMap<P = {}, D extends React.ElementType = 'div'> {
 
 declare const Avatar: OverridableComponent<AvatarTypeMap>;
 
-export type AvatarClassKey = 'root' | 'colorDefault' | 'circle' | 'rounded' | 'square' | 'img' | 'fallback';
+export type AvatarClassKey =
+  | 'root'
+  | 'colorDefault'
+  | 'circle'
+  | 'rounded'
+  | 'square'
+  | 'img'
+  | 'fallback';
 
 export type AvatarProps<
   D extends React.ElementType = AvatarTypeMap['defaultComponent'],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).


Following #18711, this updates typescript definition of `AvatarClassKey`