### PR TITLE
[core] Fix Checkbox and Radio type propType

### DIFF
--- a/docs/pages/api-docs/checkbox.md
+++ b/docs/pages/api-docs/checkbox.md
@@ -39,7 +39,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new checked state by accessing `event.target.checked` (boolean). |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be required. |
 | <span class="prop-name">size</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'</span> | <span class="prop-default">'medium'</span> | The size of the checkbox. `small` is equivalent to the dense checkbox styling. |
-| <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component prop `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the component. The DOM API casts this to a string. The browser uses "on" as the default value. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/radio.md
+++ b/docs/pages/api-docs/radio.md
@@ -38,7 +38,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback fired when the state is changed.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value` (string). You can pull out the new checked state by accessing `event.target.checked` (boolean). |
 | <span class="prop-name">required</span> | <span class="prop-type">bool</span> |  | If `true`, the `input` element will be required. |
 | <span class="prop-name">size</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'</span> | <span class="prop-default">'medium'</span> | The size of the radio. `small` is equivalent to the dense radio styling. |
-| <span class="prop-name">type</span> | <span class="prop-type">string</span> |  | The input component prop `type`. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The value of the component. The DOM API casts this to a string. |
 
 The `ref` is forwarded to the root element.

--- a/packages/material-ui/src/Checkbox/Checkbox.d.ts
+++ b/packages/material-ui/src/Checkbox/Checkbox.d.ts
@@ -3,7 +3,11 @@ import { StandardProps } from '..';
 import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 
 export interface CheckboxProps
-  extends StandardProps<SwitchBaseProps, CheckboxClassKey, 'checkedIcon' | 'color' | 'icon'> {
+  extends StandardProps<
+    SwitchBaseProps,
+    CheckboxClassKey,
+    'checkedIcon' | 'color' | 'icon' | 'type'
+  > {
   checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
   icon?: React.ReactNode;

--- a/packages/material-ui/src/Checkbox/Checkbox.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.js
@@ -169,10 +169,6 @@ Checkbox.propTypes = {
    */
   size: PropTypes.oneOf(['small', 'medium']),
   /**
-   * The input component prop `type`.
-   */
-  type: PropTypes.string,
-  /**
    * The value of the component. The DOM API casts this to a string.
    * The browser uses "on" as the default value.
    */

--- a/packages/material-ui/src/Radio/Radio.d.ts
+++ b/packages/material-ui/src/Radio/Radio.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { SwitchBaseProps, SwitchBaseClassKey } from '../internal/SwitchBase';
 
 export interface RadioProps
-  extends StandardProps<SwitchBaseProps, RadioClassKey, 'checkedIcon' | 'color' | 'icon'> {
+  extends StandardProps<SwitchBaseProps, RadioClassKey, 'checkedIcon' | 'color' | 'icon' | 'type'> {
   checkedIcon?: React.ReactNode;
   color?: 'primary' | 'secondary' | 'default';
   icon?: React.ReactNode;

--- a/packages/material-ui/src/Radio/Radio.js
+++ b/packages/material-ui/src/Radio/Radio.js
@@ -167,10 +167,6 @@ Radio.propTypes = {
    */
   size: PropTypes.oneOf(['small', 'medium']),
   /**
-   * The input component prop `type`.
-   */
-  type: PropTypes.string,
-  /**
    * The value of the component. The DOM API casts this to a string.
    */
   value: PropTypes.any,

--- a/packages/material-ui/src/internal/SwitchBase.d.ts
+++ b/packages/material-ui/src/internal/SwitchBase.d.ts
@@ -3,7 +3,7 @@ import { StandardProps } from '..';
 import { IconButtonProps } from '../IconButton';
 
 export interface SwitchBaseProps
-  extends StandardProps<IconButtonProps, SwitchBaseClassKey, 'onChange' | 'value'> {
+  extends StandardProps<IconButtonProps, SwitchBaseClassKey, 'onChange' | 'type' | 'value'> {
   autoFocus?: boolean;
   checked?: boolean;
   checkedIcon: React.ReactNode;
@@ -18,6 +18,7 @@ export interface SwitchBaseProps
   readOnly?: boolean;
   required?: boolean;
   tabIndex?: number;
+  type?: React.InputHTMLAttributes<HTMLInputElement>['type'];
   value?: unknown;
 }
 


### PR DESCRIPTION
Found these while working on more JSDOC in typescript:
1. currently we expect button types instead of input types in Checkbox and Radio i.e. `<Radio type="submit" />` currently passes because we assume that prop is spread to the IconButton but it is [passed to the input](https://github.com/mui-org/material-ui/blob/27471b4564eb40ff769352d73a29938d25804e45/packages/material-ui/src/internal/SwitchBase.js#L137)
2. I don't think we should accept an input `type` because it doesn't make any sense to me to write `<Radio type="checkbox" />` or `<Checkbox type="radio" />`. I think this is a reasonable restriction on "visuals should follow semantics". I've removed it from the TypeScript types and docs only for the time being as a form of a warning. I don't think we need any runtime behavior for this so that people can still force `<Radio type="checkbox" />`.