### PR TITLE
[Tabs] Delay indicator JS positioning

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.js
+++ b/packages/material-ui/src/Tabs/Tabs.js
@@ -110,7 +110,8 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
     }
   }
 
-  const [mounted, setMounted] = React.useState(false);
+  // const [mounted, setMounted] = React.useState(false);
+  const mounted = useRef(false);
   const [indicatorStyle, setIndicatorStyle] = React.useState({});
   const [displayScroll, setDisplayScroll] = React.useState({
     start: false,
@@ -317,6 +318,14 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
   });
 
   React.useEffect(() => {
+    mounted.current = true
+
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  React.useEffect(() => {
     const handleResize = debounce(() => {
       updateIndicatorState();
       updateScrollButtonState();
@@ -341,10 +350,6 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
       handleTabsScroll.clear();
     };
   }, [handleTabsScroll]);
-
-  React.useEffect(() => {
-    setMounted(true);
-  }, []);
 
   React.useEffect(() => {
     updateIndicatorState();
@@ -401,7 +406,7 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
     childIndex += 1;
     return React.cloneElement(child, {
       fullWidth: variant === 'fullWidth',
-      indicator: selected && !mounted && indicator,
+      indicator: selected && !mounted.current && indicator,
       selected,
       onChange,
       textColor,
@@ -444,7 +449,7 @@ const Tabs = React.forwardRef(function Tabs(props, ref) {
         >
           {children}
         </div>
-        {mounted && indicator}
+        {indicator}
       </div>
       {conditionalElements.scrollButtonEnd}
     </Component>


### PR DESCRIPTION
Updated how the component detects whether or not it is mounted. Using state to monitor component mount status can cause issues if asynchronous functionality is used; this could cause the following warning to be triggered:

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```

Storing 'mounted' in a ref might also reduce re-rendering and seems reasonable since checking whether or not a component is mounted seems to have the most value before or after the component exists.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
