### PR TITLE
[docs] Allow string literal type in jsdoc markdown generation

### DIFF
--- a/docs/src/modules/utils/generateMarkdown.js
+++ b/docs/src/modules/utils/generateMarkdown.js
@@ -94,6 +94,10 @@ function resolveType(type) {
     return type.elements.map((t) => resolveType(t)).join(' \\| ');
   }
 
+  if (type.type === 'StringLiteralType') {
+    return type.value;
+  }
+
   return type.name;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

This change allows for string literal types ( in particular union of ) in the generated md from a component's jsdoc comments.

e.g The reason parameter below.
```
/**
   * Callback fired when tree items are expanded/collapsed
   * @param {object} event The event source of the callback.
   * @param {string[]} nodeIds The ids of the expanded nodes.
   * @param {'Keyboard' | 'IconClick' | 'LabelClick'} reason The reason for the expansion / collapse.
   */
  onNodeToggle?: (
    event: React.ChangeEvent<{}>,
    nodeIds: string[],
    reason: 'Keyboard' | 'IconClick' | 'LabelClick',
  ) => void;
```

( There is an equivalent commit in https://github.com/mui-org/material-ui/pull/20609 )

Note that no test has been added as there are no tests currently for this part of the build script.