### PR TITLE
[docs] Fix alert severity of customized snackbar

### DIFF
--- a/docs/src/pages/components/snackbars/CustomizedSnackbars.js
+++ b/docs/src/pages/components/snackbars/CustomizedSnackbars.js
@@ -39,14 +39,14 @@ export default function CustomizedSnackbars() {
         Open success snackbar
       </Button>
       <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
-        <Alert onClose={handleClose} color="success">
+        <Alert onClose={handleClose} severity="success">
           This is a success message!
         </Alert>
       </Snackbar>
-      <Alert color="error">This is an error message!</Alert>
-      <Alert color="warning">This is a warning message!</Alert>
-      <Alert color="info">This is an information message!</Alert>
-      <Alert color="success">This is a success message!</Alert>
+      <Alert severity="error">This is an error message!</Alert>
+      <Alert severity="warning">This is a warning message!</Alert>
+      <Alert severity="info">This is an information message!</Alert>
+      <Alert severity="success">This is a success message!</Alert>
     </div>
   );
 }

--- a/docs/src/pages/components/snackbars/CustomizedSnackbars.tsx
+++ b/docs/src/pages/components/snackbars/CustomizedSnackbars.tsx
@@ -39,14 +39,14 @@ export default function CustomizedSnackbars() {
         Open success snackbar
       </Button>
       <Snackbar open={open} autoHideDuration={6000} onClose={handleClose}>
-        <Alert onClose={handleClose} color="success">
+        <Alert onClose={handleClose} severity="success">
           This is a success message!
         </Alert>
       </Snackbar>
-      <Alert color="error">This is an error message!</Alert>
-      <Alert color="warning">This is a warning message!</Alert>
-      <Alert color="info">This is an information message!</Alert>
-      <Alert color="success">This is a success message!</Alert>
+      <Alert severity="error">This is an error message!</Alert>
+      <Alert severity="warning">This is a warning message!</Alert>
+      <Alert severity="info">This is an information message!</Alert>
+      <Alert severity="success">This is a success message!</Alert>
     </div>
   );
 }


### PR DESCRIPTION
Hi,

In the doc for Customized Snackbar example, this PR use severity prop on Alert instead of color.
The severity prop of Alert component set color and icon.

URL in docs for review: http://localhost:3000/components/snackbars/#customized-snackbars

Before (always with success icon):
![before](https://user-images.githubusercontent.com/1902504/71900801-d21ca180-315e-11ea-88bc-127c1d603be6.png)
After:
![after](https://user-images.githubusercontent.com/1902504/71900800-d21ca180-315e-11ea-9072-a5c2cee5cdc9.png)


