### PR TITLE
[CheckBox] Add new colors to the Checkbox and IconButton

### DIFF
--- a/docs/pages/api/checkbox.md
+++ b/docs/pages/api/checkbox.md
@@ -27,7 +27,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">checked</span> | <span class="prop-type">bool</span> |  | If `true`, the component is checked. |
 | <span class="prop-name">checkedIcon</span> | <span class="prop-type">node</span> | <span class="prop-default">&lt;CheckBoxIcon /></span> | The icon to display when the component is checked. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">color</span> | <span class="prop-type">'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'default'</span> | <span class="prop-default">'secondary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
+| <span class="prop-name">color</span> | <span class="prop-type">'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'default'</span> | <span class="prop-default">'secondary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the switch will be disabled. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">icon</span> | <span class="prop-type">node</span> | <span class="prop-default">&lt;CheckBoxOutlineBlankIcon /></span> | The icon to display when the component is unchecked. |
@@ -59,6 +59,9 @@ Any other props supplied will be provided to the root element ([IconButton](/api
 | <span class="prop-name">indeterminate</span> | <span class="prop-name">.MuiCheckbox-indeterminate</span> | Pseudo-class applied to the root element if `indeterminate={true}`.
 | <span class="prop-name">colorPrimary</span> | <span class="prop-name">.MuiCheckbox-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | <span class="prop-name">.MuiCheckbox-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">colorWarning</span> | <span class="prop-name">.MuiCheckbox-colorWarning</span> | Styles applied to the root element if `color="warning"`.
+| <span class="prop-name">colorInfo</span> | <span class="prop-name">.MuiCheckbox-colorInfo</span> | Styles applied to the root element if `color="info"`.
+| <span class="prop-name">colorSuccess</span> | <span class="prop-name">.MuiCheckbox-colorSuccess</span> | Styles applied to the root element if `color="success"`.
 
 You can override the style of the component thanks to one of these customization points:
 

--- a/docs/pages/api/icon-button.md
+++ b/docs/pages/api/icon-button.md
@@ -27,7 +27,7 @@ regarding the available icon options.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The icon element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">color</span> | <span class="prop-type">'default'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
+| <span class="prop-name">color</span> | <span class="prop-type">'primary'<br>&#124;&nbsp;'secondary'<br>&#124;&nbsp;'success'<br>&#124;&nbsp;'warning'<br>&#124;&nbsp;'info'<br>&#124;&nbsp;'default'<br>&#124;&nbsp;'inherit'</span> | <span class="prop-default">'default'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
 | <span class="prop-name">disableFocusRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
 | <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled. |
@@ -51,6 +51,9 @@ Any other props supplied will be provided to the root element ([ButtonBase](/api
 | <span class="prop-name">colorInherit</span> | <span class="prop-name">.MuiIconButton-colorInherit</span> | Styles applied to the root element if `color="inherit"`.
 | <span class="prop-name">colorPrimary</span> | <span class="prop-name">.MuiIconButton-colorPrimary</span> | Styles applied to the root element if `color="primary"`.
 | <span class="prop-name">colorSecondary</span> | <span class="prop-name">.MuiIconButton-colorSecondary</span> | Styles applied to the root element if `color="secondary"`.
+| <span class="prop-name">colorWarning</span> | <span class="prop-name">.MuiIconButton-colorWarning</span> | Styles applied to the root element if `color="warning"`.
+| <span class="prop-name">colorInfo</span> | <span class="prop-name">.MuiIconButton-colorInfo</span> | Styles applied to the root element if `color="info"`.
+| <span class="prop-name">colorSuccess</span> | <span class="prop-name">.MuiIconButton-colorSuccess</span> | Styles applied to the root element if `color="success"`.
 | <span class="prop-name">disabled</span> | <span class="prop-name">.Mui-disabled</span> | Pseudo-class applied to the root element if `disabled={true}`.
 | <span class="prop-name">sizeSmall</span> | <span class="prop-name">.MuiIconButton-sizeSmall</span> | Styles applied to the root element if `size="small"`.
 | <span class="prop-name">label</span> | <span class="prop-name">.MuiIconButton-label</span> | Styles applied to the children container element.

--- a/docs/src/pages/components/checkboxes/CheckboxLabels.js
+++ b/docs/src/pages/components/checkboxes/CheckboxLabels.js
@@ -23,6 +23,9 @@ export default function CheckboxLabels() {
   const [state, setState] = React.useState({
     checkedA: true,
     checkedB: true,
+    checkedW: true,
+    checkedI: true,
+    checkedS: true,
     checkedF: true,
     checkedG: true,
   });
@@ -49,6 +52,39 @@ export default function CheckboxLabels() {
           />
         }
         label="Primary"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={state.checkedW}
+            onChange={handleChange('checkedW')}
+            value="checkedW"
+            color="warning"
+          />
+        }
+        label="Warning"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={state.checkedI}
+            onChange={handleChange('checkedI')}
+            value="checkedI"
+            color="info"
+          />
+        }
+        label="Info"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={state.checkedS}
+            onChange={handleChange('checkedS')}
+            value="checkedS"
+            color="success"
+          />
+        }
+        label="success"
       />
       <FormControlLabel control={<Checkbox value="checkedC" />} label="Uncontrolled" />
       <FormControlLabel disabled control={<Checkbox value="checkedD" />} label="Disabled" />

--- a/docs/src/pages/components/checkboxes/CheckboxLabels.tsx
+++ b/docs/src/pages/components/checkboxes/CheckboxLabels.tsx
@@ -23,6 +23,9 @@ export default function CheckboxLabels() {
   const [state, setState] = React.useState({
     checkedA: true,
     checkedB: true,
+    checkedW: true,
+    checkedI: true,
+    checkedS: true,
     checkedF: true,
     checkedG: true,
   });
@@ -49,6 +52,39 @@ export default function CheckboxLabels() {
           />
         }
         label="Primary"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={state.checkedW}
+            onChange={handleChange('checkedW')}
+            value="checkedW"
+            color="warning"
+          />
+        }
+        label="Warning"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={state.checkedI}
+            onChange={handleChange('checkedI')}
+            value="checkedI"
+            color="info"
+          />
+        }
+        label="Info"
+      />
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={state.checkedS}
+            onChange={handleChange('checkedS')}
+            value="checkedS"
+            color="success"
+          />
+        }
+        label="success"
       />
       <FormControlLabel control={<Checkbox value="checkedC" />} label="Uncontrolled" />
       <FormControlLabel disabled control={<Checkbox value="checkedD" />} label="Disabled" />

