### PR TITLE
[core] Fix OverrideProps, merge "{ component: C }" to it as "OverridableComponent" does (#19512)

### DIFF
--- a/packages/material-ui/src/OverridableComponent.d.ts
+++ b/packages/material-ui/src/OverridableComponent.d.ts
@@ -22,6 +22,7 @@ export type OverrideProps<
 > = (
   & BaseProps<M>
   & Omit<React.ComponentPropsWithRef<C>, keyof CommonProps<M>>
+  & { component?: C }
 );
 
 /**


### PR DESCRIPTION

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
