### PR TITLE
[docs] Correct "row" to "col" in Table 

### DIFF
--- a/docs/src/pages/components/tables/tables.md
+++ b/docs/src/pages/components/tables/tables.md
@@ -23,7 +23,7 @@ A data table contains a header row at the top that lists column names, followed 
 
 Checkboxes should accompany each row if the user needs to select or manipulate data.
 
-For accessibility, the first column is set to be a `<th>` element, with a `scope` of `"row"`. This enables screen readers to identify a cell's value by it's row and column name.
+For accessibility, the first column is set to be a `<th>` element, with a `scope` of `"col"`. This enables screen readers to identify a cell's value by it's row and column name.
 
 ## Simple Table
 


### PR DESCRIPTION
Under the heading "Structure" the text says:
 For accessibility, the first column is set to be a `<th>` element, with a `scope` of `"row"`.
However, for a `th` at the top of a column, the scope should be `"col"`, and inspecting the rendered table confirms that it is in fact rendered with `scope="col"`

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
