### PR TITLE
[Skeleton] Use span element for text variant

### DIFF
--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -74,7 +74,7 @@ const Skeleton = React.forwardRef(function Skeleton(props, ref) {
     animation = 'pulse',
     classes,
     className,
-    component: Component = ['rect', 'circle'].includes(props.variant) ? 'div' : 'span',
+    component: Component = ['rect', 'circle'].indexOf(props.variant) > -1 ? 'div' : 'span',
     height,
     variant = 'text',
     width,

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -74,7 +74,7 @@ const Skeleton = React.forwardRef(function Skeleton(props, ref) {
     animation = 'pulse',
     classes,
     className,
-    component: Component = 'div',
+    component: Component = ['rect', 'circle'].includes(props.variant) ? 'div' : 'span',
     height,
     variant = 'text',
     width,

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
@@ -26,27 +26,6 @@ describe('<Skeleton />', () => {
     refInstanceof: window.HTMLSpanElement,
   }));
 
-  describeConformance(<Skeleton variant="text" />, () => ({
-    classes,
-    inheritComponent: 'span',
-    mount,
-    refInstanceof: window.HTMLSpanElement,
-  }));
-
-  describeConformance(<Skeleton variant="rect" />, () => ({
-    classes,
-    inheritComponent: 'div',
-    mount,
-    refInstanceof: window.HTMLDivElement,
-  }));
-
-  describeConformance(<Skeleton variant="circle" />, () => ({
-    classes,
-    inheritComponent: 'div',
-    mount,
-    refInstanceof: window.HTMLDivElement,
-  }));
-
   it('should render', () => {
     const { container } = render(<Skeleton />);
 

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.test.js
@@ -21,6 +21,27 @@ describe('<Skeleton />', () => {
 
   describeConformance(<Skeleton />, () => ({
     classes,
+    inheritComponent: 'span',
+    mount,
+    refInstanceof: window.HTMLSpanElement,
+  }));
+
+  describeConformance(<Skeleton variant="text" />, () => ({
+    classes,
+    inheritComponent: 'span',
+    mount,
+    refInstanceof: window.HTMLSpanElement,
+  }));
+
+  describeConformance(<Skeleton variant="rect" />, () => ({
+    classes,
+    inheritComponent: 'div',
+    mount,
+    refInstanceof: window.HTMLDivElement,
+  }));
+
+  describeConformance(<Skeleton variant="circle" />, () => ({
+    classes,
     inheritComponent: 'div',
     mount,
     refInstanceof: window.HTMLDivElement,


### PR DESCRIPTION
fix #19210 

use <span> as default tag to prevent error log if Skeleto text is used in inline html tags like <p>

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
