### PR TITLE
Correctly pass `styleFunction.filterProps` to omit breaks tests.

### DIFF
--- a/packages/material-ui-system/src/css.js
+++ b/packages/material-ui-system/src/css.js
@@ -20,7 +20,7 @@ function css(styleFunction) {
     if (props.css) {
       return {
         ...merge(output, styleFunction({ theme: props.theme, ...props.css })),
-        ...omit(props.css, [styleFunction.filterProps]),
+        ...omit(props.css, styleFunction.filterProps),
       };
     }
 


### PR DESCRIPTION
This is a PR to prove the tests fails if we correctly omit styling props in system `css`.

See: https://github.com/mui-org/material-ui/pull/19176