### PR TITLE
[docs]: add controlled freesolo example to Autocomplete

### DIFF
--- a/docs/src/pages/components/autocomplete/FreeSolo.js
+++ b/docs/src/pages/components/autocomplete/FreeSolo.js
@@ -4,6 +4,7 @@ import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 
 export default function FreeSolo() {
+  const [value, setValue] = React.useState('');
   return (
     <div style={{ width: 300 }}>
       <Autocomplete
@@ -28,6 +29,16 @@ export default function FreeSolo() {
             fullWidth
             InputProps={{ ...params.InputProps, type: 'search' }}
           />
+        )}
+      />
+      <Autocomplete
+        id="free-solo-3-demo"
+        freeSolo
+        value={value}
+        onInputChange={(_, value) => setValue(value)}
+        options={top100Films.map(option => option.title)}
+        renderInput={params => (
+          <TextField {...params} label="Controlled freeSolo" margin="normal" variant="outlined" fullWidth />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/FreeSolo.js
+++ b/docs/src/pages/components/autocomplete/FreeSolo.js
@@ -35,7 +35,7 @@ export default function FreeSolo() {
         id="free-solo-3-demo"
         freeSolo
         value={value}
-        onInputChange={(_, value) => setValue(value)}
+        onInputChange={(_, newValue) => setValue(newValue)}
         options={top100Films.map(option => option.title)}
         renderInput={params => (
           <TextField

--- a/docs/src/pages/components/autocomplete/FreeSolo.js
+++ b/docs/src/pages/components/autocomplete/FreeSolo.js
@@ -38,7 +38,13 @@ export default function FreeSolo() {
         onInputChange={(_, value) => setValue(value)}
         options={top100Films.map(option => option.title)}
         renderInput={params => (
-          <TextField {...params} label="Controlled freeSolo" margin="normal" variant="outlined" fullWidth />
+          <TextField
+            {...params}
+            label="Controlled freeSolo"
+            margin="normal"
+            variant="outlined"
+            fullWidth
+          />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/FreeSolo.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSolo.tsx
@@ -4,6 +4,7 @@ import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 
 export default function FreeSolo() {
+  const [value, setValue] = React.useState('');
   return (
     <div style={{ width: 300 }}>
       <Autocomplete
@@ -28,6 +29,16 @@ export default function FreeSolo() {
             fullWidth
             InputProps={{ ...params.InputProps, type: 'search' }}
           />
+        )}
+      />
+      <Autocomplete
+        id="free-solo-3-demo"
+        freeSolo
+        value={value}
+        onInputChange={(_, value) => setValue(value)}
+        options={top100Films.map(option => option.title)}
+        renderInput={params => (
+          <TextField {...params} label="Controlled freeSolo" margin="normal" variant="outlined" fullWidth />
         )}
       />
     </div>

--- a/docs/src/pages/components/autocomplete/FreeSolo.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSolo.tsx
@@ -35,7 +35,7 @@ export default function FreeSolo() {
         id="free-solo-3-demo"
         freeSolo
         value={value}
-        onInputChange={(_, value) => setValue(value)}
+        onInputChange={(_, newValue) => setValue(newValue)}
         options={top100Films.map(option => option.title)}
         renderInput={params => (
           <TextField

--- a/docs/src/pages/components/autocomplete/FreeSolo.tsx
+++ b/docs/src/pages/components/autocomplete/FreeSolo.tsx
@@ -38,7 +38,13 @@ export default function FreeSolo() {
         onInputChange={(_, value) => setValue(value)}
         options={top100Films.map(option => option.title)}
         renderInput={params => (
-          <TextField {...params} label="Controlled freeSolo" margin="normal" variant="outlined" fullWidth />
+          <TextField
+            {...params}
+            label="Controlled freeSolo"
+            margin="normal"
+            variant="outlined"
+            fullWidth
+          />
         )}
       />
     </div>


### PR DESCRIPTION
This adds a controlled freeSolo example to Autocomplete.
This is helpful because there are two value props and two onChange props:
value/inputValue and onChange/onInputChange.  It is not as straightfoward as the non-freesolo example so an example would be extremely useful.

Please confirm this api usage is correct before merging.
Example code sandbox: https://codesandbox.io/s/material-demo-5qnws
As I mentioned in #18882 there is an issue with option filtering.  The sandbox example I have given previously in #18882 was not correct and the link above is what I wanted to show (I double checked it).

I ran yarn dev and make sure the docs with my new example is working, except for the filtering issue.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
