### PR TITLE
[docs] Add "reset focus" control to demo tools

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -18,6 +18,7 @@ import MenuItem from '@material-ui/core/MenuItem';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import Tooltip from '@material-ui/core/Tooltip';
 import RefreshIcon from '@material-ui/icons/Refresh';
+import ResetFocusIcon from '@material-ui/icons/CenterFocusWeak';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 import DemoSandboxed from 'docs/src/modules/components/DemoSandboxed';
 import DemoLanguages from 'docs/src/modules/components/DemoLanguages';
@@ -123,6 +124,14 @@ const styles = (theme) => ({
   anchorLink: {
     marginTop: -64, // height of toolbar
     position: 'absolute',
+  },
+  initialFocus: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: theme.spacing(4),
+    height: theme.spacing(4),
+    pointerEvents: 'none',
   },
 });
 
@@ -335,6 +344,11 @@ function Demo(props) {
   const demoSourceId = useUniqueId(`demo-`);
   const openDemoSource = codeOpen || showPreview;
 
+  const initialFocusRef = React.useRef(null);
+  function handleResetFocusClick() {
+    initialFocusRef.current.focusVisible();
+  }
+
   return (
     <div className={classes.root}>
       <div
@@ -344,10 +358,15 @@ function Demo(props) {
           [classes.demoBgTrue]: demoOptions.bg === true,
           [classes.demoBgInline]: demoOptions.bg === 'inline',
         })}
-        tabIndex={-1}
         onMouseEnter={handleDemoHover}
         onMouseLeave={handleDemoHover}
       >
+        <IconButton
+          aria-label={t('initialFocusLabel')}
+          className={classes.initialFocus}
+          action={initialFocusRef}
+          tabIndex={-1}
+        />
         <DemoSandboxed
           key={demoKey}
           style={demoSandboxedStyle}
@@ -424,6 +443,21 @@ function Demo(props) {
                   onClick={handleCopyClick}
                 >
                   <FileCopyIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+              <Tooltip
+                classes={{ popper: classes.tooltip }}
+                title={t('resetFocus')}
+                placement="top"
+              >
+                <IconButton
+                  aria-label={t('resetFocus')}
+                  data-ga-event-category="demo"
+                  data-ga-event-label={demoOptions.demo}
+                  data-ga-event-action="reset-focus"
+                  onClick={handleResetFocusClick}
+                >
+                  <ResetFocusIcon fontSize="small" />
                 </IconButton>
               </Tooltip>
               <Tooltip classes={{ popper: classes.tooltip }} title={t('resetDemo')} placement="top">

--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -62,6 +62,9 @@ const styles = (theme) => ({
     [theme.breakpoints.up('sm')]: {
       borderRadius: theme.shape.borderRadius,
     },
+    '&:focus': {
+      outline: `2px dashed ${theme.palette.text.primary}`,
+    },
   },
   /* Isolate the demo with an outline. */
   demoBgOutlined: {
@@ -124,14 +127,6 @@ const styles = (theme) => ({
   anchorLink: {
     marginTop: -64, // height of toolbar
     position: 'absolute',
-  },
-  initialFocus: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    width: theme.spacing(4),
-    height: theme.spacing(4),
-    pointerEvents: 'none',
   },
 });
 
@@ -346,12 +341,20 @@ function Demo(props) {
 
   const initialFocusRef = React.useRef(null);
   function handleResetFocusClick() {
-    initialFocusRef.current.focusVisible();
+    initialFocusRef.current.focus();
+  }
+  function handleDemoMouseDown(event) {
+    // Otherwise clicking any non-focusable element in the demo focuses the demo container
+    // which is surprising and not how the code would behave outside of this page
+    event.preventDefault();
   }
 
   return (
     <div className={classes.root}>
+      {/* We're actually preventing interaction here */}
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions */}
       <div
+        aria-label={t('initialFocusLabel')}
         className={clsx(classes.demo, {
           [classes.demoHiddenToolbar]: demoOptions.hideToolbar,
           [classes.demoBgOutlined]: demoOptions.bg === 'outlined',
@@ -360,13 +363,10 @@ function Demo(props) {
         })}
         onMouseEnter={handleDemoHover}
         onMouseLeave={handleDemoHover}
+        onMouseDown={handleDemoMouseDown}
+        ref={initialFocusRef}
+        tabIndex={-1}
       >
-        <IconButton
-          aria-label={t('initialFocusLabel')}
-          className={classes.initialFocus}
-          action={initialFocusRef}
-          tabIndex={-1}
-        />
         <DemoSandboxed
           key={demoKey}
           style={demoSandboxedStyle}

--- a/docs/translations/translations.json
+++ b/docs/translations/translations.json
@@ -94,6 +94,8 @@
   "viewGitHub": "View the source on GitHub",
   "visit": "Visit the website",
   "whosUsing": "Who's using Material-UI?",
+  "initialFocusLabel": "A generic container that is programmatically focused to test keyboard navigation of our components.",
+  "resetFocus": "Reset focus to test keyboard navigation",
   "pages": {
     "/getting-started": "Getting Started",
     "/getting-started/installation": "Installation",


### PR DESCRIPTION

![reset-focus-2](https://user-images.githubusercontent.com/12292047/80198792-e3f85680-8620-11ea-941e-58a49a5ee9d1.gif)


Adds a programmatically focusable marker before the demo which can be focused via a button in the toolbar.

some goals:

- should not be in tab order to not prevent normal page navigation
- should be visible focused if focus is return so that it's easier to spot (for the dev and screen captures).
- should not clutter the isolated demo container by default