### PR TITLE
[TextField] Fix label notch for custom htmlFontSize

### DIFF
--- a/packages/material-ui/src/InputBase/InputBase.js
+++ b/packages/material-ui/src/InputBase/InputBase.js
@@ -39,9 +39,8 @@ export const styles = theme => {
     /* Styles applied to the root element. */
     root: {
       // Mimics the default input display property used by browsers for an input.
-      fontFamily: theme.typography.fontFamily,
+      ...theme.typography.body1,
       color: theme.palette.text.primary,
-      fontSize: theme.typography.pxToRem(16),
       lineHeight: '1.1875em', // Reset (19px), match the native input line-height
       boxSizing: 'border-box', // Prevent padding issue with fullWidth.
       position: 'relative',

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -39,7 +39,7 @@ export const styles = theme => {
       textAlign: 'left',
       padding: 0,
       height: 11, // sync with `lineHeight` in `legend` styles
-      fontSize: '1.05rem',
+      fontSize: '0.75em',
       visibility: 'hidden',
       maxWidth: 0.01,
       transition: theme.transitions.create('max-width', {

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -39,7 +39,7 @@ export const styles = theme => {
       textAlign: 'left',
       padding: 0,
       height: 11, // sync with `lineHeight` in `legend` styles
-      fontSize: '0.75em',
+      fontSize: '1.05rem',
       visibility: 'hidden',
       maxWidth: 0.01,
       transition: theme.transitions.create('max-width', {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

It fixes #19409 PR, which introduced another bug with label notch.

![image](https://user-images.githubusercontent.com/404344/73746528-abe62380-4755-11ea-8206-a8cec4e72867.png)