### PR TITLE
[Skeleton] Fix SkeletonClassKey type

### DIFF
--- a/packages/material-ui-lab/src/Skeleton/Skeleton.d.ts
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.d.ts
@@ -14,7 +14,7 @@ export interface SkeletonTypeMap<P = {}, D extends React.ElementType = 'span'> {
 
 declare const Skeleton: OverridableComponent<SkeletonTypeMap>;
 
-export type SkeletonClassKey = 'root' | 'text' | 'rect' | 'circle' | 'animate';
+export type SkeletonClassKey = 'root' | 'text' | 'rect' | 'circle' | 'pulse' | 'wave';
 
 export type SkeletonProps<
   D extends React.ElementType = SkeletonTypeMap['defaultComponent'],


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

A change in the classes was introduce in this PR https://github.com/mui-org/material-ui/pull/19014 but we forgot to update the SkeletonClassKey in the declaration file of the Skeleton component
