### PR TITLE
[core] Export ThemeOptions

### DIFF
--- a/docs/src/pages/guides/typescript/typescript.md
+++ b/docs/src/pages/guides/typescript/typescript.md
@@ -242,8 +242,7 @@ And a custom theme factory with additional defaulted options:
 
 **./styles/createMyTheme**:
 ```ts
-import { createMuiTheme } from '@material-ui/core/styles';
-import { ThemeOptions } from '@material-ui/core/styles/createMuiTheme';
+import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';
 
 export default function createMyTheme(options: ThemeOptions) {
   return createMuiTheme({

--- a/packages/material-ui/src/styles/index.d.ts
+++ b/packages/material-ui/src/styles/index.d.ts
@@ -1,5 +1,5 @@
 export * from './colorManipulator';
-export { default as createMuiTheme, Theme, Direction } from './createMuiTheme';
+export { default as createMuiTheme, ThemeOptions, Theme, Direction } from './createMuiTheme';
 export {
   default as createPalette,
   PaletteColorOptions,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

I added export for `ThemeOptions.`
Like `import { createMuiTheme, ThemeOptions } from '@material-ui/core/styles';` and also changed the path in documentation. 

@oliviertassinari, let me know if something went wrong


- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).