### PR TITLE
[theme] Support breakpoints.between(a, b) with number

### DIFF
--- a/docs/src/pages/customization/breakpoints/breakpoints.md
+++ b/docs/src/pages/customization/breakpoints/breakpoints.md
@@ -171,8 +171,8 @@ const styles = theme => ({
 
 #### Arguments
 
-1. `start` (*String*): A breakpoint key (`xs`, `sm`, etc.).
-2. `end` (*String*): A breakpoint key (`xs`, `sm`, etc.).
+1. `start` (*String*): A breakpoint key (`xs`, `sm`, etc.) or a screen width number in pixels.
+2. `end` (*String*): A breakpoint key (`xs`, `sm`, etc.) or a screen width number in pixels.
 
 #### Returns
 

--- a/packages/material-ui/src/styles/createBreakpoints.js
+++ b/packages/material-ui/src/styles/createBreakpoints.js
@@ -38,15 +38,20 @@ export default function createBreakpoints(breakpoints) {
   }
 
   function between(start, end) {
-    const endIndex = keys.indexOf(end) + 1;
+    const endIndex = keys.indexOf(end);
 
-    if (endIndex === keys.length) {
+    if (endIndex === keys.length - 1) {
       return up(start);
     }
 
     return (
-      `@media (min-width:${values[start]}${unit}) and ` +
-      `(max-width:${values[keys[endIndex]] - step / 100}${unit})`
+      `@media (min-width:${
+        typeof values[start] === 'number' ? values[start] : start
+      }${unit}) and ` +
+      `(max-width:${(endIndex !== -1 && typeof values[keys[endIndex + 1]] === 'number'
+        ? values[keys[endIndex + 1]]
+        : end) -
+        step / 100}${unit})`
     );
   }
 

--- a/packages/material-ui/src/styles/createBreakpoints.test.js
+++ b/packages/material-ui/src/styles/createBreakpoints.test.js
@@ -23,7 +23,7 @@ describe('createBreakpoints', () => {
       assert.strictEqual(breakpoints.down('md'), '@media (max-width:1279.95px)');
     });
 
-    it('should use the specified key if it is not a recognized breakpoint', () => {
+    it('should accept a number', () => {
       assert.strictEqual(breakpoints.down(600), '@media (max-width:599.95px)');
     });
 
@@ -37,6 +37,13 @@ describe('createBreakpoints', () => {
       assert.strictEqual(
         breakpoints.between('sm', 'md'),
         '@media (min-width:600px) and (max-width:1279.95px)',
+      );
+    });
+
+    it('should accept numbers', () => {
+      assert.strictEqual(
+        breakpoints.between(600, 800),
+        '@media (min-width:600px) and (max-width:799.95px)',
       );
     });
 


### PR DESCRIPTION
This pull request implements changes to the **src/styles/createBreakpoints.js** file.
It aims to implement support for arbitrary/custom breakpoint values, for consistency purposes, as discussed in the following issue:

Closes #18652 