### PR TITLE
[TextField] Improve outlined transition

### DIFF
--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -6,8 +6,6 @@ import useTheme from '../styles/useTheme';
 import capitalize from '../utils/capitalize';
 
 export const styles = theme => {
-  const align = theme.direction === 'rtl' ? 'right' : 'left';
-
   return {
     /* Styles applied to the root element. */
     root: {
@@ -23,11 +21,6 @@ export const styles = theme => {
       borderRadius: 'inherit',
       borderStyle: 'solid',
       borderWidth: 1,
-      // Match the Input Label
-      transition: theme.transitions.create([`padding-${align}`, 'border-color', 'border-width'], {
-        duration: theme.transitions.duration.shorter,
-        easing: theme.transitions.easing.easeOut,
-      }),
     },
     /* Styles applied to the legend element when `labelWidth` is provided. */
     legend: {
@@ -35,7 +28,7 @@ export const styles = theme => {
       padding: 0,
       lineHeight: '11px', // sync with `height` in `legend` styles
       transition: theme.transitions.create('width', {
-        duration: theme.transitions.duration.shorter,
+        duration: 150,
         easing: theme.transitions.easing.easeOut,
       }),
     },
@@ -48,19 +41,21 @@ export const styles = theme => {
       visibility: 'hidden',
       maxWidth: 0.01,
       transition: theme.transitions.create('max-width', {
-        duration: theme.transitions.duration.shorter,
+        duration: 50,
         easing: theme.transitions.easing.easeOut,
       }),
       '& span': {
-        paddingLeft: 4,
-        paddingRight: 6,
+        paddingLeft: 5,
+        paddingRight: 5,
       },
     },
+    /* Styles applied to the legend element is notched. */
     legendNotched: {
       maxWidth: 1000,
       transition: theme.transitions.create('max-width', {
-        duration: theme.transitions.duration.shorter,
+        duration: 100,
         easing: theme.transitions.easing.easeOut,
+        delay: 50,
       }),
     },
   };
@@ -111,7 +106,7 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
     <fieldset
       aria-hidden
       style={{
-        [`padding${capitalize(align)}`]: 8 + (notched ? 0 : labelWidth / 2),
+        [`padding${capitalize(align)}`]: 8,
         ...style,
       }}
       className={clsx(classes.root, className)}


### PR DESCRIPTION
Continuation of #17680.

Preview: https://deploy-preview-19228--material-ui.netlify.com/

I have looked closer at the animation of the input, from a global perspective. I have used https://accounts.google.com/signin/v2/identifier and https://material.io/components/text-fields/ to benchmark. It leads me to the following. I would love to get your perspective on them:

1. It seems that Google doesn't animate the border-width nor the border-color (spec + google single singe on). On Safari and Firefox, the animation is junky. It feels like only the label actually transition, and that the border color and width wait for the end of the label transition to suddenly pick the right values, with a small delay. Removing these animations lead to a smoother experience.
2. ~It seems that the spec encourages the *shortest* duration value (150ms) instead of the *shorter* (200ms)~ I have given up on the changes, it gives me motion sickness, it moves too fast. The animation in the specification video seems to run for 180ms.
![Capture d’écran 2020-01-14 à 16 03 23](https://user-images.githubusercontent.com/3165635/72355284-736ba080-36e7-11ea-8ec0-f904be493837.png)
3. I believe that we can align the `label` and `labelWidth` animation, to be closer. In particular, we could make both starts from the left edge. But I'm not too sure. Is the long term plan (v5) to remove the `labelWidth`'s version? In which case, it doesn't really matter.
4. I have tweaked the delay and duration to make it feels like a single animation is running (not two out of sync).
