### PR TITLE
[core] Use node 10 in every CI/CD pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ defaults: &defaults
     REACT_DIST_TAG: << parameters.react-dist-tag >>
   working_directory: /tmp/material-ui
   docker:
-    - image: circleci/node:8.16
+    - image: circleci/node:dubnium
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.
@@ -154,7 +154,7 @@ jobs:
   test_regressions:
     <<: *defaults
     docker:
-      - image: circleci/node:8.16
+      - image: circleci/node:dubnium
       - image: selenium/standalone-chrome:3.11.0
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ defaults: &defaults
     REACT_DIST_TAG: << parameters.react-dist-tag >>
   working_directory: /tmp/material-ui
   docker:
-    - image: circleci/node:dubnium
+    - image: circleci/node:10
 # CircleCI has disabled the cache across forks for security reasons.
 # Following their official statement, it was a quick solution, they
 # are working on providing this feature back with appropriate security measures.
@@ -24,6 +24,11 @@ defaults: &defaults
 commands:
   install_js:
     steps:
+      - run:
+          name: View install environment
+          command: |
+            node --version
+            yarn --version
       - run:
           name: Resolve react version
           command: |
@@ -154,7 +159,7 @@ jobs:
   test_regressions:
     <<: *defaults
     docker:
-      - image: circleci/node:dubnium
+      - image: circleci/node:10
       - image: selenium/standalone-chrome:3.11.0
     steps:
       - checkout

--- a/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
+++ b/docs/src/pages/getting-started/supported-platforms/supported-platforms.md
@@ -19,7 +19,7 @@ You can expect Material-UI's components to render without major issues.
 ## Server
 
 Because Material-UI supports server-side rendering, it needs to support the latest, stable releases of [Node.js](https://github.com/nodejs/node).
-Where possible, the [LTS versions that are in maintenance](https://github.com/nodejs/Release#lts-schedule1) are supported. Right now, it supports **node v8.x** and newer versions.
+Where possible, the [LTS versions that are in maintenance](https://github.com/nodejs/Release#lts-schedule1) are supported. We recommend using **node v10.x** or newever. However we still support **node v8.x**. The support of **node v8.x** will be stopped in Material-UI Version 5.
 
 ### CSS prefixing
 


### PR DESCRIPTION
Dependencies are starting to bump their required node version (#19187 and #19299) since 8.x has reached its end of life. 10.x is now active LTS. We still officially support 8.x but to keep our test environment fast and safe we're switching to 10.x as should everybody else. If we start seeing regressions due to features being released that require 10.x we need to rethink our testing environment.

Azure pipeline was already using node 10. [Netlify is controlled via environment variables](https://docs.netlify.com/configure-builds/manage-dependencies/#node-js-environment).