### PR TITLE
[docs] Modernize DemoFrame

### DIFF
--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -21,9 +21,7 @@ const styles = (theme) => ({
 function DemoFrame(props) {
   const { children, classes, ...other } = props;
   const theme = useTheme();
-  const [state, setState] = React.useState({
-    ready: false,
-  });
+  const [state, setState] = React.useState(null);
 
   /**
    * @type {import('react').Ref<Window | null>}
@@ -37,7 +35,6 @@ function DemoFrame(props) {
 
   const onContentDidMount = () => {
     setState({
-      ready: true,
       jss: create({
         plugins: [...jssPreset().plugins, rtl()],
         insertionPoint: jssInsertionPointRef.current,
@@ -62,7 +59,7 @@ function DemoFrame(props) {
         {...other}
       >
         <div ref={jssInsertionPointRef} />
-        {state.ready ? (
+        {state !== null ? (
           <StylesProvider jss={state.jss} sheetsManager={state.sheetsManager}>
             {React.cloneElement(children, {
               window: state.window,

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -41,7 +41,6 @@ function DemoFrame(props) {
         insertionPoint: instanceRef.current.contentWindow['demo-frame-jss'],
       }),
       sheetsManager: new Map(),
-      container: instanceRef.current.contentDocument.body,
       window: () => instanceRef.current.contentWindow,
     });
   };
@@ -64,7 +63,6 @@ function DemoFrame(props) {
         {state.ready ? (
           <StylesProvider jss={state.jss} sheetsManager={state.sheetsManager}>
             {React.cloneElement(children, {
-              container: state.container,
               window: state.window,
             })}
           </StylesProvider>

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Divider from '@material-ui/core/Divider';
@@ -51,7 +52,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function ResponsiveDrawer() {
+function ResponsiveDrawer(props) {
+  const { window } = props;
   const classes = useStyles();
   const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -84,10 +86,10 @@ export default function ResponsiveDrawer() {
     </div>
   );
 
-  const [container, setContainer] = React.useState(null);
+  const container = window !== undefined ? () => window().document.body : undefined;
 
   return (
-    <div className={classes.root} ref={setContainer}>
+    <div className={classes.root}>
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
@@ -165,3 +167,13 @@ export default function ResponsiveDrawer() {
     </div>
   );
 }
+
+ResponsiveDrawer.propTypes = {
+  /**
+   * Injected by the documentation to work in an iframe.
+   * You won't need it on your project.
+   */
+  window: PropTypes.func,
+};
+
+export default ResponsiveDrawer;

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.js
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import AppBar from '@material-ui/core/AppBar';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import Divider from '@material-ui/core/Divider';
@@ -52,8 +51,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function ResponsiveDrawer(props) {
-  const { container } = props;
+export default function ResponsiveDrawer() {
   const classes = useStyles();
   const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -86,8 +84,10 @@ function ResponsiveDrawer(props) {
     </div>
   );
 
+  const [container, setContainer] = React.useState(null);
+
   return (
-    <div className={classes.root}>
+    <div className={classes.root} ref={setContainer}>
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
@@ -165,13 +165,3 @@ function ResponsiveDrawer(props) {
     </div>
   );
 }
-
-ResponsiveDrawer.propTypes = {
-  /**
-   * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
-   */
-  container: PropTypes.any,
-};
-
-export default ResponsiveDrawer;

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
@@ -53,16 +53,7 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-interface ResponsiveDrawerProps {
-  /**
-   * Injected by the documentation to work in an iframe.
-   * You won't need it on your project.
-   */
-  container?: any;
-}
-
-export default function ResponsiveDrawer(props: ResponsiveDrawerProps) {
-  const { container } = props;
+export default function ResponsiveDrawer() {
   const classes = useStyles();
   const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -95,8 +86,10 @@ export default function ResponsiveDrawer(props: ResponsiveDrawerProps) {
     </div>
   );
 
+  const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
+
   return (
-    <div className={classes.root}>
+    <div className={classes.root} ref={setContainer}>
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>

--- a/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
+++ b/docs/src/pages/components/drawers/ResponsiveDrawer.tsx
@@ -53,7 +53,16 @@ const useStyles = makeStyles((theme: Theme) =>
   }),
 );
 
-export default function ResponsiveDrawer() {
+interface Props {
+  /**
+   * Injected by the documentation to work in an iframe.
+   * You won't need it on your project.
+   */
+  window?: () => Window;
+}
+
+export default function ResponsiveDrawer(props: Props) {
+  const { window } = props;
   const classes = useStyles();
   const theme = useTheme();
   const [mobileOpen, setMobileOpen] = React.useState(false);
@@ -86,10 +95,10 @@ export default function ResponsiveDrawer() {
     </div>
   );
 
-  const [container, setContainer] = React.useState<HTMLDivElement | null>(null);
+  const container = window !== undefined ? () => window().document.body : undefined;
 
   return (
-    <div className={classes.root} ref={setContainer}>
+    <div className={classes.root}>
       <CssBaseline />
       <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>


### PR DESCRIPTION
This component causes some issues in concurrent mode. I used the opportunity to simplify the implementation:
- use 100% less refs and 100% less legacy cDM/cDU in favor of useContext and useEffect
- ~remove state.ready and instead derive it directly~
- replace contentDocument with contentWindow.document. This was likely c&p from code that needed to support IE < 8
- ~use a ref to the insertion point div instead of `window['jss-insertion-point']`. That's a cute alternative to `window.document.querySelector('#jss-insertion-point')` but, let's be honest, it's just showing of knowledge of hidden browser APIs :wink:~
- remove `container` prop. We only have a single usage for it and can be replace with a ref-based approach  which isolates the demo better.

Tested on IE11 (win10) and Safari 13.0 (macOS 10.15). 