### PR TITLE
[docs] Add Component name section to API docs

### DIFF
--- a/docs/pages/api-docs/alert-title.md
+++ b/docs/pages/api-docs/alert-title.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiAlertTitle` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/alert-title.md
+++ b/docs/pages/api-docs/alert-title.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiAlertTitle` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -32,9 +37,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiAlertTitle`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/alert.md
+++ b/docs/pages/api-docs/alert.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiAlert` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -41,9 +46,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Paper](/api/paper/)).
 
 ## CSS
-
-- Style sheet name: `MuiAlert`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/alert.md
+++ b/docs/pages/api-docs/alert.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiAlert` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/app-bar.md
+++ b/docs/pages/api-docs/app-bar.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiAppBar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/app-bar.md
+++ b/docs/pages/api-docs/app-bar.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiAppBar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -34,9 +39,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Paper](/api/paper/)).
 
 ## CSS
-
-- Style sheet name: `MuiAppBar`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/autocomplete.md
+++ b/docs/pages/api-docs/autocomplete.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiAutocomplete` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/autocomplete.md
+++ b/docs/pages/api-docs/autocomplete.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiAutocomplete` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -84,9 +89,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiAutocomplete`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/avatar-group.md
+++ b/docs/pages/api-docs/avatar-group.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiAvatarGroup` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/avatar-group.md
+++ b/docs/pages/api-docs/avatar-group.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiAvatarGroup` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -34,9 +39,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiAvatarGroup`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/avatar.md
+++ b/docs/pages/api-docs/avatar.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiAvatar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -39,9 +44,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiAvatar`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/avatar.md
+++ b/docs/pages/api-docs/avatar.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiAvatar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/backdrop.md
+++ b/docs/pages/api-docs/backdrop.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiBackdrop` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/backdrop.md
+++ b/docs/pages/api-docs/backdrop.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiBackdrop` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiBackdrop`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/badge.md
+++ b/docs/pages/api-docs/badge.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiBadge` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/badge.md
+++ b/docs/pages/api-docs/badge.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiBadge` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -41,9 +46,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiBadge`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/bottom-navigation-action.md
+++ b/docs/pages/api-docs/bottom-navigation-action.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiBottomNavigationAction` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/bottom-navigation-action.md
+++ b/docs/pages/api-docs/bottom-navigation-action.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiBottomNavigationAction` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiBottomNavigationAction`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/bottom-navigation.md
+++ b/docs/pages/api-docs/bottom-navigation.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiBottomNavigation` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/bottom-navigation.md
+++ b/docs/pages/api-docs/bottom-navigation.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiBottomNavigation` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiBottomNavigation`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/breadcrumbs.md
+++ b/docs/pages/api-docs/breadcrumbs.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiBreadcrumbs` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/breadcrumbs.md
+++ b/docs/pages/api-docs/breadcrumbs.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiBreadcrumbs` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -38,9 +43,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiBreadcrumbs`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/button-base.md
+++ b/docs/pages/api-docs/button-base.md
@@ -26,7 +26,6 @@ It contains a load of style reset and some focus/ripple logic.
 
 The `MuiButtonBase` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/button-base.md
+++ b/docs/pages/api-docs/button-base.md
@@ -22,6 +22,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 It aims to be a simple building block for creating a button.
 It contains a load of style reset and some focus/ripple logic.
 
+## Component name
+
+The `MuiButtonBase` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -45,9 +50,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiButtonBase`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/button-group.md
+++ b/docs/pages/api-docs/button-group.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiButtonGroup` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/button-group.md
+++ b/docs/pages/api-docs/button-group.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiButtonGroup` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -41,9 +46,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiButtonGroup`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/button.md
+++ b/docs/pages/api-docs/button.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiButton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -44,9 +49,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiButton`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/button.md
+++ b/docs/pages/api-docs/button.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiButton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/card-action-area.md
+++ b/docs/pages/api-docs/card-action-area.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiCardActionArea` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/card-action-area.md
+++ b/docs/pages/api-docs/card-action-area.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiCardActionArea` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -32,9 +37,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiCardActionArea`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/card-actions.md
+++ b/docs/pages/api-docs/card-actions.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiCardActions` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/card-actions.md
+++ b/docs/pages/api-docs/card-actions.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiCardActions` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiCardActions`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/card-content.md
+++ b/docs/pages/api-docs/card-content.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiCardContent` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiCardContent`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/card-content.md
+++ b/docs/pages/api-docs/card-content.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiCardContent` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/card-header.md
+++ b/docs/pages/api-docs/card-header.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiCardHeader` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -39,9 +44,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiCardHeader`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/card-header.md
+++ b/docs/pages/api-docs/card-header.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiCardHeader` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/card-media.md
+++ b/docs/pages/api-docs/card-media.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiCardMedia` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/card-media.md
+++ b/docs/pages/api-docs/card-media.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiCardMedia` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiCardMedia`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/card.md
+++ b/docs/pages/api-docs/card.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiCard` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Paper](/api/paper/)).
 
 ## CSS
