### PR TITLE
[core] Warn when defaultValue changes

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -293,7 +293,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
     setAnchorEl,
     inputValue,
     groupedOptions,
-  } = useAutocomplete(props);
+  } = useAutocomplete({ ...props, componentName: 'Autocomplete' });
 
   let startAdornment;
 

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -52,6 +52,7 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
     default: defaultExpanded,
     name: 'TreeView',
   });
+
   const expanded = expandedState || defaultExpandedDefault;
 
   const prevChildIds = React.useRef([]);

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import TreeViewContext from './TreeViewContext';
 import { withStyles } from '@material-ui/core/styles';
+import { useControlled } from '@material-ui/core/utils';
 
 export const styles = {
   /* Styles applied to the root element. */
@@ -46,28 +47,12 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
   const nodeMap = React.useRef({});
   const firstCharMap = React.useRef({});
 
-  const { current: isControlled } = React.useRef(expandedProp !== undefined);
-  const [expandedState, setExpandedState] = React.useState(defaultExpanded);
-  const expanded = (isControlled ? expandedProp : expandedState) || defaultExpandedDefault;
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (isControlled !== (expandedProp != null)) {
-        console.error(
-          [
-            `Material-UI: A component is changing ${
-              isControlled ? 'a ' : 'an un'
-            }controlled TreeView to be ${isControlled ? 'un' : ''}controlled.`,
-            'Elements should not switch from uncontrolled to controlled (or vice versa).',
-            'Decide between using a controlled or uncontrolled TreeView ' +
-              'element for the lifetime of the component.',
-            'More info: https://fb.me/react-controlled-components',
-          ].join('\n'),
-        );
-      }
-    }, [expandedProp, isControlled]);
-  }
+  const { value: expandedState, setValue: setExpandedState, isControlled } = useControlled({
+    controlled: expandedProp,
+    default: defaultExpanded,
+    name: 'TreeView',
+  });
+  const expanded = expandedState || defaultExpandedDefault;
 
   const prevChildIds = React.useRef([]);
   React.useEffect(() => {

--- a/packages/material-ui-lab/src/TreeView/TreeView.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.js
@@ -47,7 +47,7 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
   const nodeMap = React.useRef({});
   const firstCharMap = React.useRef({});
 
-  const { value: expandedState, setValue: setExpandedState, isControlled } = useControlled({
+  const [expandedState, setExpandedState] = useControlled({
     controlled: expandedProp,
     default: defaultExpanded,
     name: 'TreeView',
@@ -184,9 +184,7 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
       onNodeToggle(event, newExpanded);
     }
 
-    if (!isControlled) {
-      setExpandedState(newExpanded);
-    }
+    setExpandedState(newExpanded);
   };
 
   const expandAllSiblings = (event, id) => {
@@ -202,9 +200,7 @@ const TreeView = React.forwardRef(function TreeView(props, ref) {
     }
     const newExpanded = [...expanded, ...diff];
 
-    if (!isControlled) {
-      setExpandedState(newExpanded);
-    }
+    setExpandedState(newExpanded);
 
     if (onNodeToggle) {
       onNodeToggle(event, newExpanded);

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -49,6 +49,10 @@ export interface UseAutocompleteProps {
    */
   clearOnEscape?: boolean;
   /**
+   * The component name that is using this hook. Used for warnings.
+   */
+  componentName: string;
+  /**
    * If `true`, the popup will ignore the blur event if the input if filled.
    * You can inspect the popup markup with your browser tools.
    * Consider this option when you need to customize the component.

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -51,7 +51,7 @@ export interface UseAutocompleteProps {
   /**
    * The component name that is using this hook. Used for warnings.
    */
-  componentName: string;
+  componentName?: string;
   /**
    * If `true`, the popup will ignore the blur event if the input if filled.
    * You can inspect the popup markup with your browser tools.

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-constant-condition */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { setRef, useEventCallback } from '@material-ui/core/utils';
+import { setRef, useEventCallback, useControlled } from '@material-ui/core/utils';
 
 // https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript
 // Give up on IE 11 support for this feature
@@ -108,6 +108,7 @@ export default function useAutocomplete(props) {
     open: openProp,
     options = [],
     value: valueProp,
+    componentName = 'useAutocomplete',
   } = props;
 
   const [defaultId, setDefaultId] = React.useState();
@@ -186,30 +187,11 @@ export default function useAutocomplete(props) {
     }
   }
 
-  const { current: isControlled } = React.useRef(valueProp !== undefined);
-  const [valueState, setValue] = React.useState(() => {
-    return !isControlled ? defaultValue || (multiple ? [] : null) : null;
+  const { value, setValue: setValueState, isControlled } = useControlled({
+    controlled: valueProp,
+    default: defaultValue || (multiple ? [] : null),
+    name: componentName,
   });
-  const value = isControlled ? valueProp : valueState;
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (isControlled !== (valueProp !== undefined)) {
-        console.error(
-          [
-            `Material-UI: A component is changing ${
-              isControlled ? 'a ' : 'an un'
-            }controlled useAutocomplete to be ${isControlled ? 'un' : ''}controlled.`,
-            'Elements should not switch from uncontrolled to controlled (or vice versa).',
-            'Decide between using a controlled or uncontrolled useAutocomplete ' +
-              'element for the lifetime of the component.',
-            'More info: https://fb.me/react-controlled-components',
-          ].join('\n'),
-        );
-      }
-    }, [valueProp, isControlled]);
-  }
 
   const { current: isInputValueControlled } = React.useRef(inputValueProp != null);
   const [inputValueState, setInputValue] = React.useState('');
@@ -445,7 +427,7 @@ export default function useAutocomplete(props) {
       onChange(event, newValue);
     }
     if (!isControlled) {
-      setValue(newValue);
+      setValueState(newValue);
     }
   };
 

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -187,7 +187,7 @@ export default function useAutocomplete(props) {
     }
   }
 
-  const { value, setValue: setValueState, isControlled } = useControlled({
+  const { value, setValue, isControlled } = useControlled({
     controlled: valueProp,
     default: defaultValue || (multiple ? [] : null),
     name: componentName,
@@ -427,7 +427,7 @@ export default function useAutocomplete(props) {
       onChange(event, newValue);
     }
     if (!isControlled) {
-      setValueState(newValue);
+      setValue(newValue);
     }
   };
 

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -901,6 +901,10 @@ useAutocomplete.propTypes = {
    */
   clearOnEscape: PropTypes.bool,
   /**
+   * The component name that is using this hook. Used for warnings.
+   */
+  componentName: PropTypes.string,
+  /**
    * If `true`, the popup will ignore the blur event if the input if filled.
    * You can inspect the popup markup with your browser tools.
    * Consider this option when you need to customize the component.

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -187,7 +187,7 @@ export default function useAutocomplete(props) {
     }
   }
 
-  const { value, setValue, isControlled } = useControlled({
+  const [value, setValue] = useControlled({
     controlled: valueProp,
     default: defaultValue || (multiple ? [] : null),
     name: componentName,
@@ -426,9 +426,8 @@ export default function useAutocomplete(props) {
     if (onChange) {
       onChange(event, newValue);
     }
-    if (!isControlled) {
-      setValue(newValue);
-    }
+
+    setValue(newValue);
   };
 
   const selectNewValue = (event, newValue) => {

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -95,7 +95,7 @@ const ExpansionPanel = React.forwardRef(function ExpansionPanel(props, ref) {
     ...other
   } = props;
 
-  const { value: expanded, setValue: setExpandedState, isControlled } = useControlled({
+  const [expanded, setExpandedState] = useControlled({
     controlled: expandedProp,
     default: defaultExpanded,
     name: 'ExpansionPanel',
@@ -103,15 +103,13 @@ const ExpansionPanel = React.forwardRef(function ExpansionPanel(props, ref) {
 
   const handleChange = React.useCallback(
     event => {
-      if (!isControlled) {
-        setExpandedState(!expanded);
-      }
+      setExpandedState(!expanded);
 
       if (onChange) {
         onChange(event, !expanded);
       }
     },
-    [expanded, isControlled, onChange, setExpandedState],
+    [expanded, onChange, setExpandedState],
   );
 
   const [summary, ...children] = React.Children.toArray(childrenProp);

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js
@@ -7,6 +7,7 @@ import Collapse from '../Collapse';
 import Paper from '../Paper';
 import withStyles from '../styles/withStyles';
 import ExpansionPanelContext from './ExpansionPanelContext';
+import useControlled from '../utils/useControlled';
 
 export const styles = theme => {
   const transition = {
@@ -94,28 +95,11 @@ const ExpansionPanel = React.forwardRef(function ExpansionPanel(props, ref) {
     ...other
   } = props;
 
-  const { current: isControlled } = React.useRef(expandedProp != null);
-  const [expandedState, setExpandedState] = React.useState(defaultExpanded);
-  const expanded = isControlled ? expandedProp : expandedState;
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (isControlled !== (expandedProp != null)) {
-        console.error(
-          [
-            `Material-UI: A component is changing ${
-              isControlled ? 'a ' : 'an un'
-            }controlled ExpansionPanel to be ${isControlled ? 'un' : ''}controlled.`,
-            'Elements should not switch from uncontrolled to controlled (or vice versa).',
-            'Decide between using a controlled or uncontrolled ExpansionPanel ' +
-              'element for the lifetime of the component.',
-            'More info: https://fb.me/react-controlled-components',
-          ].join('\n'),
-        );
-      }
-    }, [expandedProp, isControlled]);
-  }
+  const { value: expanded, setValue: setExpandedState, isControlled } = useControlled({
+    controlled: expandedProp,
+    default: defaultExpanded,
+    name: 'ExpansionPanel',
+  });
 
   const handleChange = React.useCallback(
     event => {
@@ -127,7 +111,7 @@ const ExpansionPanel = React.forwardRef(function ExpansionPanel(props, ref) {
         onChange(event, !expanded);
       }
     },
-    [expanded, isControlled, onChange],
+    [expanded, isControlled, onChange, setExpandedState],
   );
 
   const [summary, ...children] = React.Children.toArray(childrenProp);

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -9,7 +9,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
   const { actions, children, name, value: valueProp, onChange, ...other } = props;
   const rootRef = React.useRef(null);
 
-  const { value, setValue, isControlled } = useControlled({
+  const [value, setValue] = useControlled({
     controlled: valueProp,
     default: props.defaultValue,
     name: 'RadioGroup',
@@ -36,9 +36,7 @@ const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
   const handleRef = useForkRef(ref, rootRef);
 
   const handleChange = event => {
-    if (!isControlled) {
-      setValue(event.target.value);
-    }
+    setValue(event.target.value);
 
     if (onChange) {
       onChange(event, event.target.value);

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -2,34 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import FormGroup from '../FormGroup';
 import useForkRef from '../utils/useForkRef';
+import useControlled from '../utils/useControlled';
 import RadioGroupContext from './RadioGroupContext';
 
 const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
   const { actions, children, name, value: valueProp, onChange, ...other } = props;
   const rootRef = React.useRef(null);
 
-  const { current: isControlled } = React.useRef(valueProp != null);
-  const [valueState, setValue] = React.useState(props.defaultValue);
-  const value = isControlled ? valueProp : valueState;
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (isControlled !== (valueProp != null)) {
-        console.error(
-          [
-            `Material-UI: A component is changing ${
-              isControlled ? 'a ' : 'an un'
-            }controlled RadioGroup to be ${isControlled ? 'un' : ''}controlled.`,
-            'Elements should not switch from uncontrolled to controlled (or vice versa).',
-            'Decide between using a controlled or uncontrolled RadioGroup ' +
-              'element for the lifetime of the component.',
-            'More info: https://fb.me/react-controlled-components',
-          ].join('\n'),
-        );
-      }
-    }, [valueProp, isControlled]);
-  }
+  const { value, setValue, isControlled } = useControlled({
+    controlled: valueProp,
+    default: props.defaultValue,
+    name: 'RadioGroup',
+  });
 
   React.useImperativeHandle(
     actions,

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -7,6 +7,7 @@ import { refType } from '@material-ui/utils';
 import Menu from '../Menu/Menu';
 import { isFilled } from '../InputBase/utils';
 import useForkRef from '../utils/useForkRef';
+import useControlled from '../utils/useControlled';
 
 function areEqualValues(a, b) {
   if (typeof b === 'object' && b !== null) {
@@ -57,28 +58,11 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     ...other
   } = props;
 
-  const { current: isControlled } = React.useRef(valueProp != null);
-  const [valueState, setValueState] = React.useState(defaultValue);
-  const value = isControlled ? valueProp : valueState;
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (isControlled !== (valueProp != null)) {
-        console.error(
-          [
-            `Material-UI: A component is changing ${
-              isControlled ? 'a ' : 'an un'
-            }controlled Select to be ${isControlled ? 'un' : ''}controlled.`,
-            'Elements should not switch from uncontrolled to controlled (or vice versa).',
-            'Decide between using a controlled or uncontrolled Select ' +
-              'element for the lifetime of the component.',
-            'More info: https://fb.me/react-controlled-components',
-          ].join('\n'),
-        );
-      }
-    }, [valueProp, isControlled]);
-  }
+  const { value, setValue, isControlled } = useControlled({
+    controlled: valueProp,
+    default: defaultValue,
+    name: 'SelectInput',
+  });
 
   const inputRef = React.useRef(null);
   const [displayNode, setDisplayNode] = React.useState(null);
@@ -152,7 +136,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     }
 
     if (!isControlled) {
-      setValueState(newValue);
+      setValue(newValue);
     }
 
     if (onChange) {

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -58,7 +58,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
     ...other
   } = props;
 
-  const { value, setValue, isControlled } = useControlled({
+  const [value, setValue] = useControlled({
     controlled: valueProp,
     default: defaultValue,
     name: 'SelectInput',
@@ -135,9 +135,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       newValue = child.props.value;
     }
 
-    if (!isControlled) {
-      setValue(newValue);
-    }
+    setValue(newValue);
 
     if (onChange) {
       event.persist();

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -10,6 +10,7 @@ import ownerDocument from '../utils/ownerDocument';
 import useEventCallback from '../utils/useEventCallback';
 import useForkRef from '../utils/useForkRef';
 import capitalize from '../utils/capitalize';
+import useControlled from '../utils/useControlled';
 import ValueLabel from './ValueLabel';
 
 function asc(a, b) {
@@ -371,28 +372,11 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const [active, setActive] = React.useState(-1);
   const [open, setOpen] = React.useState(-1);
 
-  const { current: isControlled } = React.useRef(valueProp != null);
-  const [valueState, setValueState] = React.useState(defaultValue);
-  const valueDerived = isControlled ? valueProp : valueState;
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (isControlled !== (valueProp != null)) {
-        console.error(
-          [
-            `Material-UI: A component is changing ${
-              isControlled ? 'a ' : 'an un'
-            }controlled Slider to be ${isControlled ? 'un' : ''}controlled.`,
-            'Elements should not switch from uncontrolled to controlled (or vice versa).',
-            'Decide between using a controlled or uncontrolled Slider ' +
-              'element for the lifetime of the component.',
-            'More info: https://fb.me/react-controlled-components',
-          ].join('\n'),
-        );
-      }
-    }, [valueProp, isControlled]);
-  }
+  const { value: valueDerived, setValue: setValueState, isControlled } = useControlled({
+    controlled: valueProp,
+    default: defaultValue,
+    name: 'Slider',
+  });
 
   const range = Array.isArray(valueDerived);
   const instanceRef = React.useRef();
@@ -662,25 +646,6 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       doc.removeEventListener('touchend', handleTouchEnd);
     };
   }, [handleTouchEnd, handleTouchMove, handleTouchStart]);
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (isControlled !== (valueProp != null)) {
-        console.error(
-          [
-            `Material-UI: A component is changing ${
-              isControlled ? 'a ' : 'an un'
-            }controlled Slider to be ${isControlled ? 'un' : ''}controlled.`,
-            'Elements should not switch from uncontrolled to controlled (or vice versa).',
-            'Decide between using a controlled or uncontrolled Slider ' +
-              'element for the lifetime of the component.',
-            'More info: https://fb.me/react-controlled-components',
-          ].join('\n'),
-        );
-      }
-    }, [valueProp, isControlled]);
-  }
 
   const handleMouseDown = useEventCallback(event => {
     if (onMouseDown) {

--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -372,7 +372,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
   const [active, setActive] = React.useState(-1);
   const [open, setOpen] = React.useState(-1);
 
-  const { value: valueDerived, setValue: setValueState, isControlled } = useControlled({
+  const [valueDerived, setValueState] = useControlled({
     controlled: valueProp,
     default: defaultValue,
     name: 'Slider',
@@ -487,10 +487,7 @@ const Slider = React.forwardRef(function Slider(props, ref) {
       focusThumb({ sliderRef, activeIndex: newValue.indexOf(previousValue) });
     }
 
-    if (!isControlled) {
-      setValueState(newValue);
-    }
-
+    setValueState(newValue);
     setFocusVisible(index);
 
     if (onChange) {
@@ -574,9 +571,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
     });
 
     focusThumb({ sliderRef, activeIndex, setActive });
-    if (!isControlled) {
-      setValueState(newValue);
-    }
+    setValueState(newValue);
+
     if (onChange) {
       onChange(event, newValue);
     }
@@ -621,9 +617,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
     const { newValue, activeIndex } = getFingerNewValue({ finger, values, source: valueDerived });
     focusThumb({ sliderRef, activeIndex, setActive });
 
-    if (!isControlled) {
-      setValueState(newValue);
-    }
+    setValueState(newValue);
+
     if (onChange) {
       onChange(event, newValue);
     }
@@ -657,9 +652,8 @@ const Slider = React.forwardRef(function Slider(props, ref) {
     const { newValue, activeIndex } = getFingerNewValue({ finger, values, source: valueDerived });
     focusThumb({ sliderRef, activeIndex, setActive });
 
-    if (!isControlled) {
-      setValueState(newValue);
-    }
+    setValueState(newValue);
+
     if (onChange) {
       onChange(event, newValue);
     }

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -210,14 +210,17 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   const leaveTimer = React.useRef();
   const touchTimer = React.useRef();
 
-  const { value, setValue: setOpenState, isControlled } = useControlled({
+  const [openState, setOpenState] = useControlled({
     controlled: openProp,
     default: false,
     name: 'Tooltip',
   });
-  let open = value;
+  let open = openState;
 
   if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const { current: isControlled } = React.useRef(openProp !== undefined);
+
     // eslint-disable-next-line react-hooks/rules-of-hooks
     React.useEffect(() => {
       if (
@@ -237,7 +240,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
           ].join('\n'),
         );
       }
-    }, [isControlled, title, childNode]);
+    }, [title, childNode, isControlled]);
   }
 
   const [defaultId, setDefaultId] = React.useState();
@@ -269,9 +272,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     // The mouseover event will trigger for every nested element in the tooltip.
     // We can skip rerendering when the tooltip is already open.
     // We are using the mouseover event instead of the mouseenter event to fix a hide/show issue.
-    if (!isControlled) {
-      setOpenState(true);
-    }
+    setOpenState(true);
 
     if (onOpen) {
       onOpen(event);
@@ -347,9 +348,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }, 500);
     // Use 500 ms per https://github.com/reach/reach-ui/blob/3b5319027d763a3082880be887d7a29aee7d3afc/packages/tooltip/src/index.js#L214
 
-    if (!isControlled) {
-      setOpenState(false);
-    }
+    setOpenState(false);
 
     if (onClose) {
       onClose(event);

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -11,6 +11,7 @@ import Popper from '../Popper';
 import useForkRef from '../utils/useForkRef';
 import setRef from '../utils/setRef';
 import { useIsFocusVisible } from '../utils/focusVisible';
+import useControlled from '../utils/useControlled';
 import useTheme from '../styles/useTheme';
 
 function round(value) {
@@ -209,28 +210,12 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
   const leaveTimer = React.useRef();
   const touchTimer = React.useRef();
 
-  const { current: isControlled } = React.useRef(openProp != null);
-  const [openState, setOpenState] = React.useState(false);
-  let open = isControlled ? openProp : openState;
-
-  if (process.env.NODE_ENV !== 'production') {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    React.useEffect(() => {
-      if (isControlled !== (openProp != null)) {
-        console.error(
-          [
-            `Material-UI: A component is changing ${
-              isControlled ? 'a ' : 'an un'
-            }controlled Tooltip to be ${isControlled ? 'un' : ''}controlled.`,
-            'Elements should not switch from uncontrolled to controlled (or vice versa).',
-            'Decide between using a controlled or uncontrolled Tooltip ' +
-              'element for the lifetime of the component.',
-            'More info: https://fb.me/react-controlled-components',
-          ].join('\n'),
-        );
-      }
-    }, [openProp, isControlled]);
-  }
+  const { value, setValue: setOpenState, isControlled } = useControlled({
+    controlled: openProp,
+    default: false,
+    name: 'Tooltip',
+  });
+  let open = value;
 
   if (process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line react-hooks/rules-of-hooks

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { refType } from '@material-ui/utils';
+import { useControlled } from '@material-ui/core/utils';
 import useFormControl from '../FormControl/useFormControl';
 import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';
@@ -53,9 +54,11 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
     value,
     ...other
   } = props;
-  const { current: isControlled } = React.useRef(checkedProp != null);
-  const [checkedState, setCheckedState] = React.useState(Boolean(defaultChecked));
-  const checked = isControlled ? checkedProp : checkedState;
+  const [checked, setCheckedState] = useControlled({
+    controlled: checkedProp,
+    default: Boolean(defaultChecked),
+    name: 'SwitchBase',
+  });
 
   const muiFormControl = useFormControl();
 
@@ -82,9 +85,7 @@ const SwitchBase = React.forwardRef(function SwitchBase(props, ref) {
   const handleInputChange = event => {
     const newChecked = event.target.checked;
 
-    if (!isControlled) {
-      setCheckedState(newChecked);
-    }
+    setCheckedState(newChecked);
 
     if (onChange) {
       onChange(event, newChecked);

--- a/packages/material-ui/src/internal/SwitchBase.js
+++ b/packages/material-ui/src/internal/SwitchBase.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { refType } from '@material-ui/utils';
-import { useControlled } from '@material-ui/core/utils';
+import useControlled from '../utils/useControlled';
 import useFormControl from '../FormControl/useFormControl';
 import withStyles from '../styles/withStyles';
 import IconButton from '../IconButton';

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -369,9 +369,12 @@ describe('<SwitchBase />', () => {
         expect(consoleErrorMock.callCount()).to.equal(0);
 
         wrapper.setProps({ checked: true });
-        expect(consoleErrorMock.callCount()).to.equal(1);
+        expect(consoleErrorMock.callCount()).to.equal(2);
         expect(consoleErrorMock.args()[0][0]).to.include(
           'A component is changing an uncontrolled input of type %s to be controlled.',
+        );
+        expect(consoleErrorMock.args()[1][0]).to.include(
+          'A component is changing an uncontrolled SwitchBase to be controlled.',
         );
       }),
     );
@@ -385,9 +388,12 @@ describe('<SwitchBase />', () => {
         expect(consoleErrorMock.callCount()).to.equal(0);
 
         setProps({ checked: undefined });
-        expect(consoleErrorMock.callCount()).to.equal(1);
+        expect(consoleErrorMock.callCount()).to.equal(2);
         expect(consoleErrorMock.args()[0][0]).to.include(
           'A component is changing a controlled input of type %s to be uncontrolled.',
+        );
+        expect(consoleErrorMock.args()[1][0]).to.include(
+          'A component is changing a controlled SwitchBase to be uncontrolled.',
         );
       }),
     );

--- a/packages/material-ui/src/utils/index.js
+++ b/packages/material-ui/src/utils/index.js
@@ -8,4 +8,5 @@ export { default as setRef } from './setRef';
 export { default as unsupportedProp } from './unsupportedProp';
 export { default as useEventCallback } from './useEventCallback';
 export { default as useForkRef } from './useForkRef';
+export { default as useControlled } from './useControlled';
 export { useIsFocusVisible } from './focusVisible';

--- a/packages/material-ui/src/utils/useControlled.d.ts
+++ b/packages/material-ui/src/utils/useControlled.d.ts
@@ -1,0 +1,22 @@
+export interface UseControlledProps {
+  /**
+   * This prop contains the component value when it's controlled.
+   */
+  controlled: any;
+  /**
+   * The default value.
+   */
+  default: any;
+  /**
+   * The component name displayed in warnings.
+   */
+  name: string;
+}
+
+export default function useControlled(
+  props: UseControlledProps,
+): {
+  value: any;
+  setValue: () => void;
+  isControlled: boolean;
+};

--- a/packages/material-ui/src/utils/useControlled.d.ts
+++ b/packages/material-ui/src/utils/useControlled.d.ts
@@ -13,10 +13,4 @@ export interface UseControlledProps {
   name: string;
 }
 
-export default function useControlled(
-  props: UseControlledProps,
-): {
-  value: any;
-  setValue: () => void;
-  isControlled: boolean;
-};
+export default function useControlled(props: UseControlledProps): [any, () => void];

--- a/packages/material-ui/src/utils/useControlled.js
+++ b/packages/material-ui/src/utils/useControlled.js
@@ -1,12 +1,9 @@
 /* eslint-disable react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
 import React from 'react';
 
-const useControlled = ({ controlled, default: defaultProp, name }) => {
+export default function useControlled({ controlled, default: defaultProp, name }) {
   const { current: isControlled } = React.useRef(controlled !== undefined);
-  const { current: defaultValue } = React.useRef(defaultProp);
-  const [valueState, setValue] = React.useState(() => {
-    return !isControlled && defaultValue !== undefined ? defaultValue : null;
-  });
+  const [valueState, setValue] = React.useState(defaultProp);
   const value = isControlled ? controlled : valueState;
 
   if (process.env.NODE_ENV !== 'production') {
@@ -24,7 +21,9 @@ const useControlled = ({ controlled, default: defaultProp, name }) => {
           ].join('\n'),
         );
       }
-    }, [controlled, isControlled, name]);
+    }, [controlled]);
+
+    const { current: defaultValue } = React.useRef(defaultProp);
 
     React.useEffect(() => {
       if (defaultValue !== defaultProp) {
@@ -39,6 +38,4 @@ const useControlled = ({ controlled, default: defaultProp, name }) => {
   }
 
   return { value, setValue, isControlled };
-};
-
-export default useControlled;
+}

--- a/packages/material-ui/src/utils/useControlled.js
+++ b/packages/material-ui/src/utils/useControlled.js
@@ -5,7 +5,7 @@ const useControlled = ({ controlled, default: defaultProp, name }) => {
   const { current: isControlled } = React.useRef(controlled !== undefined);
   const { current: defaultValue } = React.useRef(defaultProp);
   const [valueState, setValue] = React.useState(() => {
-    return !isControlled ? defaultValue || null : null;
+    return !isControlled && defaultValue !== undefined ? defaultValue : null;
   });
   const value = isControlled ? controlled : valueState;
 

--- a/packages/material-ui/src/utils/useControlled.js
+++ b/packages/material-ui/src/utils/useControlled.js
@@ -37,5 +37,11 @@ export default function useControlled({ controlled, default: defaultProp, name }
     }, [JSON.stringify(defaultProp)]);
   }
 
-  return { value, setValue, isControlled };
+  const setValueIfUncontrolled = React.useCallback(newValue => {
+    if (!isControlled) {
+      setValue(newValue);
+    }
+  }, []);
+
+  return [value, setValueIfUncontrolled];
 }

--- a/packages/material-ui/src/utils/useControlled.js
+++ b/packages/material-ui/src/utils/useControlled.js
@@ -1,0 +1,44 @@
+/* eslint-disable react-hooks/rules-of-hooks, react-hooks/exhaustive-deps */
+import React from 'react';
+
+const useControlled = ({ controlled, default: defaultProp, name }) => {
+  const { current: isControlled } = React.useRef(controlled !== undefined);
+  const { current: defaultValue } = React.useRef(defaultProp);
+  const [valueState, setValue] = React.useState(() => {
+    return !isControlled ? defaultValue || null : null;
+  });
+  const value = isControlled ? controlled : valueState;
+
+  if (process.env.NODE_ENV !== 'production') {
+    React.useEffect(() => {
+      if (isControlled !== (controlled !== undefined)) {
+        console.error(
+          [
+            `Material-UI: A component is changing ${
+              isControlled ? 'a ' : 'an un'
+            }controlled ${name} to be ${isControlled ? 'un' : ''}controlled.`,
+            'Elements should not switch from uncontrolled to controlled (or vice versa).',
+            `Decide between using a controlled or uncontrolled ${name} ` +
+              'element for the lifetime of the component.',
+            'More info: https://fb.me/react-controlled-components',
+          ].join('\n'),
+        );
+      }
+    }, [controlled, isControlled, name]);
+
+    React.useEffect(() => {
+      if (defaultValue !== defaultProp) {
+        console.error(
+          [
+            `Material-UI: A component is changing the default value of an uncontrolled ${name} after being initialized. ` +
+              `To suppress this warning opt to use a controlled ${name}.`,
+          ].join('\n'),
+        );
+      }
+    }, [JSON.stringify(defaultProp)]);
+  }
+
+  return { value, setValue, isControlled };
+};
+
+export default useControlled;

--- a/packages/material-ui/src/utils/useControlled.test.js
+++ b/packages/material-ui/src/utils/useControlled.test.js
@@ -64,6 +64,16 @@ describe('useControlled', () => {
     );
   });
 
+  it('warns when switching from controlled to uncontrolled', () => {
+    const { setProps } = render(<TestComponent value="foobar">{() => null}</TestComponent>);
+    expect(consoleErrorMock.callCount()).to.equal(0);
+    setProps({ value: undefined });
+    expect(consoleErrorMock.callCount()).to.equal(1);
+    expect(consoleErrorMock.args()[0][0]).to.contains(
+      'A component is changing a controlled TestComponent to be uncontrolled.',
+    );
+  });
+
   it('warns when changing the defaultValue prop after initial rendering', () => {
     const { setProps } = render(<TestComponent>{() => null}</TestComponent>);
     expect(consoleErrorMock.callCount()).to.equal(0);

--- a/packages/material-ui/src/utils/useControlled.test.js
+++ b/packages/material-ui/src/utils/useControlled.test.js
@@ -5,7 +5,7 @@ import consoleErrorMock from 'test/utils/consoleErrorMock';
 import useControlled from './useControlled';
 
 const TestComponent = ({ value: valueProp, defaultValue, children }) => {
-  const { value, setValue } = useControlled({
+  const [value, setValue] = useControlled({
     controlled: valueProp,
     default: defaultValue,
     name: 'TestComponent',

--- a/packages/material-ui/src/utils/useControlled.test.js
+++ b/packages/material-ui/src/utils/useControlled.test.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { expect } from 'chai';
+import { createClientRender } from 'test/utils/createClientRender';
+import consoleErrorMock from 'test/utils/consoleErrorMock';
+import useControlled from './useControlled';
+
+const TestComponent = ({ value: valueProp, defaultValue, children }) => {
+  const { value, setValue } = useControlled({
+    controlled: valueProp,
+    default: defaultValue,
+    name: 'TestComponent',
+  });
+  return children({ value, setValue });
+};
+
+describe('useControlled', () => {
+  const render = createClientRender();
+
+  beforeEach(() => {
+    consoleErrorMock.spy();
+  });
+
+  afterEach(() => {
+    consoleErrorMock.reset();
+  });
+
+  it('works correctly when is not controlled', () => {
+    let valueState;
+    let setValueState;
+    render(
+      <TestComponent defaultValue={1}>
+        {({ value, setValue }) => {
+          valueState = value;
+          setValueState = setValue;
+          return null;
+        }}
+      </TestComponent>,
+    );
+    expect(valueState).to.equal(1);
+    setValueState(2);
+    expect(valueState).to.equal(2);
+  });
+
+  it('works correctly when is controlled', () => {
+    let valueState;
+    render(
+      <TestComponent value={1}>
+        {({ value }) => {
+          valueState = value;
+          return null;
+        }}
+      </TestComponent>,
+    );
+    expect(valueState).to.equal(1);
+  });
+
+  it('warns when switching from uncontrolled to controlled', () => {
+    const { setProps } = render(<TestComponent>{() => null}</TestComponent>);
+    expect(consoleErrorMock.callCount()).to.equal(0);
+    setProps({ value: 'foobar' });
+    expect(consoleErrorMock.callCount()).to.equal(1);
+    expect(consoleErrorMock.args()[0][0]).to.contains(
+      'A component is changing an uncontrolled TestComponent to be controlled.',
+    );
+  });
+
+  it('warns when changing the defaultValue prop after initial rendering', () => {
+    const { setProps } = render(<TestComponent>{() => null}</TestComponent>);
+    expect(consoleErrorMock.callCount()).to.equal(0);
+    setProps({ defaultValue: 1 });
+    expect(consoleErrorMock.callCount()).to.equal(1);
+    expect(consoleErrorMock.args()[0][0]).to.contains(
+      'A component is changing the default value of an uncontrolled TestComponent after being initialized. ',
+    );
+  });
+});


### PR DESCRIPTION
Fixes #18956

This PR adds support to update the value when the `defaultValue` prop is changed after initial rendering. New default values are only propagated when the component is not dirty, to preserve the values the user may already have selected.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
