### PR TITLE
[core] Mark context value as nullable for optional providers

### DIFF
--- a/packages/material-ui/src/FormControl/useFormControl.d.ts
+++ b/packages/material-ui/src/FormControl/useFormControl.d.ts
@@ -23,4 +23,4 @@ export interface FormControlState extends Pick<FormControlProps, ContextFromProp
   onFocus: () => void;
 }
 
-export default function useFormControl(): FormControlState;
+export default function useFormControl(): FormControlState | undefined;

--- a/packages/material-ui/src/RadioGroup/useRadioGroup.d.ts
+++ b/packages/material-ui/src/RadioGroup/useRadioGroup.d.ts
@@ -3,4 +3,4 @@ import { RadioGroupProps } from './RadioGroup';
 
 export interface RadioGroupState extends Pick<RadioGroupProps, 'name' | 'onChange' | 'value'> {}
 
-export default function useRadioGroup(): RadioGroupState;
+export default function useRadioGroup(): RadioGroupState | undefined;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

`useFormControl` will return `undefined` if there is no `FormControl` provider above in the React tree. `FormControlContext` doesn't currently provide a default value. Perhaps a default value should be provided? See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/24509#issuecomment-382213106.

This could be considered a breaking change for folks that are currently using this hook, as they will now need to account for the `undefined` case. I'd be happier providing a default value to `FormControlContext`, but wanted to run it by you first.