### PR TITLE
[core] Ignore a few flaky visual tests

### DIFF
--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -79,6 +79,8 @@ const blacklist = [
   'docs-components-selects/DialogSelect.png', // Needs interaction
   'docs-components-selects/GroupedSelect.png', // Needs interaction
   'docs-components-skeleton/Animations.png', // Animation disabled
+  'docs-components-skeleton/Facebook.png', // Flaky image loading
+  'docs-components-skeleton/YouTube.png', // Flaky image loading
   'docs-components-snackbars/ConsecutiveSnackbars.png', // Needs interaction
   'docs-components-snackbars/CustomizedSnackbars.png', // Redundant
   'docs-components-snackbars/DirectionSnackbar.png', // Needs interaction
@@ -91,6 +93,7 @@ const blacklist = [
   'docs-components-stepper/HorizontalNonLinearAlternativeLabelStepper.png', // Redundant
   'docs-components-stepper/HorizontalNonLinearStepper.png', // Redundant
   'docs-components-stepper/SwipeableTextMobileStepper.png', // Redundant
+  'docs-components-steppers/SwipeableTextMobileStepper.png', // Flaky image loading
   'docs-components-textarea-autosize', // Superseded by a dedicated regression test
   'docs-components-tooltips', // Needs interaction
   'docs-components-transitions', // Needs interaction
@@ -106,6 +109,7 @@ const blacklist = [
   'docs-discover-more-showcase', // Not needed
   'docs-discover-more-team', // Not needed
   'docs-getting-started-templates', // Not needed
+  'docs-getting-started-templates-album/Album.png', // Flaky image loading
   'docs-getting-started-templates-blog', // Not needed
   'docs-getting-started-templates-checkout/AddressForm.png', // Already tested once assembled
   'docs-getting-started-templates-checkout/PaymentForm.png', // Already tested once assembled


### PR DESCRIPTION
…Waiting to see if we have more…

I have introduced them in #19175. Oops.

Ignoring these tests is a cheap and easy way out. We could imagine better approaches. For instance, wait for them to load (I have seen Happo do it). However, we have a few random images (using Unsplash API). In which cases, we could add a global class name to have them hidden.
In any case, we have them documented, so we can come back to it later (invest more time) if it proves to be an issue.

Actually, I think that if we had to invest more time on the topic, it would be great to throw if an entry in the blacklist isn't used. It would help with future demo refactorizations.