-
-- Style sheet name: `MuiCard`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/card.md
+++ b/docs/pages/api-docs/card.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiCard` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/checkbox.md
+++ b/docs/pages/api-docs/checkbox.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiCheckbox` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -47,9 +52,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([IconButton](/api/icon-button/)).
 
 ## CSS
-
-- Style sheet name: `MuiCheckbox`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/checkbox.md
+++ b/docs/pages/api-docs/checkbox.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiCheckbox` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/chip.md
+++ b/docs/pages/api-docs/chip.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 Chips represent complex entities in small blocks, such as a contact.
 
+## Component name
+
+The `MuiChip` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -43,9 +48,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiChip`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/chip.md
+++ b/docs/pages/api-docs/chip.md
@@ -24,7 +24,6 @@ Chips represent complex entities in small blocks, such as a contact.
 
 The `MuiChip` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/circular-progress.md
+++ b/docs/pages/api-docs/circular-progress.md
@@ -28,7 +28,6 @@ attribute to `true` on that region until it has finished loading.
 
 The `MuiCircularProgress` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/circular-progress.md
+++ b/docs/pages/api-docs/circular-progress.md
@@ -24,6 +24,11 @@ If the progress bar is describing the loading progress of a particular region of
 you should use `aria-describedby` to point to the progress bar, and set the `aria-busy`
 attribute to `true` on that region until it has finished loading.
 
+## Component name
+
+The `MuiCircularProgress` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -41,9 +46,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiCircularProgress`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/click-away-listener.md
+++ b/docs/pages/api-docs/click-away-listener.md
@@ -21,6 +21,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 Listen for click events that occur somewhere in the document, outside of the element itself.
 For instance, if you need to hide a menu when people click anywhere else on your page.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/collapse.md
+++ b/docs/pages/api-docs/collapse.md
@@ -26,7 +26,6 @@ It uses [react-transition-group](https://github.com/reactjs/react-transition-gro
 
 The `MuiCollapse` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/collapse.md
+++ b/docs/pages/api-docs/collapse.md
@@ -22,6 +22,11 @@ The Collapse transition is used by the
 [Vertical Stepper](/components/steppers/#vertical-stepper) StepContent component.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
 
+## Component name
+
+The `MuiCollapse` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -38,9 +43,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Transition](https://reactcommunity.org/react-transition-group/transition/#Transition-props)).
 
 ## CSS
-
-- Style sheet name: `MuiCollapse`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/container.md
+++ b/docs/pages/api-docs/container.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiContainer` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/container.md
+++ b/docs/pages/api-docs/container.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiContainer` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiContainer`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/css-baseline.md
+++ b/docs/pages/api-docs/css-baseline.md
@@ -24,7 +24,6 @@ Kickstart an elegant, consistent, and simple baseline to build upon.
 
 The `MuiCssBaseline` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/css-baseline.md
+++ b/docs/pages/api-docs/css-baseline.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 Kickstart an elegant, consistent, and simple baseline to build upon.
 
+## Component name
+
+The `MuiCssBaseline` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -31,9 +36,6 @@ The component cannot hold a ref.
 
 
 ## CSS
-
-- Style sheet name: `MuiCssBaseline`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/dialog-actions.md
+++ b/docs/pages/api-docs/dialog-actions.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiDialogActions` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiDialogActions`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/dialog-actions.md
+++ b/docs/pages/api-docs/dialog-actions.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiDialogActions` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/dialog-content-text.md
+++ b/docs/pages/api-docs/dialog-content-text.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiDialogContentText` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -32,9 +37,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Typography](/api/typography/)).
 
 ## CSS
-
-- Style sheet name: `MuiDialogContentText`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/dialog-content-text.md
+++ b/docs/pages/api-docs/dialog-content-text.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiDialogContentText` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/dialog-content.md
+++ b/docs/pages/api-docs/dialog-content.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiDialogContent` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiDialogContent`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/dialog-content.md
+++ b/docs/pages/api-docs/dialog-content.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiDialogContent` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/dialog-title.md
+++ b/docs/pages/api-docs/dialog-title.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiDialogTitle` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiDialogTitle`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/dialog-title.md
+++ b/docs/pages/api-docs/dialog-title.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiDialogTitle` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/dialog.md
+++ b/docs/pages/api-docs/dialog.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 Dialogs are overlaid modal paper based components with a backdrop.
 
+## Component name
+
+The `MuiDialog` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -55,9 +60,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Modal](/api/modal/)).
 
 ## CSS
-
-- Style sheet name: `MuiDialog`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/dialog.md
+++ b/docs/pages/api-docs/dialog.md
@@ -24,7 +24,6 @@ Dialogs are overlaid modal paper based components with a backdrop.
 
 The `MuiDialog` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/divider.md
+++ b/docs/pages/api-docs/divider.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiDivider` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/divider.md
+++ b/docs/pages/api-docs/divider.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiDivider` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -37,9 +42,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiDivider`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/drawer.md
+++ b/docs/pages/api-docs/drawer.md
@@ -25,7 +25,6 @@ when `variant="temporary"` is set.
 
 The `MuiDrawer` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/drawer.md
+++ b/docs/pages/api-docs/drawer.md
@@ -21,6 +21,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 The props of the [Modal](/api/modal/) component are available
 when `variant="temporary"` is set.
 
