### PR TITLE
[icons] ArrowDropUpOutlined and ArrowDropDownOutlined improved

### DIFF
--- a/packages/material-ui-icons/src/ArrowDropDownOutlined.js
+++ b/packages/material-ui-icons/src/ArrowDropDownOutlined.js
@@ -2,5 +2,5 @@ import React from 'react';
 import createSvgIcon from './utils/createSvgIcon';
 
 export default createSvgIcon(
-  <path d="M7 10l5 5 5-5H7z" />
+  <path d="m12 14-5-5h10zm-0.041-0.88 3.5-3.5h-7z" />
 , 'ArrowDropDownOutlined');

--- a/packages/material-ui-icons/src/ArrowDropUpOutlined.js
+++ b/packages/material-ui-icons/src/ArrowDropUpOutlined.js
@@ -2,5 +2,5 @@ import React from 'react';
 import createSvgIcon from './utils/createSvgIcon';
 
 export default createSvgIcon(
-  <path d="M7 14l5-5 5 5H7z" />
+  <path d="m12 9-5 5h10l-5-5zm-0.041 0.88 3.5 3.5h-7l3.5-3.5z" />
 , 'ArrowDropUpOutlined');


### PR DESCRIPTION
There was no difference between `ArrowDropUpOutlined` and `ArrowDropUp`.

The same problem occurred between `ArrowDropDownOutlined` and `ArrowDropDown`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [✓] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
