### PR TITLE
[ci] Let failed types-next jobs pass

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,6 +164,7 @@ jobs:
             # we want to see errors in all packages.
             # without --no-bail we only see at most a single failing package
             yarn typescript --no-bail
+            exit 0
   test_browser:
     <<: *defaults
     steps:


### PR DESCRIPTION
Continuation of #20007. CircleCI uses the last exit code so `set +e` has not effect unless the last command exits with 0.