### PR TITLE
[Tooltip] Use label semantics

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -132,6 +132,8 @@ module.exports = {
         'jsx-a11y/no-static-element-interactions': 'off',
         'jsx-a11y/tabindex-no-positive': 'off',
 
+        // same rationale as for eslint-plugin-jsx-a11y
+        'react/button-has-type': 'off',
         // They are accessed to test custom validator implementation with PropTypes.checkPropTypes
         'react/forbid-foreign-prop-types': 'off',
         // components that are defined in test are isolated enough

--- a/docs/pages/api-docs/tooltip.md
+++ b/docs/pages/api-docs/tooltip.md
@@ -31,6 +31,7 @@ The `MuiTooltip` name can be used for providing [default props](/customization/g
 | <span class="prop-name">arrow</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | If `true`, adds an arrow to the tooltip. |
 | <span class="prop-name required">children<abbr title="required">*</abbr></span> | <span class="prop-type">element</span> |  | Tooltip reference element.<br>⚠️ [Needs to be able to hold a ref](/guides/composition/#caveat-with-refs). |
 | <span class="prop-name">classes</span> | <span class="prop-type">object</span> |  | Override or extend the styles applied to the component. See [CSS API](#css) below for more details. |
+| <span class="prop-name">describeChild</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Set to `true` if the `title` acts as an accessible description. By default the `title` acts as an accessible label for the child. |
 | <span class="prop-name">disableFocusListener</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Do not respond to focus events. |
 | <span class="prop-name">disableHoverListener</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Do not respond to hover events. |
 | <span class="prop-name">disableTouchListener</span> | <span class="prop-type">bool</span> | <span class="prop-default">false</span> | Do not respond to long press touch events. |

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -209,7 +209,6 @@ function AppFrame(props) {
           <IconButton
             edge="start"
             color="inherit"
-            aria-label={t('openDrawer')}
             onClick={handleDrawerOpen}
             className={navIconClassName}
           >
@@ -222,7 +221,6 @@ function AppFrame(props) {
               color="inherit"
               aria-owns={languageMenu ? 'language-menu' : undefined}
               aria-haspopup="true"
-              aria-label={t('changeLanguage')}
               onClick={handleLanguageIconClick}
               data-ga-event-category="header"
               data-ga-event-action="language"
@@ -281,7 +279,6 @@ function AppFrame(props) {
           <Tooltip title={t('editWebsiteColors')} enterDelay={300}>
             <IconButton
               color="inherit"
-              aria-label={t('editWebsiteColors')}
               component={Link}
               naked
               href="/customization/color/#playground"
@@ -296,7 +293,6 @@ function AppFrame(props) {
               component="a"
               color="inherit"
               href="https://github.com/mui-org/material-ui"
-              aria-label={t('github')}
               data-ga-event-category="header"
               data-ga-event-action="github"
             >
@@ -307,7 +303,6 @@ function AppFrame(props) {
             <IconButton
               color="inherit"
               onClick={handleTogglePaletteType}
-              aria-label={t('toggleTheme')}
               data-ga-event-category="header"
               data-ga-event-action="dark"
             >
@@ -319,7 +314,6 @@ function AppFrame(props) {
               edge="end"
               color="inherit"
               onClick={handleToggleDirection}
-              aria-label={t('toggleRTL')}
               data-ga-event-category="header"
               data-ga-event-action="rtl"
             >

--- a/docs/src/modules/components/AppFrame.js
+++ b/docs/src/modules/components/AppFrame.js
@@ -209,6 +209,7 @@ function AppFrame(props) {
           <IconButton
             edge="start"
             color="inherit"
+            aria-label={t('openDrawer')}
             onClick={handleDrawerOpen}
             className={navIconClassName}
           >

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -458,7 +458,6 @@ function DemoToolbar(props) {
             >
               <IconButton
                 aria-controls={openDemoSource ? demoSourceId : null}
-                aria-label={showCodeLabel}
                 data-ga-event-category="demo"
                 data-ga-event-label={demoOptions.demo}
                 data-ga-event-action="expand"
@@ -476,7 +475,6 @@ function DemoToolbar(props) {
                 placement="top"
               >
                 <IconButton
-                  aria-label={t('codesandbox')}
                   data-ga-event-category="demo"
                   data-ga-event-label={demoOptions.demo}
                   data-ga-event-action="codesandbox"
@@ -489,7 +487,6 @@ function DemoToolbar(props) {
             )}
             <Tooltip classes={{ popper: classes.tooltip }} title={t('copySource')} placement="top">
               <IconButton
-                aria-label={t('copySource')}
                 data-ga-event-category="demo"
                 data-ga-event-label={demoOptions.demo}
                 data-ga-event-action="copy"
@@ -501,7 +498,6 @@ function DemoToolbar(props) {
             </Tooltip>
             <Tooltip classes={{ popper: classes.tooltip }} title={t('resetFocus')} placement="top">
               <IconButton
-                aria-label={t('resetFocus')}
                 data-ga-event-category="demo"
                 data-ga-event-label={demoOptions.demo}
                 data-ga-event-action="reset-focus"
@@ -514,7 +510,6 @@ function DemoToolbar(props) {
             <Tooltip classes={{ popper: classes.tooltip }} title={t('resetDemo')} placement="top">
               <IconButton
                 aria-controls={demoId}
-                aria-label={t('resetDemo')}
                 data-ga-event-category="demo"
                 data-ga-event-label={demoOptions.demo}
                 data-ga-event-action="reset"
@@ -528,7 +523,6 @@ function DemoToolbar(props) {
               onClick={handleMoreClick}
               aria-owns={anchorEl ? 'demo-menu-more' : undefined}
               aria-haspopup="true"
-              aria-label={t('seeMore')}
               {...getControlProps(7)}
             >
               <MoreVertIcon fontSize="small" />

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -140,7 +140,6 @@ export default function Notifications() {
           ref={anchorRef}
           aria-controls={open ? 'notifications-popup' : undefined}
           aria-haspopup="true"
-          aria-label={t('toggleNotifications')}
           onClick={handleToggle}
           data-ga-event-category="AppBar"
           data-ga-event-action="toggleNotifications"

--- a/packages/material-ui/src/Tooltip/Tooltip.d.ts
+++ b/packages/material-ui/src/Tooltip/Tooltip.d.ts
@@ -14,6 +14,11 @@ export interface TooltipProps
    */
   children: React.ReactElement<any, any>;
   /**
+   * Set to `true` if the `title` acts as an accessible description.
+   * By default the `title` acts as an accessible label for the child.
+   */
+  describeChild?: boolean;
+  /**
    * Do not respond to focus events.
    */
   disableFocusListener?: boolean;

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -166,6 +166,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     arrow = false,
     children,
     classes,
+    describeChild = false,
     disableFocusListener = false,
     disableHoverListener = false,
     disableTouchListener = false,
@@ -404,15 +405,18 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     open = false;
   }
 
-  // For accessibility and SEO concerns, we render the title to the DOM node when
-  // the tooltip is hidden. However, we have made a tradeoff when
-  // `disableHoverListener` is set. This title logic is disabled.
-  // It's allowing us to keep the implementation size minimal.
-  // We are open to change the tradeoff.
-  const shouldShowNativeTitle = !open && !disableHoverListener;
+  const nameOrDescProps = {};
+  const titleIsString = typeof title === 'string';
+  if (describeChild) {
+    nameOrDescProps['title'] = !open && titleIsString && !disableHoverListener ? title : null;
+    nameOrDescProps['aria-describedby'] = open ? id : null;
+  } else {
+    nameOrDescProps['aria-label'] = titleIsString ? title : null;
+    nameOrDescProps['aria-labelledby'] = open && !titleIsString ? id : null;
+  }
+
   const childrenProps = {
-    'aria-describedby': open ? id : null,
-    title: shouldShowNativeTitle && typeof title === 'string' ? title : null,
+    ...nameOrDescProps,
     ...other,
     ...children.props,
     className: clsx(other.className, children.props.className),
@@ -485,7 +489,7 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
         placement={placement}
         anchorEl={childNode}
         open={childNode ? open : false}
-        id={childrenProps['aria-describedby']}
+        id={id}
         transition
         {...interactiveWrapperListeners}
         {...mergedPopperProps}
@@ -538,6 +542,11 @@ Tooltip.propTypes = {
    * @ignore
    */
   className: PropTypes.string,
+  /**
+   * Set to `true` if the `title` acts as an accessible description.
+   * By default the `title` acts as an accessible label for the child.
+   */
+  describeChild: PropTypes.bool,
   /**
    * Do not respond to focus events.
    */

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -161,6 +161,9 @@ describe('<Tooltip />', () => {
       const target = screen.getByTestId('target');
       expect(target).toHaveAccessibleName('the title');
       expect(target).not.to.have.attribute('title');
+
+      // TODO: can be removed with popper@2.x
+      clock.runAll();
     });
 
     it('should label the child when open with an exotic title', () => {
@@ -173,6 +176,9 @@ describe('<Tooltip />', () => {
       const target = screen.getByTestId('target');
       expect(target).toHaveAccessibleName('the title');
       expect(target).not.to.have.attribute('title');
+
+      // TODO: can be removed with popper@2.x
+      clock.runAll();
     });
 
     it('can describe the child when closed', () => {
@@ -218,6 +224,9 @@ describe('<Tooltip />', () => {
       expect(target).toHaveAccessibleName('the label');
       expect(target).toHaveAccessibleDescription('the title');
       expect(target).not.to.have.attribute('title');
+
+      // TODO: can be removed with popper@2.x
+      clock.runAll();
     });
 
     it('can describe the child when open with an exotic title', () => {
@@ -233,6 +242,9 @@ describe('<Tooltip />', () => {
       expect(target).toHaveAccessibleName('the label');
       expect(target).toHaveAccessibleDescription('the title');
       expect(target).not.to.have.attribute('title');
+
+      // TODO: can be removed with popper@2.x
+      clock.runAll();
     });
   });
 

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -8,6 +8,7 @@ import {
   act,
   createClientRender,
   fireEvent,
+  screen,
 } from 'test/utils';
 import { camelCase } from 'lodash/string';
 import Tooltip, { testReset } from './Tooltip';
@@ -126,16 +127,112 @@ describe('<Tooltip />', () => {
       expect(queryByRole('tooltip')).to.equal(null);
     });
 
-    it('should be passed down to the child as a native title', () => {
-      const { getByRole } = render(
-        <Tooltip title="Hello World">
-          <button id="testChild" type="submit">
-            Hello World
+    it('should label the child when closed', () => {
+      render(
+        <Tooltip title="the title">
+          <button data-testid="target">The content</button>
+        </Tooltip>,
+      );
+
+      const target = screen.getByTestId('target');
+      expect(target).toHaveAccessibleName('the title');
+      expect(target).not.to.have.attribute('title');
+    });
+
+    it('cannot label the child when closed with an exotic title', () => {
+      render(
+        <Tooltip title={<div>the title</div>}>
+          <button data-testid="target">the content</button>
+        </Tooltip>,
+      );
+
+      const target = screen.getByTestId('target');
+      expect(target).toHaveAccessibleName('the content');
+      expect(target).not.to.have.attribute('title');
+    });
+
+    it('should label the child when open', () => {
+      render(
+        <Tooltip open title="the title">
+          <button data-testid="target">The content</button>
+        </Tooltip>,
+      );
+
+      const target = screen.getByTestId('target');
+      expect(target).toHaveAccessibleName('the title');
+      expect(target).not.to.have.attribute('title');
+    });
+
+    it('should label the child when open with an exotic title', () => {
+      render(
+        <Tooltip open title={<div>the title</div>}>
+          <button data-testid="target">The content</button>
+        </Tooltip>,
+      );
+
+      const target = screen.getByTestId('target');
+      expect(target).toHaveAccessibleName('the title');
+      expect(target).not.to.have.attribute('title');
+    });
+
+    it('can describe the child when closed', () => {
+      render(
+        <Tooltip describeChild title="the title">
+          <button aria-label="the label" data-testid="target">
+            The content
           </button>
         </Tooltip>,
       );
 
-      expect(getByRole('button')).to.have.attribute('title', 'Hello World');
+      const target = screen.getByTestId('target');
+      expect(target).toHaveAccessibleName('the label');
+      expect(target).toHaveAccessibleDescription('the title');
+      expect(target).to.have.attribute('title', 'the title');
+    });
+
+    it('cannot describe the child when closed with an exotic title', () => {
+      render(
+        <Tooltip describeChild title={<div>the title</div>}>
+          <button aria-label="the label" data-testid="target">
+            The content
+          </button>
+        </Tooltip>,
+      );
+
+      const target = screen.getByTestId('target');
+      expect(target).toHaveAccessibleName('the label');
+      expect(target).toHaveAccessibleDescription('');
+      expect(target).not.to.have.attribute('title');
+    });
+
+    it('can describe the child when open', () => {
+      render(
+        <Tooltip describeChild open title="the title">
+          <button aria-label="the label" data-testid="target">
+            The content
+          </button>
+        </Tooltip>,
+      );
+
+      const target = screen.getByTestId('target');
+      expect(target).toHaveAccessibleName('the label');
+      expect(target).toHaveAccessibleDescription('the title');
+      expect(target).not.to.have.attribute('title');
+    });
+
+    it('can describe the child when open with an exotic title', () => {
+      render(
+        <Tooltip describeChild open title={<div>the title</div>}>
+          <button aria-label="the label" data-testid="target">
+            The content
+          </button>
+        </Tooltip>,
+      );
+
+      const target = screen.getByTestId('target');
+      expect(target).toHaveAccessibleName('the label');
+      expect(target).toHaveAccessibleDescription('the title');
+      expect(target).not.to.have.attribute('title');
     });
   });
 

--- a/test/utils/initMatchers.js
+++ b/test/utils/initMatchers.js
@@ -2,7 +2,7 @@ import chai from 'chai';
 import chaiDom from 'chai-dom';
 import { isInaccessible } from '@testing-library/dom';
 import { prettyDOM } from '@testing-library/react/pure';
-import { computeAccessibleName } from 'dom-accessibility-api';
+import { computeAccessibleDescription, computeAccessibleName } from 'dom-accessibility-api';
 import formatUtil from 'format-util';
 
 // chai#utils.elToString that looks like stringified elements in testing-library
@@ -15,6 +15,58 @@ function elementToString(element) {
 
 chai.use(chaiDom);
 chai.use((chaiAPI, utils) => {
+  const blockElements = new Set(
+    'html',
+    'address',
+    'blockquote',
+    'body',
+    'dd',
+    'div',
+    'dl',
+    'dt',
+    'fieldset',
+    'form',
+    'frame',
+    'frameset',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'noframes',
+    'ol',
+    'p',
+    'ul',
+    'center',
+    'dir',
+    'hr',
+    'menu',
+    'pre',
+  );
+  /**
+   *
+   * @param {Element} element
+   * @returns {CSSStyleDeclaration}
+   */
+  function pretendVisibleGetComputedStyle(element) {
+    // `CSSStyleDeclaration` is not constructable
+    // https://stackoverflow.com/a/52732909/3406963
+    // this is not equivalent to the declaration from `getComputedStyle`
+    // e.g `getComputedStyle` would return a readonly declaration
+    // let's hope this doesn't get passed around until it's no longer clear where it comes from
+    const declaration = document.createElement('span').style;
+
+    // initial values
+    declaration.content = '';
+    // technically it's `inline`. We partially apply the default user agent sheet (chrome) here
+    // we're only interested in elements that use block
+    declaration.display = blockElements.has(element.tagName) ? 'block' : 'inline';
+    declaration.visibility = 'visible';
+
+    return declaration;
+  }
+
   // better diff view for expect(element).to.equal(document.activeElement)
   chai.Assertion.addMethod('toHaveFocus', function elementIsFocused() {
     const element = utils.flag(this, 'object');
@@ -92,58 +144,6 @@ chai.use((chaiAPI, utils) => {
     // make sure it's an Element
     new chai.Assertion(root.nodeType, `Expected an Element but got '${String(root)}'`).to.equal(1);
 
-    const blockElements = new Set(
-      'html',
-      'address',
-      'blockquote',
-      'body',
-      'dd',
-      'div',
-      'dl',
-      'dt',
-      'fieldset',
-      'form',
-      'frame',
-      'frameset',
-      'h1',
-      'h2',
-      'h3',
-      'h4',
-      'h5',
-      'h6',
-      'noframes',
-      'ol',
-      'p',
-      'ul',
-      'center',
-      'dir',
-      'hr',
-      'menu',
-      'pre',
-    );
-    /**
-     *
-     * @param {Element} element
-     * @returns {CSSStyleDeclaration}
-     */
-    function pretendVisibleGetComputedStyle(element) {
-      // `CSSStyleDeclaration` is not constructable
-      // https://stackoverflow.com/a/52732909/3406963
-      // this is not equivalent to the declaration from `getComputedStyle`
-      // e.g `getComputedStyle` would return a readonly declaration
-      // let's hope this doesn't get passed around until it's no longer clear where it comes from
-      const declaration = document.createElement('span').style;
-
-      // initial values
-      declaration.content = '';
-      // technically it's `inline`. We partially apply the default user agent sheet (chrome) here
-      // we're only interested in elements that use block
-      declaration.display = blockElements.has(element.tagName) ? 'block' : 'inline';
-      declaration.visibility = 'visible';
-
-      return declaration;
-    }
-
     const actualName = computeAccessibleName(root, {
       // in local development we pretend to be visible. full getComputedStyle is
       // expensive and reserved for CI
@@ -156,6 +156,35 @@ chai.use((chaiAPI, utils) => {
       `expected \n${elementToString(root)} not to have accessible name #{exp}.`,
       expectedName,
       actualName,
+    );
+  });
+
+  chai.Assertion.addMethod('toHaveAccessibleDescription', function hasAccessibleDescription(
+    expectedDescription,
+  ) {
+    const root = utils.flag(this, 'object');
+    // make sure it's an Element
+    new chai.Assertion(root.nodeType, `Expected an Element but got '${String(root)}'`).to.equal(1);
+
+    const actualDescription = computeAccessibleDescription(root, {
+      // in local development we pretend to be visible. full getComputedStyle is
+      // expensive and reserved for CI
+      getComputedStyle: process.env.CI ? undefined : pretendVisibleGetComputedStyle,
+    });
+
+    const possibleDescriptionComputationMessage = root.hasAttribute('title')
+      ? ' computeAccessibleDescription can be misleading when a `title` attribute is used. This might be a bug in `dom-accessibility-api`.'
+      : '';
+    this.assert(
+      actualDescription === expectedDescription,
+      `expected \n${elementToString(
+        root,
+      )} to have accessible description #{exp} but got #{act} instead.${possibleDescriptionComputationMessage}`,
+      `expected \n${elementToString(
+        root,
+      )} not to have accessible description #{exp}.${possibleDescriptionComputationMessage}`,
+      expectedDescription,
+      actualDescription,
     );
   });
 


### PR DESCRIPTION
The Tooltip currently applies label and description semantics (`title` + `aria-describedby`) which doesn't seem correct to me. It's apparent if you look at our usage in the docs where we pass `title` to `aria-label`.

This PR moves to label only semantics via `aria-label` for string titles or aria-labelledby for anything else. For non-string titles you'd still need to label the child separately. But this was already the case before.

It also gets rid of the  [problematic `title` attribute](https://developer.paciellogroup.com/blog/2012/01/html5-accessibility-chops-title-attribute-use-and-abuse/).

It's unclear what SEO concerns this should solve. 

Opening this for a11y testing and a11y snapshots diff in mui-scrips-incubator. In this form it can't land in v4 anyway.