### PR TITLE
[Tooltip] Remove superfluous argument in handleBlur call

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -365,7 +365,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
       if (childrenProps.onBlur && forward) {
         childrenProps.onBlur(event);
       }
-      handleBlur(event);
+      handleBlur();
     }
 
     if (


### PR DESCRIPTION
The `handleBlur` function is defined to have 0 parameters, thus the passed `event` argument is discarded and can be removed.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
