### PR TITLE
[ClickAwayListener] Remove misleading code comment

### DIFF
--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -81,9 +81,6 @@ function ClickAwayListener(props) {
     } else {
       const doc = ownerDocument(nodeRef.current);
       // TODO v6 remove dead logic https://caniuse.com/#search=composedPath.
-      // `doc.contains` works in modern browsers but isn't supported in IE 11:
-      // https://github.com/timmywil/panzoom/issues/450
-      // https://github.com/videojs/video.js/pull/5872
       insideDOM =
         !(doc.documentElement && doc.documentElement.contains(event.target)) ||
         nodeRef.current.contains(event.target);

--- a/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
+++ b/packages/material-ui/src/ClickAwayListener/ClickAwayListener.js
@@ -79,11 +79,10 @@ function ClickAwayListener(props) {
     if (event.composedPath) {
       insideDOM = event.composedPath().indexOf(nodeRef.current) > -1;
     } else {
-      const doc = ownerDocument(nodeRef.current);
       // TODO v6 remove dead logic https://caniuse.com/#search=composedPath.
+      const doc = ownerDocument(nodeRef.current);
       insideDOM =
-        !(doc.documentElement && doc.documentElement.contains(event.target)) ||
-        nodeRef.current.contains(event.target);
+        !doc.documentElement.contains(event.target) || nodeRef.current.contains(event.target);
     }
 
     if (!insideDOM && (disableReactTree || !insideReactTree)) {


### PR DESCRIPTION
In that code `.contains` is always called on `HTMLElement` never on `Document`. `HTMLElement.prototype.contains` is supported down to IE9. The linked PRs are not concerned with `HTMLElement.prototype.contains` but `Document.prototype.contains`.

@NMinhNguyen Could you clarify what the comment meant?