### PR TITLE
[docs] Add more props documentation to IntelliSense

### DIFF
--- a/docs/pages/api-docs/collapse.md
+++ b/docs/pages/api-docs/collapse.md
@@ -28,10 +28,10 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content node to be collapsed. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
-| <span class="prop-name">collapsedHeight</span> | <span class="prop-type">string<br>&#124;&nbsp;number</span> | <span class="prop-default">'0px'</span> | The height of the container when collapsed. |
+| <span class="prop-name">collapsedHeight</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> | <span class="prop-default">'0px'</span> | The height of the container when collapsed. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> | <span class="prop-default">'div'</span> | The component used for the root node. Either a string to use a DOM element or a component. |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
-| <span class="prop-name">timeout</span> | <span class="prop-type">number<br>&#124;&nbsp;{ enter?: number, exit?: number }<br>&#124;&nbsp;'auto'</span> | <span class="prop-default">duration.standard</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
+| <span class="prop-name">timeout</span> | <span class="prop-type">'auto'<br>&#124;&nbsp;number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">duration.standard</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/dialog-title.md
+++ b/docs/pages/api-docs/dialog-title.md
@@ -24,7 +24,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">node</span> |  | The content of the component. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disableTypography</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the children won't be wrapped by a typography component. For instance, this can be useful to render an h4 instead of the default h2. |
 

--- a/docs/pages/api-docs/drawer.md
+++ b/docs/pages/api-docs/drawer.md
@@ -25,7 +25,7 @@ when `variant="temporary"` is set.
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">anchor</span> | <span class="prop-type">'left'<br>&#124;&nbsp;'top'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'bottom'</span> | <span class="prop-default">'left'</span> | Side from which the drawer will appear. |
+| <span class="prop-name">anchor</span> | <span class="prop-type">'bottom'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'top'</span> | <span class="prop-default">'left'</span> | Side from which the drawer will appear. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The contents of the drawer. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">elevation</span> | <span class="prop-type">number</span> | <span class="prop-default">16</span> | The elevation of the drawer. |
@@ -34,7 +34,7 @@ when `variant="temporary"` is set.
 | <span class="prop-name">open</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the drawer is open. |
 | <span class="prop-name">PaperProps</span> | <span class="prop-type">object</span> | <span class="prop-default">{}</span> | Props applied to the [`Paper`](/api/paper/) element. |
 | <span class="prop-name">SlideProps</span> | <span class="prop-type">object</span> |  | Props applied to the [`Slide`](/api/slide/) element. |
-| <span class="prop-name">transitionDuration</span> | <span class="prop-type">number<br>&#124;&nbsp;{ enter?: number, exit?: number }</span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">transitionDuration</span> | <span class="prop-type">number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'permanent'<br>&#124;&nbsp;'persistent'<br>&#124;&nbsp;'temporary'</span> | <span class="prop-default">'temporary'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/expansion-panel-actions.md
+++ b/docs/pages/api-docs/expansion-panel-actions.md
@@ -24,7 +24,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">node</span> |  | The content of the component. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disableSpacing</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the actions do not have additional margin. |
 

--- a/docs/pages/api-docs/expansion-panel-details.md
+++ b/docs/pages/api-docs/expansion-panel-details.md
@@ -24,7 +24,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">node</span> |  | The content of the expansion panel details. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the expansion panel details. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/fade.md
+++ b/docs/pages/api-docs/fade.md
@@ -27,7 +27,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">element</span> |  | A single child content element. |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
-| <span class="prop-name">timeout</span> | <span class="prop-type">number<br>&#124;&nbsp;{ enter?: number, exit?: number }</span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">timeout</span> | <span class="prop-type">number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/grid-list-tile-bar.md
+++ b/docs/pages/api-docs/grid-list-tile-bar.md
@@ -29,7 +29,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">subtitle</span> | <span class="prop-type">node</span> |  | String or element serving as subtitle (support text). |
 | <span class="prop-name">title</span> | <span class="prop-type">node</span> |  | Title to be displayed on tile. |
-| <span class="prop-name">titlePosition</span> | <span class="prop-type">'top'<br>&#124;&nbsp;'bottom'</span> | <span class="prop-default">'bottom'</span> | Position of the title bar. |
+| <span class="prop-name">titlePosition</span> | <span class="prop-type">'bottom'<br>&#124;&nbsp;'top'</span> | <span class="prop-default">'bottom'</span> | Position of the title bar. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/grow.md
+++ b/docs/pages/api-docs/grow.md
@@ -28,7 +28,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">element</span> |  | A single child content element. |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, show the component; triggers the enter or exit animation. |
-| <span class="prop-name">timeout</span> | <span class="prop-type">number<br>&#124;&nbsp;{ enter?: number, exit?: number }<br>&#124;&nbsp;'auto'</span> | <span class="prop-default">'auto'</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
+| <span class="prop-name">timeout</span> | <span class="prop-type">'auto'<br>&#124;&nbsp;number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">'auto'</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object.<br>Set to 'auto' to automatically calculate transition time based on height. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/linear-progress.md
+++ b/docs/pages/api-docs/linear-progress.md
@@ -32,7 +32,7 @@ attribute to `true` on that region until it has finished loading.
 | <span class="prop-name">color</span> | <span class="prop-type">'primary'<br>&#124;&nbsp;'secondary'</span> | <span class="prop-default">'primary'</span> | The color of the component. It supports those theme colors that make sense for this component. |
 | <span class="prop-name">value</span> | <span class="prop-type">number</span> |  | The value of the progress indicator for the determinate and buffer variants. Value between 0 and 100. |
 | <span class="prop-name">valueBuffer</span> | <span class="prop-type">number</span> |  | The value for the buffer variant. Value between 0 and 100. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'determinate'<br>&#124;&nbsp;'indeterminate'<br>&#124;&nbsp;'buffer'<br>&#124;&nbsp;'query'</span> | <span class="prop-default">'indeterminate'</span> | The variant to use. Use indeterminate or query when there is no progress value. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'buffer'<br>&#124;&nbsp;'determinate'<br>&#124;&nbsp;'indeterminate'<br>&#124;&nbsp;'query'</span> | <span class="prop-default">'indeterminate'</span> | The variant to use. Use indeterminate or query when there is no progress value. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/menu-list.md
+++ b/docs/pages/api-docs/menu-list.md
@@ -27,8 +27,8 @@ the focus is placed inside the component it is fully keyboard accessible.
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the `[role="menu"]` container and move into tab order |
-| <span class="prop-name">autoFocusItem</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the first menuitem if `variant="menu"` or selected item if `variant="selectedMenu"` |
+| <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the `[role="menu"]` container and move into tab order. |
+| <span class="prop-name">autoFocusItem</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, will focus the first menuitem if `variant="menu"` or selected item if `variant="selectedMenu"`. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | MenuList contents, normally `MenuItem`s. |
 | <span class="prop-name">disableListWrap</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the menu items will not wrap focus. |
 | <span class="prop-name">variant</span> | <span class="prop-type">'menu'<br>&#124;&nbsp;'selectedMenu'</span> | <span class="prop-default">'selectedMenu'</span> | The variant to use. Use `menu` to prevent selected items from impacting the initial focus and the vertical alignment relative to the anchor element. |

--- a/docs/pages/api-docs/menu.md
+++ b/docs/pages/api-docs/menu.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">anchorEl</span> | <span class="prop-type">object<br>&#124;&nbsp;func</span> |  | The DOM element used to set the position of the menu. |
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | If `true` (Default) will focus the `[role="menu"]` if no focusable child is found. Disabled children are not focusable. If you set this prop to `false` focus will be placed on the parent modal container. This has severe accessibility implications and should only be considered if you manage focus otherwise. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | Menu contents, normally `MenuItem`s. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
@@ -39,7 +38,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">onExiting</span> | <span class="prop-type">func</span> |  | Callback fired when the Menu is exiting. |
 | <span class="prop-name required">open&nbsp;*</span> | <span class="prop-type">bool</span> |  | If `true`, the menu is visible. |
 | <span class="prop-name">PopoverClasses</span> | <span class="prop-type">object</span> |  | `classes` prop applied to the [`Popover`](/api/popover/) element. |
-| <span class="prop-name">transitionDuration</span> | <span class="prop-type">number<br>&#124;&nbsp;{ enter?: number, exit?: number }<br>&#124;&nbsp;'auto'</span> | <span class="prop-default">'auto'</span> | The length of the transition in `ms`, or 'auto' |
+| <span class="prop-name">transitionDuration</span> | <span class="prop-type">'auto'<br>&#124;&nbsp;number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">'auto'</span> | The length of the transition in `ms`, or 'auto' |
 | <span class="prop-name">variant</span> | <span class="prop-type">'menu'<br>&#124;&nbsp;'selectedMenu'</span> | <span class="prop-default">'selectedMenu'</span> | The variant to use. Use `menu` to prevent selected items from impacting the initial focus and the vertical alignment relative to the anchor element. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/menu.md
