### PR TITLE
[Autocomplete] Fix double change event issue

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -721,7 +721,7 @@ describe('<Autocomplete />', () => {
     });
   });
 
-  describe('freeSolo', () => {
+  describe('prop: freeSolo', () => {
     it('pressing twice enter should not call onChange listener twice', () => {
       const handleChange = spy();
       const options = [{ name: 'foo' }];
@@ -740,7 +740,6 @@ describe('<Autocomplete />', () => {
       expect(handleChange.args[0][1]).to.deep.equal(options[0]);
       fireEvent.keyDown(document.activeElement, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.args[0][1]).to.deep.equal(options[0]);
     });
   });
 });

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -720,4 +720,25 @@ describe('<Autocomplete />', () => {
       expect(options.length).to.equal(1);
     });
   });
+
+  describe('freeSolo', () => {
+    it('pressing twice enter should not call onChange listener twice', () => {
+      render(
+        <Autocomplete
+          freeSolo
+          onChange={handleChange}
+          options={[{ name: 'foo' }}]}
+          getOptionLabel={option => option.name}
+          renderInput={params => <TextField {...params} autoFocus />}
+        />,
+      );
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.equal('foo');
+      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.equal('foo');
+    });
+  });
 });

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -724,11 +724,12 @@ describe('<Autocomplete />', () => {
   describe('freeSolo', () => {
     it('pressing twice enter should not call onChange listener twice', () => {
       const handleChange = spy();
+      const options = [{ name: 'foo' }];
       render(
         <Autocomplete
           freeSolo
           onChange={handleChange}
-          options={[{ name: 'foo' }]}
+          options={options}
           getOptionLabel={option => option.name}
           renderInput={params => <TextField {...params} autoFocus />}
         />,
@@ -736,10 +737,10 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
       fireEvent.keyDown(document.activeElement, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.args[0][1]).to.equal('foo');
+      expect(handleChange.args[0][1]).to.deep.equal([options[0]]);
       fireEvent.keyDown(document.activeElement, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.args[0][1]).to.equal('foo');
+      expect(handleChange.args[0][1]).to.deep.equal([options[0]]);
     });
   });
 });

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -727,7 +727,7 @@ describe('<Autocomplete />', () => {
         <Autocomplete
           freeSolo
           onChange={handleChange}
-          options={[{ name: 'foo' }}]}
+          options={[{ name: 'foo' }]}
           getOptionLabel={option => option.name}
           renderInput={params => <TextField {...params} autoFocus />}
         />,

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -737,10 +737,10 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
       fireEvent.keyDown(document.activeElement, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.args[0][1]).to.deep.equal([options[0]]);
+      expect(handleChange.args[0][1]).to.deep.equal(options[0]);
       fireEvent.keyDown(document.activeElement, { key: 'Enter' });
       expect(handleChange.callCount).to.equal(1);
-      expect(handleChange.args[0][1]).to.deep.equal([options[0]]);
+      expect(handleChange.args[0][1]).to.deep.equal(options[0]);
     });
   });
 });

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -723,6 +723,7 @@ describe('<Autocomplete />', () => {
 
   describe('freeSolo', () => {
     it('pressing twice enter should not call onChange listener twice', () => {
+      const handleChange = spy();
       render(
         <Autocomplete
           freeSolo

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -579,7 +579,7 @@ export default function useAutocomplete(props) {
               inputRef.current.value.length,
             );
           }
-        } else if (freeSolo && inputValue !== '') {
+        } else if (freeSolo && inputValueFilter !== '') {
           selectNewValue(event, inputValue);
         }
         break;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Added the change to useAutocomplete.js from and added a test case that checks that the onChange isn't called twice when enter is pressed twice.

Closes #18344