### PR TITLE
[Autocomplete] Fix disabled + multiple combination support

### DIFF
--- a/docs/src/pages/components/autocomplete/FixedTags.js
+++ b/docs/src/pages/components/autocomplete/FixedTags.js
@@ -14,7 +14,7 @@ export default function FixedTags() {
       defaultValue={[top100Films[6], top100Films[13]]}
       renderTags={(value, getTagProps) =>
         value.map((option, index) => (
-          <Chip disabled={index === 0} label={option.title} {...getTagProps({ index })} />
+          <Chip label={option.title} {...getTagProps({ index })} disabled={index === 0} />
         ))
       }
       style={{ width: 500 }}

--- a/docs/src/pages/components/autocomplete/FixedTags.tsx
+++ b/docs/src/pages/components/autocomplete/FixedTags.tsx
@@ -14,7 +14,7 @@ export default function FixedTags() {
       defaultValue={[top100Films[6], top100Films[13]]}
       renderTags={(value: FilmOptionType[], getTagProps) =>
         value.map((option: FilmOptionType, index: number) => (
-          <Chip disabled={index === 0} label={option.title} {...getTagProps({ index })} />
+          <Chip label={option.title} {...getTagProps({ index })} disabled={index === 0} />
         ))
       }
       style={{ width: 500 }}

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -301,6 +301,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
       className: clsx(classes.tag, {
         [classes.tagSizeSmall]: size === 'small',
       }),
+      disabled,
       ...getTagProps(params),
     });
 


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

This PR forwards the disabled property down to the chip components, which results in the chips being disabled when the Autocomplete component is disabled.  

Example: https://codesandbox.io/s/material-demo-yqkrm

Resolves https://github.com/mui-org/material-ui/issues/18915