### PR TITLE
[Popover] Prevent recalculating contentAnchorOffset while is open

### DIFF
--- a/packages/material-ui/src/Popover/Popover.js
+++ b/packages/material-ui/src/Popover/Popover.js
@@ -173,9 +173,15 @@ const Popover = React.forwardRef(function Popover(props, ref) {
     [anchorEl, anchorOrigin.horizontal, anchorOrigin.vertical, anchorPosition, anchorReference],
   );
 
+  const cachedContentAnchorOffset = React.useRef(null);
+
   // Returns the vertical offset of inner content to anchor the transform on if provided
   const getContentAnchorOffset = React.useCallback(
     element => {
+      if (cachedContentAnchorOffset.current) {
+        return cachedContentAnchorOffset.current;
+      }
+
       let contentAnchorOffset = 0;
 
       if (getContentAnchorEl && anchorReference === 'anchorEl') {
@@ -203,7 +209,8 @@ const Popover = React.forwardRef(function Popover(props, ref) {
         }
       }
 
-      return contentAnchorOffset;
+      cachedContentAnchorOffset.current = contentAnchorOffset;
+      return cachedContentAnchorOffset.current;
     },
     [anchorOrigin.vertical, anchorReference, getContentAnchorEl],
   );
@@ -341,6 +348,8 @@ const Popover = React.forwardRef(function Popover(props, ref) {
   React.useEffect(() => {
     if (open) {
       setPositioningStyles();
+    } else {
+      cachedContentAnchorOffset.current = null;
     }
   });
 

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -900,6 +900,95 @@ describe('<Popover />', () => {
       assert.strictEqual(elementStyle.top, '157px');
       assert.strictEqual(elementStyle.left, '160px');
     });
+
+    it('should not change position when scrolling', () => {
+      const handleEntering = spy();
+      const divRef = React.createRef();
+      const getContentAnchorEl = () => {
+        Object.defineProperties(divRef.current, {
+          offsetTop: { value: 8, writable: true },
+          clientHeight: { value: 48 },
+          clientWidth: { value: 116 },
+        });
+        return divRef.current;
+      };
+
+      const wrapper = mount(
+        <Popover
+          anchorEl={mockedAnchorEl}
+          onEntering={handleEntering}
+          getContentAnchorEl={getContentAnchorEl}
+          open
+        >
+          <div ref={divRef} />
+        </Popover>,
+      );
+
+      const elementStyle = handleEntering.args[0][0].style;
+      const beforeStyle = {
+        top: elementStyle.top,
+        left: elementStyle.left,
+        transformOrigin: elementStyle.transformOrigin,
+      };
+      wrapper.setProps({
+        getContentAnchorEl: () => {
+          Object.defineProperty(divRef.current, 'offsetTop', { value: -80 });
+          return divRef.current;
+        },
+      });
+      const afterStyle = {
+        top: elementStyle.top,
+        left: elementStyle.left,
+        transformOrigin: elementStyle.transformOrigin,
+      };
+      expect(JSON.stringify(beforeStyle)).to.equal(JSON.stringify(afterStyle));
+    });
+
+    it('should not reuse the cached contentAnchorOffset when reopening', () => {
+      const handleEntering = spy();
+      const divRef = React.createRef();
+      const getContentAnchorEl = () => {
+        Object.defineProperties(divRef.current, {
+          offsetTop: { value: 8, writable: true },
+          clientHeight: { value: 48 },
+          clientWidth: { value: 116 },
+        });
+        return divRef.current;
+      };
+
+      const wrapper = mount(
+        <Popover
+          anchorEl={mockedAnchorEl}
+          onEntering={handleEntering}
+          getContentAnchorEl={getContentAnchorEl}
+          open
+        >
+          <div ref={divRef} />
+        </Popover>,
+      );
+
+      let elementStyle = handleEntering.args[0][0].style;
+      const beforeStyle = {
+        top: elementStyle.top,
+        left: elementStyle.left,
+        transformOrigin: elementStyle.transformOrigin,
+      };
+      wrapper.setProps({ open: false });
+      wrapper.setProps({
+        open: true,
+        getContentAnchorEl: () => {
+          Object.defineProperty(divRef.current, 'offsetTop', { value: 20 });
+          return divRef.current;
+        },
+      });
+      elementStyle = handleEntering.args[1][0].style;
+      const afterStyle = {
+        top: elementStyle.top,
+        left: elementStyle.left,
+        transformOrigin: elementStyle.transformOrigin,
+      };
+      expect(JSON.stringify(beforeStyle)).to.not.equal(JSON.stringify(afterStyle));
+    });
   });
 
   describe('prop: transitionDuration', () => {

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -266,7 +266,7 @@ describe('<Popover />', () => {
       assert.strictEqual(paper.hasClass(classes.paper), true);
     });
 
-    it('should have a elevation prop passed down', () => {
+    it('should have an elevation prop passed down', () => {
       const wrapper = mount(
         <Popover {...defaultProps} open>
           <div />


### PR DESCRIPTION
Fixes #19757 

The menu is jumping to the bottom of the page because the `contentAnchor`'s offset becomes negative after scrolling. I propose to cache the first computed offset and not recalculate it again while the popover is open.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
