### PR TITLE
[core] Remove unecessary exports from styles/transitions.js

### DIFF
--- a/packages/material-ui/src/styles/transitions.js
+++ b/packages/material-ui/src/styles/transitions.js
@@ -28,9 +28,9 @@ export const duration = {
   leavingScreen: 195,
 };
 
-export const formatMs = milliseconds => `${Math.round(milliseconds)}ms`;
-export const isString = value => typeof value === 'string';
-export const isNumber = value => !isNaN(parseFloat(value));
+function formatMs(milliseconds) {
+  return `${Math.round(milliseconds)}ms`;
+}
 
 /**
  * @param {string|Array} props
@@ -52,6 +52,8 @@ export default {
     } = options;
 
     if (process.env.NODE_ENV !== 'production') {
+      const isString = value => typeof value === 'string';
+      const isNumber = value => !isNaN(parseFloat(value));
       if (!isString(props) && !Array.isArray(props)) {
         console.error('Material-UI: argument "props" must be a string or Array.');
       }

--- a/packages/material-ui/src/styles/transitions.test.js
+++ b/packages/material-ui/src/styles/transitions.test.js
@@ -1,84 +1,74 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { stub } from 'sinon';
-import transitions, { easing, duration, formatMs, isString, isNumber } from './transitions';
+import transitions, { easing, duration } from './transitions';
 
 describe('transitions', () => {
-  let consoleErrorStub;
-
-  beforeEach(() => {
-    consoleErrorStub = stub(console, 'error');
-  });
-
-  afterEach(() => {
-    consoleErrorStub.restore();
-  });
-
-  describe('formatMs() function', () => {
-    it('should round decimal digits and return formatted value', () => {
-      const formattedValue = formatMs(12.125);
-      assert.strictEqual(formattedValue, '12ms');
-    });
-  });
-
-  describe('isString() function', () => {
-    it('should return false when passed undefined', () => {
-      const value = isString();
-      assert.strictEqual(value, false);
-    });
-
-    it('should return false when not passed a string', () => {
-      let value = isString(1);
-      assert.strictEqual(value, false);
-      value = isString({});
-      assert.strictEqual(value, false);
-      value = isString([]);
-      assert.strictEqual(value, false);
-    });
-
-    it('should return true when passed a string', () => {
-      let value = isString('');
-      assert.strictEqual(value, true);
-      value = isString('test');
-      assert.strictEqual(value, true);
-    });
-  });
-
-  describe('isNumber() function', () => {
-    it('should return false when passed undefined', () => {
-      const value = isNumber();
-      assert.strictEqual(value, false);
-    });
-
-    it('should return false when not passed a number', () => {
-      let value = isNumber('');
-      assert.strictEqual(value, false);
-      value = isNumber('test');
-      assert.strictEqual(value, false);
-      value = isNumber({});
-      assert.strictEqual(value, false);
-      value = isNumber([]);
-      assert.strictEqual(value, false);
-    });
-
-    it('should return true when passed a number', () => {
-      let value = isNumber(1);
-      assert.strictEqual(value, true);
-      value = isNumber(1.5);
-      assert.strictEqual(value, true);
-    });
-  });
-
   describe('create() function', () => {
+    describe('warnings', () => {
+      let consoleErrorStub;
+
+      beforeEach(() => {
+        consoleErrorStub = stub(console, 'error');
+      });
+
+      afterEach(() => {
+        consoleErrorStub.restore();
+      });
+
+      it('should warn when first argument is of bad type', () => {
+        transitions.create(5554);
+        expect(consoleErrorStub.args[0][0]).to.include(
+          'argument "props" must be a string or Array',
+        );
+        transitions.create({});
+        expect(consoleErrorStub.args[1][0]).to.include(
+          'argument "props" must be a string or Array',
+        );
+      });
+
+      it('should warn when bad "duration" option type', () => {
+        transitions.create('font', { duration: null });
+        expect(consoleErrorStub.args[0][0]).to.include(
+          'argument "duration" must be a number or a string but found null',
+        );
+        transitions.create('font', { duration: {} });
+        expect(consoleErrorStub.args[1][0]).to.include(
+          'argument "duration" must be a number or a string but found [object Object]',
+        );
+      });
+
+      it('should warn when bad "easing" option type', () => {
+        transitions.create('transform', { easing: 123 });
+        expect(consoleErrorStub.args[0][0]).to.include('argument "easing" must be a string');
+        transitions.create('transform', { easing: {} });
+        expect(consoleErrorStub.args[1][0]).to.include('argument "easing" must be a string');
+      });
+
+      it('should warn when bad "delay" option type', () => {
+        transitions.create('size', { delay: null });
+        expect(consoleErrorStub.args[0][0]).to.include(
+          'argument "delay" must be a number or a string',
+        );
+        transitions.create('size', { delay: {} });
+        expect(consoleErrorStub.args[1][0]).to.include(
+          'argument "delay" must be a number or a string',
+        );
+      });
+
+      it('should warn when passed unrecognized option', () => {
+        transitions.create('size', { fffds: 'value' });
+        expect(consoleErrorStub.args[0][0]).to.include('unrecognized argument(s) [fffds]');
+      });
+    });
+
     it('should create default transition without arguments', () => {
       const transition = transitions.create();
-      assert.strictEqual(transition, `all ${duration.standard}ms ${easing.easeInOut} 0ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`all ${duration.standard}ms ${easing.easeInOut} 0ms`);
     });
 
     it('should take string props as a first argument', () => {
       const transition = transitions.create('color');
-      assert.strictEqual(transition, `color ${duration.standard}ms ${easing.easeInOut} 0ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`color ${duration.standard}ms ${easing.easeInOut} 0ms`);
     });
 
     it('should also take array of props as first argument', () => {
@@ -87,122 +77,77 @@ describe('transitions', () => {
       const single1 = transitions.create('color', options);
       const single2 = transitions.create('size', options);
       const expected = `${single1},${single2}`;
-      assert.strictEqual(multiple, expected);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
-    });
-
-    it('should warn when first argument is of bad type', () => {
-      // $FlowIgnore
-      transitions.create(5554);
-      // $FlowIgnore
-      transitions.create({});
-      assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
+      expect(multiple).to.equal(expected);
     });
 
     it('should optionally accept number "duration" option in second argument', () => {
       const transition = transitions.create('font', { duration: 500 });
-      assert.strictEqual(transition, `font 500ms ${easing.easeInOut} 0ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`font 500ms ${easing.easeInOut} 0ms`);
     });
 
     it('should optionally accept string "duration" option in second argument', () => {
       const transition = transitions.create('font', { duration: '500ms' });
-      assert.strictEqual(transition, `font 500ms ${easing.easeInOut} 0ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`font 500ms ${easing.easeInOut} 0ms`);
     });
 
     it('should round decimal digits of "duration" prop to whole numbers', () => {
       const transition = transitions.create('font', { duration: 12.125 });
-      assert.strictEqual(transition, `font 12ms ${easing.easeInOut} 0ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
-    });
-
-    it('should warn when bad "duration" option type', () => {
-      // $FlowIgnore
-      transitions.create('font', { duration: null });
-      // $FlowIgnore
-      transitions.create('font', { duration: {} });
-      assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`font 12ms ${easing.easeInOut} 0ms`);
     });
 
     it('should optionally accept string "easing" option in second argument', () => {
       const transition = transitions.create('transform', { easing: easing.sharp });
-      assert.strictEqual(transition, `transform ${duration.standard}ms ${easing.sharp} 0ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
-    });
-
-    it('should warn when bad "easing" option type', () => {
-      // $FlowIgnore
-      transitions.create('transform', { easing: 123 });
-      // $FlowIgnore
-      transitions.create('transform', { easing: {} });
-      assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`transform ${duration.standard}ms ${easing.sharp} 0ms`);
     });
 
     it('should optionally accept number "delay" option in second argument', () => {
       const transition = transitions.create('size', { delay: 150 });
-      assert.strictEqual(transition, `size ${duration.standard}ms ${easing.easeInOut} 150ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`size ${duration.standard}ms ${easing.easeInOut} 150ms`);
     });
 
     it('should optionally accept string "delay" option in second argument', () => {
       const transition = transitions.create('size', { delay: '150ms' });
-      assert.strictEqual(transition, `size ${duration.standard}ms ${easing.easeInOut} 150ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`size ${duration.standard}ms ${easing.easeInOut} 150ms`);
     });
 
     it('should round decimal digits of "delay" prop to whole numbers', () => {
       const transition = transitions.create('size', { delay: 1.547 });
-      assert.strictEqual(transition, `size ${duration.standard}ms ${easing.easeInOut} 2ms`);
-      assert.strictEqual(consoleErrorStub.callCount, 0, 'Wrong number of calls of warning()');
-    });
-
-    it('should warn when bad "delay" option type', () => {
-      // $FlowIgnore
-      transitions.create('size', { delay: null });
-      // $FlowIgnore
-      transitions.create('size', { delay: {} });
-      assert.strictEqual(consoleErrorStub.callCount, 2, 'Wrong number of calls of warning()');
-    });
-
-    it('should warn when passed unrecognized option', () => {
-      transitions.create('size', { fffds: 'value' });
-      assert.strictEqual(consoleErrorStub.callCount, 1, 'Wrong number of calls of warning()');
+      expect(transition).to.equal(`size ${duration.standard}ms ${easing.easeInOut} 2ms`);
     });
 
     it('should return zero when not passed arguments', () => {
       const zeroHeightDuration = transitions.getAutoHeightDuration();
-      assert.strictEqual(zeroHeightDuration, 0);
+      expect(zeroHeightDuration).to.equal(0);
     });
 
     it('should return zero when passed undefined', () => {
       const zeroHeightDuration = transitions.getAutoHeightDuration(undefined);
-      assert.strictEqual(zeroHeightDuration, 0);
+      expect(zeroHeightDuration).to.equal(0);
     });
 
     it('should return zero when passed null', () => {
       const zeroHeightDuration = transitions.getAutoHeightDuration(null);
-      assert.strictEqual(zeroHeightDuration, 0);
+      expect(zeroHeightDuration).to.equal(0);
     });
 
     it('should return NaN when passed a negative number', () => {
       const zeroHeightDurationNegativeOne = transitions.getAutoHeightDuration(-1);
-      assert.strictEqual(isNaN(zeroHeightDurationNegativeOne), true);
+      expect(isNaN(zeroHeightDurationNegativeOne)).to.equal(true);
       const zeroHeightDurationSmallNegative = transitions.getAutoHeightDuration(-0.000001);
-      assert.strictEqual(isNaN(zeroHeightDurationSmallNegative), true);
+      expect(isNaN(zeroHeightDurationSmallNegative)).to.equal(true);
       const zeroHeightDurationBigNegative = transitions.getAutoHeightDuration(-100000);
-      assert.strictEqual(isNaN(zeroHeightDurationBigNegative), true);
+      expect(isNaN(zeroHeightDurationBigNegative)).to.equal(true);
     });
 
     it('should return values for pre-calculated positive examples', () => {
       let zeroHeightDuration = transitions.getAutoHeightDuration(14);
-      assert.strictEqual(zeroHeightDuration, 159);
+      expect(zeroHeightDuration).to.equal(159);
       zeroHeightDuration = transitions.getAutoHeightDuration(100);
-      assert.strictEqual(zeroHeightDuration, 239);
+      expect(zeroHeightDuration).to.equal(239);
       zeroHeightDuration = transitions.getAutoHeightDuration(0.0001);
-      assert.strictEqual(zeroHeightDuration, 46);
+      expect(zeroHeightDuration).to.equal(46);
       zeroHeightDuration = transitions.getAutoHeightDuration(100000);
-      assert.strictEqual(zeroHeightDuration, 6685);
+      expect(zeroHeightDuration).to.equal(6685);
     });
   });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Remove some unused/untyped exports from `styles/transitions.js`, in response to this Issue thread: 

Closes #19258