### PR TITLE
[test] Match against messages not args on console methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "eslint-plugin-react": "^7.14.3",
     "eslint-plugin-react-hooks": "^2.1.1",
     "expect-puppeteer": "^4.3.0",
+    "format-util": "^1.0.5",
     "fs-extra": "^8.1.0",
     "glob": "^7.1.2",
     "glob-gitignore": "^1.0.11",

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -777,7 +777,7 @@ describe('<Autocomplete />', () => {
       expect(handleChange.callCount).to.equal(1);
       expect(handleChange.args[0][1]).to.equal('a');
       expect(consoleErrorMock.callCount()).to.equal(2); // strict mode renders twice
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'For the input option: "a", `getOptionLabel` returns: undefined',
       );
     });
@@ -806,7 +806,7 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(document.activeElement, { key: 'Enter' });
 
       expect(consoleErrorMock.callCount()).to.equal(1); // strict mode renders twice
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'The component expects a single value to match a given option but found 2 matches.',
       );
     });

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -45,7 +45,7 @@ describe('<TreeView />', () => {
       );
 
       setProps({ expanded: undefined });
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'A component is changing a controlled TreeView to be uncontrolled',
       );
     });
@@ -58,7 +58,7 @@ describe('<TreeView />', () => {
       );
 
       setProps({ selected: undefined });
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'A component is changing a controlled TreeView to be uncontrolled',
       );
     });

--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
@@ -161,7 +161,7 @@ describe('StylesProvider', () => {
       );
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'you cannot use the jss and injectFirst props at the same time',
       );
     });

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -144,7 +144,7 @@ describe('ThemeProvider', () => {
         </ThemeProvider>,
       );
       assert.strictEqual(consoleErrorMock.callCount(), 2); // twice in strict mode
-      assert.include(consoleErrorMock.args()[0][0], 'However, no outer theme is present.');
+      assert.include(consoleErrorMock.messages()[0], 'However, no outer theme is present.');
     });
 
     it('should warn about wrong theme function', () => {
@@ -158,7 +158,7 @@ describe('ThemeProvider', () => {
       );
       assert.strictEqual(consoleErrorMock.callCount(), 2);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'you should return an object from your theme function',
       );
     });

--- a/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
+++ b/packages/material-ui-styles/src/makeStyles/makeStyles.test.js
@@ -93,7 +93,7 @@ describe('makeStyles', () => {
       assert.deepEqual(extendedClasses, { root: baseClasses.root, bar: 'undefined foo' });
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Material-UI: the key `bar` provided to the classes prop is not implemented',
       );
     });
@@ -102,9 +102,9 @@ describe('makeStyles', () => {
       const output = mountWithProps();
       output.wrapper.setProps({ classes: 'foo' });
       assert.strictEqual(consoleErrorMock.callCount() >= 1, true);
-      const args = consoleErrorMock.args();
+      const messages = consoleErrorMock.messages();
       assert.include(
-        consoleErrorMock.args()[args.length - 1][0],
+        messages[messages.length - 1],
         'You might want to use the className prop instead',
       );
     });
@@ -117,7 +117,7 @@ describe('makeStyles', () => {
       assert.deepEqual(extendedClasses, { root: `${baseClasses.root} [object Object]` });
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Material-UI: the key `root` provided to the classes prop is not valid',
       );
     });
@@ -129,7 +129,7 @@ describe('makeStyles', () => {
         mountWithProps2({});
       });
       assert.strictEqual(consoleErrorMock.callCount(), 4);
-      assert.include(consoleErrorMock.args()[1][0], 'the `styles` argument provided is invalid');
+      assert.include(consoleErrorMock.messages()[1], 'the `styles` argument provided is invalid');
     });
   });
 

