### PR TITLE
[types] Remove CoerceEmptyInterface

### DIFF
--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { PropInjector, CoerceEmptyInterface, IsEmptyInterface } from '@material-ui/types';
+import { PropInjector, IsEmptyInterface } from '@material-ui/types';
 import * as CSS from 'csstype';
 import * as JSS from 'jss';
 import { DefaultTheme } from '../defaultTheme';
@@ -83,9 +83,7 @@ export type ClassKeyOfStyles<StylesOrClassKey> = StylesOrClassKey extends string
 /**
  * infers the type of the props used in the styles
  */
-export type PropsOfStyles<StylesType> = StylesType extends Styles<any, infer Props>
-  ? CoerceEmptyInterface<Props>
-  : {};
+export type PropsOfStyles<StylesType> = StylesType extends Styles<any, infer Props> ? Props : {};
 
 /**
  * infers the type of the theme used in the styles

--- a/packages/material-ui-types/index.d.ts
+++ b/packages/material-ui-types/index.d.ts
@@ -51,11 +51,6 @@ export type Overwrite<T, U> = Omit<T, keyof U> & U;
 // https://stackoverflow.com/a/49928360/3406963 without generic branch types
 export type IsAny<T> = 0 extends (1 & T) ? true : false;
 
-/**
- * Returns an empty object type if T is any, otherwise returns T
- */
-export type CoerceEmptyInterface<T> = IsAny<T> extends true ? {} : T;
-
 export type Or<A, B, C = false> = A extends true
   ? true
   : B extends true

--- a/packages/material-ui/src/styles/withStyles.d.ts
+++ b/packages/material-ui/src/styles/withStyles.d.ts
@@ -1,4 +1,4 @@
-import { PropInjector, CoerceEmptyInterface } from '@material-ui/types';
+import { PropInjector } from '@material-ui/types';
 import { Theme } from './createMuiTheme';
 import {
   CreateCSSProperties,
@@ -49,7 +49,4 @@ export default function withStyles<
 >(
   style: Styles<Theme, Props, ClassKey>,
   options?: Options,
-): PropInjector<
-  WithStyles<ClassKey, Options['withTheme']>,
-  StyledComponentProps<ClassKey> & CoerceEmptyInterface<Props>
->;
+): PropInjector<WithStyles<ClassKey, Options['withTheme']>, StyledComponentProps<ClassKey> & Props>;


### PR DESCRIPTION
BREAKING: Remove `CoerceEmptyInterface` from `@material-ui/types`. We don't need it in any of our packages. If you need it you can introduce it into your app:

```ts
/**	
 * Returns an empty object type if T is any, otherwise returns T	
 */	
export type CoerceEmptyInterface<T> = IsAny<T> extends true ? {} : T;
```

Ref: https://github.com/eps1lon/mui-types-perf/pull/1#discussion_r367035894