### PR TITLE
[docs] Never transition preview if not shown

### DIFF
--- a/docs/src/modules/components/Demo.js
+++ b/docs/src/modules/components/Demo.js
@@ -544,7 +544,7 @@ function Demo(props) {
         <HighlightedCode
           className={classes.code}
           id={demoSourceId}
-          code={codeOpen ? demoData.raw : jsx}
+          code={showPreview && !codeOpen ? jsx : demoData.raw}
           language={demoData.sourceLanguage}
         />
       </Collapse>


### PR DESCRIPTION
Irritated me a couple of times and I wasn't sure whether this was an issue with StrictModeCollapse or not. Turns out we switch the code one to many.

On master we briefly display the jsx preview when closing even though it will never be the final state (or rather the final state is always hidden)
master:
https://material-ui.netlify.app/components/switches/#SwitchLabels.js
![demo-code-transition-master](https://user-images.githubusercontent.com/12292047/80318973-25018e00-880e-11ea-8d17-0ecee9645381.gif)

pr:
![demo-code-transition-pr](https://user-images.githubusercontent.com/12292047/80318974-2763e800-880e-11ea-8b9e-da4e408f2199.gif)
