### PR TITLE
[TextField] Fix blurry text on label

### DIFF
--- a/packages/material-ui/src/FormControl/FormControl.js
+++ b/packages/material-ui/src/FormControl/FormControl.js
@@ -18,6 +18,7 @@ export const styles = {
     padding: 0,
     margin: 0,
     border: 0,
+    zIndex: 0, // Fix blur label text issue
     verticalAlign: 'top', // Fix alignment issue on Safari.
   },
   /* Styles applied to the root element if `margin="normal"`. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR fixes blurry text on label. 
When we use variant="filled" and have progress on page then text will be blurred during progress animation.

Example https://codesandbox.io/s/material-demo-0cv2h

without animation 
![image](https://user-images.githubusercontent.com/18644653/73664327-de394780-46a7-11ea-843e-7ae6b0313e0e.png)

with animation
![image](https://user-images.githubusercontent.com/18644653/73664403-fe690680-46a7-11ea-8f3a-8d39982939d2.png)

Also there was similar issue  #17443 and PR for that #17453 we previously fixed.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
