### PR TITLE
[docs] Revert sidebar scrolling

### DIFF
--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -30,7 +30,7 @@ function PersistScroll(props) {
 
     const activeBox = activeElement.getBoundingClientRect();
 
-    if (savedScrollTop === null || activeBox.top < savedScrollTop) {
+    if (savedScrollTop === null || activeBox.top - savedScrollTop < 0) {
       // Center the selected item in the list container.
       activeElement.scrollIntoView();
       // Fix a Chrome issue, reset the tabbable ring back to the top of the document.

--- a/docs/src/modules/components/AppDrawer.js
+++ b/docs/src/modules/components/AppDrawer.js
@@ -30,7 +30,7 @@ function PersistScroll(props) {
 
     const activeBox = activeElement.getBoundingClientRect();
 
-    if (savedScrollTop !== null || activeBox.top < savedScrollTop) {
+    if (savedScrollTop === null || activeBox.top < savedScrollTop) {
       // Center the selected item in the list container.
       activeElement.scrollIntoView();
       // Fix a Chrome issue, reset the tabbable ring back to the top of the document.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

I noticed that anytime you clicked a link in the sidebar in docs that item would scroll to the very top. It mad it hard to navigate. I think at some point there was a regression that flipped this conditional and it seems to fix the behavior but maybe there was a reason for doing it. The PR that swapped the conditional is here #18395. 