### PR TITLE
[docs] Fix typo in the Avatar docs

### DIFF
--- a/docs/src/pages/components/avatars/avatars.md
+++ b/docs/src/pages/components/avatars/avatars.md
@@ -42,7 +42,7 @@ If you need square or rounded avatars, use the `variant` prop.
 If there is an error loading the avatar image, the component falls back to an alternative in the following order:
 
 - the provided children
-- the first letter of tha `alt` text
+- the first letter of the `alt` text
 - a generic avatar icon
 
 {{"demo": "pages/components/avatars/FallbackAvatars.js"}}


### PR DESCRIPTION
Fixed silly typo at line 45 because why not

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
