### PR TITLE
[docs] Fix icons + locale

### DIFF
--- a/docs/pages/components/material-icons.js
+++ b/docs/pages/components/material-icons.js
@@ -1,20 +1,14 @@
 import React from 'react';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
-import Markdown from 'docs/src/pages/components/material-icons/material-icons.md';
-import SearchIcons from 'docs/src/pages/components/material-icons/SearchIcons';
 
-const req = (name) => {
-  const map = {
-    'material-icons.md': Markdown,
-    'SearchIcons.js': {
-      default: SearchIcons,
-    },
-  };
-  return map[name];
-};
-req.keys = () => ['material-icons.md', 'SearchIcons.js'];
+const req = require.context('docs/src/pages/components/material-icons', false, /\.(md|js|tsx)$/);
+const reqSource = require.context(
+  '!raw-loader!../../src/pages/components/material-icons',
+  false,
+  /\.(js|tsx)$/,
+);
 const reqPrefix = 'pages/components/material-icons';
 
 export default function Page() {
-  return <MarkdownDocs disableToc req={req} reqSource={() => {}} reqPrefix={reqPrefix} />;
+  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
 }


### PR DESCRIPTION
It seems that the performance issue with `require.context` was solved during the Next v8 to v9 upgrade. It takes 36s on my machine between these two methods. I hope it's not just that I have a x2 better machine now. Let's see how Netlify handles it.

Solve (requested by @DDDDDanica):

<img width="875" alt="Capture d’écran 2020-03-22 à 00 21 13" src="https://user-images.githubusercontent.com/3165635/77238740-52d23200-6bd3-11ea-9079-f59255d39224.png">
