### PR TITLE
[SvgIcon] Remove wrong role

### DIFF
--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -80,7 +80,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(props, ref) {
       viewBox={viewBox}
       color={htmlColor}
       aria-hidden={titleAccess ? undefined : 'true'}
-      role={titleAccess ? 'img' : 'presentation'}
+      role={titleAccess ? 'img' : undefined}
       ref={ref}
       {...other}
     >


### PR DESCRIPTION
The possible roles are:

<img width="791" alt="Capture d’écran 2020-03-28 à 00 02 19" src="https://user-images.githubusercontent.com/3165635/77807277-a3d89f00-7087-11ea-9ed4-91eaad0574f5.png">

https://www.w3.org/TR/html-aria/#svg

This fix:

<img width="602" alt="Capture d’écran 2020-03-28 à 00 04 45" src="https://user-images.githubusercontent.com/3165635/77807325-c4085e00-7087-11ea-870f-37d1429f17af.png">

https://validator.w3.org/nu/?doc=https%3A%2F%2Fmaterial-ui.com%2F