### PR TITLE
[TextareaAutosize] Fix height inconsistency for empty last row

### DIFF
--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -45,6 +45,12 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
     const inputShallow = shadowRef.current;
     inputShallow.style.width = computedStyle.width;
     inputShallow.value = input.value || props.placeholder || 'x';
+    if (inputShallow.value.slice(-1) === '\n') {
+      // Certain fonts which overflow the line height will cause the textarea
+      // tto report a different scrollHeight depending on whether the last line
+      // is empty. Make it non-empty to avoid this issue.
+      inputShallow.value += ' ';
+    }
 
     const boxSizing = computedStyle['box-sizing'];
     const padding =

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.js
@@ -47,7 +47,7 @@ const TextareaAutosize = React.forwardRef(function TextareaAutosize(props, ref) 
     inputShallow.value = input.value || props.placeholder || 'x';
     if (inputShallow.value.slice(-1) === '\n') {
       // Certain fonts which overflow the line height will cause the textarea
-      // tto report a different scrollHeight depending on whether the last line
+      // to report a different scrollHeight depending on whether the last line
       // is empty. Make it non-empty to avoid this issue.
       inputShallow.value += ' ';
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #20574.

|  Before (when lines > 3)  | After   |
|---|---|
| ![Before](https://user-images.githubusercontent.com/13558253/79362461-a1de5f00-7f14-11ea-86f9-ba55fcdc5820.gif) |  ![After](https://user-images.githubusercontent.com/13558253/79362465-a30f8c00-7f14-11ea-9352-4f09e385eb85.gif) |

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Note that I could possibly add a test for coverage, but I don't think the existing unit test suite would be a good place for that. The only way to really demo and fix the bug is in a browser, since it's the browser's layout engine which yields the problem.
