### PR TITLE
[ExpansionPanel] Increase contrast for focus state

### DIFF
--- a/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
+++ b/packages/material-ui/src/ExpansionPanelSummary/ExpansionPanelSummary.js
@@ -25,10 +25,10 @@ export const styles = (theme) => {
         minHeight: 64,
       },
       '&$focused': {
-        backgroundColor: theme.palette.grey[300],
+        backgroundColor: theme.palette.action.focus,
       },
       '&$disabled': {
-        opacity: 0.38,
+        opacity: theme.palette.action.disabledOpacity,
       },
     },
     /* Pseudo-class applied to the root element, children wrapper element and `IconButton` component if `expanded={true}`. */


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

See https://github.com/mui-org/material-ui/issues/20692. Thanks @oliviertassinari for help identifying the fix!

Before:
<img width="1372" alt="Screen Shot 2020-04-23 at 7 51 42 AM" src="https://user-images.githubusercontent.com/1571918/80114379-59d4c300-8538-11ea-96cc-022b7e01dcde.png">

After:
<img width="1372" alt="Screen Shot 2020-04-23 at 7 52 42 AM" src="https://user-images.githubusercontent.com/1571918/80114393-5ccfb380-8538-11ea-992c-5afc5500cc55.png">

New ratio is WCAG-compliant

<img width="733" alt="Screen Shot 2020-04-23 at 8 00 08 AM" src="https://user-images.githubusercontent.com/1571918/80114468-77a22800-8538-11ea-9bb6-49ed26d0a61c.png">

