### PR TITLE
[TextField] Avoid outline label CSS leak

### DIFF
--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -32,6 +32,11 @@ export const styles = theme => {
         easing: theme.transitions.easing.easeOut,
       }),
     },
+    /* Styles applied to the label elemement. */
+    legendLabel: {
+      paddingLeft: 5,
+      paddingRight: 5,
+    },
     /* Styles applied to the legend element. */
     legendLabelled: {
       display: 'block',
@@ -46,10 +51,6 @@ export const styles = theme => {
         duration: 50,
         easing: theme.transitions.easing.easeOut,
       }),
-      '& span': {
-        paddingLeft: 5,
-        paddingRight: 5,
-      },
     },
     /* Styles applied to the legend element is notched. */
     legendNotched: {
@@ -96,7 +97,14 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
         >
           {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
           {/* eslint-disable-next-line react/no-danger */}
-          {label ? <span>{label}</span> : <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />}
+          {label ? (
+            <span className={clsx(classes.legendLabel)}>{label}</span>
+          ) : (
+            <span
+              className={clsx(classes.legendLabel)}
+              dangerouslySetInnerHTML={{ __html: '&#8203;' }}
+            />
+          )}
         </legend>
       </fieldset>
     );
@@ -126,7 +134,10 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
       >
         {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
         {/* eslint-disable-next-line react/no-danger */}
-        <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
+        <span
+          className={clsx(classes.legendLabel)}
+          dangerouslySetInnerHTML={{ __html: '&#8203;' }}
+        />
       </legend>
     </fieldset>
   );

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -36,6 +36,7 @@ export const styles = theme => {
     legendLabel: {
       paddingLeft: 5,
       paddingRight: 5,
+      display: 'inline-block',
     },
     /* Styles applied to the legend element. */
     legendLabelled: {

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -96,13 +96,13 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
             [classes.legendNotched]: notched,
           })}
         >
-          {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
-          {/* eslint-disable-next-line react/no-danger */}
           {label ? (
             <span className={clsx(classes.legendLabel)}>{label}</span>
           ) : (
+            /* Use the nominal use case of the legend, avoid rendering artefacts. */
             <span
               className={clsx(classes.legendLabel)}
+              /* eslint-disable-next-line react/no-danger */
               dangerouslySetInnerHTML={{ __html: '&#8203;' }}
             />
           )}
@@ -134,9 +134,9 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
         }}
       >
         {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
-        {/* eslint-disable-next-line react/no-danger */}
         <span
           className={clsx(classes.legendLabel)}
+          /* eslint-disable-next-line react/no-danger */
           dangerouslySetInnerHTML={{ __html: '&#8203;' }}
         />
       </legend>

--- a/packages/material-ui/src/OutlinedInput/NotchedOutline.js
+++ b/packages/material-ui/src/OutlinedInput/NotchedOutline.js
@@ -32,12 +32,6 @@ export const styles = theme => {
         easing: theme.transitions.easing.easeOut,
       }),
     },
-    /* Styles applied to the label elemement. */
-    legendLabel: {
-      paddingLeft: 5,
-      paddingRight: 5,
-      display: 'inline-block',
-    },
     /* Styles applied to the legend element. */
     legendLabelled: {
       display: 'block',
@@ -52,6 +46,11 @@ export const styles = theme => {
         duration: 50,
         easing: theme.transitions.easing.easeOut,
       }),
+      '& > span': {
+        paddingLeft: 5,
+        paddingRight: 5,
+        display: 'inline-block',
+      },
     },
     /* Styles applied to the legend element is notched. */
     legendNotched: {
@@ -96,16 +95,9 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
             [classes.legendNotched]: notched,
           })}
         >
-          {label ? (
-            <span className={clsx(classes.legendLabel)}>{label}</span>
-          ) : (
-            /* Use the nominal use case of the legend, avoid rendering artefacts. */
-            <span
-              className={clsx(classes.legendLabel)}
-              /* eslint-disable-next-line react/no-danger */
-              dangerouslySetInnerHTML={{ __html: '&#8203;' }}
-            />
-          )}
+          {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
+          {/* eslint-disable-next-line react/no-danger */}
+          {label ? <span>{label}</span> : <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />}
         </legend>
       </fieldset>
     );
@@ -134,11 +126,8 @@ const NotchedOutline = React.forwardRef(function NotchedOutline(props, ref) {
         }}
       >
         {/* Use the nominal use case of the legend, avoid rendering artefacts. */}
-        <span
-          className={clsx(classes.legendLabel)}
-          /* eslint-disable-next-line react/no-danger */
-          dangerouslySetInnerHTML={{ __html: '&#8203;' }}
-        />
+        {/* eslint-disable-next-line react/no-danger */}
+        <span dangerouslySetInnerHTML={{ __html: '&#8203;' }} />
       </legend>
     </fieldset>
   );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Currently the styles of the label in NotchedOutline of the TextField is set by the `'& span'` selector in the legendLabelled class. It basically adds padding.

When a label prop comes in, it's wrapped in a `<span>` before it's inserted.
This means that if you also send a `<span>` element as the label, you get a `<span><span>My Label</span></span>` for the label.

Because of the `'& span'` selector, both elements inherit the style, meaning you get double padding and thus extra empty space around the notch.

By changing the selector to a class, the padding will no longer be applied to other `span` elements sent to the label component.

When sending labels other than `span`, like `div`, the label `span` does not inherit the width of the `div` meaning it's only default padding(5px on each side) wide.
By setting the span `display` to to a `'inline-block'`enables the label to expand to the width of other, non-string components sent to the label.

Given code
`<TextField variant="outlined" label={<span>My Label</span>}/>`

Current behaviour
![image](https://user-images.githubusercontent.com/11502345/75697697-be4c7200-5cad-11ea-91b6-47b14e781c12.png)
![image](https://user-images.githubusercontent.com/11502345/75697759-d623f600-5cad-11ea-9a59-afdcd03811a0.png)


New behaviour
![image](https://user-images.githubusercontent.com/11502345/75698609-4a12ce00-5caf-11ea-9e61-5b6a9dbdb3a8.png)
This now also works with
`<TextField variant="outlined" label={<div>My Label</div>}/>`

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
