### PR TITLE
[RadioGroup] Update useRadioGroup.d.ts

### DIFF
--- a/packages/material-ui/src/RadioGroup/useRadioGroup.d.ts
+++ b/packages/material-ui/src/RadioGroup/useRadioGroup.d.ts
@@ -1,9 +1,6 @@
 import { Context } from 'react';
 import { RadioGroupProps } from './RadioGroup';
 
-// shut off automatic exporting
-export {};
-
 export interface RadioGroupState extends Pick<RadioGroupProps, 'name' | 'onChange' | 'value'> {}
 
 export default function useRadioGroup(): RadioGroupState;


### PR DESCRIPTION
Remove unnecessary `export {}`.

This is a follow-up to PR #18920 (sorry, I forgot to remove this when I inlined `ContextFromPropsKey`).

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
