### PR TITLE
[ListItemText] Fix display block issue

### DIFF
--- a/packages/material-ui/src/ListItemText/ListItemText.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.js
@@ -52,6 +52,7 @@ const ListItemText = React.forwardRef(function ListItemText(props, ref) {
         variant={dense ? 'body2' : 'body1'}
         className={classes.primary}
         component="span"
+        display="block"
         {...primaryTypographyProps}
       >
         {primary}
@@ -66,6 +67,7 @@ const ListItemText = React.forwardRef(function ListItemText(props, ref) {
         variant="body2"
         className={classes.secondary}
         color="textSecondary"
+        display="block"
         {...secondaryTypographyProps}
       >
         {secondary}


### PR DESCRIPTION
Fixes ListItemText with secondaryTypographyProps rendering on same line as primary. 

Closes #19943 
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
