### PR TITLE
[docs] Track bundle size of pages

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,10 +1,10 @@
 trigger:
   branches:
     include:
-    - '*'
+      - '*'
     exclude:
-    - l10n
-    - dependabot/*
+      - l10n
+      - dependabot/*
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -37,7 +37,7 @@ steps:
       globExpressions: '*.tgz'
       targetFolder: 'artifacts/$(Build.SourceBranchName)/$(Build.SourceVersion)'
       filesAcl: 'public-read'
-    displayName: "Upload distributables to S3"
+    displayName: 'Upload distributables to S3'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     env:
       AWS_ACCESS_KEY_ID: $(AWS_ACCESS_KEY_ID)
@@ -49,8 +49,11 @@ steps:
       targetPath: 'material-ui-core.tgz'
 
   - script: |
-      yarn docs:build
-    displayName: 'build docs'
+      set -o pipefail
+      mkdir -p scripts/sizeSnapshot/build	
+      yarn docs:build | tee scripts/sizeSnapshot/build/docs.next	
+      set +o pipefail
+    displayName: 'build docs for size snapshot'
 
   - script: |
       yarn size:snapshot

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -249,13 +249,13 @@ async function run() {
   <details>
   <summary>Details of bundle changes.</summary>
 
+  <p>Comparing: ${commitRange}</p>
+
   <details>
   <summary>Details of page changes</summary>
 
   ${pageDetailsTable}
   </details>
-
-  <p>Comparing: ${commitRange}</p>
 
   ${mainDetailsTable}
 

--- a/scripts/sizeSnapshot/create.js
+++ b/scripts/sizeSnapshot/create.js
@@ -98,7 +98,13 @@ async function getNextPagesSize() {
   return Array.from(matchAll(consoleOutput, pageRegex), match => {
     const { pageUrl, sizeFormatted, sizeUnit } = match.groups;
 
-    const snapshotId = `docs:${pageUrl}`;
+    let snapshotId = `docs:${pageUrl}`;
+    // used to be tracked with custom logic hence the different ids
+    if (pageUrl === '/') {
+      snapshotId = 'docs.main';
+    } else if (pageUrl === '/_app') {
+      snapshotId = 'docs.main';
+    }
     return [
       snapshotId,
       {
@@ -111,7 +117,6 @@ async function getNextPagesSize() {
 
 async function run() {
   const rollupBundles = [path.join(workspaceRoot, 'packages/material-ui/size-snapshot.json')];
-
   const bundleSizes = lodash.fromPairs([
     ...(await getWebpackSizes()),
     ...lodash.flatten(await Promise.all(rollupBundles.map(getRollupSize))),

--- a/scripts/sizeSnapshot/create.js
+++ b/scripts/sizeSnapshot/create.js
@@ -49,12 +49,73 @@ async function getWebpackSizes() {
   });
 }
 
+// waiting for String.prototype.matchAll in node 10
+function* matchAll(string, regex) {
+  let match = null;
+  do {
+    match = regex.exec(string);
+    if (match !== null) {
+      yield match;
+    }
+  } while (match !== null);
+}
+
+/**
+ * Inverse to `pretty-bytes`
+ *
+ * @param {string} n
+ * @param {'B', 'kB' | 'MB' | 'GB' | 'TB' | 'PB'} unit
+ * @returns {number}
+ */
+
+function prettyBytesInverse(n, unit) {
+  const metrixPrefix = unit.length < 2 ? '' : unit[0];
+  const metricPrefixes = ['', 'k', 'M', 'G', 'T', 'P'];
+  const metrixPrefixIndex = metricPrefixes.indexOf(metrixPrefix);
+  if (metrixPrefixIndex === -1) {
+    throw new TypeError(
+      `unrecognized metric prefix '${metrixPrefix}' in unit '${unit}'. only '${metricPrefixes.join(
+        "', '",
+      )}' are allowed`,
+    );
+  }
+
+  const power = metrixPrefixIndex * 3;
+  return n * 10 ** power;
+}
+
+/**
+ * parses output from next build to size snapshot format
+ * @returns {[string, { gzip: number, files: number, packages: number }][]}
+ */
+
+async function getNextPagesSize() {
+  const consoleOutput = await fse.readFile(path.join(__dirname, 'build/docs.next'), {
+    encoding: 'utf8',
+  });
+  const pageRegex = /^(?<treeViewPresentation>┌|├|└)\s+(?<fileType>σ|⚡|)\s+(?<pageUrl>[^\s]+)\s+(?<sizeFormatted>[0-9.]+)\s+(?<sizeUnit>\w+)/gm;
+
+  return Array.from(matchAll(consoleOutput, pageRegex), match => {
+    const { pageUrl, sizeFormatted, sizeUnit } = match.groups;
+
+    const snapshotId = `docs:${pageUrl}`;
+    return [
+      snapshotId,
+      {
+        parsed: prettyBytesInverse(sizeFormatted, sizeUnit),
+        gzip: -1,
+      },
+    ];
+  });
+}
+
 async function run() {
   const rollupBundles = [path.join(workspaceRoot, 'packages/material-ui/size-snapshot.json')];
 
   const bundleSizes = lodash.fromPairs([
     ...(await getWebpackSizes()),
     ...lodash.flatten(await Promise.all(rollupBundles.map(getRollupSize))),
+    ...(await getNextPagesSize()),
   ]);
 
   await fse.writeJSON(snapshotDestPath, bundleSizes, { spaces: 2 });

--- a/scripts/sizeSnapshot/webpack.config.js
+++ b/scripts/sizeSnapshot/webpack.config.js
@@ -1,4 +1,3 @@
-const fse = require('fs-extra');
 const globCallback = require('glob');
 const path = require('path');
 const CompressionPlugin = require('compression-webpack-plugin');
@@ -9,18 +8,6 @@ const glob = promisify(globCallback);
 const workspaceRoot = path.join(__dirname, '..', '..');
 
 async function getSizeLimitBundles() {
-  const nextDir = path.join(workspaceRoot, 'docs/.next');
-  const buildId = await fse.readFile(path.join(nextDir, 'BUILD_ID'), 'utf8');
-
-  const dirname = path.join(nextDir, 'static/chunks');
-  const [main] = (await fse.readdir(dirname)).reduce((result, filename) => {
-    if (filename.length === 31) {
-      return [...result, { path: `${dirname}/${filename}` }];
-    }
-
-    return result;
-  }, []);
-
   const corePackagePath = path.join(workspaceRoot, 'packages/material-ui/build/esm');
   const coreComponents = (await glob(path.join(corePackagePath, '[A-Z]*'))).map(componentPath => {
     const componentName = path.basename(componentPath);
@@ -94,16 +81,6 @@ async function getSizeLimitBundles() {
       name: '@material-ui/core/useMediaQuery',
       webpack: true,
       path: 'packages/material-ui/build/esm/useMediaQuery/index.js',
-    },
-    {
-      name: 'docs.main',
-      webpack: false,
-      path: path.relative(workspaceRoot, main.path),
-    },
-    {
-      name: 'docs.landing',
-      webpack: false,
-      path: path.relative(workspaceRoot, path.join(nextDir, `static/${buildId}/pages/index.js`)),
     },
   ];
 }


### PR DESCRIPTION
Brings back page tracking of #16546. 

Page tracking is done in a nested `<details />` where each row includes the linked to the deployed page (deploy-preview).