### PR TITLE
Adding post-update to gatsby and next.js examples to resolve CodeSandbox import issue

### DIFF
--- a/examples/gatsby/package.json
+++ b/examples/gatsby/package.json
@@ -14,6 +14,7 @@
   "scripts": {
     "develop": "gatsby develop",
     "build": "gatsby build",
-    "serve": "gatsby serve"
+    "serve": "gatsby serve",
+    "post-update": "yarn upgrade --latest"
   }
 }

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "dev": "next",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "post-update": "yarn upgrade --latest"
   }
 }


### PR DESCRIPTION
The gatsby and next.js examples linked in https://github.com/mui-org/material-ui/pull/19592/commits/eef5744a0e7f6d0cd1756355fa054f63d424bfc1 don't work when imported to CodeSandbox. This PR adds a post-update for yarn, which makes them work.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