--- a/packages/material-ui-styles/src/styled/styled.test.js
+++ b/packages/material-ui-styles/src/styled/styled.test.js
@@ -108,7 +108,7 @@ describe('styled', () => {
       );
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'You can not use the clone and component prop at the same time',
       );
     });

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -91,7 +91,7 @@ describe('withStyles', () => {
 
     //     assert.strictEqual(consoleErrorMock.callCount(), 1);
     //     assert.include(
-    //       consoleErrorMock.args()[0][0],
+    //       consoleErrorMock.messages()[0],
     //       'Warning: Failed prop type: Material-UI: the `innerRef` prop is deprecated',
     //     );
     //   });

--- a/packages/material-ui-styles/src/withTheme/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme/withTheme.test.js
@@ -99,7 +99,7 @@ describe('withTheme', () => {
 
         assert.strictEqual(consoleErrorMock.callCount(), 1);
         assert.include(
-          consoleErrorMock.args()[0][0],
+          consoleErrorMock.messages()[0],
           'Warning: Failed prop type: Material-UI: the `innerRef` prop is deprecated',
         );
       });

--- a/packages/material-ui-system/src/spacing.test.js
+++ b/packages/material-ui-system/src/spacing.test.js
@@ -57,9 +57,9 @@ describe('spacing', () => {
       });
       assert.deepEqual(output, { padding: undefined });
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.match(consoleErrorMock.args()[0][0], /the value provided \(3\) overflows\./);
-      assert.match(consoleErrorMock.args()[0][0], /The supported values are: \[0,3,5\]\./);
-      assert.match(consoleErrorMock.args()[0][0], /3 > 2, you need to add the missing values\./);
+      assert.match(consoleErrorMock.messages()[0], /the value provided \(3\) overflows\./);
+      assert.match(consoleErrorMock.messages()[0], /The supported values are: \[0,3,5\]\./);
+      assert.match(consoleErrorMock.messages()[0], /3 > 2, you need to add the missing values\./);
     });
 
     it('should warn if the theme transformer is invalid', () => {
@@ -72,11 +72,11 @@ describe('spacing', () => {
       assert.deepEqual(output, { padding: undefined });
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.match(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         /the `theme.spacing` value \(\[object Object\]\) is invalid\./,
       );
       assert.match(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         /It should be a number, an array or a function\./,
       );
     });

--- a/packages/material-ui-utils/src/chainPropTypes.test.js
+++ b/packages/material-ui-utils/src/chainPropTypes.test.js
@@ -43,6 +43,6 @@ describe('chainPropTypes', () => {
       componentName,
     );
     assert.strictEqual(consoleErrorMock.callCount(), 1);
-    assert.match(consoleErrorMock.args()[0][0], /something is wrong/);
+    assert.match(consoleErrorMock.messages()[0], /something is wrong/);
   });
 });

