### PR TITLE
[Rating] Fix text alignment inheritance 

### DIFF
--- a/packages/material-ui-lab/src/Rating/Rating.js
+++ b/packages/material-ui-lab/src/Rating/Rating.js
@@ -38,6 +38,7 @@ export const styles = theme => ({
     fontSize: theme.typography.pxToRem(24),
     color: '#ffb400',
     cursor: 'pointer',
+    textAlign: 'left',
     WebkitTapHighlightColor: 'transparent',
     '&$disabled': {
       opacity: 0.5,


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixes #20053 
- Explicitly stated textAlign to be left in the root Rating class so it doesn't inherit the textAlign property from its parent. 