### PR TITLE
[CardMedia] Fix propTypes to allow `component` prop

### DIFF
--- a/packages/material-ui/src/CardMedia/CardMedia.d.ts
+++ b/packages/material-ui/src/CardMedia/CardMedia.d.ts
@@ -5,7 +5,6 @@ export interface CardMediaTypeMap<P, D extends React.ElementType> {
   props: P & {
     image?: string;
     src?: string;
-    component?: string | React.Component
   };
   defaultComponent: D;
   classKey: CardMediaClassKey;

--- a/packages/material-ui/src/CardMedia/CardMedia.d.ts
+++ b/packages/material-ui/src/CardMedia/CardMedia.d.ts
@@ -5,6 +5,7 @@ export interface CardMediaTypeMap<P, D extends React.ElementType> {
   props: P & {
     image?: string;
     src?: string;
+    component?: string | React.Component
   };
   defaultComponent: D;
   classKey: CardMediaClassKey;

--- a/packages/material-ui/src/CardMedia/CardMedia.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.js
@@ -67,7 +67,9 @@ CardMedia.propTypes = {
    */
   children: chainPropTypes(PropTypes.node, props => {
     if (!props.children && !props.image && !props.src && !props.component) {
-      return new Error('Material-UI: either `children`, `image`, `src` or `component` prop must be specified.');
+      return new Error(
+        'Material-UI: either `children`, `image`, `src` or `component` prop must be specified.',
+      );
     }
     return null;
   }),

--- a/packages/material-ui/src/CardMedia/CardMedia.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.js
@@ -66,8 +66,8 @@ CardMedia.propTypes = {
    * The content of the component.
    */
   children: chainPropTypes(PropTypes.node, props => {
-    if (!props.children && !props.image && !props.src) {
-      return new Error('Material-UI: either `children`, `image` or `src` prop must be specified.');
+    if (!props.children && !props.image && !props.src && !props.component) {
+      return new Error('Material-UI: either `children`, `image`, `src` or `component` prop must be specified.');
     }
     return null;
   }),

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -91,13 +91,13 @@ describe('<CardMedia />', () => {
       PropTypes.resetWarningCache();
     });
 
-    it('warns when neither `children`, nor `image`, nor `src` are provided', () => {
+    it('warns when neither `children`, nor `image`, nor `src`, nor `component` are provided', () => {
       mount(<CardMedia />);
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
         consoleErrorMock.args()[0][0],
-        'Material-UI: either `children`, `image` or `src` prop must be specified.',
+        'Material-UI: either `children`, `image`, `src` or `component` prop must be specified.',
       );
     });
   });


### PR DESCRIPTION
- [X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

`CardMedia` already supports the `component` prop, however, console errors are generated when using it in development mode.  This change fixes that warning.