### PR TITLE
[core] Misc dependency fixes

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -96,6 +96,7 @@
     "react-draggable": "^4.0.3",
     "react-final-form": "^6.3.0",
     "react-frame-component": "^4.1.1",
+    "react-is": "^16.12.0",
     "react-number-format": "^4.0.8",
     "react-redux": "^7.1.1",
     "react-router": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "**/@babel/preset-react": "^7.7.4",
     "**/@babel/runtime-corejs2": "^7.7.4",
     "**/@babel/runtime": "^7.7.4",
-    "**/hoist-non-react-statics": "^3.2.1",
+    "**/hoist-non-react-statics": "^3.3.2",
     "**/next/terser": "^4.1.2"
   },
   "nyc": {

--- a/packages/material-ui-icons/builder.js
+++ b/packages/material-ui-icons/builder.js
@@ -7,7 +7,6 @@ import Mustache from 'mustache';
 import Queue from 'modules/waterfall/Queue';
 import util from 'util';
 import glob from 'glob';
-import mkdirp from 'mkdirp';
 import SVGO from 'svgo';
 
 const globAsync = util.promisify(glob);
@@ -160,7 +159,7 @@ async function worker({ svgPath, options, renameFilter, template }) {
 
   if (!exists2) {
     console.log(`Making dir: ${outputFileDir}`);
-    mkdirp.sync(outputFileDir);
+    fse.mkdirpSync(outputFileDir);
   }
 
   const data = await fse.readFile(svgPath, { encoding: 'utf8' });

--- a/packages/material-ui-icons/package.json
+++ b/packages/material-ui-icons/package.json
@@ -53,7 +53,6 @@
   },
   "devDependencies": {
     "fs-extra": "^8.1.0",
-    "mkdirp": "^0.5.0",
     "mustache": "^4.0.0",
     "svgo": "^1.3.0",
     "temp": "^0.9.0",

--- a/packages/material-ui-styles/package.json
+++ b/packages/material-ui-styles/package.json
@@ -54,7 +54,7 @@
     "@material-ui/utils": "^4.7.1",
     "clsx": "^1.0.2",
     "csstype": "^2.5.2",
-    "hoist-non-react-statics": "^3.2.1",
+    "hoist-non-react-statics": "^3.3.2",
     "jss": "^10.0.3",
     "jss-plugin-camel-case": "^10.0.3",
     "jss-plugin-default-unit": "^10.0.3",

--- a/packages/material-ui/package.json
+++ b/packages/material-ui/package.json
@@ -55,7 +55,7 @@
     "@types/react-transition-group": "^4.2.0",
     "clsx": "^1.0.2",
     "convert-css-length": "^2.0.1",
-    "hoist-non-react-statics": "^3.2.1",
+    "hoist-non-react-statics": "^3.3.2",
     "normalize-scroll-left": "^0.2.0",
     "popper.js": "^1.14.1",
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7785,7 +7785,7 @@ hogan.js@^3.0.2:
     mkdirp "0.3.0"
     nopt "1.0.10"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.2.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==


### PR DESCRIPTION
- fixes missing peer dependency warning when installing the monorepo
- propagates hoist-non-react-static fix downstream
- remove `mkdirp` dependency. We can use `fse.mkdirp` (thanks @merceyz )