### PR TITLE
[DialogContent] Add missing `dividers` class types

### DIFF
--- a/packages/material-ui/src/DialogContent/DialogContent.d.ts
+++ b/packages/material-ui/src/DialogContent/DialogContent.d.ts
@@ -6,7 +6,7 @@ export interface DialogContentProps
   dividers?: boolean;
 }
 
-export type DialogContentClassKey = 'root';
+export type DialogContentClassKey = 'root' | 'dividers';
 
 declare const DialogContent: React.ComponentType<DialogContentProps>;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

According to the [docs](https://material-ui.com/api/dialog-content/#css). Dialog Content could receive a `dividers` attribute in the `classes` property. Current type definitions only allows for a `root` attribute, which causes the following error if a `dividers` attribute in the `classes` property is passed:

```
TS2769: No overload matches this call.
  Overload 1 of 2, '(props: DialogContentProps, context?: any): ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)> | Component<...> | null', gave the following error.
    Type '{ dividers: string; }' is not assignable to type 'Partial<Record<"root", string>>'.
      Object literal may only specify known properties, and 'dividers' does not exist in type 'Partial<Record<"root", string>>'.
  Overload 2 of 2, '(props: PropsWithChildren<DialogContentProps>, context?: any): ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<...>)> | null) | (new (props: any) => Component<...>)> | Component<...> | null', gave the following error.
    Type '{ dividers: string; }' is not assignable to type 'Partial<Record<"root", string>>'.
      Object literal may only specify known properties, and 'dividers' does not exist in type 'Partial<Record<"root", string>>'.
```

This PR adds the `dividers` attribute to typescript type definition of the `classes` property.


