### PR TITLE
[Tooltip] Fix popper.js re-instantiation

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -482,7 +482,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }
   }
 
-  // Avoid the creation of a new Proper.js instance at each render
+  // Avoid the creation of a new Popper.js instance at each render.
   const popperOptions = React.useMemo(
     () => ({
       modifiers: {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -482,6 +482,19 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }
   }
 
+  // Avoid the creation of a new Proper.js instance at each render
+  const popperOptions = React.useMemo(
+    () => ({
+      modifiers: {
+        arrow: {
+          enabled: Boolean(arrowRef),
+          element: arrowRef,
+        },
+      },
+    }),
+    [arrowRef],
+  );
+
   return (
     <React.Fragment>
       {React.cloneElement(children, { ref: handleRef, ...childrenProps })}
@@ -495,14 +508,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
         open={childNode ? open : false}
         id={childrenProps['aria-describedby']}
         transition
-        popperOptions={{
-          modifiers: {
-            arrow: {
-              enabled: Boolean(arrowRef),
-              element: arrowRef,
-            },
-          },
-        }}
+        popperOptions={popperOptions}
         {...interactiveWrapperListeners}
         {...PopperProps}
       >

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -469,19 +469,17 @@ describe('<Tooltip />', () => {
 
   it('should use the same popper.js instance between two renders', () => {
     const popperRef = React.createRef();
-    const { setProps } = render(
+    const { forceUpdate } = render(
       <Tooltip
         {...defaultProps}
-        open={false}
+        open
         PopperProps={{
           popperRef,
         }}
       />,
     );
-    setProps({ open: true });
-    const render1 = popperRef.current;
-    setProps({ open: true });
-    const render2 = popperRef.current;
-    expect(render1).to.equal(render2);
+    const firstPopperInstance = popperRef.current;
+    forceUpdate();
+    expect(firstPopperInstance).to.equal(popperRef.current);
   });
 });

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -220,10 +220,10 @@ describe('<Tooltip />', () => {
     it('should use hysteresis with the enterDelay', () => {
       const { container } = render(
         <Tooltip
+          {...defaultProps}
           enterDelay={111}
           leaveDelay={5}
           TransitionProps={{ timeout: 6 }}
-          {...defaultProps}
         />,
       );
       const children = container.querySelector('#testChild');
@@ -465,5 +465,23 @@ describe('<Tooltip />', () => {
         'A component is changing an uncontrolled Tooltip to be controlled.',
       );
     });
+  });
+
+  it('should use the same popper.js instance between two renders', () => {
+    const popperRef = React.createRef();
+    const { setProps } = render(
+      <Tooltip
+        {...defaultProps}
+        open={false}
+        PopperProps={{
+          popperRef,
+        }}
+      />,
+    );
+    setProps({ open: true });
+    const render1 = popperRef.current;
+    setProps({ open: true });
+    const render2 = popperRef.current;
+    expect(render1).to.equal(render2);
   });
 });

--- a/test/utils/createClientRender.js
+++ b/test/utils/createClientRender.js
@@ -63,6 +63,15 @@ function clientRender(element, options = {}) {
     return result;
   };
 
+  result.forceUpdate = function forceUpdate() {
+    result.rerender(
+      React.cloneElement(element, {
+        'data-force-update': String(Math.random()),
+      }),
+    );
+    return result;
+  };
+
   return result;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes #19203 
This PR avoid the creation of a new Proper.js instance at each render.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
