### PR TITLE
[Autocomplete] Fix blurOnSelect consistency for keyboard

### DIFF
--- a/docs/src/pages/components/autocomplete/Playground.js
+++ b/docs/src/pages/components/autocomplete/Playground.js
@@ -108,6 +108,12 @@ export default function Playground() {
         disablePortal
         renderInput={(params) => <TextField {...params} label="disablePortal" margin="normal" />}
       />
+      <Autocomplete
+         {...defaultProps}
+         id="blur-on-select"
+         blurOnSelect
+         renderInput={params => <TextField {...params} label="blurOnSelect" margin="normal" />}
+       />
     </div>
   );
 }

--- a/docs/src/pages/components/autocomplete/Playground.js
+++ b/docs/src/pages/components/autocomplete/Playground.js
@@ -109,11 +109,11 @@ export default function Playground() {
         renderInput={(params) => <TextField {...params} label="disablePortal" margin="normal" />}
       />
       <Autocomplete
-         {...defaultProps}
-         id="blur-on-select"
-         blurOnSelect
-         renderInput={params => <TextField {...params} label="blurOnSelect" margin="normal" />}
-       />
+        {...defaultProps}
+        id="blur-on-select"
+        blurOnSelect
+        renderInput={(params) => <TextField {...params} label="blurOnSelect" margin="normal" />}
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/autocomplete/Playground.tsx
+++ b/docs/src/pages/components/autocomplete/Playground.tsx
@@ -106,6 +106,12 @@ export default function Playground() {
         disablePortal
         renderInput={(params) => <TextField {...params} label="disablePortal" margin="normal" />}
       />
+      <Autocomplete
+         {...defaultProps}
+         id="blur-on-select"
+         blurOnSelect
+         renderInput={params => <TextField {...params} label="blurOnSelect" margin="normal" />}
+       />
     </div>
   );
 }

--- a/docs/src/pages/components/autocomplete/Playground.tsx
+++ b/docs/src/pages/components/autocomplete/Playground.tsx
@@ -107,11 +107,11 @@ export default function Playground() {
         renderInput={(params) => <TextField {...params} label="disablePortal" margin="normal" />}
       />
       <Autocomplete
-         {...defaultProps}
-         id="blur-on-select"
-         blurOnSelect
-         renderInput={params => <TextField {...params} label="blurOnSelect" margin="normal" />}
-       />
+        {...defaultProps}
+        id="blur-on-select"
+        blurOnSelect
+        renderInput={(params) => <TextField {...params} label="blurOnSelect" margin="normal" />}
+      />
     </div>
   );
 }

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -518,7 +518,6 @@ export default function useAutocomplete(props) {
       handleClose(event, reason);
     }
 
-
     if (
       blurOnSelect === true ||
       (blurOnSelect === 'touch' && isTouch.current) ||

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -479,6 +479,8 @@ export default function useAutocomplete(props) {
     setValue(newValue);
   };
 
+  const isTouch = React.useRef(false);
+
   const selectNewValue = (event, option, reasonProp = 'select-option', origin = 'options') => {
     let reason = reasonProp;
     let newValue = option;
@@ -514,6 +516,15 @@ export default function useAutocomplete(props) {
     handleValue(event, newValue, reason, { option });
     if (!disableCloseOnSelect) {
       handleClose(event, reason);
+    }
+
+
+    if (
+      blurOnSelect === true ||
+      (blurOnSelect === 'touch' && isTouch.current) ||
+      (blurOnSelect === 'mouse' && !isTouch.current)
+    ) {
+      inputRef.current.blur();
     }
   };
 
@@ -769,8 +780,6 @@ export default function useAutocomplete(props) {
     setHighlightedIndex(index, 'mouse');
   };
 
-  const isTouch = React.useRef(false);
-
   const handleOptionTouchStart = () => {
     isTouch.current = true;
   };
@@ -778,14 +787,6 @@ export default function useAutocomplete(props) {
   const handleOptionClick = (event) => {
     const index = Number(event.currentTarget.getAttribute('data-option-index'));
     selectNewValue(event, filteredOptions[index], 'select-option');
-
-    if (
-      blurOnSelect === true ||
-      (blurOnSelect === 'touch' && isTouch.current) ||
-      (blurOnSelect === 'mouse' && !isTouch.current)
-    ) {
-      inputRef.current.blur();
-    }
 
     isTouch.current = false;
   };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #20137 

This PR allows blurOnSelect to work when using keyboard input. Prior to this PR, the popup would close, but the input field would not blur.