### PR TITLE
[Autocomplete] Fix padding to make visual height consistent

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -58,7 +58,7 @@ export const styles = theme => ({
       },
     },
     '&[class*="MuiOutlinedInput-root"]': {
-      padding: 8,
+      padding: 9,
       paddingRight: 62,
       '& $input': {
         padding: '9.5px 4px',


### PR DESCRIPTION
Adjust padding to make visual height consistent with Select and TextField

**Before:**
<img width="300" alt="Screen Shot 2019-12-15 at 12 50 42 AM" src="https://user-images.githubusercontent.com/1156264/70859288-2e353280-1edf-11ea-88e3-e72b3dcb22e2.png">
**After:**
<img width="300" alt="Screen Shot 2019-12-15 at 12 50 55 AM" src="https://user-images.githubusercontent.com/1156264/70859287-2e353280-1edf-11ea-922c-0d6be7991307.png">

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
