### PR TITLE
fix(MuiStepIcon): Remove overly specific classes (#18877)

### DIFF
--- a/packages/material-ui/src/StepIcon/StepIcon.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.js
@@ -11,15 +11,15 @@ export const styles = theme => ({
   root: {
     display: 'block',
     color: theme.palette.text.disabled,
-    '&$completed': {
-      color: theme.palette.primary.main,
-    },
-    '&$active': {
-      color: theme.palette.primary.main,
-    },
-    '&$error': {
-      color: theme.palette.error.main,
-    },
+  },
+  '$completed': {
+    color: theme.palette.primary.main,
+  },
+  '$active': {
+    color: theme.palette.primary.main,
+  },
+  '$error': {
+    color: theme.palette.error.main,
   },
   /* Styles applied to the SVG text element. */
   text: {


### PR DESCRIPTION
Overly specific default classes prevent overriden classes to take effect.

Fixes #18877

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
