### PR TITLE
[docs] Fix missing import in auto-dark theme palette example

### DIFF
--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -146,7 +146,7 @@ For instance, you can enable the dark mode automatically:
 ```jsx
 import React from 'react';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
-import { ThemeProvider } from '@material-ui/core/styles';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 
 function App() {
   const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');


### PR DESCRIPTION
While going through the example on how to configure dark theme automatically for the MUI theme, I found a slight issue in the provided example.  A required import for `createMuiTheme` was excluded.  This PR quickly fixes this issue by adding the import.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