+## Component name
+
+The `MuiDrawer` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -42,9 +47,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiDrawer`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/expansion-panel-actions.md
+++ b/docs/pages/api-docs/expansion-panel-actions.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiExpansionPanelActions` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiExpansionPanelActions`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/expansion-panel-actions.md
+++ b/docs/pages/api-docs/expansion-panel-actions.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiExpansionPanelActions` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/expansion-panel-details.md
+++ b/docs/pages/api-docs/expansion-panel-details.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiExpansionPanelDetails` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -32,9 +37,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiExpansionPanelDetails`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/expansion-panel-details.md
+++ b/docs/pages/api-docs/expansion-panel-details.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiExpansionPanelDetails` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/expansion-panel-summary.md
+++ b/docs/pages/api-docs/expansion-panel-summary.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiExpansionPanelSummary` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -34,9 +39,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiExpansionPanelSummary`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/expansion-panel-summary.md
+++ b/docs/pages/api-docs/expansion-panel-summary.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiExpansionPanelSummary` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/expansion-panel.md
+++ b/docs/pages/api-docs/expansion-panel.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiExpansionPanel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -38,9 +43,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Paper](/api/paper/)).
 
 ## CSS
-
-- Style sheet name: `MuiExpansionPanel`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/expansion-panel.md
+++ b/docs/pages/api-docs/expansion-panel.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiExpansionPanel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/fab.md
+++ b/docs/pages/api-docs/fab.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiFab` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/fab.md
+++ b/docs/pages/api-docs/fab.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiFab` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -40,9 +45,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiFab`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/fade.md
+++ b/docs/pages/api-docs/fade.md
@@ -21,6 +21,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 The Fade transition is used by the [Modal](/components/modal/) component.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/filled-input.md
+++ b/docs/pages/api-docs/filled-input.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiFilledInput` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/filled-input.md
+++ b/docs/pages/api-docs/filled-input.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiFilledInput` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -57,9 +62,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([InputBase](/api/input-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiFilledInput`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/form-control-label.md
+++ b/docs/pages/api-docs/form-control-label.md
@@ -25,7 +25,6 @@ Use this component if you want to display an extra label.
 
 The `MuiFormControlLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/form-control-label.md
+++ b/docs/pages/api-docs/form-control-label.md
@@ -21,6 +21,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 Drop in replacement of the `Radio`, `Switch` and `Checkbox` component.
 Use this component if you want to display an extra label.
 
+## Component name
+
+The `MuiFormControlLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -41,9 +46,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiFormControlLabel`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/form-control.md
+++ b/docs/pages/api-docs/form-control.md
@@ -40,6 +40,11 @@ You can find one composition example below and more going to [the demos](/compon
 
 ⚠️Only one input can be used within a FormControl.
 
+## Component name
+
+The `MuiFormControl` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -62,9 +67,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiFormControl`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/form-control.md
+++ b/docs/pages/api-docs/form-control.md
@@ -44,7 +44,6 @@ You can find one composition example below and more going to [the demos](/compon
 
 The `MuiFormControl` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/form-group.md
+++ b/docs/pages/api-docs/form-group.md
@@ -26,7 +26,6 @@ For the `Radio`, you should be using the `RadioGroup` component instead of this 
 
 The `MuiFormGroup` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/form-group.md
+++ b/docs/pages/api-docs/form-group.md
@@ -22,6 +22,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 It provides compact row layout.
 For the `Radio`, you should be using the `RadioGroup` component instead of this one.
 
+## Component name
+
+The `MuiFormGroup` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiFormGroup`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/form-helper-text.md
+++ b/docs/pages/api-docs/form-helper-text.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiFormHelperText` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/form-helper-text.md
+++ b/docs/pages/api-docs/form-helper-text.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiFormHelperText` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -40,9 +45,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiFormHelperText`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/form-label.md
+++ b/docs/pages/api-docs/form-label.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiFormLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -39,9 +44,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiFormLabel`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/form-label.md
+++ b/docs/pages/api-docs/form-label.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiFormLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/grid-list-tile-bar.md
+++ b/docs/pages/api-docs/grid-list-tile-bar.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiGridListTileBar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiGridListTileBar`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/grid-list-tile-bar.md
+++ b/docs/pages/api-docs/grid-list-tile-bar.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiGridListTileBar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/grid-list-tile.md
+++ b/docs/pages/api-docs/grid-list-tile.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiGridListTile` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/grid-list-tile.md
+++ b/docs/pages/api-docs/grid-list-tile.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiGridListTile` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiGridListTile`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/grid-list.md
+++ b/docs/pages/api-docs/grid-list.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiGridList` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiGridList`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/grid-list.md
+++ b/docs/pages/api-docs/grid-list.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiGridList` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/grid.md
+++ b/docs/pages/api-docs/grid.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiGrid` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/grid.md
+++ b/docs/pages/api-docs/grid.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiGrid` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -47,9 +52,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiGrid`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/grow.md
+++ b/docs/pages/api-docs/grow.md
@@ -22,6 +22,8 @@ The Grow transition is used by the [Tooltip](/components/tooltips/) and
 [Popover](/components/popover/) components.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/hidden.md
+++ b/docs/pages/api-docs/hidden.md
@@ -20,6 +20,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 Responsively hides children based on the selected implementation.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/icon-button.md
+++ b/docs/pages/api-docs/icon-button.md
@@ -25,7 +25,6 @@ regarding the available icon options.
 
 The `MuiIconButton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/icon-button.md
+++ b/docs/pages/api-docs/icon-button.md
@@ -21,6 +21,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 Refer to the [Icons](/components/icons/) section of the documentation
 regarding the available icon options.
 
+## Component name
+
+The `MuiIconButton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -39,9 +44,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiIconButton`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/icon.md
+++ b/docs/pages/api-docs/icon.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/icon.md
+++ b/docs/pages/api-docs/icon.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiIcon`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/input-adornment.md
+++ b/docs/pages/api-docs/input-adornment.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiInputAdornment` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/input-adornment.md
+++ b/docs/pages/api-docs/input-adornment.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiInputAdornment` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -37,9 +42,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiInputAdornment`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/input-base.md
+++ b/docs/pages/api-docs/input-base.md
@@ -26,7 +26,6 @@ It contains a load of style reset and some state logic.
 
 The `MuiInputBase` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/input-base.md
+++ b/docs/pages/api-docs/input-base.md
@@ -22,6 +22,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 It aims to be a simple building block for creating an input.
 It contains a load of style reset and some state logic.
 
+## Component name
+
+The `MuiInputBase` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -60,9 +65,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiInputBase`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/input-label.md
+++ b/docs/pages/api-docs/input-label.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiInputLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/input-label.md
+++ b/docs/pages/api-docs/input-label.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiInputLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -41,9 +46,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([FormLabel](/api/form-label/)).
 
 ## CSS
-
-- Style sheet name: `MuiInputLabel`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/input.md
+++ b/docs/pages/api-docs/input.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiInput` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -57,9 +62,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([InputBase](/api/input-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiInput`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/input.md
+++ b/docs/pages/api-docs/input.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiInput` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/linear-progress.md
+++ b/docs/pages/api-docs/linear-progress.md
@@ -24,6 +24,11 @@ If the progress bar is describing the loading progress of a particular region of
 you should use `aria-describedby` to point to the progress bar, and set the `aria-busy`
 attribute to `true` on that region until it has finished loading.
 
+## Component name
+
+The `MuiLinearProgress` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -39,9 +44,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiLinearProgress`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/linear-progress.md
+++ b/docs/pages/api-docs/linear-progress.md
@@ -28,7 +28,6 @@ attribute to `true` on that region until it has finished loading.
 
 The `MuiLinearProgress` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/link.md
+++ b/docs/pages/api-docs/link.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiLink` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -37,9 +42,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Typography](/api/typography/)).
 
 ## CSS
-
-- Style sheet name: `MuiLink`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/link.md
+++ b/docs/pages/api-docs/link.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiLink` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/list-item-avatar.md
+++ b/docs/pages/api-docs/list-item-avatar.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 A simple wrapper to apply `List` styles to an `Avatar`.
 
+## Component name
+
+The `MuiListItemAvatar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -32,9 +37,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiListItemAvatar`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/list-item-avatar.md
+++ b/docs/pages/api-docs/list-item-avatar.md
@@ -24,7 +24,6 @@ A simple wrapper to apply `List` styles to an `Avatar`.
 
 The `MuiListItemAvatar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/list-item-icon.md
+++ b/docs/pages/api-docs/list-item-icon.md
@@ -24,7 +24,6 @@ A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
 
 The `MuiListItemIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/list-item-icon.md
+++ b/docs/pages/api-docs/list-item-icon.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 A simple wrapper to apply `List` styles to an `Icon` or `SvgIcon`.
 
+## Component name
+
+The `MuiListItemIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -32,9 +37,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiListItemIcon`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/list-item-secondary-action.md
+++ b/docs/pages/api-docs/list-item-secondary-action.md
@@ -24,7 +24,6 @@ Must be used as the last child of ListItem to function properly.
 
 The `MuiListItemSecondaryAction` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/list-item-secondary-action.md
+++ b/docs/pages/api-docs/list-item-secondary-action.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 Must be used as the last child of ListItem to function properly.
 
+## Component name
+
+The `MuiListItemSecondaryAction` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -32,9 +37,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiListItemSecondaryAction`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/list-item-text.md
+++ b/docs/pages/api-docs/list-item-text.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiListItemText` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/list-item-text.md
+++ b/docs/pages/api-docs/list-item-text.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiListItemText` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -38,9 +43,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiListItemText`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/list-item.md
+++ b/docs/pages/api-docs/list-item.md
@@ -24,7 +24,6 @@ Uses an additional container component if `ListItemSecondaryAction` is the last 
 
 The `MuiListItem` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/list-item.md
+++ b/docs/pages/api-docs/list-item.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 Uses an additional container component if `ListItemSecondaryAction` is the last child.
 
+## Component name
+
+The `MuiListItem` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -43,9 +48,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiListItem`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/list-subheader.md
+++ b/docs/pages/api-docs/list-subheader.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiListSubheader` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -37,9 +42,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiListSubheader`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/list-subheader.md
+++ b/docs/pages/api-docs/list-subheader.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiListSubheader` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/list.md
+++ b/docs/pages/api-docs/list.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiList` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/list.md
+++ b/docs/pages/api-docs/list.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiList` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiList`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/menu-item.md
+++ b/docs/pages/api-docs/menu-item.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiMenuItem` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/menu-item.md
+++ b/docs/pages/api-docs/menu-item.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiMenuItem` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ListItem](/api/list-item/)).
 
 ## CSS