--- a/packages/material-ui-utils/src/elementAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementAcceptingRef.test.js
@@ -55,7 +55,7 @@ describe('elementAcceptingRef', () => {
       assert.strictEqual(
         consoleErrorMock.callCount(),
         failsOnMount ? 1 : 0,
-        `but got '${consoleErrorMock.args()[0]}'`,
+        `but got '${consoleErrorMock.messages()[0]}'`,
       );
     }
 
@@ -132,7 +132,7 @@ describe('elementAcceptingRef', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Invalid props `children` supplied to `DummyComponent`. ' +
           `Expected an element that can hold a ref. ${hint}`,
       );
@@ -141,13 +141,13 @@ describe('elementAcceptingRef', () => {
     it('rejects undefined values when required', () => {
       checkPropType(undefined, true);
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.args()[0][0], 'marked as required');
+      assert.include(consoleErrorMock.messages()[0], 'marked as required');
     });
 
     it('rejects null values when required', () => {
       checkPropType(null, true);
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.args()[0][0], 'marked as required');
+      assert.include(consoleErrorMock.messages()[0], 'marked as required');
     });
 
     it('rejects function components', () => {

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
@@ -55,7 +55,7 @@ describe('elementTypeAcceptingRef', () => {
       assert.strictEqual(
         consoleErrorMock.callCount(),
         failsOnMount ? 1 : 0,
-        `but got '${consoleErrorMock.args()[0]}'`,
+        `but got '${consoleErrorMock.messages()[0]}'`,
       );
     }
 
@@ -132,7 +132,7 @@ describe('elementTypeAcceptingRef', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Invalid props `component` supplied to `DummyComponent`. ' +
           `Expected an element type that can hold a ref. ${hint}`,
       );

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -104,7 +104,7 @@ describe('<Breadcrumbs />', () => {
       expect(getAllByRole('listitem', { hidden: false })).to.have.length(4);
       expect(getByRole('list')).to.have.text('first/second/third/fourth');
       expect(consoleErrorMock.callCount()).to.equal(2); // strict mode renders twice
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'you have provided an invalid combination of props to the Breadcrumbs.\nitemsAfterCollapse={2} + itemsBeforeCollapse={2} >= maxItems={3}',
       );
     });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -934,7 +934,7 @@ describe('<ButtonBase />', () => {
       // cant match the error message here because flakiness with mocha watchmode
       render(<ButtonBase component={Component} />);
 
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Invalid prop `component` supplied to `ForwardRef(ButtonBase)`. Expected an element type that can hold a ref',
       );
     });

--- a/packages/material-ui/src/CardMedia/CardMedia.test.js
+++ b/packages/material-ui/src/CardMedia/CardMedia.test.js
@@ -96,7 +96,7 @@ describe('<CardMedia />', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Material-UI: either `children`, `image`, `src` or `component` prop must be specified.',
       );
     });

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -165,7 +165,7 @@ describe('<ExpansionPanel />', () => {
 
         assert.throws(() => mount(<ExpansionPanel>{[]}</ExpansionPanel>));
         assert.strictEqual(consoleErrorMock.callCount(), 3);
-        assert.include(consoleErrorMock.args()[0][0], 'Material-UI: expected the first child');
+        assert.include(consoleErrorMock.messages()[0], 'Material-UI: expected the first child');
       });
 
       it('needs a valid element as the first child', () => {
@@ -176,7 +176,7 @@ describe('<ExpansionPanel />', () => {
         );
         assert.strictEqual(consoleErrorMock.callCount(), 1);
         assert.include(
-          consoleErrorMock.args()[0][0],
+          consoleErrorMock.messages()[0],
           "Material-UI: the ExpansionPanel doesn't accept a Fragment",
         );
       });
@@ -206,7 +206,7 @@ describe('<ExpansionPanel />', () => {
 
       wrapper.setProps({ expanded: undefined });
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'A component is changing a controlled ExpansionPanel to be uncontrolled.',
       );
     });
@@ -216,7 +216,7 @@ describe('<ExpansionPanel />', () => {
 
       wrapper.setProps({ expanded: true });
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'A component is changing an uncontrolled ExpansionPanel to be controlled.',
       );
     });

