### PR TITLE
[examples] Fix Next.js prop-type warning

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -338,7 +338,7 @@ export default function MyApp(props) {
 }
 
 MyApp.propTypes = {
-  Component: PropTypes.func.isRequired,
+  Component: PropTypes.elementType.isRequired,
   pageProps: PropTypes.object.isRequired,
 };
 

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -32,6 +32,6 @@ export default function MyApp(props) {
 }
 
 MyApp.propTypes = {
-  Component: PropTypes.func.isRequired,
+  Component: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
   pageProps: PropTypes.object.isRequired,
 };

--- a/examples/nextjs/pages/_app.js
+++ b/examples/nextjs/pages/_app.js
@@ -32,6 +32,6 @@ export default function MyApp(props) {
 }
 
 MyApp.propTypes = {
-  Component: PropTypes.oneOfType([PropTypes.func, PropTypes.object]).isRequired,
+  Component: PropTypes.elementType.isRequired,
   pageProps: PropTypes.object.isRequired,
 };


### PR DESCRIPTION
React.memo may return an object, whereas propType is Component only.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #20473 