### PR TITLE
[TextField] onBlur event argument can be undefined

### DIFF
--- a/docs/pages/api/input-base.md
+++ b/docs/pages/api/input-base.md
@@ -43,7 +43,7 @@ It contains a load of style reset and some state logic.
 | <span class="prop-name">margin</span> | <span class="prop-type">'dense'<br>&#124;&nbsp;'none'</span> |  | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
 | <span class="prop-name">multiline</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, a textarea element will be rendered. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | Name attribute of the `input` element. |
-| <span class="prop-name">onBlur</span> | <span class="prop-type">func</span> |  | Callback fired when the input is blurred.<br>Notice that the first argument (event) might be undefined. https://github.com/mui-org/material-ui/pull/9042 |
+| <span class="prop-name">onBlur</span> | <span class="prop-type">func</span> |  | Callback fired when the input is blurred.<br>Notice that the first argument (event) might be undefined. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value` (string). |
 | <span class="prop-name">placeholder</span> | <span class="prop-type">string</span> |  | The short hint displayed in the input before the user enters a value. |
 | <span class="prop-name">readOnly</span> | <span class="prop-type">bool</span> |  | It prevents the user from changing the value of the field (not from interacting with the field). |

--- a/docs/pages/api/input-base.md
+++ b/docs/pages/api/input-base.md
@@ -43,6 +43,7 @@ It contains a load of style reset and some state logic.
 | <span class="prop-name">margin</span> | <span class="prop-type">'dense'<br>&#124;&nbsp;'none'</span> |  | If `dense`, will adjust vertical spacing. This is normally obtained via context from FormControl. |
 | <span class="prop-name">multiline</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, a textarea element will be rendered. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | Name attribute of the `input` element. |
+| <span class="prop-name">onBlur</span> | <span class="prop-type">func</span> |  | Callback fired when the input is blurred.<br>Notice that the first argument (event) might be undefined. https://github.com/mui-org/material-ui/pull/9042 |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the value is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value` (string). |
 | <span class="prop-name">placeholder</span> | <span class="prop-type">string</span> |  | The short hint displayed in the input before the user enters a value. |
 | <span class="prop-name">readOnly</span> | <span class="prop-type">bool</span> |  | It prevents the user from changing the value of the field (not from interacting with the field). |

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -47,7 +47,7 @@ export interface InputBaseProps
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
-  onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement | undefined>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
   onFocus?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 }
 

--- a/packages/material-ui/src/InputBase/InputBase.d.ts
+++ b/packages/material-ui/src/InputBase/InputBase.d.ts
@@ -47,7 +47,7 @@ export interface InputBaseProps
   onChange?: React.ChangeEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
   onKeyUp?: React.KeyboardEventHandler<HTMLTextAreaElement | HTMLInputElement>;
-  onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
+  onBlur?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement | undefined>;
   onFocus?: React.FocusEventHandler<HTMLInputElement | HTMLTextAreaElement>;
 }
 

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -295,6 +295,8 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     }
   };
 
+  // The event argument might be undefined. See the link below.
+  // https://github.com/mui-org/material-ui/pull/9042
   const handleBlur = event => {
     if (onBlur) {
       onBlur(event);
@@ -549,7 +551,10 @@ InputBase.propTypes = {
    */
   name: PropTypes.string,
   /**
-   * @ignore
+   * Callback fired when the input is blurred.
+   * 
+   * Notice that the first argument (event) might be undefined.
+   * https://github.com/mui-org/material-ui/pull/9042
    */
   onBlur: PropTypes.func,
   /**

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -552,7 +552,7 @@ InputBase.propTypes = {
   name: PropTypes.string,
   /**
    * Callback fired when the input is blurred.
-   * 
+   *
    * Notice that the first argument (event) might be undefined.
    * https://github.com/mui-org/material-ui/pull/9042
    */

--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -295,8 +295,6 @@ const InputBase = React.forwardRef(function InputBase(props, ref) {
     }
   };
 
-  // The event argument might be undefined. See the link below.
-  // https://github.com/mui-org/material-ui/pull/9042
   const handleBlur = event => {
     if (onBlur) {
       onBlur(event);
@@ -554,7 +552,6 @@ InputBase.propTypes = {
    * Callback fired when the input is blurred.
    *
    * Notice that the first argument (event) might be undefined.
-   * https://github.com/mui-org/material-ui/pull/9042
    */
   onBlur: PropTypes.func,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

As discussed and suggested in #16402 was added some notes about the `event` argument.
This [react issue](https://github.com/facebook/react/issues/9142) also was added for contextual purposes.

Closes #16402