### PR TITLE
[Dialog] Fix TypeScript type for `children`

### DIFF
--- a/packages/material-ui/src/Dialog/Dialog.d.ts
+++ b/packages/material-ui/src/Dialog/Dialog.d.ts
@@ -17,7 +17,7 @@ export interface DialogProps
   /**
    * Dialog children, usually the included sub-components.
    */
-  children: React.ReactNode;
+  children?: React.ReactNode;
   /**
    * If `true`, clicking the backdrop will not fire the `onClose` callback.
    */

--- a/packages/material-ui/src/Dialog/Dialog.spec.tsx
+++ b/packages/material-ui/src/Dialog/Dialog.spec.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { Dialog } from '@material-ui/core';
+
+function optionalChildrenTest() {
+  <Dialog open />;
+}


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/issues/20441#issuecomment-610227931

@eps1lon I think your intention is for it to be optional. Furthermore, if you check e.g. https://github.com/DefinitelyTyped/DefinitelyTyped/blob/7a2c5458a6119695868c4cb801afc237f5a5dc4a/types/react/index.d.ts#L338 you'll see that `children` is specified as `children?` despite the fact that `ReactNode` already includes `undefined`.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
