### PR TITLE
[docs] Fix chip outlined variant

### DIFF
--- a/docs/src/pages/components/chips/SmallOutlinedChips.js
+++ b/docs/src/pages/components/chips/SmallOutlinedChips.js
@@ -38,6 +38,7 @@ export default function SmallOutlinedChips() {
         onClick={handleClick}
       />
       <Chip
+        variant="outlined"
         size="small"
         avatar={<Avatar alt="Natacha" src="/static/images/avatar/1.jpg" />}
         label="Deletable"

--- a/docs/src/pages/components/chips/SmallOutlinedChips.tsx
+++ b/docs/src/pages/components/chips/SmallOutlinedChips.tsx
@@ -40,6 +40,7 @@ export default function SmallOutlinedChips() {
         onClick={handleClick}
       />
       <Chip
+        variant="outlined"
         size="small"
         avatar={<Avatar alt="Natacha" src="/static/images/avatar/1.jpg" />}
         label="Deletable"


### PR DESCRIPTION
Noticed this stray non-outlined variant in the example for small outlined chips.

![Screen Shot 2019-12-12 at 11 02 06 AM](https://user-images.githubusercontent.com/1682194/70728174-ec35a200-1cce-11ea-8963-ecb54d5d6439.png)

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
