### PR TITLE
[Modal] Fix scroll jump issue

### DIFF
--- a/packages/material-ui/src/Modal/ModalManager.js
+++ b/packages/material-ui/src/Modal/ModalManager.js
@@ -59,23 +59,7 @@ function handleContainer(containerInfo, props) {
   let fixedNodes;
 
   if (!props.disableScrollLock) {
-    const overflowing = isOverflowing(container);
-
-    // Improve Gatsby support
-    // https://css-tricks.com/snippets/css/force-vertical-scrollbar/
-    const parent = container.parentElement;
-    const scrollContainer =
-      parent.nodeName === 'HTML' && window.getComputedStyle(parent)['overflow-y'] === 'scroll'
-        ? parent
-        : container;
-
-    restoreStyle.push({
-      value: scrollContainer.style.overflow,
-      key: 'overflow',
-      el: scrollContainer,
-    });
-
-    if (overflowing) {
+    if (isOverflowing(container)) {
       // Compute the size before applying overflow hidden to avoid any scroll jumps.
       const scrollbarSize = getScrollbarSize();
 
@@ -84,8 +68,6 @@ function handleContainer(containerInfo, props) {
         key: 'padding-right',
         el: container,
       });
-      // Disable scroll here to be processed on the same frame with padding change.
-      scrollContainer.style.overflow = 'hidden';
       // Use computed style, here to get the real padding to add our scrollbar width.
       container.style['padding-right'] = `${getPaddingRight(container) + scrollbarSize}px`;
 
@@ -95,11 +77,24 @@ function handleContainer(containerInfo, props) {
         restorePaddings.push(node.style.paddingRight);
         node.style.paddingRight = `${getPaddingRight(node) + scrollbarSize}px`;
       });
-    } else {
-      // Block the scroll even if no scrollbar is visible to account for mobile keyboard
-      // screensize shrink.
-      scrollContainer.style.overflow = 'hidden';
     }
+
+    // Improve Gatsby support
+    // https://css-tricks.com/snippets/css/force-vertical-scrollbar/
+    const parent = container.parentElement;
+    const scrollContainer =
+      parent.nodeName === 'HTML' && window.getComputedStyle(parent)['overflow-y'] === 'scroll'
+        ? parent
+        : container;
+
+    // Block the scroll even if no scrollbar is visible to account for mobile keyboard
+    // screensize shrink.
+    restoreStyle.push({
+      value: scrollContainer.style.overflow,
+      key: 'overflow',
+      el: scrollContainer,
+    });
+    scrollContainer.style.overflow = 'hidden';
   }
 
   const restore = () => {

--- a/packages/material-ui/src/Modal/ModalManager.js
+++ b/packages/material-ui/src/Modal/ModalManager.js
@@ -75,11 +75,8 @@ function handleContainer(containerInfo, props) {
       el: scrollContainer,
     });
 
-    // Block the scroll even if no scrollbar is visible to account for mobile keyboard
-    // screensize shrink.
-    scrollContainer.style.overflow = 'hidden';
-
     if (overflowing) {
+      // Compute the size before applying overflow hidden to avoid any scroll jumps.
       const scrollbarSize = getScrollbarSize();
 
       restoreStyle.push({
@@ -87,6 +84,8 @@ function handleContainer(containerInfo, props) {
         key: 'padding-right',
         el: container,
       });
+      // Disable scroll here to be processed on the same frame with padding change.
+      scrollContainer.style.overflow = 'hidden';
       // Use computed style, here to get the real padding to add our scrollbar width.
       container.style['padding-right'] = `${getPaddingRight(container) + scrollbarSize}px`;
 
@@ -96,6 +95,10 @@ function handleContainer(containerInfo, props) {
         restorePaddings.push(node.style.paddingRight);
         node.style.paddingRight = `${getPaddingRight(node) + scrollbarSize}px`;
       });
+    } else {
+      // Block the scroll even if no scrollbar is visible to account for mobile keyboard
+      // screensize shrink.
+      scrollContainer.style.overflow = 'hidden';
     }
   }
 

--- a/packages/material-ui/src/Modal/ModalManager.test.js
+++ b/packages/material-ui/src/Modal/ModalManager.test.js
@@ -135,6 +135,29 @@ describe('ModalManager', () => {
       assert.strictEqual(fixedNode.style.paddingRight, '14px');
     });
 
+    it('should disable the scroll even when not overflowing', () => {
+      // simulate non-overflowing container
+      const container2 = document.createElement('div');
+      Object.defineProperty(container2, 'scrollHeight', {
+        value: 100,
+        writable: false,
+      });
+      Object.defineProperty(container2, 'clientHeight', {
+        value: 100,
+        writable: false,
+      });
+      document.body.appendChild(container2);
+
+      const modal = {};
+      modalManager.add(modal, container2);
+      modalManager.mount(modal, {});
+      assert.strictEqual(container2.style.overflow, 'hidden');
+      modalManager.remove(modal);
+      assert.strictEqual(container2.style.overflow, '');
+
+      document.body.removeChild(container2);
+    });
+
     it('should restore styles correctly if none existed before', () => {
       const modal = {};
       modalManager.add(modal, container1);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixes scroll jump issue that occurs when opening Modal (#18793)

@oliviertassinari I deviated from your [suggested diff](https://github.com/mui-org/material-ui/issues/18793#issuecomment-564920783) so that scroll is still disabled when the container is not overflowing (I also added a related test for that).

Closes #18793