### PR TITLE
[core] Fix maintenance workflow failing on fork PRs

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -3,8 +3,9 @@ on:
   # So that PRs touching the same files as the push are updated
   push:
   # So that the `dirtyLabel` is removed if conflicts are resolved
-  pull_request:
-    types: [synchronize]
+  # On forks the secret isn't set. We need to manually remove it.
+  #pull_request:
+  #  types: [synchronize]
 
 jobs:
   main:


### PR DESCRIPTION
We can't remove the label automatically. At least we can automatically add it. Merging this in to unblock builds. Maybe I can find a better solution later.