### PR TITLE
[TablePagination] Out of range warning when "count={-1}"

### DIFF
--- a/packages/material-ui/src/TablePagination/TablePagination.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.js
@@ -246,6 +246,11 @@ TablePagination.propTypes = {
    */
   page: chainPropTypes(PropTypes.number.isRequired, props => {
     const { count, page, rowsPerPage } = props;
+
+    if (count === -1) {
+      return null;
+    }
+
     const newLastPage = Math.max(0, Math.ceil(count / rowsPerPage) - 1);
     if (page < 0 || page > newLastPage) {
       return new Error(

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -201,6 +201,31 @@ describe('<TablePagination />', () => {
       assert.strictEqual(page, 0);
     });
 
+    it('should display 0 as start number if the table is empty ', () => {
+      const wrapper = mount(
+        <table>
+          <TableFooter>
+            <TableRow>
+              <TablePagination
+                count={0}
+                page={0}
+                rowsPerPage={10}
+                onChangePage={noop}
+                onChangeRowsPerPage={noop}
+              />
+            </TableRow>
+          </TableFooter>
+        </table>,
+      );
+      assert.strictEqual(
+        wrapper
+          .find(Typography)
+          .at(1)
+          .text(),
+        '0-0 of 0',
+      );
+    });
+
     it('should handle when count is out of range', () => {
       let page = 1;
       const wrapper = mount(

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -11,7 +11,6 @@ import TableFooter from '../TableFooter';
 import TableCell from '../TableCell';
 import Typography from '../Typography';
 import TableRow from '../TableRow';
-import TableBody from '../TableBody';
 import TablePagination from './TablePagination';
 
 describe('<TablePagination />', () => {
@@ -35,11 +34,14 @@ describe('<TablePagination />', () => {
     classes = getClasses(
       <TablePagination count={1} onChangePage={() => {}} page={0} rowsPerPage={10} />,
     );
-    // StrictModeViolation: test uses #html()
+  });
+
+  beforeEach(() => {
+    // StrictModeViolation: test uses #html()()
     mount = createMount({ strict: false });
   });
 
-  after(() => {
+  afterEach(() => {
     mount.cleanUp();
   });
 

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -10,6 +10,7 @@ import TableFooter from '../TableFooter';
 import TableCell from '../TableCell';
 import Typography from '../Typography';
 import TableRow from '../TableRow';
+import TableBody from '../TableBody';
 import TablePagination from './TablePagination';
 
 describe('<TablePagination />', () => {
@@ -200,29 +201,28 @@ describe('<TablePagination />', () => {
       assert.strictEqual(page, 0);
     });
 
-    it('should display 0 as start number if the table is empty ', () => {
+    it('should hide console warning when count is out of range', () => {
+      let page = 0;
       const wrapper = mount(
         <table>
-          <TableFooter>
+          <TableBody>
             <TableRow>
               <TablePagination
-                count={0}
-                page={0}
+                count={-1}
+                page={page}
+                onChangePage={(event, nextPage) => {
+                  page = nextPage;
+                }}
                 rowsPerPage={10}
-                onChangePage={noop}
-                onChangeRowsPerPage={noop}
               />
             </TableRow>
-          </TableFooter>
+          </TableBody>
         </table>,
       );
-      assert.strictEqual(
-        wrapper
-          .find(Typography)
-          .at(1)
-          .text(),
-        '0-0 of 0',
-      );
+
+      const nextButton = wrapper.find(IconButton).at(1);
+      nextButton.simulate('click');
+      assert.strictEqual(page, 2);
     });
 
     it('should hide the rows per page selector if there are less than two options', () => {

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -201,7 +201,7 @@ describe('<TablePagination />', () => {
       assert.strictEqual(page, 0);
     });
 
-    it('should hide console warning when count is out of range', () => {
+    it('should handle when count is out of range', () => {
       let page = 0;
       const wrapper = mount(
         <table>

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -202,7 +202,7 @@ describe('<TablePagination />', () => {
     });
 
     it('should handle when count is out of range', () => {
-      let page = 0;
+      let page = 1;
       const wrapper = mount(
         <table>
           <TableBody>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Hey, 

I've added changes for TablePagination component if count value negative [issue](https://github.com/mui-org/material-ui/issues/19865). Also, we should add a test interacting with the pagination icons when`count={-1}`, as @oliviertassinari wrote. We can wait for test and merge this PR or merge this one only with my changes.

P.S I can add test but a bit later too :) 

Closes #19865