### PR TITLE
[test] Relax lint rules in test

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,6 +131,9 @@ module.exports = {
 
         // They are accessed to test custom validator implementation with PropTypes.checkPropTypes
         'react/forbid-foreign-prop-types': 'off',
+        // components that are defined in test are isolated enough
+        // that they don't need type-checking
+        'react/prop-types': 'off',
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -129,6 +129,16 @@ module.exports = {
         // is cleaned up in `afterEach` if the test causes a crash
         'mocha/no-hooks-for-single-case': 'off',
 
+        // disable eslint-plugin-jsx-a11y
+        // tests are not driven by assistive technology
+        // add `jsx-a11y` rules once you encounter them in tests
+        'jsx-a11y/click-events-have-key-events': 'off',
+        'jsx-a11y/iframe-has-title': 'off',
+        'jsx-a11y/mouse-events-have-key-events': 'off',
+        'jsx-a11y/no-noninteractive-tabindex': 'off',
+        'jsx-a11y/no-static-element-interactions': 'off',
+        'jsx-a11y/tabindex-no-positive': 'off',
+
         // They are accessed to test custom validator implementation with PropTypes.checkPropTypes
         'react/forbid-foreign-prop-types': 'off',
         // components that are defined in test are isolated enough

--- a/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
+++ b/packages/material-ui-lab/src/TreeItem/TreeItem.test.js
@@ -283,7 +283,6 @@ describe('<TreeItem />', () => {
       it('should focus the first node if none of the nodes are selected before the tree receives focus', () => {
         const { getByTestId } = render(
           <React.Fragment>
-            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
             <div data-testid="start" tabIndex={0} />
             <TreeView>
               <TreeItem nodeId="1" label="one" data-testid="one" />
@@ -305,7 +304,6 @@ describe('<TreeItem />', () => {
       it('should focus the selected node if a node is selected before the tree receives focus', () => {
         const { getByTestId, getByText } = render(
           <React.Fragment>
-            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
             <div data-testid="start" tabIndex={0} />
             <TreeView>
               <TreeItem nodeId="1" label="one" data-testid="one" />
@@ -330,7 +328,6 @@ describe('<TreeItem />', () => {
       it('should work with programmatic focus', () => {
         const { getByTestId } = render(
           <React.Fragment>
-            {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
             <div data-testid="start" tabIndex={0} />
             <TreeView>
               <TreeItem nodeId="1" label="one" data-testid="one" />

--- a/packages/material-ui/src/Chip/Chip.test.js
+++ b/packages/material-ui/src/Chip/Chip.test.js
@@ -79,7 +79,6 @@ describe('<Chip />', () => {
     });
 
     it('should apply user value of tabIndex', () => {
-      // eslint-disable-next-line jsx-a11y/tabindex-no-positive
       const { getByRole } = render(<Chip label="My Chip" onClick={() => {}} tabIndex={5} />);
 
       expect(getByRole('button')).to.have.property('tabIndex', 5);
@@ -150,7 +149,6 @@ describe('<Chip />', () => {
           avatar={<Avatar id="avatar">MB</Avatar>}
           label="Text Avatar Chip"
           onDelete={() => {}}
-          // eslint-disable-next-line jsx-a11y/tabindex-no-positive
           tabIndex={5}
         />,
       );

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable jsx-a11y/click-events-have-key-events */
-/* eslint-disable jsx-a11y/no-static-element-interactions */
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/material-ui/src/Portal/Portal.test.js
+++ b/packages/material-ui/src/Portal/Portal.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';

--- a/packages/material-ui/src/Select/Select.test.js
+++ b/packages/material-ui/src/Select/Select.test.js
@@ -833,7 +833,6 @@ describe('<Select />', () => {
     describe('prop: onChange', () => {
       it('should call onChange when clicking an item', () => {
         function ControlledSelectInput(props) {
-          // eslint-disable-next-line react/prop-types
           const { onChange } = props;
           const [values, clickedValue] = React.useReducer((currentValues, valueClicked) => {
             if (currentValues.indexOf(valueClicked) === -1) {

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -38,7 +38,6 @@ describe('<SvgIcon />', () => {
               <stop offset="90%" stopColor="#F3F" />
             </linearGradient>
           </defs>
-          {/* eslint-disable-next-line react/prop-types */}
           {props.children}
         </svg>
       ),

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/mouse-events-have-key-events */
 import * as React from 'react';
 import { assert, expect } from 'chai';
 import PropTypes from 'prop-types';

--- a/packages/material-ui/test/integration/Menu.test.js
+++ b/packages/material-ui/test/integration/Menu.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsx-a11y/tabindex-no-positive */
 import * as React from 'react';
 import PropTypes from 'prop-types';
 import { expect } from 'chai';

--- a/packages/material-ui/test/integration/NestedMenu.test.js
+++ b/packages/material-ui/test/integration/NestedMenu.test.js
@@ -5,7 +5,6 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 
 function NestedMenu(props) {
-  // eslint-disable-next-line react/prop-types
   const { firstMenuOpen, secondMenuOpen } = props;
   const [anchorEl, setAnchorEl] = React.useState(null);
   const canBeOpen = Boolean(anchorEl);


### PR DESCRIPTION
For rationale see `.eslintrc.js` changes.

- disable `react/prop-types`
- disable `jsx-a11y/*`