### PR TITLE
[MenuList] Include disabled items in keyboard navigation

### DIFF
--- a/docs/pages/api-docs/autocomplete.md
+++ b/docs/pages/api-docs/autocomplete.md
@@ -41,6 +41,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the input will be disabled. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the list box in the popup will not wrap focus. |
 | <span class="prop-name">disablePortal</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the portal behavior. The children stay within it's parent DOM hierarchy. |
+| <span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> |  | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">filterOptions</span> | <span class="prop-type">func</span> |  | A filter function that determines the options that are eligible.<br><br>**Signature:**<br>`function(options: T[], state: object) => undefined`<br>*options:* The options to render.<br>*state:* The state of the component. |
 | <span class="prop-name">filterSelectedOptions</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, hide the selected options from the list box. |
 | <span class="prop-name">forcePopupIcon</span> | <span class="prop-type">'auto'<br>&#124;&nbsp;bool</span> | <span class="prop-default">'auto'</span> | Force the visibility display of the popup icon. |

--- a/docs/pages/api-docs/autocomplete.md
+++ b/docs/pages/api-docs/autocomplete.md
@@ -41,7 +41,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the input will be disabled. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the list box in the popup will not wrap focus. |
 | <span class="prop-name">disablePortal</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the portal behavior. The children stay within it's parent DOM hierarchy. |
-| <span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> |  | If `true`, will allow focus on disabled items. |
+| <span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">filterOptions</span> | <span class="prop-type">func</span> |  | A filter function that determines the options that are eligible.<br><br>**Signature:**<br>`function(options: T[], state: object) => undefined`<br>*options:* The options to render.<br>*state:* The state of the component. |
 | <span class="prop-name">filterSelectedOptions</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, hide the selected options from the list box. |
 | <span class="prop-name">forcePopupIcon</span> | <span class="prop-type">'auto'<br>&#124;&nbsp;bool</span> | <span class="prop-default">'auto'</span> | Force the visibility display of the popup icon. |

--- a/docs/pages/api-docs/autocomplete.md
+++ b/docs/pages/api-docs/autocomplete.md
@@ -39,9 +39,9 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">disableClearable</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the input can't be cleared. |
 | <span class="prop-name">disableCloseOnSelect</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the popup won't close when a value is selected. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the input will be disabled. |
+| <span class="prop-name">disabledItemsFocusable</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the list box in the popup will not wrap focus. |
 | <span class="prop-name">disablePortal</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Disable the portal behavior. The children stay within it's parent DOM hierarchy. |
-| <span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">filterOptions</span> | <span class="prop-type">func</span> |  | A filter function that determines the options that are eligible.<br><br>**Signature:**<br>`function(options: T[], state: object) => undefined`<br>*options:* The options to render.<br>*state:* The state of the component. |
 | <span class="prop-name">filterSelectedOptions</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, hide the selected options from the list box. |
 | <span class="prop-name">forcePopupIcon</span> | <span class="prop-type">'auto'<br>&#124;&nbsp;bool</span> | <span class="prop-default">'auto'</span> | Force the visibility display of the popup icon. |

--- a/docs/pages/api-docs/menu-list.md
+++ b/docs/pages/api-docs/menu-list.md
@@ -31,7 +31,7 @@ the focus is placed inside the component it is fully keyboard accessible.
 | <span class="prop-name">autoFocusItem</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the first menuitem if `variant="menu"` or selected item if `variant="selectedMenu"`. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | MenuList contents, normally `MenuItem`s. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
-| <span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | If `true`, will allow focus on disabled items. |
+| <span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'menu'<br>&#124;&nbsp;'selectedMenu'</span> | <span class="prop-default">'selectedMenu'</span> | The variant to use. Use `menu` to prevent selected items from impacting the initial focus and the vertical alignment relative to the anchor element. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/menu-list.md
+++ b/docs/pages/api-docs/menu-list.md
@@ -31,7 +31,7 @@ the focus is placed inside the component it is fully keyboard accessible.
 | <span class="prop-name">autoFocusItem</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the first menuitem if `variant="menu"` or selected item if `variant="selectedMenu"`. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | MenuList contents, normally `MenuItem`s. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
-<span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | If `true`, will allow focus on disabled items. |
+| <span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'menu'<br>&#124;&nbsp;'selectedMenu'</span> | <span class="prop-default">'selectedMenu'</span> | The variant to use. Use `menu` to prevent selected items from impacting the initial focus and the vertical alignment relative to the anchor element. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/menu-list.md
+++ b/docs/pages/api-docs/menu-list.md
@@ -30,8 +30,8 @@ the focus is placed inside the component it is fully keyboard accessible.
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the `[role="menu"]` container and move into tab order. |
 | <span class="prop-name">autoFocusItem</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the first menuitem if `variant="menu"` or selected item if `variant="selectedMenu"`. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | MenuList contents, normally `MenuItem`s. |
