### PR TITLE
[docs] Replace react-frame-component with concurrent safe impl

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -95,7 +95,6 @@
     "react-dom": "^16.13.0",
     "react-draggable": "^4.0.3",
     "react-final-form": "^6.3.0",
-    "react-frame-component": "^4.1.1",
     "react-is": "^16.13.0",
     "react-number-format": "^4.0.8",
     "react-redux": "^7.1.1",

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -2,21 +2,10 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { create } from 'jss';
-import { withStyles, useTheme, jssPreset, StylesProvider } from '@material-ui/core/styles';
-import { exactProp } from '@material-ui/utils';
+import { makeStyles, useTheme, jssPreset, StylesProvider } from '@material-ui/core/styles';
 import rtl from 'jss-rtl';
 import { useSelector } from 'react-redux';
 import DemoErrorBoundary from 'docs/src/modules/components/DemoErrorBoundary';
-
-const styles = (theme) => ({
-  frame: {
-    backgroundColor: theme.palette.background.default,
-    flexGrow: 1,
-    height: 400,
-    border: 'none',
-    boxShadow: theme.shadows[1],
-  },
-});
 
 function FramedDemo(props) {
   const { children, document } = props;
@@ -51,8 +40,22 @@ FramedDemo.propTypes = {
   document: PropTypes.object.isRequired,
 };
 
+const useStyles = makeStyles(
+  (theme) => ({
+    frame: {
+      backgroundColor: theme.palette.background.default,
+      flexGrow: 1,
+      height: 400,
+      border: 'none',
+      boxShadow: theme.shadows[1],
+    },
+  }),
+  { name: 'DemoFrame' },
+);
+
 function DemoFrame(props) {
-  const { children, classes, title } = props;
+  const { children, title, ...other } = props;
+  const classes = useStyles();
   /**
    * @type {import('react').Ref<HTMLIFrameElement>}
    */
@@ -67,7 +70,7 @@ function DemoFrame(props) {
 
   return (
     <React.Fragment>
-      <iframe className={classes.frame} ref={frameRef} title={title} />
+      <iframe className={classes.frame} ref={frameRef} title={title} {...other} />
       {mounted
         ? ReactDOM.createPortal(
             <FramedDemo document={document}>{children}</FramedDemo>,
@@ -80,14 +83,8 @@ function DemoFrame(props) {
 
 DemoFrame.propTypes = {
   children: PropTypes.node.isRequired,
-  classes: PropTypes.object.isRequired,
   title: PropTypes.string.isRequired,
 };
-if (process.env.NODE_ENV !== 'production') {
-  DemoFrame.propTypes = exactProp(DemoFrame.propTypes);
-}
-
-const StyledFrame = withStyles(styles)(DemoFrame);
 
 /**
  * Isolates the demo component as best as possible. Additional props are spread
@@ -95,7 +92,7 @@ const StyledFrame = withStyles(styles)(DemoFrame);
  */
 function DemoSandboxed(props) {
   const { component: Component, iframe, name, onResetDemoClick, ...other } = props;
-  const Sandbox = iframe ? StyledFrame : React.Fragment;
+  const Sandbox = iframe ? DemoFrame : React.Fragment;
   const sandboxProps = iframe ? { title: `${name} demo`, ...other } : {};
 
   const t = useSelector((state) => state.options.t);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13591,11 +13591,6 @@ react-final-form@^6.3.0:
     "@babel/runtime" "^7.9.2"
     ts-essentials "^6.0.3"
 
-react-frame-component@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.1.1.tgz#ea8f7c518ef6b5ad72146dd1f648752369826894"
-  integrity sha512-NfJp90AvYA1R6+uSYafQ+n+UM2HjHqi4WGHeprVXa6quU9d8o6ZFRzQ36uemY82dlkZFzf2jigFx6E4UzNFajA==
-
 react-is@16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"


### PR DESCRIPTION
`react-frame-component` calls `document.write` during render which isn't concurrent mode safe (see https://github.com/ryanseddon/react-frame-component/pull/159). It's also unnecessary since they falsely assume portaling into `document.body` is unsafe because it's unsafe for `render()`. `createPortal()` and `render()` have different semantics.

It also has a lot of logic that we no longer need as of . Since it seems to not be maintained anymore (months old unanswered issues/prs, testing on node 6 etc) we it's not clear if these issues get addressed.

Also switches from withStyles to makeStyles