### PR TITLE
[ListItemAvatar] Add "children" prop

### DIFF
--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
@@ -1,6 +1,8 @@
 import { StandardProps } from '..';
 
-export interface ListItemAvatarProps extends StandardProps<{}, ListItemAvatarClassKey> {}
+export interface ListItemAvatarProps extends StandardProps<{}, ListItemAvatarClassKey> {
+  children: React.ReactElement;
+}
 
 export type ListItemAvatarClassKey = 'root' | 'icon';
 


### PR DESCRIPTION
ListItemAvatar should have "children" property as ListItemIcon does

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