--- a/packages/material-ui/src/GridList/GridList.test.js
+++ b/packages/material-ui/src/GridList/GridList.test.js
@@ -208,7 +208,7 @@ describe('<GridList />', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         "Material-UI: the GridList component doesn't accept a Fragment as a child.",
       );
     });

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -162,7 +162,7 @@ describe('<HiddenCss />', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Material-UI: unsupported props received by `<Hidden implementation="css" />`: xxlUp.',
       );
     });

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -142,7 +142,7 @@ describe('<IconButton />', () => {
         </IconButton>,
       );
       expect(consoleErrorMock.callCount()).to.equal(1);
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'you are providing an onClick event listener',
       );
     });

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -151,7 +151,7 @@ describe('<InputAdornment />', () => {
           </FormControl>,
         );
         expect(consoleErrorMock.callCount()).to.equal(1);
-        expect(consoleErrorMock.args()[0][0]).to.equal(
+        expect(consoleErrorMock.messages()[0]).to.equal(
           'Material-UI: The `InputAdornment` variant infers the variant ' +
             'prop you do not have to provide one.',
         );

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -500,7 +500,7 @@ describe('<InputBase />', () => {
         );
 
         expect(consoleErrorMock.callCount()).to.eq(1);
-        expect(consoleErrorMock.args()[0][0]).to.include(
+        expect(consoleErrorMock.messages()[0]).to.include(
           'Material-UI: there are multiple InputBase components inside a FormControl.',
         );
       });

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -179,12 +179,12 @@ describe('<LinearProgress />', () => {
     it('should warn when not used as expected', () => {
       shallow(<LinearProgress variant="determinate" value={undefined} />);
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.match(consoleErrorMock.args()[0][0], /Material-UI: you need to provide a value prop/);
+      assert.match(consoleErrorMock.messages()[0], /Material-UI: you need to provide a value prop/);
       shallow(<LinearProgress variant="buffer" value={undefined} />);
       assert.strictEqual(consoleErrorMock.callCount(), 3);
-      assert.match(consoleErrorMock.args()[1][0], /Material-UI: you need to provide a value prop/);
+      assert.match(consoleErrorMock.messages()[1], /Material-UI: you need to provide a value prop/);
       assert.match(
-        consoleErrorMock.args()[2][0],
+        consoleErrorMock.messages()[2],
         /Material-UI: you need to provide a valueBuffer prop/,
       );
     });

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -158,7 +158,7 @@ describe('<ListItem />', () => {
         );
 
         expect(consoleErrorMock.callCount()).to.equal(1);
-        expect(consoleErrorMock.args()[0][0]).to.include(
+        expect(consoleErrorMock.messages()[0]).to.include(
           'Warning: Failed prop type: Material-UI: you used an element',
         );
       });
@@ -167,7 +167,7 @@ describe('<ListItem />', () => {
         render(<ListItem component={NoContent} autoFocus />);
 
         expect(consoleErrorMock.callCount()).to.equal(1);
-        expect(consoleErrorMock.args()[0][0]).to.include(
+        expect(consoleErrorMock.messages()[0]).to.include(
           'Material-UI: unable to set focus to a ListItem whose component has not been rendered.',
         );
       });

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -249,7 +249,7 @@ describe('<Menu />', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 2);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         "Material-UI: the Menu component doesn't accept a Fragment as a child.",
       );
     });

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -509,7 +509,7 @@ describe('<Modal />', () => {
         </Modal>,
       );
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.match(consoleErrorMock.args()[0][0], /the modal content node does not accept focus/);
+      assert.match(consoleErrorMock.messages()[0], /the modal content node does not accept focus/);
     });
 
     it('should not attempt to focus nonexistent children', () => {

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -82,7 +82,7 @@ describe('<Paper />', () => {
 
     assert.strictEqual(consoleErrorMock.callCount(), 1);
     assert.include(
-      consoleErrorMock.args()[0][0],
+      consoleErrorMock.messages()[0],
       'Material-UI: this elevation `25` is not implemented.',
     );
   });

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -478,14 +478,14 @@ describe('<Popover />', () => {
       const otherWrapper = mount(<Popover open />);
       assert.strictEqual(otherWrapper.find(Modal).props().container, undefined);
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.args()[0][0], 'It should be an Element instance');
+      assert.include(consoleErrorMock.messages()[0], 'It should be an Element instance');
     });
 
     it('warns if a component for the Paper is used that cant hold a ref', () => {
       mount(<Popover {...defaultProps} PaperProps={{ component: () => <div />, elevation: 4 }} />);
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Warning: Failed prop type: Invalid prop `PaperProps.component` supplied to `ForwardRef(Popover)`. Expected an element type that can hold a ref.',
       );
     });
@@ -493,7 +493,7 @@ describe('<Popover />', () => {
     // it('should warn if anchorEl is not visible', () => {
     //   mount(<Popover open anchorEl={document.createElement('div')} />);
     //   assert.strictEqual(consoleErrorMock.callCount(), 1);
-    //   assert.include(consoleErrorMock.args()[0][0], 'The node element should be visible');
+    //   assert.include(consoleErrorMock.messages()[0], 'The node element should be visible');
     // });
   });
 

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -286,13 +286,13 @@ describe('<Popper />', () => {
     it('should warn if anchorEl is not valid', () => {
       mount(<Popper {...defaultProps} open anchorEl={null} />);
       assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.args()[0][0], 'It should be an HTML Element instance');
+      assert.include(consoleErrorMock.messages()[0], 'It should be an HTML Element instance');
     });
 
     // it('should warn if anchorEl is not visible', () => {
     //   mount(<Popper {...defaultProps} open anchorEl={document.createElement('div')} />);
     //   assert.strictEqual(consoleErrorMock.callCount(), 1);
-    //   assert.include(consoleErrorMock.args()[0][0], 'The node element should be visible');
+    //   assert.include(consoleErrorMock.messages()[0], 'The node element should be visible');
     // });
   });
 });

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -355,7 +355,7 @@ describe('<RadioGroup />', () => {
 
       wrapper.setProps({ value: undefined });
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'A component is changing a controlled RadioGroup to be uncontrolled.',
       );
     });
