### PR TITLE
[docs] Fix dropped iframe content in firefox

### DIFF
--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -67,6 +67,10 @@ function DemoFrame(props) {
 
   const document = frameRef.current?.contentDocument;
   React.useEffect(() => {
+    console.log('mount');
+  }, []);
+  React.useEffect(() => {
+    console.log(document, iframeLoaded, document?.readyState);
     // When we hydarte the iframe then the load event is already dispatched
     // once the iframe markup is parsed (maybe later but the important part is
     // that it happens before React can attach event listeners).
@@ -81,8 +85,17 @@ function DemoFrame(props) {
 
   return (
     <React.Fragment>
-      <iframe className={classes.frame} onLoad={onLoad} ref={frameRef} title={title} {...other} />
-      {iframeLoaded
+      <iframe
+        className={classes.frame}
+        onLoad={() => {
+          console.log('onLoad');
+          onLoad();
+        }}
+        ref={frameRef}
+        title={title}
+        {...other}
+      />
+      {iframeLoaded !== false
         ? ReactDOM.createPortal(
             <FramedDemo document={document}>{children}</FramedDemo>,
             document.body,

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -65,12 +65,8 @@ function DemoFrame(props) {
   // is dropped in firefox.
   const [iframeLoaded, onLoad] = React.useReducer(() => true, false);
 
-  const document = frameRef.current?.contentDocument;
   React.useEffect(() => {
-    console.log('mount');
-  }, []);
-  React.useEffect(() => {
-    console.log(document, iframeLoaded, document?.readyState);
+    const document = frameRef.current.contentDocument;
     // When we hydarte the iframe then the load event is already dispatched
     // once the iframe markup is parsed (maybe later but the important part is
     // that it happens before React can attach event listeners).
@@ -81,20 +77,12 @@ function DemoFrame(props) {
     if (document != null && document.readyState === 'complete' && !iframeLoaded) {
       onLoad();
     }
-  }, [document, iframeLoaded]);
+  }, [iframeLoaded]);
 
+  const document = frameRef.current?.contentDocument;
   return (
     <React.Fragment>
-      <iframe
-        className={classes.frame}
-        onLoad={() => {
-          console.log('onLoad');
-          onLoad();
-        }}
-        ref={frameRef}
-        title={title}
-        {...other}
-      />
+      <iframe className={classes.frame} onLoad={onLoad} ref={frameRef} title={title} {...other} />
       {iframeLoaded !== false
         ? ReactDOM.createPortal(
             <FramedDemo document={document}>{children}</FramedDemo>,

--- a/docs/src/modules/components/DemoSandboxed.js
+++ b/docs/src/modules/components/DemoSandboxed.js
@@ -67,7 +67,7 @@ function DemoFrame(props) {
 
   React.useEffect(() => {
     const document = frameRef.current.contentDocument;
-    // When we hydarte the iframe then the load event is already dispatched
+    // When we hydrate the iframe then the load event is already dispatched
     // once the iframe markup is parsed (maybe later but the important part is
     // that it happens before React can attach event listeners).
     // We need to check the readyState of the document once the iframe is mounted


### PR DESCRIPTION
Fixes https://github.com/mui-org/material-ui/pull/20677#issuecomment-617457308

Repro: 
1. Load https://deploy-preview-20686--material-ui.netlify.app/components/app-bar/#back-to-top
2. Demo should be loaded
3. Click on another page
4. Click on /components/app-bar
5. `back-to-top` Demo should be loaded