### PR TITLE
[docs] Update v3 wording to indicate that v4 was already released

### DIFF
--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -206,7 +206,7 @@ class AppFrame extends React.Component {
                   variant="body2"
                   noWrap
                 >
-                  {'Aww yeah, Material-UI v4 is coming!'}
+                  {'Aww yeah, Material-UI v4 is here!'}
                 </Link>
                 <Toolbar>
                   <IconButton


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Material UI v3 doc still says that v4 is coming. Since v4 has already been released, the doc should reflect that.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
