### PR TITLE
[Switch] inputProps can take additional props

### DIFF
--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -11,7 +11,7 @@ export interface SwitchBaseProps
   disabled?: boolean;
   disableRipple?: boolean;
   icon: React.ReactNode;
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  inputProps?: SwitchBaseComponentProps;
   inputRef?: React.Ref<any>;
   name?: string;
   onChange?: (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => void;
@@ -19,6 +19,11 @@ export interface SwitchBaseProps
   required?: boolean;
   tabIndex?: number;
   value?: unknown;
+}
+
+interface SwitchBaseComponentProps extends React.HTMLAttributes<HTMLInputElement> {
+  // Accommodate arbitrary additional props coming from the `inputProps` prop
+  [arbitrary: string]: any;
 }
 
 export type SwitchBaseClassKey = 'root' | 'checked' | 'disabled' | 'input';

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -21,7 +21,7 @@ export interface SwitchBaseProps
   value?: unknown;
 }
 
-interface SwitchBaseComponentProps extends React.HTMLAttributes<HTMLInputElement> {
+export interface SwitchBaseComponentProps extends React.HTMLAttributes<HTMLInputElement> {
   // Accommodate arbitrary additional props coming from the `inputProps` prop
   [arbitrary: string]: any;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

This change allows for additional attributes to be forwarded to the `input` element via `inputProps`.
This currently exists in `InputBaseComponentProps` here: https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/InputBase/InputBase.d.ts#L54-L58
