### PR TITLE
[docs] Fix various issues with heading structure

### DIFF
--- a/docs/pages/index.js
+++ b/docs/pages/index.js
@@ -130,7 +130,7 @@ export default function LandingPage() {
                 >
                   {'MATERIAL-UI'}
                 </Typography>
-                <Typography variant="h5" component="h2" color="inherit">
+                <Typography variant="h5" component="p" color="inherit">
                   {t('strapline')}
                 </Typography>
                 <Button

--- a/docs/src/pages/customization/breakpoints/MediaQuery.js
+++ b/docs/src/pages/customization/breakpoints/MediaQuery.js
@@ -22,9 +22,9 @@ export default function MediaQuery() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">{'down(sm): red'}</Typography>
-      <Typography variant="subtitle1">{'up(md): blue'}</Typography>
-      <Typography variant="subtitle1">{'up(lg): green'}</Typography>
+      <Typography>{'down(sm): red'}</Typography>
+      <Typography>{'up(md): blue'}</Typography>
+      <Typography>{'up(lg): green'}</Typography>
     </div>
   );
 }

--- a/docs/src/pages/customization/breakpoints/MediaQuery.tsx
+++ b/docs/src/pages/customization/breakpoints/MediaQuery.tsx
@@ -24,9 +24,9 @@ export default function MediaQuery() {
   const classes = useStyles();
   return (
     <div className={classes.root}>
-      <Typography variant="subtitle1">{'down(sm): red'}</Typography>
-      <Typography variant="subtitle1">{'up(md): blue'}</Typography>
-      <Typography variant="subtitle1">{'up(lg): green'}</Typography>
+      <Typography>{'down(sm): red'}</Typography>
+      <Typography>{'up(md): blue'}</Typography>
+      <Typography>{'up(lg): green'}</Typography>
     </div>
   );
 }