@@ -369,7 +369,7 @@ describe('<RadioGroup />', () => {
 
       wrapper.setProps({ value: 'foo' });
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'A component is changing an uncontrolled RadioGroup to be controlled.',
       );
     });

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -498,14 +498,14 @@ describe('<Slider />', () => {
 
     it('should warn if aria-valuetext is provided', () => {
       render(<Slider value={[20, 50]} aria-valuetext="hot" />);
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'you need to use the `getAriaValueText` prop instead of',
       );
     });
 
     it('should warn if aria-label is provided', () => {
       render(<Slider value={[20, 50]} aria-label="hot" />);
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'you need to use the `getAriaLabel` prop instead of',
       );
     });
@@ -514,7 +514,7 @@ describe('<Slider />', () => {
       const { setProps } = render(<Slider value={[20, 50]} />);
 
       setProps({ value: undefined });
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'A component is changing a controlled Slider to be uncontrolled.',
       );
     });
@@ -523,7 +523,7 @@ describe('<Slider />', () => {
       const { setProps } = render(<Slider />);
 
       setProps({ value: [20, 50] });
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'A component is changing an uncontrolled Slider to be controlled.',
       );
     });

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -536,7 +536,7 @@ describe('<SwipeableDrawer />', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Warning: Failed prop type: Invalid prop `PaperProps.component` supplied to `ForwardRef(SwipeableDrawer)`. Expected an element type that can hold a ref.',
       );
     });
@@ -553,7 +553,7 @@ describe('<SwipeableDrawer />', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Warning: Failed prop type: Invalid prop `ModalProps.BackdropProps.component` supplied to `ForwardRef(SwipeableDrawer)`. Expected an element type that can hold a ref.',
       );
     });

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -312,7 +312,7 @@ describe('<TablePagination />', () => {
       );
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'Material-UI: the page prop of a TablePagination is out of range (0 to 1, but page is 2).',
       );
     });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -65,7 +65,7 @@ describe('<Tabs />', () => {
     it('should warn if the input is invalid', () => {
       render(<Tabs value={0} centered variant="scrollable" />);
       assert.match(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         /Material-UI: you can not use the `centered={true}` and `variant="scrollable"`/,
       );
     });
@@ -234,7 +234,7 @@ describe('<Tabs />', () => {
           </Tabs>,
         );
         expect(consoleErrorMock.callCount()).to.equal(4);
-        expect(consoleErrorMock.args()[0][0]).to.include(
+        expect(consoleErrorMock.messages()[0]).to.include(
           'You can provide one of the following values: 1, 3',
         );
       });

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -267,7 +267,7 @@ describe('<TextareaAutosize />', () => {
         wrapper.update();
 
         assert.strictEqual(consoleErrorMock.callCount(), 3);
-        assert.include(consoleErrorMock.args()[0][0], 'Material-UI: too many re-renders.');
+        assert.include(consoleErrorMock.messages()[0], 'Material-UI: too many re-renders.');
       });
     });
   });

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -335,7 +335,7 @@ describe('<Tooltip />', () => {
       );
       assert.strictEqual(consoleErrorMock.callCount(), 1, 'should call console.error');
       assert.match(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         /Material-UI: you are providing a disabled `button` child to the Tooltip component/,
       );
     });
