### PR TITLE
[docs] Fix @material-ui/styles release version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,7 +292,7 @@ Here are some highlights ✨:
 - [TextField] Support padding for helperText (#19198) @hiteshkundal
 - [Tooltip] Fix popper.js re-instantiation (#19304) @netochaves
 
-### `@material-ui/styles@v4.8.0`
+### `@material-ui/styles@v4.9.0`
 
 - [styles] Overload function signature instead of conditional (#19320) @eps1lon
 


### PR DESCRIPTION
NPM currently has a 4.9.0 version, so I think that's what this was supposed to be.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
