### PR TITLE
[docs] Improve entry points for issue repros

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -29,13 +29,11 @@ about: Create a bug report for Material-UI.
   Provide a link to a live example (you can use codesandbox.io) and an unambiguous set of steps to reproduce this bug.
   Include code to reproduce, if relevant (which it most likely is).
 
-  This codesandbox.io template _may_ be a good starting point:
-  https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app
+  You should use the official codesandbox template as a starting point: https://material-ui.com/r/issue-template
 
-  If you're using typescript a better starting point would be
-  https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript
+  If you have an issue concerning TypeScript please start from this TypeScript playground: https://material-ui.com/r/ts-issue-template
 
-  If YOU DO NOT take time to provide a codesandbox.io reproduction, should the COMMUNITY take time to help you?
+  Issues without some form of live example have a longer response time.
 -->
 
 Steps:

--- a/docs/cdn/_redirects
+++ b/docs/cdn/_redirects
@@ -25,7 +25,7 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /r/pseudo-classes-guide /customization/components/#pseudo-classes 302
 /r/input-component-ref-interface /components/text-fields/#integration-with-3rd-party-input-libraries 302
 /r/issue-template https://codesandbox.io/s/material-ui-issue-dh2yh
-/r/ts-issue-template http://www.typescriptlang.org/play/#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEMhhYowZABsAtHOCdhlMnToE5o-MAii4AESwgIACgBKVnYuHgBNeSghCBUsDSA 302
+/r/ts-issue-template https://www.typescriptlang.org/play/#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEMhhYowZABsAtHOCdhlMnToE5o-MAii4AESwgIACgBKVnYuHgBNeSghCBUsDSA 302
 # To remove at some point (2021).
 
 /css-in-js/* /styles/:splat 301

--- a/docs/cdn/_redirects
+++ b/docs/cdn/_redirects
@@ -24,7 +24,8 @@ https://material-ui.dev/* https://material-ui.com/:splat 301!
 /r/caveat-with-refs-guide /guides/composition/#caveat-with-refs 302
 /r/pseudo-classes-guide /customization/components/#pseudo-classes 302
 /r/input-component-ref-interface /components/text-fields/#integration-with-3rd-party-input-libraries 302
-
+/r/issue-template https://codesandbox.io/s/material-ui-issue-dh2yh
+/r/ts-issue-template http://www.typescriptlang.org/play/#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQokscA3nXHAPSdwwAWWOLhKQAdllEx0ATwgBXOHNRYAJnQC+cIiXIABEMhhYowZABsAtHOCdhlMnToE5o-MAii4AESwgIACgBKVnYuHgBNeSghCBUsDSA 302
 # To remove at some point (2021).
 
 /css-in-js/* /styles/:splat 301


### PR DESCRIPTION
Ready for review though not mergable. ~I want to fix/improve the TypeScript playground experience first (since it doesn't support `@material-ui/core/Typography` yet). ~ Involves too much work. Would like to see https://github.com/microsoft/TypeScript-Website/issues/206 get fixed at some point though.

Opening to get feedback about the wording.

Recommended codesandbox for repros is now a dedicated codesandbox template that is owned by the team (need your names for invite).