--- a/docs/src/pages/customization/breakpoints/WithWidth.js
+++ b/docs/src/pages/customization/breakpoints/WithWidth.js
@@ -14,7 +14,7 @@ function WithWidth(props) {
   const Component = components[width] || 'span';
 
   return (
-    <Typography variant="subtitle1">
+    <Typography>
       <Component>{`Current width: ${width}`}</Component>
     </Typography>
   );

--- a/docs/src/pages/customization/breakpoints/WithWidth.tsx
+++ b/docs/src/pages/customization/breakpoints/WithWidth.tsx
@@ -16,7 +16,7 @@ function WithWidth(props: { width: Breakpoint }) {
   const Component = components[width] || 'span';
 
   return (
-    <Typography variant="subtitle1">
+    <Typography>
       <Component>{`Current width: ${width}`}</Component>
     </Typography>
   );

--- a/docs/src/pages/customization/color/ColorDemo.js
+++ b/docs/src/pages/customization/color/ColorDemo.js
@@ -73,7 +73,7 @@ function ColorDemo(props) {
             >
               <MenuIcon />
             </IconButton>
-            <Typography variant="h6" color="inherit">
+            <Typography component="div" variant="h6" color="inherit">
               Color
             </Typography>
           </Toolbar>

--- a/docs/src/pages/customization/color/ColorTool.js
+++ b/docs/src/pages/customization/color/ColorTool.js
@@ -186,18 +186,10 @@ function ColorTool(props) {
 
     return (
       <Grid item xs={12} sm={6} md={4}>
-        <Typography gutterBottom variant="h6">
+        <Typography component="label" gutterBottom htmlFor={intent} variant="h6">
           {capitalize(intent)}
         </Typography>
-        <Input
-          id={intent}
-          value={intentInput}
-          onChange={handleChangeColor(intent)}
-          inputProps={{
-            'aria-label': `${capitalize(intent)} color`,
-          }}
-          fullWidth
-        />
+        <Input id={intent} value={intentInput} onChange={handleChangeColor(intent)} fullWidth />
         <div className={classes.sliderContainer}>
           <Typography id={`${intent}ShadeSliderLabel`}>Shade:</Typography>
           <Slider

--- a/docs/src/pages/landing/Steps.js
+++ b/docs/src/pages/landing/Steps.js
@@ -92,7 +92,7 @@ function HomeSteps() {
         <Grid item xs={12} md={6} className={clsx(classes.step, classes.leftStep)}>
           <div className={classes.stepTitle}>
             <FileDownloadIcon className={classes.stepIcon} />
-            <Typography variant="h6" component="h3">
+            <Typography variant="h6" component="h2">
               {t('installation')}
             </Typography>
           </div>
@@ -132,7 +132,7 @@ $ npm install @material-ui/core
         <Grid item xs={12} md={6} className={clsx(classes.step, classes.rightStep)}>
           <div className={classes.stepTitle}>
             <BuildIcon className={classes.stepIcon} />
-            <Typography variant="h6" component="h3">
+            <Typography variant="h6" component="h2">
               {t('usage')}
             </Typography>
           </div>

--- a/docs/src/pages/styles/api/api.md
+++ b/docs/src/pages/styles/api/api.md
@@ -6,18 +6,18 @@
 
 A function which returns [a class name generator function](https://cssinjs.org/jss-api/#generate-your-class-names).
 
-#### Arguments
+### Arguments
 
 1. `options` (*Object* [optional]):
   - `options.disableGlobal` (*Boolean* [optional]): Defaults to `false`. Disable the generation of deterministic class names.
   - `options.productionPrefix` (*String* [optional]): Defaults to `'jss'`. The string used to prefix the class names in production.
   - `options.seed` (*String* [optional]): Defaults to `''`. The string used to uniquely identify the generator. It can be used to avoid class name collisions when using multiple generators in the same document.
 
-#### Returns
+### Returns
 
 `class name generator`: The generator should be provided to JSS.
 
-#### Examples
+### Examples
 
 ```jsx
 import React from 'react';
@@ -40,15 +40,15 @@ This function doesn't really "do anything" at runtime, it's just the identity
 function. Its only purpose is to defeat **TypeScript**'s type widening when providing
 style rules to `makeStyles`/`withStyles` which are a function of the `Theme`.
 
-#### Arguments
+### Arguments
 
 1. `styles` (*Function | Object*): A function generating the styles or a styles object.
 
-#### Returns
+### Returns
 
 `styles`: A function generating the styles or a styles object.
 
-#### Examples
+### Examples
 
 ```jsx
 import { makeStyles, createStyles } from '@material-ui/core/styles';
@@ -69,7 +69,7 @@ export default function MyComponent {
 
 Link a style sheet with a function component using the **hook** pattern.
 
-#### Arguments
+### Arguments
 
 1. `styles` (*Function | Object*): A function generating the styles or a styles object.
 It will be linked to the component.
@@ -80,13 +80,13 @@ Use the function signature if you need to have access to the theme. It's provide
   - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, it follows `theme.direction`.
   - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](https://cssinjs.org/jss-api/#create-style-sheet).
 
-#### Returns
+### Returns
 
 `hook`: A hook. This hook can be used in a function component. The documentation often calls this returned hook `useStyles`.
 It accepts one argument: the properties that will be used for "interpolation" in
 the style sheet.
 
-#### Examples
+### Examples
 
 ```jsx
 import React from 'react';
@@ -155,7 +155,7 @@ The method is an alternative to `.toString()` when you are rendering the whole p
 
 Link a style sheet with a function component using the **styled components** pattern.
 
-#### Arguments
+### Arguments
 
 1. `Component`: The component that will be wrapped.
 2. `styles` (*Function | Object*): A function generating the styles or a styles object.
@@ -169,11 +169,11 @@ Use the function signature if you need to have access to the theme. It's provide
   - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, it follows `theme.direction`.
   - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](https://cssinjs.org/jss-api/#create-style-sheet).
 
-#### Returns
+### Returns
 
 `Component`: The new component created.
 
-#### Examples
+### Examples
 
 ```jsx
 import React from 'react';
@@ -204,7 +204,7 @@ This component allows you to change the behavior of the styling solution. It mak
 
 It should preferably be used at **the root of your component tree**.
 
-#### Props
+### Props
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
@@ -214,7 +214,7 @@ It should preferably be used at **the root of your component tree**.
 | injectFirst | bool | false | By default, the styles are injected last in the `<head>` element of the page. As a result, they gain more specificity than any other style sheet. If you want to override Material-UI's styles, set this prop. |
 | jss | object | | JSS's instance. |
 
-#### Examples
+### Examples
 
 ```jsx
 import React from 'react';
@@ -235,14 +235,14 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 This component takes a `theme` property, and makes it available down the React tree thanks to the context.
 It should preferably be used at **the root of your component tree**.
 
-#### Props
+### Props
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
 | children&nbsp;* | node | | Your component tree. |
 | theme&nbsp;* | union:&nbsp;object&nbsp;&#124;&nbsp;func | | A theme object. You can provide a function to extend the outer theme. |
 
-#### Examples
+### Examples
 
 ```jsx
 import React from 'react';
@@ -264,11 +264,11 @@ ReactDOM.render(<App />, document.querySelector('#app'));
 
 This hook returns the `theme` object so it can be used inside a function component.
 
-#### Returns
+### Returns
 
 `theme`: The theme object previously injected in the context.
 
-#### Examples
+### Examples
 
 ```jsx
 import React from 'react';
@@ -294,7 +294,7 @@ Some implementation details that might be interesting to being aware of:
 - It does **not** copy over statics.
 For instance, it can be used to defined a `getInitialProps()` static method (next.js).
 
-#### Arguments
+### Arguments
 
 1. `styles` (*Function | Object*): A function generating the styles or a styles object.
 It will be linked to the component.
@@ -307,11 +307,11 @@ Use the function signature if you need to have access to the theme. It's provide
   - `options.flip` (*Boolean* [optional]): When set to `false`, this sheet will opt-out the `rtl` transformation. When set to `true`, the styles are inversed. When set to `null`, it follows `theme.direction`.
   - The other keys are forwarded to the options argument of [jss.createStyleSheet([styles], [options])](https://cssinjs.org/jss-api/#create-style-sheet).
 
-#### Returns
+### Returns
 
 `higher-order component`: Should be used to wrap a component.
 
-#### Examples
+### Examples
 
 ```jsx
 import React from 'react';
@@ -357,15 +357,15 @@ export default MyComponent
 Provide the `theme` object as a property of the input component so it can be used
 in the render method.
 
-#### Arguments
+### Arguments
 
 1. `Component`: The component that will be wrapped.
 
-#### Returns
+### Returns
 
 `Component`: The new component created. Does forward refs to the inner component.
 
-#### Examples
+### Examples
 
 ```jsx
 import React from 'react';


### PR DESCRIPTION
- improve heading structure of landing page
  The full strapline is too long for a heading. It also caused installation and usage to be be on the lowest heading level and didn't translate to the visual representation of the landing page
  Before:
![Screenshot from 2020-04-02 17-19-00](https://user-images.githubusercontent.com/12292047/78268785-f93e0180-7508-11ea-8b97-9b0304e0a456.png)

  After:
  ![Screenshot from 2020-04-02 17-19-22](https://user-images.githubusercontent.com/12292047/78268791-fb07c500-7508-11ea-854e-5bc13dbe0b3f.png)

- fixes issues with skipped headings
- did not check every page under  /components or /api since they're mostly auto-generated. Especially for demos I'm not that concerned with skipped headings. The demo should not be concerned with the context it's embedded in.