### PR TITLE
[system] Allow for nested css rules in system prop

### DIFF
--- a/packages/material-ui-system/src/css.js
+++ b/packages/material-ui-system/src/css.js
@@ -17,11 +17,11 @@ function styleFunctionWalk(styleFunction, theme) {
   const apply = (css) => {
     const output = {
       ...styleFunction({ theme, ...css }),
-      ...omit(css, [styleFunction.filterProps]),
+      ...omit(css, styleFunction.filterProps),
     };
 
     for (const key in css) {
-      if (typeof css[key] === 'object') {
+      if (!styleFunction.filterProps[key] && typeof css[key] === 'object') {
         output[key] = apply(css[key]);
       }
     }

--- a/packages/material-ui-system/src/css.js
+++ b/packages/material-ui-system/src/css.js
@@ -14,7 +14,7 @@ function omit(input, fields) {
 }
 
 function handleCss(styleFunction, theme) {
-  const apply = (css) => {
+  const apply = css => {
     const output = {
       ...styleFunction({ theme, ...css }),
       ...omit(css, styleFunction.filterProps),
@@ -27,7 +27,7 @@ function handleCss(styleFunction, theme) {
     }
 
     return output;
-  }
+  };
 
   return apply;
 }
@@ -37,7 +37,7 @@ function css(styleFunction) {
     const output = styleFunction(props);
 
     if (props.css) {
-      return merge(output, handleCss(styleFunction, props.theme)(props.css))
+      return merge(output, handleCss(styleFunction, props.theme)(props.css));
     }
 
     return output;

--- a/packages/material-ui-system/src/css.js
+++ b/packages/material-ui-system/src/css.js
@@ -15,7 +15,7 @@ function omit(input, fields) {
 
 function handleCss(styleFunction, theme) {
   const apply = styles => {
-    const cssStyles = omit(styles, styleFunction.filterProps)
+    const cssStyles = omit(styles, styleFunction.filterProps);
     const output = {
       ...styleFunction({ theme, ...styles }),
       ...cssStyles,

--- a/packages/material-ui-system/src/css.js
+++ b/packages/material-ui-system/src/css.js
@@ -13,32 +13,28 @@ function omit(input, fields) {
   return output;
 }
 
-function handleCss(styleFunction, theme) {
-  const apply = styles => {
-    const cssStyles = omit(styles, styleFunction.filterProps);
-    const output = {
-      ...styleFunction({ theme, ...styles }),
-      ...cssStyles,
-    };
-
-    Object.keys(cssStyles).forEach(key => {
-      if (typeof cssStyles[key] === 'object') {
-        output[key] = apply(cssStyles[key]);
-      }
-    });
-
-    return output;
-  };
-
-  return apply;
-}
-
 function css(styleFunction) {
   const newStyleFunction = props => {
     const output = styleFunction(props) || {};
 
     if (props.css) {
-      return merge(output, handleCss(styleFunction, props.theme)(props.css));
+      const apply = styles => {
+        const cssProps = omit(styles, styleFunction.filterProps);
+        const cssOutput = {
+          ...styleFunction({ theme: props.theme, ...styles }),
+          ...cssProps,
+        };
+
+        Object.keys(cssProps).forEach(key => {
+          if (cssProps[key] && typeof cssProps[key] === 'object') {
+            cssOutput[key] = apply(cssProps[key]);
+          }
+        });
+
+        return cssOutput;
+      };
+
+      return merge(output, apply(props.css));
     }
 
     return output;

--- a/packages/material-ui-system/src/css.js
+++ b/packages/material-ui-system/src/css.js
@@ -13,7 +13,7 @@ function omit(input, fields) {
   return output;
 }
 
-function styleFunctionWalk(styleFunction, theme) {
+function handleCss(styleFunction, theme) {
   const apply = (css) => {
     const output = {
       ...styleFunction({ theme, ...css }),
@@ -37,7 +37,7 @@ function css(styleFunction) {
     const output = styleFunction(props);
 
     if (props.css) {
-      return merge(output, styleFunctionWalk(styleFunction, props.theme)(props.css))
+      return merge(output, handleCss(styleFunction, props.theme)(props.css))
     }
 
     return output;

--- a/packages/material-ui-system/src/css.js
+++ b/packages/material-ui-system/src/css.js
@@ -14,17 +14,18 @@ function omit(input, fields) {
 }
 
 function handleCss(styleFunction, theme) {
-  const apply = css => {
+  const apply = styles => {
+    const cssStyles = omit(styles, styleFunction.filterProps)
     const output = {
-      ...styleFunction({ theme, ...css }),
-      ...omit(css, styleFunction.filterProps),
+      ...styleFunction({ theme, ...styles }),
+      ...cssStyles,
     };
 
-    for (const key in css) {
-      if (!styleFunction.filterProps[key] && typeof css[key] === 'object') {
-        output[key] = apply(css[key]);
+    Object.keys(cssStyles).forEach(key => {
+      if (typeof cssStyles[key] === 'object') {
+        output[key] = apply(cssStyles[key]);
       }
-    }
+    });
 
     return output;
   };
@@ -34,7 +35,7 @@ function handleCss(styleFunction, theme) {
 
 function css(styleFunction) {
   const newStyleFunction = props => {
-    const output = styleFunction(props);
+    const output = styleFunction(props) || {};
 
     if (props.css) {
       return merge(output, handleCss(styleFunction, props.theme)(props.css));

--- a/packages/material-ui-system/src/css.js
+++ b/packages/material-ui-system/src/css.js
@@ -13,15 +13,31 @@ function omit(input, fields) {
   return output;
 }
 
+function styleFunctionWalk(styleFunction, theme) {
+  const apply = (css) => {
+    const output = {
+      ...styleFunction({ theme, ...css }),
+      ...omit(css, [styleFunction.filterProps]),
+    };
+
+    for (const key in css) {
+      if (typeof css[key] === 'object') {
+        output[key] = apply(css[key]);
+      }
+    }
+
+    return output;
+  }
+
+  return apply;
+}
+
 function css(styleFunction) {
   const newStyleFunction = props => {
     const output = styleFunction(props);
 
     if (props.css) {
-      return {
-        ...merge(output, styleFunction({ theme: props.theme, ...props.css })),
-        ...omit(props.css, [styleFunction.filterProps]),
-      };
+      return merge(output, styleFunctionWalk(styleFunction, props.theme)(props.css))
     }
 
     return output;

--- a/packages/material-ui-system/src/css.test.js
+++ b/packages/material-ui-system/src/css.test.js
@@ -32,7 +32,7 @@ describe('css', () => {
         '&:hover': {
           color: 'blue',
           '> button': {
-            color: 'pink'
+            color: 'pink',
           },
         },
       },

--- a/packages/material-ui-system/src/css.test.js
+++ b/packages/material-ui-system/src/css.test.js
@@ -18,11 +18,23 @@ describe('css', () => {
         css: {
           color: 'red',
           padding: 10,
+          '&:hover': {
+            color: 'blue',
+            '> button': {
+              color: 'pink',
+            },
+          },
         },
       }),
       {
         padding: 10,
         color: 'red',
+        '&:hover': {
+          color: 'blue',
+          '> button': {
+            color: 'pink'
+          },
+        },
       },
     );
   });


### PR DESCRIPTION
This PR adds support for nested css rules in the system `css` prop:
```javascript
<Box css={{
  color: 'blue,
  '&:hover': {
    color: 'pink',
    '> button': {
      color: 'red'
    }
  }
}} />
```