### PR TITLE
[ModalManager] Port to TypeScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,8 @@ module.exports = {
     'react/static-property-placement': 'off',
 
     'import/no-extraneous-dependencies': 'off', // It would be better to enable this rule.
+    // Unclear what we would gain by consistency. It's more important that code works
+    'import/extensions': 'off',
     'import/namespace': ['error', { allowComputed: true }],
     'import/order': [
       'error',

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
   recursive: true,
   reporter: 'dot',
-  require: [require.resolve('@babel/register'), require.resolve('./test/utils/setup')],
+  require: [require.resolve('./test/utils/setup')],
 };

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -90,14 +90,14 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   const hasTransition = getHasTransition(props);
 
   const getDoc = () => ownerDocument(mountNodeRef.current);
-  const getModal = () => {
+  const updateAndGetModal = () => {
     modal.current.modalNode = modalRef.current;
     modal.current.mountNode = mountNodeRef.current;
     return modal.current;
   };
 
   const handleMounted = () => {
-    manager.mount(getModal(), { disableScrollLock });
+    manager.mount(updateAndGetModal(), { disableScrollLock });
 
     // Fix a bug on Chrome where the scroll isn't initially 0.
     modalRef.current.scrollTop = 0;
@@ -106,7 +106,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   const handleOpen = useEventCallback(() => {
     const resolvedContainer = getContainer(container) || getDoc().body;
 
-    manager.add(getModal(), resolvedContainer);
+    manager.add(updateAndGetModal(), resolvedContainer);
 
     // The element was already mounted.
     if (modalRef.current) {
@@ -114,7 +114,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
     }
   });
 
-  const isTopModal = React.useCallback(() => manager.isTopModal(getModal()), [manager]);
+  const isTopModal = React.useCallback(() => manager.isTopModal(updateAndGetModal()), [manager]);
 
   const handlePortalRef = useEventCallback((node) => {
     mountNodeRef.current = node;
@@ -135,7 +135,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   });
 
   const handleClose = React.useCallback(() => {
-    manager.remove(getModal());
+    manager.remove(updateAndGetModal());
   }, [manager]);
 
   React.useEffect(() => {

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -83,7 +83,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
   } = props;
 
   const [exited, setExited] = React.useState(true);
-  const modal = React.useRef({});
+  const modalInstanceRef = React.useRef({});
   const mountNodeRef = React.useRef(null);
   const modalRef = React.useRef(null);
   const handleRef = useForkRef(modalRef, ref);
@@ -91,9 +91,9 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
 
   const getDoc = () => ownerDocument(mountNodeRef.current);
   const updateAndGetModal = () => {
-    modal.current.modalNode = modalRef.current;
-    modal.current.mountNode = mountNodeRef.current;
-    return modal.current;
+    modalInstanceRef.current.modalNode = modalRef.current;
+    modalInstanceRef.current.mountNode = mountNodeRef.current;
+    return modalInstanceRef.current;
   };
 
   const handleMounted = () => {

--- a/packages/material-ui/src/Modal/Modal.js
+++ b/packages/material-ui/src/Modal/Modal.js
@@ -91,7 +91,7 @@ const Modal = React.forwardRef(function Modal(inProps, ref) {
 
   const getDoc = () => ownerDocument(mountNodeRef.current);
   const getModal = () => {
-    modal.current.modalRef = modalRef.current;
+    modal.current.modalNode = modalRef.current;
     modal.current.mountNode = mountNodeRef.current;
     return modal.current;
   };

--- a/packages/material-ui/src/Modal/ModalManager.ts
+++ b/packages/material-ui/src/Modal/ModalManager.ts
@@ -7,7 +7,7 @@ interface ManagedModalProps {
 }
 
 interface Modal {
-  modalRef: HTMLElement;
+  modalNode: HTMLElement;
   mountNode: HTMLElement;
 }
 
@@ -184,12 +184,12 @@ export default class ModalManager {
     this.modals.push(modal);
 
     // If the modal we are adding is already in the DOM.
-    if (modal.modalRef) {
-      ariaHidden(modal.modalRef, false);
+    if (modal.modalNode) {
+      ariaHidden(modal.modalNode, false);
     }
 
     const hiddenSiblingNodes = getHiddenSiblings(container);
-    ariaHiddenSiblings(container, modal.mountNode, modal.modalRef, hiddenSiblingNodes, true);
+    ariaHiddenSiblings(container, modal.mountNode, modal.modalNode, hiddenSiblingNodes, true);
 
     const containerIndex = findIndexOf(this.containers, (item) => item.container === container);
     if (containerIndex !== -1) {
@@ -242,15 +242,15 @@ export default class ModalManager {
         containerInfo.restore();
       }
 
-      if (modal.modalRef) {
+      if (modal.modalNode) {
         // In case the modal wasn't in the DOM yet.
-        ariaHidden(modal.modalRef, true);
+        ariaHidden(modal.modalNode, true);
       }
 
       ariaHiddenSiblings(
         containerInfo.container,
         modal.mountNode,
-        modal.modalRef,
+        modal.modalNode,
         containerInfo.hiddenSiblingNodes,
         false,
       );
@@ -261,8 +261,8 @@ export default class ModalManager {
       // as soon as a modal is adding its modalRef is undefined. it can't set
       // aria-hidden because the dom element doesn't exist either
       // when modal was unmounted before modalRef gets null
-      if (nextTop.modalRef) {
-        ariaHidden(nextTop.modalRef, false);
+      if (nextTop.modalNode) {
+        ariaHidden(nextTop.modalNode, false);
       }
     }
 

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -61,7 +61,7 @@ module.exports = function setKarmaConfig(config) {
       module: {
         rules: [
           {
-            test: /\.js$/,
+            test: /\.(js|ts)$/,
             loader: 'babel-loader',
             exclude: /node_modules/,
           },
@@ -86,6 +86,7 @@ module.exports = function setKarmaConfig(config) {
           '@testing-library/react/pure':
             '@testing-library/react/dist/@testing-library/react.pure.esm',
         },
+        extensions: ['.js', '.ts'],
       },
     },
     webpackMiddleware: {

--- a/test/utils/setup.js
+++ b/test/utils/setup.js
@@ -1,3 +1,4 @@
+require('@babel/register')({ extensions: ['.js', '.jsx', '.ts', '.tsx'] });
 const createDOM = require('./createDOM');
 
 process.browser = true;


### PR DESCRIPTION
Includes less refactoring that I'd wish for. ModalManager is the kind of code I look into every few months and need half an hour to understand what this.modal is even supposed to mean.

Hopefully this clears some things up and makes refactoring easier. So far only 
- `modalRef` -> `modalNode` (confusing if we name one `mountNode` but the other `modalRef` when both have the same type)
- `getModal` -> `updateAndGetModal` (`get*` implies it's side-effect free ergo safe during render but this is not the case here.)
- `modal` -> `modalInstanceRef` (it's important that this is an instance since we use it for referential equality)

made it in.

The `padding-right` instead of `paddingRight` seem very sketchy. Naively these would do the same thing but the tests fail both in browser and jsdom. Would need to check if there's actually a visual difference or why we special case `.mui-fixed`.