### PR TITLE
[docs] Simplify MiniDrawer demo

### DIFF
--- a/docs/src/pages/components/drawers/MiniDrawer.js
+++ b/docs/src/pages/components/drawers/MiniDrawer.js
@@ -132,7 +132,7 @@ export default function MiniDrawer() {
             [classes.drawerClose]: !open,
           }),
         }}
-        open={open}
+        open
       >
         <div className={classes.toolbar}>
           <IconButton onClick={handleDrawerClose}>

--- a/docs/src/pages/components/drawers/MiniDrawer.js
+++ b/docs/src/pages/components/drawers/MiniDrawer.js
@@ -132,7 +132,6 @@ export default function MiniDrawer() {
             [classes.drawerClose]: !open,
           }),
         }}
-        open
       >
         <div className={classes.toolbar}>
           <IconButton onClick={handleDrawerClose}>

--- a/docs/src/pages/components/drawers/MiniDrawer.tsx
+++ b/docs/src/pages/components/drawers/MiniDrawer.tsx
@@ -134,7 +134,6 @@ export default function MiniDrawer() {
             [classes.drawerClose]: !open,
           }),
         }}
-        open={open}
       >
         <div className={classes.toolbar}>
           <IconButton onClick={handleDrawerClose}>


### PR DESCRIPTION
For the minified drawer, `open` needs to always be `true`, otherwise the `Paper` inside gets hidden programmatically.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
