### PR TITLE
New FramerX components

### DIFF
--- a/framer/Material-UI.framerfx/README.md
+++ b/framer/Material-UI.framerfx/README.md
@@ -21,11 +21,13 @@ The following components are currently supported:
 - List
 - List item
 - Media card
+- Nested list
 - Paper
 - Radio
 - Radio group
 - Slider
 - Snackbar content
+- Stepper
 - Switch
 - Tabs
 - Text field
@@ -69,7 +71,7 @@ If multiple options are supplied, they take the following priority:
 - Add variant (elevation or outlined) to the Paper component.
 - Add color (primary or secondary) to the TextField component.
 - Fix an issue that caused the Material-UI Framer package to appear to have no components,
-and existing projects using Material-UI to break.
+  and existing projects using Material-UI to break.
 
 ### 1.0.0 2019-11-11
 

--- a/framer/Material-UI.framerfx/code/NestedList.tsx
+++ b/framer/Material-UI.framerfx/code/NestedList.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Collapse from '@material-ui/core/Collapse';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemText from '@material-ui/core/ListItemText';
+import MuiListItemIcon from '@material-ui/core/ListItemIcon';
+import { Icon } from './Icon';
+
+import { addPropertyControls, ControlType } from 'framer';
+
+interface Props {
+  open: boolean;
+  header: string;
+  labels: string[];
+  headerIcon?: string;
+}
+
+const useStyles = makeStyles((theme) => ({
+  nested: {
+    paddingLeft: theme.spacing(4),
+  },
+}));
+
+export const NestedList: React.SFC<Props> = (props: Props) => {
+  const classes = useStyles();
+  const { open: defaultOpen, labels, header, headerIcon } = props;
+  const [open, setOpen] = React.useState(defaultOpen);
+  return (
+    <List>
+      <ListItem button onClick={() => setOpen(!open)}>
+        {headerIcon && (
+          <MuiListItemIcon>
+            <Icon icon={headerIcon} />
+          </MuiListItemIcon>
+        )}
+        <ListItemText primary={header} />
+        {open ? <ExpandLess /> : <ExpandMore />}
+      </ListItem>
+      <Collapse in={open} timeout="auto" unmountOnExit>
+        <List component="div" disablePadding>
+          {labels.map((label, index) => (
+            <ListItem button className={classes.nested} key={index}>
+              <ListItemText primary={label} />
+            </ListItem>
+          ))}
+        </List>
+      </Collapse>
+    </List>
+  );
+};
+
+export default NestedList;
+
+NestedList.defaultProps = {
+  header: 'Inbox',
+  open: true,
+  labels: ['Starred', 'Archived'],
+  headerIcon: 'inbox',
+};
+
+addPropertyControls(NestedList, {
+  labels: {
+    type: ControlType.Array,
+    propertyControl: {
+      type: ControlType.String,
+    },
+  },
+  header: {
+    type: ControlType.String,
+    title: 'Header',
+  },
+  headerIcon: {
+    type: ControlType.String,
+    title: 'Header icon',
+  },
+});

--- a/framer/Material-UI.framerfx/code/Stepper.tsx
+++ b/framer/Material-UI.framerfx/code/Stepper.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import { addPropertyControls, ControlType } from 'framer';
+import MuiStepper from '@material-ui/core/Stepper';
+import Step from '@material-ui/core/Step';
+import StepLabel from '@material-ui/core/StepLabel';
+
+interface Props {
+  labels: string[];
+  orientation?: 'vertical' | 'horizontal';
+  activeStep: number;
+}
+
+export const Stepper: React.SFC<Props> = (props: Props) => {
+  const { labels, orientation, activeStep } = props;
+  return (
+    <MuiStepper orientation={orientation} activeStep={activeStep}>
+      {labels.map((label) => (
+        <Step>
+          <StepLabel>{label}</StepLabel>
+        </Step>
+      ))}
+    </MuiStepper>
+  );
+};
+
+Stepper.defaultProps = {
+  labels: ['Select master blaster campaign settings', 'Create an ad group', 'Create an ad'],
+};
+
+export default Stepper;
+
+addPropertyControls(Stepper, {
+  labels: {
+    type: ControlType.Array,
+    title: 'Labels',
+    propertyControl: { type: ControlType.String },
+  },
+  orientation: {
+    type: ControlType.Enum,
+    title: 'Variant',
+    options: ['vertical', 'horizontal'],
+  },
+  activeStep: {
+    type: ControlType.Number,
+    title: 'Active step',
+    min: 0,
+    step: 1,
+    defaultValue: 0,
+  },
+});