-
-- Style sheet name: `MuiMenuItem`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/menu-list.md
+++ b/docs/pages/api-docs/menu-list.md
@@ -23,6 +23,8 @@ It's exposed to help customization of the [`Menu`](/api/menu/) component. If you
 use it separately you need to move focus into the component manually. Once
 the focus is placed inside the component it is fully keyboard accessible.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/menu.md
+++ b/docs/pages/api-docs/menu.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiMenu` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/menu.md
+++ b/docs/pages/api-docs/menu.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiMenu` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -47,9 +52,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Popover](/api/popover/)).
 
 ## CSS
-
-- Style sheet name: `MuiMenu`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/mobile-stepper.md
+++ b/docs/pages/api-docs/mobile-stepper.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiMobileStepper` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -38,9 +43,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Paper](/api/paper/)).
 
 ## CSS
-
-- Style sheet name: `MuiMobileStepper`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/mobile-stepper.md
+++ b/docs/pages/api-docs/mobile-stepper.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiMobileStepper` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/modal.md
+++ b/docs/pages/api-docs/modal.md
@@ -30,6 +30,8 @@ rather than directly using Modal.
 
 This component shares many concepts with [react-overlays](https://react-bootstrap.github.io/react-overlays/#modals).
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/native-select.md
+++ b/docs/pages/api-docs/native-select.md
@@ -24,7 +24,6 @@ An alternative to `<Select native />` with a much smaller bundle size footprint.
 
 The `MuiNativeSelect` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/native-select.md
+++ b/docs/pages/api-docs/native-select.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 An alternative to `<Select native />` with a much smaller bundle size footprint.
 
+## Component name
+
+The `MuiNativeSelect` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -38,9 +43,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Input](/api/input/)).
 
 ## CSS
