### PR TITLE
 [docs] Fix heading fragment id mismatch

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -16,9 +16,9 @@ const workspaceRoot = path.join(__dirname, '../');
  * concurrent - ReactDOM.createRoot(Element).render(<App />)
  * @type {ReactRenderMode | 'legacy-strict'}
  */
-const reactMode = 'legacy-strict';
+const reactMode = 'legacy';
 // eslint-disable-next-line no-console
-console.log(`Using react '${reactMode}' mode.`);
+console.log(`Using React '${reactMode}' mode.`);
 
 module.exports = {
   typescript: {

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -8,9 +8,17 @@ const { LANGUAGES, LANGUAGES_SSR } = require('./src/modules/constants');
 const workspaceRoot = path.join(__dirname, '../');
 
 /**
- * @type {'legacy' | 'sync' | 'concurrent'}
+ * https://github.com/zeit/next.js/blob/287961ed9142a53f8e9a23bafb2f31257339ea98/packages/next/next-server/server/config.ts#L10
+ * @typedef {'legacy' | 'blocking' | 'concurrent'} ReactRenderMode
+ * legacy - ReactDOM.render(<App />)
+ * legacy-strict - ReactDOM.render(<React.StrictMode><App /></React.StrictMode>, Element)
+ * blocking - ReactDOM.createSyncRoot(Element).render(<App />)
+ * concurrent - ReactDOM.createRoot(Element).render(<App />)
+ * @type {ReactRenderMode | 'legacy-strict'}
  */
-const reactMode = 'legacy';
+const reactMode = 'legacy-strict';
+// eslint-disable-next-line no-console
+console.log(`Using react '${reactMode}' mode.`);
 
 module.exports = {
   typescript: {
@@ -44,10 +52,6 @@ module.exports = {
 
     config.resolve.alias['react-dom$'] = 'react-dom/profiling';
     config.resolve.alias['scheduler/tracing'] = 'scheduler/tracing-profiling';
-
-    if (reactMode !== 'legacy') {
-      config.resolve.alias['react-transition-group'] = '@material-ui/react-transition-group';
-    }
 
     // next includes node_modules in webpack externals. Some of those have dependencies
     // on the aliases defined above. If a module is an external those aliases won't be used.
@@ -179,5 +183,7 @@ module.exports = {
         { source: '/api/:rest*', destination: '/api-docs/:rest*' },
       ];
     },
+    reactMode: reactMode.startsWith('legacy') ? 'legacy' : reactMode,
   },
+  reactStrictMode: reactMode === 'legacy-strict',
 };

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -198,16 +198,6 @@ async function registerServiceWorker() {
   }
 }
 
-// Add the strict mode back once the number of warnings is manageable.
-// We might miss important warnings by keeping the strict mode 🌊🌊🌊.
-const ReactMode =
-  {
-    // createSyncRoot compatible
-    sync: React.StrictMode,
-    // partial createRoot, ConcurrentMode is deprecated
-    concurrent: React.unstable_ConcurrentMode,
-  }[process.env.REACT_MODE] || React.Fragment;
-
 let dependenciesLoaded = false;
 
 function loadDependencies() {
@@ -302,7 +292,7 @@ function AppWrapper(props) {
   }
 
   return (
-    <ReactMode>
+    <React.Fragment>
       <NextHead>
         {fonts.map((font) => (
           <link rel="stylesheet" href={font} key={font} />
@@ -318,7 +308,7 @@ function AppWrapper(props) {
         <LanguageNegotiation />
       </ReduxProvider>
       <GoogleAnalytics key={router.route} />
-    </ReactMode>
+    </React.Fragment>
   );
 }
 

--- a/docs/src/modules/components/useMarkdownDocs.js
+++ b/docs/src/modules/components/useMarkdownDocs.js
@@ -86,9 +86,6 @@ ${headers.components
   `);
   }
 
-  // eslint-disable-next-line no-underscore-dangle
-  global.__MARKED_UNIQUE__ = {};
-
   const element = (
     <React.Fragment>
       <svg style={{ display: 'none' }} xmlns="http://www.w3.org/2000/svg">

--- a/docs/src/modules/utils/textToHash.js
+++ b/docs/src/modules/utils/textToHash.js
@@ -9,6 +9,12 @@ function makeUnique(hash, unique, i = 1) {
   return makeUnique(hash, unique, i + 1);
 }
 
+/**
+ * @param {string} text
+ * @param {object} unique - cache object, if provided textToHash has side-effects.
+ *                          If you use it when rendering a react component be sure
+ *                          to always pass a new cache object.
+ */
 export default function textToHash(text, unique = {}) {
   return makeUnique(
     encodeURI(


### PR DESCRIPTION
Actual fix:  c0f6c7d

The rest is a refactoring in next.config.js to use their API to switch between various render modes of React.

`global.__MARKED_UNIQUE__` was problematic since it resulted in `textToHash(..., global.__MARKED_UNIQUE__)` to become impure and therefore unsuitable for rendering in react. In addition to that we also reset it during a different render making it even more problematic.

Removing it seems fine. We still avoid heading-id collisions since we reset the id cache on every render. This is the only concurrent-safe usage of `textToHash`: If it's called during render `unique` must be reset before that render call. It can only be "global" in the scope of the render call of a particular component. It cannot be re-used between two different components.