### PR TITLE
[TableSortLabel][TypeScript] Relax IconComponent requirements in TypeScript

### DIFF
--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
@@ -11,7 +11,7 @@ export type TableSortLabelTypeMap<
     active?: boolean;
     direction?: 'asc' | 'desc';
     hideSortIcon?: boolean;
-    IconComponent?: React.ComponentType<{ className: string; }>;
+    IconComponent?: React.ComponentType<{ className: string }>;
   };
   defaultComponent: D;
   classKey: TableSortLabelClassKey;

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.d.ts
@@ -11,7 +11,7 @@ export type TableSortLabelTypeMap<
     active?: boolean;
     direction?: 'asc' | 'desc';
     hideSortIcon?: boolean;
-    IconComponent?: React.ComponentType<SvgIconProps>;
+    IconComponent?: React.ComponentType<{ className: string; }>;
   };
   defaultComponent: D;
   classKey: TableSortLabelClassKey;


### PR DESCRIPTION
According to the source `TableSortLabel` only passes `className` to the `IconComponent`: https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/TableSortLabel/TableSortLabel.js#L82-L84

So this PR relaxes the requirement to `IconComponent` prop in TypeScript.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
