### PR TITLE
[TreeView] Focus selected when tree receives focus

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -93,6 +93,7 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     nodeId,
     onClick,
     onFocus,
+    onBlur,
     onKeyDown,
     onMouseDown,
     TransitionComponent = Collapse,
@@ -120,13 +121,13 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     isExpanded,
     isFocused,
     isSelected,
-    isTabbable,
     multiSelect,
     selectionDisabled,
     getParent,
     mapFirstChar,
     addNodeToNodeMap,
     removeNodeFromNodeMap,
+    unfocus,
   } = React.useContext(TreeViewContext);
 
   const nodeRef = React.useRef(null);
@@ -138,7 +139,6 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   const expandable = Boolean(Array.isArray(children) ? children.length : children);
   const expanded = isExpanded ? isExpanded(nodeId) : false;
   const focused = isFocused ? isFocused(nodeId) : false;
-  const tabbable = isTabbable ? isTabbable(nodeId) : false;
   const selected = isSelected ? isSelected(nodeId) : false;
   const icons = contextIcons || {};
   const theme = useTheme();
@@ -328,12 +328,22 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
   };
 
   const handleFocus = event => {
-    if (!focused && tabbable) {
+    if (event.currentTarget === event.target && !focused) {
       focus(nodeId);
     }
 
     if (onFocus) {
       onFocus(event);
+    }
+  };
+
+  const handleBlur = event => {
+    if (event.currentTarget === event.target) {
+      unfocus(event);
+    }
+
+    if (onBlur) {
+      onBlur(event);
     }
   };
 
@@ -374,10 +384,11 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
       role="treeitem"
       onKeyDown={handleKeyDown}
       onFocus={handleFocus}
+      onBlur={handleBlur}
       aria-expanded={expandable ? expanded : null}
       aria-selected={!selectionDisabled && isSelected ? isSelected(nodeId) : undefined}
       ref={handleRef}
-      tabIndex={tabbable ? 0 : -1}
+      tabIndex={-1}
       {...other}
     >
       <div
@@ -449,6 +460,10 @@ TreeItem.propTypes = {
    * The id of the node.
    */
   nodeId: PropTypes.string.isRequired,
+  /**
+   * @ignore
+   */
+  onBlur: PropTypes.func,
   /**
    * @ignore
    */


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

In addition to making the tree view agree with aria practices this pull request also resolves some other outstanding issues.

[TreeItem hijacks focus when typing on an input box that updates it](https://github.com/mui-org/material-ui/issues/19882)
This code is present in this [codesandbox](https://codesandbox.io/s/wandering-brook-fd11w) that replicates the one in the issue.  The steps below that result in the issue behaviour as seen in the [original sandbox](https://codesandbox.io/s/bold-hill-rw9y5) are no longer an issue.

1. Focus apples
2. Type b in the input ( to remove apples )
3. Remove the search - **apples is focused**

[TreeView programmatic focus does not change tab indices](https://github.com/mui-org/material-ui/issues/20141) inconsistent behaviour is no longer an issue as it selection and not last focus that determines what is focused when the tree receives focus ( as per aria practices ).

[TreeView cannot be controlled by keyboard after item removal](https://github.com/mui-org/material-ui/issues/20204) is also no longer an issue.

Note that there is no longer a need for tabbable state.

Remarks on the tests :
Tests that conditionally render a tree item have to render a span - due to [bug](https://github.com/mui-org/material-ui/issues/20154)
I corrected the tests regarding this focus behaviour - but perhaps the tests should be in TreeView.test.js instead of TreeItem.test.js.

Remarks on the code :
The aria practices does not describe what should happen if the tree receives focus and the selected tree item is in a collapsed parent.  I decided to expand the tree to make it visible for now ( I have not raised the event - if this behaviour is agreed I will change ), the alternative is to focus the first item.
https://github.com/tonyhallett/material-ui/blob/bebcef3ff8da24ee3daa04eed50d095da585ef89/packages/material-ui-lab/src/TreeView/TreeView.js#L483

The clean up of selected can probably be improved upon.
https://github.com/tonyhallett/material-ui/blob/bebcef3ff8da24ee3daa04eed50d095da585ef89/packages/material-ui-lab/src/TreeView/TreeView.js#L514

When a focused item is removed I have decided to refocus the tree view.  I can change this to making the TreeView tabbable again.
https://github.com/tonyhallett/material-ui/blob/bebcef3ff8da24ee3daa04eed50d095da585ef89/packages/material-ui-lab/src/TreeView/TreeView.js#L574

You can see this code on this [sandbox](https://codesandbox.io/s/confident-golick-j2nnt)