### PR TITLE
[docs] Move more prop docs into IntelliSense

### DIFF
--- a/docs/pages/api-docs/dialog.md
+++ b/docs/pages/api-docs/dialog.md
@@ -26,13 +26,13 @@ Dialogs are overlaid modal paper based components with a backdrop.
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">aria-describedby</span> | <span class="prop-type">string</span> |  | The id(s) of the element(s) that describe the dialog. |
 | <span class="prop-name">aria-labelledby</span> | <span class="prop-type">string</span> |  | The id(s) of the element(s) that label the dialog. |
-| <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">node</span> |  | Dialog children, usually the included sub-components. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | Dialog children, usually the included sub-components. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disableBackdropClick</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, clicking the backdrop will not fire the `onClose` callback. |
 | <span class="prop-name">disableEscapeKeyDown</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, hitting escape will not fire the `onClose` callback. |
 | <span class="prop-name">fullScreen</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the dialog will be full-screen |
 | <span class="prop-name">fullWidth</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the dialog stretches to `maxWidth`.<br>Notice that the dialog width grow is limited by the default margin. |
-| <span class="prop-name">maxWidth</span> | <span class="prop-type">'xs'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'lg'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;false</span> | <span class="prop-default">'sm'</span> | Determine the max-width of the dialog. The dialog width grows with the size of the screen. Set to `false` to disable `maxWidth`. |
+| <span class="prop-name">maxWidth</span> | <span class="prop-type">'lg'<br>&#124;&nbsp;'md'<br>&#124;&nbsp;'sm'<br>&#124;&nbsp;'xl'<br>&#124;&nbsp;'xs'<br>&#124;&nbsp;false</span> | <span class="prop-default">'sm'</span> | Determine the max-width of the dialog. The dialog width grows with the size of the screen. Set to `false` to disable `maxWidth`. |
 | <span class="prop-name">onBackdropClick</span> | <span class="prop-type">func</span> |  | Callback fired when the backdrop is clicked. |
 | <span class="prop-name">onClose</span> | <span class="prop-type">func</span> |  | Callback fired when the component requests to be closed.<br><br>**Signature:**<br>`function(event: object, reason: string) => void`<br>*event:* The event source of the callback.<br>*reason:* Can be: `"escapeKeyDown"`, `"backdropClick"`. |
 | <span class="prop-name">onEnter</span> | <span class="prop-type">func</span> |  | Callback fired before the dialog enters. |
