### PR TITLE
[core] Add missing test case for restricted-path-imports

### DIFF
--- a/packages/eslint-plugin-material-ui/src/rules/restricted-path-imports.test.js
+++ b/packages/eslint-plugin-material-ui/src/rules/restricted-path-imports.test.js
@@ -12,6 +12,7 @@ ruleTester.run('restricted-path-imports', rule, {
     "import { blue } from '@material-ui/core/colors'",
     "import * as colors from '@material-ui/core/colors'",
     "import * as colors from '@another/core/styles/withStyles'",
+    "import describeConformance from '@material-ui/core/test-utils/describeConformance'",
     "import describeConformance from '@another/core/test-utils/describeConformance'",
   ],
   invalid: [


### PR DESCRIPTION
This condition wasn't properly tested:

https://github.com/mui-org/material-ui/blob/396e4ef3cf3e13bafeac4d2019dd0771fe9f8ebf/packages/eslint-plugin-material-ui/src/rules/restricted-path-imports.js#L10-L11

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
