### PR TITLE
[ButtonBase] Fix when changing enableRipple prop from false to true 

### DIFF
--- a/docs/pages/api/no-ssr.md
+++ b/docs/pages/api/no-ssr.md
@@ -30,7 +30,7 @@ This component can be useful in a variety of situations:
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">node</span> |  | You can wrap a node. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | You can wrap a node. |
 | <span class="prop-name">defer</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will not only prevent server-side rendering. It will also defer the rendering of the children into a different screen frame. |
 | <span class="prop-name">fallback</span> | <span class="prop-type">node</span> | <span class="prop-default">null</span> | The fallback content to display. |
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -111,7 +111,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
   );
 
   React.useEffect(() => {
-    if (focusVisible && focusRipple && !disableRipple) {
+    if (rippleRef.current && focusVisible && focusRipple && !disableRipple) {
       rippleRef.current.pulsate();
     }
   }, [disableRipple, focusRipple, focusVisible]);

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -303,10 +303,10 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     >
       {children}
       <NoSsr>
-        {!disableRipple && !disabled && (
+        {!disableRipple && !disabled ? (
           /* TouchRipple is only needed client-side, x2 boost on the server. */
           <TouchRipple ref={rippleRef} center={centerRipple} {...TouchRippleProps} />
-        )}
+        ) : null}
       </NoSsr>
     </ComponentProp>
   );

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -111,7 +111,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
   );
 
   React.useEffect(() => {
-    if (rippleRef.current && focusVisible && focusRipple && !disableRipple) {
+    if (focusVisible && focusRipple && !disableRipple) {
       rippleRef.current.pulsate();
     }
   }, [disableRipple, focusRipple, focusVisible]);
@@ -302,12 +302,12 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
       {...other}
     >
       {children}
-      {!disableRipple && !disabled ? (
-        <NoSsr>
-          {/* TouchRipple is only needed client-side, x2 boost on the server. */}
+      <NoSsr>
+        {!disableRipple && !disabled && (
+          /* TouchRipple is only needed client-side, x2 boost on the server. */
           <TouchRipple ref={rippleRef} center={centerRipple} {...TouchRippleProps} />
-        </NoSsr>
-      ) : null}
+        )}
+      </NoSsr>
     </ComponentProp>
   );
 });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -385,7 +385,7 @@ describe('<ButtonBase />', () => {
             if (buttonRef.current) {
               buttonRef.current.focusVisible();
             } else {
-              throw new Error("buttonRef.current must be available")
+              throw new Error('buttonRef.current must be available');
             }
           }, []);
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -377,12 +377,14 @@ describe('<ButtonBase />', () => {
 
       it('should not crash when changes enableRipple from false to true', () => {
         function App() {
-          const buttonRef = React.useRef();
+          /** @type {React.MutableRefObject<import('./ButtonBase').ButtonBaseActions | null)> | null} */
+          const buttonRef = React.useRef(null);
           const [enableRipple, setRipple] = React.useState(false);
 
           React.useEffect(() => {
-            // @ts-ignore
-            buttonRef.current.focusVisible();
+            if (buttonRef.current) {
+              buttonRef.current.focusVisible();
+            }
           }, []);
 
           return (
@@ -398,7 +400,6 @@ describe('<ButtonBase />', () => {
               </button>
               <ButtonBase
                 autoFocus
-                // @ts-ignore
                 action={buttonRef}
                 TouchRippleProps={{
                   classes: {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -374,6 +374,46 @@ describe('<ButtonBase />', () => {
           button.querySelectorAll('.ripple-visible .child:not(.child-leaving)'),
         ).to.have.lengthOf(0);
       });
+
+      it('should not crash when changes enableRipple from false to true', () => {
+        function App() {
+          const [enableRipple, setRipple] = React.useState(false);
+
+          return (
+            <div>
+              <button
+                type="button"
+                data-testid="trigger"
+                onClick={() => {
+                  setRipple(true);
+                }}
+              >
+                Trigger crash
+              </button>
+              <ButtonBase
+                autoFocus
+                TouchRippleProps={{
+                  classes: {
+                    ripplePulsate: 'ripple-pulsate',
+                  },
+                }}
+                focusRipple
+                disableRipple={!enableRipple}
+              >
+                1
+              </ButtonBase>
+              <ButtonBase autoFocus focusRipple>
+                2
+              </ButtonBase>
+            </div>
+          );
+        }
+
+        const { container, getByTestId } = render(<App />);
+
+        fireEvent.click(getByTestId('trigger'));
+        expect(container.querySelectorAll('.ripple-pulsate')).to.have.lengthOf(1);
+      });
     });
   });
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -384,6 +384,8 @@ describe('<ButtonBase />', () => {
           React.useEffect(() => {
             if (buttonRef.current) {
               buttonRef.current.focusVisible();
+            } else {
+              throw new Error("buttonRef.current must be available")
             }
           }, []);
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -377,7 +377,12 @@ describe('<ButtonBase />', () => {
 
       it('should not crash when changes enableRipple from false to true', () => {
         function App() {
+          const buttonRef = React.useRef();
           const [enableRipple, setRipple] = React.useState(false);
+
+          React.useEffect(() => {
+            buttonRef.current.focusVisible();
+          }, []);
 
           return (
             <div>
@@ -392,6 +397,7 @@ describe('<ButtonBase />', () => {
               </button>
               <ButtonBase
                 autoFocus
+                action={buttonRef}
                 TouchRippleProps={{
                   classes: {
                     ripplePulsate: 'ripple-pulsate',
@@ -400,10 +406,7 @@ describe('<ButtonBase />', () => {
                 focusRipple
                 disableRipple={!enableRipple}
               >
-                1
-              </ButtonBase>
-              <ButtonBase autoFocus focusRipple>
-                2
+                the button
               </ButtonBase>
             </div>
           );

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -382,7 +382,7 @@ describe('<ButtonBase />', () => {
 
           React.useEffect(() => {
             // @ts-ignore
-            buttonRef.current.focusVisible()
+            buttonRef.current.focusVisible();
           }, []);
 
           return (
@@ -398,7 +398,7 @@ describe('<ButtonBase />', () => {
               </button>
               <ButtonBase
                 autoFocus
-                 // @ts-ignore
+                // @ts-ignore
                 action={buttonRef}
                 TouchRippleProps={{
                   classes: {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -377,7 +377,7 @@ describe('<ButtonBase />', () => {
 
       it('should not crash when changes enableRipple from false to true', () => {
         function App() {
-          /** @type {React.MutableRefObject<import('./ButtonBase').ButtonBaseActions | null)> | null} */
+          /** @type {React.MutableRefObject<import('./ButtonBase').ButtonBaseActions | null>} */
           const buttonRef = React.useRef(null);
           const [enableRipple, setRipple] = React.useState(false);
 

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -381,7 +381,8 @@ describe('<ButtonBase />', () => {
           const [enableRipple, setRipple] = React.useState(false);
 
           React.useEffect(() => {
-            buttonRef.current.focusVisible();
+            // @ts-ignore
+            buttonRef.current.focusVisible()
           }, []);
 
           return (
@@ -397,6 +398,7 @@ describe('<ButtonBase />', () => {
               </button>
               <ButtonBase
                 autoFocus
+                 // @ts-ignore
                 action={buttonRef}
                 TouchRippleProps={{
                   classes: {

--- a/packages/material-ui/src/NoSsr/NoSsr.d.ts
+++ b/packages/material-ui/src/NoSsr/NoSsr.d.ts
@@ -1,7 +1,7 @@
 import * as React from 'react';
 
 export interface NoSsrProps {
-  children: React.ReactNode;
+  children?: React.ReactNode;
   defer?: boolean;
   fallback?: React.ReactNode;
 }

--- a/packages/material-ui/src/NoSsr/NoSsr.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.js
@@ -40,7 +40,7 @@ NoSsr.propTypes = {
   /**
    * You can wrap a node.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * If `true`, the component will not only prevent server-side rendering.
    * It will also defer the rendering of the children into a different screen frame.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixing crash if ref.current is null. We always need to check that `ref.current` is available before use

Reproduce the crash: 
1. Visit https://material-ui-pickers-git-feature-accessibility.mui-org.now.sh/demo/datepicker#responsiveness
2. In the 3d dropdown select a year in the past (2000)
3. Try to open second with only keyboard (tab and space on the calendar button)
4. Observe the exception
