### PR TITLE
[core] Improve out-of-date PR story

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,9 @@ jobs:
       - checkout
       - install_js
       - run:
+          name: Check if yarn prettier was run
+          command: yarn prettier check-changed
+      - run:
           name: Generate PropTypes
           command: yarn proptypes --disable-cache
       - run:
@@ -118,9 +121,6 @@ jobs:
       - run:
           name: '`yarn docs:api` changes committed?'
           command: git diff --exit-code
-      - run:
-          name: Check if yarn prettier was run
-          command: yarn prettier check-changed
       - run:
           name: Lint
           command: yarn lint:ci

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -14,7 +14,7 @@ jobs:
       - name: check if prs are dirty
         uses: eps1lon/actions-label-merge-conflict@releases/1.x
         with:
-          dirtyLabel: 'PR: needs rebase'
+          dirtyLabel: 'PR: out-of-date'
           removeOnDirtyLabel: 'PR: ready to ship'
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           retryAfter: 130


### PR DESCRIPTION
- `PR: needs rebase` -> `PR: out-of-date`
  The strategy you use to update the branch is up to you (though you should prefer merge to aid collaboration)
  Description of the label: 
  ```diff
  - The pull request can't be merged.
  + The pull request has merge conflicts and can't be merged.
  ```
- run `yarn prettier` first in `test_static`
  If that task fails than all that generate code fail as well. Right now it's not obvious why e.g. `yarn docs:api` fails (because of out-of-date docs or out-of-date formatting style?)