### PR TITLE
[Badge] Improve demos

### DIFF
--- a/docs/src/pages/components/badges/BadgeMax.tsx
+++ b/docs/src/pages/components/badges/BadgeMax.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles((theme: Theme) =>
 );
 
 const defaultProps = {
-  color: 'secondary',
+  color: 'secondary' as 'secondary',
   children: <MailIcon />,
 };
 

--- a/docs/src/pages/components/badges/BadgeMax.tsx
+++ b/docs/src/pages/components/badges/BadgeMax.tsx
@@ -13,20 +13,19 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
+const defaultProps = {
+  color: 'secondary',
+  children: <MailIcon />,
+};
+
 export default function BadgeMax() {
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
-      <Badge badgeContent={99} color="primary">
-        <MailIcon />
-      </Badge>
-      <Badge badgeContent={100} color="primary">
-        <MailIcon />
-      </Badge>
-      <Badge badgeContent={1000} max={999} color="primary">
-        <MailIcon />
-      </Badge>
+      <Badge badgeContent={99} {...defaultProps} />
+      <Badge badgeContent={100} {...defaultProps} />
+      <Badge badgeContent={1000} max={999} {...defaultProps} />
     </div>
   );
 }

--- a/docs/src/pages/components/badges/BadgeVisibility.js
+++ b/docs/src/pages/components/badges/BadgeVisibility.js
@@ -1,33 +1,30 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import Button from '@material-ui/core/Button';
+import AddIcon from '@material-ui/icons/Add';
+import RemoveIcon from '@material-ui/icons/Remove';
 import MailIcon from '@material-ui/icons/Mail';
 import Switch from '@material-ui/core/Switch';
-import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Divider from '@material-ui/core/Divider';
 
 const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     flexDirection: 'column',
