### PR TITLE
[DialogContentText] Fix component prop

### DIFF
--- a/packages/material-ui/src/DialogContentText/DialogContentText.d.ts
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.d.ts
@@ -1,12 +1,24 @@
 import * as React from 'react';
 import { StandardProps } from '..';
-import { TypographyProps } from '../Typography';
+import { TypographyTypeMap } from '../Typography';
+import { OverrideProps, OverridableTypeMap, OverridableComponent } from '../OverridableComponent';
 
-export interface DialogContentTextProps
-  extends StandardProps<TypographyProps, DialogContentTextClassKey> {}
+export interface DialogContentTextTypeMap<
+  P = {},
+  D extends React.ElementType = TypographyTypeMap['defaultComponent']
+> {
+  props: P & TypographyTypeMap['props'];
+  defaultComponent: D;
+  classKey: DialogContentTextClassKey;
+}
 
 export type DialogContentTextClassKey = 'root';
 
-declare const DialogContentText: React.ComponentType<DialogContentTextProps>;
+declare const DialogContentText: OverridableComponent<DialogContentTextTypeMap>;
+
+export type DialogContentTextProps<
+  D extends React.ElementType = DialogContentTextTypeMap['defaultComponent'],
+  P = {}
+> = OverrideProps<DialogContentTextTypeMap<P, D>, D>;
 
 export default DialogContentText;

--- a/packages/material-ui/src/DialogContentText/DialogContentText.spec.tsx
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.spec.tsx
@@ -1,0 +1,42 @@
+import React, { FC } from 'react';
+import { DialogContentText } from '@material-ui/core';
+
+const DialogContentTextTest = () => {
+  const CustomComponent: React.FC<{ prop1: string; prop2: number }> = () => <div />;
+  return (
+    <div>
+      <DialogContentText />
+      <DialogContentText classes={{ root: 'rootClass' }} />
+      // $ExpectError
+      <DialogContentText classes={{ body1: 'body1Class' }} />
+      <DialogContentText align="inherit" color="inherit" display="block" />
+      <DialogContentText align="left" color="initial" display="inline" />
+      <DialogContentText align="right" color="primary" display="initial" />
+      <DialogContentText align="justify" color="secondary" display="initial" />
+      <DialogContentText align="inherit" color="textPrimary" />
+      <DialogContentText align="inherit" color="textSecondary" />
+      <DialogContentText align="inherit" color="error" />
+      // $ExpectError
+      <DialogContentText display="incorrectValue" />
+      <DialogContentText component="a" href="url" display="block" />
+      <DialogContentText component="label" htmlFor="html" display="block" />
+      // $ExpectError
+      <DialogContentText component="a" href="url" display="incorrectValue" />
+      // $ExpectError
+      <DialogContentText component="a" incorrectAttribute="url" />
+      // $ExpectError
+      <DialogContentText component="incorrectComponent" href="url" />
+      // $ExpectError
+      <DialogContentText component="div" href="url" />
+      // $ExpectError
+      <DialogContentText href="url" />
+      <DialogContentText component={CustomComponent} prop1="1" prop2={12} />
+      // $ExpectError
+      <DialogContentText component={CustomComponent} prop1="1" prop2={12} id="1" />
+      // $ExpectError
+      <DialogContentText component={CustomComponent} prop1="1" />
+      // $ExpectError
+      <DialogContentText component={CustomComponent} prop1="1" prop2="12" />
+    </div>
+  );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

As `DialogContentText` is based wrapper around `Typography`, `DialogContentTextProps` is almost the same as `TypographyProps`

- [ v ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #19068