### PR TITLE
[Autocomplete] Fix "fixed tags" demo

### DIFF
--- a/docs/src/pages/components/autocomplete/FixedTags.js
+++ b/docs/src/pages/components/autocomplete/FixedTags.js
@@ -5,16 +5,29 @@ import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 
 export default function FixedTags() {
+  const fixedOptions = [top100Films[6]];
+  const [value, setValue] = React.useState([...fixedOptions, top100Films[13]]);
+
   return (
     <Autocomplete
       multiple
       id="fixed-tags-demo"
+      value={value}
+      onChange={(event, newValue) => {
+        setValue([
+          ...fixedOptions,
+          ...newValue.filter((option) => fixedOptions.indexOf(option) === -1),
+        ]);
+      }}
       options={top100Films}
       getOptionLabel={(option) => option.title}
-      defaultValue={[top100Films[6], top100Films[13]]}
       renderTags={(value, getTagProps) =>
         value.map((option, index) => (
-          <Chip label={option.title} {...getTagProps({ index })} disabled={index === 0} />
+          <Chip
+            label={option.title}
+            {...getTagProps({ index })}
+            disabled={fixedOptions.indexOf(option) !== -1}
+          />
         ))
       }
       style={{ width: 500 }}

--- a/docs/src/pages/components/autocomplete/FixedTags.js
+++ b/docs/src/pages/components/autocomplete/FixedTags.js
@@ -21,8 +21,8 @@ export default function FixedTags() {
       }}
       options={top100Films}
       getOptionLabel={(option) => option.title}
-      renderTags={(value, getTagProps) =>
-        value.map((option, index) => (
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
           <Chip
             label={option.title}
             {...getTagProps({ index })}

--- a/docs/src/pages/components/autocomplete/FixedTags.tsx
+++ b/docs/src/pages/components/autocomplete/FixedTags.tsx
@@ -5,16 +5,29 @@ import TextField from '@material-ui/core/TextField';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 
 export default function FixedTags() {
+  const fixedOptions = [top100Films[6]];
+  const [value, setValue] = React.useState([...fixedOptions, top100Films[13]]);
+
   return (
     <Autocomplete
       multiple
       id="fixed-tags-demo"
+      value={value}
+      onChange={(event, newValue) => {
+        setValue([
+          ...fixedOptions,
+          ...newValue.filter((option) => fixedOptions.indexOf(option) === -1),
+        ]);
+      }}
       options={top100Films}
       getOptionLabel={(option) => option.title}
-      defaultValue={[top100Films[6], top100Films[13]]}
       renderTags={(value, getTagProps) =>
         value.map((option, index) => (
-          <Chip label={option.title} {...getTagProps({ index })} disabled={index === 0} />
+          <Chip
+            label={option.title}
+            {...getTagProps({ index })}
+            disabled={fixedOptions.indexOf(option) !== -1}
+          />
         ))
       }
       style={{ width: 500 }}

--- a/docs/src/pages/components/autocomplete/FixedTags.tsx
+++ b/docs/src/pages/components/autocomplete/FixedTags.tsx
@@ -21,8 +21,8 @@ export default function FixedTags() {
       }}
       options={top100Films}
       getOptionLabel={(option) => option.title}
-      renderTags={(value, getTagProps) =>
-        value.map((option, index) => (
+      renderTags={(tagValue, getTagProps) =>
+        tagValue.map((option, index) => (
           <Chip
             label={option.title}
             {...getTagProps({ index })}


### PR DESCRIPTION
Closes #20532
Prevent removal of fixed tags from clear all button and backspace in Autocomplete Fixed options demo

Update FixedTags.tsx and FixedTags.js to prevent the removal of fixed tags in the Autocomplete demo by controlling the value state and ignoring all attempts to remove this tag.

Running `yarn lint` gives me `'value' is already declared in the upper scope  no-shadow` but I am unsure a better name for that variable for the PR.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
