### PR TITLE
[AvatarGroup] Add max avatar prop

### DIFF
--- a/docs/pages/api-docs/avatar-group.md
+++ b/docs/pages/api-docs/avatar-group.md
@@ -27,6 +27,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The avatars to stack. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">spacing</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;number</span> | <span class="prop-default">'medium'</span> | Spacing between avatars. |
+| <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | Max avatars to display. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/avatar-group.md
+++ b/docs/pages/api-docs/avatar-group.md
@@ -26,8 +26,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The avatars to stack. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">spacing</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;number</span> | <span class="prop-default">'medium'</span> | The spacing between avatars. A group with `small` spacing value has a larger overlap. |
-| <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | The maximum number of avatars to display. An additional text avatar will display the number of hidden avatars, if any. |
+| <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | Max avatars to show before +x. |
+| <span class="prop-name">spacing</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;number</span> | <span class="prop-default">'medium'</span> | Spacing between avatars. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/avatar-group.md
+++ b/docs/pages/api-docs/avatar-group.md
@@ -26,8 +26,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The avatars to stack. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">spacing</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;number</span> | <span class="prop-default">'medium'</span> | Spacing between avatars. |
-| <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | Max avatars to display. |
+| <span class="prop-name">spacing</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'<br>&#124;&nbsp;number</span> | <span class="prop-default">'medium'</span> | The spacing between avatars. A group with `small` spacing value has a larger overlap. |
+| <span class="prop-name">max</span> | <span class="prop-type">number</span> | <span class="prop-default">5</span> | The maximum number of avatars to display. An additional text avatar will display the number of hidden avatars, if any. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/src/pages/components/avatars/GroupAvatars.js
+++ b/docs/src/pages/components/avatars/GroupAvatars.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Avatar from '@material-ui/core/Avatar';
-import AvatarGroup from '../../../../../packages/material-ui-lab/src/AvatarGroup';
+import AvatarGroup from '@material-ui/core/AvatarGroup';
 
 export default function GroupAvatars() {
   return (

--- a/docs/src/pages/components/avatars/GroupAvatars.js
+++ b/docs/src/pages/components/avatars/GroupAvatars.js
@@ -4,9 +4,10 @@ import AvatarGroup from '@material-ui/lab/AvatarGroup';
 
 export default function GroupAvatars() {
   return (
-    <AvatarGroup>
+    <AvatarGroup max={3}>
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
+      <Avatar alt="Cindy Baker" src="/static/images/avatar/3.jpg" />
       <Avatar alt="Cindy Baker" src="/static/images/avatar/3.jpg" />
     </AvatarGroup>
   );

--- a/docs/src/pages/components/avatars/GroupAvatars.js
+++ b/docs/src/pages/components/avatars/GroupAvatars.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Avatar from '@material-ui/core/Avatar';
-import AvatarGroup from '@material-ui/lab/AvatarGroup';
-import Tooltip from '@material-ui/core/Tooltip';
+import AvatarGroup from '../../../../../packages/material-ui-lab/src/AvatarGroup';
 
 export default function GroupAvatars() {
   return (
@@ -9,9 +8,6 @@ export default function GroupAvatars() {
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
       <Avatar alt="Cindy Baker" src="/static/images/avatar/3.jpg" />
-      <Tooltip title="Foo • Bar • Baz">
-        <Avatar>+3</Avatar>
-      </Tooltip>
     </AvatarGroup>
   );
 }

--- a/docs/src/pages/components/avatars/GroupAvatars.js
+++ b/docs/src/pages/components/avatars/GroupAvatars.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Avatar from '@material-ui/core/Avatar';
-import AvatarGroup from '@material-ui/core/AvatarGroup';
+import AvatarGroup from '@material-ui/lab/AvatarGroup';
 
 export default function GroupAvatars() {
   return (

--- a/docs/src/pages/components/avatars/GroupAvatars.tsx
+++ b/docs/src/pages/components/avatars/GroupAvatars.tsx
@@ -4,9 +4,10 @@ import AvatarGroup from '@material-ui/lab/AvatarGroup';
 
 export default function GroupAvatars() {
   return (
-    <AvatarGroup>
+    <AvatarGroup max={3}>
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
+      <Avatar alt="Cindy Baker" src="/static/images/avatar/3.jpg" />
       <Avatar alt="Cindy Baker" src="/static/images/avatar/3.jpg" />
     </AvatarGroup>
   );

--- a/docs/src/pages/components/avatars/GroupAvatars.tsx
+++ b/docs/src/pages/components/avatars/GroupAvatars.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Avatar from '@material-ui/core/Avatar';
 import AvatarGroup from '@material-ui/lab/AvatarGroup';
-import Tooltip from '@material-ui/core/Tooltip';
 
 export default function GroupAvatars() {
   return (
@@ -9,9 +8,6 @@ export default function GroupAvatars() {
       <Avatar alt="Remy Sharp" src="/static/images/avatar/1.jpg" />
       <Avatar alt="Travis Howard" src="/static/images/avatar/2.jpg" />
       <Avatar alt="Cindy Baker" src="/static/images/avatar/3.jpg" />
-      <Tooltip title="Foo • Bar • Baz">
-        <Avatar>+3</Avatar>
-      </Tooltip>
     </AvatarGroup>
   );
 }

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
@@ -8,13 +8,13 @@ export interface AvatarGroupProps
    */
   children: React.ReactNode;
   /**
-   * Spacing between avatars.
-   */
-  spacing?: 'small' | 'medium' | number;
-  /**
    * Max avatars to show before +x.
    */
   max?: number;
+  /**
+   * Spacing between avatars.
+   */
+  spacing?: 'small' | 'medium' | number;
 }
 
 export type AvatarGroupClassKey = 'root' | 'avatar';

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.d.ts
@@ -11,6 +11,10 @@ export interface AvatarGroupProps
    * Spacing between avatars.
    */
   spacing?: 'small' | 'medium' | number;
+  /**
+   * Max avatars to show before +x.
+   */
+  max?: number;
 }
 
 export type AvatarGroupClassKey = 'root' | 'avatar';

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -85,7 +85,7 @@ AvatarGroup.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Spacing between avatars.
+   * The spacing between avatars. A group with `small` spacing value has a larger overlap.
    */
   spacing: PropTypes.oneOfType([PropTypes.oneOf(['medium', 'small']), PropTypes.number]),
   /**

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -23,7 +23,14 @@ export const styles = theme => ({
 });
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
-  const { children: childrenProp, classes, className, spacing = 'medium', max = 5, ...other } = props;
+  const {
+    children: childrenProp,
+    classes,
+    className,
+    spacing = 'medium',
+    max = 5,
+    ...other
+  } = props;
 
   const children = React.Children.toArray(childrenProp).filter(child => {
     if (process.env.NODE_ENV !== 'production') {
@@ -54,14 +61,17 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           },
         });
       })}
-      {extraAvatars ?
+      {extraAvatars ? (
         <Avatar
           className={classes.avatar}
           style={{
             zIndex: 0,
             marginLeft: spacing && SPACINGS[spacing] !== undefined ? SPACINGS[spacing] : -spacing,
-          }}>+{extraAvatars}</Avatar>
-      : null}
+          }}
+        >
+          +{extraAvatars}
+        </Avatar>
+      ) : null}
     </div>
   );
 });
@@ -85,13 +95,13 @@ AvatarGroup.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * The spacing between avatars. A group with `small` spacing value has a larger overlap.
-   */
-  spacing: PropTypes.oneOfType([PropTypes.oneOf(['medium', 'small']), PropTypes.number]),
-  /**
-   * The maximum number of avatars to display. An additional text avatar will display the number of hidden avatars, if any.
+   * Max avatars to show before +x.
    */
   max: PropTypes.number,
+  /**
+   * Spacing between avatars.
+   */
+  spacing: PropTypes.oneOfType([PropTypes.oneOf(['medium', 'small']), PropTypes.number]),
 };
 
 export default withStyles(styles, { name: 'MuiAvatarGroup' })(AvatarGroup);

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -61,7 +61,7 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
             zIndex: 0,
             marginLeft: spacing && SPACINGS[spacing] !== undefined ? SPACINGS[spacing] : -spacing,
           }}>+{extraAvatars}</Avatar>
-      : <></>}
+      : null}
     </div>
   );
 });

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -89,7 +89,7 @@ AvatarGroup.propTypes = {
    */
   spacing: PropTypes.oneOfType([PropTypes.oneOf(['medium', 'small']), PropTypes.number]),
   /**
-   * Max avatars to show before +x.
+   * The maximum number of avatars to display. An additional text avatar will display the number of hidden avatars, if any.
    */
   max: PropTypes.number,
 };

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { isFragment } from 'react-is';
 import clsx from 'clsx';
 import { withStyles } from '@material-ui/core/styles';
