### PR TITLE
[ci] Let failed types-next jobs pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,9 +156,14 @@ jobs:
       - install_js
       - run:
           name: Tests TypeScript definitions
-          # we want to see errors in all packages.
-          # without --no-bail we only see at most a single failing package
-          command: yarn typescript --no-bail
+          command: |
+            # ignore build failures
+            # it's expected that typescript@next fails since the lines of the errors
+            # change frequently. This build is monitored regardless of its status
+            set +e
+            # we want to see errors in all packages.
+            # without --no-bail we only see at most a single failing package
+            yarn typescript --no-bail
   test_browser:
     <<: *defaults
     steps:

--- a/examples/gatsby-theme/README.md
+++ b/examples/gatsby-theme/README.md
@@ -22,6 +22,6 @@ or:
 
 ## The idea behind the example
 
-The is an alternative example to [`/examples/gatsby`](https://github.com/mui-org/material-ui/tree/master/examples/gatsby) leveraging [gatsby-theme-material-ui](https://github.com/hupe1980/gatsby-theme-material-ui/tree/master/packages/gatsby-theme-material-ui).
+This is an alternative example to [`/examples/gatsby`](https://github.com/mui-org/material-ui/tree/master/examples/gatsby) leveraging [gatsby-theme-material-ui](https://github.com/hupe1980/gatsby-theme-material-ui/tree/master/packages/gatsby-theme-material-ui).
 The example bundles different Gatsby plugins into a single Gatsby theme.
 It trades less freedom for fewer boilerplate.


### PR DESCRIPTION
Follow-up on #19857

While it's ok for `@typescript@next` to fail (`$ExpectError` position changes) it's not ok for github to display the repo state as failing:

![Screenshot from 2020-03-06 02-03-06](https://user-images.githubusercontent.com/12292047/76040121-cb3bc080-5f4e-11ea-8265-4618cd49ae1d.png)

So we tell CircleCI to let failures in these jobs not affect the job status.