### PR TITLE
[Autocomplete] Document listbox limitation

### DIFF
--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -222,9 +222,7 @@ TypeScript might solve this bug in the future.
 
 ### ListboxComponent
 
-If you provide a custom `ListboxComponent` prop, you need to make sure that the intended scroll container has the
-`role` attribute set to `listbox`. This ensures the correct behavior of the scroll, for example when using the
-keyboard to navigate.
+If you provide a custom `ListboxComponent` prop, you need to make sure that the intended scroll container has the `role` attribute set to `listbox`. This ensures the correct behavior of the scroll, for example when using the keyboard to navigate.
 
 ## Accessibility
 

--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -220,6 +220,12 @@ To fully take advantage of type inference, you need to set the `multiple` prop t
 See [this discussion](https://github.com/mui-org/material-ui/pull/18854#discussion_r364215153) for more details.
 TypeScript might solve this bug in the future.
 
+### ListboxComponent
+
+If you provide a custom `ListboxComponent` prop, you need to make sure that the intended scroll container has the
+`role` attribute set to `listbox`. This ensures the correct behavior of the scroll, for example when using the
+keyboard to navigate.
+
 ## Accessibility
 
 (WAI-ARIA: https://www.w3.org/TR/wai-aria-practices/#combobox)


### PR DESCRIPTION
Adding a ListboxComponent limitation entry for the Autocomplete component documentation as discussed in this issue:

Closes #18766

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
