### PR TITLE
Return "component" prop to Typography component

### DIFF
--- a/packages/material-ui/src/Typography/Typography.d.ts
+++ b/packages/material-ui/src/Typography/Typography.d.ts
@@ -19,6 +19,7 @@ export interface TypographyTypeMap<P = {}, D extends React.ElementType = 'span'>
     display?: 'initial' | 'block' | 'inline';
     gutterBottom?: boolean;
     noWrap?: boolean;
+    component?: string;
     paragraph?: boolean;
     variant?: Variant | 'inherit';
     variantMapping?: Partial<Record<Variant, string>>;


### PR DESCRIPTION
The component property was removed previously by accident

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
