### PR TITLE
[docs] List default attributes first

### DIFF
--- a/docs/src/pages/system/borders/BorderSubtractive.js
+++ b/docs/src/pages/system/borders/BorderSubtractive.js
@@ -12,11 +12,11 @@ const defaultProps = {
 export default function BorderSubtractive() {
   return (
     <Box display="flex" justifyContent="center">
-      <Box border={0} {...defaultProps} />
-      <Box borderTop={0} {...defaultProps} />
-      <Box borderRight={0} {...defaultProps} />
-      <Box borderBottom={0} {...defaultProps} />
-      <Box borderLeft={0} {...defaultProps} />
+      <Box {...defaultProps} border={0} />
+      <Box {...defaultProps} borderTop={0} />
+      <Box {...defaultProps} borderRight={0} />
+      <Box {...defaultProps} borderBottom={0} />
+      <Box {...defaultProps} borderLeft={0} />
     </Box>
   );
 }

--- a/docs/src/pages/system/borders/BorderSubtractive.tsx
+++ b/docs/src/pages/system/borders/BorderSubtractive.tsx
@@ -12,11 +12,11 @@ const defaultProps = {
 export default function BorderSubtractive() {
   return (
     <Box display="flex" justifyContent="center">
-      <Box border={0} {...defaultProps} />
-      <Box borderTop={0} {...defaultProps} />
-      <Box borderRight={0} {...defaultProps} />
-      <Box borderBottom={0} {...defaultProps} />
-      <Box borderLeft={0} {...defaultProps} />
+      <Box {...defaultProps} border={0} />
+      <Box {...defaultProps} borderTop={0} />
+      <Box {...defaultProps} borderRight={0} />
+      <Box {...defaultProps} borderBottom={0} />
+      <Box {...defaultProps} borderLeft={0} />
     </Box>
   );
 }


### PR DESCRIPTION
The last copy of each attribute wins, so the defaults should go before the explicit values, rather than after.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Caught with TS nightly.
