### PR TITLE
[core] Fix typos in code comments

### DIFF
--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "allowJs": false,
     "isolatedModules": true,
-    /* files are emmitted by babel */
+    /* files are emitted by babel */
     "noEmit": true,
     "noUnusedLocals": true,
     "resolveJsonModule": true,

--- a/examples/preact/config/webpack.config.js
+++ b/examples/preact/config/webpack.config.js
@@ -183,7 +183,7 @@ module.exports = function(webpackEnv) {
               comparisons: false,
               // Disabled because of an issue with Terser breaking valid code:
               // https://github.com/facebook/create-react-app/issues/5250
-              // Pending futher investigation:
+              // Pending further investigation:
               // https://github.com/terser-js/terser/issues/120
               inline: 2,
             },

--- a/examples/preact/scripts/start.js
+++ b/examples/preact/scripts/start.js
@@ -56,7 +56,7 @@ if (process.env.HOST) {
   console.log();
 }
 
-// We require that you explictly set browsers and do not fall back to
+// We require that you explicitly set browsers and do not fall back to
 // browserslist defaults.
 const { checkBrowsers } = require('react-dev-utils/browsersHelper');
 checkBrowsers(paths.appPath, isInteractive)


### PR DESCRIPTION
**Fix typos across material-ui repo**

```
material-ui/docs/tsconfig.json:7:17: "emmitted" is a misspelling of "emitted"
material-ui/examples/preact/config/webpack.config.js:186:25: "futher" is a misspelling of "further"
material-ui/examples/preact/scripts/start.js:59:23: "explictly" is a misspelling of "explicitly"
```