### PR TITLE
[docs] Parse markdown at build time

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -92,13 +92,6 @@ module.exports = {
         rules: config.module.rules.concat([
           {
             test: /\.(css|md)$/,
-            loader: 'emit-file-loader',
-            options: {
-              name: 'dist/[path][name].[ext]',
-            },
-          },
-          {
-            test: /\.(css|md)$/,
             loader: 'raw-loader',
           },
           // transpile 3rd party packages with dependencies in this repository

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -155,7 +155,7 @@ module.exports = {
     }
 
     // We want to speed-up the build of pull requests.
-    if (process.env.PULL_REQUEST === 'true') {
+    if (process.env.PULL_REQUEST === 'REVERT_THIS') {
       // eslint-disable-next-line no-console
       console.log('Considering only English for SSR');
       traverse(pages, 'en');


### PR DESCRIPTION
Alternate to #20539. Counting chunks and headings seems super sketchy to me. I think I have a better solution that also moves all the markdown parsing to build time (potentially big perf win). This would be closer to how mdx would work later.

Opening this early to deploy some refactorings that seem safe but touch on old code.