### PR TITLE
[Pagination] Fix prop forwarding of `onChange` and `page`

### DIFF
--- a/packages/material-ui-lab/src/Pagination/Pagination.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.js
@@ -27,31 +27,29 @@ function defaultGetAriaLabel(type, page, selected) {
 }
 
 const Pagination = React.forwardRef(function Pagination(props, ref) {
-  /* eslint-disable no-unused-vars */
   const {
-    boundaryCount = 1,
+    boundaryCount,
     children,
     classes,
     className,
     color = 'standard',
-    count = 1,
-    defaultPage = 1,
-    disabled = false,
+    count,
+    defaultPage,
+    disabled,
     getItemAriaLabel: getAriaLabel = defaultGetAriaLabel,
-    hideNextButton = false,
-    hidePrevButton = false,
+    hideNextButton,
+    hidePrevButton,
     onChange,
     page,
     renderItem = item => <PaginationItem {...item} />,
     shape = 'round',
-    showFirstButton = false,
-    showLastButton = false,
-    siblingCount = 1,
+    showFirstButton,
+    showLastButton,
+    siblingCount,
     size = 'medium',
     variant = 'text',
     ...other
   } = props;
-  /* eslint-enable no-unused-vars */
 
   const { items } = usePagination({ ...props, componentName: 'Pagination' });
 

--- a/packages/material-ui-lab/src/Pagination/Pagination.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.js
@@ -27,29 +27,31 @@ function defaultGetAriaLabel(type, page, selected) {
 }
 
 const Pagination = React.forwardRef(function Pagination(props, ref) {
+  /* eslint-disable no-unused-vars */
   const {
-    boundaryCount,
+    boundaryCount = 1,
     children,
     classes,
     className,
     color = 'standard',
-    count,
-    defaultPage,
-    disabled,
+    count = 1,
+    defaultPage = 1,
+    disabled = false,
     getItemAriaLabel: getAriaLabel = defaultGetAriaLabel,
-    hideNextButton,
-    hidePrevButton,
+    hideNextButton = false,
+    hidePrevButton = false,
     onChange,
     page,
     renderItem = item => <PaginationItem {...item} />,
     shape = 'round',
-    showFirstButton,
-    showLastButton,
-    siblingCount,
+    showFirstButton = false,
+    showLastButton = false,
+    siblingCount = 1,
     size = 'medium',
     variant = 'text',
     ...other
   } = props;
+  /* eslint-enable no-unused-vars */
 
   const { items } = usePagination({ ...props, componentName: 'Pagination' });
 

--- a/packages/material-ui-lab/src/Pagination/Pagination.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.js
@@ -40,6 +40,7 @@ const Pagination = React.forwardRef(function Pagination(props, ref) {
     getItemAriaLabel: getAriaLabel = defaultGetAriaLabel,
     hideNextButton = false,
     hidePrevButton = false,
+    onChange,
     page,
     renderItem = item => <PaginationItem {...item} />,
     shape = 'round',

--- a/packages/material-ui-lab/src/Pagination/Pagination.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.js
@@ -40,6 +40,7 @@ const Pagination = React.forwardRef(function Pagination(props, ref) {
     getItemAriaLabel: getAriaLabel = defaultGetAriaLabel,
     hideNextButton = false,
     hidePrevButton = false,
+    page,
     renderItem = item => <PaginationItem {...item} />,
     shape = 'round',
     showFirstButton = false,

--- a/packages/material-ui-lab/src/Pagination/Pagination.test.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.test.js
@@ -29,4 +29,14 @@ describe('<Pagination />', () => {
 
     expect(container.firstChild).to.have.class(classes.root);
   });
+
+  it('moves aria-current the the specified page', () => {
+    const { container, getAllByRole } = render(<Pagination count={3} page={1} />);
+
+    // previous, page 1
+    const [, page1] = getAllByRole('button');
+    expect(page1).to.have.attribute('aria-current', 'true');
+    // verifying no regression from previous bug where `page` wasn't intercepted
+    expect(container.querySelector('[page]')).to.be.null;
+  });
 });

--- a/packages/material-ui-lab/src/Pagination/Pagination.test.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.test.js
@@ -32,7 +32,7 @@ describe('<Pagination />', () => {
     expect(container.firstChild).to.have.class(classes.root);
   });
 
-  it('moves aria-current the the specified page', () => {
+  it('moves aria-current to the specified page', () => {
     const { container, getAllByRole } = render(<Pagination count={3} page={1} />);
 
     // previous, page 1

--- a/packages/material-ui-lab/src/Pagination/Pagination.test.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.test.js
@@ -1,9 +1,11 @@
 import * as React from 'react';
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
 import Pagination from './Pagination';
+import { fireEvent } from '@testing-library/dom';
 
 describe('<Pagination />', () => {
   let classes;
@@ -38,5 +40,29 @@ describe('<Pagination />', () => {
     expect(page1).to.have.attribute('aria-current', 'true');
     // verifying no regression from previous bug where `page` wasn't intercepted
     expect(container.querySelector('[page]')).to.be.null;
+  });
+
+  it('fires onChange when a different page is clicked', () => {
+    const handleChange = spy();
+    const { getAllByRole } = render(<Pagination count={3} onChange={handleChange} page={1} />);
+
+    // previous, page 1, page 2
+    const [, , page2] = getAllByRole('button');
+    page2.click();
+
+    expect(handleChange.callCount).to.equal(1);
+  });
+
+  it('does not attach onChange to the root element', () => {
+    const handleChange = spy();
+    const { getByRole } = render(
+      <Pagination count={3} onChange={handleChange} page={1}>
+        <input defaultValue={1} type="text" />
+      </Pagination>,
+    );
+
+    fireEvent.change(getByRole('textbox'), { target: { value: '2' } });
+
+    expect(handleChange.callCount).to.equal(0);
   });
 });


### PR DESCRIPTION
- don't forward `page` and `onChange` to the `nav`
- ~remove default values~ Solved in #19966
  ~These are not used in the component anyway. They do not mutate the value in the original `props` object~

Edit: So they're for docs only. I think I have a better idea for that.