### PR TITLE
[Badge] Fix doc about anchorOrigin

### DIFF
--- a/docs/src/pages/components/badges/badges.md
+++ b/docs/src/pages/components/badges/badges.md
@@ -47,6 +47,6 @@ You can use the `overlap` property to place the badge relative to the corner of 
 
 ## Badge alignment
 
-You can use the `horizontalAlignment` and `verticalAlignment` properties to move the badge to any corner of the wrapped element.
+You can use the `anchorOrigin` property to move the badge to any corner of the wrapped element.
 
 {{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}

--- a/docs/src/pages/components/badges/badges.md
+++ b/docs/src/pages/components/badges/badges.md
@@ -47,6 +47,6 @@ You can use the `overlap` property to place the badge relative to the corner of 
 
 ## Badge alignment
 
-You can use the `anchorOrigin` property to move the badge to any corner of the wrapped element.
+You can use the `anchorOrigin` prop to move the badge to any corner of the wrapped element.
 
 {{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}


### PR DESCRIPTION
It references a nonexistent prop name.