### PR TITLE
[MobileStepper] Fix TypeScript props not aligning with prop-types

### DIFF
--- a/packages/material-ui/src/MobileStepper/MobileStepper.d.ts
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.d.ts
@@ -6,9 +6,9 @@ import { LinearProgressProps } from '../LinearProgress';
 export interface MobileStepperProps
   extends StandardProps<PaperProps, MobileStepperClassKey, 'variant'> {
   activeStep?: number;
-  backButton: React.ReactElement;
+  backButton: React.ReactNode;
   LinearProgressProps?: Partial<LinearProgressProps>;
-  nextButton: React.ReactElement;
+  nextButton: React.ReactNode;
   position?: 'bottom' | 'top' | 'static';
   steps: number;
   variant?: 'text' | 'dots' | 'progress';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
- [x] If TypeScript declarations were changed, yarn typescript passed.

