### PR TITLE
[TreeView] Don't move focus when pressing a modifier key + letter

### DIFF
--- a/packages/material-ui-lab/src/TreeItem/TreeItem.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.js
@@ -195,14 +195,6 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
     }
   };
 
-  const printableCharacter = (event, key) => {
-    if (isPrintableCharacter(key)) {
-      focusByFirstCharacter(nodeId, key);
-      return true;
-    }
-    return false;
-  };
-
   const handleNextArrow = (event) => {
     if (expandable) {
       if (expanded) {
@@ -306,8 +298,9 @@ const TreeItem = React.forwardRef(function TreeItem(props, ref) {
           flag = true;
         } else if (multiSelect && ctrlPressed && key.toLowerCase() === 'a') {
           flag = selectAllNodes(event);
-        } else if (isPrintableCharacter(key)) {
-          flag = printableCharacter(event, key);
+        } else if (!ctrlPressed && !event.shiftKey && isPrintableCharacter(key)) {
+          focusByFirstCharacter(nodeId, key);
+          flag = true;
         }
     }
 

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -651,6 +651,28 @@ describe('<TreeItem />', () => {
           fireEvent.keyDown(document.activeElement, { key: 't' });
           expect(getByTestId('two')).to.have.focus;
         });
+
+        it('should not move focus when pressing a modifier key + letter', () => {
+          const { getByTestId } = render(
+            <TreeView>
+              <TreeItem nodeId="apple" label="apple" data-testid="apple" />
+              <TreeItem nodeId="lemon" label="lemon" data-testid="lemon" />
+              <TreeItem nodeId="coconut" label="coconut" data-testid="coconut" />
+              <TreeItem nodeId="vanilla" label="vanilla" data-testid="vanilla" />
+            </TreeView>,
+          );
+
+          getByTestId('apple').focus();
+          expect(getByTestId('apple')).to.have.focus;
+          fireEvent.keyDown(document.activeElement, { key: 'c', ctrlKey: true });
+          expect(getByTestId('apple')).to.have.focus;
+
+          fireEvent.keyDown(document.activeElement, { key: 'v', metaKey: true });
+          expect(getByTestId('apple')).to.have.focus;
+
+          fireEvent.keyDown(document.activeElement, { key: 'v', shiftKey: true });
+          expect(getByTestId('apple')).to.have.focus;
+        });
       });
 
       describe('asterisk key interaction', () => {

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -664,7 +664,7 @@ describe('<TreeItem />', () => {
 
           getByTestId('apple').focus();
           expect(getByTestId('apple')).to.have.focus;
-          fireEvent.keyDown(document.activeElement, { key: 'c', ctrlKey: true });
+          fireEvent.keyDown(document.activeElement, { key: 'v', ctrlKey: true });
           expect(getByTestId('apple')).to.have.focus;
 
           fireEvent.keyDown(document.activeElement, { key: 'v', metaKey: true });


### PR DESCRIPTION
Fixes #20243 

This PR prevents the "focus by first character" functionality from running when the user has pressed a combination of a modifier key (Ctrl, Cmd or Shift) + letter. It fixes the bug where the focus was changing when copying an item's text with Ctrl + C.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