-
-- Style sheet name: `MuiNativeSelect`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/no-ssr.md
+++ b/docs/pages/api-docs/no-ssr.md
@@ -26,6 +26,8 @@ This component can be useful in a variety of situations:
 - Reduce the rendering time on the server.
 - Under too heavy server load, you can turn on service degradation.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/outlined-input.md
+++ b/docs/pages/api-docs/outlined-input.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiOutlinedInput` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/outlined-input.md
+++ b/docs/pages/api-docs/outlined-input.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiOutlinedInput` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -59,9 +64,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([InputBase](/api/input-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiOutlinedInput`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/pagination-item.md
+++ b/docs/pages/api-docs/pagination-item.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiPaginationItem` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -39,9 +44,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiPaginationItem`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/pagination-item.md
+++ b/docs/pages/api-docs/pagination-item.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiPaginationItem` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/pagination.md
+++ b/docs/pages/api-docs/pagination.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiPagination` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/pagination.md
+++ b/docs/pages/api-docs/pagination.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiPagination` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -48,9 +53,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiPagination`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/paper.md
+++ b/docs/pages/api-docs/paper.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiPaper` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiPaper`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/paper.md
+++ b/docs/pages/api-docs/paper.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiPaper` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/popover.md
+++ b/docs/pages/api-docs/popover.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiPopover` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/popover.md
+++ b/docs/pages/api-docs/popover.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiPopover` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -54,9 +59,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Modal](/api/modal/)).
 
 ## CSS
-
-- Style sheet name: `MuiPopover`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/popper.md
+++ b/docs/pages/api-docs/popper.md
@@ -20,6 +20,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 Poppers rely on the 3rd party library [Popper.js](https://github.com/FezVrasta/popper.js) for positioning.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/portal.md
+++ b/docs/pages/api-docs/portal.md
@@ -21,6 +21,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 Portals provide a first-class way to render children into a DOM node
 that exists outside the DOM hierarchy of the parent component.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/radio-group.md
+++ b/docs/pages/api-docs/radio-group.md
@@ -20,6 +20,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/radio.md
+++ b/docs/pages/api-docs/radio.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiRadio` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/radio.md
+++ b/docs/pages/api-docs/radio.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiRadio` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -46,9 +51,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([IconButton](/api/icon-button/)).
 
 ## CSS
-
-- Style sheet name: `MuiRadio`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/rating.md
+++ b/docs/pages/api-docs/rating.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiRating` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/rating.md
+++ b/docs/pages/api-docs/rating.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiRating` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -46,9 +51,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiRating`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/root-ref.md
+++ b/docs/pages/api-docs/root-ref.md
@@ -49,6 +49,8 @@ function MyComponent() {
 }
 ```
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/scoped-css-baseline.md
+++ b/docs/pages/api-docs/scoped-css-baseline.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiScopedCssBaseline` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -32,9 +37,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiScopedCssBaseline`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/scoped-css-baseline.md
+++ b/docs/pages/api-docs/scoped-css-baseline.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiScopedCssBaseline` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/select.md
+++ b/docs/pages/api-docs/select.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSelect` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -52,9 +57,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Input](/api/input/)).
 
 ## CSS
