### PR TITLE
[Autocomplete] Should not fire change until IME is confirmed

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -910,6 +910,24 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(document.activeElement, { key: 'Enter' });
       expect(container.querySelectorAll('[class*="MuiChip-root"]')).to.have.length(3);
     });
+
+    it('should not fire change event until the IME is confirmed', () => {
+      const handleChange = spy();
+      render(
+        <Autocomplete
+          freeSolo
+          onChange={handleChange}
+          renderInput={params => <TextField {...params} autoFocus />}
+        />,
+      );
+      // Actual behavior when "あ" (Japanese) is entered on macOS/Safari with IME
+      fireEvent.change(document.activeElement, { target: { value: 'あ' } });
+      fireEvent.keyDown(document.activeElement, { key: 'Enter', keyCode: 229 });
+      expect(handleChange.callCount).to.equal(0);
+      fireEvent.keyDown(document.activeElement, { key: 'Enter', keyCode: 13 });
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.args[0][1]).to.equal('あ');
+    });
   });
 
   describe('prop: onInputChange', () => {

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -584,6 +584,10 @@ export default function useAutocomplete(props) {
         handleFocusTag(event, 'next');
         break;
       case 'Enter':
+        // Wait until IME is settled.
+        if (event.which === 229) {
+          break;
+        }
         if (highlightedIndexRef.current !== -1 && popupOpen) {
           // We don't want to validate the form.
           event.preventDefault();


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes https://github.com/mui-org/material-ui/issues/19435

Wait confirmation until the IME is settled. As far as I have tried on my PC, This fix works fine on macOS/Chrome, Safari, Firefox and Windows10/Chrome.

We can't test the various IME actually, so I wrote test code assuming Safari, which has the most inscrutable behavior. 