### PR TITLE
[Autocomplete] Warn when using wrong getOptionSelected

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -736,6 +736,36 @@ describe('<Autocomplete />', () => {
         'For the input option: "a", `getOptionLabel` returns: undefined',
       );
     });
+
+    it('warn if getOptionSelected match multiple values for a given option', () => {
+      const value = [{ id: '10', text: 'One' }, { id: '20', text: 'Two' }];
+      const options = [
+        { id: '10', text: 'One' },
+        { id: '20', text: 'Two' },
+        { id: '30', text: 'Three' },
+      ];
+
+      render(
+        <Autocomplete
+          {...defaultProps}
+          multiple
+          options={options}
+          value={value}
+          getOptionLabel={option => option.text}
+          getOptionSelected={option => value.find(v => v.id === option.id)}
+          renderInput={params => <TextField {...params} autoFocus />}
+        />,
+      );
+
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+      fireEvent.keyDown(document.activeElement, { key: 'Enter' });
+
+      expect(consoleErrorMock.callCount()).to.equal(1); // strict mode renders twice
+      expect(consoleErrorMock.args()[0][0]).to.include(
+        'The component expects a single value to match a given option but found 2 matches.',
+      );
+    });
   });
 
   describe('prop: options', () => {

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -446,7 +446,7 @@ export default function useAutocomplete(props) {
           console.error(
             [
               'Material-UI: the `getOptionSelected` method of useAutocomplete do not handle the arguments correctly.',
-              `The component expects a single value to match a given option but found ${matches}.`,
+              `The component expects a single value to match a given option but found ${matches.length} matches`,
             ].join('\n'),
           );
         }

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -446,7 +446,9 @@ export default function useAutocomplete(props) {
           console.error(
             [
               'Material-UI: the `getOptionSelected` method of useAutocomplete do not handle the arguments correctly.',
-              `The component expects a single value to match a given option but found ${matches.length} matches`,
+              `The component expects a single value to match a given option but found ${
+                matches.length
+              } matches.`,
             ].join('\n'),
           );
         }

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -439,6 +439,19 @@ export default function useAutocomplete(props) {
       const item = newValue;
       newValue = Array.isArray(value) ? [...value] : [];
 
+      if (process.env.NODE_ENV !== 'production') {
+        const matches = newValue.filter(val => getOptionSelected(item, val));
+
+        if (matches.length > 1) {
+          console.error(
+            [
+              'Material-UI: the `getOptionSelected` method of useAutocomplete do not handle the arguments correctly.',
+              `The component expects a single value to match a given option but found ${matches}.`,
+            ].join('\n'),
+          );
+        }
+      }
+
       const itemIndex = findIndex(newValue, valueItem => getOptionSelected(item, valueItem));
 
       if (itemIndex === -1) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Close #19595 

I followed what suggested in the issue, but i suggest to change the props `getOptionSelected` to be more precise. It can be as what suggested by @oliviertassinari like `optionEqualValue`, or my recommendation is `getSelectedOption`. but it's up to you guys (actually i had a little hard time thinking what this props does, but i don't know if it's will become a breaking change 🤔 )

i used array filter here. it does support all kinds of browsers except IE 6-8 based on [this report](https://caniuse.com/#feat=mdn-javascript_builtins_array_filter)

Have a nice day 😄 
