### PR TITLE
Remove duplicate <circle /> elements

### DIFF
--- a/packages/material-ui-icons/src/SentimentSatisfiedAlt.js
+++ b/packages/material-ui-icons/src/SentimentSatisfiedAlt.js
@@ -2,5 +2,5 @@ import React from 'react';
 import createSvgIcon from './utils/createSvgIcon';
 
 export default createSvgIcon(
-  <React.Fragment><circle cx="15.5" cy="9.5" r="1.5" /><circle cx="8.5" cy="9.5" r="1.5" /><circle cx="15.5" cy="9.5" r="1.5" /><circle cx="8.5" cy="9.5" r="1.5" /><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-2.5c2.33 0 4.32-1.45 5.12-3.5h-1.67c-.69 1.19-1.97 2-3.45 2s-2.75-.81-3.45-2H6.88c.8 2.05 2.79 3.5 5.12 3.5z" /></React.Fragment>
+  <React.Fragment><circle cx="8.5" cy="9.5" r="1.5" /><circle cx="15.5" cy="9.5" r="1.5" /><path d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-2.5c2.33 0 4.32-1.45 5.12-3.5h-1.67c-.69 1.19-1.97 2-3.45 2s-2.75-.81-3.45-2H6.88c.8 2.05 2.79 3.5 5.12 3.5z" /></React.Fragment>
 , 'SentimentSatisfiedAlt');


### PR DESCRIPTION
I noticed when using the SentimentSatisfiedAlt Icon that the eyes were darker than they should be.

<img width="55" alt="Screen Shot 2020-02-21 at 8 46 04 PM" src="https://user-images.githubusercontent.com/924528/75023847-9b230500-54ec-11ea-8c35-bdab5e6639e0.png">

When looking at the SVG code there appears to be 2 sets of `<circle>` elements when there should only be 1.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
