### PR TITLE
[styles] Name anonymous function type

### DIFF
--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -9,7 +9,7 @@ export {};
 
 type JSSFontface = CSS.FontFace & { fallbacks?: CSS.FontFace[] };
 
-type PropsFunc<Props, T> = (props: Props) => T;
+type PropsFunc<Props extends object, T> = (props: Props) => T;
 
 /**
  * Allows the user to augment the properties available

--- a/packages/material-ui-styles/src/withStyles/withStyles.d.ts
+++ b/packages/material-ui-styles/src/withStyles/withStyles.d.ts
@@ -9,6 +9,8 @@ export {};
 
 type JSSFontface = CSS.FontFace & { fallbacks?: CSS.FontFace[] };
 
+type PropsFunc<Props, T> = (props: Props) => T;
+
 /**
  * Allows the user to augment the properties available
  */
@@ -29,7 +31,7 @@ export interface CSSProperties extends BaseCSSProperties {
 }
 
 export type BaseCreateCSSProperties<Props extends object = {}> = {
-  [P in keyof BaseCSSProperties]: BaseCSSProperties[P] | ((props: Props) => BaseCSSProperties[P])
+  [P in keyof BaseCSSProperties]: BaseCSSProperties[P] | PropsFunc<Props, BaseCSSProperties[P]>
 };
 
 export interface CreateCSSProperties<Props extends object = {}>
@@ -55,7 +57,7 @@ export type StyleRules<Props extends object = {}, ClassKey extends string = stri
   // JSS property bag where values are based on props
   | CreateCSSProperties<Props>
   // JSS property bag based on props
-  | ((props: Props) => CreateCSSProperties<Props>)
+  | PropsFunc<Props, CreateCSSProperties<Props>>
 >;
 
 /**

--- a/packages/material-ui-styles/test/styles.spec.tsx
+++ b/packages/material-ui-styles/test/styles.spec.tsx
@@ -455,14 +455,14 @@ function forwardRefTest() {
   // If there are no props, use the definition that doesn't accept them
   // https://github.com/mui-org/material-ui/issues/16198
 
-  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<{}> | ((props: {}) => CreateCSSProperties<{}>)>
+  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<{}> | PropsFunc<{}, CreateCSSProperties<{}>>>
   const styles = createStyles({
     root: {
       width: 1,
     },
   });
 
-  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<{}> | ((props: {}) => CreateCSSProperties<{}>)>
+  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<{}> | PropsFunc<{}, CreateCSSProperties<{}>>>
   const styles2 = createStyles({
     root: () => ({
       width: 1,
@@ -473,7 +473,7 @@ function forwardRefTest() {
     foo: boolean;
   }
 
-  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<testProps> | ((props: testProps) => CreateCSSProperties<testProps>)>
+  // $ExpectType Record<"root", CSSProperties | CreateCSSProperties<testProps> | PropsFunc<testProps, CreateCSSProperties<testProps>>>
   const styles3 = createStyles({
     root: (props: testProps) => ({
       width: 1,


### PR DESCRIPTION
...to speed up compilation (by simplifying structural type comparison).  Note that, in most cases, the performance benefit of extracting a name type will be insignificant.

In this case, however, it appears to cut compilation time by 10-15%.

Change courtesy of @ahejlsberg.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
