### PR TITLE
[test] Test type libs in docs

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -1,0 +1,2 @@
+# from styled-components
+@types/react-native

--- a/.yarnclean
+++ b/.yarnclean
@@ -1,2 +1,0 @@
-# from styled-components
-@types/react-native

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "export": "rimraf docs/export && next export --threads=3 --concurrency=5 -o export && yarn build-sw && cpy \"cdn/*\" export",
     "icons": "rimraf static/icons/* && node ./scripts/buildIcons.js",
     "start": "next start",
-    "typescript": "tslint -p tsconfig.json \"src/pages/**/*.{ts,tsx}\"",
+    "typescript": "tsc -p tsconfig.json",
     "typescript:transpile": "node scripts/formattedTSDemos",
     "typescript:transpile:dev": "node scripts/formattedTSDemos --watch"
   },

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -3,6 +3,8 @@
   "include": ["types", "src/pages/**/*"],
   "compilerOptions": {
     "allowJs": false,
+    /* files are emmitted by babel */
+    "noEmit": true,
     "noUnusedLocals": true
   }
 }

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -5,6 +5,7 @@
     "allowJs": false,
     /* files are emmitted by babel */
     "noEmit": true,
-    "noUnusedLocals": true
+    "noUnusedLocals": true,
+    "types": ["react"]
   }
 }

--- a/scripts/jsonlint.js
+++ b/scripts/jsonlint.js
@@ -17,7 +17,7 @@ async function run() {
 
   const filenames = glob.sync('**/*.json', {
     cwd: workspaceRoot,
-    ignore: eslintignore,
+    ignore: [...eslintignore, 'tsconfig*.json'],
   });
 
   let passed = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2232,9 +2232,9 @@
     "@types/react-router" "*"
 
 "@types/react-router@*":
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-4.4.5.tgz#1166997dc7eef2917b5ebce890ebecb32ee5c1b3"
-  integrity sha512-12+VOu1+xiC8RPc9yrgHCyLI79VswjtuqeS2gPrMcywH6tkc8rGIUhs4LaL3AJPqo5d+RPnfRpNKiJ7MK2Qhcg==
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.4.tgz#7d70bd905543cb6bcbdcc6bd98902332054f31a6"
+  integrity sha512-PZtnBuyfL07sqCJvGg3z+0+kt6fobc/xmle08jBiezLS8FrmGeiGkJnuxL/8Zgy9L83ypUhniV5atZn/L8n9MQ==
   dependencies:
     "@types/history" "*"
     "@types/react" "*"


### PR DESCRIPTION
Started to make plain `tsc` on a considerably large part of our codebase work. I realized that this allows "type integration tests" with `@material-ui/pickers`.

~I'll try to get rid of the `patch-package`. Might require unblocking #18402 and working on pickers.~