### PR TITLE
[Autocomplete] Reset highlighted option on mouseleave

### DIFF
--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -790,6 +790,10 @@ export default function useAutocomplete(props) {
     setHighlightedIndex(index, 'mouse');
   };
 
+  const handleListboxMouseLeave = () => {
+    changeHighlightedIndex('reset', 'next');
+  };
+
   const handleOptionTouchStart = () => {
     isTouch.current = true;
   };
@@ -863,7 +867,6 @@ export default function useAutocomplete(props) {
 
   let dirty = freeSolo && inputValue.length > 0;
   dirty = dirty || (multiple ? value.length > 0 : value !== null);
-
   let groupedOptions = filteredOptions;
   if (groupBy) {
     // used to keep track of key and indexes in the result array
@@ -955,6 +958,7 @@ export default function useAutocomplete(props) {
         // Prevent blur
         event.preventDefault();
       },
+      onMouseLeave: handleListboxMouseLeave,
     }),
     getOptionProps: ({ index, option }) => {
       const selected = (multiple ? value : [value]).some(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
This PR will close ticket [#20602.](https://github.com/mui-org/material-ui/issues/20602) 
The autocomplete value will not change if the user leaves option menu without selecting anything.

 
- [X ] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Closes #20602.