### PR TITLE
[Popper] Add ref type definition

### DIFF
--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -17,11 +17,8 @@ export type PopperPlacementType =
   | 'top-start'
   | 'top';
 
-export interface PopperProps
-  extends Omit<
-    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
-    'children'
-  > {
+export interface PopperProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * A HTML element, [referenceObject](https://popper.js.org/docs/v1/#referenceObject),
    * or a function that returns either.

--- a/packages/material-ui/src/Popper/Popper.d.ts
+++ b/packages/material-ui/src/Popper/Popper.d.ts
@@ -17,7 +17,11 @@ export type PopperPlacementType =
   | 'top-start'
   | 'top';
 
-export interface PopperProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+export interface PopperProps
+  extends Omit<
+    React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>,
+    'children'
+  > {
   /**
    * A HTML element, [referenceObject](https://popper.js.org/docs/v1/#referenceObject),
    * or a function that returns either.


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

[`ref` is provided to `div` under Popper](https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/Popper/Popper.js#L208) but there is no type definition.
This PR adds the `ref` type to PopperProps.