### PR TITLE
[Autocomplete] Refresh label when options change

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -608,6 +608,37 @@ describe('<Autocomplete />', () => {
       checkHighlightIs('three');
     });
 
+    it('should update label when options change', () => {
+      const optionsRef = { current: [] };
+
+      const { container, setProps } = render(
+        <Autocomplete
+          defaultValue="one"
+          getOptionLabel={option => {
+            const fullOption = optionsRef.current.find(opt => opt.value === option);
+            return fullOption ? fullOption.label : '';
+          }}
+          renderInput={params => <TextField {...params} />}
+        />,
+      );
+
+      const input = container.querySelector('input');
+      expect(input.value).to.equal('');
+
+      optionsRef.current = [
+        {
+          value: 'one',
+          label: 'One',
+        },
+        {
+          value: 'two',
+          label: 'Two',
+        },
+      ];
+      setProps({ options: optionsRef.current });
+      expect(input.value).to.equal('One');
+    });
+
     it('should not select undefined ', () => {
       const handleChange = spy();
       const { container, getByRole } = render(

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -3,6 +3,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { setRef, useEventCallback, useControlled } from '@material-ui/core/utils';
 
+const EMPTY_OPTION_LIST = [];
+
 // https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript
 // Give up on IE 11 support for this feature
 function stripDiacritics(string) {
@@ -106,7 +108,7 @@ export default function useAutocomplete(props) {
     onOpen,
     onInputChange,
     open: openProp,
-    options = [],
+    options = EMPTY_OPTION_LIST,
     value: valueProp,
     componentName = 'useAutocomplete',
   } = props;
@@ -238,7 +240,7 @@ export default function useAutocomplete(props) {
 
   React.useEffect(() => {
     resetInputValue(null, value);
-  }, [value, resetInputValue]);
+  }, [value, resetInputValue, options]);
 
   const { current: isOpenControlled } = React.useRef(openProp != null);
   const [openState, setOpenState] = React.useState(false);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

When loading the Autocomplete component with an async option list, I have the `defaultValue` (e.g. 'PT') but not yet the actual display name (e.g. 'Portugal'). However, when the options arrive, the selected label is not re-rendered.

This PR forces that re-render when the options prop changes.