### PR TITLE
[CardActionArea] Changed descendant selectors to direct child selectors...

### DIFF
--- a/packages/material-ui/src/CardActionArea/CardActionArea.js
+++ b/packages/material-ui/src/CardActionArea/CardActionArea.js
@@ -10,10 +10,10 @@ export const styles = theme => ({
     display: 'block',
     textAlign: 'inherit',
     width: '100%',
-    '&:hover $focusHighlight': {
+    '&:hover > $focusHighlight': {
       opacity: theme.palette.action.hoverOpacity,
     },
-    '&$focusVisible $focusHighlight': {
+    '&$focusVisible > $focusHighlight': {
       opacity: 0.12,
     },
   },


### PR DESCRIPTION
... on the focusHighlight class and focusVisisble pseudo-selector.
fixes #20138 

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