-    alignItems: 'center',
-    width: '100%',
-  },
-  margin: {
-    margin: theme.spacing(1),
-  },
-  divider: {
-    margin: theme.spacing(2, 0),
-    width: '100%',
-  },
-  row: {
-    marginTop: theme.spacing(2),
+    '& > *': {
+      marginBottom: theme.spacing(2),
+    },
+    '& .MuiBadge-root': {
+      marginRight: theme.spacing(4),
+    },
   },
 }));
 
 export default function BadgeVisibility() {
   const classes = useStyles();
+  const [count, setCount] = React.useState(1);
   const [invisible, setInvisible] = React.useState(false);
 
   const handleBadgeVisibility = () => {
@@ -36,28 +33,37 @@ export default function BadgeVisibility() {
 
   return (
     <div className={classes.root}>
-      <div className={classes.row}>
-        <Badge color="secondary" badgeContent={4} invisible={invisible} className={classes.margin}>
+      <div>
+        <Badge color="secondary" badgeContent={count}>
           <MailIcon />
         </Badge>
-        <Badge color="secondary" variant="dot" invisible={invisible} className={classes.margin}>
-          <MailIcon />
-        </Badge>
+        <ButtonGroup>
+          <Button
+            aria-label="reduce"
+            onClick={() => {
+              setCount(Math.max(count - 1, 0));
+            }}
+          >
+            <RemoveIcon fontSize="small" />
+          </Button>
+          <Button
+            aria-label="increase"
+            onClick={() => {
+              setCount(count + 1);
+            }}
+          >
+            <AddIcon fontSize="small" />
+          </Button>
+        </ButtonGroup>
       </div>
-      <FormGroup row>
+      <div>
+        <Badge color="secondary" variant="dot" invisible={invisible}>
+          <MailIcon />
+        </Badge>
         <FormControlLabel
           control={<Switch color="primary" checked={!invisible} onChange={handleBadgeVisibility} />}
           label="Show Badge"
         />
-      </FormGroup>
-      <Divider className={classes.divider} />
-      <div className={classes.row}>
-        <Badge color="secondary" badgeContent={0} className={classes.margin}>
-          <MailIcon />
-        </Badge>
-        <Badge color="secondary" badgeContent={0} showZero className={classes.margin}>
-          <MailIcon />
-        </Badge>
       </div>
     </div>
   );

--- a/docs/src/pages/components/badges/BadgeVisibility.tsx
+++ b/docs/src/pages/components/badges/BadgeVisibility.tsx
@@ -1,35 +1,32 @@
 import React from 'react';
 import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import Button from '@material-ui/core/Button';
+import AddIcon from '@material-ui/icons/Add';
+import RemoveIcon from '@material-ui/icons/Remove';
 import MailIcon from '@material-ui/icons/Mail';
 import Switch from '@material-ui/core/Switch';
-import FormGroup from '@material-ui/core/FormGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Divider from '@material-ui/core/Divider';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
       display: 'flex',
       flexDirection: 'column',
-      alignItems: 'center',
-      width: '100%',
-    },
-    margin: {
-      margin: theme.spacing(1),
-    },
-    divider: {
-      margin: theme.spacing(2, 0),
-      width: '100%',
-    },
-    row: {
-      marginTop: theme.spacing(2),
+      '& > *': {
+        marginBottom: theme.spacing(2),
+      },
+      '& .MuiBadge-root': {
+        marginRight: theme.spacing(4),
+      },
     },
   }),
 );
 
 export default function BadgeVisibility() {
   const classes = useStyles();
+  const [count, setCount] = React.useState(1);
   const [invisible, setInvisible] = React.useState(false);
 
   const handleBadgeVisibility = () => {
@@ -38,28 +35,37 @@ export default function BadgeVisibility() {
 
   return (
     <div className={classes.root}>
-      <div className={classes.row}>
-        <Badge color="secondary" badgeContent={4} invisible={invisible} className={classes.margin}>
+      <div>
+        <Badge color="secondary" badgeContent={count}>
           <MailIcon />
         </Badge>
-        <Badge color="secondary" variant="dot" invisible={invisible} className={classes.margin}>
-          <MailIcon />
-        </Badge>
+        <ButtonGroup>
+          <Button
+            aria-label="reduce"
+            onClick={() => {
+              setCount(Math.max(count - 1, 0));
+            }}
+          >
+            <RemoveIcon fontSize="small" />
+          </Button>
+          <Button
+            aria-label="increase"
+            onClick={() => {
+              setCount(count + 1);
+            }}
+          >
+            <AddIcon fontSize="small" />
+          </Button>
+        </ButtonGroup>
       </div>
-      <FormGroup row>
+      <div>
+        <Badge color="secondary" variant="dot" invisible={invisible}>
+          <MailIcon />
+        </Badge>
         <FormControlLabel
           control={<Switch color="primary" checked={!invisible} onChange={handleBadgeVisibility} />}
           label="Show Badge"
         />
-      </FormGroup>
-      <Divider className={classes.divider} />
-      <div className={classes.row}>
-        <Badge color="secondary" badgeContent={0} className={classes.margin}>
-          <MailIcon />
-        </Badge>
-        <Badge color="secondary" badgeContent={0} showZero className={classes.margin}>
-          <MailIcon />
-        </Badge>
       </div>
     </div>
   );

--- a/docs/src/pages/components/badges/CustomizedBadges.js
+++ b/docs/src/pages/components/badges/CustomizedBadges.js
@@ -16,7 +16,7 @@ const StyledBadge = withStyles(theme => ({
 export default function CustomizedBadges() {
   return (
     <IconButton aria-label="cart">
-      <StyledBadge badgeContent={4} color="primary">
+      <StyledBadge badgeContent={4} color="secondary">
         <ShoppingCartIcon />
       </StyledBadge>
     </IconButton>

--- a/docs/src/pages/components/badges/CustomizedBadges.tsx
+++ b/docs/src/pages/components/badges/CustomizedBadges.tsx
@@ -18,7 +18,7 @@ const StyledBadge = withStyles((theme: Theme) =>
 export default function CustomizedBadges() {
   return (
     <IconButton aria-label="cart">
-      <StyledBadge badgeContent={4} color="primary">
+      <StyledBadge badgeContent={4} color="secondary">
         <ShoppingCartIcon />
       </StyledBadge>
     </IconButton>

--- a/docs/src/pages/components/badges/DotBadge.js
+++ b/docs/src/pages/components/badges/DotBadge.js
@@ -17,13 +17,10 @@ export default function DotBadge() {
 
   return (
     <div className={classes.root}>
-      <Badge color="primary" variant="dot">
-        <MailIcon />
-      </Badge>
       <Badge color="secondary" variant="dot">
         <MailIcon />
       </Badge>
-      <Badge color="error" variant="dot">
+      <Badge color="secondary" variant="dot">
         <Typography>Typography</Typography>
       </Badge>
     </div>

--- a/docs/src/pages/components/badges/DotBadge.tsx
+++ b/docs/src/pages/components/badges/DotBadge.tsx
@@ -19,13 +19,10 @@ export default function DotBadge() {
 
   return (
     <div className={classes.root}>
-      <Badge color="primary" variant="dot">
-        <MailIcon />
-      </Badge>
       <Badge color="secondary" variant="dot">
         <MailIcon />
       </Badge>
-      <Badge color="error" variant="dot">
+      <Badge color="secondary" variant="dot">
         <Typography>Typography</Typography>
       </Badge>
     </div>

--- a/docs/src/pages/components/badges/ShowZeroBadge.js
+++ b/docs/src/pages/components/badges/ShowZeroBadge.js
@@ -6,24 +6,22 @@ import MailIcon from '@material-ui/icons/Mail';
 const useStyles = makeStyles(theme => ({
   root: {
     '& > *': {
-      margin: theme.spacing(2),
+      margin: theme.spacing(1),
     },
   },
 }));
 
-const defaultProps = {
-  color: 'secondary',
-  children: <MailIcon />,
-};
-
-export default function BadgeMax() {
+export default function ShowZeroBadge() {
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
-      <Badge badgeContent={99} {...defaultProps} />
-      <Badge badgeContent={100} {...defaultProps} />
-      <Badge badgeContent={1000} max={999} {...defaultProps} />
+      <Badge color="secondary" badgeContent={0}>
+        <MailIcon />
+      </Badge>
+      <Badge color="secondary" badgeContent={0} showZero>
+        <MailIcon />
+      </Badge>
     </div>
   );
 }

--- a/docs/src/pages/components/badges/ShowZeroBadge.tsx
+++ b/docs/src/pages/components/badges/ShowZeroBadge.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { makeStyles, Theme, createStyles } from '@material-ui/core/styles';
+import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
 import MailIcon from '@material-ui/icons/Mail';
+import Switch from '@material-ui/core/Switch';
+import FormGroup from '@material-ui/core/FormGroup';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Divider from '@material-ui/core/Divider';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -13,18 +17,15 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-export default function SimpleBadge() {
+export default function ShowZeroBadge() {
   const classes = useStyles();
 
   return (
     <div className={classes.root}>
-      <Badge badgeContent={4} color="primary">
+      <Badge color="secondary" badgeContent={0}>
         <MailIcon />
       </Badge>
-      <Badge badgeContent={4} color="secondary">
-        <MailIcon />
-      </Badge>
-      <Badge badgeContent={4} color="error">
+      <Badge color="secondary" badgeContent={0} showZero>
         <MailIcon />
       </Badge>
     </div>

--- a/docs/src/pages/components/badges/ShowZeroBadge.tsx
+++ b/docs/src/pages/components/badges/ShowZeroBadge.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import { Theme, createStyles, makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
 import MailIcon from '@material-ui/icons/Mail';
-import Switch from '@material-ui/core/Switch';
-import FormGroup from '@material-ui/core/FormGroup';
-import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Divider from '@material-ui/core/Divider';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/docs/src/pages/components/badges/SimpleBadge.js
+++ b/docs/src/pages/components/badges/SimpleBadge.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
-import IconButton from '@material-ui/core/IconButton';
 import MailIcon from '@material-ui/icons/Mail';
 
 const useStyles = makeStyles(theme => ({
@@ -20,14 +19,12 @@ export default function SimpleBadge() {
       <Badge badgeContent={4} color="primary">
         <MailIcon />
       </Badge>
-      <Badge badgeContent={10} color="secondary">
+      <Badge badgeContent={4} color="secondary">
         <MailIcon />
       </Badge>
-      <IconButton aria-label="4 pending messages">
-        <Badge badgeContent={4} color="primary">
-          <MailIcon />
-        </Badge>
-      </IconButton>
+      <Badge badgeContent={4} color="error">
+        <MailIcon />
+      </Badge>
     </div>
   );
 }

--- a/docs/src/pages/components/badges/badges.md
+++ b/docs/src/pages/components/badges/badges.md
@@ -7,7 +7,7 @@ components: Badge
 
 <p class="description">Badge generates a small badge to the top-right of its child(ren).</p>
 
-## Simple badges
+## Basic badges
 
 Examples of badges containing text, using primary and secondary colors. The badge is applied to its children.
 

--- a/docs/src/pages/components/badges/badges.md
+++ b/docs/src/pages/components/badges/badges.md
@@ -7,7 +7,7 @@ components: Badge
 
 <p class="description">Badge generates a small badge to the top-right of its child(ren).</p>
 
-## Simple Badges
+## Simple badges
 
 Examples of badges containing text, using primary and secondary colors. The badge is applied to its children.
 
@@ -23,17 +23,19 @@ Here is an example of customizing the component. You can learn more about this i
 
 The visibility of badges can be controlled using the `invisible` property.
 
-The badge auto hides with badgeContent is zero. You can override this with the `showZero` property.
-
 {{"demo": "pages/components/badges/BadgeVisibility.js"}}
 
-## Maximum Value
+The badge auto hides with badgeContent is zero. You can override this with the `showZero` property.
+
+{{"demo": "pages/components/badges/ShowZeroBadge.js"}}
+
+## Maximum value
 
 You can use the `max` property to cap the value of the badge content.
 
 {{"demo": "pages/components/badges/BadgeMax.js"}}
 
-## Dot Badge
+## Dot badge
 
 The `dot` property changes a badge into a small dot. This can be used as a notification that something has changed without giving a count.
 

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
@@ -161,13 +161,13 @@ const Badge = React.forwardRef(function Badge(props, ref) {
     children,
     classes,
     className,
-    color = 'default',
+    color: colorProp = 'default',
     component: ComponentProp = 'span',
     invisible: invisibleProp,
     max = 99,
     overlap = 'rectangle',
     showZero = false,
-    variant = 'standard',
+    variant: variantProp = 'standard',
     ...other
   } = props;
 
@@ -175,16 +175,29 @@ const Badge = React.forwardRef(function Badge(props, ref) {
 
   if (
     invisibleProp == null &&
-    ((badgeContent === 0 && !showZero) || (badgeContent == null && variant !== 'dot'))
+    ((badgeContent === 0 && !showZero) || (badgeContent == null && variantProp !== 'dot'))
   ) {
     invisible = true;
   }
 
-  let displayValue = '';
+  let nextDisplayValue = '';
 
-  if (variant !== 'dot') {
-    displayValue = badgeContent > max ? `${max}+` : badgeContent;
+  if (variantProp !== 'dot') {
+    nextDisplayValue = badgeContent > max ? `${max}+` : badgeContent;
   }
+
+  // Retain the appearance of badge while invisible, to keep same appearance until disappearing.
+  // These should not be an attribute with transitions, or it will cause an undesirable animation at next appearing.
+  const nextNotTransitionedAttrs = {
+    displayValue: nextDisplayValue,
+    color: colorProp,
+    variant: variantProp,
+  };
+
+  const lastNotTransitionedPropsRef = useRef(nextNotTransitionedAttrs);
+  const { displayValue, color, variant } = invisible
+    ? lastNotTransitionedPropsRef.current
+    : nextNotTransitionedAttrs;
 
   return (
     <ComponentProp className={clsx(classes.root, className)} ref={ref} {...other}>

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
@@ -161,13 +161,13 @@ const Badge = React.forwardRef(function Badge(props, ref) {
     children,
     classes,
     className,
-    color: colorProp = 'default',
+    color = 'default',
     component: ComponentProp = 'span',
     invisible: invisibleProp,
     max = 99,
     overlap = 'rectangle',
     showZero = false,
-    variant: variantProp = 'standard',
+    variant = 'standard',
     ...other
   } = props;
 
@@ -175,29 +175,20 @@ const Badge = React.forwardRef(function Badge(props, ref) {
 
   if (
     invisibleProp == null &&
-    ((badgeContent === 0 && !showZero) || (badgeContent == null && variantProp !== 'dot'))
+    ((badgeContent === 0 && !showZero) || (badgeContent == null && variant !== 'dot'))
   ) {
     invisible = true;
   }
 
-  let nextDisplayValue = '';
+  let displayValue = '';
 
-  if (variantProp !== 'dot') {
-    nextDisplayValue = badgeContent > max ? `${max}+` : badgeContent;
+  if (variant !== 'dot') {
+    displayValue = badgeContent > max ? `${max}+` : badgeContent;
   }
 
-  // Retain the appearance of badge while invisible, to keep same appearance until disappearing.
-  // These should not be an attribute with transitions, or it will cause an undesirable animation at next appearing.
-  const nextNotTransitionedAttrs = {
-    displayValue: nextDisplayValue,
-    color: colorProp,
-    variant: variantProp,
-  };
-
-  const lastNotTransitionedPropsRef = useRef(nextNotTransitionedAttrs);
-  const { displayValue, color, variant } = invisible
-    ? lastNotTransitionedPropsRef.current
-    : nextNotTransitionedAttrs;
+  if (invisible && badgeContent === 0 && variant !== 'dot') {
+    displayValue = '1';
+  }
 
   return (
     <ComponentProp className={clsx(classes.root, className)} ref={ref} {...other}>

--- a/packages/material-ui/src/Badge/Badge.js
+++ b/packages/material-ui/src/Badge/Badge.js
@@ -186,10 +186,6 @@ const Badge = React.forwardRef(function Badge(props, ref) {
     displayValue = badgeContent > max ? `${max}+` : badgeContent;
   }
 
-  if (invisible && badgeContent === 0 && variant !== 'dot') {
-    displayValue = '1';
-  }
-
   return (
     <ComponentProp className={clsx(classes.root, className)} ref={ref} {...other}>
       {children}

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -3,7 +3,6 @@ import { assert } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Badge from './Badge';
-import { act } from 'react-dom/test-utils';
 
 function findBadge(wrapper) {
   return wrapper.find('span').at(1);
@@ -56,20 +55,6 @@ describe('<Badge />', () => {
   it('renders children', () => {
     const wrapper = mount(<Badge className="testClassName" {...defaultProps} />);
     assert.strictEqual(wrapper.contains(defaultProps.children), true);
-  });
-
-  it('retains text, color and variant while invisible for disappearing transition', () => {
-    const wrapper = mount(<Badge {...defaultProps} color="primary" variant="dot" />);
-    act(() => {
-      wrapper.setProps({ badgeContent: 0, color: 'secondary', variant: 'standard' });
-    });
-    assert.strictEqual(findBadge(wrapper).text(), '');
-    assert.strictEqual(findBadge(wrapper).hasClass(classes.colorPrimary), true);
-    assert.strictEqual(findBadge(wrapper).hasClass(classes.dot), true);
-    act(() => {
-      wrapper.setProps({ showZero: true });
-    });
-    assert.strictEqual(findBadge(wrapper).text(), '0');
   });
 
   describe('prop: color', () => {

--- a/packages/material-ui/src/Badge/Badge.test.js
+++ b/packages/material-ui/src/Badge/Badge.test.js
@@ -3,6 +3,7 @@ import { assert } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Badge from './Badge';
+import { act } from 'react-dom/test-utils';
 
 function findBadge(wrapper) {
   return wrapper.find('span').at(1);
@@ -55,6 +56,20 @@ describe('<Badge />', () => {
   it('renders children', () => {
     const wrapper = mount(<Badge className="testClassName" {...defaultProps} />);
     assert.strictEqual(wrapper.contains(defaultProps.children), true);
+  });
+
+  it('retains text, color and variant while invisible for disappearing transition', () => {
+    const wrapper = mount(<Badge {...defaultProps} color="primary" variant="dot" />);
+    act(() => {
+      wrapper.setProps({ badgeContent: 0, color: 'secondary', variant: 'standard' });
+    });
+    assert.strictEqual(findBadge(wrapper).text(), '');
+    assert.strictEqual(findBadge(wrapper).hasClass(classes.colorPrimary), true);
+    assert.strictEqual(findBadge(wrapper).hasClass(classes.dot), true);
+    act(() => {
+      wrapper.setProps({ showZero: true });
+    });
+    assert.strictEqual(findBadge(wrapper).text(), '0');
   });
 
   describe('prop: color', () => {


### PR DESCRIPTION
Currently, Badge will apply all appearance immediately even while disappearing transition.

It perhaps causes flicker in some cases like:

- Show red badge with counter if the user has an urgent notification.
- Otherwise show blue badge with counter.
- `<Badge color={hasUrgent ? 'error' : 'secondary'} badgeContent={count}>`
- Then it unwantedly shows disappearing blue 0 badge after the user opens notification.

Simulating such situation with demo:

docs/src/pages/components/badges/BadgeVisibility.js

```diff
-        <Badge color="secondary" badgeContent={4} invisible={invisible} className={classes.margin}>
+        <Badge color={invisible ? 'primary' : 'secondary'} badgeContent={invisible ? 0 : 4} className={classes.margin}>
```

![image](https://user-images.githubusercontent.com/400558/71449634-4b49eb00-2794-11ea-9f46-f28254a41f7a.png)
![image](https://user-images.githubusercontent.com/400558/71449642-6b79aa00-2794-11ea-96c4-d4b04223fb05.png)
![image](https://user-images.githubusercontent.com/400558/71449646-73394e80-2794-11ea-88d1-82fa30df6484.png)

This PR fixes that flicker: text, color and variant will be applied at next appearing.