### PR TITLE
[Step] Add missing expanded prop to step TypeScript

### DIFF
--- a/packages/material-ui/src/Step/Step.d.ts
+++ b/packages/material-ui/src/Step/Step.d.ts
@@ -10,6 +10,7 @@ export interface StepProps
   completed?: boolean;
   connector?: React.ReactElement;
   disabled?: boolean;
+  expanded?: boolean;
   index?: number;
   last?: boolean;
   orientation?: Orientation;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Adds missing prop to step typescript component.

resolves #19869
