### PR TITLE
[ExpansionPanel] Use theme.spacing in summary

### DIFF
--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -17,7 +17,7 @@ export const styles = (theme) => {
       display: 'flex',
       minHeight: 8 * 6,
       transition: theme.transitions.create(['min-height', 'background-color'], transition),
-      padding: theme.spacing(0, 3, 0, 3),
+      padding: theme.spacing(0, 3),
       '&:hover:not($disabled)': {
         cursor: 'pointer',
       },

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -17,7 +17,7 @@ export const styles = (theme) => {
       display: 'flex',
       minHeight: 8 * 6,
       transition: theme.transitions.create(['min-height', 'background-color'], transition),
-      padding: '0 24px 0 24px',
+      padding: theme.spacing(0, 3, 0, 3),
       '&:hover:not($disabled)': {
         cursor: 'pointer',
       },


### PR DESCRIPTION
This is a partial revert of https://github.com/mui-org/material-ui/pull/12022 to get a discussion starting why this was done since the original discussion was kept internal.

1. Not sure where the "-0.3 Kb gzipped" comes from. Let's see if we can observe a change in this PR.
2. We do currently use it internally (table, toolbar, grid, divider). If we're not using it internally we don't need to expose it in our theme
3. Fundamentally I don't understand the original change. Why hard code the spacing if we agree that spacing should be something that is applied theme-wide with scales?
  >  In practice, we do not expect people to change the value. 

  This is no longer consistent with our [density guide](https://material-ui.com/customization/density/).
4. It's not important to land this in a minor. It's probably safer anyway to do this in v5

/cc @oliviertassinari, @mbrookes 