-
-- Style sheet name: `MuiSelect`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/select.md
+++ b/docs/pages/api-docs/select.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSelect` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/skeleton.md
+++ b/docs/pages/api-docs/skeleton.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSkeleton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiSkeleton`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/skeleton.md
+++ b/docs/pages/api-docs/skeleton.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSkeleton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/slide.md
+++ b/docs/pages/api-docs/slide.md
@@ -21,6 +21,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 The Slide transition is used by the [Drawer](/components/drawers/) component.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/slider.md
+++ b/docs/pages/api-docs/slider.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSlider` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -55,9 +60,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiSlider`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/slider.md
+++ b/docs/pages/api-docs/slider.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSlider` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/snackbar-content.md
+++ b/docs/pages/api-docs/snackbar-content.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSnackbarContent` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/snackbar-content.md
+++ b/docs/pages/api-docs/snackbar-content.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSnackbarContent` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -34,9 +39,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Paper](/api/paper/)).
 
 ## CSS
-
-- Style sheet name: `MuiSnackbarContent`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/snackbar.md
+++ b/docs/pages/api-docs/snackbar.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSnackbar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/snackbar.md
+++ b/docs/pages/api-docs/snackbar.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSnackbar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -52,9 +57,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiSnackbar`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/speed-dial-action.md
+++ b/docs/pages/api-docs/speed-dial-action.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSpeedDialAction` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -38,9 +43,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Tooltip](/api/tooltip/)).
 
 ## CSS
-
-- Style sheet name: `MuiSpeedDialAction`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/speed-dial-action.md
+++ b/docs/pages/api-docs/speed-dial-action.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSpeedDialAction` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/speed-dial-icon.md
+++ b/docs/pages/api-docs/speed-dial-icon.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSpeedDialIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiSpeedDialIcon`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/speed-dial-icon.md
+++ b/docs/pages/api-docs/speed-dial-icon.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSpeedDialIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/speed-dial.md
+++ b/docs/pages/api-docs/speed-dial.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSpeedDial` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -44,9 +49,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiSpeedDial`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/speed-dial.md
+++ b/docs/pages/api-docs/speed-dial.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSpeedDial` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/step-button.md
+++ b/docs/pages/api-docs/step-button.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiStepButton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/step-button.md
+++ b/docs/pages/api-docs/step-button.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiStepButton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -34,9 +39,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiStepButton`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/step-connector.md
+++ b/docs/pages/api-docs/step-connector.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiStepConnector` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -31,9 +36,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiStepConnector`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/step-connector.md
+++ b/docs/pages/api-docs/step-connector.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiStepConnector` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/step-content.md
+++ b/docs/pages/api-docs/step-content.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiStepContent` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/step-content.md
+++ b/docs/pages/api-docs/step-content.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiStepContent` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiStepContent`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/step-icon.md
+++ b/docs/pages/api-docs/step-icon.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiStepIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiStepIcon`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/step-icon.md
+++ b/docs/pages/api-docs/step-icon.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiStepIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/step-label.md
+++ b/docs/pages/api-docs/step-label.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiStepLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/step-label.md
+++ b/docs/pages/api-docs/step-label.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiStepLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -38,9 +43,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiStepLabel`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/step.md
+++ b/docs/pages/api-docs/step.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiStep` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiStep`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/step.md
+++ b/docs/pages/api-docs/step.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiStep` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/stepper.md
+++ b/docs/pages/api-docs/stepper.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiStepper` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/stepper.md
+++ b/docs/pages/api-docs/stepper.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiStepper` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -37,9 +42,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([Paper](/api/paper/)).
 
 ## CSS
-
-- Style sheet name: `MuiStepper`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/svg-icon.md
+++ b/docs/pages/api-docs/svg-icon.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSvgIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -39,9 +44,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiSvgIcon`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/svg-icon.md
+++ b/docs/pages/api-docs/svg-icon.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSvgIcon` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/swipeable-drawer.md
+++ b/docs/pages/api-docs/swipeable-drawer.md
@@ -20,6 +20,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/switch.md
+++ b/docs/pages/api-docs/switch.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiSwitch` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/switch.md
+++ b/docs/pages/api-docs/switch.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiSwitch` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -46,9 +51,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([IconButton](/api/icon-button/)).
 
 ## CSS
-
-- Style sheet name: `MuiSwitch`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/tab.md
+++ b/docs/pages/api-docs/tab.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTab` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -39,9 +44,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiTab`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/tab.md
+++ b/docs/pages/api-docs/tab.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTab` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-body.md
+++ b/docs/pages/api-docs/table-body.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTableBody` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-body.md
+++ b/docs/pages/api-docs/table-body.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTableBody` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTableBody`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/table-cell.md
+++ b/docs/pages/api-docs/table-cell.md
@@ -21,6 +21,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 The component renders a `<th>` element when the parent context is a header
 or otherwise a `<td>` element.
 
