### PR TITLE
[docs] Mark toolbar for assistive technology

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -84,13 +84,13 @@ const styles = theme => ({
       padding: theme.spacing(3),
     },
   },
-  demoHiddenHeader: {
+  demoHiddenToolbar: {
     paddingTop: theme.spacing(2),
     [theme.breakpoints.up('sm')]: {
       paddingTop: theme.spacing(3),
     },
   },
-  header: {
+  toolbar: {
     display: 'none',
     [theme.breakpoints.up('sm')]: {
       display: 'flex',
@@ -101,7 +101,7 @@ const styles = theme => ({
     },
     justifyContent: 'space-between',
   },
-  headerButtons: {
+  toolbarButtons: {
     margin: '2px 0',
   },
   code: {
@@ -150,6 +150,21 @@ function getDemoData(codeVariant, demo, githubLocation) {
     Component: demo.js,
     sourceLanguage: 'jsx',
   };
+}
+
+// TODO: replace with React.useOpaqueReference if it is released
+function useUniqueId(prefix) {
+  // useOpaqueReference
+  const [id, setDemoId] = React.useState(null);
+  React.useEffect(() => {
+    setDemoId(
+      Math.random()
+        .toString(36)
+        .slice(2),
+    );
+  }, []);
+
+  return `${prefix}${id}`;
 }
 
 function Demo(props) {
@@ -309,7 +324,7 @@ function Demo(props) {
 
   const jsx = getJsxPreview(demoData.raw || '');
   const showPreview =
-    !demoOptions.hideHeader &&
+    !demoOptions.hideToolbar &&
     demoOptions.defaultCodeOpen !== false &&
     jsx !== demoData.raw &&
     jsx.split(/\n/).length <= 17;
@@ -321,11 +336,14 @@ function Demo(props) {
     showCodeLabel = showPreview ? t('showFullSource') : t('showSource');
   }
 
+  const demoSourceId = useUniqueId(`demo-`);
+  const openDemoSource = codeOpen || showPreview;
+
   return (
     <div className={classes.root}>
       <div
         className={clsx(classes.demo, {
-          [classes.demoHiddenHeader]: demoOptions.hideHeader,
+          [classes.demoHiddenToolbar]: demoOptions.hideToolbar,
           [classes.demoBgOutlined]: demoOptions.bg === 'outlined',
           [classes.demoBgTrue]: demoOptions.bg === true,
           [classes.demoBgInline]: demoOptions.bg === 'inline',
@@ -343,8 +361,13 @@ function Demo(props) {
       </div>
       <div className={classes.anchorLink} id={`${demoName}.js`} />
       <div className={classes.anchorLink} id={`${demoName}.tsx`} />
-      {demoOptions.hideHeader ? null : (
-        <div className={classes.header}>
+      {demoOptions.hideToolbar ? null : (
+        <div
+          aria-controls={openDemoSource ? demoSourceId : null}
+          aria-label={t('demoToolbarLabel')}
+          className={classes.toolbar}
+          role="toolbar"
+        >
           <NoSsr>
             <DemoLanguages
               demo={demo}
@@ -353,7 +376,7 @@ function Demo(props) {
               gaEventLabel={demoOptions.demo}
               onLanguageClick={handleCodeLanguageClick}
             />
-            <div className={classes.headerButtons}>
+            <div className={classes.toolbarButtons}>
               <Tooltip
                 classes={{ popper: classes.tooltip }}
                 key={showSourceHint}
@@ -471,9 +494,10 @@ function Demo(props) {
           </NoSsr>
         </div>
       )}
-      <Collapse in={codeOpen || showPreview} unmountOnExit>
+      <Collapse in={openDemoSource} unmountOnExit>
         <MarkdownElement
           className={classes.code}
+          id={demoSourceId}
           text={`\`\`\`${demoData.sourceLanguage}\n${codeOpen ? demoData.raw : jsx}\n\`\`\``}
         />
       </Collapse>

--- a/docs/src/pages/components/badges/badges-de.md
+++ b/docs/src/pages/components/badges/badges-de.md
@@ -51,4 +51,4 @@ You can use the `overlap` property to place the badge relative to the corner of 
 
 You can use the `anchorOrigin` prop to move the badge to any corner of the wrapped element.
 
-{{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}
+{{"demo": "pages/components/badges/BadgeAlignment.js", "hideToolbar": true}}

--- a/docs/src/pages/components/badges/badges-es.md
+++ b/docs/src/pages/components/badges/badges-es.md
@@ -51,4 +51,4 @@ Usted puede usar la propiedad `overlap` para establecer el Badge relativo a la e
 
 Usted puede usar la propiedad `anchorOrigin` para mover el Badge a cualquier esquina del elemento envuelto.
 
-{{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}
+{{"demo": "pages/components/badges/BadgeAlignment.js", "hideToolbar": true}}

--- a/docs/src/pages/components/badges/badges-fr.md
+++ b/docs/src/pages/components/badges/badges-fr.md
@@ -51,4 +51,4 @@ You can use the `overlap` property to place the badge relative to the corner of 
 
 You can use the `anchorOrigin` prop to move the badge to any corner of the wrapped element.
 
-{{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}
+{{"demo": "pages/components/badges/BadgeAlignment.js", "hideToolbar": true}}

--- a/docs/src/pages/components/badges/badges-ja.md
+++ b/docs/src/pages/components/badges/badges-ja.md
@@ -51,4 +51,4 @@ You can use the `overlap` property to place the badge relative to the corner of 
 
 You can use the `anchorOrigin` prop to move the badge to any corner of the wrapped element.
 
-{{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}
+{{"demo": "pages/components/badges/BadgeAlignment.js", "hideToolbar": true}}

--- a/docs/src/pages/components/badges/badges-pt.md
+++ b/docs/src/pages/components/badges/badges-pt.md
@@ -51,4 +51,4 @@ You can use the `overlap` property to place the badge relative to the corner of 
 
 You can use the `anchorOrigin` prop to move the badge to any corner of the wrapped element.
 
-{{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}
+{{"demo": "pages/components/badges/BadgeAlignment.js", "hideToolbar": true}}

--- a/docs/src/pages/components/badges/badges-ru.md
+++ b/docs/src/pages/components/badges/badges-ru.md
@@ -51,4 +51,4 @@ components: Badge
 
 Вы можете использовать проп `anchorOrigin` для перемещения значка в любой угол элемента.
 
-{{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}
+{{"demo": "pages/components/badges/BadgeAlignment.js", "hideToolbar": true}}

--- a/docs/src/pages/components/badges/badges-zh.md
+++ b/docs/src/pages/components/badges/badges-zh.md
@@ -51,4 +51,4 @@ You can use the `overlap` property to place the badge relative to the corner of 
 
 You can use the `anchorOrigin` prop to move the badge to any corner of the wrapped element.
 
-{{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}
+{{"demo": "pages/components/badges/BadgeAlignment.js", "hideToolbar": true}}

--- a/docs/src/pages/components/badges/badges.md
+++ b/docs/src/pages/components/badges/badges.md
@@ -51,4 +51,4 @@ You can use the `overlap` property to place the badge relative to the corner of 
 
 You can use the `anchorOrigin` prop to move the badge to any corner of the wrapped element.
 
-{{"demo": "pages/components/badges/BadgeAlignment.js", "hideHeader": true}}
+{{"demo": "pages/components/badges/BadgeAlignment.js", "hideToolbar": true}}

--- a/docs/src/pages/components/chips/chips-de.md
+++ b/docs/src/pages/components/chips/chips-de.md
@@ -46,7 +46,7 @@ Sie können die Requisite `size` verwenden, um einen kleinen Chip zu definieren.
 
 ## Chip Spielwiese
 
-{{"demo": "pages/components/chips/ChipsPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/chips/ChipsPlayground.js", "hideToolbar": true}}
 
 ## Barrierefreiheit
 

--- a/docs/src/pages/components/chips/chips-es.md
+++ b/docs/src/pages/components/chips/chips-es.md
@@ -46,7 +46,7 @@ You can use the `size` prop to define a small Chip.
 
 ## Chip Playground
 
-{{"demo": "pages/components/chips/ChipsPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/chips/ChipsPlayground.js", "hideToolbar": true}}
 
 ## Accesibilidad
 

--- a/docs/src/pages/components/chips/chips-fr.md
+++ b/docs/src/pages/components/chips/chips-fr.md
@@ -46,7 +46,7 @@ You can use the `size` prop to define a small Chip.
 
 ## Terrain de jeu de puce
 
-{{"demo": "pages/components/chips/ChipsPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/chips/ChipsPlayground.js", "hideToolbar": true}}
 
 ## Accessibilité
 

--- a/docs/src/pages/components/chips/chips-ja.md
+++ b/docs/src/pages/components/chips/chips-ja.md
@@ -46,7 +46,7 @@ Outlined chipsは代替スタイルを提供します。
 
 ## Chip Playground
 
-{{"demo": "pages/components/chips/ChipsPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/chips/ChipsPlayground.js", "hideToolbar": true}}
 
 ## アクセシビリティ
 

--- a/docs/src/pages/components/chips/chips-pt.md
+++ b/docs/src/pages/components/chips/chips-pt.md
@@ -46,7 +46,7 @@ Você pode usar a propriedade `size` para definir um Chip pequeno.
 
 ## Chip - Live Demo
 
-{{"demo": "pages/components/chips/ChipsPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/chips/ChipsPlayground.js", "hideToolbar": true}}
 
 ## Acessibilidade
 

--- a/docs/src/pages/components/chips/chips-ru.md
+++ b/docs/src/pages/components/chips/chips-ru.md
@@ -46,7 +46,7 @@ components: Chip
 
 ## Песочница
 
-{{"demo": "pages/components/chips/ChipsPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/chips/ChipsPlayground.js", "hideToolbar": true}}
 
 ## Доступность
 

--- a/docs/src/pages/components/chips/chips-zh.md
+++ b/docs/src/pages/components/chips/chips-zh.md
@@ -46,7 +46,7 @@ components: Chip
 
 ## 在线编译纸片组件
 
-{{"demo": "pages/components/chips/ChipsPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/chips/ChipsPlayground.js", "hideToolbar": true}}
 
 ## 可访问性
 

--- a/docs/src/pages/components/chips/chips.md
+++ b/docs/src/pages/components/chips/chips.md
@@ -54,7 +54,7 @@ You can use the `size` prop to define a small Chip.
 
 ## Chip Playground
 
-{{"demo": "pages/components/chips/ChipsPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/chips/ChipsPlayground.js", "hideToolbar": true}}
 
 ## Accessibility
 

--- a/docs/src/pages/components/grid/grid-de.md
+++ b/docs/src/pages/components/grid/grid-de.md
@@ -49,7 +49,7 @@ Für einige Spalten sind mehrere Breiten definiert, wodurch sich das Layout am d
 
 Nachfolgend finden Sie eine interaktive Demo, mit der Sie die visuellen Ergebnisse der verschiedenen Einstellungen untersuchen können:
 
-{{"demo": "pages/components/grid/InteractiveGrid.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/grid/InteractiveGrid.js", "hideToolbar": true, "bg": true}}
 
 ## Automatisches Layout
 

--- a/docs/src/pages/components/grid/grid-es.md
+++ b/docs/src/pages/components/grid/grid-es.md
@@ -49,7 +49,7 @@ Algunas columnas tienen varios anchos definidos, causando que el layout cambie e
 
 Debajo de esta línea hay una demostración interactiva que permite explorar el resultado visual de las distintas configuraciones:
 
-{{"demo": "pages/components/grid/InteractiveGrid.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/grid/InteractiveGrid.js", "hideToolbar": true, "bg": true}}
 
 ## Auto-layout
 

--- a/docs/src/pages/components/grid/grid-fr.md
+++ b/docs/src/pages/components/grid/grid-fr.md
@@ -49,7 +49,7 @@ Plusieurs colonnes ont plusieurs largeurs définies, ce qui entraîne une modifi
 
 Vous trouverez ci-dessous une démo interactive vous permettant d'explorer les résultats visuels des différents paramètres:
 
-{{"demo": "pages/components/grid/InteractiveGrid.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/grid/InteractiveGrid.js", "hideToolbar": true, "bg": true}}
 
 ## Mise en page automatique
 

--- a/docs/src/pages/components/grid/grid-ja.md
+++ b/docs/src/pages/components/grid/grid-ja.md
@@ -49,7 +49,7 @@ Fluid gridsでは、コンテンツの尺度とサイズを変更する列を使
 
 以下は、さまざまな設定の視覚的な結果を調べることができるインタラクティブなデモです。
 
-{{"demo": "pages/components/grid/InteractiveGrid.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/grid/InteractiveGrid.js", "hideToolbar": true, "bg": true}}
 
 ## 自動レイアウト
 

--- a/docs/src/pages/components/grid/grid-pt.md
+++ b/docs/src/pages/components/grid/grid-pt.md
@@ -49,7 +49,7 @@ Algumas colunas têm várias larguras definidas, fazendo com que o leiaute seja 
 
 Abaixo está uma demonstração interativa que permite explorar os resultados visuais das diferentes configurações:
 
-{{"demo": "pages/components/grid/InteractiveGrid.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/grid/InteractiveGrid.js", "hideToolbar": true, "bg": true}}
 
 ## Leiaute Automático
 

--- a/docs/src/pages/components/grid/grid-ru.md
+++ b/docs/src/pages/components/grid/grid-ru.md
@@ -49,7 +49,7 @@ components: Grid
 
 Ниже приведен интерактивный пример, который демонстрирует результаты различных настроек сетки:
 
-{{"demo": "pages/components/grid/InteractiveGrid.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/grid/InteractiveGrid.js", "hideToolbar": true, "bg": true}}
 
 ## Авто-разметка
 

--- a/docs/src/pages/components/grid/grid-zh.md
+++ b/docs/src/pages/components/grid/grid-zh.md
@@ -49,7 +49,7 @@ components: Grid
 
 下面是一个交互式的演示，您可让探索不同设置下的视觉结果：
 
-{{"demo": "pages/components/grid/InteractiveGrid.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/grid/InteractiveGrid.js", "hideToolbar": true, "bg": true}}
 
 ## 自动布局
 

--- a/docs/src/pages/components/grid/grid.md
+++ b/docs/src/pages/components/grid/grid.md
@@ -53,7 +53,7 @@ Some columns have multiple widths defined, causing the layout to change at the d
 
 Below is an interactive demo that lets you explore the visual results of the different settings:
 
-{{"demo": "pages/components/grid/InteractiveGrid.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/grid/InteractiveGrid.js", "hideToolbar": true, "bg": true}}
 
 ## Auto-layout
 

--- a/docs/src/pages/components/material-icons/material-icons-de.md
+++ b/docs/src/pages/components/material-icons/material-icons-de.md
@@ -9,6 +9,6 @@ components: Icon, SvgIcon
 
 The following npm package, [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons), includes the 1,100+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
-{{"demo": "pages/components/material-icons/SearchIcons.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
 ℹ️ The search supports synonyms. Try searching for "hamburger", or "logout".

--- a/docs/src/pages/components/material-icons/material-icons-es.md
+++ b/docs/src/pages/components/material-icons/material-icons-es.md
@@ -9,6 +9,6 @@ components: Icon, SvgIcon
 
 The following npm package, [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons), includes the 1,100+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
-{{"demo": "pages/components/material-icons/SearchIcons.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
 ℹ️ La búsqueda admite sinónimos. Intente buscar "hamburger" o "logout".

--- a/docs/src/pages/components/material-icons/material-icons-fr.md
+++ b/docs/src/pages/components/material-icons/material-icons-fr.md
@@ -9,6 +9,6 @@ components: Icones, SvgIcon
 
 The following npm package, [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons), includes the 1,100+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
-{{"demo": "pages/components/material-icons/SearchIcons.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
 La recherche inclut les synonymes. Essayez de chercher "hamburger" ou "déconnexion".

--- a/docs/src/pages/components/material-icons/material-icons-ja.md
+++ b/docs/src/pages/components/material-icons/material-icons-ja.md
@@ -9,6 +9,6 @@ components: Icon, SvgIcon
 
 The following npm package, [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons), includes the 1,100+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
-{{"demo": "pages/components/material-icons/SearchIcons.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
 ℹ️ The search supports synonyms. Try searching for "hamburger", or "logout".

--- a/docs/src/pages/components/material-icons/material-icons-pt.md
+++ b/docs/src/pages/components/material-icons/material-icons-pt.md
@@ -9,6 +9,6 @@ components: Icon, SvgIcon
 
 The following npm package, [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons), includes the 1,100+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
-{{"demo": "pages/components/material-icons/SearchIcons.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
 ℹ️ The search supports synonyms. Try searching for "hamburger", or "logout".

--- a/docs/src/pages/components/material-icons/material-icons-ru.md
+++ b/docs/src/pages/components/material-icons/material-icons-ru.md
@@ -9,6 +9,6 @@ components: Icon, SvgIcon
 
 The following npm package, [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons), includes the 1,100+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
-{{"demo": "pages/components/material-icons/SearchIcons.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
 ℹ️ The search supports synonyms. Try searching for "hamburger", or "logout".

--- a/docs/src/pages/components/material-icons/material-icons-zh.md
+++ b/docs/src/pages/components/material-icons/material-icons-zh.md
@@ -9,6 +9,6 @@ components: Icon, SvgIcon
 
 The following npm package, [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons), includes the 1,100+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
-{{"demo": "pages/components/material-icons/SearchIcons.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
 词组支持同义词。 尝试搜索"hamburger"或"logout"。

--- a/docs/src/pages/components/material-icons/material-icons.md
+++ b/docs/src/pages/components/material-icons/material-icons.md
@@ -11,6 +11,6 @@ The following npm package,
 [@material-ui/icons](https://www.npmjs.com/package/@material-ui/icons),
 includes the 1,100+ official [Material icons](https://material.io/tools/icons/?style=baseline) converted to [`SvgIcon`](/api/svg-icon/) components.
 
-{{"demo": "pages/components/material-icons/SearchIcons.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/material-icons/SearchIcons.js", "hideToolbar": true, "bg": true}}
 
 ℹ️ The search supports synonyms. Try searching for "hamburger", or "logout".

--- a/docs/src/pages/components/popover/popover-de.md
+++ b/docs/src/pages/components/popover/popover-de.md
@@ -20,7 +20,7 @@ Wissenswertes zur Verwendung der Komponente `Popover`:
 
 Verwenden Sie die Optionsfelder, um die Positionen des `AnkerOrigin` und des `TransformationOrigin` anzupassen. Sie können auch die `anchorReference` auf `anchorPosition` oder `anchorEl` setzen. Wenn `anchorPosition` ausgewählt ist, wird die Komponente, anstatt an `anchorEl`, am `anchorPosition` prop gerendert.
 
-{{"demo": "pages/components/popover/AnchorPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/popover/AnchorPlayground.js", "hideToolbar": true}}
 
 ## Maus Interaktionen
 

--- a/docs/src/pages/components/popover/popover-es.md
+++ b/docs/src/pages/components/popover/popover-es.md
@@ -20,7 +20,7 @@ Things to know when using the `Popover` component:
 
 Use the radio buttons to adjust the `anchorOrigin` and `transformOrigin` positions. You can also set the `anchorReference` to `anchorPosition` or `anchorEl`. When it is `anchorPosition`, the component will, instead of `anchorEl`, refer to the `anchorPosition` prop which you can adjust to set the position of the popover.
 
-{{"demo": "pages/components/popover/AnchorPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/popover/AnchorPlayground.js", "hideToolbar": true}}
 
 ## Mouse over interaction
 

--- a/docs/src/pages/components/popover/popover-fr.md
+++ b/docs/src/pages/components/popover/popover-fr.md
@@ -20,7 +20,7 @@ Things to know when using the `Popover` component:
 
 Use the radio buttons to adjust the `anchorOrigin` and `transformOrigin` positions. You can also set the `anchorReference` to `anchorPosition` or `anchorEl`. When it is `anchorPosition`, the component will, instead of `anchorEl`, refer to the `anchorPosition` prop which you can adjust to set the position of the popover.
 
-{{"demo": "pages/components/popover/AnchorPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/popover/AnchorPlayground.js", "hideToolbar": true}}
 
 ## Mouse over interaction
 

--- a/docs/src/pages/components/popover/popover-ja.md
+++ b/docs/src/pages/components/popover/popover-ja.md
@@ -20,7 +20,7 @@ components: Grow, Popover
 
 ラジオボタンを使用して、 `anchorOrigin` および `transformOrigin` 位置を調整します。 `anchorReference` を `anchorPosition` または `anchorEl`設定することもできます。 `anchorPosition`の場合、コンポーネントは`anchorEl`の代わりに ポップオーバーの位置を調整する`anchorPosition` >propを参照してください。
 
-{{"demo": "pages/components/popover/AnchorPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/popover/AnchorPlayground.js", "hideToolbar": true}}
 
 ## マウスオーバー操作
 

--- a/docs/src/pages/components/popover/popover-pt.md
+++ b/docs/src/pages/components/popover/popover-pt.md
@@ -20,7 +20,7 @@ Coisas para saber ao usar o componente `Popover`:
 
 Use os botões de opção para ajustar as posições `anchorOrigin` e `transformOrigin`. Você também pode definir `anchorReference` para `anchorPosition` ou `anchorEl`. Quando configurado com `anchorPosition`, o componente irá, ao contrário de `anchorEl`, basear se nas propriedades do `anchorPosition`, na qual você pode ajustar para definir a posição do popover.
 
-{{"demo": "pages/components/popover/AnchorPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/popover/AnchorPlayground.js", "hideToolbar": true}}
 
 ## Interação sobre o mouse
 

--- a/docs/src/pages/components/popover/popover-ru.md
+++ b/docs/src/pages/components/popover/popover-ru.md
@@ -20,7 +20,7 @@ Things to know when using the `Popover` component:
 
 Use the radio buttons to adjust the `anchorOrigin` and `transformOrigin` positions. You can also set the `anchorReference` to `anchorPosition` or `anchorEl`. When it is `anchorPosition`, the component will, instead of `anchorEl`, refer to the `anchorPosition` prop which you can adjust to set the position of the popover.
 
-{{"demo": "pages/components/popover/AnchorPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/popover/AnchorPlayground.js", "hideToolbar": true}}
 
 ## Mouse over interaction
 

--- a/docs/src/pages/components/popover/popover-zh.md
+++ b/docs/src/pages/components/popover/popover-zh.md
@@ -20,7 +20,7 @@ components: Grow, Popover
 
 使用单选按钮调整 `anchorOrigin` 和 `transformOrigin` 位置。 您还可以将 `anchorReference` 设置为 `anchorPosition` 或 `anchorEl`。 当它是 `anchorPosition`，该组件将代替 `anchorEl`， 指的是 `anchorPosition` 道具，其可以调整设置 的酥料饼的位置。
 
-{{"demo": "pages/components/popover/AnchorPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/popover/AnchorPlayground.js", "hideToolbar": true}}
 
 ## 鼠标悬停在互动上
 

--- a/docs/src/pages/components/popover/popover.md
+++ b/docs/src/pages/components/popover/popover.md
@@ -24,7 +24,7 @@ When it is `anchorPosition`, the component will, instead of `anchorEl`,
 refer to the `anchorPosition` prop which you can adjust to set
 the position of the popover.
 
-{{"demo": "pages/components/popover/AnchorPlayground.js", "hideHeader": true}}
+{{"demo": "pages/components/popover/AnchorPlayground.js", "hideToolbar": true}}
 
 ## Mouse over interaction
 

--- a/docs/src/pages/components/popper/popper-de.md
+++ b/docs/src/pages/components/popper/popper-de.md
@@ -43,7 +43,7 @@ Alternativ können Sie [react-spring](https://github.com/react-spring/react-spri
 
 ## Blätter Spielplatz
 
-{{"demo": "pages/components/popper/ScrollPlayground.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/popper/ScrollPlayground.js", "hideToolbar": true, "bg": true}}
 
 ## Gefälschtes Referenzobjekt
 

--- a/docs/src/pages/components/popper/popper-es.md
+++ b/docs/src/pages/components/popper/popper-es.md
@@ -43,7 +43,7 @@ Como alternativa, puedes usar [react-spring](https://github.com/react-spring/rea
 
 ## Scroll playground
 
-{{"demo": "pages/components/popper/ScrollPlayground.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/popper/ScrollPlayground.js", "hideToolbar": true, "bg": true}}
 
 ## Faked reference object
 

--- a/docs/src/pages/components/popper/popper-fr.md
+++ b/docs/src/pages/components/popper/popper-fr.md
@@ -43,7 +43,7 @@ Alternatively, you can use [react-spring](https://github.com/react-spring/react-
 
 ## Scroll playground
 
-{{"demo": "pages/components/popper/ScrollPlayground.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/popper/ScrollPlayground.js", "hideToolbar": true, "bg": true}}
 
 ## Faked reference object
 

--- a/docs/src/pages/components/popper/popper-ja.md
+++ b/docs/src/pages/components/popper/popper-ja.md
@@ -43,7 +43,7 @@ Alternatively, you can use [react-spring](https://github.com/react-spring/react-
 
 ## Scroll playground
 
-{{"demo": "pages/components/popper/ScrollPlayground.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/popper/ScrollPlayground.js", "hideToolbar": true, "bg": true}}
 
 ## 偽の参照オブジェクト
 

--- a/docs/src/pages/components/popper/popper-pt.md
+++ b/docs/src/pages/components/popper/popper-pt.md
@@ -43,7 +43,7 @@ Como alternativa, você pode usar [react-spring](https://github.com/react-spring
 
 ## Rolagem - Exemplo interativo
 
-{{"demo": "pages/components/popper/ScrollPlayground.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/popper/ScrollPlayground.js", "hideToolbar": true, "bg": true}}
 
 ## Objeto de referência falsificado
 

--- a/docs/src/pages/components/popper/popper-ru.md
+++ b/docs/src/pages/components/popper/popper-ru.md
@@ -43,7 +43,7 @@ Alternatively, you can use [react-spring](https://github.com/react-spring/react-
 
 ## Scroll playground
 
-{{"demo": "pages/components/popper/ScrollPlayground.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/popper/ScrollPlayground.js", "hideToolbar": true, "bg": true}}
 
 ## Faked reference object
 

--- a/docs/src/pages/components/popper/popper-zh.md
+++ b/docs/src/pages/components/popper/popper-zh.md
@@ -43,7 +43,7 @@ Alternatively, you can use [react-spring](https://github.com/react-spring/react-
 
 ## Scroll playground
 
-{{"demo": "pages/components/popper/ScrollPlayground.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/popper/ScrollPlayground.js", "hideToolbar": true, "bg": true}}
 
 ## Faked reference object
 

--- a/docs/src/pages/components/popper/popper.md
+++ b/docs/src/pages/components/popper/popper.md
@@ -48,7 +48,7 @@ Alternatively, you can use [react-spring](https://github.com/react-spring/react-
 
 ## Scroll playground
 
-{{"demo": "pages/components/popper/ScrollPlayground.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/components/popper/ScrollPlayground.js", "hideToolbar": true, "bg": true}}
 
 ## Faked reference object
 

--- a/docs/src/pages/customization/color/color-de.md
+++ b/docs/src/pages/customization/color/color-de.md
@@ -41,13 +41,13 @@ import HUE from '@material-ui/core/colors/HUE';
 const color = HUE[SHADE];
 ```
 
-{{"demo": "pages/customization/color/Color.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/color/Color.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Farbwerkzeug
 
 Um ein [ material.io/design/color ](https://material.io/design/color/) Farbschema mittels der Material-UI Dokumentation zu testen, wählen Sie die Farben mittels der Palette und der Regler weiter unten aus. Alternativ können Sie Hex-Werte in die Felder Primärer und Sekundärer Text eingeben.
 
-{{"demo": "pages/customization/color/ColorTool.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
 The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 

--- a/docs/src/pages/customization/color/color-es.md
+++ b/docs/src/pages/customization/color/color-es.md
@@ -41,13 +41,13 @@ import HUE from '@material-ui/core/colors/HUE';
 const color = HUE[SHADE];
 ```
 
-{{"demo": "pages/customization/color/Color.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/color/Color.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Herramienta de color
 
 Para probar un esquema de color [material.io/design/color](https://material.io/design/color/) con la documentación de Material-UI, simplemente se pueden seleccionar los colores usando la paleta y los sliders de abajo. Como alternativa, se pueden escribir valores hexadecimales en los campos de text Primary (color primario) y Secondary (color secundario).
 
-{{"demo": "pages/customization/color/ColorTool.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
 The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 

--- a/docs/src/pages/customization/color/color-fr.md
+++ b/docs/src/pages/customization/color/color-fr.md
@@ -41,13 +41,13 @@ import HUE from '@material-ui/core/colors/HUE';
 const color = HUE[SHADE];
 ```
 
-{{"demo": "pages/customization/color/Color.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/color/Color.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Color tool
 
 To test a [material.io/design/color](https://material.io/design/color/) color scheme with the Material-UI documentation, simply select colors using the palette and sliders below. Alternatively, you can enter hex values in the Primary and Secondary text fields.
 
-{{"demo": "pages/customization/color/ColorTool.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
 The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 

--- a/docs/src/pages/customization/color/color-ja.md
+++ b/docs/src/pages/customization/color/color-ja.md
@@ -41,13 +41,13 @@ import HUE from '@material-ui/core/colors/HUE';
 const color = HUE[SHADE];
 ```
 
-{{"demo": "pages/customization/color/Color.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/color/Color.js", "hideToolbar": true, "bg": "inline"}}
 
 ## カラーツール
 
 [ material.io/design/colorをテストするには](https://material.io/design/color/) Material-UIのドキュメントの配色では、以下のパレットとスライダーを使用してカラーを選択するだけです。 または、プライマリおよびセカンダリテキストフィールドに16進値を入力できます。
 
-{{"demo": "pages/customization/color/ColorTool.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
 The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 

--- a/docs/src/pages/customization/color/color-pt.md
+++ b/docs/src/pages/customization/color/color-pt.md
@@ -41,13 +41,13 @@ import HUE from '@material-ui/core/colors/HUE';
 const color = HUE[SHADE];
 ```
 
-{{"demo": "pages/customization/color/Color.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/color/Color.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Ferramenta de cor
 
 Para testar um esquema de cores do [material.io/design/color](https://material.io/design/color/) com a documentação do Material-UI, simplesmente selecione as cores usando a paleta e os controles deslizantes abaixo. Como alternativa, você pode inserir valores hexadecimais nos campos de texto Primário e Secundário.
 
-{{"demo": "pages/customization/color/ColorTool.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
 The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 

--- a/docs/src/pages/customization/color/color-ru.md
+++ b/docs/src/pages/customization/color/color-ru.md
@@ -41,13 +41,13 @@ import HUE from '@material-ui/core/colors/HUE';
 const color = HUE[SHADE];
 ```
 
-{{"demo": "pages/customization/color/Color.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/color/Color.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Инструменты для работы с цветом
 
 Используйте палитру и слайдеры, расположенные ниже, чтобы опробовать цветовую схему [material.io/design/color](https://material.io/design/color/) на документации Material-UI. Либо можете ввести шестнадцатеричные значения в текстовые поля Primary и Secondary.
 
-{{"demo": "pages/customization/color/ColorTool.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
 The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 

--- a/docs/src/pages/customization/color/color-zh.md
+++ b/docs/src/pages/customization/color/color-zh.md
@@ -41,13 +41,13 @@ import HUE from '@material-ui/core/colors/HUE';
 const color = HUE[SHADE];
 ```
 
-{{"demo": "pages/customization/color/Color.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/color/Color.js", "hideToolbar": true, "bg": "inline"}}
 
 ## 颜色工具
 
 使用Material-UI文档测试[material.io/design/color](https://material.io/design/color/)颜色方案,只需使用下面的调色板和滑块选择颜色. 或者，您可以在“Primary”和“Secondary”文本字段中输入十六进制值。
 
-{{"demo": "pages/customization/color/ColorTool.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
 The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 

--- a/docs/src/pages/customization/color/color.md
+++ b/docs/src/pages/customization/color/color.md
@@ -45,7 +45,7 @@ import HUE from '@material-ui/core/colors/HUE';
 const color = HUE[SHADE];
 ```
 
-{{"demo": "pages/customization/color/Color.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/color/Color.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Color tool
 
@@ -53,7 +53,7 @@ To test a [material.io/design/color](https://material.io/design/color/) color sc
 documentation, simply select colors using the palette and sliders below.
 Alternatively, you can enter hex values in the Primary and Secondary text fields.
 
-{{"demo": "pages/customization/color/ColorTool.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/customization/color/ColorTool.js", "hideToolbar": true, "bg": true}}
 
 The output shown in the color sample can be pasted directly into a [`createMuiTheme()`](/customization/theming/#createmuitheme-options-theme) function (to be used with [`ThemeProvider`](/customization/theming/#theme-provider)):
 

--- a/docs/src/pages/customization/default-theme/default-theme-de.md
+++ b/docs/src/pages/customization/default-theme/default-theme-de.md
@@ -6,7 +6,7 @@
 
 Explore the default theme object:
 
-{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideToolbar": true, "bg": "inline"}}
 
 > Tip: you can play with the documentation theme object in your browser console, as the `theme` variable is exposed on all the documentation pages. Please note that **the documentation site is using a custom theme**.
 

--- a/docs/src/pages/customization/default-theme/default-theme-es.md
+++ b/docs/src/pages/customization/default-theme/default-theme-es.md
@@ -6,7 +6,7 @@
 
 Explore the default theme object:
 
-{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideToolbar": true, "bg": "inline"}}
 
 > Tip: you can play with the documentation theme object in your browser console, as the `theme` variable is exposed on all the documentation pages. Please note that **the documentation site is using a custom theme**.
 

--- a/docs/src/pages/customization/default-theme/default-theme-fr.md
+++ b/docs/src/pages/customization/default-theme/default-theme-fr.md
@@ -6,7 +6,7 @@
 
 Explore the default theme object:
 
-{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideToolbar": true, "bg": "inline"}}
 
 > Tip: you can play with the documentation theme object in your browser console, as the `theme` variable is exposed on all the documentation pages. Please note that **the documentation site is using a custom theme**.
 

--- a/docs/src/pages/customization/default-theme/default-theme-ja.md
+++ b/docs/src/pages/customization/default-theme/default-theme-ja.md
@@ -6,7 +6,7 @@
 
 Explore the default theme object:
 
-{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideToolbar": true, "bg": "inline"}}
 
 > Tip: you can play with the documentation theme object in your browser console, as the `theme` variable is exposed on all the documentation pages. Please note that **the documentation site is using a custom theme**.
 

--- a/docs/src/pages/customization/default-theme/default-theme-pt.md
+++ b/docs/src/pages/customization/default-theme/default-theme-pt.md
@@ -6,7 +6,7 @@
 
 Explore the default theme object:
 
-{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideToolbar": true, "bg": "inline"}}
 
 > Tip: you can play with the documentation theme object in your browser console, as the `theme` variable is exposed on all the documentation pages. Please note that **the documentation site is using a custom theme**.
 

--- a/docs/src/pages/customization/default-theme/default-theme-ru.md
+++ b/docs/src/pages/customization/default-theme/default-theme-ru.md
@@ -6,7 +6,7 @@
 
 Explore the default theme object:
 
-{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideToolbar": true, "bg": "inline"}}
 
 > Tip: you can play with the documentation theme object in your browser console, as the `theme` variable is exposed on all the documentation pages. Please note that **the documentation site is using a custom theme**.
 

--- a/docs/src/pages/customization/default-theme/default-theme-zh.md
+++ b/docs/src/pages/customization/default-theme/default-theme-zh.md
@@ -6,7 +6,7 @@
 
 Explore the default theme object:
 
-{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideToolbar": true, "bg": "inline"}}
 
 > Tip: you can play with the documentation theme object in your browser console, as the `theme` variable is exposed on all the documentation pages. Please note that **the documentation site is using a custom theme**.
 

--- a/docs/src/pages/customization/default-theme/default-theme.md
+++ b/docs/src/pages/customization/default-theme/default-theme.md
@@ -6,7 +6,7 @@
 
 Explore the default theme object:
 
-{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/customization/default-theme/DefaultTheme.js", "hideToolbar": true, "bg": "inline"}}
 
 > Tip: you can play with the documentation theme object in your browser console,
 > as the `theme` variable is exposed on all the documentation pages.

--- a/docs/src/pages/customization/density/density-de.md
+++ b/docs/src/pages/customization/density/density-de.md
@@ -92,4 +92,4 @@ const theme = createMuiTheme({
 });
 ```
 
-{{"demo": "pages/customization/density/DensityTool.js", "hideHeader": true}}
+{{"demo": "pages/customization/density/DensityTool.js", "hideToolbar": true}}

--- a/docs/src/pages/customization/density/density-es.md
+++ b/docs/src/pages/customization/density/density-es.md
@@ -92,4 +92,4 @@ const theme = createMuiTheme({
 });
 ```
 
-{{"demo": "pages/customization/density/DensityTool.js", "hideHeader": true}}
+{{"demo": "pages/customization/density/DensityTool.js", "hideToolbar": true}}

--- a/docs/src/pages/customization/density/density-fr.md
+++ b/docs/src/pages/customization/density/density-fr.md
@@ -92,4 +92,4 @@ const theme = createMuiTheme({
 });
 ```
 
-{{"demo": "pages/customization/density/DensityTool.js", "hideHeader": true}}
+{{"demo": "pages/customization/density/DensityTool.js", "hideToolbar": true}}

--- a/docs/src/pages/customization/density/density-ja.md
+++ b/docs/src/pages/customization/density/density-ja.md
@@ -92,4 +92,4 @@ const theme = createMuiTheme({
 });
 ```
 
-{{"demo": "pages/customization/density/DensityTool.js", "hideHeader": true}}
+{{"demo": "pages/customization/density/DensityTool.js", "hideToolbar": true}}

--- a/docs/src/pages/customization/density/density-pt.md
+++ b/docs/src/pages/customization/density/density-pt.md
@@ -92,4 +92,4 @@ const theme = createMuiTheme({
 });
 ```
 
-{{"demo": "pages/customization/density/DensityTool.js", "hideHeader": true}}
+{{"demo": "pages/customization/density/DensityTool.js", "hideToolbar": true}}

--- a/docs/src/pages/customization/density/density-ru.md
+++ b/docs/src/pages/customization/density/density-ru.md
@@ -92,4 +92,4 @@ const theme = createMuiTheme({
 });
 ```
 
-{{"demo": "pages/customization/density/DensityTool.js", "hideHeader": true}}
+{{"demo": "pages/customization/density/DensityTool.js", "hideToolbar": true}}

--- a/docs/src/pages/customization/density/density-zh.md
+++ b/docs/src/pages/customization/density/density-zh.md
@@ -92,4 +92,4 @@ const theme = createMuiTheme({
 });
 ```
 
-{{"demo": "pages/customization/density/DensityTool.js", "hideHeader": true}}
+{{"demo": "pages/customization/density/DensityTool.js", "hideToolbar": true}}

--- a/docs/src/pages/customization/density/density.md
+++ b/docs/src/pages/customization/density/density.md
@@ -100,4 +100,4 @@ const theme = createMuiTheme({
 });
 ```
 
-{{"demo": "pages/customization/density/DensityTool.js", "hideHeader": true}}
+{{"demo": "pages/customization/density/DensityTool.js", "hideToolbar": true}}

--- a/docs/src/pages/customization/palette/palette-de.md
+++ b/docs/src/pages/customization/palette/palette-de.md
@@ -17,7 +17,7 @@ Die Standardpalette verwendet die mit `A` (`A200` usw.) gekennzeichneten Schatti
 
 Wenn Sie mehr über Farbe erfahren möchten, können Sie sich im [Farbabschnitt](/customization/color/) informeiren.
 
-{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 ### Individuelle Anpassung
 
@@ -114,7 +114,7 @@ const darkTheme = createMuiTheme({
 
 The colors modified by the palette type are the following:
 
-{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
 
 ### User preference
 

--- a/docs/src/pages/customization/palette/palette-es.md
+++ b/docs/src/pages/customization/palette/palette-es.md
@@ -17,7 +17,7 @@ The default palette uses the shades prefixed with `A` (`A200`, etc.) for the sec
 
 If you want to learn more about color, you can check out [the color section](/customization/color/).
 
-{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 ### Personalización
 
@@ -114,7 +114,7 @@ const darkTheme = createMuiTheme({
 
 The colors modified by the palette type are the following:
 
-{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
 
 ### User preference
 

--- a/docs/src/pages/customization/palette/palette-fr.md
+++ b/docs/src/pages/customization/palette/palette-fr.md
@@ -17,7 +17,7 @@ The default palette uses the shades prefixed with `A` (`A200`, etc.) for the sec
 
 If you want to learn more about color, you can check out [the color section](/customization/color/).
 
-{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 ### Personnalisation
 
@@ -114,7 +114,7 @@ const darkTheme = createMuiTheme({
 
 The colors modified by the palette type are the following:
 
-{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
 
 ### User preference
 

--- a/docs/src/pages/customization/palette/palette-ja.md
+++ b/docs/src/pages/customization/palette/palette-ja.md
@@ -17,7 +17,7 @@ A color intention とは、パレットをアプリケーション内の特定�
 
 色の詳細については、[色セクション](/customization/color/)をご覧ください。
 
-{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 ### カスタマイズ
 
@@ -114,7 +114,7 @@ const darkTheme = createMuiTheme({
 
 The colors modified by the palette type are the following:
 
-{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
 
 ### User preference
 

--- a/docs/src/pages/customization/palette/palette-pt.md
+++ b/docs/src/pages/customization/palette/palette-pt.md
@@ -17,7 +17,7 @@ A paleta padrão usa as sombras prefixadas com `A` (`A200`, etc.) para a intenç
 
 Se você quiser aprender mais sobre cor, você pode conferir [a seção de cores](/customization/color/).
 
-{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 ### Customização
 
@@ -114,7 +114,7 @@ const darkTheme = createMuiTheme({
 
 The colors modified by the palette type are the following:
 
-{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
 
 ### User preference
 

--- a/docs/src/pages/customization/palette/palette-ru.md
+++ b/docs/src/pages/customization/palette/palette-ru.md
@@ -17,7 +17,7 @@
 
 Для более подробного изучения цветовых настроек можно посетить [секцию про цвета](/customization/color/).
 
-{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 ### Кастомизация
 
@@ -114,7 +114,7 @@ const darkTheme = createMuiTheme({
 
 The colors modified by the palette type are the following:
 
-{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
 
 ### User preference
 

--- a/docs/src/pages/customization/palette/palette-zh.md
+++ b/docs/src/pages/customization/palette/palette-zh.md
@@ -17,7 +17,7 @@ The default palette uses the shades prefixed with `A` (`A200`, etc.) for the sec
 
 If you want to learn more about color, you can check out [the color section](/customization/color/).
 
-{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 ### 个性化
 
@@ -114,7 +114,7 @@ const darkTheme = createMuiTheme({
 
 The colors modified by the palette type are the following:
 
-{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
 
 ### User preference
 

--- a/docs/src/pages/customization/palette/palette.md
+++ b/docs/src/pages/customization/palette/palette.md
@@ -19,7 +19,7 @@ and the un-prefixed shades for the other intentions.
 
 If you want to learn more about color, you can check out [the color section](/customization/color/).
 
-{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/Intentions.js", "bg": "inline", "hideToolbar": true}}
 
 ### Customization
 
@@ -132,7 +132,7 @@ const darkTheme = createMuiTheme({
 
 The colors modified by the palette type are the following:
 
-{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideHeader": true}}
+{{"demo": "pages/customization/palette/DarkTheme.js", "bg": "inline", "hideToolbar": true}}
 
 ### User preference
 

--- a/docs/src/pages/customization/typography/typography-de.md
+++ b/docs/src/pages/customization/typography/typography-de.md
@@ -143,7 +143,7 @@ theme.typography.h3 = {
 
 To automate this setup, you can use the [`responsiveFontSizes()`](/customization/theming/#responsivefontsizes-theme-options-theme) helper to make Typography font sizes in the theme responsive.
 
-{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideHeader": true}}
+{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideToolbar": true}}
 
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 

--- a/docs/src/pages/customization/typography/typography-es.md
+++ b/docs/src/pages/customization/typography/typography-es.md
@@ -143,7 +143,7 @@ theme.typography.h3 = {
 
 To automate this setup, you can use the [`responsiveFontSizes()`](/customization/theming/#responsivefontsizes-theme-options-theme) helper to make Typography font sizes in the theme responsive.
 
-{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideHeader": true}}
+{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideToolbar": true}}
 
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 

--- a/docs/src/pages/customization/typography/typography-fr.md
+++ b/docs/src/pages/customization/typography/typography-fr.md
@@ -143,7 +143,7 @@ theme.typography.h3 = {
 
 To automate this setup, you can use the [`responsiveFontSizes()`](/customization/theming/#responsivefontsizes-theme-options-theme) helper to make Typography font sizes in the theme responsive.
 
-{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideHeader": true}}
+{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideToolbar": true}}
 
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 

--- a/docs/src/pages/customization/typography/typography-ja.md
+++ b/docs/src/pages/customization/typography/typography-ja.md
@@ -143,7 +143,7 @@ theme.typography.h3 = {
 
 To automate this setup, you can use the [`responsiveFontSizes()`](/customization/theming/#responsivefontsizes-theme-options-theme) helper to make Typography font sizes in the theme responsive.
 
-{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideHeader": true}}
+{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideToolbar": true}}
 
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 

--- a/docs/src/pages/customization/typography/typography-pt.md
+++ b/docs/src/pages/customization/typography/typography-pt.md
@@ -143,7 +143,7 @@ theme.typography.h3 = {
 
 To automate this setup, you can use the [`responsiveFontSizes()`](/customization/theming/#responsivefontsizes-theme-options-theme) helper to make Typography font sizes in the theme responsive.
 
-{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideHeader": true}}
+{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideToolbar": true}}
 
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 

--- a/docs/src/pages/customization/typography/typography-ru.md
+++ b/docs/src/pages/customization/typography/typography-ru.md
@@ -143,7 +143,7 @@ theme.typography.h3 = {
 
 To automate this setup, you can use the [`responsiveFontSizes()`](/customization/theming/#responsivefontsizes-theme-options-theme) helper to make Typography font sizes in the theme responsive.
 
-{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideHeader": true}}
+{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideToolbar": true}}
 
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 

--- a/docs/src/pages/customization/typography/typography-zh.md
+++ b/docs/src/pages/customization/typography/typography-zh.md
@@ -143,7 +143,7 @@ theme.typography.h3 = {
 
 To automate this setup, you can use the [`responsiveFontSizes()`](/customization/theming/#responsivefontsizes-theme-options-theme) helper to make Typography font sizes in the theme responsive.
 
-{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideHeader": true}}
+{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideToolbar": true}}
 
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 

--- a/docs/src/pages/customization/typography/typography.md
+++ b/docs/src/pages/customization/typography/typography.md
@@ -155,7 +155,7 @@ theme.typography.h3 = {
 
 To automate this setup, you can use the [`responsiveFontSizes()`](/customization/theming/#responsivefontsizes-theme-options-theme) helper to make Typography font sizes in the theme responsive.
 
-{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideHeader": true}}
+{{"demo": "pages/customization/typography/ResponsiveFontSizesChart.js", "hideToolbar": true}}
 
 You can see this in action in the example below. adjust your browser's window size, and notice how the font size changes as the width crosses the different [breakpoints](/customization/breakpoints/):
 

--- a/docs/src/pages/discover-more/languages/languages-de.md
+++ b/docs/src/pages/discover-more/languages/languages-de.md
@@ -2,4 +2,4 @@
 
 <p class="description">Die Dokumentation zur Material-UI ist in den folgenden Sprachen verfügbar.</p>
 
-{{"demo": "pages/discover-more/languages/Languages.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/discover-more/languages/Languages.js", "hideToolbar": true, "bg": true}}

--- a/docs/src/pages/discover-more/languages/languages-es.md
+++ b/docs/src/pages/discover-more/languages/languages-es.md
@@ -2,4 +2,4 @@
 
 <p class="description">The Material-UI documentation is available in the following languages.</p>
 
-{{"demo": "pages/discover-more/languages/Languages.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/discover-more/languages/Languages.js", "hideToolbar": true, "bg": true}}

--- a/docs/src/pages/discover-more/languages/languages-fr.md
+++ b/docs/src/pages/discover-more/languages/languages-fr.md
@@ -2,4 +2,4 @@
 
 <p class="description">La documentation de Material-UI est disponible dans les langues suivantes.</p>
 
-{{"demo": "pages/discover-more/languages/Languages.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/discover-more/languages/Languages.js", "hideToolbar": true, "bg": true}}

--- a/docs/src/pages/discover-more/languages/languages-ja.md
+++ b/docs/src/pages/discover-more/languages/languages-ja.md
@@ -2,4 +2,4 @@
 
 <p class="description">Material-UIドキュメントは、次の言語で利用可能です。</p>
 
-{{"demo": "pages/discover-more/languages/Languages.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/discover-more/languages/Languages.js", "hideToolbar": true, "bg": true}}

--- a/docs/src/pages/discover-more/languages/languages-pt.md
+++ b/docs/src/pages/discover-more/languages/languages-pt.md
@@ -2,4 +2,4 @@
 
 <p class="description">A documentação do Material-UI está disponível nos seguintes idiomas.</p>
 
-{{"demo": "pages/discover-more/languages/Languages.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/discover-more/languages/Languages.js", "hideToolbar": true, "bg": true}}

--- a/docs/src/pages/discover-more/languages/languages-ru.md
+++ b/docs/src/pages/discover-more/languages/languages-ru.md
@@ -2,4 +2,4 @@
 
 <p class="description">The Material-UI documentation is available in the following languages.</p>
 
-{{"demo": "pages/discover-more/languages/Languages.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/discover-more/languages/Languages.js", "hideToolbar": true, "bg": true}}

--- a/docs/src/pages/discover-more/languages/languages-zh.md
+++ b/docs/src/pages/discover-more/languages/languages-zh.md
@@ -2,4 +2,4 @@
 
 <p class="description">Material-UI 的文档提供了以下几种语言的版本。</p>
 
-{{"demo": "pages/discover-more/languages/Languages.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/discover-more/languages/Languages.js", "hideToolbar": true, "bg": true}}

--- a/docs/src/pages/discover-more/languages/languages.md
+++ b/docs/src/pages/discover-more/languages/languages.md
@@ -2,5 +2,5 @@
 
 <p class="description">The Material-UI documentation is available in the following languages.</p>
 
-{{"demo": "pages/discover-more/languages/Languages.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/discover-more/languages/Languages.js", "hideToolbar": true, "bg": true}}
 

--- a/docs/src/pages/discover-more/showcase/showcase-de.md
+++ b/docs/src/pages/discover-more/showcase/showcase-de.md
@@ -8,4 +8,4 @@ Möchten Sie Ihre App hinzufügen? App gefunden, die nicht mehr funktioniert ode
 - Viel Verkehr
 - Open Source
 
-{{"demo": "pages/discover-more/showcase/Showcase.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/showcase/Showcase.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/src/pages/discover-more/showcase/showcase-es.md
+++ b/docs/src/pages/discover-more/showcase/showcase-es.md
@@ -8,4 +8,4 @@ Want to add your app? Found an app that no longer works or no longer uses Materi
 - High traffic
 - Open source
 
-{{"demo": "pages/discover-more/showcase/Showcase.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/showcase/Showcase.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/src/pages/discover-more/showcase/showcase-fr.md
+++ b/docs/src/pages/discover-more/showcase/showcase-fr.md
@@ -8,4 +8,4 @@ Voulez-vous ajouter votre application? Vous avez trouvé une application qui ne 
 - High traffic
 - Open source
 
-{{"demo": "pages/discover-more/showcase/Showcase.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/showcase/Showcase.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/src/pages/discover-more/showcase/showcase-ja.md
+++ b/docs/src/pages/discover-more/showcase/showcase-ja.md
@@ -8,4 +8,4 @@ Want to add your app? Found an app that no longer works or no longer uses Materi
 - High traffic
 - オープンソース
 
-{{"demo": "pages/discover-more/showcase/Showcase.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/showcase/Showcase.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/src/pages/discover-more/showcase/showcase-pt.md
+++ b/docs/src/pages/discover-more/showcase/showcase-pt.md
@@ -8,4 +8,4 @@ Quer adicionar sua aplicação? Encontrou uma aplicação que não funciona mais
 - Alto tráfego
 - Código aberto
 
-{{"demo": "pages/discover-more/showcase/Showcase.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/showcase/Showcase.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/src/pages/discover-more/showcase/showcase-ru.md
+++ b/docs/src/pages/discover-more/showcase/showcase-ru.md
@@ -8,4 +8,4 @@ Want to add your app? Found an app that no longer works or no longer uses Materi
 - High traffic
 - Open source
 
-{{"demo": "pages/discover-more/showcase/Showcase.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/showcase/Showcase.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/src/pages/discover-more/showcase/showcase-zh.md
+++ b/docs/src/pages/discover-more/showcase/showcase-zh.md
@@ -8,4 +8,4 @@
 - 高流量
 - 开源
 
-{{"demo": "pages/discover-more/showcase/Showcase.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/showcase/Showcase.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/src/pages/discover-more/showcase/showcase.md
+++ b/docs/src/pages/discover-more/showcase/showcase.md
@@ -8,4 +8,4 @@ Want to add your app? Found an app that no longer works or no longer uses Materi
 - High traffic
 - Open source
 
-{{"demo": "pages/discover-more/showcase/Showcase.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/showcase/Showcase.js", "hideToolbar": true, "bg": "inline"}}

--- a/docs/src/pages/discover-more/team/team-de.md
+++ b/docs/src/pages/discover-more/team/team-de.md
@@ -4,7 +4,7 @@
 
 Material-UI wird von einer kleinen Gruppe unschätzbarer Kernmitarbeiter und der massiven Unterstützung und Engagement der Community gepflegt.
 
-{{"demo": "pages/discover-more/team/Team.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/team/Team.js", "hideToolbar": true, "bg": "inline"}}
 
 Machen Sie mit bei der Entwicklung von Material-UI indem Sie ein [ Problem melden](https://github.com/mui-org/material-ui/issues/new) oder einen Pull-Request erstellen. Lesen Sie unsere [ Richtlinien ](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) um Informationen darüber zu erhalten, wie wir entwickeln.
 

--- a/docs/src/pages/discover-more/team/team-es.md
+++ b/docs/src/pages/discover-more/team/team-es.md
@@ -4,7 +4,7 @@
 
 Material-UI is maintained by a small group of invaluable core contributors, with the massive support and involvement of the community.
 
-{{"demo": "pages/discover-more/team/Team.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/team/Team.js", "hideToolbar": true, "bg": "inline"}}
 
 Get involved with Material-UI development by [opening an issue](https://github.com/mui-org/material-ui/issues/new) or submitting a pull request. Read the [contributing guidelines](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.
 

--- a/docs/src/pages/discover-more/team/team-fr.md
+++ b/docs/src/pages/discover-more/team/team-fr.md
@@ -4,7 +4,7 @@
 
 Material-UI is maintained by a small group of invaluable core contributors, with the massive support and involvement of the community.
 
-{{"demo": "pages/discover-more/team/Team.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/team/Team.js", "hideToolbar": true, "bg": "inline"}}
 
 Impliquez-vous dans le développement de Material-UI en [ouvrant un problème](https://github.com/mui-org/material-ui/issues/new) ou soumettre une demande de tirage. Read the [contributing guidelines](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.
 

--- a/docs/src/pages/discover-more/team/team-ja.md
+++ b/docs/src/pages/discover-more/team/team-ja.md
@@ -4,7 +4,7 @@
 
 Material-UI is maintained by a small group of invaluable core contributors, with the massive support and involvement of the community.
 
-{{"demo": "pages/discover-more/team/Team.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/team/Team.js", "hideToolbar": true, "bg": "inline"}}
 
 Get involved with Material-UI development by [opening an issue](https://github.com/mui-org/material-ui/issues/new) or submitting a pull request. Read the [contributing guidelines](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.
 

--- a/docs/src/pages/discover-more/team/team-pt.md
+++ b/docs/src/pages/discover-more/team/team-pt.md
@@ -4,7 +4,7 @@
 
 Material-UI é mantida por um pequeno grupo de contribuidores essenciais de valor inestimável, com o apoio e envolvimento maciço da comunidade.
 
-{{"demo": "pages/discover-more/team/Team.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/team/Team.js", "hideToolbar": true, "bg": "inline"}}
 
 Colabore com o desenvolvimento de Material-UI [abrindo uma issue](https://github.com/mui-org/material-ui/issues/new) ou enviando um pull request. Leia as [diretrizes de contribuição](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) para informações sobre como nós desenvolvemos.
 

--- a/docs/src/pages/discover-more/team/team-ru.md
+++ b/docs/src/pages/discover-more/team/team-ru.md
@@ -4,7 +4,7 @@
 
 Material-UI is maintained by a small group of invaluable core contributors, with the massive support and involvement of the community.
 
-{{"demo": "pages/discover-more/team/Team.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/team/Team.js", "hideToolbar": true, "bg": "inline"}}
 
 Get involved with Material-UI development by [opening an issue](https://github.com/mui-org/material-ui/issues/new) or submitting a pull request. Read the [contributing guidelines](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.
 

--- a/docs/src/pages/discover-more/team/team-zh.md
+++ b/docs/src/pages/discover-more/team/team-zh.md
@@ -4,7 +4,7 @@
 
 Material-UI is maintained by a small group of invaluable core contributors, with the massive support and involvement of the community.
 
-{{"demo": "pages/discover-more/team/Team.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/team/Team.js", "hideToolbar": true, "bg": "inline"}}
 
 通过 [打开问题](https://github.com/mui-org/material-ui/issues/new) 或提交一个 pull request 来参与到 Material-UI 开发中来吧。 Read the [contributing guidelines](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.
 

--- a/docs/src/pages/discover-more/team/team.md
+++ b/docs/src/pages/discover-more/team/team.md
@@ -4,7 +4,7 @@
 
 Material-UI is maintained by a small group of invaluable core contributors, with the massive support and involvement of the community.
 
-{{"demo": "pages/discover-more/team/Team.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/discover-more/team/Team.js", "hideToolbar": true, "bg": "inline"}}
 
 Get involved with Material-UI development by [opening an issue](https://github.com/mui-org/material-ui/issues/new) or submitting a pull request.
 Read the [contributing guidelines](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md) for information on how we develop.

--- a/docs/src/pages/getting-started/templates/templates-de.md
+++ b/docs/src/pages/getting-started/templates/templates-de.md
@@ -10,7 +10,7 @@ The templates can be combined with one of the [example applications](https://git
 
 Abschnitte jedes Layouts sind entweder durch Kommentare oder die Verwendung separater Dateien eindeutig definiert. Dadurch wird das Extrahieren von Teilen einer Seite (z. B. "Heldeneinheit" oder Fußzeilen) für die Wiederverwendung in anderen Seiten vereinfacht. Für mehrteilige Beispiele, beschreibt eine Tabelle in der README im verknüpften Quellcode der Zweck jeder Datei.
 
-{{"demo": "pages/getting-started/templates/Templates.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/templates/Templates.js", "hideToolbar": true, "bg": true}}
 
 Wenn Sie während Sie die Beispiele verwenden Änderungen oder Verbesserungen vornehmen, die die Entwickler Erfahrung verbessern könnte, oder Sie mögen ein weiteres Beispiel dazu beitragen, denken Sie doch über einen [ Pull-Request auf GitHub](https://github.com/mui-org/material-ui/pulls) nach.
 

--- a/docs/src/pages/getting-started/templates/templates-es.md
+++ b/docs/src/pages/getting-started/templates/templates-es.md
@@ -10,7 +10,7 @@ Las plantillas pueden combinarse con una de las [aplicaciones de ejemplo](https:
 
 Las secciones de cada diseño están claramente definidas, ya sea por comentarios o por el uso de archivos separados, simplificando la extracción de partes de una página (como una "unidad de héroe" o un pie de página, por ejemplo) para reutilizar en otras páginas. Para ver ejemplos multi-partes, una tabla en el README en la ubicación del código fuente describe el propósito de cada archivo.
 
-{{"demo": "pages/getting-started/templates/Templates.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/templates/Templates.js", "hideToolbar": true, "bg": true}}
 
 Si al usar estos ejemplos realizas cambios o mejoras que podrían mejorar la experiencia del desarrollador, o deseas contribuir con un ejemplo adicional, considera crear una pull request [en GitHub](https://github.com/mui-org/material-ui/pulls).
 

--- a/docs/src/pages/getting-started/templates/templates-fr.md
+++ b/docs/src/pages/getting-started/templates/templates-fr.md
@@ -10,7 +10,7 @@ The templates can be combined with one of the [example applications](https://git
 
 Les sections de chaque mise en page sont clairement définies, soit par des commentaires, soit par l’utilisation de fichiers séparés ce qui facilite l’extraction de parties d’une page (telle qu'une "unité héros" ou un pied de page, par exemple) pour une utilisation ultérieure. Pour les exemples multi-parties, une table dans le README à l'emplacement du code source lié décrit le but de chaque fichier.
 
-{{"demo": "pages/getting-started/templates/Templates.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/templates/Templates.js", "hideToolbar": true, "bg": true}}
 
 If while using these examples you make changes or enhancements that could improve the developer experience, or you would like to contribute an additional example, please consider creating a [pull request on GitHub](https://github.com/mui-org/material-ui/pulls).
 

--- a/docs/src/pages/getting-started/templates/templates-ja.md
+++ b/docs/src/pages/getting-started/templates/templates-ja.md
@@ -10,7 +10,7 @@ title: 9+ Free React Templates
 
 各レイアウトのセクションは、コメントまたは個別のファイルの使用によって明確に定義されます。 ページの一部を簡単に抽出できるようになりました(たとえば、「ヒーローユニット」やフッタなど)。 他のページで再利用できます。 マルチパートの例については、リンクされたソースコードの場所にあるREADMEの表に各ファイルの目的が説明されています。
 
-{{"demo": "pages/getting-started/templates/Templates.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/templates/Templates.js", "hideToolbar": true, "bg": true}}
 
 これらのサンプルを使用している間に、開発者のエクスペリエンスを改善する可能性のある変更や拡張を行ったり、追加のサンプルを提供したい場合は、GitHub</a>でプルリクエストを作成することを検討してください。</p> 
 

--- a/docs/src/pages/getting-started/templates/templates-pt.md
+++ b/docs/src/pages/getting-started/templates/templates-pt.md
@@ -10,7 +10,7 @@ Os modelos podem ser combinados com uma das [aplicações de exemplo](https://gi
 
 Seções de cada leiaute são claramente definidas por comentários ou uso de arquivos separados, tornando simples extrair partes de uma página (como uma "hero unit" ou rodapé, por exemplo) para reutilização em outras páginas. Para exemplos de várias partes, uma tabela no README no local do código-fonte vinculado descreve a finalidade de cada arquivo.
 
-{{"demo": "pages/getting-started/templates/Templates.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/templates/Templates.js", "hideToolbar": true, "bg": true}}
 
 Se, ao usar estes exemplos você faz mudanças ou melhorias que poderiam melhorar a experiência do desenvolvedor, ou você gostaria de contribuir com um exemplo adicional, por favor considere a criação de um [pull request no GitHub](https://github.com/mui-org/material-ui/pulls).
 

--- a/docs/src/pages/getting-started/templates/templates-ru.md
+++ b/docs/src/pages/getting-started/templates/templates-ru.md
@@ -10,7 +10,7 @@ The templates can be combined with one of the [example applications](https://git
 
 Разделы каждого макета четко определяются либо комментариями, либо использованием отдельных файлов, упрощая извлечение частей страницы (например, «героя» или нижнего колонтитула) для повторного использования на других страницах. For multi-part examples, a table in the README at the linked source code location describes the purpose of each file.
 
-{{"demo": "pages/getting-started/templates/Templates.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/templates/Templates.js", "hideToolbar": true, "bg": true}}
 
 If while using these examples you make changes or enhancements that could improve the developer experience, or you would like to contribute an additional example, please consider creating a [pull request on GitHub](https://github.com/mui-org/material-ui/pulls).
 

--- a/docs/src/pages/getting-started/templates/templates-zh.md
+++ b/docs/src/pages/getting-started/templates/templates-zh.md
@@ -10,7 +10,7 @@ title: 9+ Free React Templates
 
 Sections of each layout are clearly defined either by comments or use of separate files, making it simple to extract parts of a page (such as a "hero unit", or footer, for example) for reuse in other pages. For multi-part examples, a table in the README at the linked source code location describes the purpose of each file.
 
-{{"demo": "pages/getting-started/templates/Templates.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/templates/Templates.js", "hideToolbar": true, "bg": true}}
 
 如果您在使用这些示例时进行了更改或增强以改善开发人员的体验，或者您想提供其他示例，请考虑在GitHub</a>上创建 pull 请求。</p> 
 

--- a/docs/src/pages/getting-started/templates/templates.md
+++ b/docs/src/pages/getting-started/templates/templates.md
@@ -14,7 +14,7 @@ for reuse in other pages.
 For multi-part examples, a table in the README at the linked source code location describes
 the purpose of each file.
 
-{{"demo": "pages/getting-started/templates/Templates.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/templates/Templates.js", "hideToolbar": true, "bg": true}}
 
 If while using these examples you make changes or enhancements that could improve the
 developer experience, or you would like to contribute an additional example,

--- a/docs/src/pages/getting-started/usage/usage-de.md
+++ b/docs/src/pages/getting-started/usage/usage-de.md
@@ -28,7 +28,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 Ja, das ist tatsächlich alles, das Sie für den Start brauchen. In dieser interaktiven Live-Demo können Sie dies ausprobieren:
 
-{{"demo": "pages/getting-started/usage/Usage.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## Globale Objekte
 

--- a/docs/src/pages/getting-started/usage/usage-es.md
+++ b/docs/src/pages/getting-started/usage/usage-es.md
@@ -28,7 +28,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 Así es! Esto es todo lo que necesitas para empezar, como podrás comprobar con la siguiente demostración interactiva en vivo:
 
-{{"demo": "pages/getting-started/usage/Usage.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## Globales
 

--- a/docs/src/pages/getting-started/usage/usage-fr.md
+++ b/docs/src/pages/getting-started/usage/usage-fr.md
@@ -28,7 +28,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 Oui, c'est tout ce dont vous avez besoin pour commencer, comme vous pouvez le voir dans cette démo en direct et interactive :
 
-{{"demo": "pages/getting-started/usage/Usage.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## Variables globales
 

--- a/docs/src/pages/getting-started/usage/usage-ja.md
+++ b/docs/src/pages/getting-started/usage/usage-ja.md
@@ -28,7 +28,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 そうです。これは本当に始めるのに必要な全てです。この編集可能なデモで確認できるように:
 
-{{"demo": "pages/getting-started/usage/Usage.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## Globals
 

--- a/docs/src/pages/getting-started/usage/usage-pt.md
+++ b/docs/src/pages/getting-started/usage/usage-pt.md
@@ -28,7 +28,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 Sim, isso é tudo o que você precisa para começar, como você pode ver nesta demonstração ao vivo e interativa:
 
-{{"demo": "pages/getting-started/usage/Usage.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## Globais
 

--- a/docs/src/pages/getting-started/usage/usage-ru.md
+++ b/docs/src/pages/getting-started/usage/usage-ru.md
@@ -28,7 +28,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 Да, это действительно все, что вам нужно для начала, как вы можете увидеть в этой интерактивной демонстрации:
 
-{{"demo": "pages/getting-started/usage/Usage.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## Глобальная настройка
 

--- a/docs/src/pages/getting-started/usage/usage-zh.md
+++ b/docs/src/pages/getting-started/usage/usage-zh.md
@@ -28,7 +28,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 是的，这就是您开始使用所需的一切，您也可以在这个实时的交互式的演示中所查看：
 
-{{"demo": "pages/getting-started/usage/Usage.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## 全局变量
 

--- a/docs/src/pages/getting-started/usage/usage.md
+++ b/docs/src/pages/getting-started/usage/usage.md
@@ -31,7 +31,7 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 Yes, this really is all you need to get started, as you can see in this live and interactive demo:
 
-{{"demo": "pages/getting-started/usage/Usage.js", "hideHeader": true, "bg": true}}
+{{"demo": "pages/getting-started/usage/Usage.js", "hideToolbar": true, "bg": true}}
 
 ## Globals
 

--- a/docs/src/pages/guides/interoperability/interoperability-de.md
+++ b/docs/src/pages/guides/interoperability/interoperability-de.md
@@ -15,7 +15,7 @@ In diesem Handbuch sollen die beliebtesten Alternativen dokumentiert werden, abe
 
 Nothing fancy, just plain CSS.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plain-css-mtzri)
 
@@ -68,7 +68,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **PlainCssButtonDeep.css**
 
@@ -156,7 +156,7 @@ import { StylesProvider } from '@material-ui/core/styles';
 
 The `styled()` method works perfectly on all of the components.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-r1fsr)
 
@@ -327,7 +327,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 
 It's hard to know the market share of [this styling solution](https://github.com/css-modules/css-modules) as it's dependent on the bundling solution people are using.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/css-modules-3j29h)
 
@@ -382,7 +382,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **CssModulesButtonDeep.css**
 
@@ -426,7 +426,7 @@ export default function CssModulesButtonDeep() {
 
 Emotion's **css()** method works seamlessly with Material-UI.
 
-{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/emotion-bgfxj)
 

--- a/docs/src/pages/guides/interoperability/interoperability-es.md
+++ b/docs/src/pages/guides/interoperability/interoperability-es.md
@@ -15,7 +15,7 @@ This guide aims to document the most popular alternatives, but you should find t
 
 Nothing fancy, just plain CSS.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plain-css-mtzri)
 
@@ -68,7 +68,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **PlainCssButtonDeep.css**
 
@@ -156,7 +156,7 @@ import { StylesProvider } from '@material-ui/core/styles';
 
 The `styled()` method works perfectly on all of the components.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-r1fsr)
 
@@ -327,7 +327,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 
 It's hard to know the market share of [this styling solution](https://github.com/css-modules/css-modules) as it's dependent on the bundling solution people are using.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/css-modules-3j29h)
 
@@ -382,7 +382,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **CssModulesButtonDeep.css**
 
@@ -426,7 +426,7 @@ export default function CssModulesButtonDeep() {
 
 Emotion's **css()** method works seamlessly with Material-UI.
 
-{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/emotion-bgfxj)
 

--- a/docs/src/pages/guides/interoperability/interoperability-fr.md
+++ b/docs/src/pages/guides/interoperability/interoperability-fr.md
@@ -15,7 +15,7 @@ This guide aims to document the most popular alternatives, but you should find t
 
 Nothing fancy, just plain CSS.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plain-css-mtzri)
 
@@ -68,7 +68,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **PlainCssButtonDeep.css**
 
@@ -156,7 +156,7 @@ import { StylesProvider } from '@material-ui/core/styles';
 
 The `styled()` method works perfectly on all of the components.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-r1fsr)
 
@@ -327,7 +327,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 
 It's hard to know the market share of [this styling solution](https://github.com/css-modules/css-modules) as it's dependent on the bundling solution people are using.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/css-modules-3j29h)
 
@@ -382,7 +382,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **CssModulesButtonDeep.css**
 
@@ -426,7 +426,7 @@ export default function CssModulesButtonDeep() {
 
 Emotion's **css()** method works seamlessly with Material-UI.
 
-{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/emotion-bgfxj)
 

--- a/docs/src/pages/guides/interoperability/interoperability-ja.md
+++ b/docs/src/pages/guides/interoperability/interoperability-ja.md
@@ -15,7 +15,7 @@ This guide aims to document the most popular alternatives, but you should find t
 
 Nothing fancy, just plain CSS.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plain-css-mtzri)
 
@@ -68,7 +68,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **PlainCssButtonDeep.css**
 
@@ -156,7 +156,7 @@ import { StylesProvider } from '@material-ui/core/styles';
 
 The `styled()` method works perfectly on all of the components.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-r1fsr)
 
@@ -327,7 +327,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 
 It's hard to know the market share of [this styling solution](https://github.com/css-modules/css-modules) as it's dependent on the bundling solution people are using.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/css-modules-3j29h)
 
@@ -382,7 +382,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **CssModulesButtonDeep.css**
 
@@ -426,7 +426,7 @@ export default function CssModulesButtonDeep() {
 
 Emotion's **css()** method works seamlessly with Material-UI.
 
-{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/emotion-bgfxj)
 

--- a/docs/src/pages/guides/interoperability/interoperability-pt.md
+++ b/docs/src/pages/guides/interoperability/interoperability-pt.md
@@ -15,7 +15,7 @@ Este guia tem como objetivo documentar as alternativas mais populares, mas você
 
 Nothing fancy, just plain CSS.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plain-css-mtzri)
 
@@ -68,7 +68,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **PlainCssButtonDeep.css**
 
@@ -156,7 +156,7 @@ import { StylesProvider } from '@material-ui/core/styles';
 
 The `styled()` method works perfectly on all of the components.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-r1fsr)
 
@@ -327,7 +327,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 
 It's hard to know the market share of [this styling solution](https://github.com/css-modules/css-modules) as it's dependent on the bundling solution people are using.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/css-modules-3j29h)
 
@@ -382,7 +382,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **CssModulesButtonDeep.css**
 
@@ -426,7 +426,7 @@ export default function CssModulesButtonDeep() {
 
 Emotion's **css()** method works seamlessly with Material-UI.
 
-{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/emotion-bgfxj)
 

--- a/docs/src/pages/guides/interoperability/interoperability-ru.md
+++ b/docs/src/pages/guides/interoperability/interoperability-ru.md
@@ -15,7 +15,7 @@ This guide aims to document the most popular alternatives, but you should find t
 
 Nothing fancy, just plain CSS.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plain-css-mtzri)
 
@@ -68,7 +68,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **PlainCssButtonDeep.css**
 
@@ -156,7 +156,7 @@ import { StylesProvider } from '@material-ui/core/styles';
 
 The `styled()` method works perfectly on all of the components.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-r1fsr)
 
@@ -327,7 +327,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 
 It's hard to know the market share of [this styling solution](https://github.com/css-modules/css-modules) as it's dependent on the bundling solution people are using.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/css-modules-3j29h)
 
@@ -382,7 +382,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **CssModulesButtonDeep.css**
 
@@ -426,7 +426,7 @@ export default function CssModulesButtonDeep() {
 
 Emotion's **css()** method works seamlessly with Material-UI.
 
-{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/emotion-bgfxj)
 

--- a/docs/src/pages/guides/interoperability/interoperability-zh.md
+++ b/docs/src/pages/guides/interoperability/interoperability-zh.md
@@ -15,7 +15,7 @@
 
 Nothing fancy, just plain CSS.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plain-css-mtzri)
 
@@ -68,7 +68,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **PlainCssButtonDeep.css**
 
@@ -156,7 +156,7 @@ import { StylesProvider } from '@material-ui/core/styles';
 
 The `styled()` method works perfectly on all of the components.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-r1fsr)
 
@@ -327,7 +327,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 
 It's hard to know the market share of [this styling solution](https://github.com/css-modules/css-modules) as it's dependent on the bundling solution people are using.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/css-modules-3j29h)
 
@@ -382,7 +382,7 @@ If you attempt to style a Drawer with variant permanent, you will likely need to
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **CssModulesButtonDeep.css**
 
@@ -426,7 +426,7 @@ export default function CssModulesButtonDeep() {
 
 Emotion's **css()** method works seamlessly with Material-UI.
 
-{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/emotion-bgfxj)
 

--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -17,7 +17,7 @@ There are examples for the following styling solutions:
 
 Nothing fancy, just plain CSS.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/plain-css-mtzri)
 
@@ -71,7 +71,7 @@ You need to use the [`classes`](/styles/advanced/#overriding-styles-classes-prop
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **PlainCssButtonDeep.css**
 ```css
@@ -158,7 +158,7 @@ import { StylesProvider } from '@material-ui/core/styles';
 
 The `styled()` method works perfectly on all of the components.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/styled-components-r1fsr)
 
@@ -339,7 +339,7 @@ const StyledMenu = styled(({ className, ...props }) => (
 It's hard to know the market share of [this styling solution](https://github.com/css-modules/css-modules) as it's dependent on the
 bundling solution people are using.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/css-modules-3j29h)
 
@@ -395,7 +395,7 @@ You need to use the [`classes`](/styles/advanced/#overriding-styles-classes-prop
 
 The following example overrides the `label` style of `Button` in addition to the custom styles on the button itself.
 
-{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/StyledComponents.js", "hideToolbar": true}}
 
 **CssModulesButtonDeep.css**
 ```css
@@ -439,7 +439,7 @@ export default function CssModulesButtonDeep() {
 
 Emotion's **css()** method works seamlessly with Material-UI.
 
-{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideHeader": true}}
+{{"demo": "pages/guides/interoperability/EmotionCSS.js", "hideToolbar": true}}
 
 [![Edit Button](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/emotion-bgfxj)
 

--- a/docs/src/pages/versions/versions-de.md
+++ b/docs/src/pages/versions/versions-de.md
@@ -6,13 +6,13 @@
 
 Die aktuellste Version wird in der Produktion empfohlen.
 
-{{"demo": "pages/versions/StableVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Neueste Versionen
 
 Hier finden Sie die neuesten unveröffentlichten Dokumentationen und Codes. Sie können damit feststellen, welche Änderungen bevorstehen, und den Mitwirkenden der Material-UI besseres Feedback geben.
 
-{{"demo": "pages/versions/LatestVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/LatestVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Versionierungsstrategie
 

--- a/docs/src/pages/versions/versions-es.md
+++ b/docs/src/pages/versions/versions-es.md
@@ -6,13 +6,13 @@
 
 La versión más reciente se recomienda en producción.
 
-{{"demo": "pages/versions/StableVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Latest versions
 
 Aquí puedes encontrar la version inédita mas reciente de la documentación y código. Puedes usarlo para ver qué cambios se avecinan y proporcionar mejores comentarios a los contribuyentes de Material-UI.
 
-{{"demo": "pages/versions/LatestVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/LatestVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Estrategia para versionado
 

--- a/docs/src/pages/versions/versions-fr.md
+++ b/docs/src/pages/versions/versions-fr.md
@@ -6,13 +6,13 @@
 
 La version la plus récente est recommandée en production.
 
-{{"demo": "pages/versions/StableVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Versions les plus récentes
 
 Ici vous pouvez trouver la dernière documentation non publiée et le code. Vous pouvez l'utiliser pour voir les modifications à venir et fournir des retours aux contributeurs de Material-UI.
 
-{{"demo": "pages/versions/LatestVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/LatestVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Stratégie de gestion des versions
 

--- a/docs/src/pages/versions/versions-ja.md
+++ b/docs/src/pages/versions/versions-ja.md
@@ -6,13 +6,13 @@
 
 本番環境では最新バージョンをお勧めします。
 
-{{"demo": "pages/versions/StableVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## 最新バージョン
 
 ここには、最新の未発表の文書とコードがあります。 これを使用して、変更点を確認し、Material-UIの貢献者により良いフィードバックを提供できます。
 
-{{"demo": "pages/versions/LatestVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/LatestVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## バージョン管理戦略
 

--- a/docs/src/pages/versions/versions-pt.md
+++ b/docs/src/pages/versions/versions-pt.md
@@ -6,13 +6,13 @@
 
 É recomendado usar a versão mais recente em ambiente de produção.
 
-{{"demo": "pages/versions/StableVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Últimas versões
 
 Aqui pode encontrar a versão em desenvolvimento e sua documentação. Poderá usar esta versão para ver quais alterações que estão a ser implementadas e fornecer um feedback melhor para os contribuidores de Material-UI.
 
-{{"demo": "pages/versions/LatestVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/LatestVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Estratégia de controle de versão
 

--- a/docs/src/pages/versions/versions-ru.md
+++ b/docs/src/pages/versions/versions-ru.md
@@ -6,13 +6,13 @@
 
 The most recent version is recommended in production.
 
-{{"demo": "pages/versions/StableVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Последние версии
 
 Здесь вы можете найти последнюю неопубликованную документацию и код. You can use it to see what changes are coming and provide better feedback to Material-UI contributors.
 
-{{"demo": "pages/versions/LatestVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/LatestVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Versioning strategy
 

--- a/docs/src/pages/versions/versions-zh.md
+++ b/docs/src/pages/versions/versions-zh.md
@@ -6,13 +6,13 @@
 
 我们推荐在生产开发中使用最新版本。
 
-{{"demo": "pages/versions/StableVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## 最新版本
 
 在这里您可以找到尚未发布的最新文档和代码。 您可以使用它来查看未来的更新，并给 Material-UI 的贡献者提供更好的反馈。
 
-{{"demo": "pages/versions/LatestVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/LatestVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## 版本控制方案
 

--- a/docs/src/pages/versions/versions.md
+++ b/docs/src/pages/versions/versions.md
@@ -6,14 +6,14 @@
 
 The most recent version is recommended in production.
 
-{{"demo": "pages/versions/StableVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/StableVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Latest versions
 
 Here you can find the latest unreleased documentation and code.
 You can use it to see what changes are coming and provide better feedback to Material-UI contributors.
 
-{{"demo": "pages/versions/LatestVersions.js", "hideHeader": true, "bg": "inline"}}
+{{"demo": "pages/versions/LatestVersions.js", "hideToolbar": true, "bg": "inline"}}
 
 ## Versioning strategy
 

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -91,6 +91,7 @@
   "decreaseSpacing": "decrease spacing",
   "getProfessionalSupport": "Get Professional Support",
   "diamondSponsors": "Diamond Sponsors",
+  "demoToolbarLabel": "demo source",
   "pages": {
     "/getting-started": "Getting Started",
     "/getting-started/installation": "Installation",


### PR DESCRIPTION
Use `toolbar` semantics for the group of elements that changes the demo source code. I was always a bit uncomfortable with the `hideHeader` options. Since we have proper a11y semantics for it we should leverage it.

Motivated by the desire to easily skip these elements from the a11y snapshot tests. Will do some tests with AT to see the impact.

Edit:

Did some tests and nvda+firefox and VoiceOver correctly identify it (adds a line that you're in the "demo source toolbar"). VoiceOver even implements arrow controls. This is a good first step. Eventually we'll remove all the buttons in it from tab order and manage focus via arrow keys (i.e. make an accessible ToolBar component) but that can be done later. 