### PR TITLE
test: Exclude inaccessible elements by default in browser tests

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -54,6 +54,7 @@ module.exports = function setKarmaConfig(config) {
         new webpack.DefinePlugin({
           'process.env': {
             NODE_ENV: JSON.stringify('test'),
+            CI: JSON.stringify(process.env.CI),
           },
         }),
       ],


### PR DESCRIPTION
The browser tests are bundled with webpack. They don't have access to environment variables unless we explicitly inject them with a webpack plugin.

CI is supposed to exclude inaccessible elements by default which was not the case. See e.g. https://app.circleci.com/jobs/github/mui-org/material-ui/136811 where it logs "WARN: 'including inaccessible elements by default'"