+## Component name
+
+The `MuiTableCell` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -40,9 +45,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTableCell`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/table-cell.md
+++ b/docs/pages/api-docs/table-cell.md
@@ -25,7 +25,6 @@ or otherwise a `<td>` element.
 
 The `MuiTableCell` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-container.md
+++ b/docs/pages/api-docs/table-container.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTableContainer` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-container.md
+++ b/docs/pages/api-docs/table-container.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTableContainer` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTableContainer`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/table-footer.md
+++ b/docs/pages/api-docs/table-footer.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTableFooter` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTableFooter`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/table-footer.md
+++ b/docs/pages/api-docs/table-footer.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTableFooter` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-head.md
+++ b/docs/pages/api-docs/table-head.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTableHead` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-head.md
+++ b/docs/pages/api-docs/table-head.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTableHead` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -33,9 +38,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTableHead`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/table-pagination.md
+++ b/docs/pages/api-docs/table-pagination.md
@@ -24,7 +24,6 @@ A `TableCell` based component for placing inside `TableFooter` for pagination.
 
 The `MuiTablePagination` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-pagination.md
+++ b/docs/pages/api-docs/table-pagination.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 A `TableCell` based component for placing inside `TableFooter` for pagination.
 
+## Component name
+
+The `MuiTablePagination` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -46,9 +51,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([TableCell](/api/table-cell/)).
 
 ## CSS
-
-- Style sheet name: `MuiTablePagination`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/table-row.md
+++ b/docs/pages/api-docs/table-row.md
@@ -21,6 +21,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 Will automatically set dynamic row height
 based on the material table element parent (head, body, etc).
 
+## Component name
+
+The `MuiTableRow` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTableRow`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/table-row.md
+++ b/docs/pages/api-docs/table-row.md
@@ -25,7 +25,6 @@ based on the material table element parent (head, body, etc).
 
 The `MuiTableRow` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-sort-label.md
+++ b/docs/pages/api-docs/table-sort-label.md
@@ -24,7 +24,6 @@ A button based label for placing inside `TableCell` for column sorting.
 
 The `MuiTableSortLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table-sort-label.md
+++ b/docs/pages/api-docs/table-sort-label.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 A button based label for placing inside `TableCell` for column sorting.
 
+## Component name
+
+The `MuiTableSortLabel` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiTableSortLabel`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/table.md
+++ b/docs/pages/api-docs/table.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTable` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/table.md
+++ b/docs/pages/api-docs/table.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTable` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTable`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/tabs.md
+++ b/docs/pages/api-docs/tabs.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTabs` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -44,9 +49,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTabs`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/tabs.md
+++ b/docs/pages/api-docs/tabs.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTabs` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/text-field.md
+++ b/docs/pages/api-docs/text-field.md
@@ -53,7 +53,6 @@ For advanced cases, please look at the source of TextField by clicking on the
 
 The `MuiTextField` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/text-field.md
+++ b/docs/pages/api-docs/text-field.md
@@ -49,6 +49,11 @@ For advanced cases, please look at the source of TextField by clicking on the
 - using the upper case props for passing values directly to the components
 - using the underlying components directly as shown in the demos
 
+## Component name
+
+The `MuiTextField` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -89,9 +94,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([FormControl](/api/form-control/)).
 
 ## CSS
-
-- Style sheet name: `MuiTextField`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/textarea-autosize.md
+++ b/docs/pages/api-docs/textarea-autosize.md
@@ -20,6 +20,8 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/toggle-button-group.md
+++ b/docs/pages/api-docs/toggle-button-group.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiToggleButtonGroup` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -36,9 +41,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiToggleButtonGroup`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/toggle-button-group.md
+++ b/docs/pages/api-docs/toggle-button-group.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiToggleButtonGroup` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/toggle-button.md
+++ b/docs/pages/api-docs/toggle-button.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiToggleButton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -37,9 +42,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element ([ButtonBase](/api/button-base/)).
 
 ## CSS
-
-- Style sheet name: `MuiToggleButton`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/toggle-button.md
+++ b/docs/pages/api-docs/toggle-button.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiToggleButton` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/toolbar.md
+++ b/docs/pages/api-docs/toolbar.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiToolbar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -35,9 +40,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiToolbar`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/toolbar.md
+++ b/docs/pages/api-docs/toolbar.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiToolbar` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/tooltip.md
+++ b/docs/pages/api-docs/tooltip.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTooltip` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -51,9 +56,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTooltip`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/tooltip.md
+++ b/docs/pages/api-docs/tooltip.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTooltip` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/tree-item.md
+++ b/docs/pages/api-docs/tree-item.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTreeItem` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/tree-item.md
+++ b/docs/pages/api-docs/tree-item.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTreeItem` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -40,9 +45,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTreeItem`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/tree-view.md
+++ b/docs/pages/api-docs/tree-view.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTreeView` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -44,9 +49,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTreeView`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/tree-view.md
+++ b/docs/pages/api-docs/tree-view.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTreeView` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/typography.md
+++ b/docs/pages/api-docs/typography.md
@@ -24,7 +24,6 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 The `MuiTypography` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
 
