### PR TITLE
[core] Enable module augmentation of CommonColors

### DIFF
--- a/packages/material-ui/src/styles/createPalette.d.ts
+++ b/packages/material-ui/src/styles/createPalette.d.ts
@@ -1,8 +1,12 @@
 import { Color, PaletteType } from '..';
-import common from '../colors/common';
 
 export {};
-type CommonColors = Record<keyof typeof common, string>;
+// use standalone interface over typeof colors/commons
+// to enable module augmentation
+export interface CommonColors {
+  black: string;
+  white: string;
+}
 
 export type ColorPartial = Partial<Color>;
 

--- a/packages/material-ui/src/styles/createPalette.spec.ts
+++ b/packages/material-ui/src/styles/createPalette.spec.ts
@@ -1,9 +1,10 @@
 import { Color } from '@material-ui/core';
-import { blue } from '@material-ui/core/colors';
+import { blue, common } from '@material-ui/core/colors';
 import {
   createPalette,
   PaletteColorOptions,
   SimplePaletteColorOptions,
+  Theme,
 } from '@material-ui/core/styles';
 
 {
@@ -21,4 +22,8 @@ import {
   palette.augmentColor(colorOrOption);
   palette.augmentColor(colorOrOption, 400); // $ExpectError
   const augmentedColor = palette.augmentColor(colorOrOption);
+}
+
+{
+  const themeCommons: Theme['palette']['common'] = common;
 }


### PR DESCRIPTION
Closes #20180

Allows `createMuiTheme({ palette: { common: { red: 'pink' } } })` with

```ts
declare module '@material-ui/core/styles/createPalette' {
  interface CommonColors {
    red: string
  }
}
```

Need to test this with csb deploy.