### PR TITLE
[FormGroup] [RadioGroup] Able to customise root component

### DIFF
--- a/docs/pages/api/form-group.md
+++ b/docs/pages/api/form-group.md
@@ -28,6 +28,7 @@ For the `Radio`, you should be using the `RadioGroup` component instead of this 
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">row</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Display group of elements in a compact row. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api/radio-group.md
+++ b/docs/pages/api/radio-group.md
@@ -25,6 +25,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
+| <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default `input` element value. Use when the component is not controlled. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | The name used to reference the value of the control. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when a radio button is selected.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value` (string). |

--- a/packages/material-ui/src/FormGroup/FormGroup.d.ts
+++ b/packages/material-ui/src/FormGroup/FormGroup.d.ts
@@ -3,6 +3,7 @@ import { StandardProps } from '..';
 
 export interface FormGroupProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, FormGroupClassKey> {
+  component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
   row?: boolean;
 }
 

--- a/packages/material-ui/src/FormGroup/FormGroup.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.js
@@ -22,10 +22,10 @@ export const styles = {
  * For the `Radio`, you should be using the `RadioGroup` component instead of this one.
  */
 const FormGroup = React.forwardRef(function FormGroup(props, ref) {
-  const { classes, className, row = false, ...other } = props;
+  const { classes, component: Component = 'div', className, row = false, ...other } = props;
 
   return (
-    <div
+    <Component
       className={clsx(
         classes.root,
         {
@@ -53,6 +53,11 @@ FormGroup.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.elementType,
   /**
    * Display group of elements in a compact row.
    */

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -62,6 +62,11 @@ RadioGroup.propTypes = {
    */
   children: PropTypes.node,
   /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
+  component: PropTypes.elementType,
+  /**
    * The default `input` element value. Use when the component is not controlled.
    */
   defaultValue: PropTypes.any,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Currently using `<FormGroup />` or `<RadioFormGroup />` the output component is limited to `<div />`, this PR would allow include <RadioFormGroup component={TableRow} children={...} />`

The only issue remaining is that the default style applied includes `display: flex` where if using TableRow it should be `display: table-row;` 