### PR TITLE
[Select] Fix react does not recognize fullWidth #17226

### DIFF
--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -6,7 +6,7 @@ import { SelectInputProps } from './SelectInput';
 
 export interface SelectProps
   extends StandardProps<InputProps, SelectClassKey, 'value' | 'onChange'>,
-    Pick<SelectInputProps, 'onChange'> {
+    Pick<SelectInputProps, 'onChange'> implements InputProps {
   autoWidth?: boolean;
   displayEmpty?: boolean;
   IconComponent?: React.ElementType;


### PR DESCRIPTION
React does not recognize the `fullWidth` prop on a DOM element

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