+import Avatar from '@material-ui/core/Avatar';
 
 const SPACINGS = {
   small: -16,
@@ -22,7 +23,7 @@ export const styles = theme => ({
 });
 
 const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
-  const { children: childrenProp, classes, className, spacing = 'medium', ...other } = props;
+  const { children: childrenProp, classes, className, spacing = 'medium', max = 5, ...other } = props;
 
   const children = React.Children.toArray(childrenProp).filter(child => {
     if (process.env.NODE_ENV !== 'production') {
@@ -39,9 +40,11 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
     return React.isValidElement(child);
   });
 
+  const extraAvatars = children.length > max ? children.length - max : 0;
+
   return (
     <div className={clsx(classes.root, className)} ref={ref} {...other}>
-      {children.map((child, index) => {
+      {children.slice(0, children.length - extraAvatars).map((child, index) => {
         return React.cloneElement(child, {
           className: clsx(child.props.className, classes.avatar),
           style: {
@@ -51,6 +54,14 @@ const AvatarGroup = React.forwardRef(function AvatarGroup(props, ref) {
           },
         });
       })}
+      {extraAvatars ?
+        <Avatar
+          className={classes.avatar}
+          style={{
+            zIndex: 0,
+            marginLeft: spacing && SPACINGS[spacing] !== undefined ? SPACINGS[spacing] : -spacing,
+          }}>+{extraAvatars}</Avatar>
+      : <></>}
     </div>
   );
 });
@@ -77,6 +88,10 @@ AvatarGroup.propTypes = {
    * Spacing between avatars.
    */
   spacing: PropTypes.oneOfType([PropTypes.oneOf(['medium', 'small']), PropTypes.number]),
+  /**
+   * Max avatars to show before +x.
+   */
+  max: PropTypes.number,
 };
 
 export default withStyles(styles, { name: 'MuiAvatarGroup' })(AvatarGroup);

--- a/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.test.js
+++ b/packages/material-ui-lab/src/AvatarGroup/AvatarGroup.test.js
@@ -1,11 +1,15 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
+import { createClientRender } from 'test/utils/createClientRender';
 import AvatarGroup from './AvatarGroup';
+import { Avatar } from '@material-ui/core';
 
 describe('<AvatarGroup />', () => {
   let mount;
   let classes;
+  const render = createClientRender();
 
   before(() => {
     mount = createMount({ strict: true });
@@ -23,4 +27,16 @@ describe('<AvatarGroup />', () => {
     refInstanceof: window.HTMLDivElement,
     skip: ['componentProp'],
   }));
+
+  it('should not display all the avatars', () => {
+    const { container } = render(
+      <AvatarGroup max={1}>
+        <Avatar src="broken-url" />
+        <Avatar src="broken-url" />
+        <Avatar src="broken-url" />
+      </AvatarGroup>,
+    );
+    expect(container.querySelectorAll('img').length).to.equal(1);
+    expect(container.textContent).to.equal('+2');
+  });
 });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This adds the max avatars displayed prop to the `AvatarGroup` for automatically adding an avatar with `+x` functionality. The default value is `5` and can be overridden with `max=x`. The docs and examples have been updated.

References #18869 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
