### PR TITLE
[Skeleton] Improve wave dark mode support

### DIFF
--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -49,7 +49,7 @@ export const styles = theme => ({
     overflow: 'hidden',
     '&::after': {
       animation: '$wave 1.6s linear 0.5s infinite',
-      background: 'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.7), transparent)',
+      background: `linear-gradient(90deg, transparent, ${theme.palette.action.hover}, transparent)`,
       content: '""',
       position: 'absolute',
       transform: 'translateX(-100%)', // Avoid flash during server-side hydration

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -49,7 +49,7 @@ export const styles = theme => ({
     overflow: 'hidden',
     '&::after': {
       animation: '$wave 1.6s linear 0.5s infinite',
-      background: `linear-gradient(90deg, transparent, ${theme.palette.action.hover}, transparent)`,
+      background: `linear-gradient(90deg, transparent, ${theme.palette.action.selected}, transparent)`,
       content: '""',
       position: 'absolute',
       transform: 'translateX(-100%)', // Avoid flash during server-side hydration

--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -49,7 +49,7 @@ export const styles = theme => ({
     overflow: 'hidden',
     '&::after': {
       animation: '$wave 1.6s linear 0.5s infinite',
-      background: `linear-gradient(90deg, transparent, ${theme.palette.action.selected}, transparent)`,
+      background: `linear-gradient(90deg, transparent, ${theme.palette.action.hover}, transparent)`,
       content: '""',
       position: 'absolute',
       transform: 'translateX(-100%)', // Avoid flash during server-side hydration


### PR DESCRIPTION
The new strategy is to double the opacity for the wave animation. It seems to perform better:

- In light mode, the emphasis is performed with a darker background, like Facebook
- in dark mode, it looks much better

**Before**

<img width="409" alt="Capture d’écran 2020-03-15 à 00 58 58" src="https://user-images.githubusercontent.com/3165635/76692534-3163ca00-6658-11ea-92eb-ad12bb2505cd.png">

**After**

<img width="451" alt="Capture d’écran 2020-03-15 à 00 58 48" src="https://user-images.githubusercontent.com/3165635/76692533-30cb3380-6658-11ea-8d21-ba9c7345f0f0.png">