--- a/framer/Material-UI.framerfx/design/document.json
+++ b/framer/Material-UI.framerfx/design/document.json
@@ -6649,6 +6649,210 @@
         "visible" : true,
         "width" : 451,
         "widthType" : 0
+      },
+      {
+        "__class" : "FrameNode",
+        "aspectRatio" : null,
+        "blendingEnabled" : 0,
+        "blendingMode" : "normal",
+        "bottom" : null,
+        "centerAnchorX" : 0,
+        "centerAnchorY" : 0,
+        "children" : [
+          {
+            "__class" : "CodeComponentNode",
+            "aspectRatio" : null,
+            "bottom" : 0,
+            "centerAnchorX" : 0.5,
+            "centerAnchorY" : 0.5,
+            "children" : [
+
+            ],
+            "clip" : true,
+            "codeComponentIdentifier" : ".\/NestedList.tsx_NestedList",
+            "codeComponentProps" : {
+              "header" : "Inbox",
+              "headerIcon" : "inbox",
+              "labels" : [
+                {
+                  "enabled" : true,
+                  "type" : "string",
+                  "value" : "Starred"
+                },
+                {
+                  "enabled" : true,
+                  "type" : "string",
+                  "value" : "Archived"
+                }
+              ]
+            },
+            "codeOverrideEnabled" : false,
+            "constraintsLocked" : false,
+            "deviceType" : null,
+            "exportOptions" : [
+
+            ],
+            "fillColor" : "rgba(255,255,255,1)",
+            "fillEnabled" : false,
+            "fillImage" : null,
+            "fillImageOriginalName" : null,
+            "fillImagePixelHeight" : null,
+            "fillImagePixelWidth" : null,
+            "fillImageResize" : "fill",
+            "fillType" : "color",
+            "height" : 165,
+            "heightType" : 0,
+            "id" : "O03ZHZjYS",
+            "intrinsicHeight" : null,
+            "intrinsicWidth" : null,
+            "left" : 0,
+            "locked" : false,
+            "name" : null,
+            "opacity" : 1,
+            "originalid" : null,
+            "parentid" : "YRPVJt6WM",
+            "previewSettings" : null,
+            "radius" : 0,
+            "radiusBottomLeft" : 0,
+            "radiusBottomRight" : 0,
+            "radiusIsRelative" : false,
+            "radiusPerCorner" : false,
+            "radiusTopLeft" : 0,
+            "radiusTopRight" : 0,
+            "right" : 0,
+            "rotation" : 0,
+            "top" : 0,
+            "visible" : true,
+            "width" : 279,
+            "widthType" : 0
+          }
+        ],
+        "clip" : true,
+        "codeOverrideEnabled" : false,
+        "constraintsLocked" : false,
+        "deviceType" : null,
+        "exportOptions" : [
+
+        ],
+        "fillColor" : "white",
+        "fillEnabled" : true,
+        "fillImage" : null,
+        "fillImageOriginalName" : null,
+        "fillImagePixelHeight" : null,
+        "fillImagePixelWidth" : null,
+        "fillImageResize" : "fill",
+        "fillType" : "color",
+        "guidesX" : [
+
+        ],
+        "guidesY" : [
+
+        ],
+        "height" : 165,
+        "heightType" : 0,
+        "id" : "YRPVJt6WM",
+        "intrinsicHeight" : null,
+        "intrinsicWidth" : null,
+        "isExternalMaster" : null,
+        "isMaster" : false,
+        "isTarget" : false,
+        "left" : -1113,
+        "locked" : false,
+        "name" : null,
+        "navigationTarget" : null,
+        "navigationTransition" : "push",
+        "navigationTransitionBackdropColor" : "rgba(4,4,15,.4)",
+        "navigationTransitionDirection" : "left",
+        "opacity" : 1,
+        "originalid" : null,
+        "parentid" : "BnkWog8YS",
+        "previewSettings" : null,
+        "radius" : 0,
+        "radiusBottomLeft" : 0,
+        "radiusBottomRight" : 0,
+        "radiusIsRelative" : false,
+        "radiusPerCorner" : false,
+        "radiusTopLeft" : 0,
+        "radiusTopRight" : 0,
+        "replicaInfo" : null,
+        "right" : null,
+        "rotation" : 0,
+        "top" : 651,
+        "visible" : true,
+        "width" : 279,
+        "widthType" : 0
+      },
+      {
+        "__class" : "CodeComponentNode",
+        "aspectRatio" : null,
+        "bottom" : null,
+        "centerAnchorX" : 0,
+        "centerAnchorY" : 0,
+        "children" : [
+
+        ],
+        "clip" : true,
+        "codeComponentIdentifier" : ".\/Stepper.tsx_Stepper",
+        "codeComponentProps" : {
+          "activeStep" : 0,
+          "labels" : [
+            {
+              "enabled" : true,
+              "type" : "string",
+              "value" : "Select master blaster campaign settings"
+            },
+            {
+              "enabled" : true,
+              "type" : "string",
+              "value" : "Create an ad group"
+            },
+            {
+              "enabled" : true,
+              "type" : "string",
+              "value" : "Create an ad"
+            }
+          ],
+          "orientation" : "vertical"
+        },
+        "codeOverrideEnabled" : false,
+        "constraintsLocked" : false,
+        "deviceType" : null,
+        "exportOptions" : [
+
+        ],
+        "fillColor" : "rgba(255,255,255,1)",
+        "fillEnabled" : false,
+        "fillImage" : null,
+        "fillImageOriginalName" : null,
+        "fillImagePixelHeight" : null,
+        "fillImagePixelWidth" : null,
+        "fillImageResize" : "fill",
+        "fillType" : "color",
+        "height" : 200,
+        "heightType" : 0,
+        "id" : "gdABoDb_d",
+        "intrinsicHeight" : null,
+        "intrinsicWidth" : null,
+        "left" : -587,
+        "locked" : false,
+        "name" : null,
+        "opacity" : 1,
+        "originalid" : null,
+        "parentid" : "BnkWog8YS",
+        "previewSettings" : null,
+        "radius" : 0,
+        "radiusBottomLeft" : 0,
+        "radiusBottomRight" : 0,
+        "radiusIsRelative" : false,
+        "radiusPerCorner" : false,
+        "radiusTopLeft" : 0,
+        "radiusTopRight" : 0,
+        "right" : null,
+        "rotation" : 0,
+        "top" : 429,
+        "visible" : true,
+        "width" : 389,
+        "widthType" : 0
       }
     ],
     "guidesX" : [


### PR DESCRIPTION
I've added FramerX wrappers for:

- Stepper
<img width="600" alt="Screenshot 2020-03-22 at 15 14 56" src="https://user-images.githubusercontent.com/784018/77253160-e26df400-6c58-11ea-8fbf-fb8172938f3a.png">

- Nested List
<img width="498" alt="Screenshot 2020-03-22 at 15 14 32" src="https://user-images.githubusercontent.com/784018/77253162-e3068a80-6c58-11ea-92ba-d25c6f52eb01.png">

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
