### PR TITLE
[Autocomplete] Expand virtualized example to have grouped items

### DIFF
--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -20,10 +20,10 @@ function renderRow(props) {
   });
 }
 
-const outerElementPropsContext = React.createContext({});
+const OuterElementContext = React.createContext({});
 
 const OuterElementType = React.forwardRef((props, ref) => {
-  const outerProps = React.useContext(outerElementPropsContext);
+  const outerProps = React.useContext(OuterElementContext);
   return <div ref={ref} {...props} {...outerProps} />;
 });
 
@@ -53,7 +53,7 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
 
   return (
     <div ref={ref}>
-      <outerElementPropsContext.Provider value={other}>
+      <OuterElementContext.Provider value={other}>
         <VariableSizeList
           itemData={itemData}
           height={getHeight() + 2 * LISTBOX_PADDING}
@@ -67,7 +67,7 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
         >
           {renderRow}
         </VariableSizeList>
-      </outerElementPropsContext.Provider>
+      </OuterElementContext.Provider>
     </div>
   );
 });

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -22,13 +22,20 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
   const itemCount = itemData.length;
   const itemSize = smUp ? 36 : 48;
 
-  const getItemSize = index => {
-    const child = itemData[index];
+  const getChildSize = child => {
     if (React.isValidElement(child) && child.type === ListSubheader) {
       return 48;
     }
 
     return itemSize;
+  };
+
+  const getHeight = () => {
+    if (itemCount > 8) {
+      return 8 * itemSize;
+    } else {
+      return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
+    }
   };
 
   const outerElementType = React.useMemo(() => {
@@ -38,17 +45,12 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
   return (
     <div ref={ref}>
       <VariableSizeList
-        style={{
-          padding: 0,
-          height: Math.min(8, itemCount) * itemSize,
-          maxHeight: 'auto',
-        }}
         itemData={itemData}
-        height={250}
+        height={getHeight()}
         width="100%"
         outerElementType={outerElementType}
         innerElementType="ul"
-        itemSize={getItemSize}
+        itemSize={index => getChildSize(itemData[index])}
         overscanCount={5}
         itemCount={itemCount}
       >

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -15,7 +15,7 @@ function renderRow(props) {
 
 // Adapter for react-window
 const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) {
-  const { children, ...other } = props;
+  const { children, className, ...other } = props;
   const itemData = React.Children.toArray(children);
   const theme = useTheme();
   const smUp = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
@@ -42,7 +42,7 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <div ref={ref}>
+    <div ref={ref} className={className}>
       <VariableSizeList
         itemData={itemData}
         height={getHeight()}

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -15,7 +15,7 @@ function renderRow(props) {
 
 // Adapter for react-window
 const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) {
-  const { children, className, ...other } = props;
+  const { children, ...other } = props;
   const itemData = React.Children.toArray(children);
   const theme = useTheme();
   const smUp = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
@@ -42,7 +42,7 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
-    <div ref={ref} className={className}>
+    <div ref={ref}>
       <VariableSizeList
         itemData={itemData}
         height={getHeight()}

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -3,30 +3,33 @@ import PropTypes from 'prop-types';
 import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
+import ListSubheader from '@material-ui/core/ListSubheader';
 import { useTheme, makeStyles } from '@material-ui/core/styles';
-import { FixedSizeList } from 'react-window';
+import { VariableSizeList } from 'react-window';
+import { Typography } from '@material-ui/core';
 
 function renderRow(props) {
   const { data, index, style } = props;
-
-  return React.cloneElement(data[index], {
-    style: {
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-      display: 'block',
-      ...style,
-    },
-  });
+  return React.cloneElement(data[index], { style });
 }
 
 // Adapter for react-window
 const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) {
   const { children, ...other } = props;
+  const itemData = React.Children.toArray(children);
   const theme = useTheme();
-  const smUp = useMediaQuery(theme.breakpoints.up('sm'));
-  const itemCount = Array.isArray(children) ? children.length : 0;
+  const smUp = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
+  const itemCount = itemData.length;
   const itemSize = smUp ? 36 : 48;
+
+  const getItemSize = index => {
+    const child = itemData[index];
+    if (React.isValidElement(child) && child.type === ListSubheader) {
+      return 48;
+    }
+
+    return itemSize;
+  };
 
   const outerElementType = React.useMemo(() => {
     return React.forwardRef((props2, ref2) => <div ref={ref2} {...props2} {...other} />);
@@ -34,19 +37,23 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
 
   return (
     <div ref={ref}>
-      <FixedSizeList
-        style={{ padding: 0, height: Math.min(8, itemCount) * itemSize, maxHeight: 'auto' }}
-        itemData={children}
+      <VariableSizeList
+        style={{
+          padding: 0,
+          height: Math.min(8, itemCount) * itemSize,
+          maxHeight: 'auto',
+        }}
+        itemData={itemData}
         height={250}
         width="100%"
         outerElementType={outerElementType}
         innerElementType="ul"
-        itemSize={itemSize}
+        itemSize={getItemSize}
         overscanCount={5}
         itemCount={itemCount}
       >
         {renderRow}
-      </FixedSizeList>
+      </VariableSizeList>
     </div>
   );
 });
@@ -75,6 +82,17 @@ const useStyles = makeStyles({
   },
 });
 
+const OPTIONS = Array.from(new Array(10000))
+  .map(() => random(10 + Math.ceil(Math.random() * 20)))
+  .sort((a, b) => a.toUpperCase().localeCompare(b.toUpperCase()));
+
+const renderGroup = params => [
+  <ListSubheader key={params.key} component="div">
+    {params.key}
+  </ListSubheader>,
+  params.children,
+];
+
 export default function Virtualize() {
   const classes = useStyles();
 
@@ -85,10 +103,13 @@ export default function Virtualize() {
       disableListWrap
       classes={classes}
       ListboxComponent={ListboxComponent}
-      options={Array.from(new Array(10000)).map(() => random(Math.ceil(Math.random() * 18)))}
+      renderGroup={renderGroup}
+      options={OPTIONS}
+      groupBy={option => option[0].toUpperCase()}
       renderInput={params => (
         <TextField {...params} variant="outlined" label="10,000 options" fullWidth />
       )}
+      renderOption={option => <Typography noWrap>{option}</Typography>}
     />
   );
 }

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -33,9 +33,8 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
   const getHeight = () => {
     if (itemCount > 8) {
       return 8 * itemSize;
-    } else {
-      return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
     }
+    return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
   };
 
   const outerElementType = React.useMemo(() => {

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -8,15 +8,24 @@ import { useTheme, makeStyles } from '@material-ui/core/styles';
 import { VariableSizeList } from 'react-window';
 import { Typography } from '@material-ui/core';
 
+const LISTBOX_PADDING = 8; // px
+
 function renderRow(props) {
   const { data, index, style } = props;
   return React.cloneElement(data[index], {
     style: {
       ...style,
-      top: style.top + 8,
+      top: style.top + LISTBOX_PADDING,
     },
   });
 }
+
+const outerElementPropsContext = React.createContext({});
+
+const OuterElementType = React.forwardRef((props, ref) => {
+  const outerProps = React.useContext(outerElementPropsContext);
+  return <div ref={ref} {...props} {...outerProps} />;
+});
 
 // Adapter for react-window
 const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) {
@@ -42,25 +51,23 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
     return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
   };
 
-  const outerElementType = React.useMemo(() => {
-    return React.forwardRef((props2, ref2) => <div ref={ref2} {...props2} {...other} />);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
   return (
     <div ref={ref}>
-      <VariableSizeList
-        itemData={itemData}
-        height={getHeight() + 16}
-        width="100%"
-        key={itemCount}
-        outerElementType={outerElementType}
-        innerElementType="ul"
-        itemSize={index => getChildSize(itemData[index])}
-        overscanCount={5}
-        itemCount={itemCount}
-      >
-        {renderRow}
-      </VariableSizeList>
+      <outerElementPropsContext.Provider value={other}>
+        <VariableSizeList
+          itemData={itemData}
+          height={getHeight() + 2 * LISTBOX_PADDING}
+          width="100%"
+          key={itemCount}
+          outerElementType={OuterElementType}
+          innerElementType="ul"
+          itemSize={index => getChildSize(itemData[index])}
+          overscanCount={5}
+          itemCount={itemCount}
+        >
+          {renderRow}
+        </VariableSizeList>
+      </outerElementPropsContext.Provider>
     </div>
   );
 });

--- a/docs/src/pages/components/autocomplete/Virtualize.js
+++ b/docs/src/pages/components/autocomplete/Virtualize.js
@@ -10,7 +10,12 @@ import { Typography } from '@material-ui/core';
 
 function renderRow(props) {
   const { data, index, style } = props;
-  return React.cloneElement(data[index], { style });
+  return React.cloneElement(data[index], {
+    style: {
+      ...style,
+      top: style.top + 8,
+    },
+  });
 }
 
 // Adapter for react-window
@@ -45,8 +50,9 @@ const ListboxComponent = React.forwardRef(function ListboxComponent(props, ref) 
     <div ref={ref}>
       <VariableSizeList
         itemData={itemData}
-        height={getHeight()}
+        height={getHeight() + 16}
         width="100%"
+        key={itemCount}
         outerElementType={outerElementType}
         innerElementType="ul"
         itemSize={index => getChildSize(itemData[index])}

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -9,7 +9,12 @@ import { Typography } from '@material-ui/core';
 
 function renderRow(props: ListChildComponentProps) {
   const { data, index, style } = props;
-  return React.cloneElement(data[index], { style });
+  return React.cloneElement(data[index], {
+    style: {
+      ...style,
+      top: (style.top as number) + 8,
+    },
+  });
 }
 
 // Adapter for react-window
@@ -46,8 +51,9 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxCompon
     <div ref={ref}>
       <VariableSizeList
         itemData={itemData}
-        height={getHeight()}
+        height={getHeight() + 16}
         width="100%"
+        key={itemCount}
         outerElementType={outerElementType}
         innerElementType="ul"
         itemSize={index => getChildSize(itemData[index])}

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -35,9 +35,8 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxCompon
   const getHeight = () => {
     if (itemCount > 8) {
       return 8 * itemSize;
-    } else {
-      return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
     }
+    return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
   };
 
   const outerElementType = React.useMemo(() => {

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -13,54 +13,52 @@ function renderRow(props: ListChildComponentProps) {
 }
 
 // Adapter for react-window
-const ListboxComponent = React.forwardRef<HTMLDivElement, { className: string }>(
-  function ListboxComponent(props, ref) {
-    const { children, className, ...other } = props;
-    const itemData = React.Children.toArray(children);
-    const theme = useTheme();
-    const smUp = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
-    const itemCount = itemData.length;
-    const itemSize = smUp ? 36 : 48;
+const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxComponent(props, ref) {
+  const { children, ...other } = props;
+  const itemData = React.Children.toArray(children);
+  const theme = useTheme();
+  const smUp = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
+  const itemCount = itemData.length;
+  const itemSize = smUp ? 36 : 48;
 
-    const getChildSize = (child: React.ReactNode) => {
-      if (React.isValidElement(child) && child.type === ListSubheader) {
-        return 48;
-      }
+  const getChildSize = (child: React.ReactNode) => {
+    if (React.isValidElement(child) && child.type === ListSubheader) {
+      return 48;
+    }
 
-      return itemSize;
-    };
+    return itemSize;
+  };
 
-    const getHeight = () => {
-      if (itemCount > 8) {
-        return 8 * itemSize;
-      }
-      return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
-    };
+  const getHeight = () => {
+    if (itemCount > 8) {
+      return 8 * itemSize;
+    }
+    return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
+  };
 
-    const outerElementType = React.useMemo(() => {
-      return React.forwardRef<HTMLDivElement>((props2, ref2) => (
-        <div ref={ref2} {...props2} {...other} />
-      ));
-    }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  const outerElementType = React.useMemo(() => {
+    return React.forwardRef<HTMLDivElement>((props2, ref2) => (
+      <div ref={ref2} {...props2} {...other} />
+    ));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-    return (
-      <div ref={ref} className={className}>
-        <VariableSizeList
-          itemData={itemData}
-          height={getHeight()}
-          width="100%"
-          outerElementType={outerElementType}
-          innerElementType="ul"
-          itemSize={index => getChildSize(itemData[index])}
-          overscanCount={5}
-          itemCount={itemCount}
-        >
-          {renderRow}
-        </VariableSizeList>
-      </div>
-    );
-  },
-);
+  return (
+    <div ref={ref}>
+      <VariableSizeList
+        itemData={itemData}
+        height={getHeight()}
+        width="100%"
+        outerElementType={outerElementType}
+        innerElementType="ul"
+        itemSize={index => getChildSize(itemData[index])}
+        overscanCount={5}
+        itemCount={itemCount}
+      >
+        {renderRow}
+      </VariableSizeList>
+    </div>
+  );
+});
 
 function random(length: number) {
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -13,52 +13,54 @@ function renderRow(props: ListChildComponentProps) {
 }
 
 // Adapter for react-window
-const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxComponent(props, ref) {
-  const { children, ...other } = props;
-  const itemData = React.Children.toArray(children);
-  const theme = useTheme();
-  const smUp = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
-  const itemCount = itemData.length;
-  const itemSize = smUp ? 36 : 48;
+const ListboxComponent = React.forwardRef<HTMLDivElement, { className: string }>(
+  function ListboxComponent(props, ref) {
+    const { children, className, ...other } = props;
+    const itemData = React.Children.toArray(children);
+    const theme = useTheme();
+    const smUp = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
+    const itemCount = itemData.length;
+    const itemSize = smUp ? 36 : 48;
 
-  const getChildSize = (child: React.ReactNode) => {
-    if (React.isValidElement(child) && child.type === ListSubheader) {
-      return 48;
-    }
+    const getChildSize = (child: React.ReactNode) => {
+      if (React.isValidElement(child) && child.type === ListSubheader) {
+        return 48;
+      }
 
-    return itemSize;
-  };
+      return itemSize;
+    };
 
-  const getHeight = () => {
-    if (itemCount > 8) {
-      return 8 * itemSize;
-    }
-    return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
-  };
+    const getHeight = () => {
+      if (itemCount > 8) {
+        return 8 * itemSize;
+      }
+      return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
+    };
 
-  const outerElementType = React.useMemo(() => {
-    return React.forwardRef<HTMLDivElement>((props2, ref2) => (
-      <div ref={ref2} {...props2} {...other} />
-    ));
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+    const outerElementType = React.useMemo(() => {
+      return React.forwardRef<HTMLDivElement>((props2, ref2) => (
+        <div ref={ref2} {...props2} {...other} />
+      ));
+    }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return (
-    <div ref={ref}>
-      <VariableSizeList
-        itemData={itemData}
-        height={getHeight()}
-        width="100%"
-        outerElementType={outerElementType}
-        innerElementType="ul"
-        itemSize={index => getChildSize(itemData[index])}
-        overscanCount={5}
-        itemCount={itemCount}
-      >
-        {renderRow}
-      </VariableSizeList>
-    </div>
-  );
-});
+    return (
+      <div ref={ref} className={className}>
+        <VariableSizeList
+          itemData={itemData}
+          height={getHeight()}
+          width="100%"
+          outerElementType={outerElementType}
+          innerElementType="ul"
+          itemSize={index => getChildSize(itemData[index])}
+          overscanCount={5}
+          itemCount={itemCount}
+        >
+          {renderRow}
+        </VariableSizeList>
+      </div>
+    );
+  },
+);
 
 function random(length: number) {
   const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -7,15 +7,24 @@ import { useTheme, makeStyles } from '@material-ui/core/styles';
 import { VariableSizeList, ListChildComponentProps } from 'react-window';
 import { Typography } from '@material-ui/core';
 
+const LISTBOX_PADDING = 8; // px
+
 function renderRow(props: ListChildComponentProps) {
   const { data, index, style } = props;
   return React.cloneElement(data[index], {
     style: {
       ...style,
-      top: (style.top as number) + 8,
+      top: (style.top as number) + LISTBOX_PADDING,
     },
   });
 }
+
+const outerElementPropsContext = React.createContext({});
+
+const OuterElementType = React.forwardRef<HTMLDivElement>((props, ref) => {
+  const outerProps = React.useContext(outerElementPropsContext);
+  return <div ref={ref} {...props} {...outerProps} />;
+});
 
 // Adapter for react-window
 const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxComponent(props, ref) {
@@ -41,27 +50,23 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxCompon
     return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
   };
 
-  const outerElementType = React.useMemo(() => {
-    return React.forwardRef<HTMLDivElement>((props2, ref2) => (
-      <div ref={ref2} {...props2} {...other} />
-    ));
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
   return (
     <div ref={ref}>
-      <VariableSizeList
-        itemData={itemData}
-        height={getHeight() + 16}
-        width="100%"
-        key={itemCount}
-        outerElementType={outerElementType}
-        innerElementType="ul"
-        itemSize={index => getChildSize(itemData[index])}
-        overscanCount={5}
-        itemCount={itemCount}
-      >
-        {renderRow}
-      </VariableSizeList>
+      <outerElementPropsContext.Provider value={other}>
+        <VariableSizeList
+          itemData={itemData}
+          height={getHeight() + 2 * LISTBOX_PADDING}
+          width="100%"
+          key={itemCount}
+          outerElementType={OuterElementType}
+          innerElementType="ul"
+          itemSize={index => getChildSize(itemData[index])}
+          overscanCount={5}
+          itemCount={itemCount}
+        >
+          {renderRow}
+        </VariableSizeList>
+      </outerElementPropsContext.Provider>
     </div>
   );
 });

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -19,10 +19,10 @@ function renderRow(props: ListChildComponentProps) {
   });
 }
 
-const outerElementPropsContext = React.createContext({});
+const OuterElementContext = React.createContext({});
 
 const OuterElementType = React.forwardRef<HTMLDivElement>((props, ref) => {
-  const outerProps = React.useContext(outerElementPropsContext);
+  const outerProps = React.useContext(OuterElementContext);
   return <div ref={ref} {...props} {...outerProps} />;
 });
 
@@ -52,7 +52,7 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxCompon
 
   return (
     <div ref={ref}>
-      <outerElementPropsContext.Provider value={other}>
+      <OuterElementContext.Provider value={other}>
         <VariableSizeList
           itemData={itemData}
           height={getHeight() + 2 * LISTBOX_PADDING}
@@ -66,7 +66,7 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxCompon
         >
           {renderRow}
         </VariableSizeList>
-      </outerElementPropsContext.Provider>
+      </OuterElementContext.Provider>
     </div>
   );
 });

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -13,14 +13,11 @@ function renderRow(props: ListChildComponentProps) {
 }
 
 // Adapter for react-window
-const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxComponent(
-  props,
-  ref
-) {
+const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxComponent(props, ref) {
   const { children, ...other } = props;
   const itemData = React.Children.toArray(children);
   const theme = useTheme();
-  const smUp = useMediaQuery(theme.breakpoints.up("sm"), { noSsr: true });
+  const smUp = useMediaQuery(theme.breakpoints.up('sm'), { noSsr: true });
   const itemCount = itemData.length;
   const itemSize = smUp ? 36 : 48;
 
@@ -91,7 +88,7 @@ const renderGroup = (params: RenderGroupParams) => [
   <ListSubheader key={params.key} component="div">
     {params.key}
   </ListSubheader>,
-  params.children
+  params.children,
 ];
 
 export default function Virtualize() {

--- a/docs/src/pages/components/autocomplete/Virtualize.tsx
+++ b/docs/src/pages/components/autocomplete/Virtualize.tsx
@@ -24,13 +24,20 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxCompon
   const itemCount = itemData.length;
   const itemSize = smUp ? 36 : 48;
 
-  const getItemSize = (index: number) => {
-    const child = itemData[index];
+  const getChildSize = (child: React.ReactNode) => {
     if (React.isValidElement(child) && child.type === ListSubheader) {
       return 48;
     }
 
     return itemSize;
+  };
+
+  const getHeight = () => {
+    if (itemCount > 8) {
+      return 8 * itemSize;
+    } else {
+      return itemData.map(getChildSize).reduce((a, b) => a + b, 0);
+    }
   };
 
   const outerElementType = React.useMemo(() => {
@@ -42,17 +49,12 @@ const ListboxComponent = React.forwardRef<HTMLDivElement>(function ListboxCompon
   return (
     <div ref={ref}>
       <VariableSizeList
-        style={{
-          padding: 0,
-          height: Math.min(8, itemCount) * itemSize,
-          maxHeight: "auto"
-        }}
         itemData={itemData}
-        height={250}
+        height={getHeight()}
         width="100%"
         outerElementType={outerElementType}
         innerElementType="ul"
-        itemSize={getItemSize}
+        itemSize={index => getChildSize(itemData[index])}
         overscanCount={5}
         itemCount={itemCount}
       >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixes https://github.com/mui-org/material-ui/issues/18597

I also tweaked the responsiveness a bit. There were some edge cases.