### PR TITLE
[docs] Fix heading fragment id mismatch

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -162,7 +162,9 @@ module.exports = {
     }
 
     // We want to speed-up the build of pull requests.
-    if (process.env.PULL_REQUEST === 'true') {
+    // TODO: revert
+    // eslint-disable-next-line no-constant-condition
+    if (false) {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -16,7 +16,7 @@ const workspaceRoot = path.join(__dirname, '../');
  * concurrent - ReactDOM.createRoot(Element).render(<App />)
  * @type {ReactRenderMode | 'legacy-strict'}
  */
-const reactMode = 'legacy';
+const reactMode = 'legacy-strict';
 // eslint-disable-next-line no-console
 console.log(`Using React '${reactMode}' mode.`);
 

--- a/docs/pages/components/buttons.js
+++ b/docs/pages/components/buttons.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import * as PropTypes from 'prop-types';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import { getToc } from 'docs/src/modules/utils/experimental';
 
 const req = require.context('docs/src/pages/components/buttons', false, /\.(md|js|tsx)$/);
 const reqSource = require.context(
@@ -9,6 +11,14 @@ const reqSource = require.context(
 );
 const reqPrefix = 'pages/components/buttons';
 
-export default function Page() {
-  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+export default function Page({ toc }) {
+  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} toc={toc} />;
+}
+
+Page.propTypes = {
+  toc: PropTypes.array.isRequired,
+};
+
+export async function getStaticProps() {
+  return { props: { toc: getToc(req) } };
 }

--- a/docs/pages/styles/api.js
+++ b/docs/pages/styles/api.js
@@ -1,10 +1,20 @@
 import React from 'react';
+import * as PropTypes from 'prop-types';
 import MarkdownDocs from 'docs/src/modules/components/MarkdownDocs';
+import { getToc } from 'docs/src/modules/utils/experimental';
 
 const req = require.context('docs/src/pages/styles/api', false, /\.(md|js|tsx)$/);
 const reqSource = require.context('!raw-loader!../../src/pages/styles/api', false, /\.(js|tsx)$/);
 const reqPrefix = 'pages/styles/api';
 
-export default function Page() {
-  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} />;
+export default function Page({ toc }) {
+  return <MarkdownDocs req={req} reqSource={reqSource} reqPrefix={reqPrefix} toc={toc} />;
+}
+
+Page.propTypes = {
+  toc: PropTypes.array.isRequired,
+};
+
+export async function getStaticProps() {
+  return { props: { toc: getToc(req) } };
 }

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -19,6 +19,7 @@ import PageContext from 'docs/src/modules/components/PageContext';
 import { getHeaders, getTitle, getDescription } from 'docs/src/modules/utils/parseMarkdown';
 import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 import Link from 'docs/src/modules/components/Link';
+import MarkdownDocsContext from './MarkdownDocsContext';
 
 const styles = (theme) => ({
   root: {
@@ -96,6 +97,7 @@ function MarkdownDocs(props) {
     req,
     reqPrefix,
     reqSource,
+    toc,
   } = props;
 
   const t = useSelector((state) => state.options.t);
@@ -144,7 +146,9 @@ function MarkdownDocs(props) {
           <div className={classes.actions}>
             <EditPage markdownLocation={markdownDocs.location} />
           </div>
-          {markdownDocs.element}
+          <MarkdownDocsContext.Provider value={{ toc }}>
+            {markdownDocs.element}
+          </MarkdownDocsContext.Provider>
           <footer className={classes.footer}>
             {!currentPage ||
             currentPage.displayNav === false ||
@@ -200,6 +204,10 @@ MarkdownDocs.propTypes = {
   req: PropTypes.func,
   reqPrefix: PropTypes.string,
   reqSource: PropTypes.func,
+  /**
+   * pre-built table of content for the given markdown
+   */
+  toc: PropTypes.array,
 };
 
 export default withStyles(styles)(MarkdownDocs);

--- a/docs/src/modules/components/MarkdownDocsContext.js
+++ b/docs/src/modules/components/MarkdownDocsContext.js
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const MarkdownDocsContext = React.createContext(undefined);
+if (process.env.NODE_ENV !== 'production') {
+  MarkdownDocsContext.displayName = 'MarkdownDocsContext';
+}
+export default MarkdownDocsContext;

--- a/docs/src/modules/components/useMarkdownDocs.js
+++ b/docs/src/modules/components/useMarkdownDocs.js
@@ -145,7 +145,9 @@ ${headers.components
           );
         }
 
-        return <MarkdownElement className="markdownElement" key={index} text={content} />;
+        return (
+          <MarkdownElement className="markdownElement" key={index} index={index} text={content} />
+        );
       })}
     </React.Fragment>
   );

--- a/docs/src/modules/components/useMarkdownDocs.js
+++ b/docs/src/modules/components/useMarkdownDocs.js
@@ -137,7 +137,7 @@ ${headers.components
 
           return (
             <Demo
-              key={`${content}${index}`}
+              key={index}
               demo={demos[name]}
               demoOptions={demoOptions}
               githubLocation={`${SOURCE_CODE_ROOT_URL}/docs/src/${name}`}

--- a/docs/src/modules/utils/experimental.js
+++ b/docs/src/modules/utils/experimental.js
@@ -1,0 +1,69 @@
+import marked from 'marked/lib/marked';
+import { demoRegexp, getContents } from './parseMarkdown';
+import textToHash from './textToHash';
+
+// Monkey patch to preserve non-breaking spaces
+// https://github.com/chjj/marked/blob/6b0416d10910702f73da9cb6bb3d4c8dcb7dead7/lib/marked.js#L142-L150
+marked.Lexer.prototype.lex = function lex(src) {
+  src = src
+    .replace(/\r\n|\r/g, '\n')
+    .replace(/\t/g, '    ')
+    .replace(/\u2424/g, '\n');
+
+  return this.token(src, true);
+};
+
+function getHeadings(markdown, hashCache) {
+  const headings = [];
+  const renderer = new marked.Renderer();
+  renderer.heading = (text, level) => {
+    // Small title. No need for an anchor.
+    // It's reducing the risk of duplicated id and it's fewer elements in the DOM.
+    if (level < 4) {
+      const hash = textToHash(text, hashCache);
+      headings.push(hash);
+    }
+
+    return '';
+  };
+
+  const markedOptions = {
+    gfm: true,
+    tables: true,
+    breaks: false,
+    pedantic: false,
+    sanitize: false,
+    smartLists: true,
+    smartypants: false,
+    renderer,
+  };
+
+  marked(markdown, markedOptions);
+
+  return headings;
+}
+
+// eslint-disable-next-line  import/prefer-default-export
+export function getToc(req) {
+  const toc = {};
+  req.keys().forEach((filename) => {
+    if (filename.indexOf('.md') !== -1) {
+      const localeMatch = filename.match(/-([a-z]{2})\.md$/);
+      const locale = localeMatch === null ? 'en' : localeMatch[1];
+
+      const markdown = req(filename);
+      const contents = getContents(markdown);
+
+      toc[locale] = new Array(contents.length);
+      const headingsHashCache = {};
+
+      contents.forEach((content, index) => {
+        if (!demoRegexp.test(content)) {
+          toc[locale][index] = getHeadings(content, headingsHashCache);
+        }
+      });
+    }
+  });
+
+  return toc;
+}


### PR DESCRIPTION
Alternate to #20520 using `getStaticProps` as suggested in https://github.com/mui-org/material-ui/pull/20520#issuecomment-613050591.

This is just thrown together. I'll clean this up if the deploy works.

Example page using the new ToC generator:
- https://deploy-preview-20539--material-ui.netlify.com/components/buttons/
- https://deploy-preview-20539--material-ui.netlify.com/styles/api/