### PR TITLE
[Breadcrumbs] Keep focus in the component after expanding

### DIFF
--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -63,8 +63,9 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(props, ref) {
   const [expanded, setExpanded] = React.useState(false);
 
   const renderItemsBeforeAndAfter = (allItems) => {
-    const handleClickExpand = () => {
+    const handleClickExpand = (event) => {
       setExpanded(true);
+      event.currentTarget.parentNode.querySelector('a').focus();
     };
 
     // This defends against someone passing weird input, to ensure that if all

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.js
@@ -65,7 +65,13 @@ const Breadcrumbs = React.forwardRef(function Breadcrumbs(props, ref) {
   const renderItemsBeforeAndAfter = (allItems) => {
     const handleClickExpand = (event) => {
       setExpanded(true);
-      event.currentTarget.parentNode.querySelector('a').focus();
+
+      // The clicked element received the focus but gets removed from the DOM.
+      // Let's keep the focus in the component after expanding.
+      const focusable = event.currentTarget.parentNode.querySelector('a[href],button,[tabindex]');
+      if (focusable) {
+        focusable.focus();
+      }
     };
 
     // This defends against someone passing weird input, to ensure that if all

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -64,9 +64,9 @@ describe('<Breadcrumbs />', () => {
   });
 
   it('should expand when `BreadcrumbCollapsed` is clicked', () => {
-    const { getAllByRole, getByRole } = render(
+    const { getAllByRole, getByRole, getByText } = render(
       <Breadcrumbs>
-        <span>first</span>
+        <span tabIndex="-1">first</span>
         <span>second</span>
         <span>third</span>
         <span>fourth</span>
@@ -79,7 +79,7 @@ describe('<Breadcrumbs />', () => {
     );
 
     getByRole('button').click();
-
+    expect(document.activeElement).to.equal(getByText('first'));
     expect(getAllByRole('listitem', { hidden: false })).to.have.length(9);
   });
 


### PR DESCRIPTION
This PR successfully closes #20280. I have tested the code on IE-11 and Latest Chrome version.

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
