### PR TITLE
[Tabs] Add missing updateScrollButtons type in TabActions

### DIFF
--- a/packages/material-ui/src/Tabs/Tabs.d.ts
+++ b/packages/material-ui/src/Tabs/Tabs.d.ts
@@ -37,6 +37,7 @@ export type TabsClassKey =
 
 export interface TabsActions {
   updateIndicator(): void;
+  updateScrollButtons(): void;
 }
 
 export type TabsProps<


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