@@ -47,7 +47,7 @@ Dialogs are overlaid modal paper based components with a backdrop.
 | <span class="prop-name">PaperProps</span> | <span class="prop-type">object</span> | <span class="prop-default">{}</span> | Props applied to the [`Paper`](/api/paper/) element. |
 | <span class="prop-name">scroll</span> | <span class="prop-type">'body'<br>&#124;&nbsp;'paper'</span> | <span class="prop-default">'paper'</span> | Determine the container for scrolling the dialog. |
 | <span class="prop-name">TransitionComponent</span> | <span class="prop-type">elementType</span> | <span class="prop-default">Fade</span> | The component used for the transition. [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component. |
-| <span class="prop-name">transitionDuration</span> | <span class="prop-type">number<br>&#124;&nbsp;{ enter?: number, exit?: number }</span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">transitionDuration</span> | <span class="prop-type">number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">{ enter: duration.enteringScreen, exit: duration.leavingScreen }</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 | <span class="prop-name">TransitionProps</span> | <span class="prop-type">object</span> |  | Props applied to the [`Transition`](http://reactcommunity.org/react-transition-group/transition#Transition-props) element. |
 
 The `ref` is forwarded to the root element.

--- a/docs/pages/api-docs/native-select.md
+++ b/docs/pages/api-docs/native-select.md
@@ -31,7 +31,7 @@ An alternative to `<Select native />` with a much smaller bundle size footprint.
 | <span class="prop-name">inputProps</span> | <span class="prop-type">object</span> |  | Attributes applied to the `select` element. |
 | <span class="prop-name">onChange</span> | <span class="prop-type">func</span> |  | Callback function fired when a menu item is selected.<br><br>**Signature:**<br>`function(event: object) => void`<br>*event:* The event source of the callback. You can pull out the new value by accessing `event.target.value` (string). |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The input value. The DOM API casts this to a string. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'standard'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'filled'</span> |  | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'</span> |  | The variant to use. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/select.md
+++ b/docs/pages/api-docs/select.md
@@ -45,7 +45,7 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 | <span class="prop-name">renderValue</span> | <span class="prop-type">func</span> |  | Render the selected value. You can only use it when the `native` prop is `false` (default).<br><br>**Signature:**<br>`function(value: any) => ReactNode`<br>*value:* The `value` provided to the component. |
 | <span class="prop-name">SelectDisplayProps</span> | <span class="prop-type">object</span> |  | Props applied to the clickable div element. |
 | <span class="prop-name">value</span> | <span class="prop-type">any</span> |  | The input value. Providing an empty string will select no options. This prop is required when the `native` prop is `false` (default). Set to an empty string `''` if you don't want any of the available options to be selected.<br>If the value is an object it must have reference equality with the option in order to be selected. If the value is not an object, the string representation must match with the string representation of the option in order to be selected. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'standard'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'filled'</span> | <span class="prop-default">'standard'</span> | The variant to use. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'filled'<br>&#124;&nbsp;'outlined'<br>&#124;&nbsp;'standard'</span> | <span class="prop-default">'standard'</span> | The variant to use. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/table-cell.md
+++ b/docs/pages/api-docs/table-cell.md
@@ -25,15 +25,15 @@ or otherwise a `<td>` element.
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">align</span> | <span class="prop-type">'inherit'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'center'<br>&#124;&nbsp;'right'<br>&#124;&nbsp;'justify'</span> | <span class="prop-default">'inherit'</span> | Set the text-align on the table cell content.<br>Monetary or generally number fields **should be right aligned** as that allows you to add them up quickly in your head without having to worry about decimals. |
+| <span class="prop-name">align</span> | <span class="prop-type">'center'<br>&#124;&nbsp;'inherit'<br>&#124;&nbsp;'justify'<br>&#124;&nbsp;'left'<br>&#124;&nbsp;'right'</span> | <span class="prop-default">'inherit'</span> | Set the text-align on the table cell content.<br>Monetary or generally number fields **should be right aligned** as that allows you to add them up quickly in your head without having to worry about decimals. |
 | <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The table cell contents. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">component</span> | <span class="prop-type">elementType</span> |  | The component used for the root node. Either a string to use a DOM element or a component. |
-| <span class="prop-name">padding</span> | <span class="prop-type">'default'<br>&#124;&nbsp;'checkbox'<br>&#124;&nbsp;'none'</span> |  | Sets the padding applied to the cell. By default, the Table parent component set the value (`default`). |
+| <span class="prop-name">padding</span> | <span class="prop-type">'checkbox'<br>&#124;&nbsp;'default'<br>&#124;&nbsp;'none'</span> |  | Sets the padding applied to the cell. By default, the Table parent component set the value (`default`). |
 | <span class="prop-name">scope</span> | <span class="prop-type">string</span> |  | Set scope attribute. |
-| <span class="prop-name">size</span> | <span class="prop-type">'small'<br>&#124;&nbsp;'medium'</span> |  | Specify the size of the cell. By default, the Table parent component set the value (`medium`). |
+| <span class="prop-name">size</span> | <span class="prop-type">'medium'<br>&#124;&nbsp;'small'</span> |  | Specify the size of the cell. By default, the Table parent component set the value (`medium`). |
 | <span class="prop-name">sortDirection</span> | <span class="prop-type">'asc'<br>&#124;&nbsp;'desc'<br>&#124;&nbsp;false</span> |  | Set aria-sort direction. |
-| <span class="prop-name">variant</span> | <span class="prop-type">'head'<br>&#124;&nbsp;'body'<br>&#124;&nbsp;'footer'</span> |  | Specify the cell type. By default, the TableHead, TableBody or TableFooter parent component set the value. |
+| <span class="prop-name">variant</span> | <span class="prop-type">'body'<br>&#124;&nbsp;'footer'<br>&#124;&nbsp;'head'</span> |  | Specify the cell type. By default, the TableHead, TableBody or TableFooter parent component set the value. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/textarea-autosize.md
+++ b/docs/pages/api-docs/textarea-autosize.md
@@ -24,9 +24,9 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name">rows</span> | <span class="prop-type">string<br>&#124;&nbsp;number</span> |  | Use `rowsMin` instead. The prop will be removed in v5. |
-| <span class="prop-name">rowsMax</span> | <span class="prop-type">string<br>&#124;&nbsp;number</span> |  | Maximum number of rows to display. |
-| <span class="prop-name">rowsMin</span> | <span class="prop-type">string<br>&#124;&nbsp;number</span> | <span class="prop-default">1</span> | Minimum number of rows to display. |
+| <span class="prop-name">rows</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Use `rowsMin` instead. The prop will be removed in v5. |
+| <span class="prop-name">rowsMax</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> |  | Maximum number of rows to display. |
+| <span class="prop-name">rowsMin</span> | <span class="prop-type">number<br>&#124;&nbsp;string</span> | <span class="prop-default">1</span> | Minimum number of rows to display. |
 
 The `ref` is forwarded to the root element.
 

--- a/docs/pages/api-docs/zoom.md
+++ b/docs/pages/api-docs/zoom.md
@@ -28,7 +28,7 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 |:-----|:-----|:--------|:------------|
 | <span class="prop-name">children</span> | <span class="prop-type">element</span> |  | A single child content element. |
 | <span class="prop-name">in</span> | <span class="prop-type">bool</span> |  | If `true`, the component will transition in. |
-| <span class="prop-name">timeout</span> | <span class="prop-type">number<br>&#124;&nbsp;{ enter?: number, exit?: number }</span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
+| <span class="prop-name">timeout</span> | <span class="prop-type">number<br>&#124;&nbsp;{ appear?: number, enter?: number, exit?: number }</span> | <span class="prop-default">{  enter: duration.enteringScreen,  exit: duration.leavingScreen,}</span> | The duration for the transition, in milliseconds. You may specify a single timeout for all transitions, or individually with an object. |
 
 The `ref` is forwarded to the root element.
 

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "ts-node": "^8.3.0",
     "tslint": "5.14.0",
     "typescript": "^3.8.2",
-    "typescript-to-proptypes": "^1.4.0",
+    "typescript-to-proptypes": "^1.4.2",
     "unist-util-visit": "^2.0.2",
     "vrtest-mui": "^0.3.3",
     "webpack": "^4.41.0",

--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -6,15 +6,111 @@ import { TransitionHandlerProps, TransitionProps } from '../transitions/transiti
 
 export interface DialogProps
   extends StandardProps<ModalProps & Partial<TransitionHandlerProps>, DialogClassKey, 'children'> {
-  children?: React.ReactNode;
+  /**
+   * The id(s) of the element(s) that describe the dialog.
+   */
+  'aria-describedby'?: string;
+  /**
+   * The id(s) of the element(s) that label the dialog.
+   */
+  'aria-labelledby'?: string;
+  /**
+   * Dialog children, usually the included sub-components.
+   */
+  children: React.ReactNode;
+  /**
+   * If `true`, clicking the backdrop will not fire the `onClose` callback.
+   */
+  disableBackdropClick?: boolean;
+  /**
+   * If `true`, hitting escape will not fire the `onClose` callback.
+   */
+  disableEscapeKeyDown?: boolean;
+  /**
+   * If `true`, the dialog will be full-screen
+   */
   fullScreen?: boolean;
+  /**
+   * If `true`, the dialog stretches to `maxWidth`.
+   *
+   * Notice that the dialog width grow is limited by the default margin.
+   */
   fullWidth?: boolean;
+  /**
+   * Determine the max-width of the dialog.
+   * The dialog width grows with the size of the screen.
+   * Set to `false` to disable `maxWidth`.
+   */
   maxWidth?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | false;
+  /**
+   * Callback fired when the backdrop is clicked.
+   */
+  onBackdropClick?: ModalProps['onBackdropClick'];
+  /**
+   * Callback fired when the component requests to be closed.
+   *
+   * @param {object} event The event source of the callback.
+   * @param {string} reason Can be: `"escapeKeyDown"`, `"backdropClick"`.
+   */
+  onClose?: ModalProps['onClose'];
+  /**
+   * Callback fired before the dialog enters.
+   */
+  onEnter?: TransitionHandlerProps['onEnter'];
+  /**
+   * Callback fired when the dialog has entered.
+   */
+  onEntered?: TransitionHandlerProps['onEntered'];
+  /**
+   * Callback fired when the dialog is entering.
+   */
+  onEntering?: TransitionHandlerProps['onEntering'];
+  /**
+   * Callback fired when the escape key is pressed,
+   * `disableKeyboard` is false and the modal is in focus.
+   */
+  onEscapeKeyDown?: ModalProps['onEscapeKeyDown'];
+  /**
+   * Callback fired before the dialog exits.
+   */
+  onExit?: TransitionHandlerProps['onExit'];
+  /**
+   * Callback fired when the dialog has exited.
+   */
+  onExited?: TransitionHandlerProps['onExited'];
+  /**
+   * Callback fired when the dialog is exiting.
+   */
+  onExiting?: TransitionHandlerProps['onExiting'];
+  /**
+   * If `true`, the Dialog is open.
+   */
+  open: ModalProps['open'];
+  /**
+   * The component used to render the body of the dialog.
+   */
   PaperComponent?: React.ComponentType<PaperProps>;
+  /**
+   * Props applied to the [`Paper`](/api/paper/) element.
+   */
   PaperProps?: Partial<PaperProps>;
+  /**
+   * Determine the container for scrolling the dialog.
+   */
   scroll?: 'body' | 'paper';
+  /**
+   * The component used for the transition.
+   * [Follow this guide](/components/transitions/#transitioncomponent-prop) to learn more about the requirements for this component.
+   */
   TransitionComponent?: React.ComponentType<TransitionProps>;
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
   transitionDuration?: TransitionProps['timeout'];
+  /**
+   * Props applied to the [`Transition`](http://reactcommunity.org/react-transition-group/transition#Transition-props) element.
+   */
   TransitionProps?: TransitionProps;
 }
 
@@ -46,6 +142,4 @@ export type DialogClassKey =
  * - [Dialog API](https://material-ui.com/api/dialog/)
  * - inherits [Modal API](https://material-ui.com/api/modal/)
  */
-declare const Dialog: React.ComponentType<DialogProps>;
-
-export default Dialog;
+export default function Dialog(props: DialogProps): JSX.Element;

--- a/packages/material-ui/src/Dialog/Dialog.js
+++ b/packages/material-ui/src/Dialog/Dialog.js
@@ -264,6 +264,10 @@ const Dialog = React.forwardRef(function Dialog(props, ref) {
 });
 
 Dialog.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The id(s) of the element(s) that describe the dialog.
    */
@@ -279,12 +283,12 @@ Dialog.propTypes = {
   /**
    * Dialog children, usually the included sub-components.
    */
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -312,7 +316,7 @@ Dialog.propTypes = {
    * The dialog width grows with the size of the screen.
    * Set to `false` to disable `maxWidth`.
    */
-  maxWidth: PropTypes.oneOf(['xs', 'sm', 'md', 'lg', 'xl', false]),
+  maxWidth: PropTypes.oneOf(['lg', 'md', 'sm', 'xl', 'xs', false]),
   /**
    * Callback fired when the backdrop is clicked.
    */
@@ -380,7 +384,11 @@ Dialog.propTypes = {
    */
   transitionDuration: PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
   ]),
   /**
    * Props applied to the [`Transition`](http://reactcommunity.org/react-transition-group/transition#Transition-props) element.

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.d.ts
@@ -1,7 +1,12 @@
 import { StandardProps } from '..';
 
 export interface ListItemSecondaryActionProps
-  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ListItemSecondaryActionClassKey> {}
+  extends StandardProps<React.HTMLAttributes<HTMLDivElement>, ListItemSecondaryActionClassKey> {
+  /**
+   * The content of the component, normally an `IconButton` or selection control.
+   */
+  children?: React.ReactNode;
+}
 
 export type ListItemSecondaryActionClassKey = 'root';
 
@@ -15,6 +20,4 @@ export type ListItemSecondaryActionClassKey = 'root';
  *
  * - [ListItemSecondaryAction API](https://material-ui.com/api/list-item-secondary-action/)
  */
-declare const ListItemSecondaryAction: React.ComponentType<ListItemSecondaryActionProps>;
-
-export default ListItemSecondaryAction;
+export default function ListItemSecondaryAction(props: ListItemSecondaryActionProps): JSX.Element;

--- a/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js
+++ b/packages/material-ui/src/ListItemSecondaryAction/ListItemSecondaryAction.js
@@ -23,6 +23,10 @@ const ListItemSecondaryAction = React.forwardRef(function ListItemSecondaryActio
 });
 
 ListItemSecondaryAction.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The content of the component, normally an `IconButton` or selection control.
    */
@@ -31,7 +35,7 @@ ListItemSecondaryAction.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.d.ts
@@ -4,11 +4,40 @@ import { InputProps } from '../Input';
 import { NativeSelectInputProps } from './NativeSelectInput';
 
 export interface NativeSelectProps
-  extends StandardProps<InputProps, NativeSelectClassKey, 'value' | 'onChange'>,
-    Pick<NativeSelectInputProps, 'onChange'> {
+  extends StandardProps<InputProps, NativeSelectClassKey, 'inputProps' | 'value' | 'onChange'> {
+  /**
+   * The option elements to populate the select with.
+   * Can be some `<option>` elements.
+   */
+  children?: React.ReactNode;
+  /**
+   * The icon that displays the arrow.
+   */
   IconComponent?: React.ElementType;
-  input?: React.ReactNode;
+  /**
+   * An `Input` element; does not have to be a material-ui specific `Input`.
+   */
+  input?: React.ReactElement<any, any>;
+  /**
+   * Attributes applied to the `select` element.
+   */
+  inputProps?: NativeSelectInputProps;
+  /**
+   * Callback function fired when a menu item is selected.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (string).
+   * @document
+   */
+  onChange?: NativeSelectInputProps['onChange'];
+  /**
+   * The input value. The DOM API casts this to a string.
+   * @document
+   */
   value?: unknown;
+  /**
+   * The variant to use.
+   */
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
@@ -34,6 +63,4 @@ export type NativeSelectClassKey =
  * - [NativeSelect API](https://material-ui.com/api/native-select/)
  * - inherits [Input API](https://material-ui.com/api/input/)
  */
-declare const NativeSelect: React.ComponentType<NativeSelectProps>;
-
-export default NativeSelect;
+export default function NativeSelect(props: NativeSelectProps): JSX.Element;

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -166,7 +166,7 @@ NativeSelect.propTypes = {
   /**
    * The input value. The DOM API casts this to a string.
    */
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any,
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/NativeSelect/NativeSelect.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.js
@@ -130,6 +130,10 @@ const NativeSelect = React.forwardRef(function NativeSelect(props, ref) {
 });
 
 NativeSelect.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The option elements to populate the select with.
    * Can be some `<option>` elements.
@@ -139,7 +143,7 @@ NativeSelect.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * The icon that displays the arrow.
    */
@@ -162,11 +166,11 @@ NativeSelect.propTypes = {
   /**
    * The input value. The DOM API casts this to a string.
    */
-  value: PropTypes.any,
+  value: PropTypes.any.isRequired,
   /**
    * The variant to use.
    */
-  variant: PropTypes.oneOf(['standard', 'outlined', 'filled']),
+  variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
 };
 
 NativeSelect.muiName = 'Select';

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.d.ts
@@ -1,14 +1,9 @@
 import * as React from 'react';
 
-export interface NativeSelectInputProps {
+export interface NativeSelectInputProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   disabled?: boolean;
   IconComponent?: React.ElementType;
-  inputRef?: (
-    ref: HTMLSelectElement | { node: HTMLInputElement; value: NativeSelectInputProps['value'] },
-  ) => void;
-  name?: string;
-  onChange?: (event: React.ChangeEvent<HTMLSelectElement>, child: React.ReactNode) => void;
-  value?: unknown;
+  inputRef?: React.Ref<HTMLSelectElement>;
   variant?: 'standard' | 'outlined' | 'filled';
 }
 

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -21,6 +21,7 @@ export interface SelectProps
   children?: React.ReactNode;
   /**
    * The default element value. Use when the component is not controlled.
+   * @document
    */
   defaultValue?: unknown;
   /**
@@ -74,6 +75,7 @@ export interface SelectProps
    * @param {object} event The event source of the callback.
    * You can pull out the new value by accessing `event.target.value` (any).
    * @param {object} [child] The react element that was selected when `native` is `false` (default).
+   * @document
    */
   onChange?: SelectInputProps['onChange'];
   /**

--- a/packages/material-ui/src/Select/Select.d.ts
+++ b/packages/material-ui/src/Select/Select.d.ts
@@ -7,22 +7,119 @@ import { SelectInputProps } from './SelectInput';
 export interface SelectProps
   extends StandardProps<InputProps, SelectClassKey, 'value' | 'onChange'>,
     Pick<SelectInputProps, 'onChange'> {
+  /**
+   * If `true`, the width of the popover will automatically be set according to the items inside the
+   * menu, otherwise it will be at least the width of the select input.
+   */
   autoWidth?: boolean;
+  /**
+   * The option elements to populate the select with.
+   * Can be some `MenuItem` when `native` is false and `option` when `native` is true.
+   *
+   * ⚠️The `MenuItem` elements **must** be direct descendants when `native` is false.
+   */
+  children?: React.ReactNode;
+  /**
+   * The default element value. Use when the component is not controlled.
+   */
+  defaultValue?: unknown;
+  /**
+   * If `true`, a value is displayed even if no items are selected.
+   *
+   * In order to display a meaningful value, a function should be passed to the `renderValue` prop which returns the value to be displayed when no items are selected.
+   * You can only use it when the `native` prop is `false` (default).
+   */
   displayEmpty?: boolean;
+  /**
+   * The icon that displays the arrow.
+   */
   IconComponent?: React.ElementType;
-  input?: React.ReactNode;
+  /**
+   * An `Input` element; does not have to be a material-ui specific `Input`.
+   */
+  input?: React.ReactElement<any, any>;
+  /**
+   * [Attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#Attributes) applied to the `input` element.
+   * When `native` is `true`, the attributes are applied on the `select` element.
+   */
+  inputProps?: InputProps['inputProps'];
+  /**
+   * See [OutlinedInput#label](/api/outlined-input/#props)
+   */
   label?: React.ReactNode;
+  /**
+   * The ID of an element that acts as an additional label. The Select will
+   * be labelled by the additional label and the selected value.
+   */
   labelId?: string;
+  /**
+   * See [OutlinedInput#label](/api/outlined-input/#props)
+   */
   labelWidth?: number;
+  /**
+   * Props applied to the [`Menu`](/api/menu/) element.
+   */
   MenuProps?: Partial<MenuProps>;
+  /**
+   * If `true`, `value` must be an array and the menu will support multiple selections.
+   */
   multiple?: boolean;
+  /**
+   * If `true`, the component will be using a native `select` element.
+   */
   native?: boolean;
+  /**
+   * Callback function fired when a menu item is selected.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (any).
+   * @param {object} [child] The react element that was selected when `native` is `false` (default).
+   */
+  onChange?: SelectInputProps['onChange'];
+  /**
+   * Callback fired when the component requests to be closed.
+   * Use in controlled mode (see open).
+   *
+   * @param {object} event The event source of the callback.
+   */
   onClose?: (event: React.ChangeEvent<{}>) => void;
+  /**
+   * Callback fired when the component requests to be opened.
+   * Use in controlled mode (see open).
+   *
+   * @param {object} event The event source of the callback.
+   */
   onOpen?: (event: React.ChangeEvent<{}>) => void;
+  /**
+   * Control `select` open state.
+   * You can only use it when the `native` prop is `false` (default).
+   */
   open?: boolean;
+  /**
+   * Render the selected value.
+   * You can only use it when the `native` prop is `false` (default).
+   *
+   * @param {any} value The `value` provided to the component.
+   * @returns {ReactNode}
+   */
   renderValue?: (value: SelectProps['value']) => React.ReactNode;
+  /**
+   * Props applied to the clickable div element.
+   */
   SelectDisplayProps?: React.HTMLAttributes<HTMLDivElement>;
+  /**
+   * The input value. Providing an empty string will select no options.
+   * This prop is required when the `native` prop is `false` (default).
+   * Set to an empty string `''` if you don't want any of the available options to be selected.
+   *
+   * If the value is an object it must have reference equality with the option in order to be selected.
+   * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
+   * @document
+   */
   value?: unknown;
+  /**
+   * The variant to use.
+   */
   variant?: 'standard' | 'outlined' | 'filled';
 }
 
@@ -49,6 +146,4 @@ export type SelectClassKey =
  * - [Select API](https://material-ui.com/api/select/)
  * - inherits [Input API](https://material-ui.com/api/input/)
  */
-declare const Select: React.ComponentType<SelectProps>;
-
-export default Select;
+export default function Select(props: SelectProps): JSX.Element;

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -119,6 +119,10 @@ Select.propTypes = {
    */
   classes: PropTypes.object,
   /**
+   * The default element value. Use when the component is not controlled.
+   */
+  defaultValue: PropTypes.any.isRequired,
+  /**
    * If `true`, a value is displayed even if no items are selected.
    *
    * In order to display a meaningful value, a function should be passed to the `renderValue` prop which returns the value to be displayed when no items are selected.
@@ -167,6 +171,14 @@ Select.propTypes = {
    * If `true`, the component will be using a native `select` element.
    */
   native: PropTypes.bool,
+  /**
+   * Callback function fired when a menu item is selected.
+   *
+   * @param {object} event The event source of the callback.
+   * You can pull out the new value by accessing `event.target.value` (any).
+   * @param {object} [child] The react element that was selected when `native` is `false` (default).
+   */
+  onChange: PropTypes.func,
   /**
    * Callback fired when the component requests to be closed.
    * Use in controlled mode (see open).

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -121,7 +121,7 @@ Select.propTypes = {
   /**
    * The default element value. Use when the component is not controlled.
    */
-  defaultValue: PropTypes.any.isRequired,
+  defaultValue: PropTypes.any,
   /**
    * If `true`, a value is displayed even if no items are selected.
    *
@@ -218,7 +218,7 @@ Select.propTypes = {
    * If the value is an object it must have reference equality with the option in order to be selected.
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
    */
-  value: PropTypes.any.isRequired,
+  value: PropTypes.any,
   /**
    * The variant to use.
    */

--- a/packages/material-ui/src/Select/Select.js
+++ b/packages/material-ui/src/Select/Select.js
@@ -97,6 +97,10 @@ const Select = React.forwardRef(function Select(props, ref) {
 });
 
 Select.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * If `true`, the width of the popover will automatically be set according to the items inside the
    * menu, otherwise it will be at least the width of the select input.
@@ -113,11 +117,7 @@ Select.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
-  /**
-   * The default element value. Use when the component is not controlled.
-   */
-  defaultValue: PropTypes.any,
+  classes: PropTypes.object,
   /**
    * If `true`, a value is displayed even if no items are selected.
    *
@@ -168,14 +168,6 @@ Select.propTypes = {
    */
   native: PropTypes.bool,
   /**
-   * Callback function fired when a menu item is selected.
-   *
-   * @param {object} event The event source of the callback.
-   * You can pull out the new value by accessing `event.target.value` (any).
-   * @param {object} [child] The react element that was selected when `native` is `false` (default).
-   */
-  onChange: PropTypes.func,
-  /**
    * Callback fired when the component requests to be closed.
    * Use in controlled mode (see open).
    *
@@ -214,11 +206,11 @@ Select.propTypes = {
    * If the value is an object it must have reference equality with the option in order to be selected.
    * If the value is not an object, the string representation must match with the string representation of the option in order to be selected.
    */
-  value: PropTypes.any,
+  value: PropTypes.any.isRequired,
   /**
    * The variant to use.
    */
-  variant: PropTypes.oneOf(['standard', 'outlined', 'filled']),
+  variant: PropTypes.oneOf(['filled', 'outlined', 'standard']),
 };
 
 Select.muiName = 'Select';

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.d.ts
@@ -2,9 +2,20 @@ import * as React from 'react';
 import { StandardProps } from '..';
 import { PaperProps } from '../Paper';
 
-export interface SnackbarContentProps extends StandardProps<PaperProps, SnackbarContentClassKey> {
+export interface SnackbarContentProps
+  extends StandardProps<PaperProps, SnackbarContentClassKey, 'children'> {
+  /**
+   * The action to display. It renders after the message, at the end of the snackbar.
+   */
   action?: React.ReactNode;
+  /**
+   * The message to display.
+   */
   message?: React.ReactNode;
+  /**
+   * The ARIA role attribute of the element.
+   */
+  role?: PaperProps['role'];
 }
 
 export type SnackbarContentClassKey = 'root' | 'message' | 'action';
@@ -20,6 +31,4 @@ export type SnackbarContentClassKey = 'root' | 'message' | 'action';
  * - [SnackbarContent API](https://material-ui.com/api/snackbar-content/)
  * - inherits [Paper API](https://material-ui.com/api/paper/)
  */
-declare const SnackbarContent: React.ComponentType<SnackbarContentProps>;
-
-export default SnackbarContent;
+export default function SnackbarContent(props: SnackbarContentProps): JSX.Element;

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.js
@@ -60,6 +60,10 @@ const SnackbarContent = React.forwardRef(function SnackbarContent(props, ref) {
 });
 
 SnackbarContent.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * The action to display. It renders after the message, at the end of the snackbar.
    */
@@ -68,7 +72,7 @@ SnackbarContent.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */

--- a/packages/material-ui/src/Step/Step.d.ts
+++ b/packages/material-ui/src/Step/Step.d.ts
@@ -4,16 +4,27 @@ import { Orientation } from '../Stepper';
 
 export interface StepProps
   extends StandardProps<React.HTMLAttributes<HTMLDivElement>, StepClasskey> {
+  /**
+   * Sets the step as active. Is passed to child components.
+   */
   active?: boolean;
-  alternativeLabel?: boolean;
+  /**
+   * Should be `Step` sub-components such as `StepLabel`, `StepContent`.
+   */
   children?: React.ReactNode;
+  /**
+   * Mark the step as completed. Is passed to child components.
+   */
   completed?: boolean;
-  connector?: React.ReactElement;
+  /**
+   * Mark the step as disabled, will also disable the button if
+   * `StepButton` is a child of `Step`. Is passed to child components.
+   */
   disabled?: boolean;
+  /**
+   * Expand the step.
+   */
   expanded?: boolean;
-  index?: number;
-  last?: boolean;
-  orientation?: Orientation;
 }
 
 export type StepClasskey = 'root' | 'horizontal' | 'vertical' | 'alternativeLabel' | 'completed';
@@ -28,6 +39,4 @@ export type StepClasskey = 'root' | 'horizontal' | 'vertical' | 'alternativeLabe
  *
  * - [Step API](https://material-ui.com/api/step/)
  */
-declare const Step: React.ComponentType<StepProps>;
-
-export default Step;
+export default function Step(props: StepProps): JSX.Element;

--- a/packages/material-ui/src/Step/Step.js
+++ b/packages/material-ui/src/Step/Step.js
@@ -26,16 +26,21 @@ export const styles = {
 const Step = React.forwardRef(function Step(props, ref) {
   const {
     active = false,
+    // eslint-disable-next-line react/prop-types
     alternativeLabel,
     children,
     classes,
     className,
     completed = false,
+    // eslint-disable-next-line react/prop-types
     connector,
     disabled = false,
     expanded = false,
+    // eslint-disable-next-line react/prop-types
     index,
+    // eslint-disable-next-line react/prop-types
     last,
+    // eslint-disable-next-line react/prop-types
     orientation,
     ...other
   } = props;
@@ -65,6 +70,7 @@ const Step = React.forwardRef(function Step(props, ref) {
           completed,
           disabled,
         })}
+
       {React.Children.map(children, (child) => {
         if (!React.isValidElement(child)) {
           return null;
@@ -98,15 +104,14 @@ const Step = React.forwardRef(function Step(props, ref) {
 });
 
 Step.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * Sets the step as active. Is passed to child components.
    */
   active: PropTypes.bool,
-  /**
-   * @ignore
-   * Set internally by Stepper when it's supplied with the alternativeLabel property.
-   */
-  alternativeLabel: PropTypes.bool,
   /**
    * Should be `Step` sub-components such as `StepLabel`, `StepContent`.
    */
@@ -115,7 +120,7 @@ Step.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -125,11 +130,6 @@ Step.propTypes = {
    */
   completed: PropTypes.bool,
   /**
-   * @ignore
-   * Passed down from Stepper if alternativeLabel is also set.
-   */
-  connector: PropTypes.element,
-  /**
    * Mark the step as disabled, will also disable the button if
    * `StepButton` is a child of `Step`. Is passed to child components.
    */
@@ -138,19 +138,6 @@ Step.propTypes = {
    * Expand the step.
    */
   expanded: PropTypes.bool,
-  /**
-   * @ignore
-   * Used internally for numbering.
-   */
-  index: PropTypes.number,
-  /**
-   * @ignore
-   */
-  last: PropTypes.bool,
-  /**
-   * @ignore
-   */
-  orientation: PropTypes.oneOf(['horizontal', 'vertical']),
 };
 
 export default withStyles(styles, { name: 'MuiStep' })(Step);

--- a/packages/material-ui/src/TableCell/TableCell.d.ts
+++ b/packages/material-ui/src/TableCell/TableCell.d.ts
@@ -14,11 +14,44 @@ export { Padding, Size };
  */
 export interface TableCellProps
   extends StandardProps<TableCellBaseProps, TableCellClassKey, 'align'> {
+  /**
+   * Set the text-align on the table cell content.
+   *
+   * Monetary or generally number fields **should be right aligned** as that allows
+   * you to add them up quickly in your head without having to worry about decimals.
+   */
   align?: 'inherit' | 'left' | 'center' | 'right' | 'justify';
+  /**
+   * The table cell contents.
+   */
+  children?: React.ReactNode;
+  /**
+   * The component used for the root node.
+   * Either a string to use a DOM element or a component.
+   */
   component?: React.ElementType<TableCellBaseProps>;
+  /**
+   * Sets the padding applied to the cell.
+   * By default, the Table parent component set the value (`default`).
+   */
   padding?: Padding;
+  /**
+   * Set scope attribute.
+   */
+  scope?: TableCellBaseProps['scope'];
+  /**
+   * Specify the size of the cell.
+   * By default, the Table parent component set the value (`medium`).
+   */
   size?: Size;
+  /**
+   * Set aria-sort direction.
+   */
   sortDirection?: SortDirection;
+  /**
+   * Specify the cell type.
+   * By default, the TableHead, TableBody or TableFooter parent component set the value.
+   */
   variant?: 'head' | 'body' | 'footer';
 }
 
@@ -52,6 +85,4 @@ export type TableCellClassKey =
  *
  * - [TableCell API](https://material-ui.com/api/table-cell/)
  */
-declare const TableCell: React.ComponentType<TableCellProps>;
-
-export default TableCell;
+export default function TableCell(props: TableCellProps): JSX.Element;

--- a/packages/material-ui/src/TableCell/TableCell.js
+++ b/packages/material-ui/src/TableCell/TableCell.js
@@ -164,13 +164,17 @@ const TableCell = React.forwardRef(function TableCell(props, ref) {
 });
 
 TableCell.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * Set the text-align on the table cell content.
    *
    * Monetary or generally number fields **should be right aligned** as that allows
    * you to add them up quickly in your head without having to worry about decimals.
    */
-  align: PropTypes.oneOf(['inherit', 'left', 'center', 'right', 'justify']),
+  align: PropTypes.oneOf(['center', 'inherit', 'justify', 'left', 'right']),
   /**
    * The table cell contents.
    */
@@ -179,7 +183,7 @@ TableCell.propTypes = {
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.
    */
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   /**
    * @ignore
    */
@@ -193,7 +197,7 @@ TableCell.propTypes = {
    * Sets the padding applied to the cell.
    * By default, the Table parent component set the value (`default`).
    */
-  padding: PropTypes.oneOf(['default', 'checkbox', 'none']),
+  padding: PropTypes.oneOf(['checkbox', 'default', 'none']),
   /**
    * Set scope attribute.
    */
@@ -202,7 +206,7 @@ TableCell.propTypes = {
    * Specify the size of the cell.
    * By default, the Table parent component set the value (`medium`).
    */
-  size: PropTypes.oneOf(['small', 'medium']),
+  size: PropTypes.oneOf(['medium', 'small']),
   /**
    * Set aria-sort direction.
    */
@@ -211,7 +215,7 @@ TableCell.propTypes = {
    * Specify the cell type.
    * By default, the TableHead, TableBody or TableFooter parent component set the value.
    */
-  variant: PropTypes.oneOf(['head', 'body', 'footer']),
+  variant: PropTypes.oneOf(['body', 'footer', 'head']),
 };
 
 export default withStyles(styles, { name: 'MuiTableCell' })(TableCell);

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.d.ts
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.d.ts
@@ -1,7 +1,21 @@
 import * as React from 'react';
 
-export interface TextareaAutosizeProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+export interface TextareaAutosizeProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'children' | 'rows'> {
+  ref?: React.Ref<HTMLTextAreaElement>;
+  /**
+   * Use `rowsMin` instead. The prop will be removed in v5.
+   *
+   * @deprecated
+   */
+  rows?: string | number;
+  /**
+   * Maximum number of rows to display.
+   */
   rowsMax?: string | number;
+  /**
+   * Minimum number of rows to display.
+   */
   rowsMin?: string | number;
 }
 
@@ -15,10 +29,4 @@ export interface TextareaAutosizeProps extends React.TextareaHTMLAttributes<HTML
  *
  * - [TextareaAutosize API](https://material-ui.com/api/textarea-autosize/)
  */
-declare const TextareaAutosize: React.ComponentType<
-  TextareaAutosizeProps & {
-    ref?: React.Ref<HTMLTextAreaElement>;
-  }
->;
-
-export default TextareaAutosize;
+export default function TextareaAutosize(props: TextareaAutosizeProps): JSX.Element;

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -169,6 +169,10 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
 });
 
 TextareaAutosize.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * @ignore
    */
@@ -186,15 +190,15 @@ TextareaAutosize.propTypes = {
    *
    * @deprecated
    */
-  rows: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  rows: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * Maximum number of rows to display.
    */
-  rowsMax: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  rowsMax: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * Minimum number of rows to display.
    */
-  rowsMin: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  rowsMin: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /**
    * @ignore
    */
@@ -202,7 +206,11 @@ TextareaAutosize.propTypes = {
   /**
    * @ignore
    */
-  value: PropTypes.any,
+  value: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+    PropTypes.string,
+  ]),
 };
 
 export default TextareaAutosize;

--- a/packages/material-ui/src/Zoom/Zoom.d.ts
+++ b/packages/material-ui/src/Zoom/Zoom.d.ts
@@ -3,8 +3,26 @@ import { Theme } from '../styles/createMuiTheme';
 import { TransitionProps } from '../transitions/transition';
 
 export interface ZoomProps extends TransitionProps {
+  /**
+   * A single child content element.
+   */
+  children?: React.ReactElement<any, any>;
+  /**
+   * If `true`, the component will transition in.
+   */
+  in?: boolean;
+  /**
+   */
+  onEnter?: TransitionProps['onEnter'];
+  /**
+   */
+  onExit?: TransitionProps['onExit'];
   ref?: React.Ref<unknown>;
-  theme?: Theme;
+  /**
+   * The duration for the transition, in milliseconds.
+   * You may specify a single timeout for all transitions, or individually with an object.
+   */
+  timeout?: TransitionProps['timeout'];
 }
 
 /**
@@ -20,6 +38,4 @@ export interface ZoomProps extends TransitionProps {
  * - [Zoom API](https://material-ui.com/api/zoom/)
  * - inherits [Transition API](https://reactcommunity.org/react-transition-group/transition#Transition-props)
  */
-declare const Zoom: React.ComponentType<ZoomProps>;
-
-export default Zoom;
+export default function Zoom(props: ZoomProps): JSX.Element;

--- a/packages/material-ui/src/Zoom/Zoom.js
+++ b/packages/material-ui/src/Zoom/Zoom.js
@@ -48,6 +48,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
         mode: 'enter',
       },
     );
+
     node.style.webkitTransition = theme.transitions.create('transform', transitionProps);
     node.style.transition = theme.transitions.create('transform', transitionProps);
 
@@ -63,6 +64,7 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
         mode: 'exit',
       },
     );
+
     node.style.webkitTransition = theme.transitions.create('transform', transitionProps);
     node.style.transition = theme.transitions.create('transform', transitionProps);
 
@@ -98,6 +100,10 @@ const Zoom = React.forwardRef(function Zoom(props, ref) {
 });
 
 Zoom.propTypes = {
+  // ----------------------------- Warning --------------------------------
+  // | These PropTypes are generated from the TypeScript type definitions |
+  // |     To update them edit the d.ts file and run "yarn proptypes"     |
+  // ----------------------------------------------------------------------
   /**
    * A single child content element.
    */
@@ -124,7 +130,11 @@ Zoom.propTypes = {
    */
   timeout: PropTypes.oneOfType([
     PropTypes.number,
-    PropTypes.shape({ enter: PropTypes.number, exit: PropTypes.number }),
+    PropTypes.shape({
+      appear: PropTypes.number,
+      enter: PropTypes.number,
+      exit: PropTypes.number,
+    }),
   ]),
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16020,10 +16020,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-to-proptypes@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/typescript-to-proptypes/-/typescript-to-proptypes-1.4.0.tgz#6253e85b4640a5a1829c3c6bc92a3941062621b2"
-  integrity sha512-kGatNmhRV1jjwKCxzo0ohoQZCYqfY3pP9Zzskq02LzaKdIrlh6eLyTk9ucBw5eIWyq5ZoavxXPkRreVFUp9zGw==
+typescript-to-proptypes@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/typescript-to-proptypes/-/typescript-to-proptypes-1.4.2.tgz#ccc0d8844043a35bc00ce5eed1cbe5083a737b77"
+  integrity sha512-tEJcKj73nsJebMl69Cn2DS4MDf4GYl80Gh9kQdF2YCtinXCEqd4w8BsIgF4wShQKRqm7ApG4qP1qJovCdMNl6w==
   dependencies:
     "@babel/core" "^7.5.4"
     "@babel/plugin-syntax-class-properties" "^7.2.0"


### PR DESCRIPTION
Includes the following fixes to TypeScript types:
- `NativeSelect` `input` only allows `ReactElements` not just any `ReactNode`
- `NativeSelect` `inputProps` now allows all `<select>` attributes

Blocked until new release of typescript-to-proptypes