### PR TITLE
[FormControl]  Add `fullWidth` prop to `FormControl` context

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -162,6 +162,7 @@ const FormControl = React.forwardRef(function FormControl(props, ref) {
     error,
     filled,
     focused,
+    fullWidth,
     hiddenLabel,
     margin: (size === 'small' ? 'dense' : undefined) || margin,
     onBlur: () => {

--- a/packages/material-ui/src/FormControl/FormControl.test.js
+++ b/packages/material-ui/src/FormControl/FormControl.test.js
@@ -224,6 +224,16 @@ describe('<FormControl />', () => {
         setProps({ margin: 'dense' });
         expect(formControlRef.current).to.have.property('margin', 'dense');
       });
+
+      it('should have the fullWidth prop from the instance', () => {
+        const formControlRef = React.createRef();
+        const { setProps } = render(<FormControlled ref={formControlRef} />);
+
+        expect(formControlRef.current).to.have.property('fullWidth', false);
+
+        setProps({ fullWidth: true });
+        expect(formControlRef.current).to.have.property('fullWidth', true);
+      });
     });
 
     describe('callbacks', () => {

--- a/packages/material-ui/src/FormControl/useFormControl.d.ts
+++ b/packages/material-ui/src/FormControl/useFormControl.d.ts
@@ -4,7 +4,7 @@ import { FormControlProps } from './FormControl';
 // shut off automatic exporting
 export {};
 
-type ContextFromPropsKey = 'disabled' | 'error' | 'hiddenLabel' | 'margin' | 'required' | 'variant';
+type ContextFromPropsKey = 'disabled' | 'error' | 'fullWidth' | 'hiddenLabel' | 'margin' | 'required' | 'variant';
 
 export interface FormControlState extends Pick<FormControlProps, ContextFromPropsKey> {
   adornedStart: boolean;

--- a/packages/material-ui/src/FormControl/useFormControl.d.ts
+++ b/packages/material-ui/src/FormControl/useFormControl.d.ts
@@ -4,7 +4,14 @@ import { FormControlProps } from './FormControl';
 // shut off automatic exporting
 export {};
 
-type ContextFromPropsKey = 'disabled' | 'error' | 'fullWidth' | 'hiddenLabel' | 'margin' | 'required' | 'variant';
+type ContextFromPropsKey =
+  | 'disabled'
+  | 'error'
+  | 'fullWidth'
+  | 'hiddenLabel'
+  | 'margin'
+  | 'required'
+  | 'variant';
 
 export interface FormControlState extends Pick<FormControlProps, ContextFromPropsKey> {
   adornedStart: boolean;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Per the discussion in #19336, I've added the `FormControl` prop `fullWidth` to the `FormControl` context. I've also added a test to ensure this prop is present in the context and updated the type of `useFormControl`. 

I'm also not sure if there is any documentation to update. I don't see anything, but I may have missed something.