-
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/pages/api-docs/typography.md
+++ b/docs/pages/api-docs/typography.md
@@ -20,6 +20,11 @@ You can learn more about the difference by [reading this guide](/guides/minimizi
 
 
 
+## Component name
+
+The `MuiTypography` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+
+
 ## Props
 
 | Name | Type | Default | Description |
@@ -41,9 +46,6 @@ The `ref` is forwarded to the root element.
 Any other props supplied will be provided to the root element (native element).
 
 ## CSS
-
-- Style sheet name: `MuiTypography`.
-- Style sheet details:
 
 | Rule name | Global class | Description |
 |:-----|:-------------|:------------|

--- a/docs/pages/api-docs/zoom.md
+++ b/docs/pages/api-docs/zoom.md
@@ -22,6 +22,8 @@ The Zoom transition can be used for the floating variant of the
 [Button](/components/buttons/#floating-action-buttons) component.
 It uses [react-transition-group](https://github.com/reactjs/react-transition-group) internally.
 
+
+
 ## Props
 
 | Name | Type | Default | Description |

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -253,6 +253,17 @@ function getProp(props, key) {
   }
 }
 
+function generateName(reactAPI) {
+  if (!reactAPI.styles.classes.length) {
+    return '';
+  }
+
+  return `## Component name
+
+The \`${reactAPI.styles.name}\` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
+`
+}
+
 function generateProps(reactAPI) {
   const header = '## Props';
 
@@ -371,9 +382,6 @@ function generateClasses(reactAPI) {
 
   return `## CSS
 
-- Style sheet name: \`${reactAPI.styles.name}\`.
-- Style sheet details:
-
 ${text}
 
 You can override the style of the component thanks to one of these customization points:
@@ -473,6 +481,8 @@ export default function generateMarkdown(reactAPI) {
     generateImportStatement(reactAPI),
     '',
     reactAPI.description,
+    '',
+    generateName(reactAPI),
     '',
     generateProps(reactAPI),
     '',

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -63,10 +63,6 @@ function getChained(type) {
   return false;
 }
 
-function styleNameError(reactAPIName) {
-  throw new Error(`Missing styles name on ${reactAPIName} component`);
-}
-
 function escapeCell(value) {
   // As the pipe is use for the table structure
   return value.replace(/</g, '&lt;').replace(/`&lt;/g, '`<').replace(/\|/g, '\\|');
@@ -263,7 +259,7 @@ function generateName(reactAPI) {
   }
 
   if (!reactAPI.styles.name) {
-    styleNameError(reactAPI.name);
+    throw new Error(`Missing styles name on ${reactAPI.name} component`);
   }
 
   return `## Component name
@@ -363,7 +359,7 @@ function generateClasses(reactAPI) {
   }
 
   if (!reactAPI.styles.name) {
-    styleNameError(reactAPI.name);
+    throw new Error(`Missing styles name on ${reactAPI.name} component`);
   }
 
   let text = '';

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -63,6 +63,10 @@ function getChained(type) {
   return false;
 }
 
+function styleNameError(reactAPIName) {
+  throw new Error(`Missing styles name on ${reactAPIName} component`);
+}
+
 function escapeCell(value) {
   // As the pipe is use for the table structure
   return value.replace(/</g, '&lt;').replace(/`&lt;/g, '`<').replace(/\|/g, '\\|');
@@ -258,6 +262,10 @@ function generateName(reactAPI) {
     return '';
   }
 
+  if (!reactAPI.styles.name) {
+    styleNameError(reactAPI.name);
+  }
+
   return `## Component name
 
 The \`${reactAPI.styles.name}\` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
@@ -355,7 +363,7 @@ function generateClasses(reactAPI) {
   }
 
   if (!reactAPI.styles.name) {
-    throw new Error(`Missing styles name on ${reactAPI.name} component`);
+    styleNameError(reactAPI.name);
   }
 
   let text = '';

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -269,7 +269,7 @@ function generateName(reactAPI) {
   return `## Component name
 
 The \`${reactAPI.styles.name}\` name can be used for providing [default props](/customization/globals/#default-props) or [style overrides](/customization/globals/#css) at the theme level.
-`
+`;
 }
 
 function generateProps(reactAPI) {

--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -259,7 +259,7 @@ function getProp(props, key) {
 
 function generateName(reactAPI) {
   if (!reactAPI.styles.classes.length) {
-    return '';
+    return '\n';
   }
 
   if (!reactAPI.styles.name) {
@@ -491,7 +491,6 @@ export default function generateMarkdown(reactAPI) {
     reactAPI.description,
     '',
     generateName(reactAPI),
-    '',
     generateProps(reactAPI),
     '',
     `${generateClasses(reactAPI)}${generateInheritance(reactAPI)}${generateDemos(reactAPI)}`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixes [#17245](https://github.com/mui-org/material-ui/issues/17245)

generateName() function added to generateMarkdonw.js to create "Component Name" entry in each component's .md file. If the component does not have styling available there will be no entry. "Style sheet" name line has been removed from generateProps() as it is now redundant. Markdown files updated and reviewed. Added function styleNameError() to throw an error when the component is missing a style name. The same error is thrown in the recently added generateName() function, so the error was consolidated to avoid DRY.