### PR TITLE
fix(Modal): Children Only render if Modal Visible

### DIFF
--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -248,7 +248,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
           isEnabled={isTopModal}
           open={open}
         >
-          {React.cloneElement(children, childProps)}
+          {!open ? React.cloneElement(children, { ref: handleRef }) : null}
         </TrapFocus>
       </div>
     </Portal>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


Modal render children without open that's why if we use `useQuery` in children then query run without open which destroy user experience bcz we handle loading state and skeleton on Modal visible 