### PR TITLE
[slider] Fix focus after click

### DIFF
--- a/packages/material-ui/src/Slider/Slider.js
+++ b/packages/material-ui/src/Slider/Slider.js
@@ -100,7 +100,7 @@ function focusThumb({ sliderRef, activeIndex, setActive }) {
     !sliderRef.current.contains(document.activeElement) ||
     Number(document.activeElement.getAttribute('data-index')) !== activeIndex
   ) {
-    sliderRef.current.querySelector(`[data-index="${activeIndex}"]`).focus();
+    sliderRef.current.querySelector(`[role="slider"][data-index="${activeIndex}"]`).focus();
   }
 
   if (setActive) {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -180,26 +180,11 @@ describe('<Slider />', () => {
       expect(thumb2.getAttribute('aria-valuenow')).to.equal('29');
     });
 
-    it('should support keyboard with marks variant', () => {
-      const { getAllByRole } = render(
-        <Slider defaultValue={30} step={10} marks min={10} max={110} />,
-      );
-      const [thumb] = getAllByRole('slider');
-
-      thumb.focus();
-      fireEvent.keyDown(document.activeElement, {
-        key: 'ArrowRight',
-      });
-      expect(thumb.getAttribute('aria-valuenow')).to.equal('40');
-
-      thumb.focus();
-      fireEvent.keyDown(document.activeElement, {
-        key: 'ArrowLeft',
-      });
-      fireEvent.keyDown(document.activeElement, {
-        key: 'ArrowLeft',
-      });
-      expect(thumb.getAttribute('aria-valuenow')).to.equal('20');
+    it('should focus the slider when dragging', () => {
+      const { getByRole } = render(<Slider defaultValue={30} step={10} marks />);
+      const thumb = getByRole('slider');
+      fireEvent.mouseDown(thumb);
+      expect(document.activeElement).to.equal(thumb);
     });
 
     it('should support mouse events', () => {

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -180,6 +180,31 @@ describe('<Slider />', () => {
       expect(thumb2.getAttribute('aria-valuenow')).to.equal('29');
     });
 
+    it('with marks should support keyboard events', () => {
+      const { getAllByRole } = render(<Slider
+          defaultValue={30}
+          step={10}
+          marks
+          min={10}
+          max={110} />);
+      const [thumb] = getAllByRole('slider');
+
+      thumb.focus();
+      fireEvent.keyDown(document.activeElement, {
+        key: 'ArrowRight',
+      });
+      expect(thumb.getAttribute('aria-valuenow')).to.equal('40');
+
+      thumb.focus();
+      fireEvent.keyDown(document.activeElement, {
+        key: 'ArrowLeft',
+      });
+      fireEvent.keyDown(document.activeElement, {
+        key: 'ArrowLeft',
+      });
+      expect(thumb.getAttribute('aria-valuenow')).to.equal('20');
+    });
+
     it('should support mouse events', () => {
       const handleChange = spy();
       const { container } = render(<Slider defaultValue={[20, 30]} onChange={handleChange} />);

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -181,12 +181,9 @@ describe('<Slider />', () => {
     });
 
     it('should support keyboard with marks variant', () => {
-      const { getAllByRole } = render(<Slider
-          defaultValue={30}
-          step={10}
-          marks
-          min={10}
-          max={110} />);
+      const { getAllByRole } = render(
+        <Slider defaultValue={30} step={10} marks min={10} max={110} />,
+      );
       const [thumb] = getAllByRole('slider');
 
       thumb.focus();

--- a/packages/material-ui/src/Slider/Slider.test.js
+++ b/packages/material-ui/src/Slider/Slider.test.js
@@ -180,7 +180,7 @@ describe('<Slider />', () => {
       expect(thumb2.getAttribute('aria-valuenow')).to.equal('29');
     });
 
-    it('with marks should support keyboard events', () => {
+    it('should support keyboard with marks variant', () => {
       const { getAllByRole } = render(<Slider
           defaultValue={30}
           step={10}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

This fixes a regression with the `Slider` variant with `marks` that was introduced in `4.9.10`, which broke keyboard interaction.  This fixes that and adds a new test to check for this behavior.  Original bug report:

Closes #20645 