### PR TITLE
[Hidden] Add TypeScript type for `className`

### DIFF
--- a/packages/material-ui/src/Hidden/Hidden.d.ts
+++ b/packages/material-ui/src/Hidden/Hidden.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Breakpoint } from '../styles/createBreakpoints';
 
 export interface HiddenProps {
+  className?: string;
   /**
    * Specify which implementation to use.  'js' is the default, 'css' works better for
    * server-side rendering.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Fixes partially the #19704 issue

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Hi,

I want to use the `Hidden` component with a custom `className` with TypeScript **3.8.3**.
I have the same issue as [this comment](https://github.com/mui-org/material-ui/pull/10165#issuecomment-559108750), the `HiddenCss` component props interface has not been updated.

So, I added `className` type within the `HiddenCssProps` interface :pray: 

**[UPDATE]**

I added `className` type within the `HiddenProps` interface and not `HiddenCssProps`.