### PR TITLE
[docs] Use reasonable unitless line-height for Box

### DIFF
--- a/docs/src/pages/system/typography/LineHeight.js
+++ b/docs/src/pages/system/typography/LineHeight.js
@@ -9,7 +9,7 @@ export default function LineHeight() {
         Normal height.
       </Box>
       <Box lineHeight={10} m={1}>
-        10 px.
+        line-height: 10
       </Box>
     </Typography>
   );

--- a/docs/src/pages/system/typography/LineHeight.js
+++ b/docs/src/pages/system/typography/LineHeight.js
@@ -8,8 +8,8 @@ export default function LineHeight() {
       <Box lineHeight="normal" m={1}>
         Normal height.
       </Box>
-      <Box lineHeight={10} m={1}>
-        line-height: 10
+      <Box lineHeight={2} m={1}>
+        line-height: 2
       </Box>
     </Typography>
   );

--- a/docs/src/pages/system/typography/LineHeight.tsx
+++ b/docs/src/pages/system/typography/LineHeight.tsx
@@ -9,7 +9,7 @@ export default function LineHeight() {
         Normal height.
       </Box>
       <Box lineHeight={10} m={1}>
-        10 px.
+        line-height: 10
       </Box>
     </Typography>
   );

--- a/docs/src/pages/system/typography/LineHeight.tsx
+++ b/docs/src/pages/system/typography/LineHeight.tsx
@@ -8,8 +8,8 @@ export default function LineHeight() {
       <Box lineHeight="normal" m={1}>
         Normal height.
       </Box>
-      <Box lineHeight={10} m={1}>
-        line-height: 10
+      <Box lineHeight={2} m={1}>
+        line-height: 2
       </Box>
     </Typography>
   );


### PR DESCRIPTION
The official docs currently appear like so:

<img width="847" alt="Screen Shot 2020-01-16 at 14 46 03" src="https://user-images.githubusercontent.com/364725/72497140-13a00180-386f-11ea-9927-edc7d016a268.png">

However, using the lineHeight property does not set the unit to "px" in the generated css rule.

<img width="922" alt="Screen Shot 2020-01-16 at 14 50 18" src="https://user-images.githubusercontent.com/364725/72497315-87daa500-386f-11ea-8506-38a70da70eb8.png">

Assuming this is the correct action for the property, the docs should reflect the final state rather than the misleading "10px" label which currently exists.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
