### PR TITLE
[docs] Improve demo error boundary

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -17,6 +17,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import Tooltip from '@material-ui/core/Tooltip';
+import RefreshIcon from '@material-ui/icons/Refresh';
 import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import DemoSandboxed from 'docs/src/modules/components/DemoSandboxed';
 import DemoLanguages from 'docs/src/modules/components/DemoLanguages';
@@ -336,6 +337,8 @@ function Demo(props) {
     showCodeLabel = showPreview ? t('showFullSource') : t('showSource');
   }
 
+  const [demoKey, resetDemo] = React.useReducer(key => key + 1, 0);
+
   const demoSourceId = useUniqueId(`demo-`);
   const openDemoSource = codeOpen || showPreview;
 
@@ -353,10 +356,12 @@ function Demo(props) {
         onMouseLeave={handleDemoHover}
       >
         <DemoSandboxed
+          key={demoKey}
           style={demoSandboxedStyle}
           component={DemoComponent}
           iframe={demoOptions.iframe}
           name={demoName}
+          resetDemo={resetDemo}
         />
       </div>
       <div className={classes.anchorLink} id={`${demoName}.js`} />
@@ -426,6 +431,17 @@ function Demo(props) {
                   onClick={handleCopyClick}
                 >
                   <FileCopyIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip classes={{ popper: classes.tooltip }} title={t('resetDemo')} placement="top">
+                <IconButton
+                  aria-label={t('resetDemo')}
+                  data-ga-event-category="demo"
+                  data-ga-event-label={demoOptions.demo}
+                  data-ga-event-action="reset"
+                  onClick={resetDemo}
+                >
+                  <RefreshIcon fontSize="small" />
                 </IconButton>
               </Tooltip>
               <IconButton

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -361,7 +361,7 @@ function Demo(props) {
           component={DemoComponent}
           iframe={demoOptions.iframe}
           name={demoName}
-          resetDemo={resetDemo}
+          onResetDemoClick={resetDemo}
         />
       </div>
       <div className={classes.anchorLink} id={`${demoName}.js`} />

--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -13,7 +13,7 @@ export default class DemoErrorBoundary extends React.Component {
   }
 
   render() {
-    const { children } = this.props;
+    const { children, errorActions } = this.props;
     const { error } = this.state;
 
     if (error) {
@@ -31,6 +31,7 @@ export default class DemoErrorBoundary extends React.Component {
             .
           </Typography>
           <pre>{error.toString()}</pre>
+          {errorActions}
         </div>
       );
       /* eslint-enable material-ui/no-hardcoded-labels */
@@ -42,4 +43,8 @@ export default class DemoErrorBoundary extends React.Component {
 
 DemoErrorBoundary.propTypes = {
   children: PropTypes.node,
+  /**
+   * actions that should be displayed when the error fallback is displayed
+   */
+  errorActions: PropTypes.node,
 };

--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Typography from '@material-ui/core/Typography';
 import Link from '@material-ui/core/Link';
+import Button from '@material-ui/core/Button';
 
 export default class DemoErrorBoundary extends React.Component {
   state = {
@@ -13,7 +14,7 @@ export default class DemoErrorBoundary extends React.Component {
   }
 
   render() {
-    const { children, errorActions } = this.props;
+    const { children, onResetDemoClick, t } = this.props;
     const { error } = this.state;
 
     if (error) {
@@ -34,7 +35,9 @@ export default class DemoErrorBoundary extends React.Component {
             .
           </Typography>
           <pre>{error.toString()}</pre>
-          {errorActions}
+          <Button color="secondary" onClick={onResetDemoClick} variant="text">
+            {t('resetDemo')}
+          </Button>
         </div>
       );
       /* eslint-enable material-ui/no-hardcoded-labels */
@@ -46,8 +49,9 @@ export default class DemoErrorBoundary extends React.Component {
 
 DemoErrorBoundary.propTypes = {
   children: PropTypes.node,
+  onResetDemoClick: PropTypes.func.isRequired,
   /**
-   * actions that should be displayed when the error fallback is displayed
+   * translate function from redux store
    */
-  errorActions: PropTypes.node,
+  t: PropTypes.func.isRequired,
 };

--- a/docs/src/modules/components/DemoErrorBoundary.js
+++ b/docs/src/modules/components/DemoErrorBoundary.js
@@ -25,7 +25,10 @@ export default class DemoErrorBoundary extends React.Component {
           </Typography>
           <Typography>
             We would appreciate it if you report this error directly to our{' '}
-            <Link href="https://github.com/mui-org/material-ui/issues/new/choose" target="_blank">
+            <Link
+              href="https://github.com/mui-org/material-ui/issues/new?template=1.bug.md"
+              target="_blank"
+            >
               issue tracker
             </Link>
             .

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { create } from 'jss';
 import { withStyles, useTheme, jssPreset, StylesProvider } from '@material-ui/core/styles';
 import NoSsr from '@material-ui/core/NoSsr';
-import Button from '@material-ui/core/Button';
 import rtl from 'jss-rtl';
 import Frame from 'react-frame-component';
 import { useSelector } from 'react-redux';
@@ -87,20 +86,14 @@ const StyledFrame = withStyles(styles)(DemoFrame);
  * to an `iframe` if `iframe={true}`.
  */
 function DemoSandboxed(props) {
-  const { component: Component, iframe, name, resetDemo, ...other } = props;
+  const { component: Component, iframe, name, onResetDemoClick, ...other } = props;
   const Sandbox = iframe ? StyledFrame : React.Fragment;
   const sandboxProps = iframe ? { title: `${name} demo`, ...other } : {};
 
   const t = useSelector(state => state.options.t);
 
   return (
-    <DemoErrorBoundary
-      errorActions={
-        <Button color="secondary" onClick={resetDemo} variant="text">
-          {t('resetDemo')}
-        </Button>
-      }
-    >
+    <DemoErrorBoundary onResetDemoClick={onResetDemoClick} t={t}>
       <Sandbox {...sandboxProps}>
         <Component />
       </Sandbox>
@@ -112,7 +105,7 @@ DemoSandboxed.propTypes = {
   component: PropTypes.elementType.isRequired,
   iframe: PropTypes.bool,
   name: PropTypes.string.isRequired,
-  resetDemo: PropTypes.func.isRequired,
+  onResetDemoClick: PropTypes.func.isRequired,
 };
 
 export default React.memo(DemoSandboxed);

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import { create } from 'jss';
 import { withStyles, useTheme, jssPreset, StylesProvider } from '@material-ui/core/styles';
 import NoSsr from '@material-ui/core/NoSsr';
+import Button from '@material-ui/core/Button';
 import rtl from 'jss-rtl';
 import Frame from 'react-frame-component';
+import { useSelector } from 'react-redux';
 import DemoErrorBoundary from 'docs/src/modules/components/DemoErrorBoundary';
 
 const styles = theme => ({
@@ -85,12 +87,20 @@ const StyledFrame = withStyles(styles)(DemoFrame);
  * to an `iframe` if `iframe={true}`.
  */
 function DemoSandboxed(props) {
-  const { component: Component, iframe, name, ...other } = props;
+  const { component: Component, iframe, name, resetDemo, ...other } = props;
   const Sandbox = iframe ? StyledFrame : React.Fragment;
   const sandboxProps = iframe ? { title: `${name} demo`, ...other } : {};
 
+  const t = useSelector(state => state.options.t);
+
   return (
-    <DemoErrorBoundary>
+    <DemoErrorBoundary
+      errorActions={
+        <Button color="secondary" onClick={resetDemo} variant="text">
+          {t('resetDemo')}
+        </Button>
+      }
+    >
       <Sandbox {...sandboxProps}>
         <Component />
       </Sandbox>
@@ -102,6 +112,7 @@ DemoSandboxed.propTypes = {
   component: PropTypes.elementType.isRequired,
   iframe: PropTypes.bool,
   name: PropTypes.string.isRequired,
+  resetDemo: PropTypes.func.isRequired,
 };
 
 export default React.memo(DemoSandboxed);

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -92,6 +92,7 @@
   "getProfessionalSupport": "Get Professional Support",
   "diamondSponsors": "Diamond Sponsors",
   "demoToolbarLabel": "demo source",
+  "resetDemo": "Reset demo",
   "pages": {
     "/getting-started": "Getting Started",
     "/getting-started/installation": "Installation",


### PR DESCRIPTION
- Add ability to reset a demo (useful for playing around or when the demo crashes)
- Make "Bug report" the default choice when reporting a demo runtime error (nudges user to make the right decision for almost all scenarios in which this link is clicked and removes one step where the user could exit the issue reporting process)