### PR TITLE
[core] Automatically apply "PR: needs rebase" PR label

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -1,0 +1,18 @@
+name: 'Maintenance'
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolved
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check if prs are dirty
+        uses: eps1lon/actions-label-merge-conflict@releases/1.x
+        with:
+          dirtyLabel: 'PR: needs rebase'
+          removeOnDirtyLabel: 'PR: ready to ship'
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
Moves maintainer chores to bot chores:

![label lifecycle](https://github.com/eps1lon/actions-label-merge-conflict/raw/master/label-lifecycle.png)

Would be nice to automatically send out notifications at some point (https://github.com/eps1lon/actions-label-merge-conflict/issues/4). Though this should be a sufficient first pitch to test its usefulness.