### PR TITLE
[docs] Add links to sandbox option in examples readme files

### DIFF
--- a/examples/create-react-app-with-typescript/README.md
+++ b/examples/create-react-app-with-typescript/README.md
@@ -16,6 +16,10 @@ npm install
 npm start
 ```
 
+or:
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app-with-typescript)
+
 ## The idea behind the example
 
 This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app) with [TypeScript](https://github.com/Microsoft/TypeScript).

--- a/examples/create-react-app/README.md
+++ b/examples/create-react-app/README.md
@@ -16,6 +16,10 @@ npm install
 npm start
 ```
 
+or:
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/create-react-app)
+
 ## The idea behind the example
 
 This example demonstrates how you can use [Create React App](https://github.com/facebookincubator/create-react-app).

--- a/examples/gatsby-theme/README.md
+++ b/examples/gatsby-theme/README.md
@@ -16,6 +16,10 @@ npm install
 npm run develop
 ```
 
+or:
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/gatsby-theme)
+
 ## The idea behind the example
 
 The is an alternative example to [`/examples/gatsby`](https://github.com/mui-org/material-ui/tree/master/examples/gatsby) leveraging [gatsby-theme-material-ui](https://github.com/hupe1980/gatsby-theme-material-ui/tree/master/packages/gatsby-theme-material-ui).

--- a/examples/gatsby/README.md
+++ b/examples/gatsby/README.md
@@ -16,6 +16,10 @@ npm install
 npm run develop
 ```
 
+or:
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/gatsby)
+
 ## The idea behind the example
 
 [Gatsby](https://github.com/gatsbyjs/gatsby) is a static site generator for React.

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -23,6 +23,10 @@ yarn
 yarn dev
 ```
 
+or:
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/nextjs-with-typescript)
+
 ## The idea behind the example
 
 [Next.js](https://github.com/zeit/next.js) is a framework for server-rendered React apps.

--- a/examples/nextjs-with-typescript/README.md
+++ b/examples/nextjs-with-typescript/README.md
@@ -16,13 +16,6 @@ npm install
 npm run dev
 ```
 
-or
-
-```sh
-yarn
-yarn dev
-```
-
 or:
 
 [![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/nextjs-with-typescript)

--- a/examples/nextjs/README.md
+++ b/examples/nextjs/README.md
@@ -16,6 +16,10 @@ npm install
 npm run dev
 ```
 
+or:
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/nextjs)
+
 ## The idea behind the example
 
 [Next.js](https://github.com/zeit/next.js) is a framework for server-rendered React apps.

--- a/examples/ssr/README.md
+++ b/examples/ssr/README.md
@@ -15,6 +15,9 @@ Install it and run:
 npm install
 npm run start
 ```
+or:
+
+[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/mui-org/material-ui/tree/master/examples/ssr)
 
 ## The idea behind the example
 


### PR DESCRIPTION
Most of the examples linked from getting-started/example-projects can be run on CodeSandbox. This PR adds links to the readme files using their import repo feature so folks can edit the project on CodeSandbox without local setup.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
