### PR TITLE
[docs] Use button in backdrop demo

### DIFF
--- a/docs/src/pages/components/backdrop/SimpleBackdrop.js
+++ b/docs/src/pages/components/backdrop/SimpleBackdrop.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Backdrop from '@material-ui/core/Backdrop';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import Button from "@material-ui/core/Button";
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(theme => ({
@@ -22,9 +23,9 @@ export default function SimpleBackdrop() {
 
   return (
     <div>
-      <button type="button" onClick={handleToggle}>
+      <Button variant="contained" color="primary" onClick={handleToggle}>
         Show backdrop
-      </button>
+      </Button>
       <Backdrop className={classes.backdrop} open={open} onClick={handleClose}>
         <CircularProgress color="inherit" />
       </Backdrop>

--- a/docs/src/pages/components/backdrop/SimpleBackdrop.js
+++ b/docs/src/pages/components/backdrop/SimpleBackdrop.js
@@ -23,7 +23,7 @@ export default function SimpleBackdrop() {
 
   return (
     <div>
-      <Button variant="contained" color="primary" onClick={handleToggle}>
+      <Button variant="contained" onClick={handleToggle}>
         Show backdrop
       </Button>
       <Backdrop className={classes.backdrop} open={open} onClick={handleClose}>

--- a/docs/src/pages/components/backdrop/SimpleBackdrop.js
+++ b/docs/src/pages/components/backdrop/SimpleBackdrop.js
@@ -23,7 +23,7 @@ export default function SimpleBackdrop() {
 
   return (
     <div>
-      <Button variant="contained" onClick={handleToggle}>
+      <Button variant="outlined" color="primary" onClick={handleToggle}>
         Show backdrop
       </Button>
       <Backdrop className={classes.backdrop} open={open} onClick={handleClose}>

--- a/docs/src/pages/components/backdrop/SimpleBackdrop.js
+++ b/docs/src/pages/components/backdrop/SimpleBackdrop.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Backdrop from '@material-ui/core/Backdrop';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import Button from "@material-ui/core/Button";
+import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles(theme => ({

--- a/docs/src/pages/components/backdrop/SimpleBackdrop.tsx
+++ b/docs/src/pages/components/backdrop/SimpleBackdrop.tsx
@@ -25,7 +25,7 @@ export default function SimpleBackdrop() {
 
   return (
     <div>
-      <Button variant="contained" onClick={handleToggle}>
+      <Button variant="outlined" color="primary" onClick={handleToggle}>
         Show backdrop
       </Button>
       <Backdrop className={classes.backdrop} open={open} onClick={handleClose}>

--- a/docs/src/pages/components/backdrop/SimpleBackdrop.tsx
+++ b/docs/src/pages/components/backdrop/SimpleBackdrop.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Backdrop from '@material-ui/core/Backdrop';
 import CircularProgress from '@material-ui/core/CircularProgress';
+import Button from '@material-ui/core/Button';
 import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme: Theme) =>
@@ -24,9 +25,9 @@ export default function SimpleBackdrop() {
 
   return (
     <div>
-      <button type="button" onClick={handleToggle}>
+      <Button variant="contained" onClick={handleToggle}>
         Show backdrop
-      </button>
+      </Button>
       <Backdrop className={classes.backdrop} open={open} onClick={handleClose}>
         <CircularProgress color="inherit" />
       </Backdrop>

--- a/docs/src/pages/components/dialogs/CustomizedDialogs.js
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.js
@@ -61,7 +61,7 @@ export default function CustomizedDialogs() {
 
   return (
     <div>
-      <Button variant="outlined" color="secondary" onClick={handleClickOpen}>
+      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
         Open dialog
       </Button>
       <Dialog onClose={handleClose} aria-labelledby="customized-dialog-title" open={open}>

--- a/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
+++ b/docs/src/pages/components/dialogs/CustomizedDialogs.tsx
@@ -68,7 +68,7 @@ export default function CustomizedDialogs() {
 
   return (
     <div>
-      <Button variant="outlined" color="secondary" onClick={handleClickOpen}>
+      <Button variant="outlined" color="primary" onClick={handleClickOpen}>
         Open dialog
       </Button>
       <Dialog onClose={handleClose} aria-labelledby="customized-dialog-title" open={open}>

--- a/docs/src/pages/components/dialogs/SimpleDialog.js
+++ b/docs/src/pages/components/dialogs/SimpleDialog.js
@@ -55,7 +55,7 @@ function SimpleDialog(props) {
               <AddIcon />
             </Avatar>
           </ListItemAvatar>
-          <ListItemText primary="add account" />
+          <ListItemText primary="Add account" />
         </ListItem>
       </List>
     </Dialog>

--- a/docs/src/pages/components/dialogs/SimpleDialog.tsx
+++ b/docs/src/pages/components/dialogs/SimpleDialog.tsx
@@ -59,7 +59,7 @@ function SimpleDialog(props: SimpleDialogProps) {
               <AddIcon />
             </Avatar>
           </ListItemAvatar>
-          <ListItemText primary="add account" />
+          <ListItemText primary="Add account" />
         </ListItem>
       </List>
     </Dialog>


### PR DESCRIPTION
Currently the button to open a backdrop uses raw html. This change will make the button use a primary Material UI button.