### PR TITLE
[docs] Next.js: Remove unused config files

### DIFF
--- a/examples/nextjs-with-typescript/.babelrc
+++ b/examples/nextjs-with-typescript/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}

--- a/examples/nextjs-with-typescript/next.config.js
+++ b/examples/nextjs-with-typescript/next.config.js
@@ -1,1 +1,0 @@
-module.exports = {};

--- a/examples/nextjs/.babelrc
+++ b/examples/nextjs/.babelrc
@@ -1,3 +1,0 @@
-{
-  "presets": ["next/babel"]
-}

--- a/examples/nextjs/next.config.js
+++ b/examples/nextjs/next.config.js
@@ -1,1 +1,0 @@
-module.exports = {};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

## Changelog

- [x] Mirgate `examples/nextjs` Remove unused config files
- [x] Mirgate `examples/nextjs-with-typescript` Remove unused config files

## Motivation

Lets follow Convention over Configuration here. In addition to that the following Warning now has been removed:

```log
Warning: Detected next.config.js, no exported configuration found. https://err.sh/zeit/next.js/empty-configuration
```