### PR TITLE
[Collapse] Add `hidden` class key to Collapse typings

### DIFF
--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -11,7 +11,7 @@ export interface CollapseProps extends StandardProps<TransitionProps, CollapseCl
   timeout?: TransitionProps['timeout'] | 'auto';
 }
 
-export type CollapseClassKey = 'container' | 'entered' | 'wrapper' | 'wrapperInner';
+export type CollapseClassKey = 'container' | 'entered' | 'hidden' | 'wrapper' | 'wrapperInner';
 
 declare const Collapse: React.ComponentType<CollapseProps>;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

While attempting to override classes for the `Collapse` component, TypeScript did not accept the `hidden` field, although it [is documented](https://github.com/mui-org/material-ui/blob/0c7ca746674cfb47a46cad8ebea21155702fd38c/docs/pages/api/collapse.md). This change adds it.