### PR TITLE
[AvatarGroup] Add spacing prop

### DIFF
--- a/docs/pages/api/avatar-group.md
+++ b/docs/pages/api/avatar-group.md
@@ -26,6 +26,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The avatars to stack. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">spacing</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large</span> |  | Defines the spacing between `avatar` as `'large': -4px`, `'medium': -8px`, and `'small': -16px`. |
+
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api/avatar-group.md
+++ b/docs/pages/api/avatar-group.md
@@ -26,7 +26,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The avatars to stack. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">spacing</span> | <span class="prop-type">'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;number</span> | <span class="prop-default">'medium'</span> | Spacing between avatars. |
+| <span class="prop-name">spacing</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;number</span> | <span class="prop-default">'medium'</span> | Spacing between avatars. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api/avatar-group.md
+++ b/docs/pages/api/avatar-group.md
@@ -26,8 +26,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The avatars to stack. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">spacing</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;number</span> |  | Defines the spacing between `avatar` as `'large': -4px`, `'medium': -8px`, and `'small': -16px` or define a `number` as the spacing. |
-
+| <span class="prop-name">spacing</span> | <span class="prop-type">'large'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;number</span> | <span class="prop-default">'medium'</span> | Spacing between avatars. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api/avatar-group.md
+++ b/docs/pages/api/avatar-group.md
@@ -26,7 +26,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The avatars to stack. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">spacing</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large</span> |  | Defines the spacing between `avatar` as `'large': -4px`, `'medium': -8px`, and `'small': -16px`. |
+| <span class="prop-name">spacing</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'<br>&#124;&nbsp;'large'<br>&#124;&nbsp;number</span> |  | Defines the spacing between `avatar` as `'large': -4px`, `'medium': -8px`, and `'small': -16px` or define a `number` as the spacing. |
 
 
 The `ref` is forwarded to the root element.

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
@@ -15,4 +15,4 @@ export interface AvatarGroupProps
 
 export type AvatarGroupClassKey = 'root' | 'avatar';
 
-export default function AvatarGroup(props: AvatarGroupProps): JSX.Element | null;
+export default function AvatarGroup(props: AvatarGroupProps): JSX.Element;

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
@@ -8,9 +8,9 @@ export interface AvatarGroupProps
    */
   children: React.ReactNode;
   /**
-   * Spacing between avatars
+   * Spacing between avatars.
    */
-  spacing?: 'small' | 'medium' | 'large';
+  spacing?: 'small' | 'medium' | 'large' | number;
 }
 
 export type AvatarGroupClassKey = 'root' | 'avatar';

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
@@ -10,7 +10,7 @@ export interface AvatarGroupProps
   /**
    * Spacing between avatars.
    */
-  spacing?: 'small' | 'medium' | 'large' | number;
+  spacing?: 'small' | 'medium' | number;
 }
 
 export type AvatarGroupClassKey = 'root' | 'avatar';

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
@@ -7,6 +7,10 @@ export interface AvatarGroupProps
    * The avatars to stack.
    */
   children: React.ReactNode;
+  /**
+   * Spacing between avatars
+   */
+  spacing?: 'small' | 'medium' | 'large';
 }
 
 export type AvatarGroupClassKey = 'root' | 'avatar';

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -45,7 +45,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           className: clsx(child.props.className, classes.avatar),
           style: {
             zIndex: children.length - index,
-            marginLeft: spacing && SPACINGS[spacing] ? SPACINGS[spacing] : spacing,
+            marginLeft: spacing ? (SPACINGS[spacing] ? SPACINGS[spacing] : spacing) : -8,
             ...child.props.style,
           },
         });

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -69,12 +69,9 @@ AvatarGroup.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * Defines the space between the type `avatar` component.
+   * Spacing between avatars.
    */
-  spacing:  PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.number,
-  ]),
+  spacing: PropTypes.oneOfType([PropTypes.oneOf(['large', 'medium', 'small']), PropTypes.number]),
   /**
    * @ignore
    */

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -41,7 +41,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           className: clsx(child.props.className, classes.avatar),
           style: {
             zIndex: children.length - index,
-            marginLeft: spacing && SPACINGS[spacing] ? SPACINGS[spacing] : -8,
+            marginLeft: spacing && SPACINGS[spacing] ? SPACINGS[spacing] : spacing,
             ...child.props.style,
           },
         });
@@ -67,7 +67,10 @@ AvatarGroup.propTypes = {
   /**
    * Defines the space between the type `avatar` component.
    */
-  spacing: PropTypes.oneOf(SPACINGS),
+  spacing:  PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+  ]),
   /**
    * @ignore
    */

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -5,8 +5,8 @@ import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 
 const SPACINGS = {
-  large: -4,
   small: -16,
+  medium: null,
 };
 
 export const styles = theme => ({
@@ -46,7 +46,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           className: clsx(child.props.className, classes.avatar),
           style: {
             zIndex: children.length - index,
-            marginLeft: spacing && SPACINGS[spacing] ? SPACINGS[spacing] : -spacing,
+            marginLeft: spacing && SPACINGS[spacing] !== undefined ? SPACINGS[spacing] : -spacing,
             ...child.props.style,
           },
         });
