### PR TITLE
[docs] Fix incorrect type for fontWeight

### DIFF
--- a/docs/src/pages/getting-started/templates/checkout/Review.js
+++ b/docs/src/pages/getting-started/templates/checkout/Review.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles(theme => ({
     padding: theme.spacing(1, 0),
   },
   total: {
-    fontWeight: '700',
+    fontWeight: 700,
   },
   title: {
     marginTop: theme.spacing(2),


### PR DESCRIPTION
```js
✖ ｢atl｣: Checking finished with 1 errors
[at-loader] ./src/components/Review.tsx:30:30 
    TS2769: No overload matches this call.
  Overload 1 of 2, '(style: Styles<Theme, {}, "title" | "listItem" | "total">, options?: Pick<WithStylesOptions<Theme>, "link" | "meta" | "flip" | "element" | ... 5 more ... | "classNamePrefix">): (props?: any) => Record<...>', gave the following error.
    Argument of type '(theme: Theme) => { listItem: { padding: string; }; total: { fontWeight: "700"; }; title: { marginTop: number; }; }' is not assignable to parameter of type 'Styles<Theme, {}, "title" | "listItem" | "total">'.
      Type '(theme: Theme) => { listItem: { padding: string; }; total: { fontWeight: "700"; }; title: { marginTop: number; }; }' is not assignable to type 'StyleRulesCallback<Theme, {}, "title" | "listItem" | "total">'.
        Call signature return types '{ listItem: { padding: string; }; total: { fontWeight: "700"; }; title: { marginTop: number; }; }' and 'Record<"title" | "listItem" | "total", CSSProperties | CreateCSSProperties<{}> | ((props: {}) => CreateCSSProperties<{}>)>' are incompatible.
          The types of 'total' are incompatible between these types.
            Type '{ fontWeight: "700"; }' is not assignable to type 'CSSProperties | CreateCSSProperties<{}> | ((props: {}) => CreateCSSProperties<{}>)'.
              Type '{ fontWeight: "700"; }' is not assignable to type 'CreateCSSProperties<{}>'.
                Types of property 'fontWeight' are incompatible.
                  Type '"700"' is not assignable to type 'number | "-moz-initial" | "inherit" | "initial" | "revert" | "unset" | "normal" | "bold" | "bolder" | "lighter" | ((props: {}) => FontWeightProperty)'.
  Overload 2 of 2, '(styles: Styles<Theme, {}, "title" | "listItem" | "total">, options?: Pick<WithStylesOptions<Theme>, "link" | "meta" | "flip" | "element" | ... 5 more ... | "classNamePrefix">): (props: {}) => Record<...>', gave the following error.
    Argument of type '(theme: Theme) => { listItem: { padding: string; }; total: { fontWeight: "700"; }; title: { marginTop: number; }; }' is not assignable to parameter of type 'Styles<Theme, {}, "title" | "listItem" | "total">'.
      Type '(theme: Theme) => { listItem: { padding: string; }; total: { fontWeight: "700"; }; title: { marginTop: number; }; }' is not assignable to type 'StyleRulesCallback<Theme, {}, "title" | "listItem" | "total">'. 
```

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
