### PR TITLE
[docs] Fix typo in sticky footer template

### DIFF
--- a/docs/src/pages/getting-started/templates/sticky-footer/README.md
+++ b/docs/src/pages/getting-started/templates/sticky-footer/README.md
@@ -2,4 +2,4 @@
 
 ## Usage
 
-Simply copy the files into your project, or one of the [example applications](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `StickFooter` component.
+Simply copy the files into your project, or one of the [example applications](https://github.com/mui-org/material-ui/tree/master/examples), and import and use the `StickyFooter` component.


### PR DESCRIPTION
`StickFooter` → `StickyFooter`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
