### PR TITLE
[MenuList] Remove if-statement that is always true

### DIFF
--- a/packages/material-ui/src/MenuList/MenuList.js
+++ b/packages/material-ui/src/MenuList/MenuList.js
@@ -236,9 +236,7 @@ const MenuList = React.forwardRef(function MenuList(props, ref) {
         newChildProps.tabIndex = 0;
       }
 
-      if (newChildProps !== null) {
-        return React.cloneElement(child, newChildProps);
-      }
+      return React.cloneElement(child, newChildProps);
     }
 
     return child;


### PR DESCRIPTION
The removed if-statement always evaluates to true due to the non-null const nature of `newChildProps` and thus seems unnecessary.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
