### PR TITLE
[core] Fix docs:start which should start next.js server

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs:export": "yarn workspace docs export",
     "docs:icons": "yarn workspace docs icons",
     "docs:size-why": "cross-env DOCS_STATS_ENABLED=true yarn docs:build",
-    "docs:start": "yarn workspace docs icons",
+    "docs:start": "yarn workspace docs start",
     "docs:i18n": "cross-env BABEL_ENV=test babel-node ./docs/scripts/i18n.js",
     "docs:typescript": "yarn workspace docs typescript:transpile:dev",
     "docs:typescript:check": "yarn workspace docs typescript",


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

resolve #20201