### PR TITLE
[Autocomplete] Fix hidden items during keyboard navigation

### DIFF
--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -182,8 +182,11 @@ export default function useAutocomplete(props) {
       const elementBottom = element.offsetTop + element.offsetHeight;
       if (elementBottom > scrollBottom) {
         listboxNode.scrollTop = elementBottom - listboxNode.clientHeight;
-      } else if (element.offsetTop < listboxNode.scrollTop) {
-        listboxNode.scrollTop = element.offsetTop;
+      } else if (
+        element.offsetTop - element.offsetHeight * (groupBy ? 1.3 : 0) <
+        listboxNode.scrollTop
+      ) {
+        listboxNode.scrollTop = element.offsetTop - element.offsetHeight * (groupBy ? 1.3 : 0);
       }
     }
   }


### PR DESCRIPTION
This PR implements @oliviertassinari's suggestion for #19217 with a couple tweaks

The differences were mainly to preserve the existing behaviour on lists without groups and on the downward scrolling of lists with groups.

| Original | Original suggestion | This PR
----------|------------------|--------------------- 

![comparison-small](https://user-images.githubusercontent.com/431708/72691995-33058b80-3b08-11ea-9f20-c20e45d4690b.gif)

While scrolling up with the keyboard, position the top part of the
option so that the both the group label and the row are fully visible.
No changes were made for the scroll down behaviour, which already
handled skipping the group label.

Doesn't interfere with the current behaviour of autoselects without
groups.

The 1.3 ratio was selected through visual inspection, and is the value
that minimizes misaligments and/or cropping of the topmost option.

Fixes #19217

Some guidance is definitely needed on how to test this behaviour given its dynamic nature. Would it be possible to send keystrokes to the element before taking a visual regression snapshot, for example?

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).