### PR TITLE
[TextareaAutosize] Prevent "Maximum update depth exceeded"

### DIFF
--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -72,7 +72,8 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
 
     // Take the box sizing into account for applying this value as a style.
     const outerHeightStyle = outerHeight + (boxSizing === 'border-box' ? padding + border : 0);
-    const overflow = Math.abs(outerHeight - innerHeight) <= 1;
+    const diff = Math.abs(outerHeight - innerHeight);
+    const overflow = diff <= 1 || diff === innerHeight;
 
     setState(prevState => {
       // Need a large enough difference to update the height.
@@ -106,7 +107,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
 
   useEnhancedEffect(() => {
     syncHeight();
-  }, []);
+  });
 
   const handleChange = event => {
     if (!isControlled) {

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -75,7 +75,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
     const overflow = Math.abs(outerHeight - innerHeight) <= 1;
 
     setState(prevState => {
-      // Need a large enough different to update the height.
+      // Need a large enough difference to update the height.
       // This prevents infinite rendering loop.
       if (
         (outerHeightStyle > 0 &&
@@ -106,7 +106,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
 
   useEnhancedEffect(() => {
     syncHeight();
-  });
+  }, []);
 
   const handleChange = event => {
     if (!isControlled) {
@@ -128,7 +128,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
         rows={rowsMin}
         style={{
           height: state.outerHeightStyle,
-          // Need a large enough different to allow scrolling.
+          // Need a large enough difference to allow scrolling.
           // This prevents infinite rendering loop.
           overflow: state.overflow ? 'hidden' : null,
           ...style,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Hi, 

This is a fix for [this issue](https://github.com/mui-org/material-ui/issues/17672). It seems that adding an empty array of dependencies to useEnhancedEffect fixes it. 
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #17672