### PR TITLE
[core] Remove redundant plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -44,7 +44,6 @@ module.exports = {
   plugins: [
     'babel-plugin-optimize-clsx',
     ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-object-rest-spread', { loose: true }],
     // any package needs to declare 7.4.4 as a runtime dependency. default is ^7.0.0
     ['@babel/plugin-transform-runtime', { version: '^7.4.4' }],
     // for IE 11 support

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@babel/core": "^7.9.0",
     "@babel/node": "^7.8.7",
     "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.9.0",
     "@babel/plugin-transform-object-assign": "^7.8.3",
     "@babel/plugin-transform-react-constant-elements": "^7.9.0",
     "@babel/plugin-transform-runtime": "^7.9.0",


### PR DESCRIPTION
object-rest-spread is stage 4 and therefore part of preset-env.

If the bundle size stays the same then the plugins entry was ignored. If it increases then it wasn't ignored and we can actually override loose mode on a per plugin basis.
