### PR TITLE
[docs] Improve table of contents cmd+click

### DIFF
--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -156,14 +156,7 @@ export default function AppTableOfContents(props) {
   }, [itemsServer]);
 
   const [activeState, setActiveState] = React.useState(null);
-  const clickedRef = React.useRef(false);
-  const unsetClickedRef = React.useRef(null);
   const findActiveIndex = React.useCallback(() => {
-    // Don't set the active index based on scroll if a link was just clicked
-    if (clickedRef.current) {
-      return;
-    }
-
     let active;
     for (let i = itemsClientRef.current.length - 1; i >= 0; i -= 1) {
       // No hash if we're near the top of the page
@@ -198,32 +191,12 @@ export default function AppTableOfContents(props) {
   // Corresponds to 10 frames at 60 Hz
   useThrottledOnScroll(itemsServer.length > 0 ? findActiveIndex : null, 166);
 
-  const handleClick = hash => () => {
-    // Used to disable findActiveIndex if the page scrolls due to a click
-    clickedRef.current = true;
-    unsetClickedRef.current = setTimeout(() => {
-      clickedRef.current = false;
-    }, 1000);
-
-    if (activeState !== hash) {
-      setActiveState(hash);
-    }
-  };
-
-  React.useEffect(
-    () => () => {
-      clearTimeout(unsetClickedRef.current);
-    },
-    [],
-  );
-
   const itemLink = (item, secondary) => (
     <Link
       display="block"
       color={activeState === item.hash ? 'textPrimary' : 'textSecondary'}
       href={`#${item.hash}`}
       underline="none"
-      onClick={handleClick(item.hash)}
       className={clsx(
         classes.item,
         { [classes.secondaryItem]: secondary },

--- a/docs/src/modules/components/AppTableOfContents.js
+++ b/docs/src/modules/components/AppTableOfContents.js
@@ -205,8 +205,8 @@ export default function AppTableOfContents(props) {
       event.button !== 0 || // ignore everything but left-click
       event.metaKey ||
       event.ctrlKey ||
-      event.shiftKey ||
-      (event.nativeEvent && event.nativeEvent.which === 2)
+      event.altKey ||
+      event.shiftKey
     ) {
       return;
     }

--- a/docs/src/modules/components/MarkdownLinks.js
+++ b/docs/src/modules/components/MarkdownLinks.js
@@ -9,8 +9,8 @@ export async function handleEvent(event, as) {
     event.button !== 0 || // ignore everything but left-click
     event.metaKey ||
     event.ctrlKey ||
-    event.shiftKey ||
-    (event.nativeEvent && event.nativeEvent.which === 2)
+    event.altKey ||
+    event.shiftKey
   ) {
     return;
   }


### PR DESCRIPTION
Related to #18756

Just relying on `findActiveIndex` seems to be enough. This code would activate items when cmd+clicked (or middle click) without scrolling.

Alternatively we could pass the click event and check for `.metaKey` and middle mouse button, but that seems overly complex to me.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
