### PR TITLE
[Autocomplete] Fix option grouping

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -955,4 +955,31 @@ describe('<Autocomplete />', () => {
       expect(options).to.have.length(3);
     });
   });
+
+  describe('prop: groupBy', () => {
+    it('correctly groups options and preserves option order in each group', () => {
+      const data = [
+        { group: 1, value: 'A' },
+        { group: 2, value: 'D' },
+        { group: 2, value: 'E' },
+        { group: 1, value: 'B' },
+        { group: 3, value: 'G' },
+        { group: 2, value: 'F' },
+        { group: 1, value: 'C' },
+      ];
+      const { getAllByRole } = render(
+        <Autocomplete
+          options={data}
+          getOptionLabel={option => option.value}
+          renderInput={params => <TextField {...params} autoFocus />}
+          open
+          groupBy={option => option.group}
+        />,
+      );
+
+      const options = getAllByRole('option').map(el => el.textContent);
+      expect(options).to.have.length(7);
+      expect(options).to.deep.equal(['A', 'B', 'C', 'D', 'E', 'F', 'G']);
+    });
+  });
 });

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -782,21 +782,33 @@ export default function useAutocomplete(props) {
 
   let groupedOptions = filteredOptions;
   if (groupBy) {
-    groupedOptions = filteredOptions.reduce((acc, option, index) => {
+    const result = [];
+
+    // used to keep track of key and indexes in the result array
+    const indexByKey = new Map();
+    let currentResultIndex = 0;
+
+    filteredOptions.forEach(option => {
       const key = groupBy(option);
-
-      if (acc.length > 0 && acc[acc.length - 1].key === key) {
-        acc[acc.length - 1].options.push(option);
-      } else {
-        acc.push({
+      if (indexByKey.get(key) === undefined) {
+        indexByKey.set(key, currentResultIndex);
+        result.push({
           key,
-          index,
-          options: [option],
+          options: [],
         });
+        currentResultIndex += 1;
       }
+      result[indexByKey.get(key)].options.push(option);
+    });
 
-      return acc;
-    }, []);
+    // now we can add the `index` property based on the options length
+    let indexCounter = 0;
+    result.forEach(option => {
+      option.index = indexCounter;
+      indexCounter += option.options.length;
+    });
+
+    groupedOptions = result;
   }
 
   return {


### PR DESCRIPTION
Fixes issue where grouping with `groupBy` doesn't group options together correctly, see

Closes #19109 

```ts
const data = [
    { group: 1, value: "A" },
    { group: 2, value: "B" },
    { group: 2, value: "C" },
    { group: 1, value: "D" },
    { group: 3, value: "E" },
    { group: 2, value: "F" },
    { group: 1, value: "G" }
]

const groupBy = datum => datum.group
```

Before fix (this causes rendering of options to misbehave in React):
```
[ { key: 1, index: 0, options: [ [Object] ] },
  { key: 2, index: 1, options: [ [Object], [Object] ] },
  { key: 1, index: 3, options: [ [Object] ] },
  { key: 3, index: 4, options: [ [Object] ] },
  { key: 2, index: 5, options: [ [Object] ] },
  { key: 1, index: 6, options: [ [Object] ] } ]
```

After fix:
```
[ { key: 1, options: [ [Object], [Object], [Object] ], index: 0 },
  { key: 2, options: [ [Object], [Object], [Object] ], index: 3 },
  { key: 3, options: [ [Object] ], index: 6 } ]
```
- [x] Added tests
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