+| <span class="prop-name">disabledItemsFocusable</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
-| <span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'menu'<br>&#124;&nbsp;'selectedMenu'</span> | <span class="prop-default">'selectedMenu'</span> | The variant to use. Use `menu` to prevent selected items from impacting the initial focus and the vertical alignment relative to the anchor element. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/menu-list.md
+++ b/docs/pages/api-docs/menu-list.md
@@ -31,6 +31,7 @@ the focus is placed inside the component it is fully keyboard accessible.
 | <span class="prop-name">autoFocusItem</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the first menuitem if `variant="menu"` or selected item if `variant="selectedMenu"`. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | MenuList contents, normally `MenuItem`s. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
+<span class="prop-name">enableFocusForDisabledItems</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | If `true`, will allow focus on disabled items. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'menu'<br>&#124;&nbsp;'selectedMenu'</span> | <span class="prop-default">'selectedMenu'</span> | The variant to use. Use `menu` to prevent selected items from impacting the initial focus and the vertical alignment relative to the anchor element. |
 
 The `ref` is forwarded to the root element.

--- a/docs/src/pages/components/autocomplete/LimitTags.js
+++ b/docs/src/pages/components/autocomplete/LimitTags.js
@@ -21,7 +21,7 @@ export default function LimitTags() {
       <Autocomplete
         multiple
         limitTags={2}
-        id="tags-standard"
+        id="limit-tags"
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13], top100Films[12], top100Films[11]]}

