### PR TITLE
[docs] Remove old workarounds

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -261,7 +261,9 @@ function AppWrapper(props) {
   const { children, pageProps } = props;
 
   const router = useRouter();
-  const [redux] = React.useState(() => initRedux(pageProps.reduxServerState));
+  const [redux] = React.useState(() =>
+    initRedux({ options: { userLanguage: pageProps.userLanguage } }),
+  );
 
   React.useEffect(() => {
     loadDependencies();
@@ -333,24 +335,10 @@ MyApp.propTypes = {
 };
 
 MyApp.getInitialProps = async ({ ctx, Component }) => {
-  let pageProps = {};
+  let pageProps = { userLanguage: ctx.query.userLanguage };
 
   if (Component.getInitialProps) {
     pageProps = await Component.getInitialProps(ctx);
-  }
-
-  if (!process.browser) {
-    const redux = initRedux({
-      options: {
-        userLanguage: ctx.query.userLanguage,
-      },
-    });
-    pageProps = {
-      ...pageProps,
-      // No need to include other initial Redux state because when it
-      // initialises on the client-side it'll create it again anyway
-      reduxServerState: redux.getState(),
-    };
   }
 
   return {

--- a/docs/src/modules/components/MarkdownDocs.js
+++ b/docs/src/modules/components/MarkdownDocs.js
@@ -19,6 +19,7 @@ import PageContext from 'docs/src/modules/components/PageContext';
 import { getHeaders, getTitle, getDescription } from 'docs/src/modules/utils/parseMarkdown';
 import { pageToTitleI18n } from 'docs/src/modules/utils/helpers';
 import Link from 'docs/src/modules/components/Link';
+import { exactProp } from '@material-ui/utils';
 
 const styles = (theme) => ({
   root: {
@@ -92,7 +93,6 @@ function MarkdownDocs(props) {
     disableAd = false,
     disableToc = false,
     markdown: markdownProp,
-    markdownLocation: markdownLocationProp,
     req,
     reqPrefix,
     reqSource,
@@ -102,7 +102,6 @@ function MarkdownDocs(props) {
 
   const markdownDocs = useMarkdownDocs({
     markdown: markdownProp,
-    markdownLocation: markdownLocationProp,
     req,
     reqPrefix,
     reqSource,
@@ -194,12 +193,13 @@ MarkdownDocs.propTypes = {
   disableAd: PropTypes.bool,
   disableToc: PropTypes.bool,
   markdown: PropTypes.string,
-  // You can define the direction location of the markdown file.
-  // Otherwise, we try to determine it with an heuristic.
-  markdownLocation: PropTypes.string,
   req: PropTypes.func,
   reqPrefix: PropTypes.string,
   reqSource: PropTypes.func,
 };
+
+if (process.env.NODE_ENV !== 'production') {
+  MarkdownDocs.propTypes = exactProp(MarkdownDocs.propTypes);
+}
 
 export default withStyles(styles)(MarkdownDocs);

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -89,8 +89,8 @@ TopLayoutBlog.propTypes = {
 };
 
 if (process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line no-useless-concat, react/forbid-foreign-prop-types
-  TopLayoutBlog['propTypes' + ''] = exactProp(TopLayoutBlog.propTypes);
+  // eslint-disable-next-line react/forbid-foreign-prop-types
+  TopLayoutBlog.propTypes = exactProp(TopLayoutBlog.propTypes);
 }
 
 export default withStyles(styles)(TopLayoutBlog);

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -8,6 +8,7 @@ import Link from '@material-ui/core/Link';
 import useMarkdownDocs from 'docs/src/modules/components/useMarkdownDocs';
 import { getHeaders, getTitle, getDescription } from 'docs/src/modules/utils/parseMarkdown';
 import AppFooter from 'docs/src/modules/components/AppFooter';
+import { exactProp } from '@material-ui/utils';
 
 const styles = (theme) => ({
   root: {
@@ -44,18 +45,10 @@ const styles = (theme) => ({
 });
 
 function TopLayoutBlog(props) {
-  const {
-    classes,
-    markdown: markdownProp,
-    markdownLocation: markdownLocationProp,
-    req,
-    reqPrefix,
-    reqSource,
-  } = props;
+  const { classes, markdown: markdownProp, req, reqPrefix, reqSource } = props;
 
   const markdownDocs = useMarkdownDocs({
     markdown: markdownProp,
-    markdownLocation: markdownLocationProp,
     req,
     reqPrefix,
     reqSource,
@@ -90,12 +83,14 @@ function TopLayoutBlog(props) {
 TopLayoutBlog.propTypes = {
   classes: PropTypes.object.isRequired,
   markdown: PropTypes.string,
-  // You can define the direction location of the markdown file.
-  // Otherwise, we try to determine it with an heuristic.
-  markdownLocation: PropTypes.string,
   req: PropTypes.func,
   reqPrefix: PropTypes.string,
   reqSource: PropTypes.func,
 };
+
+if (process.env.NODE_ENV !== 'production') {
+  // eslint-disable-next-line no-useless-concat, react/forbid-foreign-prop-types
+  TopLayoutBlog['propTypes' + ''] = exactProp(TopLayoutBlog.propTypes);
+}
 
 export default withStyles(styles)(TopLayoutBlog);

--- a/docs/src/modules/components/TopLayoutBlog.js
+++ b/docs/src/modules/components/TopLayoutBlog.js
@@ -89,7 +89,6 @@ TopLayoutBlog.propTypes = {
 };
 
 if (process.env.NODE_ENV !== 'production') {
-  // eslint-disable-next-line react/forbid-foreign-prop-types
   TopLayoutBlog.propTypes = exactProp(TopLayoutBlog.propTypes);
 }
 

--- a/docs/src/modules/components/useMarkdownDocs.js
+++ b/docs/src/modules/components/useMarkdownDocs.js
@@ -9,13 +9,7 @@ import MarkdownElement from 'docs/src/modules/components/MarkdownElement';
 import { LANGUAGES_IN_PROGRESS, SOURCE_CODE_ROOT_URL } from 'docs/src/modules/constants';
 
 export default function useMarkdownDocs(options) {
-  const {
-    markdownLocation: locationProp,
-    markdown: markdownProp,
-    req,
-    reqPrefix,
-    reqSource,
-  } = options;
+  const { markdown: markdownProp, req, reqPrefix, reqSource } = options;
 
   const userLanguage = useSelector((state) => state.options.userLanguage);
   let demos;
@@ -58,10 +52,10 @@ export default function useMarkdownDocs(options) {
   const headers = getHeaders(markdown);
 
   const { activePage } = React.useContext(PageContext);
-  let location = locationProp || (activePage && activePage.pathname);
+  let location = activePage && activePage.pathname;
   const t = useSelector((state) => state.options.t);
 
-  if (location && !locationProp) {
+  if (location) {
     const token = location.split('/');
     token.push(token[token.length - 1]);
     location = token.join('/');

--- a/docs/src/modules/redux/initRedux.js
+++ b/docs/src/modules/redux/initRedux.js
@@ -13,7 +13,7 @@ if (
   devtools = window.__REDUX_DEVTOOLS_EXTENSION__();
 }
 
-function create(initialState) {
+export default function create(initialState) {
   let middleware = [];
 
   if (
@@ -36,19 +36,4 @@ function create(initialState) {
     initialState, // Hydrate the store with server-side data
     compose(applyMiddleware(...middleware), devtools),
   );
-}
-
-export default function initRedux(initialState) {
-  // Make sure to create a new store for every server-side request so that data
-  // isn't shared between connections (which would be bad)
-  if (!process.browser) {
-    return create(initialState);
-  }
-
-  // Reuse store on the client-side
-  if (!global.__INIT_REDUX_STORE__) {
-    global.__INIT_REDUX_STORE__ = create(initialState);
-  }
-
-  return global.__INIT_REDUX_STORE__;
 }

--- a/docs/src/modules/redux/initRedux.js
+++ b/docs/src/modules/redux/initRedux.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
 import optionsReducer from 'docs/src/modules/redux/optionsReducer';
+import { createLogger } from 'redux-logger';
 
 // Get the Redux DevTools extension and fallback to a no-op function
 let devtools = (x) => x;
@@ -23,9 +24,6 @@ export default function create(initialState) {
     // redux-logger needs this feature
     Object.hasOwnProperty('assign')
   ) {
-    // eslint-disable-next-line global-require
-    const createLogger = require('redux-logger').createLogger;
-
     middleware = [...middleware, createLogger()];
   }
 


### PR DESCRIPTION
Removes some older workarounds that are no longer needed and make the code needlessly complicate in their current state.
- removing `markdownLocation` prop (it seems to be unused)
- remove dynamic require() of redux-logger. it's dropped from the prod bundle with a static import
- remove global shared redux store. Seems not necessary anymore.