### PR TITLE
[Autocomplete] Prevent focusing control / opening dropdown on clear

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -205,6 +205,27 @@ describe('<Autocomplete />', () => {
       expect(handleOpen.callCount).to.equal(1);
     });
 
+    it('does not open on clear', () => {
+      const handleOpen = spy();
+      const handleChange = spy();
+      const { container } = render (
+        <Autocomplete
+          onOpen={handleOpen}
+          onChange={handleChange}
+          open={false}
+          options={['one', 'two']}
+          value="one"
+          renderInput={params => <TextField {...params}/>}
+        />,
+      )
+
+      const clear = container.querySelector('button')
+      fireEvent.click(clear);
+
+      expect(handleOpen.callCount).to.equal(0);
+      expect(handleChange.callCount).to.equal(1);
+    });
+
     ['ArrowDown', 'ArrowUp'].forEach(key => {
       it(`opens on ${key} when focus is on the textbox without moving focus`, () => {
         const handleOpen = spy();

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -208,18 +208,18 @@ describe('<Autocomplete />', () => {
     it('does not open on clear', () => {
       const handleOpen = spy();
       const handleChange = spy();
-      const { container } = render (
+      const { container } = render(
         <Autocomplete
           onOpen={handleOpen}
           onChange={handleChange}
           open={false}
           options={['one', 'two']}
           value="one"
-          renderInput={params => <TextField {...params}/>}
+          renderInput={params => <TextField {...params} />}
         />,
-      )
+      );
 
-      const clear = container.querySelector('button')
+      const clear = container.querySelector('button');
       fireEvent.click(clear);
 
       expect(handleOpen.callCount).to.equal(0);

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -108,6 +108,7 @@ export default function useAutocomplete(props) {
     setDefaultId(`mui-autocomplete-${Math.round(Math.random() * 1e5)}`);
   }, []);
 
+  const ignoreFocus = React.useRef(false);
   const firstFocus = React.useRef(true);
   const inputRef = React.useRef(null);
   const listboxRef = React.useRef(null);
@@ -509,10 +510,8 @@ export default function useAutocomplete(props) {
   };
 
   const handleClear = event => {
+    ignoreFocus.current = true;
     handleValue(event, multiple ? [] : null);
-    if (disableOpenOnFocus) {
-      handleClose();
-    }
     setInputValue('');
   };
 
@@ -614,7 +613,7 @@ export default function useAutocomplete(props) {
   const handleFocus = event => {
     setFocused(true);
 
-    if (!disableOpenOnFocus) {
+    if (!disableOpenOnFocus && !ignoreFocus.current) {
       handleOpen(event);
     }
   };
@@ -622,6 +621,7 @@ export default function useAutocomplete(props) {
   const handleBlur = event => {
     setFocused(false);
     firstFocus.current = true;
+    ignoreFocus.current = false;
 
     if (debug && inputValue !== '') {
       return;
@@ -706,8 +706,6 @@ export default function useAutocomplete(props) {
   });
 
   const handlePopupIndicator = event => {
-    inputRef.current.focus();
-
     if (open) {
       handleClose(event);
     } else {
@@ -715,13 +713,14 @@ export default function useAutocomplete(props) {
     }
   };
 
+  // Prevent input blur when interacting with the combobox
   const handleMouseDown = event => {
     if (event.target.nodeName !== 'INPUT') {
-      // Prevent blur
       event.preventDefault();
     }
   };
 
+  // Focus the input when first interacting with the combobox
   const handleClick = () => {
     if (
       firstFocus.current &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

As discussed in #18873 this PR changes the default behaviour of the Autocomplete control to prevent focus/open when the Clear button is clicked.

This could be further customised by providing a boolean option to re-enable the previous behaviour, but that hasn't yet been discussed and is not in this PR.

Resolves #18873 