### PR TITLE
[TextField] Fix missing size prop in TypeScript types

### DIFF
--- a/packages/material-ui/src/TextField/TextField.d.ts
+++ b/packages/material-ui/src/TextField/TextField.d.ts
@@ -36,6 +36,7 @@ export interface BaseTextFieldProps
   required?: boolean;
   rows?: string | number;
   rowsMax?: string | number;
+  size?: 'small' | 'medium';
   select?: boolean;
   SelectProps?: Partial<SelectProps>;
   type?: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixes #18743 