### PR TITLE
[Autocomplete] Fix popup open logic when non empty

### DIFF
--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -1610,5 +1610,25 @@ describe('<Autocomplete />', () => {
       expect(handleChange.args[1][1]).to.equal(options[0]);
       expect(handleChange.args[1][2]).to.equal('mouse');
     });
+
+    it('should open list box even if there is only one option', () => {
+      const handleChange = spy();
+      const { queryByRole, getByRole, getAllByRole } = render(
+        <Autocomplete
+          onHighlightChange={handleChange}
+          options={['one']}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+      const textbox = getByRole('textbox');
+      expect(queryByRole('presentation')).to.equal(null);
+      fireEvent.mouseDown(textbox);
+      expect(queryByRole('presentation')).to.not.equal(null);
+      const options = getAllByRole('option');
+      fireEvent.click(options[0]);
+      expect(queryByRole('presentation')).to.equal(null);
+      fireEvent.mouseDown(textbox);
+      expect(queryByRole('presentation')).to.not.equal(null);
+    });
   });
 });

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -1119,6 +1119,51 @@ describe('<Autocomplete />', () => {
       fireEvent.click(queryByTitle('Open'));
       expect(textbox).toHaveFocus();
     });
+
+    it('should mantain list box open clicking on input when it is not empty', () => {
+      const handleChange = spy();
+      const { getByRole, getAllByRole } = render(
+        <Autocomplete
+          onHighlightChange={handleChange}
+          options={['one']}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+      const combobox = getByRole('combobox');
+      const textbox = getByRole('textbox');
+
+      expect(combobox).to.have.attribute('aria-expanded', 'false');
+      fireEvent.mouseDown(textbox); // Open listbox
+      expect(combobox).to.have.attribute('aria-expanded', 'true');
+      const options = getAllByRole('option');
+      fireEvent.click(options[0]);
+      expect(combobox).to.have.attribute('aria-expanded', 'false');
+      fireEvent.mouseDown(textbox); // Open listbox
+      expect(combobox).to.have.attribute('aria-expanded', 'true');
+      fireEvent.mouseDown(textbox); // Remain open listbox
+      expect(combobox).to.have.attribute('aria-expanded', 'true');
+    });
+
+    it('should toggle list box when input is empty', () => {
+      const handleChange = spy();
+      const { getByRole } = render(
+        <Autocomplete
+          onHighlightChange={handleChange}
+          options={['one']}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+      const combobox = getByRole('combobox');
+      const textbox = getByRole('textbox');
+
+      expect(combobox).to.have.attribute('aria-expanded', 'false');
+      fireEvent.mouseDown(textbox); // Open listbox
+      expect(combobox).to.have.attribute('aria-expanded', 'true');
+      fireEvent.mouseDown(textbox); // close listbox
+      expect(combobox).to.have.attribute('aria-expanded', 'false');
+      fireEvent.mouseDown(textbox); // open listbox
+      expect(combobox).to.have.attribute('aria-expanded', 'true');
+    });
   });
 
   describe('controlled', () => {
@@ -1609,47 +1654,6 @@ describe('<Autocomplete />', () => {
       expect(handleChange.args[1][0]).to.not.equal(undefined);
       expect(handleChange.args[1][1]).to.equal(options[0]);
       expect(handleChange.args[1][2]).to.equal('mouse');
-    });
-
-    it('should mantain list box open clicking on input when it is not empty', () => {
-      const handleChange = spy();
-      const { queryByRole, getByRole, getAllByRole } = render(
-        <Autocomplete
-          onHighlightChange={handleChange}
-          options={['one']}
-          renderInput={(params) => <TextField {...params} />}
-        />,
-      );
-      const textbox = getByRole('textbox');
-      expect(queryByRole('presentation')).to.equal(null);
-      fireEvent.mouseDown(textbox); // Open listbox
-      expect(queryByRole('presentation')).to.not.equal(null);
-      const options = getAllByRole('option');
-      fireEvent.click(options[0]);
-      expect(queryByRole('presentation')).to.equal(null);
-      fireEvent.mouseDown(textbox); // Open listbox
-      expect(queryByRole('presentation')).to.not.equal(null);
-      fireEvent.mouseDown(textbox); // Remain open listbox
-      expect(queryByRole('presentation')).to.not.equal(null);
-    });
-
-    it('should toggle list box when input is empty', () => {
-      const handleChange = spy();
-      const { queryByRole, getByRole } = render(
-        <Autocomplete
-          onHighlightChange={handleChange}
-          options={['one']}
-          renderInput={(params) => <TextField {...params} />}
-        />,
-      );
-      const textbox = getByRole('textbox');
-      expect(queryByRole('presentation')).to.equal(null);
-      fireEvent.mouseDown(textbox); // Open listbox
-      expect(queryByRole('presentation')).to.not.equal(null);
-      fireEvent.mouseDown(textbox); // close listbox
-      expect(queryByRole('presentation')).to.equal(null);
-      fireEvent.mouseDown(textbox); // open listbox
-      expect(queryByRole('presentation')).to.not.equal(null);
     });
   });
 });

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -1611,7 +1611,7 @@ describe('<Autocomplete />', () => {
       expect(handleChange.args[1][2]).to.equal('mouse');
     });
 
