### PR TITLE
[styles] Reexport ts definitions for StylesHook from @material-ui/styles

### DIFF
--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -7,7 +7,7 @@ export {
 } from './createPalette';
 export { default as createStyles } from './createStyles';
 export { TypographyStyle } from './createTypography';
-export { default as makeStyles } from './makeStyles';
+export * from './makeStyles';
 export { default as responsiveFontSizes } from './responsiveFontSizes';
 export { ComponentsPropsList } from './props';
 export * from './transitions';

--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -7,7 +7,7 @@ export {
 } from './createPalette';
 export { default as createStyles } from './createStyles';
 export { TypographyStyle } from './createTypography';
-export * from './makeStyles';
+export { default as makeStyles, StylesHook } from './makeStyles';
 export { default as responsiveFontSizes } from './responsiveFontSizes';
 export { ComponentsPropsList } from './props';
 export * from './transitions';

--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -11,3 +11,5 @@ export default function makeStyles<
   styles: Styles<Theme, Props, ClassKey>,
   options?: Omit<WithStylesOptions<Theme>, 'withTheme'>,
 ): StylesHook<Styles<Theme, Props, ClassKey>>;
+
+export { makeStyles, StylesHook }

--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -12,4 +12,4 @@ export default function makeStyles<
   options?: Omit<WithStylesOptions<Theme>, 'withTheme'>,
 ): StylesHook<Styles<Theme, Props, ClassKey>>;
 
-export { makeStyles, StylesHook };
+export { StylesHook };

--- a/packages/material-ui/src/styles/makeStyles.d.ts
+++ b/packages/material-ui/src/styles/makeStyles.d.ts
@@ -12,4 +12,4 @@ export default function makeStyles<
   options?: Omit<WithStylesOptions<Theme>, 'withTheme'>,
 ): StylesHook<Styles<Theme, Props, ClassKey>>;
 
-export { makeStyles, StylesHook }
+export { makeStyles, StylesHook };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

@mui-org/material-ui-pickers  are [using](https://github.com/mui-org/material-ui-pickers/blob/next/lib/src/typings/overrides.ts) `StyleHook` type, but it is not exported from the @material-ui/core. This is the only reason we need to add `@material-ui/styles` as a dependency for typescript users :( 

