### PR TITLE
[material-ui-docs] Fix extraneous dependencies

### DIFF
--- a/packages/material-ui-docs/package.json
+++ b/packages/material-ui-docs/package.json
@@ -45,10 +45,7 @@
   "dependencies": {
     "@babel/runtime": "^7.4.4",
     "@material-ui/utils": "^4.9.6",
-    "clsx": "^1.0.4",
-    "marked": "^1.0.0",
-    "nprogress": "^0.2.0",
-    "prismjs": "^1.17.1"
+    "nprogress": "^0.2.0"
   },
   "devDependencies": {},
   "publishConfig": {


### PR DESCRIPTION
Noticed in #20760:

- `marked`, `prismjs` and `clsx` are no longer used