@@ -497,7 +497,7 @@ describe('<Tooltip />', () => {
 
       wrapper.setProps({ open: true });
       assert.include(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         'A component is changing an uncontrolled Tooltip to be controlled.',
       );
     });

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -373,10 +373,10 @@ describe('<SwitchBase />', () => {
 
         wrapper.setProps({ checked: true });
         expect(consoleErrorMock.callCount()).to.equal(2);
-        expect(consoleErrorMock.args()[0][0]).to.include(
-          'A component is changing an uncontrolled input of type %s to be controlled.',
+        expect(consoleErrorMock.messages()[0]).to.include(
+          'A component is changing an uncontrolled input of type checkbox to be controlled.',
         );
-        expect(consoleErrorMock.args()[1][0]).to.include(
+        expect(consoleErrorMock.messages()[1]).to.include(
           'A component is changing an uncontrolled SwitchBase to be controlled.',
         );
       }),
@@ -392,10 +392,10 @@ describe('<SwitchBase />', () => {
 
         setProps({ checked: undefined });
         expect(consoleErrorMock.callCount()).to.equal(2);
-        expect(consoleErrorMock.args()[0][0]).to.include(
-          'A component is changing a controlled input of type %s to be uncontrolled.',
+        expect(consoleErrorMock.messages()[0]).to.include(
+          'A component is changing a controlled input of type checkbox to be uncontrolled.',
         );
-        expect(consoleErrorMock.args()[1][0]).to.include(
+        expect(consoleErrorMock.messages()[1]).to.include(
           'A component is changing a controlled SwitchBase to be uncontrolled.',
         );
       }),

--- a/packages/material-ui/src/styles/createMuiTheme.test.js
+++ b/packages/material-ui/src/styles/createMuiTheme.test.js
@@ -104,14 +104,14 @@ describe('createMuiTheme', () => {
 
       theme = createMuiTheme({ overrides: { Button: { disabled: { color: 'blue' } } } });
       assert.strictEqual(Object.keys(theme.overrides.Button.disabled).length, 1);
-      assert.strictEqual(consoleErrorMock.args().length, 0);
+      assert.strictEqual(consoleErrorMock.messages().length, 0);
       theme = createMuiTheme({ overrides: { MuiButton: { root: { color: 'blue' } } } });
-      assert.strictEqual(consoleErrorMock.args().length, 0);
+      assert.strictEqual(consoleErrorMock.messages().length, 0);
       theme = createMuiTheme({ overrides: { MuiButton: { disabled: { color: 'blue' } } } });
       assert.strictEqual(Object.keys(theme.overrides.MuiButton.disabled).length, 0);
-      assert.strictEqual(consoleErrorMock.args().length, 1);
+      assert.strictEqual(consoleErrorMock.messages().length, 1);
       assert.match(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         /the `MuiButton` component increases the CSS specificity of the `disabled` internal state./,
       );
     });

--- a/packages/material-ui/src/styles/createPalette.test.js
+++ b/packages/material-ui/src/styles/createPalette.test.js
@@ -91,7 +91,7 @@ describe('createPalette()', () => {
   it('logs an error when an invalid type is specified', () => {
     createPalette({ type: 'foo' });
     expect(consoleErrorMock.callCount()).to.equal(1);
-    expect(consoleErrorMock.args()[0][0]).to.match(
+    expect(consoleErrorMock.messages()[0]).to.match(
       /Material-UI: the palette type `foo` is not supported/,
     );
   });
@@ -159,7 +159,7 @@ describe('createPalette()', () => {
       getContrastText('#fefefe');
 
       expect(consoleErrorMock.callCount()).to.equal(3);
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'falls below the WCAG recommended absolute minimum contrast ratio of 3:1',
       );
     });

--- a/packages/material-ui/src/styles/createSpacing.test.js
+++ b/packages/material-ui/src/styles/createSpacing.test.js
@@ -52,7 +52,7 @@ describe('createSpacing', () => {
       const spacing = createSpacing(11);
       expect(spacing.unit).to.equal(11);
       expect(consoleErrorMock.callCount()).to.equal(1);
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'theme.spacing.unit usage has been deprecated',
       );
     });
@@ -62,7 +62,7 @@ describe('createSpacing', () => {
         unit: 4,
       });
       expect(consoleErrorMock.callCount()).to.equal(1);
-      expect(consoleErrorMock.args()[0][0]).to.include(
+      expect(consoleErrorMock.messages()[0]).to.include(
         'the `theme.spacing` value ([object Object]) is invalid',
       );
     });

--- a/packages/material-ui/src/styles/createTypography.test.js
+++ b/packages/material-ui/src/styles/createTypography.test.js
@@ -87,7 +87,7 @@ describe('createTypography', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.match(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         /Material-UI: `fontSize` is required to be a number./,
       );
     });
@@ -97,7 +97,7 @@ describe('createTypography', () => {
 
       assert.strictEqual(consoleErrorMock.callCount(), 1);
       assert.match(
-        consoleErrorMock.args()[0][0],
+        consoleErrorMock.messages()[0],
         /Material-UI: `htmlFontSize` is required to be a number./,
       );
     });

--- a/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
+++ b/packages/material-ui/src/useMediaQuery/useMediaQuery.test.js
@@ -285,7 +285,7 @@ describe('useMediaQuery', () => {
       }
 
       render(<MyComponent />);
-      expect(consoleErrorMock.args()[0][0]).to.include('the `query` argument provided is invalid');
+      expect(consoleErrorMock.messages()[0]).to.include('the `query` argument provided is invalid');
     });
   });
 });

