### PR TITLE
[ci] fix heap out of memory in azure pipelines

### DIFF
--- a/scripts/sizeSnapshot/create.js
+++ b/scripts/sizeSnapshot/create.js
@@ -1,10 +1,11 @@
-const childProcess = require('child_process');
 const fse = require('fs-extra');
 const lodash = require('lodash');
 const path = require('path');
 const { promisify } = require('util');
+const webpackCallbackBased = require('webpack');
+const createWebpackConfig = require('./webpack.config');
 
-const exec = promisify(childProcess.exec);
+const webpack = promisify(webpackCallbackBased);
 
 const workspaceRoot = path.join(__dirname, '../../');
 const snapshotDestPath = path.join(workspaceRoot, 'size-snapshot.json');
@@ -33,11 +34,12 @@ async function getRollupSize(snapshotPath) {
 async function getWebpackSizes() {
   await fse.mkdirp(path.join(__dirname, 'build'));
 
-  const configPath = path.join(__dirname, 'webpack.config.js');
-  const statsPath = path.join(__dirname, 'build', 'stats.json');
-  await exec(`webpack --config ${configPath} --json > ${statsPath}`);
+  // webpack --config $configPath --json > $statsPath
+  // will create a 300MB big json file which sometimes requires up to 1.5GB
+  // memory. This will sometimes crash node in azure pipelines with "heap out of memory"
+  const webpackStats = await webpack(await createWebpackConfig(webpack));
+  const stats = webpackStats.toJson();
 
-  const stats = await fse.readJSON(statsPath);
   const assets = new Map(stats.assets.map(asset => [asset.name, asset]));
 
   return Object.entries(stats.assetsByChunkName).map(([chunkName, assetName]) => {


### PR DESCRIPTION
Fixes "heap out of memory" during `yarn size:snapshot` in the Azure pipelines. 