### PR TITLE
[system] Add boxSizing to sizing styled system

### DIFF
--- a/docs/src/pages/system/api/api.md
+++ b/docs/src/pages/system/api/api.md
@@ -38,6 +38,7 @@
 | [sizing](/system/sizing/) | `minHeight` | `minHeight`| `min-height` | none |
 | [sizing](/system/sizing/) | `minWidth` | `minWidth` | `min-width` | none |
 | [sizing](/system/sizing/) | `width` | `width` | `width` | none |
+| [sizing](/system/sizing/) | `boxSizing` | `boxSizing` | `box-sizing` | none |
 | [spacing](/system/spacing/) | `spacing` | `m` | `margin` | [`spacing`](/customization/default-theme/?expand-path=$.spacing) |
 | [spacing](/system/spacing/) | `spacing` | `mb` | `margin-bottom` | [`spacing`](/customization/default-theme/?expand-path=$.spacing) |
 | [spacing](/system/spacing/) | `spacing` | `ml` | `margin-left` | [`spacing`](/customization/default-theme/?expand-path=$.spacing) |

--- a/docs/src/pages/system/sizing/sizing.md
+++ b/docs/src/pages/system/sizing/sizing.md
@@ -52,3 +52,4 @@ import { sizing } from '@material-ui/system';
 | `height` | `height` | `height` | none |
 | `maxHeight` | `maxHeight`| `max-height` | none |
 | `minHeight` | `minHeight`| `min-height` | none |
+| `boxSizing` | `boxSizing`| `box-sizing` | none |

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -122,6 +122,7 @@ export const maxHeight: SimpleStyleFunction<'maxHeight'>;
 export const minHeight: SimpleStyleFunction<'minHeight'>;
 export const sizeWidth: SimpleStyleFunction<'sizeWidth'>;
 export const sizeHeight: SimpleStyleFunction<'sizeHeight'>;
+export const boxSizing: SimpleStyleFunction<'boxSizing'>;
 export const sizing: SimpleStyleFunction<
   | 'width'
   | 'maxWidth'
@@ -131,6 +132,7 @@ export const sizing: SimpleStyleFunction<
   | 'minHeight'
   | 'sizeWidth'
   | 'sizeHeight'
+  | 'boxSizing'
 >;
 export type SizingProps = PropsFor<typeof sizing>;
 

--- a/packages/material-ui-system/src/sizing.js
+++ b/packages/material-ui-system/src/sizing.js
@@ -47,6 +47,10 @@ export const sizeHeight = style({
   transform,
 });
 
+export const boxSizing = style({
+  prop: 'boxSizing',
+});
+
 const sizing = compose(
   width,
   maxWidth,
@@ -54,6 +58,7 @@ const sizing = compose(
   height,
   maxHeight,
   minHeight,
+  boxSizing,
 );
 
 export default sizing;


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
 
This PR would make the css property `box-sizing` part of the `syzing` system.
This would allow users to customize the box model of their components more easily, turning this:
```jsx
import styled from 'styled-components';
import { style } from '@material-ui/system';
import MuiBox from '@material-ui/core/Box';

const boxSizing = style({
  prop: 'boxSizing',
});

const Box = styled(MuiBox)`
  ${boxSizing}
`;

const MyActualComponent = ({ ...props }) => (
  <Box
    boxSizing="border-box"
    display="inline-flex"
    px={1}
    minWidth='18px'
    minHeight='18px'
    {...props}
  />
);

export default MyActualComponent;
```
into this:
```jsx
import Box from '@material-ui/core/Box';

const MyActualComponent = ({ ...props }) => (
  <Box
    boxSizing="border-box"
    display="inline-flex"
    px={1}
    minWidth='18px'
    minHeight='18px'
    {...props}
  />
);

export default MyActualComponent;
```