### PR TITLE
[docs] Improve draggable dialog demo

### DIFF
--- a/docs/src/pages/components/dialogs/DraggableDialog.js
+++ b/docs/src/pages/components/dialogs/DraggableDialog.js
@@ -10,7 +10,7 @@ import Draggable from 'react-draggable';
 
 function PaperComponent(props) {
   return (
-    <Draggable cancel={'[class*="MuiDialogContent-root"]'}>
+    <Draggable handle="#draggable-dialog-title" cancel={'[class*="MuiDialogContent-root"]'}>
       <Paper {...props} />
     </Draggable>
   );

--- a/docs/src/pages/components/dialogs/DraggableDialog.tsx
+++ b/docs/src/pages/components/dialogs/DraggableDialog.tsx
@@ -10,7 +10,7 @@ import Draggable from 'react-draggable';
 
 function PaperComponent(props: PaperProps) {
   return (
-    <Draggable cancel={'[class*="MuiDialogContent-root"]'}>
+    <Draggable handle="#draggable-dialog-title" cancel={'[class*="MuiDialogContent-root"]'}>
       <Paper {...props} />
     </Draggable>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Since we're explicitly setting `style={{ cursor: 'move' }}` in the `DialogTitle`. We should also make sure only the title is "draggle", not the whole dialog.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
