### PR TITLE
[ToggleButton] Add size prop type definition

### DIFF
--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -13,6 +13,7 @@ export type ToggleButtonTypeMap<
     disableFocusRipple?: boolean;
     selected?: boolean;
     value?: any;
+    size?: 'small' | 'medium' | 'large';
   };
   defaultComponent: D;
   classKey: ToggleButtonClassKey;

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.d.ts
@@ -12,8 +12,8 @@ export type ToggleButtonTypeMap<
   props: P & {
     disableFocusRipple?: boolean;
     selected?: boolean;
-    value?: any;
     size?: 'small' | 'medium' | 'large';
+    value?: any;
   };
   defaultComponent: D;
   classKey: ToggleButtonClassKey;


### PR DESCRIPTION
The `size` attribute for `ToggleButton` was missing in the types definition. This adds it. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

I have also ran `yarn typescript` and confirmed it passes.

