### PR TITLE
[Tooltip] Fix flip invalid CSS property error

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -22,7 +22,6 @@ function round(value) {
 function arrowGenerator() {
   return {
     '&[x-placement*="bottom"] $arrow': {
-      flip: false,
       top: 0,
       left: 0,
       marginTop: '-0.95em',
@@ -36,7 +35,6 @@ function arrowGenerator() {
       },
     },
     '&[x-placement*="top"] $arrow': {
-      flip: false,
       bottom: 0,
       left: 0,
       marginBottom: '-0.95em',
@@ -50,7 +48,6 @@ function arrowGenerator() {
       },
     },
     '&[x-placement*="right"] $arrow': {
-      flip: false,
       left: 0,
       marginLeft: '-0.95em',
       marginTop: 4,
@@ -63,7 +60,6 @@ function arrowGenerator() {
       },
     },
     '&[x-placement*="left"] $arrow': {
-      flip: false,
       right: 0,
       marginRight: '-0.95em',
       marginTop: 4,
@@ -82,8 +78,7 @@ export const styles = (theme) => ({
   /* Styles applied to the Popper component. */
   popper: {
     zIndex: theme.zIndex.tooltip,
-    pointerEvents: 'none',
-    flip: false, // disable jss-rtl plugin
+    pointerEvents: 'none', // disable jss-rtl plugin
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
   popperInteractive: {
@@ -649,4 +644,4 @@ Tooltip.propTypes = {
   TransitionProps: PropTypes.object,
 };
 
-export default withStyles(styles, { name: 'MuiTooltip' })(Tooltip);
+export default withStyles(styles, { name: 'MuiTooltip', flip: false })(Tooltip);

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -22,6 +22,7 @@ function round(value) {
 function arrowGenerator() {
   return {
     '&[x-placement*="bottom"] $arrow': {
+      flip: false,
       top: 0,
       left: 0,
       marginTop: '-0.95em',
@@ -35,6 +36,7 @@ function arrowGenerator() {
       },
     },
     '&[x-placement*="top"] $arrow': {
+      flip: false,
       bottom: 0,
       left: 0,
       marginBottom: '-0.95em',
@@ -48,6 +50,7 @@ function arrowGenerator() {
       },
     },
     '&[x-placement*="right"] $arrow': {
+      flip: false,
       left: 0,
       marginLeft: '-0.95em',
       marginTop: 4,
@@ -60,6 +63,7 @@ function arrowGenerator() {
       },
     },
     '&[x-placement*="left"] $arrow': {
+      flip: false,
       right: 0,
       marginRight: '-0.95em',
       marginTop: 4,
@@ -79,6 +83,7 @@ export const styles = (theme) => ({
   popper: {
     zIndex: theme.zIndex.tooltip,
     pointerEvents: 'none',
+    flip: false, // disable jss-rtl plugin
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
   popperInteractive: {

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -22,7 +22,6 @@ function round(value) {
 function arrowGenerator() {
   return {
     '&[x-placement*="bottom"] $arrow': {
-      flip: false,
       top: 0,
       left: 0,
       marginTop: '-0.95em',
@@ -31,13 +30,11 @@ function arrowGenerator() {
       width: '2em',
       height: '1em',
       '&::before': {
-        flip: false,
         borderWidth: '0 1em 1em 1em',
         borderColor: 'transparent transparent currentcolor transparent',
       },
     },
     '&[x-placement*="top"] $arrow': {
-      flip: false,
       bottom: 0,
       left: 0,
       marginBottom: '-0.95em',
@@ -46,13 +43,11 @@ function arrowGenerator() {
       width: '2em',
       height: '1em',
       '&::before': {
-        flip: false,
         borderWidth: '1em 1em 0 1em',
         borderColor: 'currentcolor transparent transparent transparent',
       },
     },
     '&[x-placement*="right"] $arrow': {
-      flip: false,
       left: 0,
       marginLeft: '-0.95em',
       marginTop: 4,
@@ -60,13 +55,11 @@ function arrowGenerator() {
       height: '2em',
       width: '1em',
       '&::before': {
-        flip: false,
         borderWidth: '1em 1em 1em 0',
         borderColor: 'transparent currentcolor transparent transparent',
       },
     },
     '&[x-placement*="left"] $arrow': {
-      flip: false,
       right: 0,
       marginRight: '-0.95em',
       marginTop: 4,
@@ -74,7 +67,6 @@ function arrowGenerator() {
       height: '2em',
       width: '1em',
       '&::before': {
-        flip: false,
         borderWidth: '1em 0 1em 1em',
         borderColor: 'transparent transparent transparent currentcolor',
       },
@@ -87,7 +79,6 @@ export const styles = (theme) => ({
   popper: {
     zIndex: theme.zIndex.tooltip,
     pointerEvents: 'none',
-    flip: false, // disable jss-rtl plugin
   },
   /* Styles applied to the Popper component if `interactive={true}`. */
   popperInteractive: {


### PR DESCRIPTION
flip is not a valid css property.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

<img width="576" alt="Capture d’écran 2020-04-25 à 12 11 28" src="https://user-images.githubusercontent.com/3165635/80277229-eb396600-86ed-11ea-81cd-377e10e7452e.png">

https://validator.w3.org/nu/?doc=https%3A%2F%2Fwww.a11ywatch.com%2F