-    it('should open list box even if there is only one option', () => {
+    it('should open list box even if the input contains an option value', () => {
       const handleChange = spy();
       const { queryByRole, getByRole, getAllByRole } = render(
         <Autocomplete

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -1611,7 +1611,7 @@ describe('<Autocomplete />', () => {
       expect(handleChange.args[1][2]).to.equal('mouse');
     });
 
-    it('should open list box even if the input contains an option value', () => {
+    it('should mantain list box open clicking on input when it is not empty', () => {
       const handleChange = spy();
       const { queryByRole, getByRole, getAllByRole } = render(
         <Autocomplete
@@ -1622,12 +1622,33 @@ describe('<Autocomplete />', () => {
       );
       const textbox = getByRole('textbox');
       expect(queryByRole('presentation')).to.equal(null);
-      fireEvent.mouseDown(textbox);
+      fireEvent.mouseDown(textbox); // Open listbox
       expect(queryByRole('presentation')).to.not.equal(null);
       const options = getAllByRole('option');
       fireEvent.click(options[0]);
       expect(queryByRole('presentation')).to.equal(null);
-      fireEvent.mouseDown(textbox);
+      fireEvent.mouseDown(textbox); // Open listbox
+      expect(queryByRole('presentation')).to.not.equal(null);
+      fireEvent.mouseDown(textbox); // Remain open listbox
+      expect(queryByRole('presentation')).to.not.equal(null);
+    });
+
+    it('should toggle list box when input is empty', () => {
+      const handleChange = spy();
+      const { queryByRole, getByRole } = render(
+        <Autocomplete
+          onHighlightChange={handleChange}
+          options={['one']}
+          renderInput={(params) => <TextField {...params} />}
+        />,
+      );
+      const textbox = getByRole('textbox');
+      expect(queryByRole('presentation')).to.equal(null);
+      fireEvent.mouseDown(textbox); // Open listbox
+      expect(queryByRole('presentation')).to.not.equal(null);
+      fireEvent.mouseDown(textbox); // close listbox
+      expect(queryByRole('presentation')).to.equal(null);
+      fireEvent.mouseDown(textbox); // open listbox
       expect(queryByRole('presentation')).to.not.equal(null);
     });
   });

--- a/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
+++ b/packages/material-ui-lab/src/Autocomplete/Autocomplete.test.js
@@ -1144,10 +1144,11 @@ describe('<Autocomplete />', () => {
       expect(combobox).to.have.attribute('aria-expanded', 'true');
     });
 
-    it('should toggle list box when input is empty', () => {
+    it('should not toggle list box', () => {
       const handleChange = spy();
       const { getByRole } = render(
         <Autocomplete
+          value="one"
           onHighlightChange={handleChange}
           options={['one']}
           renderInput={(params) => <TextField {...params} />}
@@ -1157,11 +1158,9 @@ describe('<Autocomplete />', () => {
       const textbox = getByRole('textbox');
 
       expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox); // Open listbox
+      fireEvent.mouseDown(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
-      fireEvent.mouseDown(textbox); // close listbox
-      expect(combobox).to.have.attribute('aria-expanded', 'false');
-      fireEvent.mouseDown(textbox); // open listbox
+      fireEvent.mouseDown(textbox);
       expect(combobox).to.have.attribute('aria-expanded', 'true');
     });
   });

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -860,7 +860,9 @@ export default function useAutocomplete(props) {
   };
 
   const handleInputMouseDown = (event) => {
-    handlePopupIndicator(event);
+    if (inputValue === '' || !open) {
+      handlePopupIndicator(event);
+    }
   };
 
   let dirty = freeSolo && inputValue.length > 0;

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -860,9 +860,7 @@ export default function useAutocomplete(props) {
   };
 
   const handleInputMouseDown = (event) => {
-    if (inputValue === '') {
-      handlePopupIndicator(event);
-    }
+    handlePopupIndicator(event);
   };
 
   let dirty = freeSolo && inputValue.length > 0;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
fix #20730 
- [ X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
