### PR TITLE
[core] Fix mixins not being assignable as JSS styles

### DIFF
--- a/packages/material-ui/src/styles/createMixins.d.ts
+++ b/packages/material-ui/src/styles/createMixins.d.ts
@@ -1,10 +1,10 @@
 import { Breakpoints } from './createBreakpoints';
 import { Spacing } from './createSpacing';
-import * as React from 'react';
+import { CSSProperties } from './withStyles';
 
 export interface Mixins {
-  gutters: (styles?: React.CSSProperties) => React.CSSProperties;
-  toolbar: React.CSSProperties;
+  gutters: (styles?: CSSProperties) => CSSProperties;
+  toolbar: CSSProperties;
   // ... use interface declaration merging to add custom mixins
 }
 

--- a/packages/material-ui/src/styles/createMixins.spec.ts
+++ b/packages/material-ui/src/styles/createMixins.spec.ts
@@ -1,0 +1,29 @@
+import { createMuiTheme, makeStyles } from '@material-ui/core/styles';
+
+{
+   const theme = createMuiTheme({
+        mixins: {
+            toolbar: {
+                background: '#fff',
+                minHeight: 36,
+                '@media (min-width:0px) and (orientation: landscape)': {
+                    minHeight: 24
+                },
+                '@media (min-width:600px)': {
+                    minHeight: 48
+                }
+            },
+        }
+    });
+
+    const useStyles = makeStyles(theme => ({
+        appBarSpacer: theme.mixins.toolbar,
+        toolbarIcon: {
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'flex-end',
+            padding: '0 8px',
+            ...theme.mixins.toolbar,
+        },
+    }));
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

This pull request reverts one of the changes made in #19263 and addresses #19362 . 

The intent of original pull request was to avoid using the CSS-in-JS (JSS) implementation specific "CSSProperties" type where the simpler React.CSSProperties can be used. However, createMixins does directly rely on ability to specify media query nested selectors, a feature not present in React.CSSProperties

This change allows us to continue to override the toolbar implementation in Typescript. Whereas it is supported in vanilla JS.
```typescript
const theme = createMuiTheme({
        mixins: {
            toolbar: {
                background: '#fff',
                minHeight: 36,
                '@media (min-width:0px) and (orientation: landscape)': {
                    minHeight: 24
                },
                '@media (min-width:600px)': {
                    minHeight: 48
                }
            },
        }
    });
```