### PR TITLE
Fix adding extra className for focused Button

### DIFF
--- a/packages/material-ui/src/Button/Button.js
+++ b/packages/material-ui/src/Button/Button.js
@@ -309,7 +309,7 @@ const Button = React.forwardRef(function Button(props, ref) {
       component={component}
       disabled={disabled}
       focusRipple={!disableFocusRipple}
-      focusVisibleClassName={clsx(classes.focusVisible, focusVisibleClassName)}
+      focusVisibleClassName={focusVisibleClassName}
       ref={ref}
       type={type}
       {...other}

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -363,7 +363,9 @@ describe('<Button />', () => {
     // @ts-ignore
     buttonActionsRef.current.focus();
 
-    expect(button.className).to.equal('MuiButtonBase-root MuiButton-root MuiButton-text Mui-focusVisible focusVisible');
+    expect(button.className).to.equal(
+      'MuiButtonBase-root MuiButton-root MuiButton-text Mui-focusVisible focusVisible',
+    );
   });
 
   describe('server-side', () => {

--- a/packages/material-ui/src/Button/Button.test.js
+++ b/packages/material-ui/src/Button/Button.test.js
@@ -351,6 +351,21 @@ describe('<Button />', () => {
     expect(button.querySelector('.pulsate-focus-visible')).to.equal(null);
   });
 
+  it('should add right className for focused button', () => {
+    const buttonActionsRef = React.createRef();
+    const { getByRole } = render(
+      <Button ref={buttonActionsRef} focusVisibleClassName="focusVisible">
+        Hello
+      </Button>,
+    );
+
+    const button = getByRole('button');
+    // @ts-ignore
+    buttonActionsRef.current.focus();
+
+    expect(button.className).to.equal('MuiButtonBase-root MuiButton-root MuiButton-text Mui-focusVisible focusVisible');
+  });
+
   describe('server-side', () => {
     // Only run the test on node.
     if (!/jsdom/.test(window.navigator.userAgent)) {


### PR DESCRIPTION
- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Seems like there is some repeating classes for focused Button.
<img width="522" alt="Снимок экрана 2020-04-19 в 16 50 33" src="https://user-images.githubusercontent.com/22371328/79689528-21926380-825e-11ea-95a7-58dc05685190.png">
