### PR TITLE
[styles] Fix jss StyleSheet attach() call

### DIFF
--- a/packages/material-ui-benchmark/src/styles.js
+++ b/packages/material-ui-benchmark/src/styles.js
@@ -128,7 +128,8 @@ suite
       const dynamicSheet = jss.createStyleSheet(dynamicStyles, {
         link: true,
       });
-      dynamicSheet.update({}).attach();
+      dynamicSheet.update({});
+      dynamicSheet.attach();
       sheetsRegistry.add(dynamicSheet);
     }
 

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.js
@@ -109,7 +109,8 @@ function attach({ state, theme, stylesOptions, stylesCreator, name }, props) {
       ...options,
     });
 
-    dynamicSheet.update(props).attach();
+    dynamicSheet.update(props);
+    dynamicSheet.attach();
 
     state.dynamicSheet = dynamicSheet;
     state.classes = mergeClasses({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fix #19005 

In the latest jss (10.0.1), a breaking change was introduced, making the `StyleSheet.update()` to return undefined instead of `this` - https://github.com/cssinjs/jss/pull/1242/files#diff-29aac1ba5d08e188c14800bc889c5474L186. 
If was described here as well - https://github.com/cssinjs/jss/issues/1249#issuecomment-569451973

I Simply separated the calls


