### PR TITLE
[Container] Reset display block for IE11

### DIFF
--- a/packages/material-ui/src/Container/Container.js
+++ b/packages/material-ui/src/Container/Container.js
@@ -13,6 +13,7 @@ export const styles = theme => ({
     marginRight: 'auto',
     paddingLeft: theme.spacing(2),
     paddingRight: theme.spacing(2),
+    display: 'block', // Fix IE 11 layout when used with main.
     [theme.breakpoints.up('sm')]: {
       paddingLeft: theme.spacing(3),
       paddingRight: theme.spacing(3),


### PR DESCRIPTION
It's helpful when using the following `<Container component="main" />` with IE 11. The issue was first seen in #19969.