### PR TITLE
[ButtonBase] Fix ripple size when clientX or clientY is 0

### DIFF
--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -184,8 +184,8 @@ const TouchRipple = React.forwardRef(function TouchRipple(props, ref) {
         rippleX = Math.round(rect.width / 2);
         rippleY = Math.round(rect.height / 2);
       } else {
-        const clientX = event.clientX ? event.clientX : event.touches[0].clientX;
-        const clientY = event.clientY ? event.clientY : event.touches[0].clientY;
+        const clientX = event.clientX >= 0 ? event.clientX : event.touches[0].clientX;
+        const clientY = event.clientY >= 0 ? event.clientY : event.touches[0].clientY;
         rippleX = Math.round(clientX - rect.left);
         rippleY = Math.round(clientY - rect.top);
       }

--- a/packages/material-ui/src/ButtonBase/TouchRipple.js
+++ b/packages/material-ui/src/ButtonBase/TouchRipple.js
@@ -184,8 +184,7 @@ const TouchRipple = React.forwardRef(function TouchRipple(props, ref) {
         rippleX = Math.round(rect.width / 2);
         rippleY = Math.round(rect.height / 2);
       } else {
-        const clientX = event.clientX >= 0 ? event.clientX : event.touches[0].clientX;
-        const clientY = event.clientY >= 0 ? event.clientY : event.touches[0].clientY;
+        const { clientX, clientY } = event.touches ? event.touches[0] : event;
         rippleX = Math.round(clientX - rect.left);
         rippleY = Math.round(clientY - rect.top);
       }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

#12362

When click Button with `clientX === 0` or `clientY === 0` (ex. clientX = 10, clientY = 0), it has error `Cannot read property '0' of undefined`(becuase event.touches is undefined in click event).