--- a/packages/material-ui/src/utils/deprecatedPropType.test.js
+++ b/packages/material-ui/src/utils/deprecatedPropType.test.js
@@ -43,7 +43,7 @@ describe('deprecatedPropType', () => {
       componentName,
     );
     assert.strictEqual(consoleErrorMock.callCount(), 1);
-    assert.match(consoleErrorMock.args()[0][0], /give me a reason/);
+    assert.match(consoleErrorMock.messages()[0], /give me a reason/);
     PropTypes.checkPropTypes(
       {
         [propName]: deprecatedPropType(PropTypes.string, 'give me a reason'),

--- a/packages/material-ui/src/utils/useControlled.test.js
+++ b/packages/material-ui/src/utils/useControlled.test.js
@@ -59,7 +59,7 @@ describe('useControlled', () => {
     expect(consoleErrorMock.callCount()).to.equal(0);
     setProps({ value: 'foobar' });
     expect(consoleErrorMock.callCount()).to.equal(1);
-    expect(consoleErrorMock.args()[0][0]).to.contains(
+    expect(consoleErrorMock.messages()[0]).to.contains(
       'A component is changing an uncontrolled TestComponent to be controlled.',
     );
   });
@@ -69,7 +69,7 @@ describe('useControlled', () => {
     expect(consoleErrorMock.callCount()).to.equal(0);
     setProps({ value: undefined });
     expect(consoleErrorMock.callCount()).to.equal(1);
-    expect(consoleErrorMock.args()[0][0]).to.contains(
+    expect(consoleErrorMock.messages()[0]).to.contains(
       'A component is changing a controlled TestComponent to be uncontrolled.',
     );
   });
@@ -79,7 +79,7 @@ describe('useControlled', () => {
     expect(consoleErrorMock.callCount()).to.equal(0);
     setProps({ defaultValue: 1 });
     expect(consoleErrorMock.callCount()).to.equal(1);
-    expect(consoleErrorMock.args()[0][0]).to.contains(
+    expect(consoleErrorMock.messages()[0]).to.contains(
       'A component is changing the default value of an uncontrolled TestComponent after being initialized. ',
     );
   });

--- a/test/utils/consoleErrorMock.js
+++ b/test/utils/consoleErrorMock.js
@@ -38,7 +38,7 @@ class ConsoleErrorMock {
   args = () => {
     throw new TypeError(
       'args() was removed in favor of messages(). ' +
-        'Use messages to match against the actual error message that will be displayed in the console.',
+        'Use messages() to match against the actual error message that will be displayed in the console.',
     );
   };
 

--- a/test/utils/consoleErrorMock.js
+++ b/test/utils/consoleErrorMock.js
@@ -35,6 +35,13 @@ class ConsoleErrorMock {
     throw new Error('Requested call count before spy() was called');
   };
 
+  args = () => {
+    throw new TypeError(
+      'args() was removed in favor of messages(). ' +
+        'Use messages to match against the actual error message that will be displayed in the console.',
+    );
+  };
+
   /**
    * returns the formatted message for each call
    *

--- a/test/utils/consoleErrorMock.js
+++ b/test/utils/consoleErrorMock.js
@@ -1,3 +1,4 @@
+import utilFormat from 'format-util';
 import { spy } from 'sinon';
 
 /**
@@ -34,12 +35,24 @@ class ConsoleErrorMock {
     throw new Error('Requested call count before spy() was called');
   };
 
-  args = () => {
-    if (this.consoleErrorContainer) {
-      return console.error.args;
+  /**
+   * returns the formatted message for each call
+   *
+   * you could call console.error("type %s", "foo") which would log
+   * "type foo". If you  want to assert on the actual message use messages() instead
+   */
+  messages = () => {
+    if (!this.consoleErrorContainer) {
+      throw new Error('Requested call count before spy() was called');
     }
 
-    throw new Error('Requested call count before spy() was called');
+    /**
+     * @type {import('sinon').SinonSpy}
+     */
+    const consoleSpy = console.error;
+    return consoleSpy.args.map(loggerArgs => {
+      return utilFormat(...loggerArgs);
+    });
   };
 }
 

--- a/test/utils/consoleErrorMock.test.js
+++ b/test/utils/consoleErrorMock.test.js
@@ -14,7 +14,7 @@ describe('consoleErrorMock()', () => {
     it('was removed but throws a descriptive error', () => {
       assert.throws(
         () => consoleErrorMock.args(),
-        'args() was removed in favor of messages(). Use messages to match against the actual error message that will be displayed in the console.',
+        'args() was removed in favor of messages(). Use messages() to match against the actual error message that will be displayed in the console.',
       );
     });
   });

--- a/test/utils/consoleErrorMock.test.js
+++ b/test/utils/consoleErrorMock.test.js
@@ -10,6 +10,15 @@ describe('consoleErrorMock()', () => {
     });
   });
 
+  describe('args', () => {
+    it('was removed but throws a descriptive error', () => {
+      assert.throws(
+        () => consoleErrorMock.args(),
+        'args() was removed in favor of messages(). Use messages to match against the actual error message that will be displayed in the console.',
+      );
+    });
+  });
+
   describe('messages()', () => {
     describe('when not spying', () => {
       it('should throw error', () => {

--- a/test/utils/consoleErrorMock.test.js
+++ b/test/utils/consoleErrorMock.test.js
@@ -10,11 +10,29 @@ describe('consoleErrorMock()', () => {
     });
   });
 
-  describe('args()', () => {
-    it('should throw error when calling args() before spy()', () => {
-      assert.throws(() => {
-        consoleErrorMock.args();
-      }, 'Requested call count before spy() was called');
+  describe('messages()', () => {
+    describe('when not spying', () => {
+      it('should throw error', () => {
+        assert.throws(() => {
+          consoleErrorMock.messages();
+        }, 'Requested call count before spy() was called');
+      });
+    });
+
+    describe('when spying', () => {
+      beforeEach(() => {
+        consoleErrorMock.spy();
+      });
+
+      afterEach(() => {
+        consoleErrorMock.reset();
+      });
+
+      it('returns the formatted output', () => {
+        console.error('expected %s but got %s', '1', 2);
+
+        assert.strictEqual(consoleErrorMock.messages()[0], 'expected 1 but got 2');
+      });
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7137,6 +7137,11 @@ form-data@~2.3.2:
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
 
+format-util@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
+  integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"


### PR DESCRIPTION
`react@next` leverages the formatting signature of `console.error` (`console.error(message, ...substitutions)`) when checking `prop-types`. This makes `consoleErrorMock.args()` more brittle.

We want to match against the error message anyway so we switch from args() to messages(). It should return the same output as one would see in the browser (node uses util.format so we use an implementation of util.format that works in the browser).