### PR TITLE
[test] Test against typescript nightlies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,24 @@ jobs:
       - run:
           name: Tests TypeScript definitions
           command: yarn typescript
+  test_types_next:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Resolve typescript version
+          environment:
+            TYPESCRIPT_DIST_TAG: next
+          command: |
+            node scripts/use-typescript-dist-tag
+            # log a patch for maintainers who want to check out this change
+            git diff HEAD
+      - install_js
+      - run:
+          name: Tests TypeScript definitions
+          # we want to see errors in all packages.
+          # without --no-bail we only see at most a single failing package
+          command: yarn typescript --no-bail
   test_browser:
     <<: *defaults
     steps:
@@ -215,3 +233,13 @@ workflows:
             - test_unit
             - test_browser
           react-dist-tag: next
+  typescript-next:
+    triggers:
+      - schedule:
+          cron: '0 0 * * *'
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - test_types_next

--- a/scripts/use-typescript-dist-tag.js
+++ b/scripts/use-typescript-dist-tag.js
@@ -1,0 +1,54 @@
+/**
+ * Workaround for failing `yarn add -D -W typescript@next`
+ * See https://github.com/yarnpkg/yarn/issues/7935
+ *
+ * Given an environment variable called `TYPESCRIPT_DIST_TAG` fetch the corresponding
+ * version and make sure this version used in the worktree as well as in dtslint.
+ *
+ * If you work on this file:
+ * WARNING: This script can only use built-in modules since it has to run before
+ * `yarn install`
+ */
+const childProcess = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { promisify } = require('util');
+
+const exec = promisify(childProcess.exec);
+
+async function main(distTag) {
+  if (typeof distTag !== 'string') {
+    throw new TypeError(`expected distTag: string but got '${distTag}'`);
+  }
+
+  if (distTag === 'stable') {
+    // eslint-disable-next-line no-console
+    console.log('nothing to do with stable');
+    return;
+  }
+
+  const { stdout: versions } = await exec(`npm dist-tag ls typescript ${distTag}`);
+  const tagMapping = versions.split('\n').find(mapping => {
+    return mapping.startsWith(`${distTag}: `);
+  });
+  if (tagMapping === undefined) {
+    throw new Error(`Could not find '${distTag}' in "${versions}"`);
+  }
+
+  const version = tagMapping.replace(`${distTag}: `, '');
+
+  const packageJsonPath = path.resolve(__dirname, '../package.json');
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+
+  packageJson.devDependencies.typescript = version;
+  packageJson.resolutions['**/dtslint/typescript'] = version;
+
+  // CircleCI seemingly times out if it has a newline diff at the end
+  fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}${os.EOL}`);
+}
+
+main(process.env.TYPESCRIPT_DIST_TAG).catch(error => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
Helps us anticipating breaking changes in upcoming TypeScript releases.

Some issues might not be resolvable until we upgrade the stable version on master so this workflow will keep failing. I suggest unsubscribing from this workflow for any non-ts maintainer if this creates too much noise for you.