### PR TITLE
[typescript] Add dateIOAdapter definition to the core theme

### DIFF
--- a/packages/material-ui/src/styles/createMuiTheme.d.ts
+++ b/packages/material-ui/src/styles/createMuiTheme.d.ts
@@ -16,6 +16,7 @@ export interface ThemeOptions {
   shape?: ShapeOptions;
   breakpoints?: BreakpointsOptions;
   direction?: Direction;
+  dateIOAdapter?: any;
   mixins?: MixinsOptions;
   overrides?: Overrides;
   palette?: PaletteOptions;
@@ -31,6 +32,7 @@ export interface Theme {
   shape: Shape;
   breakpoints: Breakpoints;
   direction: Direction;
+  dateIOAdapter?: any;
   mixins: Mixins;
   overrides?: Overrides;
   palette: Palette;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

As we discussed with @oliviertassinari the next material-ui-pickers version will allow sharing dateIOAdapter through the theme. Just adding definition to not force every typescript user to extend definitions with module augmentation 