### PR TITLE
[system] Improve breakpoints types

### DIFF
--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -36,7 +36,7 @@ type DefaultBreakPoints = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
  */
 export function breakpoints<Props, Breakpoints extends string = DefaultBreakPoints>(
   styleFunction: StyleFunction<Props>
-): StyleFunction<Partial<Record<Breakpoints, Props>>>;
+): StyleFunction<Partial<Record<Breakpoints, Props>> & Props>;
 
 // compose.js
 /**
@@ -56,7 +56,7 @@ export function compose<T extends Array<StyleFunction<any>>>(...args: T): Compos
 // css.js
 export function css<Props>(
   styleFunction: StyleFunction<Props>
-): StyleFunction<Props & { css: Omit<Props, 'theme'> }>;
+): StyleFunction<Props & { css?: Omit<Props, 'theme'> }>;
 
 export const display: SimpleStyleFunction<
   'display' | 'displayPrint' | 'overflow' | 'textOverflow' | 'visibility' | 'whiteSpace'

--- a/packages/material-ui-system/src/index.d.ts
+++ b/packages/material-ui-system/src/index.d.ts
@@ -56,7 +56,7 @@ export function compose<T extends Array<StyleFunction<any>>>(...args: T): Compos
 // css.js
 export function css<Props>(
   styleFunction: StyleFunction<Props>
-): StyleFunction<Props & { css?: Omit<Props, 'theme'> }>;
+): StyleFunction<Props & { css: Omit<Props, 'theme'> }>;
 
 export const display: SimpleStyleFunction<
   'display' | 'displayPrint' | 'overflow' | 'textOverflow' | 'visibility' | 'whiteSpace'

--- a/packages/material-ui-system/src/index.spec.tsx
+++ b/packages/material-ui-system/src/index.spec.tsx
@@ -1,4 +1,12 @@
-import { compose, css, palette, StyleFunction, spacing, style } from '@material-ui/system';
+import {
+  compose,
+  css,
+  palette,
+  StyleFunction,
+  spacing,
+  style,
+  breakpoints,
+} from '@material-ui/system';
 import * as React from 'react';
 import styled from 'styled-components';
 
@@ -65,4 +73,14 @@ function interopTest() {
     ${mixin}
   `;
   <SystemSpacingBox m={2} />;
+}
+
+function breakpointsTest() {
+  function styleFunction(props: { color?: string }) {
+    return {};
+  }
+
+  const styler = breakpoints(styleFunction);
+  // Allows styleFunction props
+  styler({ color: 'red' });
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

Hi guys. Your awesome material-ui-system package allows doing this:
```javascript
const composedStyle = breakpoints(
    css(
        compose(
            borders,
            display,
            flexbox,
            palette,
            positions,
            shadows,
            sizing,
            spacing,
            typography
        )
    )
)

const Box = styled.div`
    ${composedStyle}
`

// use component
const Compoennt = () => (
    <Box sm={{ width: 500, css: { height: 800 } }}>Hello World!</Box>
)
```
But current typescript implementation breaks everything.
```javascript

// Property 'css' is missing, css prop is a must
const Compoennt = () => (
    <Box sm={{ width: 500, css: { height: 800 } }}>Hello World!</Box>
)

// I just added height prop, breakpoints function type doesn't allow 
// adding props as args of styled functions i.e. borders, display, flexbox, etc.
const Compoennt = () => (
    <Box height={800} sm={{ width: 500, css: { height: 800 } }}>
        Hello World!
    </Box>
)
```
