### PR TITLE
[core] Transpile with preset-env in loose mode

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -11,6 +11,7 @@ if (process.env.BABEL_ENV === 'es') {
       '@babel/preset-env',
       {
         bugfixes: true,
+        loose: true,
         modules: ['esm', 'production-umd'].includes(process.env.BABEL_ENV) ? false : 'commonjs',
       },
     ],


### PR DESCRIPTION
Getting an overview about size implications first before evaluating if this is safe for each plugin. We can't [switch to loose on a per-plugin basis](https://github.com/babel/babel/issues/6978).

## Plugins switch too loose

- [`proposal-nullish-coalescing-operator`](https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator#loose)
  Pretend `document.all` doesn't exist
- [`proposal-optional-chaining`](https://babeljs.io/docs/en/babel-plugin-proposal-optional-chaining#loose)
  Pretend `document.all` doesn't exist
- [`transform-parameters`](https://babeljs.io/docs/en/babel-plugin-transform-parameters#loose)
  We don't check arity of arguments.lengt and generally shouldn't since it does not work with spread parameters e.g. `func(...args)`
- [`proposal-object-rest-spread`](https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread#loose)
  Already in loose mode
- [`transform-template-literals`](https://babeljs.io/docs/en/babel-plugin-transform-template-literals#loose)
  - We don't use Symbol.toPrimitive or symbols in general in template literals. Since we support IE 11 symbol usage is restricted anyway.
- [`transform-classes`](https://babeljs.io/docs/en/babel-plugin-transform-classes#loose)
  Seems safe since we rarely use classes. See documentation of this plugin
- [`transform-computed-properties`](https://babeljs.io/docs/en/babel-plugin-transform-computed-properties#loose)
  " his is a case that is very unlikely to appear in production code however it's something to keep in mind."
- [`transform-for-of`](https://babeljs.io/docs/en/babel-plugin-transform-for-of#loose)
  We don't use iterators and therefore are unlikely to encounter these issues.
- [`transform-spread`](https://babeljs.io/docs/en/babel-plugin-transform-spread#loose)
  Probably the most dangerous one but these cases can be reconciled with a manual Array.from. The overhead is negligible compared to over-transpiling all the time.
- [`transform-destructuring`](https://babeljs.io/docs/en/babel-plugin-transform-destructuring#loose)

  Same as transform-spread

## Conclusion

All of these cases are pretty safe theoretically. I'm looking at the failing tests to see if these fail because the test rely on spec-compliant behavior or if the implementation relies on it.

If we land this we should setup a task that runs the tests without loose mode anyway. A scheduled task should be sufficient.