### PR TITLE
[Modal] Fix zoom out on iOS

### DIFF
--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -4,6 +4,7 @@ import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import Fade from '../Fade';
 
+//work to be done here
 export const styles = {
   /* Styles applied to the root element. */
   root: {

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import withStyles from '../styles/withStyles';
 import Fade from '../Fade';
 
-//work to be done here
 export const styles = {
   /* Styles applied to the root element. */
   root: {

--- a/packages/material-ui/src/Backdrop/Backdrop.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.js
@@ -20,8 +20,6 @@ export const styles = {
     left: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     WebkitTapHighlightColor: 'transparent',
-    // Disable scroll capabilities.
-    touchAction: 'none',
   },
   /* Styles applied to the root element if `invisible={true}`. */
   invisible: {

--- a/packages/material-ui/src/Modal/SimpleBackdrop.js
+++ b/packages/material-ui/src/Modal/SimpleBackdrop.js
@@ -12,8 +12,6 @@ export const styles = {
     left: 0,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     WebkitTapHighlightColor: 'transparent',
-    // Disable scroll capabilities.
-    touchAction: 'none',
   },
   /* Styles applied to the root element if `invisible={true}`. */
   invisible: {


### PR DESCRIPTION
Attempting to fix this issue.
- The bug also appears in iPhone 11, prior to making the changes.
- Made the requested changes from the issue and now I can zoom in and out on dialog fullscreen.
-test static seems to be failing.

Deployed link of this branch to test on mobile:
https://deploy-preview-19548--material-ui.netlify.com/

Anything else I can do to test it let me know. Before merging, It might good to use this PR to test other instances of this issue if they exist elsewhere and not just dialog fullscreen. Like other pages with similar code:
`    // Disable scroll capabilities.
    touchAction: 'none',`

I will keep editing / updating this initial post with the significant changes.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #19117