### PR TITLE
[List] Change ListItemIcon `children` type from element to Node

### DIFF
--- a/docs/pages/api-docs/list-item-icon.md
+++ b/docs/pages/api-docs/list-item-icon.md
@@ -28,7 +28,7 @@ The `MuiListItemIcon` name can be used for providing [default props](/customizat
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
-| <span class="prop-name required">children&nbsp;*</span> | <span class="prop-type">element</span> |  | The content of the component, normally `Icon`, `SvgIcon`, or a `@material-ui/icons` SVG icon element. |
+| <span class="prop-name">children</span> | <span class="prop-type">node</span> |  | The content of the component, normally `Icon`, `SvgIcon`, or a `@material-ui/icons` SVG icon element. |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
 
 The `ref` is forwarded to the root element.

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
@@ -6,7 +6,7 @@ export interface ListItemIconProps
    * The content of the component, normally `Icon`, `SvgIcon`,
    * or a `@material-ui/icons` SVG icon element.
    */
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }
 
 export type ListItemIconClassKey = 'root';

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.d.ts
@@ -6,7 +6,7 @@ export interface ListItemIconProps
    * The content of the component, normally `Icon`, `SvgIcon`,
    * or a `@material-ui/icons` SVG icon element.
    */
-  children: React.ReactElement;
+  children: React.ReactNode;
 }
 
 export type ListItemIconClassKey = 'root';

--- a/packages/material-ui/src/ListItemIcon/ListItemIcon.js
+++ b/packages/material-ui/src/ListItemIcon/ListItemIcon.js
@@ -49,7 +49,7 @@ ListItemIcon.propTypes = {
    * The content of the component, normally `Icon`, `SvgIcon`,
    * or a `@material-ui/icons` SVG icon element.
    */
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node,
   /**
    * Override or extend the styles applied to the component.
    * See [CSS API](#css) below for more details.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Fixes [#15911](https://github.com/mui-org/material-ui/issues/15911)
