### PR TITLE
[docs] Add blocks section to related-projects

### DIFF
--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -76,6 +76,10 @@ They support many different use cases (editable, filtering, grouping, sorting, s
 
 - [material-ui-confirm](https://github.com/jonatanklosko/material-ui-confirm): Provides easy to use confirmation dialogs to simplify confirming user actions without writing boilerplate code.
 
+### Molecules
+
+- [components-extra](https://github.com/alexandre-lelain/components-extra): Provides a set of "molecule" components built on top of Material-UI like a Footer, a CookiesBanner, a BackToTop button and other complex elements highly customizable to help devs build the macro parts of their UI very quickly. Those components are often duplicated across sites - this library solves this exact problem.
+
 ## Theming
 
 - [create-mui-theme](https://react-theming.github.io/create-mui-theme/): An online tool for creating Material-UI themes via Material Design Color Tool.

--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -76,7 +76,7 @@ They support many different use cases (editable, filtering, grouping, sorting, s
 
 - [material-ui-confirm](https://github.com/jonatanklosko/material-ui-confirm): Provides easy to use confirmation dialogs to simplify confirming user actions without writing boilerplate code.
 
-### Molecules
+### Blocks
 
 - [components-extra](https://github.com/alexandre-lelain/components-extra): Provides a set of "molecule" components built on top of Material-UI like a Footer, a CookiesBanner, a BackToTop button and other complex elements highly customizable to help devs build the macro parts of their UI very quickly. Those components are often duplicated across sites - this library solves this exact problem.
 

--- a/docs/src/pages/discover-more/related-projects/related-projects.md
+++ b/docs/src/pages/discover-more/related-projects/related-projects.md
@@ -76,7 +76,7 @@ They support many different use cases (editable, filtering, grouping, sorting, s
 
 - [material-ui-confirm](https://github.com/jonatanklosko/material-ui-confirm): Provides easy to use confirmation dialogs to simplify confirming user actions without writing boilerplate code.
 
-### Blocks
+## Blocks
 
 - [components-extra](https://github.com/alexandre-lelain/components-extra): Provides a set of "molecule" components built on top of Material-UI like a Footer, a CookiesBanner, a BackToTop button and other complex elements highly customizable to help devs build the macro parts of their UI very quickly. Those components are often duplicated across sites - this library solves this exact problem.
 


### PR DESCRIPTION
Hello,

**Big Thanks** to all contributors for this awesome library!

# What this PR does

It adds a section `Molecules` to the `related-projects` page of the docs. It also adds one item redirecting to an open source library I built that provides a set of molecule components (like a Footer, a CookiesBanner and more) built on top of Material-UI.

# Disclaimer

I feel like [components-extra](https://components-extra.netlify.com/) solves a recurring problem (like code duplication) and as stated on Material-UI's related-projects page: *"Feel free to submit a pull request to add another project"*, I jumped on the occasion. I would totally understand if you don't find it suitable.