@@ -76,7 +76,7 @@ AvatarGroup.propTypes = {
   /**
    * Spacing between avatars.
    */
-  spacing: PropTypes.oneOfType([PropTypes.oneOf(['large', 'medium', 'small']), PropTypes.number]),
+  spacing: PropTypes.oneOfType([PropTypes.oneOf(['medium', 'small']), PropTypes.number]),
 };
 
 export default withStyles(styles, { name: 'MuiAvatarGroup' })(AvatarGroup);

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -4,6 +4,8 @@ import { isFragment } from 'react-is';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 
+const SPACINGS = {"large":-4, "medium":-8, "small":-16};
+
 export const styles = theme => ({
   /* Styles applied to the root element. */
   root: {
@@ -12,13 +14,11 @@ export const styles = theme => ({
   /* Styles applied to the avatar elements. */
   avatar: {
     border: `2px solid ${theme.palette.background.default}`,
-    marginLeft: -8,
   },
 });
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
-  const { children: childrenProp, classes, className, ...other } = props;
-
+  const { children: childrenProp, classes, className, spacing, ...other } = props;
   const children = React.Children.toArray(childrenProp).filter(child => {
     if (process.env.NODE_ENV !== 'production') {
       if (isFragment(child)) {
@@ -41,6 +41,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           className: clsx(child.props.className, classes.avatar),
           style: {
             zIndex: children.length - index,
+            marginLeft: spacing && SPACINGS[spacing] ? SPACINGS[spacing] : -8,
             ...child.props.style,
           },
         });
@@ -63,6 +64,10 @@ AvatarGroup.propTypes = {
    * See [CSS API](#css) below for more details.
    */
   classes: PropTypes.object,
+  /**
+   * Defines the space between the type `avatar` component.
+   */
+  spacing: PropTypes.oneOf(SPACINGS),
   /**
    * @ignore
    */

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -5,9 +5,8 @@ import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 
 const SPACINGS = {
-  large: -4, 
-  medium: -8, 
-  small: -16
+  large: -4,
+  small: -16,
 };
 
 export const styles = theme => ({
@@ -18,11 +17,13 @@ export const styles = theme => ({
   /* Styles applied to the avatar elements. */
   avatar: {
     border: `2px solid ${theme.palette.background.default}`,
+    marginLeft: -8,
   },
 });
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
-  const { children: childrenProp, classes, className, spacing, ...other } = props;
+  const { children: childrenProp, classes, className, spacing = 'medium', ...other } = props;
+
   const children = React.Children.toArray(childrenProp).filter(child => {
     if (process.env.NODE_ENV !== 'production') {
       if (isFragment(child)) {
@@ -45,7 +46,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           className: clsx(child.props.className, classes.avatar),
           style: {
             zIndex: children.length - index,
-            marginLeft: spacing ? (SPACINGS[spacing] ? SPACINGS[spacing] : spacing) : -8,
+            marginLeft: spacing && SPACINGS[spacing] ? SPACINGS[spacing] : -spacing,
             ...child.props.style,
           },
         });
@@ -69,13 +70,13 @@ AvatarGroup.propTypes = {
    */
   classes: PropTypes.object,
   /**
-   * Spacing between avatars.
-   */
-  spacing: PropTypes.oneOfType([PropTypes.oneOf(['large', 'medium', 'small']), PropTypes.number]),
-  /**
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * Spacing between avatars.
+   */
+  spacing: PropTypes.oneOfType([PropTypes.oneOf(['large', 'medium', 'small']), PropTypes.number]),
 };
 
 export default withStyles(styles, { name: 'MuiAvatarGroup' })(AvatarGroup);

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -4,7 +4,11 @@ import { isFragment } from 'react-is';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 
-const SPACINGS = {'large': -4, 'medium': -8, 'small': -16};
+const SPACINGS = {
+  large: -4, 
+  medium: -8, 
+  small: -16
+};
 
 export const styles = theme => ({
   /* Styles applied to the root element. */

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -4,7 +4,7 @@ import { isFragment } from 'react-is';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
 
-const SPACINGS = {"large":-4, "medium":-8, "small":-16};
+const SPACINGS = {'large': -4, 'medium': -8, 'small': -16};
 
 export const styles = theme => ({
   /* Styles applied to the root element. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This corresponds to [issue:18869](https://github.com/mui-org/material-ui/issues/18869) with the enhancement of adding a spacing prop to the AvatarGroup lab component.

Add spacing prop with following options:

- `'small': -16`
- `'medium': -8`
- `'large': -4`

This should allow the users to manipulate the spacing between avatars without directly requiring more css changes. This PR adds this functionality.

e.g.
```jsx
<AvatarGroup spacing="large">
  <Avatar></Avatar>
  <Avatar></Avatar>
</AvatarGroup>
```

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
