### PR TITLE
[docs] Fix unclear crash in IE11

### DIFF
--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -117,6 +117,14 @@ function MarkdownDocs(props) {
   const prevPage = pageList[currentPageNum - 1];
   const nextPage = pageList[currentPageNum + 1];
 
+  // TODO: prevents crash of localized pages (e.g. /de/api/alert-tile) in IE11
+  // but unclear why
+  const getAddContainer = React.useCallback(() => {
+    const container = document.querySelector('.description');
+    container.classList.add('ad');
+    return container;
+  }, []);
+
   return (
     <AppFrame>
       <Head
@@ -124,13 +132,7 @@ function MarkdownDocs(props) {
         description={headers.description || getDescription(markdownDocs.markdown)}
       />
       {disableAd ? null : (
-        <Portal
-          container={() => {
-            const container = document.querySelector('.description');
-            container.classList.add('ad');
-            return container;
-          }}
-        >
+        <Portal container={getAddContainer}>
           <Ad />
         </Portal>
       )}


### PR DESCRIPTION
Fixes crash on https://material-ui.netlify.com/de/api/alert-title/ in IE11. Verify in https://deploy-preview-19968--material-ui.netlify.com/de/api/alert-title/

Could not reproduce with https://codesandbox.io/s/mui-docs-portal-repro-bjvfi so it might be an issue with either `next` or what the ads are doing. 

Either way fixing the symptom for now until we find out why this happens. If we're lucky next 9 fixes this.