### PR TITLE
[docs] Add color preview to default theme tree

### DIFF
--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -120,9 +120,6 @@ const useObjectEntryStyles = makeStyles({
       backgroundColor: lighten('#333', 0.08),
     },
   },
-  colorBox: {
-    margin: '0 5px 0 10px',
-  },
 });
 
 function ObjectEntry(props) {

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -82,7 +82,7 @@ function ObjectEntryLabel({ objectKey, objectValue }) {
 
   return (
     <React.Fragment>
-      {objectKey}:
+      {`${objectKey}: `}
       <span className={clsx('token', tokenType)}>
         {includeColorSample && (
           <svg

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -97,7 +97,7 @@ function ObjectEntryLabel({ objectKey, objectValue }) {
               height="12"
               fill={label.replace(/['"]+/g, '')}
               stroke="#fff"
-              stroke-width="3"
+              strokeWidth="3"
             />
           </svg>
         )}

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -77,8 +77,8 @@ function ObjectEntryLabel({ objectKey, objectValue }) {
   const classes = useObjectEntryLabelStyles();
 
   const includeColorSample =
-    label.includes('#') ||
-    (label.includes('rgba') && !label.includes('rgba(0, 0, 0, ') && !label.includes('rgba(0,0,0'));
+    (label.includes('#') ||
+    label.includes('rgba')) && !label.includes('rgba(0, 0, 0, ') && !label.includes('rgba(0,0,0'));
 
   return (
     <React.Fragment>

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -78,7 +78,7 @@ function ObjectEntryLabel({ objectKey, objectValue }) {
 
   const includeColorSample =
     (label.includes('#') ||
-    label.includes('rgba')) && !label.includes('rgba(0, 0, 0, ') && !label.includes('rgba(0,0,0'));
+    label.includes('rgba')) && !label.includes('rgba(0, 0, 0, ') && !label.includes('rgba(0,0,0');
 
   return (
     <React.Fragment>

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -64,14 +64,45 @@ function useTokenType(type) {
   }
 }
 
+const useObjectEntryLabelStyles = makeStyles({
+  colorPreview: {
+    margin: '0 5px 0 5px',
+  },
+});
+
 function ObjectEntryLabel({ objectKey, objectValue }) {
   const type = useType(objectValue);
   const label = useLabel(objectValue, type);
   const tokenType = useTokenType(type);
+  const classes = useObjectEntryLabelStyles();
+
+  const includeColorSample =
+    label.includes('#') ||
+    (label.includes('rgba') && !label.includes('rgba(0, 0, 0, ') && !label.includes('rgba(0,0,0'));
 
   return (
     <React.Fragment>
-      {objectKey}: <span className={clsx('token', tokenType)}>{label}</span>
+      {objectKey}:
+      <span className={clsx('token', tokenType)}>
+        {includeColorSample && (
+          <svg
+            width="12"
+            height="12"
+            version="1.1"
+            xmlns="http://www.w3.org/2000/svg"
+            className={classes.colorPreview}
+          >
+            <rect
+              width="12"
+              height="12"
+              fill={label.replace(/['"]+/g, '')}
+              stroke="white"
+              stroke-width="3"
+            />
+          </svg>
+        )}
+        {label}
+      </span>
     </React.Fragment>
   );
 }
@@ -88,6 +119,9 @@ const useObjectEntryStyles = makeStyles({
     '&:hover': {
       backgroundColor: lighten('#333', 0.08),
     },
+  },
+  colorBox: {
+    margin: '0 5px 0 10px',
   },
 });
 

--- a/docs/src/pages/customization/default-theme/DefaultTheme.js
+++ b/docs/src/pages/customization/default-theme/DefaultTheme.js
@@ -96,7 +96,7 @@ function ObjectEntryLabel({ objectKey, objectValue }) {
               width="12"
               height="12"
               fill={label.replace(/['"]+/g, '')}
-              stroke="white"
+              stroke="#fff"
               stroke-width="3"
             />
           </svg>


### PR DESCRIPTION
fixes #20077

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

<img width="425" alt="Capture d’écran 2020-03-23 à 00 24 48" src="https://user-images.githubusercontent.com/3165635/77265343-c12ef700-6c9c-11ea-80a7-af5d5d8f0209.png">

https://deploy-preview-20082--material-ui.netlify.com/customization/default-theme/#explore

*Note: let me know if I should write tests for these*