### PR TITLE
[Select] Apply disabled color to the icon

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -134,8 +134,9 @@ export const styles = (theme) => ({
   clearIndicator: {
     marginRight: -2,
     padding: 4,
-    color: theme.palette.action.active,
     visibility: 'hidden',
+    color: 'currentColor',
+    opacity: 0.6,
   },
   /* Styles applied to the clear indicator if the input is dirty. */
   clearIndicatorDirty: {},
@@ -143,10 +144,10 @@ export const styles = (theme) => ({
   popupIndicator: {
     padding: 2,
     marginRight: -2,
-    color: 'currentColor', // Unify behavior with Select component.
-    opacity: .8,
+    color: 'currentColor',
+    opacity: 0.6,
     '&:disabled': {
-      color: 'currentColor', // Overrides IconButton's disabled color.
+      color: 'currentColor',
     },
   },
   /* Styles applied to the popup indicator if the popup is open. */

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -135,8 +135,6 @@ export const styles = (theme) => ({
     marginRight: -2,
     padding: 4,
     visibility: 'hidden',
-    color: 'currentColor',
-    opacity: 0.6,
   },
   /* Styles applied to the clear indicator if the input is dirty. */
   clearIndicatorDirty: {},
@@ -144,11 +142,6 @@ export const styles = (theme) => ({
   popupIndicator: {
     padding: 2,
     marginRight: -2,
-    color: 'currentColor',
-    opacity: 0.6,
-    '&:disabled': {
-      color: 'currentColor',
-    },
   },
   /* Styles applied to the popup indicator if the popup is open. */
   popupIndicatorOpen: {

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -143,7 +143,11 @@ export const styles = (theme) => ({
   popupIndicator: {
     padding: 2,
     marginRight: -2,
-    color: theme.palette.action.active,
+    color: 'currentColor', // Unify behavior with Select component.
+    opacity: .8,
+    '&:disabled': {
+      color: 'currentColor', // Overrides IconButton's disabled color.
+    },
   },
   /* Styles applied to the popup indicator if the popup is open. */
   popupIndicatorOpen: {

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -72,8 +72,8 @@ export const styles = (theme) => ({
     position: 'absolute',
     right: 0,
     top: 'calc(50% - 12px)', // Center vertically
-    color: 'currentColor', // Ensure color stays consistent when disabled.
-    opacity: 0.8, // Reduced opacity to account for the icon's large surface area.
+    color: 'currentColor',
+    opacity: 0.6, // Reduced opacity to account for the icon's large surface area.
     pointerEvents: 'none', // Don't block pointer events on the select under the icon.
   },
   /* Styles applied to the icon component if the popup is open. */

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -72,7 +72,8 @@ export const styles = (theme) => ({
     position: 'absolute',
     right: 0,
     top: 'calc(50% - 12px)', // Center vertically
-    color: theme.palette.action.active,
+    color: 'currentColor', // Ensure color stays consistent when disabled.
+    opacity: 0.8, // Reduced opacity to account for the icon's large surface area.
     pointerEvents: 'none', // Don't block pointer events on the select under the icon.
   },
   /* Styles applied to the icon component if the popup is open. */

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -72,9 +72,11 @@ export const styles = (theme) => ({
     position: 'absolute',
     right: 0,
     top: 'calc(50% - 12px)', // Center vertically
-    color: 'currentColor',
-    opacity: 0.6, // Reduced opacity to account for the icon's large surface area.
     pointerEvents: 'none', // Don't block pointer events on the select under the icon.
+    color: theme.palette.action.active,
+    '&$disabled': {
+      color: theme.palette.action.disabled,
+    },
   },
   /* Styles applied to the icon component if the popup is open. */
   iconOpen: {

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.js
@@ -35,7 +35,11 @@ const NativeSelectInput = React.forwardRef(function NativeSelectInput(props, ref
         {...other}
       />
       {props.multiple ? null : (
-        <IconComponent className={clsx(classes.icon, classes[`icon${capitalize(variant)}`])} />
+        <IconComponent
+          className={clsx(classes.icon, classes[`icon${capitalize(variant)}`], {
+            [classes.disabled]: disabled,
+          })}
+        />
       )}
     </React.Fragment>
   );

--- a/packages/material-ui/src/Select/SelectInput.js
+++ b/packages/material-ui/src/Select/SelectInput.js
@@ -349,6 +349,7 @@ const SelectInput = React.forwardRef(function SelectInput(props, ref) {
       <IconComponent
         className={clsx(classes.icon, classes[`icon${capitalize(variant)}`], {
           [classes.iconOpen]: open,
+          [classes.disabled]: disabled,
         })}
       />
       <Menu


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Resolves https://github.com/mui-org/material-ui/issues/19833.

This PR both applies the disabled color to the `Select` element's icon, and apply the same method to `Autocomplete` for consistency.
I hope it's okay to combine those two changes together in one PR?

One thing I'm not really confident of is re-applying `currentColor` to `disabled` pseudo class, because it looks redundant.
Any feedback is appreciated.