--- a/docs/src/pages/components/autocomplete/LimitTags.tsx
+++ b/docs/src/pages/components/autocomplete/LimitTags.tsx
@@ -23,7 +23,7 @@ export default function LimitTags() {
       <Autocomplete
         multiple
         limitTags={2}
-        id="tags-standard"
+        id="limit-tags"
         options={top100Films}
         getOptionLabel={(option) => option.title}
         defaultValue={[top100Films[13], top100Films[12], top100Films[11]]}

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -587,6 +587,10 @@ Autocomplete.propTypes = {
    */
   disablePortal: PropTypes.bool,
   /**
+   * If `true`, will allow focus on disabled items.
+   */
+  enableFocusForDisabledItems: PropTypes.bool,
+  /**
    * A filter function that determines the options that are eligible.
    *
    * @param {T[]} options The options to render.

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -587,10 +587,6 @@ Autocomplete.propTypes = {
    */
   disablePortal: PropTypes.bool,
   /**
-   * If `true`, will allow focus on disabled items.
-   */
-  enableFocusForDisabledItems: PropTypes.bool,
-  /**
    * A filter function that determines the options that are eligible.
    *
    * @param {T[]} options The options to render.

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -251,9 +251,9 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
     disableClearable = false,
     disableCloseOnSelect = false,
     disabled = false,
+    disabledItemsFocusable = false,
     disableListWrap = false,
     disablePortal = false,
-    enableFocusForDisabledItems = false,
     filterOptions,
     filterSelectedOptions = false,
     forcePopupIcon = 'auto',
@@ -579,6 +579,10 @@ Autocomplete.propTypes = {
    */
   disabled: PropTypes.bool,
   /**
+   * If `true`, will allow focus on disabled items.
+   */
+  disabledItemsFocusable: PropTypes.bool,
+  /**
    * If `true`, the list box in the popup will not wrap focus.
    */
   disableListWrap: PropTypes.bool,
@@ -587,10 +591,6 @@ Autocomplete.propTypes = {
    * The children stay within it's parent DOM hierarchy.
    */
   disablePortal: PropTypes.bool,
-  /**
-   * If `true`, will allow focus on disabled items.
-   */
-  enableFocusForDisabledItems: PropTypes.bool,
   /**
    * A filter function that determines the options that are eligible.
    *

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -253,6 +253,7 @@ const Autocomplete = React.forwardRef(function Autocomplete(props, ref) {
     disabled = false,
     disableListWrap = false,
     disablePortal = false,
+    enableFocusForDisabledItems = false,
     filterOptions,
     filterSelectedOptions = false,
     forcePopupIcon = 'auto',

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -67,13 +67,13 @@ export interface UseAutocompleteCommonProps<T> {
    */
   disableCloseOnSelect?: boolean;
   /**
+   * If `true`, will allow focus on disabled items.
+   */
+  disabledItemsFocusable?: boolean;
+  /**
    * If `true`, the list box in the popup will not wrap focus.
    */
   disableListWrap?: boolean;
-  /**
-   * If `true`, will allow focus on disabled items.
-   */
-  enableFocusForDisabledItems?: boolean;
   /**
    * A filter function that determines the options that are eligible.
    *
@@ -185,6 +185,10 @@ export type AutocompleteInputChangeReason = 'input' | 'reset' | 'clear';
 
 export interface UseAutocompleteMultipleProps<T> extends UseAutocompleteCommonProps<T> {
   /**
+   * The default input value. Use when the component is not controlled.
+   */
+  defaultValue?: T[];
+  /**
    * If `true`, `value` must be an array and the menu will support multiple selections.
    */
   multiple: true;
@@ -195,10 +199,6 @@ export interface UseAutocompleteMultipleProps<T> extends UseAutocompleteCommonPr
    * You can customize the equality behavior with the `getOptionSelected` prop.
    */
   value?: T[];
-  /**
-   * The default input value. Use when the component is not controlled.
-   */
-  defaultValue?: T[];
   /**
    * Callback fired when the value changes.
    *
@@ -216,6 +216,10 @@ export interface UseAutocompleteMultipleProps<T> extends UseAutocompleteCommonPr
 
 export interface UseAutocompleteSingleProps<T> extends UseAutocompleteCommonProps<T> {
   /**
+   * The default input value. Use when the component is not controlled.
+   */
+  defaultValue?: T;
+  /**
    * If `true`, `value` must be an array and the menu will support multiple selections.
    */
   multiple?: false;
@@ -226,10 +230,6 @@ export interface UseAutocompleteSingleProps<T> extends UseAutocompleteCommonProp
    * You can customize the equality behavior with the `getOptionSelected` prop.
    */
   value?: T | null;
-  /**
-   * The default input value. Use when the component is not controlled.
-   */
-  defaultValue?: T;
   /**
    * Callback fired when the value changes.
    *

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -73,7 +73,7 @@ export interface UseAutocompleteCommonProps<T> {
   /**
    * If `true`, will allow focus on disabled items.
    */
-  enableFocusForDisabledItems?: boolean,
+  enableFocusForDisabledItems?: boolean;
   /**
    * A filter function that determines the options that are eligible.
    *

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -71,6 +71,10 @@ export interface UseAutocompleteCommonProps<T> {
    */
   disableListWrap?: boolean;
   /**
+   * If `true`, will allow focus on disabled items.
+   */
+  enableFocusForDisabledItems?: boolean,
+  /**
    * A filter function that determines the options that are eligible.
    *
    * @param {T[]} options The options to render.

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -73,8 +73,8 @@ export default function useAutocomplete(props) {
     defaultValue = props.multiple ? [] : null,
     disableClearable = false,
     disableCloseOnSelect = false,
+    disabledItemsFocusable = false,
     disableListWrap = false,
-    enableFocusForDisabledItems = false,
     filterOptions = defaultFilterOptions,
     filterSelectedOptions = false,
     freeSolo = false,
@@ -313,11 +313,12 @@ export default function useAutocomplete(props) {
       const option = listboxRef.current.querySelector(`[data-option-index="${nextFocus}"]`);
 
       // Same logic as MenuList.js
-      const nextFocusDisabled = enableFocusForDisabledItems
+      const nextFocusDisabled = disabledItemsFocusable
         ? false
         : option && (option.disabled || option.getAttribute('aria-disabled') === 'true');
 
       if ((option && !option.hasAttribute('tabindex')) || nextFocusDisabled) {
+        // Move to the next element.
         nextFocus += direction === 'next' ? 1 : -1;
       } else {
         return nextFocus;
@@ -641,9 +642,16 @@ export default function useAutocomplete(props) {
           break;
         }
         if (highlightedIndexRef.current !== -1 && popupOpen) {
+          const option = filteredOptions[highlightedIndexRef.current];
+          const disabled = getOptionDisabled ? getOptionDisabled(option) : false;
+
+          if (disabled) {
+            return;
+          }
+
           // We don't want to validate the form.
           event.preventDefault();
-          selectNewValue(event, filteredOptions[highlightedIndexRef.current], 'select-option');
+          selectNewValue(event, option, 'select-option');
 
           // Move the selection to the end.
           if (autoComplete) {
@@ -1012,13 +1020,13 @@ useAutocomplete.propTypes = {
    */
   disableCloseOnSelect: PropTypes.bool,
   /**
+   * If `true`, will allow focus on disabled items.
+   */
+  disabledItemsFocusable: PropTypes.bool,
+  /**
    * If `true`, the list box in the popup will not wrap focus.
    */
   disableListWrap: PropTypes.bool,
-  /**
-   * If `true`, will allow focus on disabled items.
-   */
-  enableFocusForDisabledItems: PropTypes.bool,
   /**
    * A filter function that determins the options that are eligible.
    *

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -1016,6 +1016,10 @@ useAutocomplete.propTypes = {
    */
   disableListWrap: PropTypes.bool,
   /**
+   * If `true`, will allow focus on disabled items.
+   */
+  enableFocusForDisabledItems: PropTypes.bool,
+  /**
    * A filter function that determins the options that are eligible.
    *
    * @param {any} options The options to render.

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -74,6 +74,7 @@ export default function useAutocomplete(props) {
     disableClearable = false,
     disableCloseOnSelect = false,
     disableListWrap = false,
+    enableFocusForDisabledItems = false,
     filterOptions = defaultFilterOptions,
     filterSelectedOptions = false,
     freeSolo = false,
@@ -312,12 +313,11 @@ export default function useAutocomplete(props) {
       const option = listboxRef.current.querySelector(`[data-option-index="${nextFocus}"]`);
 
       // Same logic as MenuList.js
-      if (
-        option &&
-        (!option.hasAttribute('tabindex') ||
-          option.disabled ||
-          option.getAttribute('aria-disabled') === 'true')
-      ) {
+      const nextFocusDisabled = enableFocusForDisabledItems
+        ? false
+        : option && (option.disabled || option.getAttribute('aria-disabled') === 'true');
+
+      if ((option && !option.hasAttribute('tabindex')) || nextFocusDisabled) {
         nextFocus += direction === 'next' ? 1 : -1;
       } else {
         return nextFocus;

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -159,7 +159,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     false,
   );
 
-  const handleFocus = useEventCallback(event => {
+  const handleFocus = useEventCallback((event) => {
     // Fix for https://github.com/facebook/react/issues/7769
     if (!buttonRef.current) {
       buttonRef.current = event.currentTarget;
@@ -212,7 +212,12 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     }
 
     // Keyboard accessibility for non interactive elements
-    if (event.target === event.currentTarget && isNonNativeButton() && event.key === 'Enter') {
+    if (
+      event.target === event.currentTarget &&
+      isNonNativeButton() &&
+      event.key === 'Enter' &&
+      !disabled
+    ) {
       event.preventDefault();
       if (onClick) {
         onClick(event);

--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -158,11 +158,8 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
     },
     false,
   );
-  const handleFocus = useEventCallback((event) => {
-    if (disabled) {
-      return;
-    }
 
+  const handleFocus = useEventCallback(event => {
     // Fix for https://github.com/facebook/react/issues/7769
     if (!buttonRef.current) {
       buttonRef.current = event.currentTarget;

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -611,7 +611,7 @@ describe('<ButtonBase />', () => {
   });
 
   describe('event: focus', () => {
-    it('when disabled should not call onFocus', () => {
+    it('when disabled should be called onFocus', () => {
       const onFocusSpy = spy();
       const { getByRole } = render(
         <ButtonBase component="div" disabled onFocus={onFocusSpy}>
@@ -621,7 +621,7 @@ describe('<ButtonBase />', () => {
 
       getByRole('button').focus();
 
-      expect(onFocusSpy.callCount).to.equal(0);
+      expect(onFocusSpy.callCount).to.equal(1);
     });
 
     it('has a focus-visible polyfill', () => {

--- a/packages/material-ui/src/MenuList/MenuList.d.ts
+++ b/packages/material-ui/src/MenuList/MenuList.d.ts
@@ -17,6 +17,10 @@ export interface MenuListProps extends StandardProps<ListProps, MenuListClassKey
    */
   children?: React.ReactNode;
   /**
+   * If `true`, will allow focus on disabled items.
+   */
+  disabledItemsFocusable?: boolean;
+  /**
    * If `true`, the menu items will not wrap focus.
    */
   disableListWrap?: boolean;

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -103,7 +103,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
     children,
     className,
     disableListWrap = false,
-    enableFocusForDisabledItems = true,
+    enableFocusForDisabledItems = false,
     onKeyDown,
     variant = 'selectedMenu',
     ...other

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -46,7 +46,14 @@ function textCriteriaMatches(nextFocus, textCriteria) {
   return text.indexOf(textCriteria.keys.join('')) === 0;
 }
 
-function moveFocus(list, currentFocus, disableListWrap, enableFocusForDisabledItems, traversalFunction, textCriteria) {
+function moveFocus(
+  list,
+  currentFocus,
+  disableListWrap,
+  enableFocusForDisabledItems,
+  traversalFunction,
+  textCriteria,
+) {
   let wrappedOnce = false;
   let nextFocus = traversalFunction(list, currentFocus, currentFocus ? disableListWrap : false);
 
@@ -59,8 +66,14 @@ function moveFocus(list, currentFocus, disableListWrap, enableFocusForDisabledIt
       wrappedOnce = true;
     }
 
-    const nextFocusDisabled = enableFocusForDisabledItems ? false : nextFocus.disabled || nextFocus.getAttribute('aria-disabled') === 'true';
-    if (!nextFocusDisabled && nextFocus.hasAttribute('tabindex') && textCriteriaMatches(nextFocus, textCriteria)) {
+    const nextFocusDisabled = enableFocusForDisabledItems
+      ? false
+      : nextFocus.disabled || nextFocus.getAttribute('aria-disabled') === 'true';
+    if (
+      !nextFocusDisabled &&
+      nextFocus.hasAttribute('tabindex') &&
+      textCriteriaMatches(nextFocus, textCriteria)
+    ) {
       nextFocus.focus();
       return true;
     }
@@ -173,7 +186,8 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
         currentFocus && !criteria.repeating && textCriteriaMatches(currentFocus, criteria);
       if (
         criteria.previousKeyMatched &&
-        (keepFocusOnCurrent || moveFocus(list, currentFocus, false, enableFocusForDisabledItems, nextItem, criteria))
+        (keepFocusOnCurrent ||
+          moveFocus(list, currentFocus, false, enableFocusForDisabledItems, nextItem, criteria))
       ) {
         event.preventDefault();
       } else {

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -103,7 +103,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
     children,
     className,
     disableListWrap = false,
-    enableFocusForDisabledItems = false,
+    enableFocusForDisabledItems = true,
     onKeyDown,
     variant = 'selectedMenu',
     ...other

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -297,7 +297,7 @@ MenuList.propTypes = {
    */
   disableListWrap: PropTypes.bool,
   /**
-   * If `true`, disabled menu items can receive focus from keyboard navigation.
+   * If `true`, will allow focus on disabled items.
    */
   enableFocusForDisabledItems: PropTypes.bool,
   /**

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -59,10 +59,7 @@ function moveFocus(list, currentFocus, disableListWrap, traversalFunction, textC
       wrappedOnce = true;
     }
     // Move to the next element.
-    if (
-      !nextFocus.hasAttribute('tabindex') ||
-      !textCriteriaMatches(nextFocus, textCriteria)
-    ) {
+    if (!nextFocus.hasAttribute('tabindex') || !textCriteriaMatches(nextFocus, textCriteria)) {
       nextFocus = traversalFunction(list, nextFocus, disableListWrap);
     } else {
       nextFocus.focus();

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -61,8 +61,6 @@ function moveFocus(list, currentFocus, disableListWrap, traversalFunction, textC
     // Move to the next element.
     if (
       !nextFocus.hasAttribute('tabindex') ||
-      nextFocus.disabled ||
-      nextFocus.getAttribute('aria-disabled') === 'true' ||
       !textCriteriaMatches(nextFocus, textCriteria)
     ) {
       nextFocus = traversalFunction(list, nextFocus, disableListWrap);

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -58,13 +58,13 @@ function moveFocus(list, currentFocus, disableListWrap, traversalFunction, textC
       }
       wrappedOnce = true;
     }
-    // Move to the next element.
-    if (!nextFocus.hasAttribute('tabindex') || !textCriteriaMatches(nextFocus, textCriteria)) {
-      nextFocus = traversalFunction(list, nextFocus, disableListWrap);
-    } else {
+    if (nextFocus.hasAttribute('tabindex') && textCriteriaMatches(nextFocus, textCriteria)) {
       nextFocus.focus();
       return true;
     }
+
+    // Move to the next element.
+    nextFocus = traversalFunction(list, nextFocus, disableListWrap);
   }
 
   return false;

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -312,9 +312,56 @@ describe('<MenuList> integration', () => {
     });
   });
 
-  it('should skip divider', () => {
+  it('should skip divider and disabled menu item', () => {
     const { getAllByRole } = render(
       <MenuList autoFocus>
+        <MenuItem>Menu Item 1</MenuItem>
+        <Divider component="li" />
+        <MenuItem>Menu Item 2</MenuItem>
+        <MenuItem disabled>Menu Item 3</MenuItem>
+        <MenuItem>Menu Item 4</MenuItem>
+      </MenuList>,
+    );
+    const menuitems = getAllByRole('menuitem');
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+    expect(menuitems[0]).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+    expect(menuitems[1]).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+    expect(menuitems[3]).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+    expect(menuitems[0]).to.have.focus;
+
+    // and ArrowUp again
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+
+    expect(menuitems[3]).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+
+    expect(menuitems[1]).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+
+    expect(menuitems[0]).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+
+    expect(menuitems[3]).to.have.focus;
+  });
+
+  it('should skip divider and not disabled menu item when enableFocusForDisabledItems = true', () => {
+    const { getAllByRole } = render(
+      <MenuList autoFocus enableFocusForDisabledItems>
         <MenuItem>Menu Item 1</MenuItem>
         <Divider component="li" />
         <MenuItem>Menu Item 2</MenuItem>
@@ -384,9 +431,41 @@ describe('<MenuList> integration', () => {
     expect(menuitems[0]).to.have.focus;
   });
 
-  it('should allow focus on disabled items', () => {
-    const { getAllByRole } = render(
+  it('should keep focus on the menu if all items are disabled', () => {
+    const { getByRole } = render(
       <MenuList autoFocus>
+        <MenuItem disabled>Menu Item 1</MenuItem>
+        <MenuItem disabled>Menu Item 2</MenuItem>
+        <MenuItem disabled>Menu Item 3</MenuItem>
+        <MenuItem disabled>Menu Item 4</MenuItem>
+      </MenuList>,
+    );
+    const menu = getByRole('menu');
+
+    fireEvent.keyDown(document.activeElement, { key: 'Home' });
+
+    expect(menu).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+    expect(menu).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+    expect(menu).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'End' });
+
+    expect(menu).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
+
+    expect(menu).to.have.focus;
+  });
+  
+  it('should allow focus on disabled items when enableFocusForDisabledItems = true', () => {
+    const { getAllByRole } = render(
+      <MenuList autoFocus enableFocusForDisabledItems>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem disabled>Menu Item 2</MenuItem>
         <MenuItem disabled>Menu Item 3</MenuItem>

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -312,9 +312,9 @@ describe('<MenuList> integration', () => {
     });
   });
 
-  it('should skip divider and disabled menu item when enableFocusForDisabledItems=false', () => {
+  it('should skip divider and disabled menu item', () => {
     const { getAllByRole } = render(
-      <MenuList autoFocus enableFocusForDisabledItems={false}>
+      <MenuList autoFocus>
         <MenuItem>Menu Item 1</MenuItem>
         <Divider component="li" />
         <MenuItem>Menu Item 2</MenuItem>
@@ -325,90 +325,28 @@ describe('<MenuList> integration', () => {
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[0]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[1]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[3]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[0]).to.have.focus;
 
     // and ArrowUp again
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
     expect(menuitems[3]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
     expect(menuitems[1]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
     expect(menuitems[0]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
     expect(menuitems[3]).to.have.focus;
-  });
-
-  it('should skip divider', () => {
-    const { getAllByRole } = render(
-      <MenuList autoFocus>
-        <MenuItem>Menu Item 1</MenuItem>
-        <Divider component="li" />
-        <MenuItem>Menu Item 2</MenuItem>
-        <Divider component="li" />
-        <MenuItem>Menu Item 3</MenuItem>
-      </MenuList>,
-    );
-    const menuitems = getAllByRole('menuitem');
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
-    expect(menuitems[0]).to.have.focus;
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
-    expect(menuitems[1]).to.have.focus;
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
-    expect(menuitems[2]).to.have.focus;
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
-    expect(menuitems[0]).to.have.focus;
-
-    // and ArrowUp again
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
-    expect(menuitems[2]).to.have.focus;
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
-    expect(menuitems[1]).to.have.focus;
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
-    expect(menuitems[0]).to.have.focus;
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
-    expect(menuitems[2]).to.have.focus;
   });
 
   it('should stay on a single item if it is the only focusable one', () => {
     const { getAllByRole } = render(
-      <MenuList autoFocus enableFocusForDisabledItems={false}>
+      <MenuList autoFocus>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem>Menu Item 2</MenuItem>
         <MenuItem disabled>Menu Item 3</MenuItem>
@@ -418,29 +356,20 @@ describe('<MenuList> integration', () => {
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[1]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[1]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[1]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
     expect(menuitems[1]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
     expect(menuitems[1]).to.have.focus;
   });
 
-  it('should keep focus on the menu if all items are disabled and enableFocusForDisabledItems=false', () => {
+  it('should keep focus on the menu if all items are disabled', () => {
     const { getByRole } = render(
-      <MenuList autoFocus enableFocusForDisabledItems={false}>
+      <MenuList autoFocus>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem disabled>Menu Item 2</MenuItem>
         <MenuItem disabled>Menu Item 3</MenuItem>
@@ -450,29 +379,20 @@ describe('<MenuList> integration', () => {
     const menu = getByRole('menu');
 
     fireEvent.keyDown(document.activeElement, { key: 'Home' });
-
     expect(menu).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menu).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menu).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'End' });
-
     expect(menu).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
     expect(menu).to.have.focus;
   });
 
-  it('should allow focus on disabled items when enableFocusForDisabledItems=true', () => {
+  it('should allow focus on disabled items when disabledItemsFocusable=true', () => {
     const { getAllByRole } = render(
-      <MenuList autoFocus enableFocusForDisabledItems>
+      <MenuList autoFocus disabledItemsFocusable>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem disabled>Menu Item 2</MenuItem>
         <MenuItem disabled>Menu Item 3</MenuItem>
@@ -483,23 +403,14 @@ describe('<MenuList> integration', () => {
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'Home' });
-
     expect(menuitems[0]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[1]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
     expect(menuitems[2]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'End' });
-
     expect(menuitems[3]).to.have.focus;
-
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-
     expect(menuitems[2]).to.have.focus;
   });
 

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -409,26 +409,33 @@ describe('<MenuList> integration', () => {
   it('should stay on a single item if it is the only focusable one', () => {
     const { getAllByRole } = render(
       <MenuList autoFocus>
+        <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem>Menu Item 2</MenuItem>
+        <MenuItem disabled>Menu Item 3</MenuItem>
+        <MenuItem disabled>Menu Item 4</MenuItem>
       </MenuList>,
     );
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[1]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[1]).to.have.focus;
+
+    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
+
+    expect(menuitems[1]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[1]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[1]).to.have.focus;
   });
 
   it('should keep focus on the menu if all items are disabled', () => {
@@ -462,7 +469,7 @@ describe('<MenuList> integration', () => {
 
     expect(menu).to.have.focus;
   });
-  
+
   it('should allow focus on disabled items when enableFocusForDisabledItems = true', () => {
     const { getAllByRole } = render(
       <MenuList autoFocus enableFocusForDisabledItems>

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -470,9 +470,9 @@ describe('<MenuList> integration', () => {
     expect(menu).to.have.focus;
   });
 
-  it('should allow focus on disabled items', () => {
+  it('should allow focus on disabled items when enableFocusForDisabledItems=true', () => {
     const { getAllByRole } = render(
-      <MenuList autoFocus>
+      <MenuList autoFocus enableFocusForDisabledItems>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem disabled>Menu Item 2</MenuItem>
         <MenuItem disabled>Menu Item 3</MenuItem>

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -312,14 +312,14 @@ describe('<MenuList> integration', () => {
     });
   });
 
-  it('should skip divider and disabled menu item', () => {
+  it('should skip divider', () => {
     const { getAllByRole } = render(
       <MenuList autoFocus>
         <MenuItem>Menu Item 1</MenuItem>
         <Divider component="li" />
         <MenuItem>Menu Item 2</MenuItem>
-        <MenuItem disabled>Menu Item 3</MenuItem>
-        <MenuItem>Menu Item 4</MenuItem>
+        <Divider component="li" />
+        <MenuItem>Menu Item 3</MenuItem>
       </MenuList>,
     );
     const menuitems = getAllByRole('menuitem');
@@ -334,7 +334,7 @@ describe('<MenuList> integration', () => {
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-    expect(menuitems[3]).to.have.focus;
+    expect(menuitems[2]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
@@ -344,7 +344,7 @@ describe('<MenuList> integration', () => {
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-    expect(menuitems[3]).to.have.focus;
+    expect(menuitems[2]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
@@ -356,43 +356,36 @@ describe('<MenuList> integration', () => {
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-    expect(menuitems[3]).to.have.focus;
+    expect(menuitems[2]).to.have.focus;
   });
 
   it('should stay on a single item if it is the only focusable one', () => {
     const { getAllByRole } = render(
       <MenuList autoFocus>
-        <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem>Menu Item 2</MenuItem>
-        <MenuItem disabled>Menu Item 3</MenuItem>
-        <MenuItem disabled>Menu Item 4</MenuItem>
       </MenuList>,
     );
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[0]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-    expect(menuitems[1]).to.have.focus;
-
-    fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[0]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[0]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[0]).to.have.focus;
   });
 
-  it('should keep focus on the menu if all items are disabled', () => {
-    const { getByRole } = render(
+  it('should allow focus on disabled items', () => {
+    const { getAllByRole } = render(
       <MenuList autoFocus>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem disabled>Menu Item 2</MenuItem>
@@ -400,27 +393,28 @@ describe('<MenuList> integration', () => {
         <MenuItem disabled>Menu Item 4</MenuItem>
       </MenuList>,
     );
-    const menu = getByRole('menu');
+
+    const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'Home' });
 
-    expect(menu).to.have.focus;
+    expect(menuitems[0]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-    expect(menu).to.have.focus;
+    expect(menuitems[1]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-    expect(menu).to.have.focus;
+    expect(menuitems[2]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'End' });
 
-    expect(menu).to.have.focus;
+    expect(menuitems[3]).to.have.focus;
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-    expect(menu).to.have.focus;
+    expect(menuitems[2]).to.have.focus;
   });
 
   describe('MenuList text-based keyboard controls', () => {

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -73,7 +73,7 @@ describe('<MenuList> integration', () => {
       expect(menuitems[2]).to.have.property('tabIndex', -1);
     });
 
-    it('should select the secont item when pressing down if the first item is selected', () => {
+    it('should select the second item when pressing down if the first item is selected', () => {
       const { getAllByRole } = render(
         <MenuList autoFocusItem>
           <MenuItem selected>Menu Item 1</MenuItem>
@@ -312,9 +312,9 @@ describe('<MenuList> integration', () => {
     });
   });
 
-  it('should skip divider and disabled menu item', () => {
+  it('should skip divider and disabled menu item when enableFocusForDisabledItems=false', () => {
     const { getAllByRole } = render(
-      <MenuList autoFocus>
+      <MenuList autoFocus enableFocusForDisabledItems={false}>
         <MenuItem>Menu Item 1</MenuItem>
         <Divider component="li" />
         <MenuItem>Menu Item 2</MenuItem>
@@ -359,9 +359,9 @@ describe('<MenuList> integration', () => {
     expect(menuitems[3]).to.have.focus;
   });
 
-  it('should skip divider and not disabled menu item when enableFocusForDisabledItems = true', () => {
+  it('should skip divider', () => {
     const { getAllByRole } = render(
-      <MenuList autoFocus enableFocusForDisabledItems>
+      <MenuList autoFocus>
         <MenuItem>Menu Item 1</MenuItem>
         <Divider component="li" />
         <MenuItem>Menu Item 2</MenuItem>
@@ -408,7 +408,7 @@ describe('<MenuList> integration', () => {
 
   it('should stay on a single item if it is the only focusable one', () => {
     const { getAllByRole } = render(
-      <MenuList autoFocus>
+      <MenuList autoFocus enableFocusForDisabledItems={false}>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem>Menu Item 2</MenuItem>
         <MenuItem disabled>Menu Item 3</MenuItem>
@@ -438,9 +438,9 @@ describe('<MenuList> integration', () => {
     expect(menuitems[1]).to.have.focus;
   });
 
-  it('should keep focus on the menu if all items are disabled', () => {
+  it('should keep focus on the menu if all items are disabled and enableFocusForDisabledItems=false', () => {
     const { getByRole } = render(
-      <MenuList autoFocus>
+      <MenuList autoFocus enableFocusForDisabledItems={false}>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem disabled>Menu Item 2</MenuItem>
         <MenuItem disabled>Menu Item 3</MenuItem>
@@ -470,9 +470,9 @@ describe('<MenuList> integration', () => {
     expect(menu).to.have.focus;
   });
 
-  it('should allow focus on disabled items when enableFocusForDisabledItems = true', () => {
+  it('should allow focus on disabled items', () => {
     const { getAllByRole } = render(
-      <MenuList autoFocus enableFocusForDisabledItems>
+      <MenuList autoFocus>
         <MenuItem disabled>Menu Item 1</MenuItem>
         <MenuItem disabled>Menu Item 2</MenuItem>
         <MenuItem disabled>Menu Item 3</MenuItem>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Small change to make menulist inline with WCAG specifications. (https://www.w3.org/TR/wai-aria-practices/#kbd_disabled_controls)

Disabled items should not be skipped in the menu lists during keyboard navigation as a visually impaired user will not be correctly notified via screen readers.