### PR TITLE
[test] Use method calls over property access expressions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,8 +115,6 @@ module.exports = {
       rules: {
         // does not work with wildcard imports. Mistakes will throw at runtime anyway
         'import/named': 'off',
-        // for expect style assertions
-        'no-unused-expressions': 'off',
 
         // no rationale provided in /recommended
         'mocha/no-mocha-arrows': 'off',

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -350,7 +350,7 @@ describe('<Autocomplete />', () => {
 
       // listbox is not only inaccessible but not in the DOM
       const listbox = queryByRole('listbox', { hidden: true });
-      expect(listbox).to.be.null;
+      expect(listbox).to.equal(null);
 
       const buttons = getAllByRole('button');
       expect(buttons).to.have.length(2);
@@ -764,7 +764,7 @@ describe('<Autocomplete />', () => {
           />,
         );
         const input = getByRole('textbox');
-        expect(input.disabled).to.be.true;
+        expect(input.disabled).to.equal(true);
       });
 
       it('should disable the popup button', () => {
@@ -776,7 +776,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} />}
           />,
         );
-        expect(queryByTitle('Open').disabled).to.be.true;
+        expect(queryByTitle('Open').disabled).to.equal(true);
       });
 
       it('should not render the clear button', () => {
@@ -788,7 +788,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} />}
           />,
         );