+++ b/docs/pages/api-docs/menu.md
@@ -24,6 +24,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name">anchorEl</span> | <span class="prop-type">func<br>&#124;&nbsp;Element</span> |  | The DOM element used to set the position of the menu. |
 | <span class="prop-name">autoFocus</span> | <span class="prop-type">bool</span> | <span class="prop-default">true</span> | If `true` (Default) will focus the `[role="menu"]` if no focusable child is found. Disabled children are not focusable. If you set this prop to `false` focus will be placed on the parent modal container. This has severe accessibility implications and should only be considered if you manage focus otherwise. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | Menu contents, normally `MenuItem`s. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |

--- a/docs/pages/api-docs/mobile-stepper.md
+++ b/docs/pages/api-docs/mobile-stepper.md
@@ -29,9 +29,9 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">LinearProgressProps</span> | <span class="prop-type">object</span> |  | Props applied to the `LinearProgress` element. |
 | <span class="prop-name">nextButton</span> | <span class="prop-type">node</span> |  | A next button element. For instance, it can be a `Button` or an `IconButton`. |
-| <span class="prop-name">position</span> | <span class="prop-type">'bottom'<br>&#124;&nbsp;'top'<br>&#124;&nbsp;'static'</span> | <span class="prop-default">'bottom'</span> | Set the positioning type. |
+| <span class="prop-name">position</span> | <span class="prop-type">'bottom'<br>&#124;&nbsp;'static'<br>&#124;&nbsp;'top'</span> | <span class="prop-default">'bottom'</span> | Set the positioning type. |
 | <span class="prop-name required">steps&nbsp;*</span> | <span class="prop-type">number</span> |  | The total steps. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'text'<br>&#124;&nbsp;'dots'<br>&#124;&nbsp;'progress'</span> | <span class="prop-default">'dots'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'dots'<br>&#124;&nbsp;'progress'<br>&#124;&nbsp;'text'</span> | <span class="prop-default">'dots'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/radio-group.md
+++ b/docs/pages/api-docs/radio-group.md
@@ -25,7 +25,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component. |
-| <span class="prop-name">defaultValue</span> | <span class="prop-type">any</span> |  | The default `input` element value. Use when the component is not controlled. |
+| <span class="prop-name">defaultValue</span> | <span class="prop-type">Array&lt;string&gt;<br>&#124;&nbsp;number<br>&#124;&nbsp;string</span> |  | The default `input` element value. Use when the component is not controlled. |
 | <span class="prop-name">name</span> | <span class="prop-type">string</span> |  | The name used to reference the value of the control. If you don't provide this prop, it falls back to a randomly generated name. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when a radio button is selected.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value` (string). |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | Value of the selected radio button. The DOM API casts this to a string. |

