### PR TITLE
[docs] Update v0 wording to indicate that v1 was already released

### DIFF
--- a/docs/src/app/components/Master.js
+++ b/docs/src/app/components/Master.js
@@ -210,7 +210,7 @@ class Master extends Component {
               Material-UI v1
             </span>
           </a>
-          &nbsp; is coming! We &nbsp;
+          &nbsp; is here! We &nbsp;
           <a
             style={prepareStyles(styles.v1Link)}
             href="https://github.com/mui-org/material-ui#should-i-start-with-v1-beta"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Material UI v0 doc still says that v1 is coming. Since v1 has already been released, the doc should reflect that.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
