### PR TITLE
[docs] Fix /api not being considered for client-side navigation

### DIFF
--- a/docs/src/modules/components/Link.js
+++ b/docs/src/modules/components/Link.js
@@ -28,25 +28,24 @@ function Link(props) {
   const {
     activeClassName = 'active',
     className: classNameProps,
-    href: routerHref,
+    href,
     innerRef,
     naked,
     role: roleProp,
+    as: asProp = href,
     ...other
   } = props;
-
-  // apply nextjs rewrites
-  const href = routerHref.replace(/\/api-docs\/(.*)/, '/api/$1');
 
   const router = useRouter();
 
   const userLanguage = useSelector((state) => state.options.userLanguage);
   const className = clsx(classNameProps, {
-    [activeClassName]: router.pathname === routerHref && activeClassName,
+    [activeClassName]: router.pathname === href && activeClassName,
   });
 
-  if (userLanguage !== 'en' && href.indexOf('/') === 0 && href.indexOf('/blog') !== 0) {
-    other.as = `/${userLanguage}${href}`;
+  let linkAs = asProp.replace(/\/api-docs\/(.*)/, '/api/$1');
+  if (userLanguage !== 'en' && linkAs.indexOf('/') === 0 && linkAs.indexOf('/blog') !== 0) {
+    linkAs = `/${userLanguage}${linkAs}`;
   }
 
   // catch role passed from ButtonBase. This is definitely a link
@@ -59,11 +58,21 @@ function Link(props) {
   }
 
   if (naked) {
-    return <NextComposed className={className} href={href} ref={innerRef} role={role} {...other} />;
+    return (
+      <NextComposed
+        as={linkAs}
+        className={className}
+        href={href}
+        ref={innerRef}
+        role={role}
+        {...other}
+      />
+    );
   }
 
   return (
     <MuiLink
+      as={linkAs}
       component={NextComposed}
       className={className}
       href={href}


### PR DESCRIPTION
Pages under /api currently cause a full page reload i.e. are not part of client-side navigation:
1. goto  https://material-ui.netlify.com/api/app-bar/
2. click on another api page
3. notice theme flash indicating a full page reload

This PR fixes this by rewriting `as` instead of `href`:
1. goto https://deploy-preview-20392--material-ui.netlify.com/api/app-bar/
2. click on another api page
3. no more flash

Aside:
Once we get getStaticProps for _app we're able to refactor the routing of our docs. It's currently very hard to follow.

The problem is that `next` needs to map the `href` to an actual page in the file system. This is not the same what is displayed in the actual `href` of the anchor tag. This sounds backwards to me. I would find `<Link href="/some-arbitrary-url" to="/some/page/under/docs/pages" />` more intuitive since `href` keeps it's meaning. Redefining an existing prop under a different context makes things needlessly complicate. I think they even plan on implementing the `to` prop if I recall correctly.