### PR TITLE
[docs] Fix missing OutlinedLabel#label link in Select API docs

### DIFF
--- a/docs/pages/api-docs/select.md
+++ b/docs/pages/api-docs/select.md
@@ -34,7 +34,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object</span> |  | [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element. When `native` is `true`, the attributes are applied on the `select` element. |
 | <span class="prop-name">label</span> | <span class="prop-type">node</span> |  | See [OutlinedLabel#label](/api/outlined-input/#props) |
 | <span class="prop-name">labelId</span> | <span class="prop-type">string</span> |  | The ID of an element that acts as an additional label. The Select will be labelled by the additional label and the selected value. |
-| <span class="prop-name">labelWidth</span> | <span class="prop-type">number</span> | <span class="prop-default">0</span> | See OutlinedLabel#label |
+| <span class="prop-name">labelWidth</span> | <span class="prop-type">number</span> | <span class="prop-default">0</span> | See [OutlinedLabel#label](/api/outlined-input/#props) |
 | <span class="prop-name">MenuProps</span> | <span class="prop-type">object</span> |  | Props applied to the [`Menu`](/api/menu/) element. |
 | <span class="prop-name">multiple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, `value` must be an array and the menu will support multiple selections. |
 | <span class="prop-name">native</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the component will be using a native `select` element. |

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -152,7 +152,7 @@ Select.propTypes = {
    */
   labelId: PropTypes.string,
   /**
-   * See OutlinedLabel#label
+   * See [OutlinedLabel#label](/api/outlined-input/#props)
    */
   labelWidth: PropTypes.number,
   /**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
