### PR TITLE
[docs] Add "material-ui-confirm" to the related projects

### DIFF
--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -68,6 +68,10 @@ They support many different use cases (editable, filtering, grouping, sorting, s
 
 - [dx-react-chart-material-ui](https://devexpress.github.io/devextreme-reactive/react/chart/): Charts for Material-UI that visualizes data using a variety of series types, including bar, line, area, scatter, pie, and more ([paid license](https://js.devexpress.com/licensing/)).
 
+### Dialogs
+
+- [material-ui-confirm](https://github.com/jonatanklosko/material-ui-confirm): Provides easy to use confirmation dialogs to simplify confirming user actions without writing boilerplate code.
+
 ## Theming
 
 - [create-mui-theme](https://react-theming.github.io/create-mui-theme/): An online tool for creating Material-UI themes via Material Design Color Tool.


### PR DESCRIPTION
Confirming user actions is a very common tasks and ideally wouldn't be much harder than using the native `confirm` function, so I've attempted to build a simplistic, yet effective [package](https://github.com/jonatanklosko/material-ui-confirm) for that. Please see the [demo](https://codesandbox.io/s/materialuiconfirm-demo-hzzdr?fontsize=14) for an example usage. Creating a PR in case you consider it valuable enough =)