### PR TITLE
[Checkbox] WIP Allow intuitive detection of checkbox checked state

### DIFF
--- a/packages/material-ui/src/Checkbox/Checkbox.test.js
+++ b/packages/material-ui/src/Checkbox/Checkbox.test.js
@@ -83,5 +83,23 @@ describe('<Checkbox />', () => {
         expect(getByRole('checkbox')).not.to.have.attribute('disabled');
       });
     });
+
+    describe('checkbox checked state', () => {
+     it('should detect unchecked checkbox using aria-checked', () => {
+        const { getByRole } = render(
+          <Checkbox />
+          );
+         
+        expect(getByRole('checkbox')).to.have.attribute('aria-checked', 'false');
+      })
+      it('should detect checked checkbox with aria-checked', () => {
+        const { getByRole } = render(
+          <Checkbox />
+          );
+        getByRole('checkbox').click()
+        
+        expect(getByRole('checkbox')).to.have.attribute('aria-checked', 'true');
+      });
+    });
   });
 });


### PR DESCRIPTION
Hi,

Related to https://github.com/mui-org/material-ui/issues/12507 and https://github.com/facebook/react/issues/7051.
To sum it up flawed DOM API makes it impossible to write correct e2e and unit tests for checkbox clicking. The `input` of type `checkbox` provides absolutely no mean to tell whether it is checked or not.

Using `checked` attribute might prove a bad idea, but what about `aria-checked`? [According to the best practices of role checkbox](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role) from Mozilla:

"The developer is required to change the value of the aria-checked attribute dynamically when the checkbox is activated."

I provide only a failing test (did not even run it at this point) showing the idea. Happy to add implementation if the idea is accepted.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