--- a/docs/pages/api-docs/snackbar.md
+++ b/docs/pages/api-docs/snackbar.md
@@ -25,7 +25,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">action</span> | <span class="prop-type">node</span> |  | The action to display. It renders after the message, at the end of the snackbar. |
-| <span class="prop-name">anchorOrigin</span> | <span class="prop-type">{ horizontal: 'left'<br>&#124;&nbsp;'center'<br>&#124;&nbsp;'right', vertical: 'top'<br>&#124;&nbsp;'bottom' }</span> | <span class="prop-default">{ vertical: 'bottom', horizontal: 'center' }</span> | The anchor of the `Snackbar`. |
+| <span class="prop-name">anchorOrigin</span> | <span class="prop-type">{ horizontal: 'center'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right', vertical: 'bottom'<br>&#124;&nbsp;'top' }</span> | <span class="prop-default">{ vertical: 'bottom', horizontal: 'center' }</span> | The anchor of the `Snackbar`. |
 | <span class="prop-name">autoHideDuration</span> | <span class="prop-type">number</span> | <span class="prop-default">null</span> | The number of milliseconds to wait before automatically calling the `onClose` function. `onClose` should then set the state of the `open` prop to hide the Snackbar. This behavior is disabled by default with the `null` value. |
 | <span class="prop-name">children</span> | <span class="prop-type">element</span> |  | Replace the `SnackbarContent` component. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
@@ -44,7 +44,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">open</span> | <span class="prop-type">bool</span> |  | If `true`, `Snackbar` is open. |
 | <span class="prop-name">resumeHideDuration</span> | <span class="prop-type">number</span> |  | The number of milliseconds to wait before dismissing after user interaction. If `autoHideDuration` prop isn't specified, it does nothing. If `autoHideDuration` prop is specified but `resumeHideDuration` isn't, we default to `autoHideDuration / 2` ms. |
 | <span class="prop-name">TransitionComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">Grow</span> | The component used for the transition. [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component. |
-| <span class="prop-name">transitionDuration</span> | <span class="prop-type">number<br>&#124;&nbsp;{ enter?: number, exit?: number }</span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">transitionDuration</span> | <span class="prop-type">number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Props applied to the [`Transition`](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
 
 The `ref` is forwarded to the root element.

--- a/docs/src/modules/utils/defaultPropsHandler.js
+++ b/docs/src/modules/utils/defaultPropsHandler.js
@@ -61,6 +61,13 @@ function getDefaultValuesFromProps(properties, documentation) {
       if (!propName) return;
 
       const propDescriptor = documentation.getPropDescriptor(propName);
+      if (propDescriptor.description === undefined) {
+        // private props have no propsType validator and therefore
+        // not description.
+        // They are either not subject to eslint react/prop-types
+        // or are and then we catch these issues during linting.
+        return;
+      }
 
       const jsdocDefaultValue = getJsdocDefaultValue(
         parseDoctrine(propDescriptor.description, {

--- a/docs/src/pages/components/snackbars/TransitionsSnackbar.tsx
+++ b/docs/src/pages/components/snackbars/TransitionsSnackbar.tsx
@@ -15,7 +15,10 @@ function GrowTransition(props: TransitionProps) {
 }
 
 export default function TransitionsSnackbar() {
-  const [state, setState] = React.useState({
+  const [state, setState] = React.useState<{
+    open: boolean;
+    Transition: React.ComponentType<TransitionProps>;
+  }>({
     open: false,
     Transition: Fade,
   });

--- a/packages/material-ui/src/Backdrop/Backdrop.d.ts
+++ b/packages/material-ui/src/Backdrop/Backdrop.d.ts
@@ -5,7 +5,7 @@ import { TransitionProps } from '../transitions/transition';
 
 export interface BackdropProps
   extends StandardProps<
-    React.HTMLAttributes<HTMLDivElement> & Partial<FadeProps>,
+    React.HTMLAttributes<HTMLDivElement> & Partial<Omit<FadeProps, 'children'>>,
     BackdropClassKey
   > {
   /**

--- a/packages/material-ui/src/Card/Card.d.ts
+++ b/packages/material-ui/src/Card/Card.d.ts
@@ -3,6 +3,9 @@ import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
 
 export interface CardProps extends StandardProps<PaperProps, CardClassKey> {
+  /**
+   * If `true`, the card will use raised styling.
+   */
   raised?: boolean;
 }
 
@@ -19,6 +22,4 @@ export type CardClassKey = 'root';
  * - [Card API](https://material-ui.com/api/card/)
  * - inherits [Paper API](https://material-ui.com/api/paper/)
  */
-declare const Card: React.ComponentType<CardProps>;
-
-export default Card;
+export default function Card(props: CardProps): JSX.Element;

--- a/packages/material-ui/src/Card/Card.js
+++ b/packages/material-ui/src/Card/Card.js
@@ -25,6 +25,10 @@ const Card = React.forwardRef(function Card(props, ref) {
 });
 
 Card.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
@@ -33,7 +37,7 @@ Card.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/CardActions/CardActions.d.ts
+++ b/packages/material-ui/src/CardActions/CardActions.d.ts
@@ -3,6 +3,9 @@ import { StandardProps } from '..';
 
 export interface CardActionsProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, CardActionsClassKey> {
+  /**
+   * If `true`, the actions do not have additional margin.
+   */
   disableSpacing?: boolean;
 }
 
@@ -18,6 +21,4 @@ export type CardActionsClassKey = 'root' | 'spacing';
  *
  * - [CardActions API](https://material-ui.com/api/card-actions/)
  */
-declare const CardActions: React.ComponentType<CardActionsProps>;
-
-export default CardActions;
+export default function CardActions(props: CardActionsProps): JSX.Element;

--- a/packages/material-ui/src/CardActions/CardActions.js
+++ b/packages/material-ui/src/CardActions/CardActions.js
@@ -31,6 +31,10 @@ const CardActions = React.forwardRef(function CardActions(props, ref) {
 });
 
 CardActions.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
@@ -39,7 +43,7 @@ CardActions.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/Collapse/Collapse.d.ts
+++ b/packages/material-ui/src/Collapse/Collapse.d.ts
@@ -4,10 +4,44 @@ import { Theme } from '../styles/createMuiTheme';
 import { TransitionProps } from '../transitions/transition';
 
 export interface CollapseProps extends StandardProps<TransitionProps, CollapseClassKey, 'timeout'> {
+  /**
+   * The content node to be collapsed.
+   */
   children?: React.ReactNode;
+  /**
+   * The height of the container when collapsed.
+   */
   collapsedHeight?: string | number;
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
   component?: React.ElementType<TransitionProps>;
-  theme?: Theme;
+  /**
+   * If `true`, the component will transition in.
+   */
+  in?: boolean;
+  /**
+   */
+  onEnter?: TransitionProps['onEnter'];
+  /**
+   */
+  onEntered?: TransitionProps['onEntered'];
+  /**
+   */
+  onEntering?: TransitionProps['onEntering'];
+  /**
+   */
+  onExit?: TransitionProps['onExit'];
+  /**
+   */
+  onExiting?: TransitionProps['onExiting'];
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   *
+   * Set to 'auto' to automatically calculate transition time based on height.
+   */
   timeout?: TransitionProps['timeout'] | 'auto';
 }
 
@@ -28,6 +62,5 @@ export type CollapseClassKey = 'container' | 'entered' | 'hidden' | 'wrapper' | 
  * - [Collapse API](https://material-ui.com/api/collapse/)
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition#Transition-props)
  */
-declare const Collapse: React.ComponentType<CollapseProps>;
 
-export default Collapse;
+export default function Collapse(props: CollapseProps): JSX.Element;

--- a/packages/material-ui/src/Collapse/Collapse.js
+++ b/packages/material-ui/src/Collapse/Collapse.js
@@ -191,6 +191,10 @@ const Collapse = React.forwardRef(function Collapse(props, ref) {
 });
 
 Collapse.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content node to be collapsed.
    */
@@ -199,7 +203,7 @@ Collapse.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -207,7 +211,7 @@ Collapse.propTypes = {
   /**
    * The height of the container when collapsed.
    */
-  collapsedHeight: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  collapsedHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * The component used for the root node.
    * Either a string to use a DOM element or a component.
@@ -248,9 +252,13 @@ Collapse.propTypes = {
    * Set to 'auto' to automatically calculate transition time based on height.
    */
   timeout: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
     PropTypes.oneOf(['auto']),
+    PropTypes.number,
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
   ]),
 };
 

--- a/packages/material-ui/src/DialogActions/DialogActions.d.ts
+++ b/packages/material-ui/src/DialogActions/DialogActions.d.ts
@@ -3,6 +3,9 @@ import { StandardProps } from '..';
 
 export interface DialogActionsProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, DialogActionsClassKey> {
+  /**
+   * If `true`, the actions do not have additional margin.
+   */
   disableSpacing?: boolean;
 }
 
@@ -18,6 +21,4 @@ export type DialogActionsClassKey = 'root' | 'spacing';
  *
  * - [DialogActions API](https://material-ui.com/api/dialog-actions/)
  */
-declare const DialogActions: React.ComponentType<DialogActionsProps>;
-
-export default DialogActions;
+export default function DialogActions(props: DialogActionsProps): JSX.Eleement;

--- a/packages/material-ui/src/DialogActions/DialogActions.d.ts
+++ b/packages/material-ui/src/DialogActions/DialogActions.d.ts
@@ -21,4 +21,4 @@ export type DialogActionsClassKey = 'root' | 'spacing';
  *
  * - [DialogActions API](https://material-ui.com/api/dialog-actions/)
  */
-export default function DialogActions(props: DialogActionsProps): JSX.Eleement;
+export default function DialogActions(props: DialogActionsProps): JSX.Element;

--- a/packages/material-ui/src/DialogActions/DialogActions.js
+++ b/packages/material-ui/src/DialogActions/DialogActions.js
@@ -33,6 +33,10 @@ const DialogActions = React.forwardRef(function DialogActions(props, ref) {
 });
 
 DialogActions.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
@@ -41,7 +45,7 @@ DialogActions.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/DialogContent/DialogContent.d.ts
+++ b/packages/material-ui/src/DialogContent/DialogContent.d.ts
@@ -3,6 +3,9 @@ import { StandardProps } from '..';
 
 export interface DialogContentProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, DialogContentClassKey> {
+  /**
+   * Display the top and bottom dividers.
+   */
   dividers?: boolean;
 }
 
@@ -18,6 +21,4 @@ export type DialogContentClassKey = 'root' | 'dividers';
  *
  * - [DialogContent API](https://material-ui.com/api/dialog-content/)
  */
-declare const DialogContent: React.ComponentType<DialogContentProps>;
-
-export default DialogContent;
+export default function DialogContent(props: DialogContentProps): JSX.Element;

--- a/packages/material-ui/src/DialogContent/DialogContent.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.js
@@ -42,6 +42,10 @@ const DialogContent = React.forwardRef(function DialogContent(props, ref) {
 });
 
 DialogContent.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
@@ -50,7 +54,7 @@ DialogContent.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/DialogTitle/DialogTitle.d.ts
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.d.ts
@@ -3,6 +3,10 @@ import { StandardProps } from '..';
 
 export interface DialogTitleProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, DialogTitleClassKey> {
+  /**
+   * If `true`, the children won't be wrapped by a typography component.
+   * For instance, this can be useful to render an h4 instead of the default h2.
+   */
   disableTypography?: boolean;
 }
 
@@ -18,6 +22,4 @@ export type DialogTitleClassKey = 'root';
  *
  * - [DialogTitle API](https://material-ui.com/api/dialog-title/)
  */
-declare const DialogTitle: React.ComponentType<DialogTitleProps>;
-
-export default DialogTitle;
+export default function DialogTitle(props: DialogTitleProps): JSX.Element;

--- a/packages/material-ui/src/DialogTitle/DialogTitle.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.js
@@ -30,15 +30,19 @@ const DialogTitle = React.forwardRef(function DialogTitle(props, ref) {
 });
 
 DialogTitle.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/Drawer/Drawer.d.ts
+++ b/packages/material-ui/src/Drawer/Drawer.d.ts
@@ -82,6 +82,4 @@ export type DrawerClassKey =
  *
  * - [Drawer API](https://material-ui.com/api/drawer/)
  */
-declare const Drawer: React.ComponentType<DrawerProps>;
-
-export default Drawer;
+export default function Drawer(props: DrawerProps): JSX.Element;

--- a/packages/material-ui/src/Drawer/Drawer.d.ts
+++ b/packages/material-ui/src/Drawer/Drawer.d.ts
@@ -12,15 +12,48 @@ export interface DrawerProps
     DrawerClassKey,
     'open' | 'children'
   > {
+  /**
+   * Side from which the drawer will appear.
+   */
   anchor?: 'left' | 'top' | 'right' | 'bottom';
+  /**
+   * The contents of the drawer.
+   */
   children?: React.ReactNode;
+  /**
+   * The elevation of the drawer.
+   */
   elevation?: number;
+  /**
+   * Props applied to the [`Modal`](/api/modal/) element.
+   */
   ModalProps?: Partial<ModalProps>;
+  /**
+   * Callback fired when the component requests to be closed.
+   *
+   * @param {object} event The event source of the callback.
+   */
+  onClose?: ModalProps['onClose'];
+  /**
+   * If `true`, the drawer is open.
+   */
   open?: boolean;
+  /**
+   * Props applied to the [`Paper`](/api/paper/) element.
+   */
   PaperProps?: Partial<PaperProps>;
+  /**
+   * Props applied to the [`Slide`](/api/slide/) element.
+   */
   SlideProps?: Partial<SlideProps>;
-  theme?: Theme;
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
   transitionDuration?: TransitionProps['timeout'];
+  /**
+   * The variant to use.
+   */
   variant?: 'permanent' | 'persistent' | 'temporary';
 }
 

--- a/packages/material-ui/src/Drawer/Drawer.js
+++ b/packages/material-ui/src/Drawer/Drawer.js
@@ -198,10 +198,14 @@ const Drawer = React.forwardRef(function Drawer(props, ref) {
 });
 
 Drawer.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * Side from which the drawer will appear.
    */
-  anchor: PropTypes.oneOf(['left', 'top', 'right', 'bottom']),
+  anchor: PropTypes.oneOf(['bottom', 'left', 'right', 'top']),
   /**
    * @ignore
    */
@@ -214,7 +218,7 @@ Drawer.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -251,7 +255,11 @@ Drawer.propTypes = {
    */
   transitionDuration: PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
   ]),
   /**
    * The variant to use.

--- a/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.d.ts
+++ b/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.d.ts
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface ExpansionPanelActionsProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ExpansionPanelActionsClassKey> {}
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ExpansionPanelActionsClassKey> {
+  /**
+   * If `true`, the actions do not have additional margin.
+   */
+  disableSpacing?: boolean;
+}
 
 export type ExpansionPanelActionsClassKey = 'root' | 'spacing';
 

--- a/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.d.ts
+++ b/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.d.ts
@@ -21,6 +21,4 @@ export type ExpansionPanelActionsClassKey = 'root' | 'spacing';
  *
  * - [ExpansionPanelActions API](https://material-ui.com/api/expansion-panel-actions/)
  */
-declare const ExpansionPanelActions: React.ComponentType<ExpansionPanelActionsProps>;
-
-export default ExpansionPanelActions;
+export default function ExpansionPanelActions(props: ExpansionPanelActionsProps): JSX.Element;

--- a/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.js
+++ b/packages/material-ui/src/ExpansionPanelActions/ExpansionPanelActions.js
@@ -32,15 +32,19 @@ const ExpansionPanelActions = React.forwardRef(function ExpansionPanelActions(pr
 });
 
 ExpansionPanelActions.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.d.ts
+++ b/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.d.ts
@@ -21,6 +21,4 @@ export type ExpansionPanelDetailsClassKey = 'root';
  *
  * - [ExpansionPanelDetails API](https://material-ui.com/api/expansion-panel-details/)
  */
-declare const ExpansionPanelDetails: React.ComponentType<ExpansionPanelDetailsProps>;
-
-export default ExpansionPanelDetails;
+export default function ExpansionPanelDetails(props: ExpansionPanelDetailsProps): JSX.Element;

--- a/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.d.ts
+++ b/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.d.ts
@@ -2,7 +2,12 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface ExpansionPanelDetailsProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ExpansionPanelDetailsClassKey> {}
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ExpansionPanelDetailsClassKey> {
+  /**
+   * The content of the expansion panel details.
+   */
+  children?: React.ReactNode;
+}
 
 export type ExpansionPanelDetailsClassKey = 'root';
 

--- a/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.js
+++ b/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.js
@@ -18,15 +18,19 @@ const ExpansionPanelDetails = React.forwardRef(function ExpansionPanelDetails(pr
 });
 
 ExpansionPanelDetails.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the expansion panel details.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -1,16 +1,21 @@
 import * as React from 'react';
-import { Theme } from '../styles/createMuiTheme';
 import { TransitionProps } from '../transitions/transition';
 
-export interface FadeProps extends TransitionProps {
+export interface FadeProps extends Omit<TransitionProps, 'children'> {
   /**
    * A single child content element.
    */
-  children?: React.ReactElement;
+  children?: React.ReactElement<any, any>;
   /**
    * If `true`, the component will transition in.
    */
   in?: boolean;
+  /**
+   */
+  onEnter?: TransitionProps['onEnter'];
+  /**
+   */
+  onExit?: TransitionProps['onExit'];
   ref?: React.Ref<unknown>;
   /**
    * The duration for the transition, in milliseconds.
@@ -31,6 +36,4 @@ export interface FadeProps extends TransitionProps {
  * - [Fade API](https://material-ui.com/api/fade/)
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition#Transition-props)
  */
-declare const Fade: React.ComponentType<FadeProps>;
-
-export default Fade;
+export default function Fade(props: FadeProps): JSX.Element;

--- a/packages/material-ui/src/Fade/Fade.d.ts
+++ b/packages/material-ui/src/Fade/Fade.d.ts
@@ -3,8 +3,20 @@ import { Theme } from '../styles/createMuiTheme';
 import { TransitionProps } from '../transitions/transition';
 
 export interface FadeProps extends TransitionProps {
+  /**
+   * A single child content element.
+   */
+  children?: React.ReactElement;
+  /**
+   * If `true`, the component will transition in.
+   */
+  in?: boolean;
   ref?: React.Ref<unknown>;
-  theme?: Theme;
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
+  timeout?: TransitionProps['timeout'];
 }
 
 /**

--- a/packages/material-ui/src/Fade/Fade.js
+++ b/packages/material-ui/src/Fade/Fade.js
@@ -46,6 +46,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
         mode: 'enter',
       },
     );
+
     node.style.webkitTransition = theme.transitions.create('opacity', transitionProps);
     node.style.transition = theme.transitions.create('opacity', transitionProps);
 
@@ -61,6 +62,7 @@ const Fade = React.forwardRef(function Fade(props, ref) {
         mode: 'exit',
       },
     );
+
     node.style.webkitTransition = theme.transitions.create('opacity', transitionProps);
     node.style.transition = theme.transitions.create('opacity', transitionProps);
 
@@ -96,6 +98,10 @@ const Fade = React.forwardRef(function Fade(props, ref) {
 });
 
 Fade.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * A single child content element.
    */
@@ -122,7 +128,11 @@ Fade.propTypes = {
    */
   timeout: PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
   ]),
 };
 

--- a/packages/material-ui/src/FormGroup/FormGroup.d.ts
+++ b/packages/material-ui/src/FormGroup/FormGroup.d.ts
@@ -3,6 +3,9 @@ import { StandardProps } from '..';
 
 export interface FormGroupProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, FormGroupClassKey> {
+  /**
+   * Display group of elements in a compact row.
+   */
   row?: boolean;
 }
 
@@ -21,6 +24,4 @@ export type FormGroupClassKey = 'root' | 'row';
  *
  * - [FormGroup API](https://material-ui.com/api/form-group/)
  */
-declare const FormGroup: React.ComponentType<FormGroupProps>;
-
-export default FormGroup;
+export default function FormGroup(props: FormGroupProps): JSX.Element;

--- a/packages/material-ui/src/FormGroup/FormGroup.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.js
@@ -40,6 +40,10 @@ const FormGroup = React.forwardRef(function FormGroup(props, ref) {
 });
 
 FormGroup.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
@@ -48,7 +52,7 @@ FormGroup.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.d.ts
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.d.ts
@@ -2,10 +2,26 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface GridListTileBarProps extends StandardProps<{}, GridListTileBarClassKey> {
+  /**
+   * An IconButton element to be used as secondary action target
+   * (primary action target is the tile itself).
+   */
   actionIcon?: React.ReactNode;
+  /**
+   * Position of secondary action IconButton.
+   */
   actionPosition?: 'left' | 'right';
+  /**
+   * String or element serving as subtitle (support text).
+   */
   subtitle?: React.ReactNode;
+  /**
+   * Title to be displayed on tile.
+   */
   title?: React.ReactNode;
+  /**
+   * Position of the title bar.
+   */
   titlePosition?: 'top' | 'bottom';
 }
 
@@ -32,6 +48,4 @@ export type GridListTileBarClassKey =
  *
  * - [GridListTileBar API](https://material-ui.com/api/grid-list-tile-bar/)
  */
-declare const GridListTileBar: React.ComponentType<GridListTileBarProps>;
-
-export default GridListTileBar;
+export default function GridListTileBar(props: GridListTileBarProps): JSX.Element;

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.js
@@ -118,6 +118,10 @@ const GridListTileBar = React.forwardRef(function GridListTileBar(props, ref) {
 });
 
 GridListTileBar.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * An IconButton element to be used as secondary action target
    * (primary action target is the tile itself).
@@ -131,7 +135,7 @@ GridListTileBar.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -147,7 +151,7 @@ GridListTileBar.propTypes = {
   /**
    * Position of the title bar.
    */
-  titlePosition: PropTypes.oneOf(['top', 'bottom']),
+  titlePosition: PropTypes.oneOf(['bottom', 'top']),
 };
 
 export default withStyles(styles, { name: 'MuiGridListTileBar' })(GridListTileBar);

--- a/packages/material-ui/src/Grow/Grow.d.ts
+++ b/packages/material-ui/src/Grow/Grow.d.ts
@@ -4,8 +4,27 @@ import { Theme } from '../styles/createMuiTheme';
 import { TransitionProps } from '../transitions/transition';
 
 export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
+  /**
+   * A single child content element.
+   */
+  children?: React.ReactElement<any, any>;
+  /**
+   * If `true`, show the component; triggers the enter or exit animation.
+   */
+  in?: boolean;
+  /**
+   */
+  onEnter?: TransitionProps['onEnter'];
+  /**
+   */
+  onExit?: TransitionProps['onExit'];
   ref?: React.Ref<unknown>;
-  theme?: Theme;
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   *
+   * Set to 'auto' to automatically calculate transition time based on height.
+   */
   timeout?: TransitionProps['timeout'] | 'auto';
 }
 
@@ -23,6 +42,4 @@ export interface GrowProps extends Omit<TransitionProps, 'timeout'> {
  * - [Grow API](https://material-ui.com/api/grow/)
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition#Transition-props)
  */
-declare const Grow: React.ComponentType<GrowProps>;
-
-export default Grow;
+export default function Grow(props: GrowProps): JSX.Element;

--- a/packages/material-ui/src/Grow/Grow.js
+++ b/packages/material-ui/src/Grow/Grow.js
@@ -142,6 +142,10 @@ const Grow = React.forwardRef(function Grow(props, ref) {
 });
 
 Grow.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * A single child content element.
    */
@@ -169,9 +173,13 @@ Grow.propTypes = {
    * Set to 'auto' to automatically calculate transition time based on height.
    */
   timeout: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
     PropTypes.oneOf(['auto']),
+    PropTypes.number,
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
   ]),
 };
 

--- a/packages/material-ui/src/Hidden/Hidden.d.ts
+++ b/packages/material-ui/src/Hidden/Hidden.d.ts
@@ -2,18 +2,66 @@ import * as React from 'react';
 import { Breakpoint } from '../styles/createBreakpoints';
 
 export interface HiddenProps {
+  /**
+   * Specify which implementation to use.  'js' is the default, 'css' works better for
+   * server-side rendering.
+   */
   implementation?: 'js' | 'css';
+  /**
+   * You can use this prop when choosing the `js` implementation with server-side rendering.
+   *
+   * As `window.innerWidth` is unavailable on the server,
+   * we default to rendering an empty component during the first mount.
+   * You might want to use an heuristic to approximate
+   * the screen width of the client browser screen width.
+   *
+   * For instance, you could be using the user-agent or the client-hints.
+   * https://caniuse.com/#search=client%20hint
+   */
   initialWidth?: Breakpoint;
+  /**
+   * If `true`, screens this size and down will be hidden.
+   */
   lgDown?: boolean;
+  /**
+   * If `true`, screens this size and up will be hidden.
+   */
   lgUp?: boolean;
+  /**
+   * If `true`, screens this size and down will be hidden.
+   */
   mdDown?: boolean;
+  /**
+   * If `true`, screens this size and up will be hidden.
+   */
   mdUp?: boolean;
+  /**
+   * Hide the given breakpoint(s).
+   */
   only?: Breakpoint | Breakpoint[];
+  /**
+   * If `true`, screens this size and down will be hidden.
+   */
   smDown?: boolean;
+  /**
+   * If `true`, screens this size and up will be hidden.
+   */
   smUp?: boolean;
+  /**
+   * If `true`, screens this size and down will be hidden.
+   */
   xlDown?: boolean;
+  /**
+   * If `true`, screens this size and up will be hidden.
+   */
   xlUp?: boolean;
+  /**
+   * If `true`, screens this size and down will be hidden.
+   */
   xsDown?: boolean;
+  /**
+   * If `true`, screens this size and up will be hidden.
+   */
   xsUp?: boolean;
 }
 

--- a/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.d.ts
@@ -2,10 +2,25 @@ import * as React from 'react';
 import { StandardProps } from '..';
 
 export interface LinearProgressProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, LinearProgressClassKey> {
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, LinearProgressClassKey, 'children'> {
+  /**
+   * The color of the component. It supports those theme colors that make sense for this component.
+   */
   color?: 'primary' | 'secondary';
+  /**
+   * The value of the progress indicator for the determinate and buffer variants.
+   * Value between 0 and 100.
+   */
   value?: number;
+  /**
+   * The value for the buffer variant.
+   * Value between 0 and 100.
+   */
   valueBuffer?: number;
+  /**
+   * The variant to use.
+   * Use indeterminate or query when there is no progress value.
+   */
   variant?: 'determinate' | 'indeterminate' | 'buffer' | 'query';
 }
 
@@ -43,6 +58,4 @@ export type LinearProgressClassKey =
  *
  * - [LinearProgress API](https://material-ui.com/api/linear-progress/)
  */
-declare const LinearProgress: React.ComponentType<LinearProgressProps>;
-
-export default LinearProgress;
+export default function LinearProgress(props: LinearProgressProps): JSX.Element;

--- a/packages/material-ui/src/LinearProgress/LinearProgress.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.js
@@ -253,11 +253,15 @@ const LinearProgress = React.forwardRef(function LinearProgress(props, ref) {
 });
 
 LinearProgress.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -280,7 +284,7 @@ LinearProgress.propTypes = {
    * The variant to use.
    * Use indeterminate or query when there is no progress value.
    */
-  variant: PropTypes.oneOf(['determinate', 'indeterminate', 'buffer', 'query']),
+  variant: PropTypes.oneOf(['buffer', 'determinate', 'indeterminate', 'query']),
 };
 
 export default withStyles(styles, { name: 'MuiLinearProgress' })(LinearProgress);

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
@@ -1,6 +1,9 @@
 import { StandardProps } from '..';
 
 export interface ListItemAvatarProps extends StandardProps<{}, ListItemAvatarClassKey> {
+  /**
+   * The content of the component – normally `Avatar`.
+   */
   children: React.ReactElement;
 }
 

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.d.ts
@@ -19,6 +19,4 @@ export type ListItemAvatarClassKey = 'root' | 'icon';
  *
  * - [ListItemAvatar API](https://material-ui.com/api/list-item-avatar/)
  */
-declare const ListItemAvatar: React.ComponentType<ListItemAvatarProps>;
-
-export default ListItemAvatar;
+export default function ListItemAvatar(props: ListItemAvatarProps): JSX.Element;

--- a/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
+++ b/packages/material-ui/src/ListItemAvatar/ListItemAvatar.js
@@ -39,6 +39,10 @@ const ListItemAvatar = React.forwardRef(function ListItemAvatar(props, ref) {
 });
 
 ListItemAvatar.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component – normally `Avatar`.
    */
@@ -47,7 +51,7 @@ ListItemAvatar.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
@@ -2,6 +2,10 @@ import { StandardProps } from '..';
 
 export interface ListItemIconProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ListItemIconClassKey> {
+  /**
+   * The content of the component, normally `Icon`, `SvgIcon`,
+   * or a `@material-ui/icons` SVG icon element.
+   */
   children: React.ReactElement;
 }
 
@@ -17,6 +21,4 @@ export type ListItemIconClassKey = 'root';
  *
  * - [ListItemIcon API](https://material-ui.com/api/list-item-icon/)
  */
-declare const ListItemIcon: React.ComponentType<ListItemIconProps>;
-
-export default ListItemIcon;
+export default function ListItemIcon(props: ListItemIconProps): JSX.Element;

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -41,6 +41,10 @@ const ListItemIcon = React.forwardRef(function ListItemIcon(props, ref) {
 });
 
 ListItemIcon.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component, normally `Icon`, `SvgIcon`,
    * or a `@material-ui/icons` SVG icon element.
@@ -50,7 +54,7 @@ ListItemIcon.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -7,12 +7,88 @@ import { TransitionHandlerProps, TransitionProps } from '../transitions/transiti
 
 export interface MenuProps
   extends StandardProps<PopoverProps & Partial<TransitionHandlerProps>, MenuClassKey> {
+  /**
+   * The DOM element used to set the position of the menu.
+   */
+  anchorEl?: PopoverProps['anchorEl'];
+  /**
+   * If `true` (Default) will focus the `[role="menu"]` if no focusable child is found. Disabled
+   * children are not focusable. If you set this prop to `false` focus will be placed
+   * on the parent modal container. This has severe accessibility implications
+   * and should only be considered if you manage focus otherwise.
+   */
   autoFocus?: boolean;
+  /**
+   * Menu contents, normally `MenuItem`s.
+   */
+  children?: React.ReactNode;
+  /**
+   * When opening the menu will not focus the active item but the `[role="menu"]`
+   * unless `autoFocus` is also set to `false`. Not using the default means not
+   * following WAI-ARIA authoring practices. Please be considerate about possible
+   * accessibility implications.
+   */
   disableAutoFocusItem?: boolean;
+  /**
+   * Props applied to the [`MenuList`](/api/menu-list/) element.
+   */
   MenuListProps?: Partial<MenuListProps>;
+  /**
+   * Callback fired when the component requests to be closed.
+   *
+   * @param {object} event The event source of the callback.
+   * @param {string} reason Can be: `"escapeKeyDown"`, `"backdropClick"`, `"tabKeyDown"`.
+   */
+  onClose?: PopoverProps['onClose'];
+  /**
+   * Callback fired before the Menu enters.
+   * @document
+   */
+  onEnter?: PopoverProps['onEnter'];
+  /**
+   * Callback fired when the Menu has entered.
+   * @document
+   */
+  onEntered?: PopoverProps['onEntered'];
+  /**
+   * Callback fired when the Menu is entering.
+   * @document
+   */
+  onEntering?: PopoverProps['onEntering'];
+  /**
+   * Callback fired before the Menu exits.
+   * @document
+   */
+  onExit?: PopoverProps['onExit'];
+  /**
+   * Callback fired when the Menu has exited.
+   * @document
+   */
+  onExited?: PopoverProps['onExited'];
+  /**
+   * Callback fired when the Menu is exiting.
+   * @document
+   */
+  onExiting?: PopoverProps['onExiting'];
+  /**
+   * If `true`, the menu is visible.
+   */
+  open: boolean;
+  /**
+   */
   PaperProps?: Partial<PaperProps>;
+  /**
+   * `classes` prop applied to the [`Popover`](/api/popover/) element.
+   */
   PopoverClasses?: PopoverProps['classes'];
+  /**
+   * The length of the transition in `ms`, or 'auto'
+   */
   transitionDuration?: TransitionProps['timeout'] | 'auto';
+  /**
+   * The variant to use. Use `menu` to prevent selected items from impacting the initial focus
+   * and the vertical alignment relative to the anchor element.
+   */
   variant?: 'menu' | 'selectedMenu';
 }
 
@@ -30,6 +106,4 @@ export type MenuClassKey = 'paper' | 'list';
  * - [Menu API](https://material-ui.com/api/menu/)
  * - inherits [Popover API](https://material-ui.com/api/popover/)
  */
-declare const Menu: React.ComponentType<MenuProps>;
-
-export default Menu;
+export default function Menu(props: MenuProps): JSX.Element;

--- a/packages/material-ui/src/Menu/Menu.d.ts
+++ b/packages/material-ui/src/Menu/Menu.d.ts
@@ -9,6 +9,7 @@ export interface MenuProps
   extends StandardProps<PopoverProps & Partial<TransitionHandlerProps>, MenuClassKey> {
   /**
    * The DOM element used to set the position of the menu.
+   * @document
    */
   anchorEl?: PopoverProps['anchorEl'];
   /**

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -171,6 +171,13 @@ Menu.propTypes = {
   // |     To update them edit the d.ts file and run "yarn proptypes"     |
   // ----------------------------------------------------------------------
   /**
+   * The DOM element used to set the position of the menu.
+   */
+  anchorEl: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.instanceOf(typeof Element === 'undefined' ? Object : Element),
+  ]),
+  /**
    * If `true` (Default) will focus the `[role="menu"]` if no focusable child is found. Disabled
    * children are not focusable. If you set this prop to `false` focus will be placed
    * on the parent modal container. This has severe accessibility implications

--- a/packages/material-ui/src/Menu/Menu.js
+++ b/packages/material-ui/src/Menu/Menu.js
@@ -166,10 +166,10 @@ const Menu = React.forwardRef(function Menu(props, ref) {
 });
 
 Menu.propTypes = {
-  /**
-   * The DOM element used to set the position of the menu.
-   */
-  anchorEl: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * If `true` (Default) will focus the `[role="menu"]` if no focusable child is found. Disabled
    * children are not focusable. If you set this prop to `false` focus will be placed
@@ -185,7 +185,7 @@ Menu.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * When opening the menu will not focus the active item but the `[role="menu"]`
    * unless `autoFocus` is also set to `false`. Not using the default means not
@@ -244,9 +244,13 @@ Menu.propTypes = {
    * The length of the transition in `ms`, or 'auto'
    */
   transitionDuration: PropTypes.oneOfType([
-    PropTypes.number,
-    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
     PropTypes.oneOf(['auto']),
+    PropTypes.number,
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
   ]),
   /**
    * The variant to use. Use `menu` to prevent selected items from impacting the initial focus

--- a/packages/material-ui/src/MenuList/MenuList.d.ts
+++ b/packages/material-ui/src/MenuList/MenuList.d.ts
@@ -3,9 +3,27 @@ import { StandardProps } from '..';
 import { ListProps, ListClassKey } from '../List';
 
 export interface MenuListProps extends StandardProps<ListProps, MenuListClassKey> {
+  /**
+   * If `true`, will focus the `[role="menu"]` container and move into tab order
+   */
   autoFocus?: boolean;
+  /**
+   * If `true`, will focus the first menuitem if `variant="menu"` or selected item
+   * if `variant="selectedMenu"`
+   */
   autoFocusItem?: boolean;
+  /**
+   * MenuList contents, normally `MenuItem`s.
+   */
+  children?: React.ReactNode;
+  /**
+   * If `true`, the menu items will not wrap focus.
+   */
   disableListWrap?: boolean;
+  /**
+   * The variant to use. Use `menu` to prevent selected items from impacting the initial focus
+   * and the vertical alignment relative to the anchor element.
+   */
   variant?: 'menu' | 'selectedMenu';
 }
 

--- a/packages/material-ui/src/MenuList/MenuList.d.ts
+++ b/packages/material-ui/src/MenuList/MenuList.d.ts
@@ -4,12 +4,12 @@ import { ListProps, ListClassKey } from '../List';
 
 export interface MenuListProps extends StandardProps<ListProps, MenuListClassKey> {
   /**
-   * If `true`, will focus the `[role="menu"]` container and move into tab order
+   * If `true`, will focus the `[role="menu"]` container and move into tab order.
    */
   autoFocus?: boolean;
   /**
    * If `true`, will focus the first menuitem if `variant="menu"` or selected item
-   * if `variant="selectedMenu"`
+   * if `variant="selectedMenu"`.
    */
   autoFocusItem?: boolean;
   /**
@@ -43,6 +43,4 @@ export type MenuListClassKey = ListClassKey;
  * - [MenuList API](https://material-ui.com/api/menu-list/)
  * - inherits [List API](https://material-ui.com/api/list/)
  */
-declare const MenuList: React.ComponentType<MenuListProps>;
-
-export default MenuList;
+export default function MenuList(props: MenuListProps): JSX.Element;

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -261,13 +261,17 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
 });
 
 MenuList.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
-   * If `true`, will focus the `[role="menu"]` container and move into tab order
+   * If `true`, will focus the `[role="menu"]` container and move into tab order.
    */
   autoFocus: PropTypes.bool,
   /**
    * If `true`, will focus the first menuitem if `variant="menu"` or selected item
-   * if `variant="selectedMenu"`
+   * if `variant="selectedMenu"`.
    */
   autoFocusItem: PropTypes.bool,
   /**

--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -85,6 +85,8 @@ const useEnhancedEffect = typeof window === 'undefined' ? React.useEffect : Reac
  */
 const MenuList = React.forwardRef(function MenuList(props, ref) {
   const {
+    // private
+    // eslint-disable-next-line react/prop-types
     actions,
     autoFocus = false,
     autoFocusItem = false,
@@ -259,10 +261,6 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
 });
 
 MenuList.propTypes = {
-  /**
-   * @ignore
-   */
-  actions: PropTypes.shape({ current: PropTypes.object }),
   /**
    * If `true`, will focus the `[role="menu"]` container and move into tab order
    */

--- a/packages/material-ui/src/MobileStepper/MobileStepper.d.ts
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.d.ts
@@ -4,13 +4,35 @@ import { PaperProps } from '../Paper';
 import { LinearProgressProps } from '../LinearProgress';
 
 export interface MobileStepperProps
-  extends StandardProps<PaperProps, MobileStepperClassKey, 'variant'> {
+  extends StandardProps<PaperProps, MobileStepperClassKey, 'children' | 'variant'> {
+  /**
+   * Set the active step (zero based index).
+   * Defines which dot is highlighted when the variant is 'dots'.
+   */
   activeStep?: number;
+  /**
+   * A back button element. For instance, it can be a `Button` or an `IconButton`.
+   */
   backButton: React.ReactNode;
+  /**
+   * Props applied to the `LinearProgress` element.
+   */
   LinearProgressProps?: Partial<LinearProgressProps>;
+  /**
+   * A next button element. For instance, it can be a `Button` or an `IconButton`.
+   */
   nextButton: React.ReactNode;
+  /**
+   * Set the positioning type.
+   */
   position?: 'bottom' | 'top' | 'static';
+  /**
+   * The total steps.
+   */
   steps: number;
+  /**
+   * The variant to use.
+   */
   variant?: 'text' | 'dots' | 'progress';
 }
 
@@ -35,6 +57,4 @@ export type MobileStepperClassKey =
  * - [MobileStepper API](https://material-ui.com/api/mobile-stepper/)
  * - inherits [Paper API](https://material-ui.com/api/paper/)
  */
-declare const MobileStepper: React.ComponentType<MobileStepperProps>;
-
-export default MobileStepper;
+export default function MobileStepper(props: MobileStepperProps): JSX.Element;

--- a/packages/material-ui/src/MobileStepper/MobileStepper.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.js
@@ -85,6 +85,7 @@ const MobileStepper = React.forwardRef(function MobileStepper(props, ref) {
           {activeStep + 1} / {steps}
         </React.Fragment>
       )}
+
       {variant === 'dots' && (
         <div className={classes.dots}>
           {[...new Array(steps)].map((_, index) => (
@@ -97,6 +98,7 @@ const MobileStepper = React.forwardRef(function MobileStepper(props, ref) {
           ))}
         </div>
       )}
+
       {variant === 'progress' && (
         <LinearProgress
           className={classes.progress}
@@ -105,12 +107,17 @@ const MobileStepper = React.forwardRef(function MobileStepper(props, ref) {
           {...LinearProgressProps}
         />
       )}
+
       {nextButton}
     </Paper>
   );
 });
 
 MobileStepper.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * Set the active step (zero based index).
    * Defines which dot is highlighted when the variant is 'dots'.
@@ -124,7 +131,7 @@ MobileStepper.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -140,7 +147,7 @@ MobileStepper.propTypes = {
   /**
    * Set the positioning type.
    */
-  position: PropTypes.oneOf(['bottom', 'top', 'static']),
+  position: PropTypes.oneOf(['bottom', 'static', 'top']),
   /**
    * The total steps.
    */
@@ -148,7 +155,7 @@ MobileStepper.propTypes = {
   /**
    * The variant to use.
    */
-  variant: PropTypes.oneOf(['text', 'dots', 'progress']),
+  variant: PropTypes.oneOf(['dots', 'progress', 'text']),
 };
 
 export default withStyles(styles, { name: 'MuiMobileStepper' })(MobileStepper);

--- a/packages/material-ui/src/NoSsr/NoSsr.d.ts
+++ b/packages/material-ui/src/NoSsr/NoSsr.d.ts
@@ -1,8 +1,18 @@
 import * as React from 'react';
 
 export interface NoSsrProps {
+  /**
+   * You can wrap a node.
+   */
   children?: React.ReactNode;
+  /**
+   * If `true`, the component will not only prevent server-side rendering.
+   * It will also defer the rendering of the children into a different screen frame.
+   */
   defer?: boolean;
+  /**
+   * The fallback content to display.
+   */
   fallback?: React.ReactNode;
 }
 
@@ -23,6 +33,4 @@ export interface NoSsrProps {
  *
  * - [NoSsr API](https://material-ui.com/api/no-ssr/)
  */
-declare const NoSsr: React.ComponentType<NoSsrProps>;
-
-export default NoSsr;
+export default function NoSsr(props: NoSsrProps): JSX.Element;

--- a/packages/material-ui/src/NoSsr/NoSsr.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.js
@@ -37,6 +37,10 @@ function NoSsr(props) {
 }
 
 NoSsr.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * You can wrap a node.
    */

--- a/packages/material-ui/src/Paper/Paper.d.ts
+++ b/packages/material-ui/src/Paper/Paper.d.ts
@@ -3,9 +3,23 @@ import { StandardProps } from '..';
 
 export interface PaperProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, PaperClassKey> {
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
   component?: React.ElementType<React.HTMLAttributes<HTMLElement>>;
+  /**
+   * Shadow depth, corresponds to `dp` in the spec.
+   * It accepts values between 0 and 24 inclusive.
+   */
   elevation?: number;
+  /**
+   * If `true`, rounded corners are disabled.
+   */
   square?: boolean;
+  /**
+   * The variant to use.
+   */
   variant?: 'elevation' | 'outlined';
 }
 
@@ -50,6 +64,4 @@ export type PaperClassKey =
  *
  * - [Paper API](https://material-ui.com/api/paper/)
  */
-declare const Paper: React.ComponentType<PaperProps>;
-
-export default Paper;
+export default function Paper(props: PaperProps): JSX.Element;

--- a/packages/material-ui/src/Paper/Paper.js
+++ b/packages/material-ui/src/Paper/Paper.js
@@ -65,6 +65,10 @@ const Paper = React.forwardRef(function Paper(props, ref) {
 });
 
 Paper.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
@@ -73,7 +77,7 @@ Paper.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.d.ts
@@ -4,8 +4,25 @@ import { FormGroupProps, FormGroupClassKey } from '../FormGroup';
 
 export interface RadioGroupProps
   extends StandardProps<FormGroupProps, RadioGroupClassKey, 'onChange'> {
+  /**
+   * The default `input` element value. Use when the component is not controlled.
+   */
+  defaultValue?: FormGroupProps['defaultValue'];
+  /**
+   * The name used to reference the value of the control.
+   * If you don't provide this prop, it falls back to a randomly generated name.
+   */
   name?: string;
+  /**
+   * Callback fired when a radio button is selected.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>, value: string) => void;
+  /**
+   * Value of the selected radio button. The DOM API casts this to a string.
+   */
   value?: any;
 }
 
@@ -22,6 +39,4 @@ export type RadioGroupClassKey = FormGroupClassKey;
  * - [RadioGroup API](https://material-ui.com/api/radio-group/)
  * - inherits [FormGroup API](https://material-ui.com/api/form-group/)
  */
-declare const RadioGroup: React.ComponentType<RadioGroupProps>;
-
-export default RadioGroup;
+export default function RadioGroup(props: RadioGroupProps): JSX.Element;

--- a/packages/material-ui/src/RadioGroup/RadioGroup.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.js
@@ -6,7 +6,16 @@ import useControlled from '../utils/useControlled';
 import RadioGroupContext from './RadioGroupContext';
 
 const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
-  const { actions, children, name: nameProp, value: valueProp, onChange, ...other } = props;
+  const {
+    // private
+    // eslint-disable-next-line react/prop-types
+    actions,
+    children,
+    name: nameProp,
+    value: valueProp,
+    onChange,
+    ...other
+  } = props;
   const rootRef = React.useRef(null);
 
   const [value, setValue] = useControlled({
@@ -62,10 +71,10 @@ const RadioGroup = React.forwardRef(function RadioGroup(props, ref) {
 });
 
 RadioGroup.propTypes = {
-  /**
-   * @ignore
-   */
-  actions: PropTypes.shape({ current: PropTypes.object }),
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component.
    */
@@ -73,16 +82,16 @@ RadioGroup.propTypes = {
   /**
    * The default `input` element value. Use when the component is not controlled.
    */
-  defaultValue: PropTypes.any,
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
   /**
    * The name used to reference the value of the control.
    * If you don't provide this prop, it falls back to a randomly generated name.
    */
   name: PropTypes.string,
-  /**
-   * @ignore
-   */
-  onBlur: PropTypes.func,
   /**
    * Callback fired when a radio button is selected.
    *
@@ -90,10 +99,6 @@ RadioGroup.propTypes = {
    * You can pull out the new value by accessing `event.target.value` (string).
    */
   onChange: PropTypes.func,
-  /**
-   * @ignore
-   */
-  onKeyDown: PropTypes.func,
   /**
    * Value of the selected radio button. The DOM API casts this to a string.
    */

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -16,20 +16,110 @@ export interface SnackbarProps
     React.HTMLAttributes<HTMLDivElement> & Partial<TransitionHandlerProps>,
     SnackbarClassKey
   > {
+  /**
+   * The action to display. It renders after the message, at the end of the snackbar.
+   */
   action?: SnackbarContentProps['action'];
+  /**
+   * The anchor of the `Snackbar`.
+   */
   anchorOrigin?: SnackbarOrigin;
+  /**
+   * The number of milliseconds to wait before automatically calling the
+   * `onClose` function. `onClose` should then set the state of the `open`
+   * prop to hide the Snackbar. This behavior is disabled by default with
+   * the `null` value.
+   */
   autoHideDuration?: number | null;
+  /**
+   * Replace the `SnackbarContent` component.
+   */
+  children?: React.ReactElement<any, any>;
+  /**
+   * Props applied to the `ClickAwayListener` element.
+   */
   ClickAwayListenerProps?: Partial<ClickAwayListenerProps>;
+  /**
+   * Props applied to the [`SnackbarContent`](/api/snackbar-content/) element.
+   */
   ContentProps?: Partial<SnackbarContentProps>;
+  /**
+   * If `true`, the `autoHideDuration` timer will expire even if the window is not focused.
+   */
   disableWindowBlurListener?: boolean;
+  /**
+   * When displaying multiple consecutive Snackbars from a parent rendering a single
+   * <Snackbar/>, add the key prop to ensure independent treatment of each message.
+   * e.g. <Snackbar key={message} />, otherwise, the message may update-in-place and
+   * features such as autoHideDuration may be canceled.
+   * @document
+   */
+  key?: any;
+  /**
+   * The message to display.
+   */
   message?: SnackbarContentProps['message'];
+  /**
+   * Callback fired when the component requests to be closed.
+   * Typically `onClose` is used to set state in the parent component,
+   * which is used to control the `Snackbar` `open` prop.
+   * The `reason` parameter can optionally be used to control the response to `onClose`,
+   * for example ignoring `clickaway`.
+   *
+   * @param {object} event The event source of the callback.
+   * @param {string} reason Can be: `"timeout"` (`autoHideDuration` expired), `"clickaway"`.
+   */
   onClose?: (event: React.SyntheticEvent<any>, reason: SnackbarCloseReason) => void;
+  /**
+   * Callback fired before the transition is entering.
+   */
+  onEnter: TransitionHandlerProps['onEnter'];
+  /**
+   * Callback fired when the transition has entered.
+   */
+  onEntered: TransitionHandlerProps['onEntered'];
+  /**
+   * Callback fired when the transition is entering.
+   */
+  onEntering: TransitionHandlerProps['onEntering'];
+  /**
+   * Callback fired before the transition is exiting.
+   */
+  onExit: TransitionHandlerProps['onExit'];
+  /**
+   * Callback fired when the transition has exited.
+   */
+  onExited: TransitionHandlerProps['onExited'];
+  /**
+   * Callback fired when the transition is exiting.
+   */
+  onExiting: TransitionHandlerProps['onExiting'];
   onMouseEnter?: React.MouseEventHandler<any>;
   onMouseLeave?: React.MouseEventHandler<any>;
-  open: boolean;
+  /**
+   * If `true`, `Snackbar` is open.
+   */
+  open?: boolean;
+  /**
+   * The number of milliseconds to wait before dismissing after user interaction.
+   * If `autoHideDuration` prop isn't specified, it does nothing.
+   * If `autoHideDuration` prop is specified but `resumeHideDuration` isn't,
+   * we default to `autoHideDuration / 2` ms.
+   */
   resumeHideDuration?: number;
+  /**
+   * The component used for the transition.
+   * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
+   */
   TransitionComponent?: React.ComponentType<TransitionProps>;
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
   transitionDuration?: TransitionProps['timeout'];
+  /**
+   * Props applied to the [`Transition`](http://reactcommunity.org/react-transition-group/transition#Transition-props) element.
+   */
   TransitionProps?: TransitionProps;
 }
 
@@ -52,6 +142,4 @@ export type SnackbarClassKey =
  *
  * - [Snackbar API](https://material-ui.com/api/snackbar/)
  */
-declare const Snackbar: React.ComponentType<SnackbarProps>;
-
-export default Snackbar;
+export default function Snackbar(props: SnackbarProps): JSX.Element;

--- a/packages/material-ui/src/Snackbar/Snackbar.d.ts
+++ b/packages/material-ui/src/Snackbar/Snackbar.d.ts
@@ -73,27 +73,27 @@ export interface SnackbarProps
   /**
    * Callback fired before the transition is entering.
    */
-  onEnter: TransitionHandlerProps['onEnter'];
+  onEnter?: TransitionHandlerProps['onEnter'];
   /**
    * Callback fired when the transition has entered.
    */
-  onEntered: TransitionHandlerProps['onEntered'];
+  onEntered?: TransitionHandlerProps['onEntered'];
   /**
    * Callback fired when the transition is entering.
    */
-  onEntering: TransitionHandlerProps['onEntering'];
+  onEntering?: TransitionHandlerProps['onEntering'];
   /**
    * Callback fired before the transition is exiting.
    */
-  onExit: TransitionHandlerProps['onExit'];
+  onExit?: TransitionHandlerProps['onExit'];
   /**
    * Callback fired when the transition has exited.
    */
-  onExited: TransitionHandlerProps['onExited'];
+  onExited?: TransitionHandlerProps['onExited'];
   /**
    * Callback fired when the transition is exiting.
    */
-  onExiting: TransitionHandlerProps['onExiting'];
+  onExiting?: TransitionHandlerProps['onExiting'];
   onMouseEnter?: React.MouseEventHandler<any>;
   onMouseLeave?: React.MouseEventHandler<any>;
   /**

--- a/packages/material-ui/src/Snackbar/Snackbar.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.js
@@ -252,6 +252,10 @@ const Snackbar = React.forwardRef(function Snackbar(props, ref) {
 });
 
 Snackbar.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The action to display. It renders after the message, at the end of the snackbar.
    */
@@ -260,8 +264,8 @@ Snackbar.propTypes = {
    * The anchor of the `Snackbar`.
    */
   anchorOrigin: PropTypes.shape({
-    horizontal: PropTypes.oneOf(['left', 'center', 'right']).isRequired,
-    vertical: PropTypes.oneOf(['top', 'bottom']).isRequired,
+    horizontal: PropTypes.oneOf(['center', 'left', 'right']).isRequired,
+    vertical: PropTypes.oneOf(['bottom', 'top']).isRequired,
   }),
   /**
    * The number of milliseconds to wait before automatically calling the
@@ -278,7 +282,7 @@ Snackbar.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -371,7 +375,11 @@ Snackbar.propTypes = {
    */
   transitionDuration: PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
   ]),
   /**
    * Props applied to the [`Transition`](http://reactcommunity.org/react-transition-group/transition#Transition-props) element.

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -91,12 +91,12 @@ async function generateProptypes(
 }
 
 interface HandlerArgv {
-  'ignore-cache': boolean;
+  'disable-cache': boolean;
   pattern: string;
   verbose: boolean;
 }
 async function run(argv: HandlerArgv) {
-  const { 'ignore-cache': ignoreCache, pattern, verbose } = argv;
+  const { 'disable-cache': ignoreCache, pattern, verbose } = argv;
 
   const filePattern = new RegExp(pattern);
   if (pattern.length > 0) {
@@ -170,7 +170,7 @@ yargs
     describe: 'formats codebase',
     builder: (command) => {
       return command
-        .option('ignore-cache', {
+        .option('disable-cache', {
           default: false,
           describe: 'Considers all files on every run',
           type: 'boolean',

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -75,6 +75,7 @@ async function generateProptypes(
         prop.jsDoc = prop.jsDoc.replace(documentRegExp, '');
         return true;
       }
+      console.log(prop);
 
       return undefined;
     },

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -118,7 +118,7 @@ async function run(argv: HandlerArgv) {
     ),
   );
 
-  const programFiles = _.flatten(allFiles)
+  const files = _.flatten(allFiles)
     // Filter out files where the directory name and filename doesn't match
     // Example: Modal/ModalManager.d.ts
     .filter((filePath) => {
@@ -126,14 +126,11 @@ async function run(argv: HandlerArgv) {
       const fileName = path.basename(filePath, '.d.ts');
 
       return fileName === folderName;
+    })
+    .filter((filePath) => {
+      return filePattern.test(filePath);
     });
-  // I believe that the program still needs every file
-  // for import-extends. Not sure but compiling all to be sure
-  const program = ttp.createProgram(programFiles, tsconfig);
-
-  const files = programFiles.filter((filePath) => {
-    return filePattern.test(filePath);
-  });
+  const program = ttp.createProgram(files, tsconfig);
 
   const promises = files.map<Promise<GenerateResult>>(async (tsFile) => {
     const jsFile = tsFile.replace('.d.ts', '.js');

--- a/scripts/generateProptypes.ts
+++ b/scripts/generateProptypes.ts
@@ -167,7 +167,7 @@ async function run(argv: HandlerArgv) {
 yargs
   .command({
     command: '$0',
-    describe: 'formats codebase',
+    describe: 'Generates Component.propTypes from TypeScript declarations',
     builder: (command) => {
       return command
         .option('disable-cache', {


### PR DESCRIPTION
- adds `--pattern` to `yarn proptypes`: `yarn proptypes --pattern Button` only generates proptypes for `Button` and `ButtonBase`
- adds prop documentation for many more components. Diff is mostly noise apart from:
  - DialogTitle, `ExpansionPanelActions`, `ExpansionPanelDetails` no longer issue proptypes warnings on emtpy children. These components work perfectly well without them.
  - removes propTypes validation from private properties in favor of eslint-disable
  - Fade now correctly rejects renderprops