### PR TITLE
[Autocomplete] Add missing startAfter type

### DIFF
--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -7,6 +7,7 @@ export interface CreateFilterOptionsConfig<T> {
   stringify?: (option: T) => string;
   trim?: boolean;
   limit?: number;
+  startAfter?: number;
 }
 
 export interface FilterOptionsState<T> {

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.d.ts
@@ -3,11 +3,11 @@ import * as React from 'react';
 export interface CreateFilterOptionsConfig<T> {
   ignoreAccents?: boolean;
   ignoreCase?: boolean;
+  limit?: number;
   matchFrom?: 'any' | 'start';
+  startAfter?: number;
   stringify?: (option: T) => string;
   trim?: boolean;
-  limit?: number;
-  startAfter?: number;
 }
 
 export interface FilterOptionsState<T> {


### PR DESCRIPTION
Add missing type `startAfter` in typings `CreateFilterOptionsConfig`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
