### PR TITLE
[ToggleButton] Don't set default for disableRipple prop

### DIFF
--- a/docs/pages/api-docs/toggle-button.md
+++ b/docs/pages/api-docs/toggle-button.md
@@ -32,7 +32,7 @@ The `MuiToggleButton` name can be used for providing [default props](/customizat
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 | <span class="prop-name">disabled</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the button will be disabled. |
 | <span class="prop-name">disableFocusRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the  keyboard focus ripple will be disabled. `disableRipple` must also be true. |
-| <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, the ripple effect will be disabled. |
+| <span class="prop-name">disableRipple</span> | <span class="prop-type">bool</span> |  | If `true`, the ripple effect will be disabled. |
 | <span class="prop-name">selected</span> | <span class="prop-type">bool</span> |  | If `true`, the button will be rendered in an active state. |
 | <span class="prop-name required">value&nbsp;*</span> | <span class="prop-type">any</span> |  | The value to associate with the button when selected in a ToggleButtonGroup. |
 

--- a/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
+++ b/packages/material-ui-lab/src/ToggleButton/ToggleButton.js
@@ -75,7 +75,6 @@ const ToggleButton = React.forwardRef(function ToggleButton(props, ref) {
     className,
     disabled = false,
     disableFocusRipple = false,
-    disableRipple = false,
     onChange,
     onClick,
     selected,
@@ -114,7 +113,6 @@ const ToggleButton = React.forwardRef(function ToggleButton(props, ref) {
       onClick={handleChange}
       onChange={onChange}
       value={value}
-      disableRipple={disableRipple}
       aria-pressed={selected}
       {...other}
     >


### PR DESCRIPTION
Doing so removes the ability to disable ripples globally, as documented in the
FAQ at https://material-ui.com/getting-started/faq/#how-can-i-disable-the-ripple-effect-globally

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