-        expect(queryByTitle('Clear')).to.be.null;
+        expect(queryByTitle('Clear')).to.equal(null);
       });
 
       it('should not apply the hasClearIcon class', () => {
@@ -815,7 +815,7 @@ describe('<Autocomplete />', () => {
             renderInput={(params) => <TextField {...params} />}
           />,
         );
-        expect(queryByTitle('Clear')).to.be.null;
+        expect(queryByTitle('Clear')).to.equal(null);
         expect(container.querySelector(`.${classes.root}`)).to.have.class(classes.hasPopupIcon);
         expect(container.querySelector(`.${classes.root}`)).not.to.have.class(classes.hasClearIcon);
       });

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -354,9 +354,9 @@ describe('<Autocomplete />', () => {
 
       const buttons = getAllByRole('button');
       expect(buttons).to.have.length(2);
-      expect(buttons[0]).to.have.accessibleName('Clear');
+      expect(buttons[0]).toHaveAccessibleName('Clear');
       expect(buttons[0]).to.have.attribute('title', 'Clear');
-      expect(buttons[1]).to.have.accessibleName('Open');
+      expect(buttons[1]).toHaveAccessibleName('Open');
       expect(buttons[1]).to.have.attribute('title', 'Open');
       buttons.forEach((button) => {
         expect(button, 'button is not in tab order').to.have.property('tabIndex', -1);
@@ -396,9 +396,9 @@ describe('<Autocomplete />', () => {
 
       const buttons = getAllByRole('button');
       expect(buttons).to.have.length(2);
-      expect(buttons[0]).to.have.accessibleName('Clear');
+      expect(buttons[0]).toHaveAccessibleName('Clear');
       expect(buttons[0]).to.have.attribute('title', 'Clear');
-      expect(buttons[1]).to.have.accessibleName('Close');
+      expect(buttons[1]).toHaveAccessibleName('Close');
       expect(buttons[1]).to.have.attribute('title', 'Close');
       buttons.forEach((button) => {
         expect(button, 'button is not in tab order').to.have.property('tabIndex', -1);

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -595,7 +595,7 @@ describe('<Autocomplete />', () => {
       const combobox = getByRole('combobox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      expect(textbox).to.have.focus;
+      expect(textbox).toHaveFocus();
 
       fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
@@ -603,12 +603,12 @@ describe('<Autocomplete />', () => {
 
       document.activeElement.blur();
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      expect(textbox).to.not.have.focus;
+      expect(textbox).not.toHaveFocus();
 
       fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      expect(textbox).to.have.focus;
+      expect(textbox).toHaveFocus();
 
       fireEvent.mouseDown(textbox);
       fireEvent.click(textbox);
@@ -629,7 +629,7 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
       const options = getAllByRole('option');
-      expect(document.activeElement).to.have.focus;
+      expect(document.activeElement).toHaveFocus();
       expect(document.activeElement).to.have.attribute(
         'aria-activedescendant',
         options[options.length - 1].getAttribute('id'),
@@ -648,7 +648,7 @@ describe('<Autocomplete />', () => {
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
       const options = getAllByRole('option');
-      expect(document.activeElement).to.have.focus;
+      expect(document.activeElement).toHaveFocus();
       expect(document.activeElement).to.have.attribute(
         'aria-activedescendant',
         options[0].getAttribute('id'),
@@ -668,7 +668,7 @@ describe('<Autocomplete />', () => {
         fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
         fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-        expect(document.activeElement).to.have.focus;
+        expect(document.activeElement).toHaveFocus();
         expect(document.activeElement).not.to.have.attribute('aria-activedescendant');
       });
 
@@ -684,7 +684,7 @@ describe('<Autocomplete />', () => {
         fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
         fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-        expect(document.activeElement).to.have.focus;
+        expect(document.activeElement).toHaveFocus();
         expect(document.activeElement).not.to.have.attribute('aria-activedescendant');
       });
     });
@@ -702,7 +702,7 @@ describe('<Autocomplete />', () => {
         fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
         fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-        expect(document.activeElement).to.have.focus;
+        expect(document.activeElement).toHaveFocus();
         expect(document.activeElement).to.have.attribute(
           'aria-activedescendant',
           getAllByRole('option')[0].getAttribute('id'),
@@ -723,7 +723,7 @@ describe('<Autocomplete />', () => {
 
         const textbox = getByRole('textbox');
         const options = getAllByRole('option');
-        expect(textbox).to.have.focus;
+        expect(textbox).toHaveFocus();
         expect(textbox).to.have.attribute(
           'aria-activedescendant',
           options[options.length - 1].getAttribute('id'),
@@ -745,7 +745,7 @@ describe('<Autocomplete />', () => {
 
         const textbox = getByRole('textbox');
         const options = getAllByRole('option');
-        expect(textbox).to.have.focus;
+        expect(textbox).toHaveFocus();
         expect(textbox).to.have.attribute(
           'aria-activedescendant',
           options[options.length - 1].getAttribute('id'),
@@ -1092,11 +1092,11 @@ describe('<Autocomplete />', () => {
 
       const textbox = getByRole('textbox');
       fireEvent.click(textbox);
-      expect(textbox).to.have.focus;
+      expect(textbox).toHaveFocus();
       textbox.blur();
 
       fireEvent.click(queryByTitle('Open'));
-      expect(textbox).to.have.focus;
+      expect(textbox).toHaveFocus();
     });
   });
 
@@ -1422,16 +1422,16 @@ describe('<Autocomplete />', () => {
       );
       const textbox = getByRole('textbox');
       let firstOption = getByRole('option');
-      expect(textbox).to.have.focus;
+      expect(textbox).toHaveFocus();
       fireEvent.click(firstOption);
-      expect(textbox).to.not.have.focus;
+      expect(textbox).not.toHaveFocus();
 
       fireEvent.click(queryByTitle('Open'));
-      expect(textbox).to.have.focus;
+      expect(textbox).toHaveFocus();
       firstOption = getByRole('option');
       fireEvent.touchStart(firstOption);
       fireEvent.click(firstOption);
-      expect(textbox).to.not.have.focus;
+      expect(textbox).not.toHaveFocus();
     });
 
     it('[blurOnSelect="touch"] should only blur the input when an option is touched', () => {
@@ -1448,13 +1448,13 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('textbox');
       let firstOption = getByRole('option');
       fireEvent.click(firstOption);
-      expect(textbox).to.have.focus;
+      expect(textbox).toHaveFocus();
 
       fireEvent.click(queryByTitle('Open'));
       firstOption = getByRole('option');
       fireEvent.touchStart(firstOption);
       fireEvent.click(firstOption);
-      expect(textbox).to.not.have.focus;
+      expect(textbox).not.toHaveFocus();
     });
 
     it('[blurOnSelect="mouse"] should only blur the input when an option is clicked', () => {
@@ -1472,12 +1472,12 @@ describe('<Autocomplete />', () => {
       let firstOption = getByRole('option');
       fireEvent.touchStart(firstOption);
       fireEvent.click(firstOption);
-      expect(textbox).to.have.focus;
+      expect(textbox).toHaveFocus();
 
       fireEvent.click(queryByTitle('Open'));
       firstOption = getByRole('option');
       fireEvent.click(firstOption);
-      expect(textbox).to.not.have.focus;
+      expect(textbox).not.toHaveFocus();
     });
   });
 

--- a/packages/material-ui-lab/src/Pagination/Pagination.test.js
+++ b/packages/material-ui-lab/src/Pagination/Pagination.test.js
@@ -39,7 +39,7 @@ describe('<Pagination />', () => {
     const [, page1] = getAllByRole('button');
     expect(page1).to.have.attribute('aria-current', 'true');
     // verifying no regression from previous bug where `page` wasn't intercepted
-    expect(container.querySelector('[page]')).to.be.null;
+    expect(container.querySelector('[page]')).to.equal(null);
   });
 
   it('fires onChange when a different page is clicked', () => {

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -97,10 +97,10 @@ describe('<TreeItem />', () => {
     const { getByTestId, queryByTestId } = render(<TestComponent />);
 
     expect(getByTestId('1')).to.have.attribute('aria-expanded', 'true');
-    expect(getByTestId('2')).to.not.be.null;
+    expect(getByTestId('2')).not.to.equal(null);
     fireEvent.click(getByTestId('button'));
     expect(getByTestId('1')).to.not.have.attribute('aria-expanded');
-    expect(queryByTestId('2')).to.be.null;
+    expect(queryByTestId('2')).to.equal(null);
   });
 
   it('should treat an empty array equally to no children', () => {
@@ -537,11 +537,11 @@ describe('<TreeItem />', () => {
 
           const { queryByTestId, getByTestId } = render(<TestComponent />);
 
-          expect(getByTestId('one')).to.not.be.null;
+          expect(getByTestId('one')).not.to.equal(null);
           fireEvent.click(getByTestId('button'));
-          expect(queryByTestId('one')).to.be.null;
+          expect(queryByTestId('one')).to.equal(null);
           fireEvent.click(getByTestId('button'));
-          expect(getByTestId('one')).to.not.be.null;
+          expect(getByTestId('one')).not.to.equal(null);
 
           getByTestId('one').focus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -294,12 +294,12 @@ describe('<TreeItem />', () => {
         );
 
         getByTestId('start').focus();
-        expect(getByTestId('start')).to.have.focus;
+        expect(getByTestId('start')).toHaveFocus();
 
         fireEvent.keyDown(document.activeElement, { key: 'Tab' });
         getByTestId('one').focus();
 
-        expect(getByTestId('one')).to.have.focus;
+        expect(getByTestId('one')).toHaveFocus();
       });
 
       it('should focus the selected node if a node is selected before the tree receives focus', () => {
@@ -316,15 +316,15 @@ describe('<TreeItem />', () => {
         );
 
         fireEvent.click(getByText('two'));
-        expect(getByTestId('two')).to.have.focus;
+        expect(getByTestId('two')).toHaveFocus();
 
         getByTestId('start').focus();
-        expect(getByTestId('start')).to.have.focus;
+        expect(getByTestId('start')).toHaveFocus();
 
         fireEvent.keyDown(document.activeElement, { key: 'Tab' });
         getByTestId('two').focus();
 
-        expect(getByTestId('two')).to.have.focus;
+        expect(getByTestId('two')).toHaveFocus();
       });
 
       it('should work with programmatic focus', () => {
@@ -363,7 +363,7 @@ describe('<TreeItem />', () => {
           getByTestId('one').focus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
         });
 
         it('should move focus to the first child if focus is on an open node', () => {
@@ -378,7 +378,7 @@ describe('<TreeItem />', () => {
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
           getByTestId('one').focus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
         });
 
         it('should do nothing if focus is on an end node', () => {
@@ -391,9 +391,9 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('two'));
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
         });
       });
 
@@ -412,7 +412,7 @@ describe('<TreeItem />', () => {
           getByTestId('one').focus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
         });
 
         it("should move focus to the node's parent node if focus is on a child node that is an end node", () => {
@@ -427,7 +427,7 @@ describe('<TreeItem />', () => {
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
           fireEvent.click(getByText('two'));
           fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
         });
 
@@ -449,7 +449,7 @@ describe('<TreeItem />', () => {
           fireEvent.click(getByText('two'));
           expect(getByTestId('two')).to.have.attribute('aria-expanded', 'false');
           fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
         });
 
@@ -465,7 +465,7 @@ describe('<TreeItem />', () => {
           getByTestId('one').focus();
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'false');
           fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
         });
 
         it('should do nothing if focus is on a root node that is an end node', () => {
@@ -477,7 +477,7 @@ describe('<TreeItem />', () => {
 
           getByTestId('one').focus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowLeft' });
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
         });
       });
 
@@ -492,7 +492,7 @@ describe('<TreeItem />', () => {
 
           getByTestId('one').focus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
         });
 
         it('moves focus to a child node', () => {
@@ -507,7 +507,7 @@ describe('<TreeItem />', () => {
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
           getByTestId('one').focus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
         });
 
         it('moves focus to a child node works with a dynamic tree', () => {
@@ -546,7 +546,7 @@ describe('<TreeItem />', () => {
           getByTestId('one').focus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
         });
 
         it("moves focus to a parent's sibling", () => {
@@ -561,9 +561,9 @@ describe('<TreeItem />', () => {
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
           fireEvent.click(getByText('two'));
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-          expect(getByTestId('three')).to.have.focus;
+          expect(getByTestId('three')).toHaveFocus();
         });
       });
 
@@ -577,9 +577,9 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('two'));
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
         });
 
         it('moves focus to a parent', () => {
@@ -593,9 +593,9 @@ describe('<TreeItem />', () => {
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
           fireEvent.click(getByText('two'));
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
         });
 
         it("moves focus to a sibling's child", () => {
@@ -610,9 +610,9 @@ describe('<TreeItem />', () => {
 
           expect(getByTestId('one')).to.have.attribute('aria-expanded', 'true');
           fireEvent.click(getByText('three'));
-          expect(getByTestId('three')).to.have.focus;
+          expect(getByTestId('three')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
         });
       });
 
@@ -628,9 +628,9 @@ describe('<TreeItem />', () => {
           );
 
           fireEvent.click(getByText('four'));
-          expect(getByTestId('four')).to.have.focus;
+          expect(getByTestId('four')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'Home' });
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
         });
       });
 
@@ -646,9 +646,9 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'End' });
-          expect(getByTestId('four')).to.have.focus;
+          expect(getByTestId('four')).toHaveFocus();
         });
 
         it('moves focus to the last node in the tree with expanded items', () => {
@@ -666,9 +666,9 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'End' });
-          expect(getByTestId('six')).to.have.focus;
+          expect(getByTestId('six')).toHaveFocus();
         });
       });
 
@@ -684,15 +684,15 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 't' });
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
 
           fireEvent.keyDown(document.activeElement, { key: 'f' });
-          expect(getByTestId('four')).to.have.focus;
+          expect(getByTestId('four')).toHaveFocus();
 
           fireEvent.keyDown(document.activeElement, { key: 'o' });
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
         });
 
         it('moves focus to the next node with the same starting character', () => {
@@ -706,15 +706,15 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('one').focus();
-          expect(getByTestId('one')).to.have.focus;
+          expect(getByTestId('one')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 't' });
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
 
           fireEvent.keyDown(document.activeElement, { key: 't' });
-          expect(getByTestId('three')).to.have.focus;
+          expect(getByTestId('three')).toHaveFocus();
 
           fireEvent.keyDown(document.activeElement, { key: 't' });
-          expect(getByTestId('two')).to.have.focus;
+          expect(getByTestId('two')).toHaveFocus();
         });
 
         it('should not move focus when pressing a modifier key + letter', () => {
@@ -728,15 +728,15 @@ describe('<TreeItem />', () => {
           );
 
           getByTestId('apple').focus();
-          expect(getByTestId('apple')).to.have.focus;
+          expect(getByTestId('apple')).toHaveFocus();
           fireEvent.keyDown(document.activeElement, { key: 'v', ctrlKey: true });
-          expect(getByTestId('apple')).to.have.focus;
+          expect(getByTestId('apple')).toHaveFocus();
 
           fireEvent.keyDown(document.activeElement, { key: 'v', metaKey: true });
-          expect(getByTestId('apple')).to.have.focus;
+          expect(getByTestId('apple')).toHaveFocus();
 
           fireEvent.keyDown(document.activeElement, { key: 'v', shiftKey: true });
-          expect(getByTestId('apple')).to.have.focus;
+          expect(getByTestId('apple')).toHaveFocus();
         });
       });
 
@@ -876,7 +876,7 @@ describe('<TreeItem />', () => {
           fireEvent.click(getByText('three'));
           expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
           fireEvent.keyDown(document.activeElement, { key: 'ArrowDown', shiftKey: true });
-          expect(getByTestId('four')).to.have.focus;
+          expect(getByTestId('four')).toHaveFocus();
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(2);
           fireEvent.keyDown(document.activeElement, { key: 'ArrowDown', shiftKey: true });
           expect(getByTestId('three')).to.have.attribute('aria-selected', 'true');
@@ -884,7 +884,7 @@ describe('<TreeItem />', () => {
           expect(getByTestId('five')).to.have.attribute('aria-selected', 'true');
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(3);
           fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
-          expect(getByTestId('four')).to.have.focus;
+          expect(getByTestId('four')).toHaveFocus();
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(2);
           fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(1);
@@ -912,7 +912,7 @@ describe('<TreeItem />', () => {
 
           fireEvent.click(getByText('three'));
           fireEvent.keyDown(document.activeElement, { key: 'ArrowDown', shiftKey: true });
-          expect(getByTestId('four')).to.have.focus;
+          expect(getByTestId('four')).toHaveFocus();
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(0);
           fireEvent.keyDown(document.activeElement, { key: 'ArrowUp', shiftKey: true });
           expect(container.querySelectorAll('[aria-selected=true]').length).to.equal(0);
@@ -1242,11 +1242,11 @@ describe('<TreeItem />', () => {
 
     fireEvent.click(getByText('two'));
 
-    expect(getByTestId('two')).to.have.focus;
+    expect(getByTestId('two')).toHaveFocus();
 
     getByRole('button').focus();
 
-    expect(getByRole('button')).to.have.focus;
+    expect(getByRole('button')).toHaveFocus();
 
     act(() => {
       setActiveItemMounted(false);
@@ -1255,6 +1255,6 @@ describe('<TreeItem />', () => {
       setActiveItemMounted(true);
     });
 
-    expect(getByRole('button')).to.have.focus;
+    expect(getByRole('button')).toHaveFocus();
   });
 });

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -190,9 +190,9 @@ describe('<TreeView />', () => {
 
     const { getByText, queryByText } = render(<TestComponent />);
 
-    expect(getByText('test')).to.not.be.null;
+    expect(getByText('test')).not.to.equal(null);
     fireEvent.click(getByText('Hide'));
-    expect(queryByText('test')).to.be.null;
+    expect(queryByText('test')).to.equal(null);
   });
 
   describe('onNodeToggle', () => {
@@ -218,7 +218,7 @@ describe('<TreeView />', () => {
     it('(TreeView) should have the role `tree`', () => {
       const { getByRole } = render(<TreeView />);
 
-      expect(getByRole('tree')).to.be.ok;
+      expect(getByRole('tree')).not.to.equal(null);
     });
 
     it('(TreeView) should have the attribute `aria-multiselectable=false if using single select`', () => {

--- a/packages/material-ui-lab/src/TreeView/TreeView.test.js
+++ b/packages/material-ui-lab/src/TreeView/TreeView.test.js
@@ -165,13 +165,13 @@ describe('<TreeView />', () => {
     const { getByText, getByTestId } = render(<MyComponent />);
 
     fireEvent.click(getByText('one'));
-    expect(getByTestId('one')).to.have.focus;
+    expect(getByTestId('one')).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(getByTestId('two')).to.have.focus;
+    expect(getByTestId('two')).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(getByTestId('one')).to.have.focus;
+    expect(getByTestId('one')).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(getByTestId('two')).to.have.focus;
+    expect(getByTestId('two')).toHaveFocus();
   });
 
   it('should support conditional rendered tree items', () => {

--- a/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
+++ b/packages/material-ui/src/BottomNavigationAction/BottomNavigationAction.test.js
@@ -65,7 +65,7 @@ describe('<BottomNavigationAction />', () => {
   it('should render the passed `icon`', () => {
     const { getByRole } = render(<BottomNavigationAction icon={<div data-testid="icon" />} />);
 
-    expect(within(getByRole('button')).getByTestId('icon')).to.be.ok;
+    expect(within(getByRole('button')).getByTestId('icon')).not.to.equal(null);
   });
 
   describe('prop: onClick', () => {

--- a/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/material-ui/src/Breadcrumbs/Breadcrumbs.test.js
@@ -60,7 +60,7 @@ describe('<Breadcrumbs />', () => {
 
     expect(listitems).to.have.length(2);
     expect(getByRole('list')).to.have.text('first//ninth');
-    expect(getByRole('button').querySelector('[data-mui-test="MoreHorizIcon"]')).to.be.ok;
+    expect(getByRole('button').querySelector('[data-mui-test="MoreHorizIcon"]')).not.to.equal(null);
   });
 
   it('should expand when `BreadcrumbCollapsed` is clicked', () => {

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -295,7 +295,7 @@ describe('<Button />', () => {
     );
     const button = getByRole('button');
 
-    expect(button.querySelector('.touch-ripple')).to.be.ok;
+    expect(button.querySelector('.touch-ripple')).not.to.equal(null);
   });
 
   it('can disable the ripple', () => {
@@ -306,7 +306,7 @@ describe('<Button />', () => {
     );
     const button = getByRole('button');
 
-    expect(button.querySelector('.touch-ripple')).to.be.null;
+    expect(button.querySelector('.touch-ripple')).to.equal(null);
   });
 
   it('can disable the elevation', () => {
@@ -329,7 +329,7 @@ describe('<Button />', () => {
       button.focus();
     });
 
-    expect(button.querySelector('.pulsate-focus-visible')).to.be.ok;
+    expect(button.querySelector('.pulsate-focus-visible')).not.to.equal(null);
   });
 
   it('can disable the focusRipple', () => {
@@ -348,7 +348,7 @@ describe('<Button />', () => {
       button.focus();
     });
 
-    expect(button.querySelector('.pulsate-focus-visible')).to.be.null;
+    expect(button.querySelector('.pulsate-focus-visible')).to.equal(null);
   });
 
   describe('server-side', () => {

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -656,7 +656,7 @@ describe('<ButtonBase />', () => {
       // so we need to check if we're resilient against it
       const { getByText } = render(<ButtonBase autoFocus>Hello</ButtonBase>);
 
-      expect(getByText('Hello')).to.have.focus;
+      expect(getByText('Hello')).toHaveFocus();
     });
   });
 
@@ -900,7 +900,7 @@ describe('<ButtonBase />', () => {
       expect(typeof buttonActionsRef.current.focusVisible).to.equal('function');
       // @ts-ignore
       buttonActionsRef.current.focusVisible();
-      expect(getByText('Hello')).to.have.focus;
+      expect(getByText('Hello')).toHaveFocus();
       expect(getByText('Hello')).to.match('.focusVisible');
     });
   });

--- a/packages/material-ui/src/ButtonBase/ButtonBase.test.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.test.js
@@ -723,7 +723,7 @@ describe('<ButtonBase />', () => {
           </ButtonBase>,
         );
 
-        expect(getByText('Hello').querySelector('.touch-ripple')).to.be.null;
+        expect(getByText('Hello').querySelector('.touch-ripple')).to.equal(null);
       });
     });
 

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -75,7 +75,7 @@ describe('<Chip />', () => {
 
       const button = getByRole('button');
       expect(button).to.have.property('tabIndex', 0);
-      expect(button).to.have.accessibleName('My Chip');
+      expect(button).toHaveAccessibleName('My Chip');
     });
 
     it('should apply user value of tabIndex', () => {

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -141,7 +141,7 @@ describe('<Chip />', () => {
       );
 
       expect(getByRole('button')).to.have.property('tabIndex', 0);
-      expect(container.querySelector('#avatar')).to.be.ok;
+      expect(container.querySelector('#avatar')).not.to.equal(null);
     });
 
     it('should apply user value of tabIndex', () => {

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -333,7 +333,7 @@ describe('<Chip />', () => {
       fireEvent.keyUp(document.activeElement, { key: 'Escape' });
 
       expect(handleBlur.callCount).to.equal(1);
-      expect(chip).not.to.to.have.focus;
+      expect(chip).not.toHaveFocus();
     });
 
     it('should call onClick when `space` is released ', () => {

--- a/packages/material-ui/src/Dialog/Dialog.test.js
+++ b/packages/material-ui/src/Dialog/Dialog.test.js
@@ -97,7 +97,7 @@ describe('<Dialog />', () => {
     }
     const { getByRole, queryByRole } = render(<TestCase />);
     const dialog = getByRole('dialog');
-    expect(dialog).to.be.ok;
+    expect(dialog).not.to.equal(null);
 
     dialog.click();
     fireEvent.keyDown(document.activeElement, { key: 'Esc' });
@@ -122,7 +122,7 @@ describe('<Dialog />', () => {
       </Dialog>,
     );
     const dialog = getByRole('dialog');
-    expect(dialog).to.be.ok;
+    expect(dialog).not.to.equal(null);
 
     dialog.click();
     fireEvent.keyDown(document.activeElement, { key: 'Esc' });
@@ -186,7 +186,7 @@ describe('<Dialog />', () => {
 
       fireEvent.mouseDown(getByRole('heading'));
       findBackdrop(document.body).click();
-      expect(getByRole('dialog')).to.be.ok;
+      expect(getByRole('dialog')).not.to.equal(null);
     });
   });
 

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -62,7 +62,7 @@ describe('<ExpansionPanelSummary />', () => {
 
     const expandIcon = container.querySelector(`.${classes.expandIcon}`);
     expect(expandIcon).to.have.text('Icon');
-    expect(expandIcon).to.be.inaccessible;
+    expect(expandIcon).toBeInaccessible();
   });
 
   it('focusing adds the `focused` class if focused visible', () => {

--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.test.js
@@ -77,7 +77,7 @@ describe('<ExpansionPanelSummary />', () => {
     fireEvent.keyDown(document.activeElement, { key: 'Tab' }); // not actually focusing (yet)
     button.focus();
 
-    expect(button).to.have.focus;
+    expect(button).toHaveFocus();
     expect(button).to.have.class(classes.focused);
   });
 
@@ -90,7 +90,7 @@ describe('<ExpansionPanelSummary />', () => {
 
     button.blur();
 
-    expect(button).not.to.have.focus;
+    expect(button).not.toHaveFocus();
     expect(button).not.to.have.class(classes.focused);
   });
 

--- a/packages/material-ui/src/Fab/Fab.test.js
+++ b/packages/material-ui/src/Fab/Fab.test.js
@@ -118,7 +118,7 @@ describe('<Fab />', () => {
     const { getByTestId } = render(<Fab>{iconChild}</Fab>);
     const renderedIconChild = getByTestId('icon');
 
-    expect(renderedIconChild).to.be.ok;
+    expect(renderedIconChild).not.to.equal(null);
     expect(renderedIconChild).to.have.class(childClassName);
   });
 

--- a/packages/material-ui/src/IconButton/IconButton.test.js
+++ b/packages/material-ui/src/IconButton/IconButton.test.js
@@ -55,7 +55,7 @@ describe('<IconButton />', () => {
     const { container } = render(
       <IconButton TouchRippleProps={{ className: 'touch-ripple' }}>book</IconButton>,
     );
-    expect(container.querySelector('.touch-ripple')).to.be.ok;
+    expect(container.querySelector('.touch-ripple')).not.to.equal(null);
   });
 
   it('can disable the ripple', () => {
@@ -64,7 +64,7 @@ describe('<IconButton />', () => {
         book
       </IconButton>,
     );
-    expect(container.querySelector('.touch-ripple')).to.be.null;
+    expect(container.querySelector('.touch-ripple')).to.equal(null);
   });
 
   it('should pass centerRipple={true} to ButtonBase', () => {

--- a/packages/material-ui/src/InputAdornment/InputAdornment.test.js
+++ b/packages/material-ui/src/InputAdornment/InputAdornment.test.js
@@ -34,7 +34,7 @@ describe('<InputAdornment />', () => {
     const typographyClasses = getClasses(<Typography />);
     const typography = container.querySelector(`.${typographyClasses.root}`);
 
-    expect(typography).to.be.ok;
+    expect(typography).not.to.equal(null);
     expect(typography).to.have.text('foo');
   });
 
@@ -178,7 +178,7 @@ describe('<InputAdornment />', () => {
     );
     const typographyClasses = getClasses(<Typography />);
 
-    expect(container.querySelector(`.${typographyClasses.root}`)).to.be.null;
+    expect(container.querySelector(`.${typographyClasses.root}`)).to.equal(null);
   });
 
   it('should render children', () => {

--- a/packages/material-ui/src/InputBase/InputBase.test.js
+++ b/packages/material-ui/src/InputBase/InputBase.test.js
@@ -609,7 +609,7 @@ describe('<InputBase />', () => {
         />,
       );
 
-      expect(getByTestId('adornment')).to.be.ok;
+      expect(getByTestId('adornment')).not.to.equal(null);
     });
 
     it('should render adornment after input', () => {
@@ -623,7 +623,7 @@ describe('<InputBase />', () => {
         />,
       );
 
-      expect(getByTestId('adornment')).to.be.ok;
+      expect(getByTestId('adornment')).not.to.equal(null);
     });
 
     it('should allow a Select as an adornment', () => {

--- a/packages/material-ui/src/ListItem/ListItem.test.js
+++ b/packages/material-ui/src/ListItem/ListItem.test.js
@@ -83,7 +83,7 @@ describe('<ListItem />', () => {
       const listItem = getByRole('listitem');
 
       expect(listItem).to.have.class(classes.container);
-      expect(listItem.querySelector(`div.${classes.root}`)).to.be.ok;
+      expect(listItem.querySelector(`div.${classes.root}`)).not.to.equal(null);
     });
 
     it('should accept a component property', () => {
@@ -96,7 +96,7 @@ describe('<ListItem />', () => {
       const listItem = getByRole('listitem');
 
       expect(listItem).to.have.class(classes.container);
-      expect(listItem.querySelector(`span.${classes.root}`)).to.be.ok;
+      expect(listItem.querySelector(`span.${classes.root}`)).not.to.equal(null);
     });
 
     it('should accept a button property', () => {
@@ -109,7 +109,7 @@ describe('<ListItem />', () => {
       const listItem = getByRole('listitem');
 
       expect(listItem).to.have.class(classes.container);
-      expect(queries.getByRole(listItem, 'button')).to.be.ok;
+      expect(queries.getByRole(listItem, 'button')).not.to.equal(null);
     });
 
     it('should accept a ContainerComponent property', () => {
@@ -123,7 +123,7 @@ describe('<ListItem />', () => {
 
       expect(listItem).to.have.property('nodeName', 'DIV');
       expect(listItem).to.have.class(classes.container);
-      expect(listItem.querySelector(`div.${classes.root}`)).to.be.ok;
+      expect(listItem.querySelector(`div.${classes.root}`)).not.to.equal(null);
     });
 
     it('should allow customization of the wrapper', () => {

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -589,15 +589,15 @@ describe('<Modal />', () => {
         const { getByRole, setProps } = render(<WithRemovableElement />);
         const dialog = getByRole('dialog');
         const toggleButton = getByRole('button');
-        expect(dialog).to.have.focus;
+        expect(dialog).toHaveFocus();
 
         toggleButton.focus();
-        expect(toggleButton).to.have.focus;
+        expect(toggleButton).toHaveFocus();
 
         setProps({ hideButton: true });
-        expect(dialog).not.to.have.focus;
+        expect(dialog).not.toHaveFocus();
         clock.tick(500); // wait for the interval check to kick in.
-        expect(dialog).to.have.focus;
+        expect(dialog).toHaveFocus();
       });
     });
   });

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -838,7 +838,7 @@ describe('<Modal />', () => {
           </Modal>
         </div>,
       );
-      expect(within(getByTestId('parent')).getByTestId('child')).to.be.ok;
+      expect(within(getByTestId('parent')).getByTestId('child')).not.to.equal(null);
     });
   });
 });

--- a/packages/material-ui/src/Modal/Modal.test.js
+++ b/packages/material-ui/src/Modal/Modal.test.js
@@ -353,10 +353,10 @@ describe('<Modal />', () => {
         </Modal>,
       );
       const modalNode = modalRef.current;
-      expect(modalNode).to.be.ariaHidden;
+      expect(modalNode).toBeAriaHidden();
 
       wrapper.setProps({ open: true });
-      expect(modalNode).not.to.be.ariaHidden;
+      expect(modalNode).not.toBeAriaHidden();
     });
 
     // Test case for https://github.com/mui-org/material-ui/issues/15180

--- a/packages/material-ui/src/Modal/ModalManager.test.js
+++ b/packages/material-ui/src/Modal/ModalManager.test.js
@@ -192,17 +192,17 @@ describe('ModalManager', () => {
       const modal2 = {};
       modalManager.add(modal1, container3);
       modalManager.mount(modal1, {});
-      expect(container3.children[0]).to.be.ariaHidden;
+      expect(container3.children[0]).toBeAriaHidden();
 
       modalManager.add(modal2, container4);
       modalManager.mount(modal2, {});
-      expect(container4.children[0]).to.be.ariaHidden;
+      expect(container4.children[0]).toBeAriaHidden();
 
       modalManager.remove(modal2);
-      expect(container4.children[0]).not.to.be.ariaHidden;
+      expect(container4.children[0]).not.toBeAriaHidden();
 
       modalManager.remove(modal1);
-      expect(container3.children[0]).not.to.be.ariaHidden;
+      expect(container3.children[0]).not.toBeAriaHidden();
     });
 
     afterEach(() => {
@@ -233,14 +233,14 @@ describe('ModalManager', () => {
       const modal2 = document.createElement('div');
       modal2.setAttribute('aria-hidden', 'true');
 
-      expect(modal2).to.be.ariaHidden;
+      expect(modal2).toBeAriaHidden();
       modalManager.add({ modalRef: modal2 }, container2);
-      expect(modal2).not.to.be.ariaHidden;
+      expect(modal2).not.toBeAriaHidden();
     });
 
     it('should add aria-hidden to container siblings', () => {
       modalManager.add({}, container2);
-      expect(container2.children[0]).to.be.ariaHidden;
+      expect(container2.children[0]).toBeAriaHidden();
     });
 
     it('should add aria-hidden to previous modals', () => {
@@ -252,13 +252,13 @@ describe('ModalManager', () => {
 
       modalManager.add({ modalRef: modal2 }, container2);
       // Simulate the main React DOM true.
-      expect(container2.children[0]).to.be.ariaHidden;
-      expect(container2.children[1]).not.to.be.ariaHidden;
+      expect(container2.children[0]).toBeAriaHidden();
+      expect(container2.children[1]).not.toBeAriaHidden();
 
       modalManager.add({ modalRef: modal3 }, container2);
-      expect(container2.children[0]).to.be.ariaHidden;
-      expect(container2.children[1]).to.be.ariaHidden;
-      expect(container2.children[2]).not.to.be.ariaHidden;
+      expect(container2.children[0]).toBeAriaHidden();
+      expect(container2.children[1]).toBeAriaHidden();
+      expect(container2.children[2]).not.toBeAriaHidden();
     });
 
     it('should remove aria-hidden on siblings', () => {
@@ -266,9 +266,9 @@ describe('ModalManager', () => {
 
       modalManager.add(modal, container2);
       modalManager.mount(modal, {});
-      expect(container2.children[0]).not.to.be.ariaHidden;
+      expect(container2.children[0]).not.toBeAriaHidden();
       modalManager.remove(modal, container2);
-      expect(container2.children[0]).to.be.ariaHidden;
+      expect(container2.children[0]).toBeAriaHidden();
     });
 
     it('should keep previous aria-hidden siblings hidden', () => {
@@ -283,11 +283,11 @@ describe('ModalManager', () => {
 
       modalManager.add(modal, container2);
       modalManager.mount(modal, {});
-      expect(container2.children[0]).not.to.be.ariaHidden;
+      expect(container2.children[0]).not.toBeAriaHidden();
       modalManager.remove(modal, container2);
-      expect(container2.children[0]).to.be.ariaHidden;
-      expect(container2.children[1]).to.be.ariaHidden;
-      expect(container2.children[2]).not.to.be.ariaHidden;
+      expect(container2.children[0]).toBeAriaHidden();
+      expect(container2.children[1]).toBeAriaHidden();
+      expect(container2.children[2]).not.toBeAriaHidden();
     });
   });
 });

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.test.js
@@ -30,6 +30,6 @@ describe('<OutlinedInput />', () => {
       <OutlinedInput classes={{ notchedOutline: 'notched-outlined' }} labelWidth={0} />,
     );
 
-    expect(container.querySelector('.notched-outlined')).to.be.ok;
+    expect(container.querySelector('.notched-outlined')).not.to.equal(null);
   });
 });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -197,7 +197,7 @@ describe('<Select />', () => {
     fireEvent.mouseDown(getByRole('button'));
 
     // TODO not matching WAI-ARIA authoring practices. It should focus the first (or selected) item.
-    expect(getByRole('listbox')).to.have.focus;
+    expect(getByRole('listbox')).toHaveFocus();
   });
 
   describe('prop: onChange', () => {
@@ -405,7 +405,7 @@ describe('<Select />', () => {
 
       getByRole('listbox').focus();
 
-      expect(getByRole('listbox')).to.have.focus;
+      expect(getByRole('listbox')).toHaveFocus();
     });
 
     it('identifies each selectable element containing an option', () => {
@@ -646,11 +646,11 @@ describe('<Select />', () => {
       fireEvent.click(openSelect);
 
       const option = getByRole('option');
-      expect(option).to.have.focus;
+      expect(option).toHaveFocus();
       fireEvent.click(option);
 
       expect(container.querySelectorAll('.Mui-focused').length).to.equal(0);
-      expect(openSelect).to.have.focus;
+      expect(openSelect).toHaveFocus();
     });
 
     it('should allow to control closing by passing onClose props', () => {
@@ -886,7 +886,7 @@ describe('<Select />', () => {
     it('should focus select after Select did mount', () => {
       const { getByRole } = render(<Select value="" autoFocus />);
 
-      expect(getByRole('button')).to.have.focus;
+      expect(getByRole('button')).toHaveFocus();
     });
   });
 
@@ -920,7 +920,7 @@ describe('<Select />', () => {
         ref.current.focus();
       });
 
-      expect(getByRole('button')).to.have.focus;
+      expect(getByRole('button')).toHaveFocus();
     });
   });
 

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -223,7 +223,7 @@ describe('<Select />', () => {
       fireEvent.mouseDown(getByRole('button'));
       getAllByRole('option')[1].click();
 
-      expect(onChangeHandler.calledOnce).to.be.true;
+      expect(onChangeHandler.calledOnce).to.equal(true);
       const selected = onChangeHandler.args[0][1];
       expect(React.isValidElement(selected)).to.equal(true);
     });
@@ -717,10 +717,10 @@ describe('<Select />', () => {
 
       // If clicked by the right/middle mouse button, no options list should be opened
       fireEvent.mouseDown(trigger, { button: 1 });
-      expect(queryByRole('listbox')).to.not.exist;
+      expect(queryByRole('listbox')).to.equal(null);
 
       fireEvent.mouseDown(trigger, { button: 2 });
-      expect(queryByRole('listbox')).to.not.exist;
+      expect(queryByRole('listbox')).to.equal(null);
     });
   });
 

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -357,7 +357,7 @@ describe('<Select />', () => {
           <option value={2}>Two</option>
         </Select>,
       );
-      expect(container.querySelector('svg')).to.be.visible;
+      expect(container.querySelector('svg')).toBeVisible();
     });
   });
 
@@ -397,7 +397,7 @@ describe('<Select />', () => {
     it('renders an element with listbox behavior', () => {
       const { getByRole } = render(<Select open value="" />);
 
-      expect(getByRole('listbox')).to.be.visible;
+      expect(getByRole('listbox')).toBeVisible();
     });
 
     specify('the listbox is focusable', () => {

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -681,7 +681,7 @@ describe('<Select />', () => {
       // it from the DOM. but it's at least immediately inaccessible.
       // It's desired that this fails one day. The additional tick required to remove
       // this from the DOM is not a feature
-      expect(getByRole('listbox', { hidden: true })).to.be.inaccessible;
+      expect(getByRole('listbox', { hidden: true })).toBeInaccessible();
       act(() => {
         clock.tick(0);
       });

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -112,7 +112,7 @@ describe('<Select />', () => {
     fireEvent.mouseDown(trigger);
 
     expect(handleBlur.callCount).to.equal(0);
-    expect(getByRole('listbox')).to.be.ok;
+    expect(getByRole('listbox')).not.to.equal(null);
 
     act(() => {
       const options = getAllByRole('option');
@@ -121,7 +121,7 @@ describe('<Select />', () => {
     });
 
     expect(handleBlur.callCount).to.equal(0);
-    expect(queryByRole('listbox', { hidden: false })).to.be.null;
+    expect(queryByRole('listbox', { hidden: false })).to.equal(null);
   });
 
   it('options should have a data-value attribute', () => {
@@ -148,10 +148,10 @@ describe('<Select />', () => {
       getByRole('button').focus();
 
       fireEvent.keyDown(document.activeElement, { key });
-      expect(getByRole('listbox', { hidden: false })).to.be.ok;
+      expect(getByRole('listbox', { hidden: false })).not.to.equal(null);
 
       fireEvent.keyUp(document.activeElement, { key });
-      expect(getByRole('listbox', { hidden: false })).to.be.ok;
+      expect(getByRole('listbox', { hidden: false })).not.to.equal(null);
     });
   });
 
@@ -346,7 +346,7 @@ describe('<Select />', () => {
           <option value={2}>Two</option>
         </Select>,
       );
-      expect(container.querySelector('svg')).to.be.null;
+      expect(container.querySelector('svg')).to.equal(null);
     });
 
     it('should present an SVG icon', () => {
@@ -514,10 +514,10 @@ describe('<Select />', () => {
       getByRole('button').focus();
 
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-      expect(queryByRole('listbox')).not.to.be.ok;
+      expect(queryByRole('listbox')).to.equal(null);
 
       fireEvent.keyUp(document.activeElement, { key: 'ArrowDown' });
-      expect(queryByRole('listbox')).not.to.be.ok;
+      expect(queryByRole('listbox')).to.equal(null);
     });
   });
 
@@ -672,7 +672,7 @@ describe('<Select />', () => {
       const { getByRole, queryByRole } = render(<ControlledWrapper />);
 
       fireEvent.mouseDown(getByRole('button'));
-      expect(getByRole('listbox')).to.be.ok;
+      expect(getByRole('listbox')).not.to.equal(null);
 
       act(() => {
         getByRole('option').click();
@@ -686,7 +686,7 @@ describe('<Select />', () => {
         clock.tick(0);
       });
 
-      expect(queryByRole('listbox', { hidden: true })).to.be.null;
+      expect(queryByRole('listbox', { hidden: true })).to.equal(null);
     });
 
     it('should be open when initially true', () => {
@@ -696,7 +696,7 @@ describe('<Select />', () => {
         </Select>,
       );
 
-      expect(getByRole('listbox')).to.be.ok;
+      expect(getByRole('listbox')).not.to.equal(null);
     });
 
     it('open only with the left mouse button click', () => {
@@ -942,7 +942,7 @@ describe('<Select />', () => {
     it('renders a <select />', () => {
       const { container } = render(<Select native />);
 
-      expect(container.querySelector('select')).not.to.be.null;
+      expect(container.querySelector('select')).not.to.equal(null);
     });
 
     it('can be labelled with a <label />', () => {

--- a/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
+++ b/packages/material-ui/src/SnackbarContent/SnackbarContent.test.js
@@ -41,8 +41,8 @@ describe('<SnackbarContent />', () => {
       const { getByText } = render(
         <SnackbarContent message="message" action={[action0, action1]} />,
       );
-      expect(getByText('action0')).to.not.be.null;
-      expect(getByText('action1')).to.not.be.null;
+      expect(getByText('action0')).not.to.equal(null);
+      expect(getByText('action1')).not.to.equal(null);
     });
   });
 

--- a/packages/material-ui/src/Step/Step.test.js
+++ b/packages/material-ui/src/Step/Step.test.js
@@ -98,7 +98,7 @@ describe('<Step />', () => {
         </Step>,
       );
 
-      expect(within(getByTestId('root')).getByTestId('child')).to.be.ok;
+      expect(within(getByTestId('root')).getByTestId('child')).not.to.equal(null);
     });
 
     it('renders children with all props passed through', () => {
@@ -145,7 +145,7 @@ describe('<Step />', () => {
         </Step>,
       );
 
-      expect(getByTestId('child')).to.be.ok;
+      expect(getByTestId('child')).not.to.equal(null);
     });
   });
 });

--- a/packages/material-ui/src/StepButton/StepButton.test.js
+++ b/packages/material-ui/src/StepButton/StepButton.test.js
@@ -132,6 +132,6 @@ describe('<StepButton />', () => {
       </Step>,
     );
 
-    expect(getByRole('button')).to.be.ok;
+    expect(getByRole('button')).not.to.equal(null);
   });
 });

--- a/packages/material-ui/src/Switch/Switch.test.js
+++ b/packages/material-ui/src/Switch/Switch.test.js
@@ -43,7 +43,7 @@ describe('<Switch />', () => {
       <Switch classes={{ thumb: 'thumb', switchBase: 'switch-base' }} />,
     );
 
-    expect(container.querySelector('.switch-base .thumb')).to.be.ok;
+    expect(container.querySelector('.switch-base .thumb')).not.to.equal(null);
   });
 
   it('should render the track as the 2nd child', () => {

--- a/packages/material-ui/src/Tab/Tab.test.js
+++ b/packages/material-ui/src/Tab/Tab.test.js
@@ -29,7 +29,7 @@ describe('<Tab />', () => {
   it('should have a ripple by default', () => {
     const { container } = render(<Tab TouchRippleProps={{ className: 'touch-ripple' }} />);
 
-    expect(container.querySelector('.touch-ripple')).to.be.ok;
+    expect(container.querySelector('.touch-ripple')).not.to.equal(null);
   });
 
   it('can disable the ripple', () => {
@@ -37,7 +37,7 @@ describe('<Tab />', () => {
       <Tab disableRipple TouchRippleProps={{ className: 'touch-ripple' }} />,
     );
 
-    expect(container.querySelector('.touch-ripple')).to.be.null;
+    expect(container.querySelector('.touch-ripple')).to.equal(null);
   });
 
   it('should have a focusRipple by default', () => {
@@ -53,7 +53,7 @@ describe('<Tab />', () => {
       getByRole('tab').focus();
     });
 
-    expect(container.querySelector('.focus-ripple')).to.be.ok;
+    expect(container.querySelector('.focus-ripple')).not.to.equal(null);
   });
 
   it('can disable the focusRipple', () => {
@@ -69,7 +69,7 @@ describe('<Tab />', () => {
       getByRole('tab').focus();
     });
 
-    expect(container.querySelector('.focus-ripple')).to.be.null;
+    expect(container.querySelector('.focus-ripple')).to.equal(null);
   });
 
   describe('prop: selected', () => {
@@ -126,7 +126,7 @@ describe('<Tab />', () => {
     it('should render icon element', () => {
       const { getByTestId } = render(<Tab icon={<div data-testid="icon" />} />);
 
-      expect(getByTestId('icon')).to.be.ok;
+      expect(getByTestId('icon')).not.to.equal(null);
     });
   });
 

--- a/packages/material-ui/src/Table/Table.test.js
+++ b/packages/material-ui/src/Table/Table.test.js
@@ -50,7 +50,7 @@ describe('<Table />', () => {
       </Table>,
     );
 
-    expect(getByTestId('children')).to.be.ok;
+    expect(getByTestId('children')).not.to.equal(null);
   });
 
   it('should define table in the child context', () => {

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -170,9 +170,9 @@ describe('<Tabs />', () => {
           </Tabs>,
         );
         const tabElements = getAllByRole('tab');
-        expect(tabElements[0].querySelector(`.${classes.indicator}`)).to.not.be.ok;
-        expect(tabElements[1].querySelector(`.${classes.indicator}`)).to.not.be.ok;
-        expect(container.querySelector(`.${classes.indicator}`)).to.be.ok;
+        expect(tabElements[0].querySelector(`.${classes.indicator}`)).to.equal(null);
+        expect(tabElements[1].querySelector(`.${classes.indicator}`)).to.equal(null);
+        expect(container.querySelector(`.${classes.indicator}`)).not.to.equal(null);
       });
 
       it('should update the indicator at each render', function test() {
@@ -341,8 +341,8 @@ describe('<Tabs />', () => {
       );
       const baseSelector = `.${classes.scroller}`;
       const selector = `.${classes.scroller}.${classes.scrollable}`;
-      expect(container.querySelector(baseSelector)).to.be.ok;
-      expect(container.querySelector(selector)).to.not.be.ok;
+      expect(container.querySelector(baseSelector)).not.to.equal(null);
+      expect(container.querySelector(selector)).to.equal(null);
     });
   });
 

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -181,7 +181,7 @@ describe('<TextField />', () => {
         </TextField>,
       );
 
-      expect(getByRole('button')).to.have.accessibleName('Release: Stable');
+      expect(getByRole('button')).toHaveAccessibleName('Release: Stable');
     });
 
     it('creates an input[hidden] that has no accessible properties', () => {

--- a/packages/material-ui/src/TextField/TextField.test.js
+++ b/packages/material-ui/src/TextField/TextField.test.js
@@ -52,7 +52,7 @@ describe('<TextField />', () => {
     it('label the input', () => {
       const { getByLabelText } = render(<TextField id="labelled" label="Foo bar" />);
 
-      expect(getByLabelText('Foo bar')).to.be.ok;
+      expect(getByLabelText('Foo bar')).not.to.equal(null);
     });
 
     it('should apply the className to the label', () => {
@@ -67,7 +67,7 @@ describe('<TextField />', () => {
       it(`should not render empty (${label}) label element`, () => {
         const { container } = render(<TextField id="labelled" label={label} />);
 
-        expect(container.querySelector('label')).to.be.null;
+        expect(container.querySelector('label')).to.equal(null);
       });
     });
   });
@@ -130,7 +130,7 @@ describe('<TextField />', () => {
         <TextField InputProps={{ 'data-testid': 'InputComponent' }} />,
       );
 
-      expect(getByTestId('InputComponent')).to.be.ok;
+      expect(getByTestId('InputComponent')).not.to.equal(null);
     });
   });
 
@@ -152,7 +152,7 @@ describe('<TextField />', () => {
       );
 
       const select = container.querySelector('select');
-      expect(select).to.be.ok;
+      expect(select).not.to.equal(null);
       expect(select.options).to.have.lengthOf(2);
     });
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -403,7 +403,7 @@ describe('<Tooltip />', () => {
         <Tooltip {...defaultProps} open PopperProps={{ 'data-testid': 'popper' }} />,
       );
 
-      expect(getByTestId('popper')).to.be.ok;
+      expect(getByTestId('popper')).not.to.equal(null);
     });
 
     it('should merge popperOptions with arrow modifier', () => {

--- a/packages/material-ui/src/internal/SwitchBase.test.js
+++ b/packages/material-ui/src/internal/SwitchBase.test.js
@@ -69,7 +69,7 @@ describe('<SwitchBase />', () => {
       />,
     );
 
-    expect(getByTestId('TouchRipple')).to.be.ok;
+    expect(getByTestId('TouchRipple')).not.to.equal(null);
   });
 
   it('can disable the ripple ', () => {
@@ -83,7 +83,7 @@ describe('<SwitchBase />', () => {
       />,
     );
 
-    expect(queryByTestId('TouchRipple')).to.be.null;
+    expect(queryByTestId('TouchRipple')).to.equal(null);
   });
 
   it('should pass tabIndex to the input so it can be taken out of focus rotation', () => {
@@ -136,7 +136,7 @@ describe('<SwitchBase />', () => {
 
       expect(container.firstChild).to.have.class(classes.checked);
       expect(getByRole('checkbox')).to.have.property('checked', true);
-      expect(getByTestId('checked-icon')).to.be.ok;
+      expect(getByTestId('checked-icon')).not.to.equal(null);
     });
 
     it('should uncheck the checkbox', () => {
@@ -152,7 +152,7 @@ describe('<SwitchBase />', () => {
 
       expect(container.firstChild).not.to.have.class(classes.checked);
       expect(getByRole('checkbox')).to.have.property('checked', false);
-      expect(getByTestId('unchecked-icon')).to.be.ok;
+      expect(getByTestId('unchecked-icon')).not.to.equal(null);
     });
   });
 
@@ -169,19 +169,19 @@ describe('<SwitchBase />', () => {
 
     expect(container.firstChild).to.have.class(classes.checked);
     expect(checkbox).to.have.property('checked', true);
-    expect(getByTestId('checked-icon')).to.be.ok;
+    expect(getByTestId('checked-icon')).not.to.equal(null);
 
     checkbox.click();
 
     expect(container.firstChild).not.to.have.class(classes.checked);
     expect(checkbox).to.have.property('checked', false);
-    expect(getByTestId('unchecked-icon')).to.be.ok;
+    expect(getByTestId('unchecked-icon')).not.to.equal(null);
 
     checkbox.click();
 
     expect(container.firstChild).to.have.class(classes.checked);
     expect(checkbox).to.have.property('checked', true);
-    expect(getByTestId('checked-icon')).to.be.ok;
+    expect(getByTestId('checked-icon')).not.to.equal(null);
   });
 
   describe('handleInputChange()', () => {

--- a/packages/material-ui/src/utils/unstable_useId.test.js
+++ b/packages/material-ui/src/utils/unstable_useId.test.js
@@ -19,18 +19,18 @@ describe('unstable_useId', () => {
   it('returns the provided ID', () => {
     const { getByText, setProps } = render(<TestComponent id="some-id" />);
 
-    expect(getByText('some-id')).to.not.be.null;
+    expect(getByText('some-id')).not.to.equal(null);
 
     setProps({ id: 'another-id' });
-    expect(getByText('another-id')).to.not.be.null;
+    expect(getByText('another-id')).not.to.equal(null);
   });
 
   it("generates an ID if one isn't provided", () => {
     const { getByText, setProps } = render(<TestComponent />);
 
-    expect(getByText(/^mui-[0-9]+$/)).to.not.be.null;
+    expect(getByText(/^mui-[0-9]+$/)).not.to.equal(null);
 
     setProps({ id: 'another-id' });
-    expect(getByText('another-id')).to.not.be.null;
+    expect(getByText('another-id')).not.to.equal(null);
   });
 });

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -104,7 +104,7 @@ describe('<Menu /> integration', () => {
     button.focus();
     button.click();
 
-    expect(getAllByRole('menuitem')[0]).to.have.focus;
+    expect(getAllByRole('menuitem')[0]).toHaveFocus();
   });
 
   it('changes focus according to keyboard navigation', () => {
@@ -116,22 +116,22 @@ describe('<Menu /> integration', () => {
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[0]).toHaveFocus();
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[2]).to.have.focus;
+    expect(menuitems[2]).toHaveFocus();
 
     fireEvent.keyDown(document.activeElement, { key: 'Home' });
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[0]).toHaveFocus();
 
     fireEvent.keyDown(document.activeElement, { key: 'End' });
-    expect(menuitems[2]).to.have.focus;
+    expect(menuitems[2]).toHaveFocus();
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowRight' });
-    expect(menuitems[2], 'no change on unassociated keys').to.have.focus;
+    expect(menuitems[2], 'no change on unassociated keys').toHaveFocus();
   });
 
   it('focuses the selected item when opening', () => {
@@ -141,7 +141,7 @@ describe('<Menu /> integration', () => {
     button.focus();
     button.click();
 
-    expect(getAllByRole('menuitem')[2]).to.have.focus;
+    expect(getAllByRole('menuitem')[2]).toHaveFocus();
   });
 
   describe('Menu variant differences', () => {
@@ -159,7 +159,7 @@ describe('<Menu /> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[0]).to.have.focus;
+      expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -175,7 +175,7 @@ describe('<Menu /> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[0]).to.have.focus;
+      expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -192,7 +192,7 @@ describe('<Menu /> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[2]).to.have.focus;
+      expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -208,7 +208,7 @@ describe('<Menu /> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[0]).to.have.focus;
+      expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -224,7 +224,7 @@ describe('<Menu /> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[1]).to.have.focus;
+      expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', 0);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -240,7 +240,7 @@ describe('<Menu /> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[1]).to.have.focus;
+      expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', 2);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -262,7 +262,7 @@ describe('<Menu /> integration', () => {
         );
         const menuitems = getAllByRole('menuitem');
 
-        expect(menuitems[1]).to.have.focus;
+        expect(menuitems[1]).toHaveFocus();
         expect(menuitems[0]).to.have.property('tabIndex', -1);
         expect(menuitems[1]).to.have.property('tabIndex', 0);
         expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -283,7 +283,7 @@ describe('<Menu /> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(getByTestId('Paper')).to.have.focus;
+      expect(getByTestId('Paper')).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', 0);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -306,7 +306,7 @@ describe('<Menu /> integration', () => {
         getByRole('button').click();
         const menuitems = getAllByRole('menuitem');
 
-        expect(menuitems[1]).to.have.focus;
+        expect(menuitems[1]).toHaveFocus();
         expect(menuitems[0]).to.have.property('tabIndex', -1);
         expect(menuitems[1]).to.have.property('tabIndex', 0);
         expect(menuitems[2]).to.have.property('tabIndex', -1);

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -88,7 +88,7 @@ describe('<Menu /> integration', () => {
   it('is part of the DOM by default but hidden', () => {
     const { getByRole } = render(<ButtonMenu />);
 
-    expect(getByRole('menu', { hidden: true })).to.be.inaccessible;
+    expect(getByRole('menu', { hidden: true })).toBeInaccessible();
   });
 
   it('does not gain any focus when mounted ', () => {
@@ -324,7 +324,7 @@ describe('<Menu /> integration', () => {
     // react-transition-group uses one commit per state transition so we need to wait a bit
     clock.tick(0);
 
-    expect(getByRole('menu', { hidden: true })).to.be.inaccessible;
+    expect(getByRole('menu', { hidden: true })).toBeInaccessible();
   });
 
   it('closes the menu when the backdrop is clicked', () => {
@@ -337,6 +337,6 @@ describe('<Menu /> integration', () => {
     document.querySelector('[data-mui-test="Backdrop"]').click();
     clock.tick(0);
 
-    expect(getByRole('menu', { hidden: true })).to.be.inaccessible;
+    expect(getByRole('menu', { hidden: true })).toBeInaccessible();
   });
 });

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -52,7 +52,7 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
 
-      expect(getAllByRole('menuitem')[0]).to.have.focus;
+      expect(getAllByRole('menuitem')[0]).toHaveFocus();
     });
 
     it('should select the last item when pressing up if the first item is focused', () => {
@@ -67,7 +67,7 @@ describe('<MenuList> integration', () => {
       fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[2]).to.have.focus;
+      expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -85,7 +85,7 @@ describe('<MenuList> integration', () => {
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[1]).to.have.focus;
+      expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -104,7 +104,7 @@ describe('<MenuList> integration', () => {
       fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[0]).to.have.focus;
+      expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -128,9 +128,9 @@ describe('<MenuList> integration', () => {
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
-      expect(menuitems[0]).not.to.have.focus;
-      expect(menuitems[1]).not.to.have.focus;
-      expect(menuitems[2]).not.to.have.focus;
+      expect(menuitems[0]).not.toHaveFocus();
+      expect(menuitems[1]).not.toHaveFocus();
+      expect(menuitems[2]).not.toHaveFocus();
     });
 
     it('can imperatively focus the first item', () => {
@@ -145,7 +145,7 @@ describe('<MenuList> integration', () => {
 
       menuitems[0].focus();
 
-      expect(menuitems[0]).to.have.focus;
+      expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -163,14 +163,14 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-      expect(menuitems[1]).to.have.focus;
+      expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
 
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-      expect(menuitems[2]).to.have.focus;
+      expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -190,7 +190,7 @@ describe('<MenuList> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[1]).to.have.focus;
+      expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', 0);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -210,7 +210,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-      expect(menuitems[2]).to.have.focus;
+      expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', 0);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -230,7 +230,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-      expect(menuitems[0]).to.have.focus;
+      expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', 0);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -250,7 +250,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-      expect(menuitems[2]).to.have.focus;
+      expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', 0);
       expect(menuitems[2]).to.have.property('tabIndex', -1);
@@ -270,7 +270,7 @@ describe('<MenuList> integration', () => {
       );
       const menuitems = getAllByRole('menuitem');
 
-      expect(menuitems[2]).to.have.focus;
+      expect(menuitems[2]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
       expect(menuitems[2]).to.have.property('tabIndex', 0);
@@ -290,7 +290,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
 
-      expect(menuitems[0]).to.have.focus;
+      expect(menuitems[0]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', 0);
       expect(menuitems[1]).to.have.property('tabIndex', -1);
     });
@@ -306,7 +306,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
 
-      expect(menuitems[1]).to.have.focus;
+      expect(menuitems[1]).toHaveFocus();
       expect(menuitems[0]).to.have.property('tabIndex', -1);
       expect(menuitems[1]).to.have.property('tabIndex', 0);
     });
@@ -325,23 +325,23 @@ describe('<MenuList> integration', () => {
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[0]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[3]).to.have.focus;
+    expect(menuitems[3]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[0]).toHaveFocus();
 
     // and ArrowUp again
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[3]).to.have.focus;
+    expect(menuitems[3]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[0]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[3]).to.have.focus;
+    expect(menuitems[3]).toHaveFocus();
   });
 
   it('should stay on a single item if it is the only focusable one', () => {
@@ -356,15 +356,15 @@ describe('<MenuList> integration', () => {
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
   });
 
   it('should keep focus on the menu if all items are disabled', () => {
@@ -379,15 +379,15 @@ describe('<MenuList> integration', () => {
     const menu = getByRole('menu');
 
     fireEvent.keyDown(document.activeElement, { key: 'Home' });
-    expect(menu).to.have.focus;
+    expect(menu).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menu).to.have.focus;
+    expect(menu).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menu).to.have.focus;
+    expect(menu).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'End' });
-    expect(menu).to.have.focus;
+    expect(menu).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menu).to.have.focus;
+    expect(menu).toHaveFocus();
   });
 
   it('should allow focus on disabled items when disabledItemsFocusable=true', () => {
@@ -403,15 +403,15 @@ describe('<MenuList> integration', () => {
     const menuitems = getAllByRole('menuitem');
 
     fireEvent.keyDown(document.activeElement, { key: 'Home' });
-    expect(menuitems[0]).to.have.focus;
+    expect(menuitems[0]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[1]).to.have.focus;
+    expect(menuitems[1]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowDown' });
-    expect(menuitems[2]).to.have.focus;
+    expect(menuitems[2]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'End' });
-    expect(menuitems[3]).to.have.focus;
+    expect(menuitems[3]).toHaveFocus();
     fireEvent.keyDown(document.activeElement, { key: 'ArrowUp' });
-    expect(menuitems[2]).to.have.focus;
+    expect(menuitems[2]).toHaveFocus();
   });
 
   describe('MenuList text-based keyboard controls', () => {
@@ -434,7 +434,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'a' });
 
-      expect(getByText('Arizona')).to.have.focus;
+      expect(getByText('Arizona')).toHaveFocus();
     });
 
     it('selects the next item starting with the typed character', () => {
@@ -448,7 +448,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'a' });
 
-      expect(getByText('Arcansas')).to.have.focus;
+      expect(getByText('Arcansas')).toHaveFocus();
     });
 
     it('should not get focusVisible class on click', () => {
@@ -464,7 +464,7 @@ describe('<MenuList> integration', () => {
       menuitem.focus();
       fireEvent.click(menuitem);
 
-      expect(menuitem).to.have.focus;
+      expect(menuitem).toHaveFocus();
       expect(menuitem).not.to.have.class('focus-visible');
     });
 
@@ -478,7 +478,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'c' });
 
-      expect(getByText('Arizona')).to.have.focus;
+      expect(getByText('Arizona')).toHaveFocus();
     });
 
     it('should not move focus when keys match current focus', () => {
@@ -491,11 +491,11 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'A' });
 
-      expect(getByText('Arizona')).to.have.focus;
+      expect(getByText('Arizona')).toHaveFocus();
 
       fireEvent.keyDown(document.activeElement, { key: 'r' });
 
-      expect(getByText('Arizona')).to.have.focus;
+      expect(getByText('Arizona')).toHaveFocus();
     });
 
     it('should not move focus if focus starts on descendant and the key doesnt match', () => {
@@ -512,7 +512,7 @@ describe('<MenuList> integration', () => {
 
       fireEvent.keyDown(document.activeElement, { key: 'z' });
 
-      expect(button).to.have.focus;
+      expect(button).toHaveFocus();
     });
 
     it('matches rapidly typed text', () => {
@@ -526,7 +526,7 @@ describe('<MenuList> integration', () => {
       fireEvent.keyDown(document.activeElement, { key: 'W' });
       fireEvent.keyDown(document.activeElement, { key: 'o' });
 
-      expect(getByText('Worm')).to.have.focus;
+      expect(getByText('Worm')).toHaveFocus();
     });
 
     it('should reset the character buffer after 500ms', (done) => {
@@ -541,7 +541,7 @@ describe('<MenuList> integration', () => {
       setTimeout(() => {
         fireEvent.keyDown(document.activeElement, { key: 'o' });
 
-        expect(getByText('Ordinary')).to.have.focus;
+        expect(getByText('Ordinary')).toHaveFocus();
         done();
       }, 500);
     });
@@ -564,7 +564,7 @@ describe('<MenuList> integration', () => {
       fireEvent.keyDown(document.activeElement, { key: 'W' });
       fireEvent.keyDown(document.activeElement, { key: 'o' });
 
-      expect(getByText('Worm')).to.have.focus;
+      expect(getByText('Worm')).toHaveFocus();
     });
   });
 });

--- a/packages/material-ui/test/integration/MenuList.test.js
+++ b/packages/material-ui/test/integration/MenuList.test.js
@@ -120,7 +120,7 @@ describe('<MenuList> integration', () => {
         </MenuList>,
       );
 
-      expect(document.activeElement).to.be.ok;
+      expect(document.activeElement).not.to.equal(null);
       document.activeElement.blur();
       const menuitems = getAllByRole('menuitem');
 

--- a/packages/material-ui/test/integration/NestedMenu.test.js
+++ b/packages/material-ui/test/integration/NestedMenu.test.js
@@ -51,14 +51,14 @@ describe('<NestedMenu> integration', () => {
     const { getByRole } = render(<NestedMenu firstMenuOpen />);
 
     expect(getByRole('menu')).to.have.id('first-menu');
-    expect(within(getByRole('menu')).getAllByRole('menuitem')[0]).to.have.focus;
+    expect(within(getByRole('menu')).getAllByRole('menuitem')[0]).toHaveFocus();
   });
 
   it('should focus the first item of the second menu when nothing has been selected', () => {
     const { getByRole } = render(<NestedMenu secondMenuOpen />);
 
     expect(getByRole('menu')).to.have.id('second-menu');
-    expect(within(getByRole('menu')).getAllByRole('menuitem')[0]).to.have.focus;
+    expect(within(getByRole('menu')).getAllByRole('menuitem')[0]).toHaveFocus();
   });
 
   it('should open the first menu after it was closed', () => {
@@ -68,7 +68,7 @@ describe('<NestedMenu> integration', () => {
     setProps({ firstMenuOpen: true });
 
     expect(getByRole('menu')).to.have.id('first-menu');
-    expect(within(getByRole('menu')).getAllByRole('menuitem')[0]).to.have.focus;
+    expect(within(getByRole('menu')).getAllByRole('menuitem')[0]).toHaveFocus();
   });
 
   it('should be able to open second menu again', () => {
@@ -78,6 +78,6 @@ describe('<NestedMenu> integration', () => {
     setProps({ secondMenuOpen: true });
 
     expect(getByRole('menu')).to.have.id('second-menu');
-    expect(within(getByRole('menu')).getAllByRole('menuitem')[0]).to.have.focus;
+    expect(within(getByRole('menu')).getAllByRole('menuitem')[0]).toHaveFocus();
   });
 });

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -61,14 +61,14 @@ describe('<Select> integration', () => {
       fireEvent.mouseDown(trigger);
 
       const options = getAllByRole('option');
-      expect(options[1]).to.have.focus;
+      expect(options[1]).toHaveFocus();
 
       // Now, let's close the select component
       getByTestId('select-backdrop').click();
       clock.tick(0);
 
       expect(queryByRole('listbox')).to.be.null;
-      expect(trigger).to.have.focus;
+      expect(trigger).toHaveFocus();
     });
 
     it('should be able to change the selected item', () => {
@@ -81,14 +81,14 @@ describe('<Select> integration', () => {
       fireEvent.mouseDown(trigger);
 
       const options = getAllByRole('option');
-      expect(options[1]).to.have.focus;
+      expect(options[1]).toHaveFocus();
 
       // Now, let's close the select component
       options[2].click();
       clock.tick(0);
 
       expect(queryByRole('listbox')).to.be.null;
-      expect(trigger).to.have.focus;
+      expect(trigger).toHaveFocus();
       expect(trigger).to.have.text('Twenty');
     });
   });

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -67,7 +67,7 @@ describe('<Select> integration', () => {
       getByTestId('select-backdrop').click();
       clock.tick(0);
 
-      expect(queryByRole('listbox')).to.be.null;
+      expect(queryByRole('listbox')).to.equal(null);
       expect(trigger).toHaveFocus();
     });
 
@@ -87,7 +87,7 @@ describe('<Select> integration', () => {
       options[2].click();
       clock.tick(0);
 
-      expect(queryByRole('listbox')).to.be.null;
+      expect(queryByRole('listbox')).to.equal(null);
       expect(trigger).toHaveFocus();
       expect(trigger).to.have.text('Twenty');
     });

--- a/packages/material-ui/test/integration/Select.test.js
+++ b/packages/material-ui/test/integration/Select.test.js
@@ -75,7 +75,7 @@ describe('<Select> integration', () => {
       const { getAllByRole, getByRole, queryByRole } = render(<SelectAndDialog />);
 
       const trigger = getByRole('button');
-      expect(trigger).to.have.accessibleName('Ten');
+      expect(trigger).toHaveAccessibleName('Ten');
       // Let's open the select component
       // in the browser user click also focuses
       fireEvent.mouseDown(trigger);
@@ -105,7 +105,7 @@ describe('<Select> integration', () => {
         </FormControl>,
       );
 
-      expect(getByRole('button')).to.have.accessibleName('Age Ten');
+      expect(getByRole('button')).toHaveAccessibleName('Age Ten');
     });
 
     // we're somewhat abusing "focus" here. What we're actually interested in is

--- a/test/utils/init.d.ts
+++ b/test/utils/init.d.ts
@@ -14,7 +14,7 @@ declare namespace Chai {
      * Does not replace accessibility check as that requires display/visibility/layout
      * @deprecated Use `inaccessible` + `visible` instead
      */
-    ariaHidden: Assertion;
+    toBeAriaHidden(): Assertion;
     /**
      * checks if the element is inaccessible
      */

--- a/test/utils/init.d.ts
+++ b/test/utils/init.d.ts
@@ -8,7 +8,7 @@ declare namespace Chai {
      * @see https://www.w3.org/TR/accname-1.2/
      * @param name
      */
-    accessibleName(name: string): Assertion;
+    toHaveAccessibleName(name: string): Assertion;
     /**
      * checks if the element in question is considered aria-hidden
      * Does not replace accessibility check as that requires display/visibility/layout

--- a/test/utils/init.d.ts
+++ b/test/utils/init.d.ts
@@ -18,7 +18,7 @@ declare namespace Chai {
     /**
      * checks if the element is inaccessible
      */
-    inaccessible: Assertion;
+    toBeInaccessible(): Assertion;
     /**
      * checks if the element is focused
      */

--- a/test/utils/init.d.ts
+++ b/test/utils/init.d.ts
@@ -3,13 +3,6 @@
 declare namespace Chai {
   interface Assertion {
     /**
-     * checks if the accessible name computation (according to `accname` spec)
-     * matches the expectation.
-     * @see https://www.w3.org/TR/accname-1.2/
-     * @param name
-     */
-    toHaveAccessibleName(name: string): Assertion;
-    /**
      * checks if the element in question is considered aria-hidden
      * Does not replace accessibility check as that requires display/visibility/layout
      * @deprecated Use `inaccessible` + `visible` instead
@@ -19,6 +12,13 @@ declare namespace Chai {
      * checks if the element is inaccessible
      */
     toBeInaccessible(): Assertion;
+    /**
+     * checks if the accessible name computation (according to `accname` spec)
+     * matches the expectation.
+     * @see https://www.w3.org/TR/accname-1.2/
+     * @param name
+     */
+    toHaveAccessibleName(name: string): Assertion;
     /**
      * checks if the element is focused
      */

--- a/test/utils/init.d.ts
+++ b/test/utils/init.d.ts
@@ -9,6 +9,10 @@ declare namespace Chai {
      */
     toBeAriaHidden(): Assertion;
     /**
+     * Check if an element is not visually hidden
+     */
+    toBeVisible(): Assertion;
+    /**
      * checks if the element is inaccessible
      */
     toBeInaccessible(): Assertion;

--- a/test/utils/init.d.ts
+++ b/test/utils/init.d.ts
@@ -22,6 +22,6 @@ declare namespace Chai {
     /**
      * checks if the element is focused
      */
-    focus: Assertion;
+    toHaveFocus(): Assertion;
   }
 }

--- a/test/utils/init.d.ts
+++ b/test/utils/init.d.ts
@@ -7,25 +7,25 @@ declare namespace Chai {
      * Does not replace accessibility check as that requires display/visibility/layout
      * @deprecated Use `inaccessible` + `visible` instead
      */
-    toBeAriaHidden(): Assertion;
+    toBeAriaHidden(): void;
     /**
      * Check if an element is not visually hidden
      */
-    toBeVisible(): Assertion;
+    toBeVisible(): void;
     /**
      * checks if the element is inaccessible
      */
-    toBeInaccessible(): Assertion;
+    toBeInaccessible(): void;
     /**
      * checks if the accessible name computation (according to `accname` spec)
      * matches the expectation.
      * @see https://www.w3.org/TR/accname-1.2/
      * @param name
      */
-    toHaveAccessibleName(name: string): Assertion;
+    toHaveAccessibleName(name: string): void;
     /**
      * checks if the element is focused
      */
-    toHaveFocus(): Assertion;
+    toHaveFocus(): void;
   }
 }

--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -7,8 +7,7 @@ import { computeAccessibleName } from 'dom-accessibility-api';
 chai.use(chaiDom);
 chai.use((chaiAPI, utils) => {
   // better diff view for expect(element).to.equal(document.activeElement)
-  // use as `.to.have.focus` to match `toHaveFocus` from `jest-dom`
-  chai.Assertion.addProperty('focus', function elementIsFocused() {
+  chai.Assertion.addMethod('toHaveFocus', function elementIsFocused() {
     const element = utils.flag(this, 'object');
 
     this.assert(

--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -63,7 +63,7 @@ chai.use((chaiAPI, utils) => {
     );
   });
 
-  chai.Assertion.addMethod('accessibleName', function hasAccessibleName(expectedName) {
+  chai.Assertion.addMethod('toHaveAccessibleName', function hasAccessibleName(expectedName) {
     const root = utils.flag(this, 'object');
     // make sure it's an Element
     new chai.Assertion(root.nodeType, `Expected an Element but got '${String(root)}'`).to.equal(1);

--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -51,7 +51,7 @@ chai.use((chaiAPI, utils) => {
     );
   });
 
-  chai.Assertion.addProperty('inaccessible', function elementIsAccessible() {
+  chai.Assertion.addMethod('toBeInaccessible', function elementIsAccessible() {
     const element = utils.flag(this, 'object');
 
     const inaccessible = isInaccessible(element);

--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -19,7 +19,7 @@ chai.use((chaiAPI, utils) => {
     );
   });
 
-  chai.Assertion.addProperty('ariaHidden', function elementIsAccessible() {
+  chai.Assertion.addMethod('toBeAriaHidden', function elementIsAccessible() {
     const element = utils.flag(this, 'object');
 
     // used for debugging failed assertions, will either point to the top most node

--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -134,4 +134,12 @@ chai.use((chaiAPI, utils) => {
       `expected ${utils.elToString(root)} not to have accessible name '${expectedName}'.`,
     );
   });
+
+  /**
+   * Correct name for `to.be.visible`
+   */
+  chai.Assertion.addMethod('toBeVisible', function toBeVisible() {
+    // eslint-disable-next-line no-underscore-dangle, no-unused-expressions
+    new chai.Assertion(this._obj).to.be.visible;
+  });
 });


### PR DESCRIPTION
- removes chaining in favor of  single method name for custom matchers
  ```diff
  -to.have.focus
  +toHaveFocus()
  -to.be.ariaHidden
  +toBeAriaHidden()
  -to.be.inaccessible
  +toBeInaccessible()
  -to.have.accessibleName()
  +toHaveAccessibleName()
  ```
  1. more familiar for users used to jest-expect
  2. no accidental unused-expression 
  3. consistent negation (we had to.not.have.focus and not.to.have.focus)
- use method calls over property access expressions 
  ```diff
  -to.be.ok
  +not.to.equal(null)
  -to.be.true
  +to.equal(true)
  -to.be.visible
  +toBeVisible()
  ```
  1. `to.be.ok` goes against existing lint rules since it loosely compares against `true`. All of them actually assert that the element is not `null`
  2. inconsistent chaining. It was more of a contest what valid english would be.
  3. https://github.com/chaijs/chai/issues/726