### PR TITLE
[Drawer] Fix PaperProps className merge

### DIFF
--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -134,6 +134,7 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
     <Paper
       elevation={variant === 'temporary' ? elevation : 0}
       square
+      {...PaperProps}
       className={clsx(
         classes.paper,
         classes[`paperAnchor${capitalize(anchor)}`],
@@ -142,7 +143,6 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
         },
         PaperProps.className,
       )}
-      {...PaperProps}
     >
       {children}
     </Paper>

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -217,7 +217,6 @@ describe('<Drawer />', () => {
     });
   });
 
-
   describe('prop: PaperProps', () => {
     const drawerElement = (
       <Drawer PaperProps={{ className: 'my-class' }} open>
@@ -315,5 +314,4 @@ describe('<Drawer />', () => {
       assert.strictEqual(getAnchor(theme, 'right'), 'left');
     });
   });
-
 });

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import describeConformance from '../test-utils/describeConformance';
@@ -7,10 +7,12 @@ import Slide from '../Slide';
 import Paper from '../Paper';
 import Modal from '../Modal';
 import Drawer, { getAnchor, isHorizontal } from './Drawer';
+import { createClientRender } from 'test/utils/createClientRender';
 
 describe('<Drawer />', () => {
   let mount;
   let classes;
+  const render = createClientRender({ strict: false });
 
   before(() => {
     // StrictModeViolation: uses Slide
@@ -218,24 +220,13 @@ describe('<Drawer />', () => {
   });
 
   describe('prop: PaperProps', () => {
-    const drawerElement = (
-      <Drawer PaperProps={{ className: 'my-class' }} open>
-        <h1>Hello</h1>
-      </Drawer>
-    );
-
-    it('should render paper with my-class', () => {
-      const wrapper = mount(drawerElement);
-
-      const paper = wrapper.find(Paper);
-      assert.strictEqual(paper.hasClass('my-class'), true);
-    });
-
-    it('should render paper with classes.paper', () => {
-      const wrapper = mount(drawerElement);
-
-      const paper = wrapper.find(Paper);
-      assert.strictEqual(paper.hasClass(classes.paper), true);
+    it('should merge class names', () => {
+      const { container } = render(
+        <Drawer PaperProps={{ className: 'my-class' }} variant="permanent">
+          <h1>Hello</h1>
+        </Drawer>,
+      );
+      expect(container.querySelector(`.${classes.paper}`)).to.have.class('my-class');
     });
   });
 

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -217,6 +217,29 @@ describe('<Drawer />', () => {
     });
   });
 
+
+  describe('prop: PaperProps', () => {
+    const drawerElement = (
+      <Drawer PaperProps={{ className: 'my-class' }} open>
+        <h1>Hello</h1>
+      </Drawer>
+    );
+
+    it('should render paper with my-class', () => {
+      const wrapper = mount(drawerElement);
+
+      const paper = wrapper.find(Paper);
+      assert.strictEqual(paper.hasClass('my-class'), true);
+    });
+
+    it('should render paper with classes.paper', () => {
+      const wrapper = mount(drawerElement);
+
+      const paper = wrapper.find(Paper);
+      assert.strictEqual(paper.hasClass(classes.paper), true);
+    });
+  });
+
   describe('slide direction', () => {
     it('should return the opposing slide direction', () => {
       const wrapper = mount(
@@ -292,4 +315,5 @@ describe('<Drawer />', () => {
       assert.strictEqual(getAnchor(theme, 'right'), 'left');
     });
   });
+
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
There was a bug in #18740 so this is the actual fix to #18714. 

I also added some tests to make sure custom className and the normal paper classes are applied. 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
