### PR TITLE
[Autocomplete] Reset input on blur for freeSolo mode too

### DIFF
--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -758,7 +758,7 @@ export default function useAutocomplete(props) {
       selectNewValue(event, filteredOptions[highlightedIndexRef.current], 'blur');
     } else if (autoSelect && freeSolo && inputValue !== '') {
       selectNewValue(event, inputValue, 'blur', 'freeSolo');
-    } else if (!freeSolo) {
+    } else {
       resetInputValue(event, value);
     }
 


### PR DESCRIPTION
When using Autocomplete in freeSolo mode, editing the field manually
(with keyboard) and then blurring the field, make sure the field is
reset to its current value. Otherwise, the actual field value does not
correspond to the last value used in onChange.

Closes #19423 

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
