### PR TITLE
[docs] update MenuAppBar menu open prop

### DIFF
--- a/docs/src/pages/components/app-bar/MenuAppBar.js
+++ b/docs/src/pages/components/app-bar/MenuAppBar.js
@@ -28,7 +28,6 @@ export default function MenuAppBar() {
   const classes = useStyles();
   const [auth, setAuth] = React.useState(true);
   const [anchorEl, setAnchorEl] = React.useState(null);
-  const open = Boolean(anchorEl);
 
   const handleChange = event => {
     setAuth(event.target.checked);
@@ -81,7 +80,7 @@ export default function MenuAppBar() {
                   vertical: 'top',
                   horizontal: 'right',
                 }}
-                open={open}
+                open={Boolean(anchorEl)}
                 onClose={handleClose}
               >
                 <MenuItem onClick={handleClose}>Profile</MenuItem>

--- a/docs/src/pages/components/app-bar/MenuAppBar.tsx
+++ b/docs/src/pages/components/app-bar/MenuAppBar.tsx
@@ -30,7 +30,6 @@ export default function MenuAppBar() {
   const classes = useStyles();
   const [auth, setAuth] = React.useState(true);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const open = Boolean(anchorEl);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setAuth(event.target.checked);
@@ -83,7 +82,7 @@ export default function MenuAppBar() {
                   vertical: 'top',
                   horizontal: 'right',
                 }}
-                open={open}
+                open={Boolean(anchorEl)}
                 onClose={handleClose}
               >
                 <MenuItem onClick={handleClose}>Profile</MenuItem>


### PR DESCRIPTION
minor refactor to make the `open` prop of `Menu` component tied with the `anchorEl` local state, which is consistently used in the `Menu` docs page

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
