### PR TITLE
[core] Use out-file-extension to build esm version

### DIFF
--- a/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
+++ b/docs/src/pages/guides/minimizing-bundle-size/minimizing-bundle-size.md
@@ -50,7 +50,7 @@ Head to [Option 2](#option-2) for the approach that yields the best DX and UX.
 While importing directly in this manner doesn't use the exports in [`@material-ui/core/index.js`](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/index.js), this file can serve as a handy reference as to which modules are public.
 
 Be aware that we only support first and second level imports.
-Anything deeper is considered private and can cause issues, such as module duplication in your bundle.
+Anything deeper is considered private.
 
 ```js
 // ✅ OK
@@ -98,8 +98,7 @@ Pick one of the following plugins:
       'babel-plugin-import',
       {
         'libraryName': '@material-ui/core',
-        // Use "'libraryDirectory': ''," if your bundler does not support ES modules
-        'libraryDirectory': 'esm',
+        'libraryDirectory': '',
         'camel2DashComponentName': false
       },
       'core'
@@ -108,8 +107,7 @@ Pick one of the following plugins:
       'babel-plugin-import',
       {
         'libraryName': '@material-ui/icons',
-        // Use "'libraryDirectory': ''," if your bundler does not support ES modules
-        'libraryDirectory': 'esm',
+        'libraryDirectory': '',
         'camel2DashComponentName': false
       },
       'icons'
@@ -131,13 +129,11 @@ Pick one of the following plugins:
       'babel-plugin-transform-imports',
       {
         '@material-ui/core': {
-          // Use "transform: '@material-ui/core/${member}'," if your bundler does not support ES modules
-          'transform': '@material-ui/core/esm/${member}',
+          'transform': '@material-ui/core/${member}',
           'preventFullImport': true
         },
         '@material-ui/icons': {
-          // Use "transform: '@material-ui/icons/${member}'," if your bundler does not support ES modules
-          'transform': '@material-ui/icons/esm/${member}',
+          'transform': '@material-ui/icons/${member}',
           'preventFullImport': true
         }
       }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "typescript": "lerna run typescript --parallel"
   },
   "devDependencies": {
-    "@babel/cli": "^7.7.4",
+    "@babel/cli": "^7.8.3",
     "@babel/core": "^7.7.4",
     "@babel/node": "^7.7.4",
     "@babel/plugin-proposal-class-properties": "^7.7.4",

--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -23,9 +23,11 @@
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-lab",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:esm && yarn build:copy-files",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:esm:old && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "#TODO: Remove build:esm:old in V5": "",
+    "build:esm:old": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build --out-file-extension .mjs --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",
     "release": "yarn build && npm publish build --tag latest",

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -23,9 +23,11 @@
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-icons",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:typings && yarn build:copy-files",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:esm:old && yarn build:es && yarn build:typings && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "#TODO: Remove build:esm:old in V5": "",
+    "build:esm:old": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build --out-file-extension .mjs --ignore \"**/*.test.js\"",
     "build:es": "echo 'skip es folder'",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "build:typings": "babel-node --config-file ../../babel.config.js ./scripts/create-typings.js",

--- a/packages/material-ui-lab/package.json
+++ b/packages/material-ui-lab/package.json
@@ -23,9 +23,11 @@
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-lab",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:esm:old && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "#TODO: Remove build:esm:old in V5": "",
+    "build:esm:old": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build --out-file-extension .mjs --ignore \"**/*.test.js\"",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -27,9 +27,11 @@
     "url": "https://opencollective.com/material-ui"
   },
   "scripts": {
-    "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:esm:old && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "#TODO: Remove build:esm:old in V5": "",
+    "build:esm:old": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build --out-file-extension .mjs --ignore \"**/*.test.js\"",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",

--- a/packages/material-ui-system/package.json
+++ b/packages/material-ui-system/package.json
@@ -27,9 +27,11 @@
     "url": "https://opencollective.com/material-ui"
   },
   "scripts": {
-    "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:esm:old && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "#TODO: Remove build:esm:old in V5": "",
+    "build:esm:old": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build --out-file-extension .mjs --ignore \"**/*.test.js\"",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",

--- a/packages/material-ui-utils/package.json
+++ b/packages/material-ui-utils/package.json
@@ -23,9 +23,11 @@
   },
   "homepage": "https://github.com/mui-org/material-ui/tree/master/packages/material-ui-utils",
   "scripts": {
-    "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:copy-files",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:esm:old && yarn build:es && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "#TODO: Remove build:esm:old in V5": "",
+    "build:esm:old": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build --out-file-extension .mjs --ignore \"**/*.test.js\"",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:copy-files": "node ../../scripts/copy-files.js",
     "prebuild": "rimraf build",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -25,9 +25,11 @@
     "url": "https://opencollective.com/material-ui"
   },
   "scripts": {
-    "build": "yarn build:cjs && yarn build:esm && yarn build:es && yarn build:umd && yarn build:copy-files",
+    "build": "yarn build:cjs && yarn build:esm && yarn build:esm:old && yarn build:es && yarn build:umd && yarn build:copy-files",
     "build:cjs": "cross-env NODE_ENV=production BABEL_ENV=cjs babel --config-file ../../babel.config.js ./src --out-dir ./build --ignore \"**/*.test.js\"",
-    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "#TODO: Remove build:esm:old in V5": "",
+    "build:esm:old": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build/esm --ignore \"**/*.test.js\"",
+    "build:esm": "cross-env NODE_ENV=production BABEL_ENV=esm babel --config-file ../../babel.config.js ./src --out-dir ./build --out-file-extension .mjs --ignore \"**/*.test.js\"",
     "build:es": "cross-env NODE_ENV=production BABEL_ENV=es babel --config-file ../../babel.config.js ./src --out-dir ./build/es --ignore \"**/*.test.js\"",
     "build:umd": "cross-env BABEL_ENV=production-umd rollup -c scripts/rollup.config.js",
     "build:copy-files": "node ../../scripts/copy-files.js",

--- a/scripts/copy-files.js
+++ b/scripts/copy-files.js
@@ -14,42 +14,6 @@ async function includeFileInBuild(file) {
   console.log(`Copied ${sourcePath} to ${targetPath}`);
 }
 
-/**
- * Puts a package.json into every immediate child directory of rootDir.
- * That package.json contains information about esm for bundlers so that imports
- * like import Typography from '@material-ui/core/Typography' are tree-shakeable.
- *
- * It also tests that an this import can be used in typescript by checking
- * if an index.d.ts is present at that path.
- *
- * @param {string} rootDir
- */
-async function createModulePackages({ from, to }) {
-  const directoryPackages = glob.sync('*/index.js', { cwd: from }).map(path.dirname);
-
-  await Promise.all(
-    directoryPackages.map(async directoryPackage => {
-      const packageJson = {
-        sideEffects: false,
-        module: path.join('../esm', directoryPackage, 'index.js'),
-        typings: './index.d.ts',
-      };
-      const packageJsonPath = path.join(to, directoryPackage, 'package.json');
-
-      const [typingsExist] = await Promise.all([
-        fse.exists(path.join(to, directoryPackage, 'index.d.ts')),
-        fse.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2)),
-      ]);
-
-      if (!typingsExist) {
-        throw new Error(`index.d.ts for ${directoryPackage} is missing`);
-      }
-
-      return packageJsonPath;
-    }),
-  );
-}
-
 async function typescriptCopy({ from, to }) {
   if (!(await fse.exists(to))) {
     console.warn(`path ${to} does not exists`);
@@ -70,7 +34,7 @@ async function createPackageFile() {
     ...packageDataOther,
     private: false,
     main: './index.js',
-    module: './esm/index.js',
+    module: './index.mjs',
     typings: './index.d.ts',
   };
   const targetPath = path.resolve(buildPath, './package.json');
@@ -96,6 +60,8 @@ async function addLicense(packageData) {
   await Promise.all(
     [
       './index.js',
+      './index.mjs',
+      // TODO: Remove next line in v5
       './esm/index.js',
       './umd/material-ui.development.js',
       './umd/material-ui.production.min.js',
@@ -130,8 +96,6 @@ async function run() {
 
     // TypeScript
     await typescriptCopy({ from: srcPath, to: buildPath });
-
-    await createModulePackages({ from: srcPath, to: buildPath });
   } catch (err) {
     console.error(err);
     process.exit(1);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@babel/cli@^7.7.4":
-  version "7.7.4"
-  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.7.4.tgz#38804334c8db40209f88c69a5c90998e60cca18b"
-  integrity sha512-O7mmzaWdm+VabWQmxuM8hqNrWGGihN83KfhPUzp2lAW4kzIMwBxujXkZbD4fMwKMYY9FXTbDvXsJqU+5XHXi4A==
+"@babel/cli@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.8.3.tgz#121beb7c273e0521eb2feeb3883a2b7435d12328"
+  integrity sha512-K2UXPZCKMv7KwWy9Bl4sa6+jTNP7JyDiHKzoOiUUygaEDbC60vaargZDnO9oFMvlq8pIKOOyUUgeMYrsaN9djA==
   dependencies:
     commander "^4.0.1"
     convert-source-map "^1.1.0"


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Updated `@babel/cli` to make use of https://babeljs.io/docs/en/babel-cli#set-file-extensions when building the ESM version of the packages.
Thanks @eps1lon 

This enables treeshaking on all levels and simplifies the build script since we don't need to create a `package.json` file in the subfolders anymore.
Even though we consider 3rd level imports private, there is nothing stopping people from using them, so they do. This will benefit them with reduced bundle sizes

For backwards compatability it still builds the `esm` folder which we can remove in v5