### PR TITLE
Add freesolo property to autocomplete component for typescript type.

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.d.ts
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.d.ts
@@ -89,6 +89,10 @@ export interface AutocompleteProps<T>
    */
   fullWidth?: boolean;
   /**
+   * If `true`, the textbox can contain an arbitrary value.
+   */
+  freesolo?: boolean;
+  /**
    * The label to display when the tags are truncated (`limitTags`).
    *
    * @param {number} more The number of truncated tags.

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.js
@@ -621,6 +621,10 @@ Autocomplete.propTypes = {
    */
   forcePopupIcon: PropTypes.oneOfType([PropTypes.oneOf(['auto']), PropTypes.bool]),
   /**
+   * If `true`, the textbox can contain an arbitrary value.
+   */
+  freesolo: PropTypes.bool,
+  /**
    * If `true`, the Autocomplete is free solo, meaning that the user input is not bound to provided options.
    */
   freeSolo: PropTypes.bool,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Added missing `freesolo` property to Autocomplete type declaration file.