--- a/docs/src/pages/components/checkboxes/Checkboxes.js
+++ b/docs/src/pages/components/checkboxes/Checkboxes.js
@@ -22,6 +22,24 @@ export default function Checkboxes() {
         color="primary"
         inputProps={{ 'aria-label': 'secondary checkbox' }}
       />
+      <Checkbox
+        defaultChecked
+        value="warning"
+        color="warning"
+        inputProps={{ 'aria-label': 'warning checkbox' }}
+      />
+      <Checkbox
+        defaultChecked
+        value="info"
+        color="info"
+        inputProps={{ 'aria-label': 'info checkbox' }}
+      />
+      <Checkbox
+        defaultChecked
+        value="success"
+        color="success"
+        inputProps={{ 'aria-label': 'success checkbox' }}
+      />
       <Checkbox value="uncontrolled" inputProps={{ 'aria-label': 'uncontrolled-checkbox' }} />
       <Checkbox disabled value="disabled" inputProps={{ 'aria-label': 'disabled checkbox' }} />
       <Checkbox

--- a/docs/src/pages/components/checkboxes/Checkboxes.tsx
+++ b/docs/src/pages/components/checkboxes/Checkboxes.tsx
@@ -22,6 +22,24 @@ export default function Checkboxes() {
         color="primary"
         inputProps={{ 'aria-label': 'secondary checkbox' }}
       />
+      <Checkbox
+        defaultChecked
+        value="warning"
+        color="warning"
+        inputProps={{ 'aria-label': 'warning checkbox' }}
+      />
+      <Checkbox
+        defaultChecked
+        value="info"
+        color="info"
+        inputProps={{ 'aria-label': 'info checkbox' }}
+      />
+      <Checkbox
+        defaultChecked
+        value="success"
+        color="success"
+        inputProps={{ 'aria-label': 'success checkbox' }}
+      />
       <Checkbox value="uncontrolled" inputProps={{ 'aria-label': 'uncontrolled-checkbox' }} />
       <Checkbox disabled value="disabled" inputProps={{ 'aria-label': 'disabled checkbox' }} />
       <Checkbox

--- a/packages/material-ui/src/Checkbox/Checkbox.d.ts
+++ b/packages/material-ui/src/Checkbox/Checkbox.d.ts
@@ -5,7 +5,7 @@ import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 export interface CheckboxProps
   extends StandardProps<SwitchBaseProps, CheckboxClassKey, 'checkedIcon' | 'color' | 'icon'> {
   checkedIcon?: React.ReactNode;
-  color?: 'primary' | 'secondary' | 'default';
+  color?: 'primary' | 'secondary' | 'success' | 'warning' | 'info' | 'default';
   icon?: React.ReactNode;
   indeterminate?: boolean;
   indeterminateIcon?: React.ReactNode;
@@ -16,7 +16,10 @@ export type CheckboxClassKey =
   | SwitchBaseClassKey
   | 'indeterminate'
   | 'colorPrimary'
-  | 'colorSecondary';
+  | 'colorSecondary'
+  | 'colorSuccess'
+  | 'colorWarning'
+  | 'colorInfo';
 
 declare const Checkbox: React.ComponentType<CheckboxProps>;
 

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -53,6 +53,54 @@ export const styles = theme => ({
       color: theme.palette.action.disabled,
     },
   },
+  /* Styles applied to the root element if `color="warning"`. */
+  colorWarning: {
+    '&$checked': {
+      color: theme.palette.warning.main,
+      '&:hover': {
+        backgroundColor: fade(theme.palette.warning.main, theme.palette.action.hoverOpacity),
+        // Reset on touch devices, it doesn't add specificity
+        '@media (hover: none)': {
+          backgroundColor: 'transparent',
+        },
+      },
+    },
+    '&$disabled': {
+      color: theme.palette.action.disabled,
+    },
+  },
+  /* Styles applied to the root element if `color="info"`. */
+  colorInfo: {
+    '&$checked': {
+      color: theme.palette.info.main,
+      '&:hover': {
+        backgroundColor: fade(theme.palette.info.main, theme.palette.action.hoverOpacity),
+        // Reset on touch devices, it doesn't add specificity
+        '@media (hover: none)': {
+          backgroundColor: 'transparent',
+        },
+      },
+    },
+    '&$disabled': {
+      color: theme.palette.action.disabled,
+    },
+  },
+  /* Styles applied to the root element if `color="success"`. */
+  colorSuccess: {
+    '&$checked': {
+      color: theme.palette.success.main,
+      '&:hover': {
+        backgroundColor: fade(theme.palette.success.main, theme.palette.action.hoverOpacity),
+        // Reset on touch devices, it doesn't add specificity
+        '@media (hover: none)': {
+          backgroundColor: 'transparent',
+        },
+      },
+    },
+    '&$disabled': {
+      color: theme.palette.action.disabled,
+    },
+  },
 });
 
 const defaultCheckedIcon = <CheckBoxIcon />;
@@ -118,7 +166,7 @@ Checkbox.propTypes = {
   /**
    * The color of the component. It supports those theme colors that make sense for this component.
    */
-  color: PropTypes.oneOf(['primary', 'secondary', 'default']),
+  color: PropTypes.oneOf(['primary', 'secondary', 'warning', 'info', 'success', 'default']),
   /**
    * If `true`, the switch will be disabled.
    */

--- a/packages/material-ui/src/IconButton/IconButton.d.ts
+++ b/packages/material-ui/src/IconButton/IconButton.d.ts
@@ -25,6 +25,9 @@ export type IconButtonClassKey =
   | 'colorInherit'
   | 'colorPrimary'
   | 'colorSecondary'
+  | 'colorWarning'
+  | 'colorInfo'
+  | 'colorSuccess'
   | 'disabled'
   | 'sizeSmall'
   | 'label';

--- a/packages/material-ui/src/IconButton/IconButton.d.ts
+++ b/packages/material-ui/src/IconButton/IconButton.d.ts
@@ -7,7 +7,7 @@ export type IconButtonTypeMap<
   D extends React.ElementType = 'button'
 > = ExtendButtonBaseTypeMap<{
   props: P & {
-    color?: PropTypes.Color;
+    color?: 'primary' | 'secondary' | 'success' | 'warning' | 'info' | 'default' | 'inherit';
     disableFocusRipple?: boolean;
     edge?: 'start' | 'end' | false;
     size?: 'small' | 'medium';

--- a/packages/material-ui/src/IconButton/IconButton.js
+++ b/packages/material-ui/src/IconButton/IconButton.js
@@ -72,6 +72,39 @@ export const styles = theme => ({
       },
     },
   },
+  /* Styles applied to the root element if `color="warning"`. */
+  colorWarning: {
+    color: theme.palette.warning.main,
+    '&:hover': {
+      backgroundColor: fade(theme.palette.warning.main, theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
+  },
+  /* Styles applied to the root element if `color="info"`. */
+  colorInfo: {
+    color: theme.palette.info.main,
+    '&:hover': {
+      backgroundColor: fade(theme.palette.info.main, theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
+  },
+  /* Styles applied to the root element if `color="success"`. */
+  colorSuccess: {
+    color: theme.palette.success.main,
+    '&:hover': {
+      backgroundColor: fade(theme.palette.success.main, theme.palette.action.hoverOpacity),
+      // Reset on touch devices, it doesn't add specificity
+      '@media (hover: none)': {
+        backgroundColor: 'transparent',
+      },
+    },
+  },
   /* Pseudo-class applied to the root element if `disabled={true}`. */
   disabled: {},
   /* Styles applied to the root element if `size="small"`. */
@@ -164,7 +197,15 @@ IconButton.propTypes = {
   /**
    * The color of the component. It supports those theme colors that make sense for this component.
    */
-  color: PropTypes.oneOf(['default', 'inherit', 'primary', 'secondary']),
+  color: PropTypes.oneOf([
+    'primary',
+    'secondary',
+    'success',
+    'warning',
+    'info',
+    'default',
+    'inherit',
+  ]),
   /**
    * If `true`, the button will be disabled.
    */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ x ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
This PR adds the support for `success`, `info` and `warning` colors for the `Checkbox` and `IconButton` components. Had to do both, b/c `Checkbox` renders the `IconButton` under the hood and otherwise, it got type warnings. I started with the `Checkbox` component as it is simple enough and can give insights on how to implement these colors for everything else.
