### PR TITLE
[theme] Describe what each argument of theme.spacing affects

### DIFF
--- a/packages/material-ui/src/styles/createSpacing.d.ts
+++ b/packages/material-ui/src/styles/createSpacing.d.ts
@@ -4,14 +4,14 @@ export type SpacingArgument = number;
 
 export interface Spacing {
   (): number;
-  (value1: SpacingArgument): number;
-  (value1: SpacingArgument, value2: SpacingArgument): string;
-  (value1: SpacingArgument, value2: SpacingArgument, value3: SpacingArgument): string;
+  (value: SpacingArgument): number;
+  (topBottom: SpacingArgument, rightLeft: SpacingArgument): string;
+  (top: SpacingArgument, rightLeft: SpacingArgument, bottom: SpacingArgument): string;
   (
-    value1: SpacingArgument,
-    value2: SpacingArgument,
-    value3: SpacingArgument,
-    value4: SpacingArgument,
+    top: SpacingArgument,
+    right: SpacingArgument,
+    bottom: SpacingArgument,
+    left: SpacingArgument,
   ): string;
 }
 


### PR DESCRIPTION
I can't seem to get the [shorthand order](https://developer.mozilla.org/en-US/docs/Web/CSS/margin#Syntax) into my head. Luckily there's typescript:

![spacing-description](https://user-images.githubusercontent.com/12292047/75786858-31192400-5d66-11ea-9382-94dd74c42985.png)

