### PR TITLE
[test] Migrate from assert to expect

### DIFF
--- a/docs/src/modules/utils/helpers.test.js
+++ b/docs/src/modules/utils/helpers.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { getDependencies } from './helpers';
 
 describe('docs getDependencies helpers', () => {
@@ -21,7 +21,7 @@ const styles = theme => ({
 `;
 
   it('should handle @ dependencies', () => {
-    assert.deepEqual(getDependencies(s1), {
+    expect(getDependencies(s1)).to.deep.equal({
       '@foo-bar/bip': 'latest',
       '@material-ui/core': 'latest',
       'prop-types': 'latest',
@@ -45,7 +45,7 @@ import { withStyles } from '@material-ui/core/styles';
 const suggestions = [
 `;
 
-    assert.deepEqual(getDependencies(source), {
+    expect(getDependencies(source)).to.deep.equal({
       '@material-ui/core': 'latest',
       '@unexisting/thing': 'latest',
       'autosuggest-highlight': 'latest',
@@ -57,7 +57,7 @@ const suggestions = [
   });
 
   it('should support next dependencies', () => {
-    assert.deepEqual(getDependencies(s1, { reactVersion: 'next' }), {
+    expect(getDependencies(s1, { reactVersion: 'next' })).to.deep.equal({
       '@foo-bar/bip': 'latest',
       '@material-ui/core': 'latest',
       'prop-types': 'latest',
@@ -77,7 +77,7 @@ import DateFnsUtils from '@date-io/date-fns';
 import { MuiPickersUtilsProvider, TimePicker, DatePicker } from '@material-ui/pickers';
 `;
 
-    assert.deepEqual(getDependencies(source), {
+    expect(getDependencies(source)).to.deep.equal({
       'date-fns': 'latest',
       '@date-io/date-fns': 'v1',
       '@material-ui/pickers': 'latest',
@@ -89,7 +89,7 @@ import { MuiPickersUtilsProvider, TimePicker, DatePicker } from '@material-ui/pi
   });
 
   it('can collect required @types packages', () => {
-    assert.deepEqual(getDependencies(s1, { codeLanguage: 'TS' }), {
+    expect(getDependencies(s1, { codeLanguage: 'TS' })).to.deep.equal({
       '@foo-bar/bip': 'latest',
       '@material-ui/core': 'latest',
       'prop-types': 'latest',
@@ -114,7 +114,7 @@ import {
 } from '@material-ui/pickers';
     `;
 
-    assert.deepEqual(getDependencies(source), {
+    expect(getDependencies(source)).to.deep.equal({
       'date-fns': 'latest',
       '@material-ui/pickers': 'latest',
       react: 'latest',
@@ -127,7 +127,7 @@ import {
 import lab from '@material-ui/lab';
     `;
 
-    assert.deepEqual(getDependencies(source), {
+    expect(getDependencies(source)).to.deep.equal({
       '@material-ui/core': 'latest',
       '@material-ui/lab': 'latest',
       react: 'latest',

--- a/packages/material-ui-icons/builder.test.js
+++ b/packages/material-ui-icons/builder.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import fs from 'fs';
 import path from 'path';
 import temp from 'temp';
@@ -22,16 +22,16 @@ describe('builder', () => {
 
   describe('#getComponentName', () => {
     it('should change capitalize dashes', () => {
-      assert.strictEqual(getComponentName('hi-world'), 'HiWorld', true);
+      expect(getComponentName('hi-world')).to.equal('HiWorld');
     });
 
     it('should capitalize based on environment path.sep', () => {
-      assert.strictEqual(getComponentName(`this${path.sep}dir`), 'ThisDir', true);
+      expect(getComponentName(`this${path.sep}dir`)).to.equal('ThisDir');
     });
   });
 
   it('should have icons to test with', () => {
-    assert.strictEqual(fs.lstatSync(MUI_ICONS_SVG_DIR).isDirectory(), true);
+    expect(fs.lstatSync(MUI_ICONS_SVG_DIR).isDirectory()).to.equal(true);
   });
 
   it('should have main', () => {
@@ -58,8 +58,8 @@ describe('builder', () => {
 
     it('script outputs to directory', async () => {
       await main(options);
-      assert.strictEqual(fs.lstatSync(options.outputDir).isDirectory(), true);
-      assert.strictEqual(fs.lstatSync(path.join(options.outputDir, 'index.js')).isFile(), true);
+      expect(fs.lstatSync(options.outputDir).isDirectory()).to.equal(true);
+      expect(fs.lstatSync(path.join(options.outputDir, 'index.js')).isFile()).to.equal(true);
     });
   });
 
@@ -83,11 +83,8 @@ describe('builder', () => {
 
     it('script outputs to directory', async () => {
       await main(options);
-      assert.strictEqual(fs.lstatSync(options.outputDir).isDirectory(), true);
-      assert.strictEqual(
-        fs.lstatSync(path.join(options.outputDir, 'delapouite')).isDirectory(),
-        true,
-      );
+      expect(fs.lstatSync(options.outputDir).isDirectory()).to.equal(true);
+      expect(fs.lstatSync(path.join(options.outputDir, 'delapouite')).isDirectory()).to.equal(true);
 
       const actualFilePath = path.join(
         options.outputDir,
@@ -98,10 +95,10 @@ describe('builder', () => {
         'transparent',
         'Dice-six-faces-four.js',
       );
-      assert.strictEqual(fs.existsSync(actualFilePath), true);
+      expect(fs.existsSync(actualFilePath)).to.equal(true);
 
       const actualFileData = fs.readFileSync(actualFilePath, { encoding: 'utf8' });
-      assert.include(actualFileData, "import createSvgIcon from './utils/createSvgIcon'");
+      expect(actualFileData).to.include("import createSvgIcon from './utils/createSvgIcon'");
     });
   });
 
@@ -125,7 +122,7 @@ describe('builder', () => {
 
     it('should produce the expected output', async () => {
       await main(options);
-      assert.strictEqual(fs.lstatSync(options.outputDir).isDirectory(), true);
+      expect(fs.lstatSync(options.outputDir).isDirectory()).to.equal(true);
 
       const cases = [
         'Accessibility.js',
@@ -143,7 +140,7 @@ describe('builder', () => {
           encoding: 'utf8',
         });
 
-        assert.include(actual, expected);
+        expect(actual).to.include(expected);
       });
     });
   });

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import {
   createMount,
@@ -56,7 +56,7 @@ describe('<SpeedDial />', () => {
         <FakeAction />
       </SpeedDial>,
     );
-    assert.strictEqual(findOutermostIntrinsic(wrapper).type(), 'div');
+    expect(findOutermostIntrinsic(wrapper).type()).to.equal('div');
   });
 
   it('should render a Fab', () => {
@@ -66,7 +66,7 @@ describe('<SpeedDial />', () => {
       </SpeedDial>,
     );
     const buttonWrapper = wrapper.find('[aria-expanded]').first();
-    assert.strictEqual(buttonWrapper.type(), Fab);
+    expect(buttonWrapper.type()).to.equal(Fab);
   });
 
   it('should render with a null child', () => {
@@ -77,7 +77,7 @@ describe('<SpeedDial />', () => {
         <SpeedDialAction icon={icon} tooltipTitle="Three" />
       </SpeedDial>,
     );
-    assert.strictEqual(wrapper.find(SpeedDialAction).length, 2);
+    expect(wrapper.find(SpeedDialAction).length).to.equal(2);
   });
 
   it('should pass the open prop to its children', () => {
@@ -89,7 +89,7 @@ describe('<SpeedDial />', () => {
       </SpeedDial>,
     );
     const actions = wrapper.find('[role="menuitem"]').filterWhere(wrapsIntrinsicElement);
-    assert.strictEqual(actions.some('.is-closed'), false);
+    expect(actions.some('.is-closed')).to.equal(false);
   });
 
   describe('prop: onKeyDown', () => {
@@ -106,8 +106,8 @@ describe('<SpeedDial />', () => {
         key: ' ',
         eventMock,
       });
-      assert.strictEqual(handleKeyDown.callCount, 1);
-      assert.strictEqual(handleKeyDown.calledWithMatch({ eventMock }), true);
+      expect(handleKeyDown.callCount).to.equal(1);
+      expect(handleKeyDown.calledWithMatch({ eventMock })).to.equal(true);
     });
   });
 
@@ -120,7 +120,7 @@ describe('<SpeedDial />', () => {
           <SpeedDialAction icon={icon} tooltipTitle="action2" />
         </SpeedDial>,
       );
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes[className]), true);
+      expect(findOutermostIntrinsic(wrapper).hasClass(classes[className])).to.equal(true);
     };
 
     it('should place actions in correct position', () => {
@@ -204,20 +204,20 @@ describe('<SpeedDial />', () => {
 
     it('displays the actions on focus gain', () => {
       resetDialToOpen();
-      assert.strictEqual(wrapper.find(SpeedDial).props().open, true);
+      expect(wrapper.find(SpeedDial).props().open).to.equal(true);
     });
 
     describe('first item selection', () => {
       it('considers arrow keys with the same initial orientation', () => {
         resetDialToOpen();
         getDialButton().simulate('keydown', { key: 'left' });
-        assert.strictEqual(isActionFocused(0), true);
+        expect(isActionFocused(0)).to.equal(true);
         getDialButton().simulate('keydown', { key: 'up' });
-        assert.strictEqual(isActionFocused(0), true);
+        expect(isActionFocused(0)).to.equal(true);
         getDialButton().simulate('keydown', { key: 'left' });
-        assert.strictEqual(isActionFocused(1), true);
+        expect(isActionFocused(1)).to.equal(true);
         getDialButton().simulate('keydown', { key: 'right' });
-        assert.strictEqual(isActionFocused(0), true);
+        expect(isActionFocused(0)).to.equal(true);
       });
     });
 
@@ -236,11 +236,7 @@ describe('<SpeedDial />', () => {
         resetDialToOpen(dialDirection);
 
         getDialButton().simulate('keydown', { key: firstKey });
-        assert.strictEqual(
-          isActionFocused(firstFocusedAction),
-          true,
-          `focused action initial ${firstKey} should be ${firstFocusedAction}`,
-        );
+        expect(isActionFocused(firstFocusedAction)).to.equal(true);
 
         combination.forEach((arrowKey, i) => {
           const previousFocusedAction = foci[i - 1] || firstFocusedAction;
@@ -250,8 +246,7 @@ describe('<SpeedDial />', () => {
           getActionButton(previousFocusedAction).simulate('keydown', {
             key: arrowKey,
           });
-          assert.strictEqual(
-            isActionFocused(expectedFocusedAction),
+          expect(isActionFocused(expectedFocusedAction)).to.equal(
             true,
             `focused action after ${combinationUntilNot.join(
               ',',

--- a/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
+++ b/packages/material-ui-lab/src/SpeedDial/SpeedDial.test.js
@@ -236,7 +236,10 @@ describe('<SpeedDial />', () => {
         resetDialToOpen(dialDirection);
 
         getDialButton().simulate('keydown', { key: firstKey });
-        expect(isActionFocused(firstFocusedAction)).to.equal(true);
+        expect(isActionFocused(firstFocusedAction)).to.equal(
+          true,
+          `focused action initial ${firstKey} should be ${firstFocusedAction}`,
+        );
 
         combination.forEach((arrowKey, i) => {
           const previousFocusedAction = foci[i - 1] || firstFocusedAction;

--- a/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
+++ b/packages/material-ui-lab/src/SpeedDialAction/SpeedDialAction.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import Icon from '@material-ui/core/Icon';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -38,24 +38,24 @@ describe('<SpeedDialAction />', () => {
     const wrapper = mount(
       <SpeedDialAction {...defaultProps} TooltipClasses={{ tooltip: 'bar' }} />,
     );
-    assert.include(wrapper.find(Tooltip).props().classes.tooltip, 'bar');
+    expect(wrapper.find(Tooltip).props().classes.tooltip).to.include('bar');
   });
 
   it('should render a Fab', () => {
     const wrapper = mount(<SpeedDialAction {...defaultProps} />);
-    assert.strictEqual(wrapper.find(Fab).exists(), true);
+    expect(wrapper.find(Fab).exists()).to.equal(true);
   });
 
   it('should render the button with the fab class', () => {
     const wrapper = mount(<SpeedDialAction {...defaultProps} open />);
     const buttonWrapper = wrapper.find('button');
-    assert.strictEqual(buttonWrapper.hasClass(classes.fab), true);
+    expect(buttonWrapper.hasClass(classes.fab)).to.equal(true);
   });
 
   it('should render the button with the fab and fabClosed classes', () => {
     const wrapper = mount(<SpeedDialAction {...defaultProps} />);
     const buttonWrapper = wrapper.find('button');
-    assert.strictEqual(buttonWrapper.hasClass(classes.fab), true);
-    assert.strictEqual(buttonWrapper.hasClass(classes.fabClosed), true);
+    expect(buttonWrapper.hasClass(classes.fab)).to.equal(true);
+    expect(buttonWrapper.hasClass(classes.fabClosed)).to.equal(true);
   });
 });

--- a/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
+++ b/packages/material-ui-lab/src/SpeedDialIcon/SpeedDialIcon.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import Icon from '@material-ui/core/Icon';
 import SpeedDialIcon from './SpeedDialIcon';
@@ -29,59 +29,56 @@ describe('<SpeedDialIcon />', () => {
 
   it('should render the Add icon by default', () => {
     const wrapper = mount(<SpeedDialIcon />);
-    assert.strictEqual(
-      findOutermostIntrinsic(wrapper).find('svg[data-mui-test="AddIcon"]').length,
-      1,
-    );
+    expect(findOutermostIntrinsic(wrapper).find('svg[data-mui-test="AddIcon"]').length).to.equal(1);
   });
 
   it('should render an Icon', () => {
     const wrapper = mount(<SpeedDialIcon icon={icon} />);
     const iconWrapper = findOutermostIntrinsic(wrapper).childAt(0);
-    assert.strictEqual(iconWrapper.find(Icon).length, 1);
+    expect(iconWrapper.find(Icon).length).to.equal(1);
   });
 
   it('should render an openIcon', () => {
     const wrapper = mount(<SpeedDialIcon openIcon={icon} />);
     const iconWrapper = findOutermostIntrinsic(wrapper).childAt(0);
-    assert.strictEqual(iconWrapper.find(Icon).length, 1);
+    expect(iconWrapper.find(Icon).length).to.equal(1);
   });
 
   it('should render the icon with the icon class', () => {
     const wrapper = mount(<SpeedDialIcon />);
     const iconWrapper = findOutermostIntrinsic(wrapper).childAt(0);
-    assert.strictEqual(iconWrapper.hasClass(classes.icon), true);
-    assert.strictEqual(iconWrapper.hasClass(classes.iconOpen), false);
-    assert.strictEqual(iconWrapper.hasClass(classes.iconWithOpenIconOpen), false);
+    expect(iconWrapper.hasClass(classes.icon)).to.equal(true);
+    expect(iconWrapper.hasClass(classes.iconOpen)).to.equal(false);
+    expect(iconWrapper.hasClass(classes.iconWithOpenIconOpen)).to.equal(false);
   });
 
   it('should render the icon with the icon and iconOpen classes', () => {
     const wrapper = mount(<SpeedDialIcon open />);
     const iconWrapper = findOutermostIntrinsic(wrapper).childAt(0);
-    assert.strictEqual(iconWrapper.hasClass(classes.icon), true);
-    assert.strictEqual(iconWrapper.hasClass(classes.iconOpen), true);
-    assert.strictEqual(iconWrapper.hasClass(classes.iconWithOpenIconOpen), false);
+    expect(iconWrapper.hasClass(classes.icon)).to.equal(true);
+    expect(iconWrapper.hasClass(classes.iconOpen)).to.equal(true);
+    expect(iconWrapper.hasClass(classes.iconWithOpenIconOpen)).to.equal(false);
   });
 
   it('should render the icon with the icon, iconOpen iconWithOpenIconOpen classes', () => {
     const wrapper = mount(<SpeedDialIcon open openIcon={icon} />);
     const iconWrapper = findOutermostIntrinsic(wrapper).childAt(1);
-    assert.strictEqual(iconWrapper.hasClass(classes.icon), true);
-    assert.strictEqual(iconWrapper.hasClass(classes.iconOpen), true);
-    assert.strictEqual(iconWrapper.hasClass(classes.iconWithOpenIconOpen), true);
+    expect(iconWrapper.hasClass(classes.icon)).to.equal(true);
+    expect(iconWrapper.hasClass(classes.iconOpen)).to.equal(true);
+    expect(iconWrapper.hasClass(classes.iconWithOpenIconOpen)).to.equal(true);
   });
 
   it('should render the openIcon with the openIcon class', () => {
     const wrapper = mount(<SpeedDialIcon openIcon={icon} />);
     const iconWrapper = findOutermostIntrinsic(wrapper).childAt(0);
-    assert.strictEqual(iconWrapper.hasClass(classes.openIcon), true);
-    assert.strictEqual(iconWrapper.hasClass(classes.openIconOpen), false);
+    expect(iconWrapper.hasClass(classes.openIcon)).to.equal(true);
+    expect(iconWrapper.hasClass(classes.openIconOpen)).to.equal(false);
   });
 
   it('should render the openIcon with the openIcon, openIconOpen classes', () => {
     const wrapper = mount(<SpeedDialIcon open openIcon={icon} />);
     const iconWrapper = findOutermostIntrinsic(wrapper).childAt(0);
-    assert.strictEqual(iconWrapper.hasClass(classes.openIcon), true);
-    assert.strictEqual(iconWrapper.hasClass(classes.openIconOpen), true);
+    expect(iconWrapper.hasClass(classes.openIcon)).to.equal(true);
+    expect(iconWrapper.hasClass(classes.openIconOpen)).to.equal(true);
   });
 });

--- a/packages/material-ui-lab/src/ToggleButtonGroup/isValueSelected.test.js
+++ b/packages/material-ui-lab/src/ToggleButtonGroup/isValueSelected.test.js
@@ -1,40 +1,40 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import isValueSelected from './isValueSelected';
 
 describe('<ToggleButton /> isValueSelected', () => {
   it('is false when value is undefined', () => {
-    assert.strictEqual(isValueSelected(undefined, [undefined]), false);
+    expect(isValueSelected(undefined, [undefined])).to.equal(false);
   });
 
   it('is false when candidate is undefined', () => {
-    assert.strictEqual(isValueSelected('example', undefined), false);
+    expect(isValueSelected('example', undefined)).to.equal(false);
   });
 
   describe('non exclusive', () => {
     it('is true if candidate is contained in value', () => {
-      assert.strictEqual(isValueSelected('one', ['one']), true);
+      expect(isValueSelected('one', ['one'])).to.equal(true);
     });
 
     it('is false if value is not contained in candidate', () => {
-      assert.strictEqual(isValueSelected('one', ['two']), false);
+      expect(isValueSelected('one', ['two'])).to.equal(false);
     });
 
     it('is false if value is loosely contained in candidate', () => {
-      assert.strictEqual(isValueSelected('3', [3]), false);
+      expect(isValueSelected('3', [3])).to.equal(false);
     });
   });
 
   describe('exclusive', () => {
     it('is true if candidate strictly equals value', () => {
-      assert.strictEqual(isValueSelected('one', 'one'), true);
+      expect(isValueSelected('one', 'one')).to.equal(true);
     });
 
     it('is false if candidate does not equal value', () => {
-      assert.strictEqual(isValueSelected('two', 'one'), false);
+      expect(isValueSelected('two', 'one')).to.equal(false);
     });
 
     it('is false if candidate loosely equals value', () => {
-      assert.strictEqual(isValueSelected('3', 3), false);
+      expect(isValueSelected('3', 3)).to.equal(false);
     });
   });
 });

--- a/packages/material-ui-lab/src/index.test.js
+++ b/packages/material-ui-lab/src/index.test.js
@@ -4,17 +4,17 @@
  * import the entire lib for coverage reporting
  */
 
-import { assert } from 'chai';
+import { expect } from 'chai';
 import * as MaterialUI from './index';
 
 describe('@material-ui/lab', () => {
   it('should have exports', () => {
-    assert.strictEqual(typeof MaterialUI, 'object');
+    expect(typeof MaterialUI).to.equal('object');
   });
 
   it('should not do undefined exports', () => {
     Object.keys(MaterialUI).forEach((exportKey) =>
-      assert.strictEqual(Boolean(MaterialUI[exportKey]), true),
+      expect(Boolean(MaterialUI[exportKey])).to.equal(true),
     );
   });
 });

--- a/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
+++ b/packages/material-ui-styles/src/StylesProvider/StylesProvider.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOMServer from 'react-dom/server';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { create, SheetsRegistry } from 'jss';
 import { createMount } from '@material-ui/core/test-utils';
 import StylesProvider, { StylesContext } from './StylesProvider';
@@ -39,7 +39,7 @@ describe('StylesProvider', () => {
         <Test />
       </StylesProvider>,
     );
-    assert.strictEqual(getOptions(wrapper).disableGeneration, true);
+    expect(getOptions(wrapper).disableGeneration).to.equal(true);
   });
 
   it('should merge the themes', () => {
@@ -50,7 +50,7 @@ describe('StylesProvider', () => {
         </StylesProvider>
       </StylesProvider>,
     );
-    assert.strictEqual(getOptions(wrapper).disableGeneration, true);
+    expect(getOptions(wrapper).disableGeneration).to.equal(true);
   });
 
   it('should handle injectFirst', () => {
@@ -59,7 +59,7 @@ describe('StylesProvider', () => {
         <Test />
       </StylesProvider>,
     );
-    assert.strictEqual(getOptions(wrapper).jss.options.insertionPoint.nodeType, 8);
+    expect(getOptions(wrapper).jss.options.insertionPoint.nodeType).to.equal(8);
   });
 
   describe('server-side', () => {
@@ -75,10 +75,10 @@ describe('StylesProvider', () => {
     };
 
     function assertRendering(markup, sheetsRegistry) {
-      assert.notStrictEqual(markup.match('Hello World'), null);
-      assert.strictEqual(sheetsRegistry.registry.length, 1);
-      assert.strictEqual(sheetsRegistry.toString().length > 10, true);
-      assert.deepEqual(sheetsRegistry.registry[0].classes, {
+      expect(markup.match('Hello World')).to.not.equal(null);
+      expect(sheetsRegistry.registry.length).to.equal(1);
+      expect(sheetsRegistry.toString().length > 10).to.equal(true);
+      expect(sheetsRegistry.registry[0].classes).to.deep.equal({
         root: 'makeStyles-root-1',
       });
     }
@@ -129,7 +129,7 @@ describe('StylesProvider', () => {
       assertRendering(markup2, sheetsRegistry2);
 
       // The most important check:
-      assert.strictEqual(sheetsRegistry1.registry[0], sheetsRegistry2.registry[0]);
+      expect(sheetsRegistry1.registry[0]).to.equal(sheetsRegistry2.registry[0]);
     });
   });
 
@@ -140,7 +140,7 @@ describe('StylesProvider', () => {
         <Test />
       </StylesProvider>,
     );
-    assert.strictEqual(getOptions(wrapper).jss, jss);
+    expect(getOptions(wrapper).jss).to.equal(jss);
   });
 
   describe('warnings', () => {
@@ -159,9 +159,8 @@ describe('StylesProvider', () => {
           <Test />
         </StylesProvider>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'you cannot use the jss and injectFirst props at the same time',
       );
     });

--- a/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
+++ b/packages/material-ui-styles/src/ThemeProvider/ThemeProvider.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { createMount } from '@material-ui/core/test-utils';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -33,7 +33,7 @@ describe('ThemeProvider', () => {
         <Test />
       </ThemeProvider>,
     );
-    assert.strictEqual(text(), 'foo');
+    expect(text()).to.equal('foo');
   });
 
   it('should merge the themes', () => {
@@ -57,7 +57,7 @@ describe('ThemeProvider', () => {
         </ThemeProvider>
       </ThemeProvider>,
     );
-    assert.strictEqual(text(), 'foobar');
+    expect(text()).to.equal('foobar');
   });
 
   it('should memoize the merged output', () => {
@@ -94,10 +94,10 @@ describe('ThemeProvider', () => {
     }
 
     const wrapper = mount(<Container />);
-    assert.strictEqual(text(), 'foobar');
+    expect(text()).to.equal('foobar');
     wrapper.setProps({});
-    assert.strictEqual(text(), 'foobar');
-    assert.strictEqual(themes.length, 1);
+    expect(text()).to.equal('foobar');
+    expect(themes.length).to.equal(1);
   });
 
   it('does not allow setting mui.nested manually', () => {
@@ -145,8 +145,8 @@ describe('ThemeProvider', () => {
           <div />
         </ThemeProvider>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 2); // twice in strict mode
-      assert.include(consoleErrorMock.messages()[0], 'However, no outer theme is present.');
+      expect(consoleErrorMock.callCount()).to.equal(2); // twice in strict mode
+      expect(consoleErrorMock.messages()[0]).to.include('However, no outer theme is present.');
     });
 
     it('should warn about wrong theme function', () => {
@@ -158,9 +158,8 @@ describe('ThemeProvider', () => {
           ,
         </ThemeProvider>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 2);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(2);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'you should return an object from your theme function',
       );
     });

--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassName.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import createGenerateClassName from './createGenerateClassName';
 import nested from '../ThemeProvider/nested';
@@ -6,7 +6,7 @@ import nested from '../ThemeProvider/nested';
 describe('createGenerateClassName', () => {
   it('should generate a class name', () => {
     const generateClassName = createGenerateClassName();
-    assert.strictEqual(
+    expect(
       generateClassName(
         {
           key: 'key',
@@ -18,13 +18,12 @@ describe('createGenerateClassName', () => {
           },
         },
       ),
-      'classNamePrefix-key-1',
-    );
+    ).to.equal('classNamePrefix-key-1');
   });
 
   it('should increase the counter', () => {
     const generateClassName = createGenerateClassName();
-    assert.strictEqual(
+    expect(
       generateClassName(
         {
           key: 'key',
@@ -35,9 +34,8 @@ describe('createGenerateClassName', () => {
           },
         },
       ),
-      'classNamePrefix-key-1',
-    );
-    assert.strictEqual(
+    ).to.equal('classNamePrefix-key-1');
+    expect(
       generateClassName(
         {
           key: 'key',
@@ -48,26 +46,24 @@ describe('createGenerateClassName', () => {
           },
         },
       ),
-      'classNamePrefix-key-2',
-    );
+    ).to.equal('classNamePrefix-key-2');
   });
 
   it('should work without a classNamePrefix', () => {
     const generateClassName = createGenerateClassName();
-    assert.strictEqual(
+    expect(
       generateClassName(
         { key: 'root' },
         {
           options: {},
         },
       ),
-      'root-1',
-    );
+    ).to.equal('root-1');
   });
 
   it('should generate global class names', () => {
     const generateClassName = createGenerateClassName();
-    assert.strictEqual(
+    expect(
       generateClassName(
         { key: 'root' },
         {
@@ -77,9 +73,8 @@ describe('createGenerateClassName', () => {
           },
         },
       ),
-      'MuiButton-root',
-    );
-    assert.strictEqual(
+    ).to.equal('MuiButton-root');
+    expect(
       generateClassName(
         { key: 'root' },
         {
@@ -91,9 +86,8 @@ describe('createGenerateClassName', () => {
           },
         },
       ),
-      'MuiButton-root-2',
-    );
-    assert.strictEqual(
+    ).to.equal('MuiButton-root-2');
+    expect(
       generateClassName(
         { key: 'disabled' },
         {
@@ -103,8 +97,7 @@ describe('createGenerateClassName', () => {
           },
         },
       ),
-      'Mui-disabled',
-    );
+    ).to.equal('Mui-disabled');
   });
 
   describe('production', () => {
@@ -129,30 +122,28 @@ describe('createGenerateClassName', () => {
 
     it('should output a short representation', () => {
       const generateClassName = createGenerateClassName();
-      assert.strictEqual(
+      expect(
         generateClassName(
           { key: 'root' },
           {
             options: {},
           },
         ),
-        'jss1',
-      );
+      ).to.equal('jss1');
     });
 
     it('should use the seed', () => {
       const generateClassName = createGenerateClassName({
         seed: 'dark',
       });
-      assert.strictEqual(
+      expect(
         generateClassName(
           { key: 'root' },
           {
             options: {},
           },
         ),
-        'dark-jss1',
-      );
+      ).to.equal('dark-jss1');
     });
   });
 });

--- a/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassNameHash.test.js
+++ b/packages/material-ui-styles/src/createGenerateClassName/createGenerateClassNameHash.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import createGenerateClassNameHash from './createGenerateClassNameHash';
 
@@ -8,7 +8,7 @@ describe('createGenerateClassNameHash', () => {
 
   describe('dangerouslyUseGlobalCSS', () => {
     it('should have a stable classname', () => {
-      assert.strictEqual(
+      expect(
         generateClassNameGlobal(
           {
             key: 'key',
@@ -19,9 +19,8 @@ describe('createGenerateClassNameHash', () => {
             },
           },
         ),
-        'MuiGrid-key',
-      );
-      assert.strictEqual(
+      ).to.equal('MuiGrid-key');
+      expect(
         generateClassNameGlobal(
           {
             key: 'key',
@@ -38,13 +37,12 @@ describe('createGenerateClassNameHash', () => {
             },
           },
         ),
-        'classNamePrefix-key-1',
-      );
+      ).to.equal('classNamePrefix-key-1');
     });
   });
 
   it('should generate a class name', () => {
-    assert.strictEqual(
+    expect(
       generateClassName(
         {
           key: 'key',
@@ -63,12 +61,11 @@ describe('createGenerateClassNameHash', () => {
           },
         },
       ),
-      'classNamePrefix-key-1mx1qso',
-    );
+    ).to.equal('classNamePrefix-key-1mx1qso');
   });
 
   it('should increase the counter only when needed', () => {
-    assert.strictEqual(
+    expect(
       generateClassName(
         {
           key: 'key',
@@ -87,9 +84,8 @@ describe('createGenerateClassNameHash', () => {
           },
         },
       ),
-      'classNamePrefix-key-1mx1qso',
-    );
-    assert.strictEqual(
+    ).to.equal('classNamePrefix-key-1mx1qso');
+    expect(
       generateClassName(
         {
           key: 'key',
@@ -106,9 +102,8 @@ describe('createGenerateClassNameHash', () => {
           },
         },
       ),
-      'classNamePrefix-key-1',
-    );
-    assert.strictEqual(
+    ).to.equal('classNamePrefix-key-1');
+    expect(
       generateClassName(
         {
           key: 'key',
@@ -125,12 +120,11 @@ describe('createGenerateClassNameHash', () => {
           },
         },
       ),
-      'classNamePrefix-key-2',
-    );
+    ).to.equal('classNamePrefix-key-2');
   });
 
   it('should use the theme object, rule key and the style raw', () => {
-    assert.strictEqual(
+    expect(
       generateClassName(
         {
           key: 'key1',
@@ -149,9 +143,8 @@ describe('createGenerateClassNameHash', () => {
           },
         },
       ),
-      'classNamePrefix-key1-1s3krrz',
-    );
-    assert.strictEqual(
+    ).to.equal('classNamePrefix-key1-1s3krrz');
+    expect(
       generateClassName(
         {
           key: 'key2',
@@ -170,9 +163,8 @@ describe('createGenerateClassNameHash', () => {
           },
         },
       ),
-      'classNamePrefix-key2-l5j9wx',
-    );
-    assert.strictEqual(
+    ).to.equal('classNamePrefix-key2-l5j9wx');
+    expect(
       generateClassName(
         {
           key: 'key2',
@@ -191,9 +183,8 @@ describe('createGenerateClassNameHash', () => {
           },
         },
       ),
-      'classNamePrefix-key2-1q3ldtd',
-    );
-    assert.strictEqual(
+    ).to.equal('classNamePrefix-key2-1q3ldtd');
+    expect(
       generateClassName(
         {
           key: 'key2',
@@ -214,8 +205,7 @@ describe('createGenerateClassNameHash', () => {
           },
         },
       ),
-      'classNamePrefix-key2-b6l15m',
-    );
+    ).to.equal('classNamePrefix-key2-b6l15m');
   });
 
   describe('classNamePrefix', () => {
@@ -226,7 +216,7 @@ describe('createGenerateClassNameHash', () => {
         options: {},
       };
       const generateClassName2 = createGenerateClassNameHash();
-      assert.strictEqual(generateClassName2(rule, styleSheet), 'root-11u5x61');
+      expect(generateClassName2(rule, styleSheet)).to.equal('root-11u5x61');
     });
   });
 
@@ -257,7 +247,7 @@ describe('createGenerateClassNameHash', () => {
         options: {},
       };
       const generateClassName2 = createGenerateClassNameHash();
-      assert.strictEqual(generateClassName2(rule, styleSheet), 'jss11u5x61');
+      expect(generateClassName2(rule, styleSheet)).to.equal('jss11u5x61');
     });
   });
 });

--- a/packages/material-ui-styles/src/createStyles/createStyles.test.js
+++ b/packages/material-ui-styles/src/createStyles/createStyles.test.js
@@ -1,9 +1,9 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import createStyles from './createStyles';
 
 describe('createStyles', () => {
   it('is the identity function', () => {
     const styles = {};
-    assert.strictEqual(createStyles(styles), styles);
+    expect(createStyles(styles)).to.equal(styles);
   });
 });

--- a/packages/material-ui-styles/src/getThemeProps/getThemeProps.test.js
+++ b/packages/material-ui-styles/src/getThemeProps/getThemeProps.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import getThemeProps from './getThemeProps';
 
 describe('getThemeProps', () => {
@@ -8,7 +8,7 @@ describe('getThemeProps', () => {
       name: 'MuiFoo',
       props: {},
     });
-    assert.deepEqual(props, {});
+    expect(props).to.deep.equal({});
   });
 
   it('should ignore different component', () => {
@@ -23,7 +23,7 @@ describe('getThemeProps', () => {
       name: 'MuiFoo',
       props: {},
     });
-    assert.deepEqual(props, {});
+    expect(props).to.deep.equal({});
   });
 
   it('should return the props', () => {
@@ -38,7 +38,7 @@ describe('getThemeProps', () => {
       name: 'MuiFoo',
       props: {},
     });
-    assert.deepEqual(props, {
+    expect(props).to.deep.equal({
       disableRipple: true,
     });
   });

--- a/packages/material-ui-styles/src/makeStyles/multiKeyStore.test.js
+++ b/packages/material-ui-styles/src/makeStyles/multiKeyStore.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import multiKeyStore from './multiKeyStore';
 
 describe('multiKeyStore', () => {
@@ -6,10 +6,10 @@ describe('multiKeyStore', () => {
     const cache = new Map();
     const key1 = {};
     const key2 = {};
-    assert.strictEqual(multiKeyStore.get(cache, key1, key2), undefined);
+    expect(multiKeyStore.get(cache, key1, key2)).to.equal(undefined);
     multiKeyStore.set(cache, key1, key2, 'foo');
-    assert.strictEqual(multiKeyStore.get(cache, key1, key2), 'foo');
+    expect(multiKeyStore.get(cache, key1, key2)).to.equal('foo');
     multiKeyStore.delete(cache, key1, key2, 'foo');
-    assert.strictEqual(multiKeyStore.get(cache, key1, key2), undefined);
+    expect(multiKeyStore.get(cache, key1, key2)).to.equal(undefined);
   });
 });

--- a/packages/material-ui-styles/src/mergeClasses/mergeClasses.test.js
+++ b/packages/material-ui-styles/src/mergeClasses/mergeClasses.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import mergeClasses from './mergeClasses';
 
 describe('mergeClasses', () => {
@@ -11,7 +11,7 @@ describe('mergeClasses', () => {
         root: 'bar',
       },
     });
-    assert.deepEqual(output, {
+    expect(output).to.deep.equal({
       root: 'foo bar',
     });
   });

--- a/packages/material-ui-styles/src/styled/styled.test.js
+++ b/packages/material-ui-styles/src/styled/styled.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import styled from './styled';
 import { SheetsRegistry } from 'jss';
@@ -40,8 +40,8 @@ describe('styled', () => {
       </StylesProvider>,
     );
 
-    assert.strictEqual(sheetsRegistry.registry.length, 1);
-    assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'button-root-1' });
+    expect(sheetsRegistry.registry.length).to.equal(1);
+    expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'button-root-1' });
   });
 
   describe('prop: clone', () => {
@@ -56,15 +56,15 @@ describe('styled', () => {
     });
 
     it('should be able to pass props to cloned element', () => {
-      assert.strictEqual(wrapper.find('div').props()['data-test'], 'enzyme');
+      expect(wrapper.find('div').props()['data-test']).to.equal('enzyme');
     });
 
     it('should be able to clone the child element', () => {
-      assert.strictEqual(wrapper.getDOMNode().nodeName, 'DIV');
+      expect(wrapper.getDOMNode().nodeName).to.equal('DIV');
       wrapper.setProps({
         clone: false,
       });
-      assert.strictEqual(wrapper.getDOMNode().nodeName, 'BUTTON');
+      expect(wrapper.getDOMNode().nodeName).to.equal('BUTTON');
     });
   });
 
@@ -86,8 +86,8 @@ describe('styled', () => {
         Styled Components
       </StyledDiv>,
     );
-    assert.strictEqual(wrapper.find('div').props().color, undefined);
-    assert.strictEqual(wrapper.find('div').props()['data-test'], 'enzyme');
+    expect(wrapper.find('div').props().color).to.equal(undefined);
+    expect(wrapper.find('div').props()['data-test']).to.equal('enzyme');
   });
 
   describe('warnings', () => {
@@ -108,9 +108,8 @@ describe('styled', () => {
         'StyledButton',
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'You can not use the clone and component prop at the same time',
       );
     });

--- a/packages/material-ui-styles/src/useTheme/useTheme.test.js
+++ b/packages/material-ui-styles/src/useTheme/useTheme.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount } from '@material-ui/core/test-utils';
 import useTheme from './useTheme';
 import ThemeProvider from '../ThemeProvider';
@@ -29,6 +29,6 @@ describe('useTheme', () => {
         <Test />
       </ThemeProvider>,
     );
-    assert.strictEqual(text(), 'foo');
+    expect(text()).to.equal('foo');
   });
 });

--- a/packages/material-ui-styles/src/withStyles/withStyles.test.js
+++ b/packages/material-ui-styles/src/withStyles/withStyles.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { stub } from 'sinon';
@@ -34,15 +34,15 @@ describe('withStyles', () => {
     const Test = () => null;
     Test.someStatic = 'will not get hoisted';
     const TestWithStyles = withStyles({})(Test);
-    assert.strictEqual(TestWithStyles.someStatic, Test.someStatic);
+    expect(TestWithStyles.someStatic).to.equal(Test.someStatic);
   });
 
   it('hoists mui internals', () => {
-    assert.strictEqual(isMuiElement(<Input />, ['Input']), true);
+    expect(isMuiElement(<Input />, ['Input'])).to.equal(true);
     // the imported Input is decorated with @material-ui/core/styles
     const StyledInput = withStyles({})(Input);
 
-    assert.strictEqual(isMuiElement(<StyledInput />, ['Input']), true);
+    expect(isMuiElement(<StyledInput />, ['Input'])).to.equal(true);
   });
 
   describe('refs', () => {
@@ -67,7 +67,7 @@ describe('withStyles', () => {
 
       const ref = React.createRef();
       mount(<StyledTarget ref={ref} />);
-      assert.strictEqual(ref.current.nodeName, 'DIV');
+      expect(ref.current.nodeName).to.equal('DIV');
     });
 
     // describe('innerRef', () => {
@@ -105,7 +105,7 @@ describe('withStyles', () => {
     };
     const StyledComponent = withStyles({})(Test);
     const wrapper = mount(<StyledComponent foo="bar" />);
-    assert.strictEqual(wrapper.text(), 'bar');
+    expect(wrapper.text()).to.equal('bar');
   });
 
   it('should work with no theme', () => {
@@ -115,7 +115,7 @@ describe('withStyles', () => {
     };
     const StyledComponent = withStyles({}, { name: 'Foo' })(Test);
     const wrapper = mount(<StyledComponent foo="bar" />);
-    assert.strictEqual(wrapper.text(), 'bar');
+    expect(wrapper.text()).to.equal('bar');
   });
 
   describe('integration', () => {
@@ -136,17 +136,17 @@ describe('withStyles', () => {
           </StylesProvider>
         </ThemeProvider>,
       );
-      assert.strictEqual(sheetsRegistry.registry.length, 1);
-      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Empty-root-1' });
+      expect(sheetsRegistry.registry.length).to.equal(1);
+      expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'Empty-root-1' });
       wrapper.update();
-      assert.strictEqual(sheetsRegistry.registry.length, 1);
-      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Empty-root-1' });
+      expect(sheetsRegistry.registry.length).to.equal(1);
+      expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'Empty-root-1' });
       wrapper.setProps({ theme: createMuiTheme() });
-      assert.strictEqual(sheetsRegistry.registry.length, 1);
-      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'Empty-root-2' });
+      expect(sheetsRegistry.registry.length).to.equal(1);
+      expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'Empty-root-2' });
 
       wrapper.unmount();
-      assert.strictEqual(sheetsRegistry.registry.length, 0);
+      expect(sheetsRegistry.registry.length).to.equal(0);
     });
 
     it('should supply correct props to jss callbacks', () => {
@@ -160,13 +160,12 @@ describe('withStyles', () => {
       const StyledComponent = withStyles(styles)(MyComp);
       mount(<StyledComponent mySuppliedProp={222} />);
 
-      assert.strictEqual(
+      expect(
         jssCallbackStub.calledWith({
           myDefaultProp: 111,
           mySuppliedProp: 222,
         }),
-        true,
-      );
+      ).to.equal(true);
     });
 
     it('should support theme.props', () => {
@@ -187,7 +186,7 @@ describe('withStyles', () => {
         </ThemeProvider>,
       );
 
-      assert.strictEqual(wrapper.find(Empty).props().foo, 'bar');
+      expect(wrapper.find(Empty).props().foo).to.equal('bar');
       wrapper.unmount();
     });
 
@@ -214,7 +213,7 @@ describe('withStyles', () => {
         </ThemeProvider>,
       );
 
-      assert.strictEqual(wrapper.find(MuiFoo).props().foo, 'bar');
+      expect(wrapper.find(MuiFoo).props().foo).to.equal('bar');
       wrapper.unmount();
     });
 
@@ -229,11 +228,11 @@ describe('withStyles', () => {
           </StylesProvider>
         </ThemeProvider>,
       );
-      assert.strictEqual(sheetsRegistry.registry.length, 1);
-      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root' });
+      expect(sheetsRegistry.registry.length).to.equal(1);
+      expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'MuiTextField-root' });
       wrapper.setProps({ theme: createMuiTheme({ foo: 'bar' }) });
-      assert.strictEqual(sheetsRegistry.registry.length, 1);
-      assert.deepEqual(sheetsRegistry.registry[0].classes, { root: 'MuiTextField-root' });
+      expect(sheetsRegistry.registry.length).to.equal(1);
+      expect(sheetsRegistry.registry[0].classes).to.deep.equal({ root: 'MuiTextField-root' });
     });
 
     it('should support the overrides key', () => {
@@ -258,8 +257,8 @@ describe('withStyles', () => {
         </ThemeProvider>,
       );
 
-      assert.strictEqual(sheetsRegistry.registry.length, 1);
-      assert.deepEqual(sheetsRegistry.registry[0].rules.raw, { root: { padding: 9 } });
+      expect(sheetsRegistry.registry.length).to.equal(1);
+      expect(sheetsRegistry.registry[0].rules.raw).to.deep.equal({ root: { padding: 9 } });
     });
 
     describe('options: disableGeneration', () => {
@@ -272,10 +271,10 @@ describe('withStyles', () => {
             <StyledComponent />
           </StylesProvider>,
         );
-        assert.strictEqual(sheetsRegistry.registry.length, 0);
-        assert.deepEqual(wrapper.find(Empty).props().classes, {});
+        expect(sheetsRegistry.registry.length).to.equal(0);
+        expect(wrapper.find(Empty).props().classes).to.deep.equal({});
         wrapper.unmount();
-        assert.strictEqual(sheetsRegistry.registry.length, 0);
+        expect(sheetsRegistry.registry.length).to.equal(0);
       });
     });
   });
@@ -299,18 +298,17 @@ describe('withStyles', () => {
           <StyledComponent3 />
         </StylesProvider>,
       );
-      assert.strictEqual(sheetsRegistry.registry[0].options.classNamePrefix, 'a');
-      assert.strictEqual(sheetsRegistry.registry[0].options.name, undefined);
-      assert.strictEqual(sheetsRegistry.registry[1].options.classNamePrefix, 'fooo');
-      assert.strictEqual(sheetsRegistry.registry[1].options.name, undefined);
-      assert.strictEqual(sheetsRegistry.registry[2].options.classNamePrefix, 'AppLayout');
-      assert.strictEqual(sheetsRegistry.registry[2].options.name, 'AppLayout');
+      expect(sheetsRegistry.registry[0].options.classNamePrefix).to.equal('a');
+      expect(sheetsRegistry.registry[0].options.name).to.equal(undefined);
+      expect(sheetsRegistry.registry[1].options.classNamePrefix).to.equal('fooo');
+      expect(sheetsRegistry.registry[1].options.name).to.equal(undefined);
+      expect(sheetsRegistry.registry[2].options.classNamePrefix).to.equal('AppLayout');
+      expect(sheetsRegistry.registry[2].options.name).to.equal('AppLayout');
     });
   });
 
   it('should throw is the import is invalid', () => {
-    assert.throw(
-      () => withStyles({})(undefined),
+    expect(() => withStyles({})(undefined)).to.throw(
       'You are calling withStyles(styles)(Component) with an undefined component',
     );
   });
@@ -327,7 +325,7 @@ describe('withStyles', () => {
           <StyledComponent />
         </ThemeProvider>,
       );
-      assert.strictEqual(wrapper.find('option').props().theme, theme);
+      expect(wrapper.find('option').props().theme).to.equal(theme);
     });
   });
 });

--- a/packages/material-ui-styles/src/withTheme/withTheme.test.js
+++ b/packages/material-ui-styles/src/withTheme/withTheme.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import { createMount } from '@material-ui/core/test-utils';
 import { Input } from '@material-ui/core';
 import { isMuiElement } from '@material-ui/core/utils';
@@ -37,22 +37,22 @@ describe('withTheme', () => {
         <TestWithTheme />
       </ThemeProvider>,
     );
-    assert.strictEqual(text(), 'foo');
+    expect(text()).to.equal('foo');
   });
 
   it('hoist statics', () => {
     const Test = () => null;
     Test.someStatic = 'will not get hoisted';
     const TestWithTheme = withTheme(Test);
-    assert.strictEqual(TestWithTheme.someStatic, Test.someStatic);
+    expect(TestWithTheme.someStatic).to.equal(Test.someStatic);
   });
 
   it('hoists mui internals', () => {
-    assert.strictEqual(isMuiElement(<Input />, ['Input']), true);
+    expect(isMuiElement(<Input />, ['Input'])).to.equal(true);
 
     const ThemedInput = withTheme(Input);
 
-    assert.strictEqual(isMuiElement(<ThemedInput />, ['Input']), true);
+    expect(isMuiElement(<ThemedInput />, ['Input'])).to.equal(true);
   });
 
   describe('refs', () => {
@@ -79,7 +79,7 @@ describe('withTheme', () => {
       const ref = React.createRef();
       mount(<ThemedTarget ref={ref} />);
 
-      assert.strictEqual(ref.current.nodeName, 'DIV');
+      expect(ref.current.nodeName).to.equal('DIV');
     });
 
     describe('innerRef', () => {
@@ -101,9 +101,8 @@ describe('withTheme', () => {
           'ThemedDiv',
         );
 
-        assert.strictEqual(consoleErrorMock.callCount(), 1);
-        assert.include(
-          consoleErrorMock.messages()[0],
+        expect(consoleErrorMock.callCount()).to.equal(1);
+        expect(consoleErrorMock.messages()[0]).to.include(
           'Warning: Failed prop type: Material-UI: the `innerRef` prop is deprecated',
         );
       });
@@ -111,8 +110,7 @@ describe('withTheme', () => {
   });
 
   it('should throw is the import is invalid', () => {
-    assert.throw(
-      () => withTheme(undefined),
+    expect(() => withTheme(undefined)).to.throw(
       'You are calling withTheme(Component) with an undefined component',
     );
   });

--- a/packages/material-ui-system/src/breakpoints.test.js
+++ b/packages/material-ui-system/src/breakpoints.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import breakpoints from './breakpoints';
 import style from './style';
 
@@ -11,8 +11,8 @@ describe('breakpoints', () => {
   it('should work', () => {
     const palette = breakpoints(textColor);
 
-    assert.strictEqual(palette.filterProps.length, 6);
-    assert.deepEqual(
+    expect(palette.filterProps.length).to.equal(6);
+    expect(
       palette({
         theme: {},
         color: 'red',
@@ -20,12 +20,11 @@ describe('breakpoints', () => {
           color: 'blue',
         },
       }),
-      {
-        color: 'red',
-        '@media (min-width:600px)': {
-          color: 'blue',
-        },
+    ).to.deep.equal({
+      color: 'red',
+      '@media (min-width:600px)': {
+        color: 'blue',
       },
-    );
+    });
   });
 });

--- a/packages/material-ui-system/src/compose.test.js
+++ b/packages/material-ui-system/src/compose.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import compose from './compose';
 import style from './style';
 
@@ -17,17 +17,16 @@ describe('compose', () => {
   it('should compose', () => {
     const palette = compose(textColor, bgcolor);
 
-    assert.strictEqual(palette.filterProps.length, 2);
-    assert.deepEqual(
+    expect(palette.filterProps.length).to.equal(2);
+    expect(
       palette({
         theme: {},
         color: 'red',
         bgcolor: 'gree',
       }),
-      {
-        backgroundColor: 'gree',
-        color: 'red',
-      },
-    );
+    ).to.deep.equal({
+      backgroundColor: 'gree',
+      color: 'red',
+    });
   });
 });

--- a/packages/material-ui-system/src/css.test.js
+++ b/packages/material-ui-system/src/css.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import css from './css';
 import style from './style';
 
@@ -11,8 +11,8 @@ describe('css', () => {
   it('should work', () => {
     const palette = css(textColor);
 
-    assert.strictEqual(palette.filterProps.length, 2);
-    assert.deepEqual(
+    expect(palette.filterProps.length).to.equal(2);
+    expect(
       palette({
         theme: {},
         css: {
@@ -20,10 +20,9 @@ describe('css', () => {
           padding: 10,
         },
       }),
-      {
-        padding: 10,
-        color: 'red',
-      },
-    );
+    ).to.deep.equal({
+      padding: 10,
+      color: 'red',
+    });
   });
 });

--- a/packages/material-ui-system/src/merge.test.js
+++ b/packages/material-ui-system/src/merge.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import merge from './merge';
 
 describe('merge', () => {
@@ -17,7 +17,7 @@ describe('merge', () => {
         },
       },
     );
-    assert.deepEqual(output, {
+    expect(output).to.deep.equal({
       '@media (min-width:600px)': {
         margin: 16,
         padding: 8,
@@ -40,7 +40,7 @@ describe('merge', () => {
         },
       },
     );
-    assert.deepEqual(output, {
+    expect(output).to.deep.equal({
       '@media (min-width:600px)': {
         padding: 8,
       },

--- a/packages/material-ui-system/src/spacing.test.js
+++ b/packages/material-ui-system/src/spacing.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import spacing from './spacing';
 
@@ -9,7 +9,7 @@ describe('spacing', () => {
         theme: {},
         p: 1,
       });
-      assert.deepEqual(output, { padding: 8 });
+      expect(output).to.deep.equal({ padding: 8 });
     });
 
     it('should be able to customize the unit value', () => {
@@ -19,7 +19,7 @@ describe('spacing', () => {
         },
         p: 2,
       });
-      assert.deepEqual(output1, { padding: 4 });
+      expect(output1).to.deep.equal({ padding: 4 });
 
       const output2 = spacing({
         theme: {
@@ -27,7 +27,7 @@ describe('spacing', () => {
         },
         p: 1,
       });
-      assert.deepEqual(output2, { padding: 3 });
+      expect(output2).to.deep.equal({ padding: 3 });
 
       const output3 = spacing({
         theme: {
@@ -35,7 +35,7 @@ describe('spacing', () => {
         },
         p: 2,
       });
-      assert.deepEqual(output3, { padding: 4 });
+      expect(output3).to.deep.equal({ padding: 4 });
     });
   });
 
@@ -55,11 +55,13 @@ describe('spacing', () => {
         },
         p: 3,
       });
-      assert.deepEqual(output, { padding: undefined });
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.match(consoleErrorMock.messages()[0], /the value provided \(3\) overflows\./);
-      assert.match(consoleErrorMock.messages()[0], /The supported values are: \[0,3,5\]\./);
-      assert.match(consoleErrorMock.messages()[0], /3 > 2, you need to add the missing values\./);
+      expect(output).to.deep.equal({ padding: undefined });
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.match(/the value provided \(3\) overflows\./);
+      expect(consoleErrorMock.messages()[0]).to.match(/The supported values are: \[0,3,5\]\./);
+      expect(consoleErrorMock.messages()[0]).to.match(
+        /3 > 2, you need to add the missing values\./,
+      );
     });
 
     it('should warn if the theme transformer is invalid', () => {
@@ -69,14 +71,12 @@ describe('spacing', () => {
         },
         p: 3,
       });
-      assert.deepEqual(output, { padding: undefined });
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.match(
-        consoleErrorMock.messages()[0],
+      expect(output).to.deep.equal({ padding: undefined });
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.match(
         /the `theme.spacing` value \(\[object Object\]\) is invalid\./,
       );
-      assert.match(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.messages()[0]).to.match(
         /It should be a number, an array or a function\./,
       );
     });
@@ -87,7 +87,7 @@ describe('spacing', () => {
       theme: {},
       p: -1,
     });
-    assert.deepEqual(output, { padding: -8 });
+    expect(output).to.deep.equal({ padding: -8 });
   });
 
   it('should support composes values', () => {
@@ -95,7 +95,7 @@ describe('spacing', () => {
       theme: {},
       px: 1,
     });
-    assert.deepEqual(output, {
+    expect(output).to.deep.equal({
       paddingLeft: 8,
       paddingRight: 8,
     });
@@ -108,7 +108,7 @@ describe('spacing', () => {
       },
       p: -1,
     });
-    assert.deepEqual(output, { padding: '-2em' });
+    expect(output).to.deep.equal({ padding: '-2em' });
   });
 
   it('should support breakpoints', () => {
@@ -116,7 +116,7 @@ describe('spacing', () => {
       theme: {},
       p: [1, 2],
     });
-    assert.deepEqual(output1, {
+    expect(output1).to.deep.equal({
       '@media (min-width:0px)': {
         padding: 8,
       },
@@ -132,7 +132,7 @@ describe('spacing', () => {
         sm: 2,
       },
     });
-    assert.deepEqual(output2, {
+    expect(output2).to.deep.equal({
       '@media (min-width:0px)': {
         padding: 8,
       },
@@ -161,14 +161,14 @@ describe('spacing', () => {
       theme: {},
       paddingTop: 1,
     });
-    assert.deepEqual(output1, {
+    expect(output1).to.deep.equal({
       paddingTop: 8,
     });
     const output2 = spacing({
       theme: {},
       paddingY: 1,
     });
-    assert.deepEqual(output2, {
+    expect(output2).to.deep.equal({
       paddingBottom: 8,
       paddingTop: 8,
     });
@@ -179,7 +179,7 @@ describe('spacing', () => {
       theme: {},
       pt: '10px',
     });
-    assert.deepEqual(output, {
+    expect(output).to.deep.equal({
       paddingTop: '10px',
     });
   });

--- a/packages/material-ui-system/src/style.test.js
+++ b/packages/material-ui-system/src/style.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import style from './style';
 
 describe('style', () => {
@@ -13,7 +13,7 @@ describe('style', () => {
       theme: {},
       bgcolor: 'blue',
     });
-    assert.deepEqual(output, {
+    expect(output).to.deep.equal({
       backgroundColor: 'blue',
     });
   });
@@ -23,7 +23,7 @@ describe('style', () => {
       theme: {},
       bgcolor: ['blue', 'red'],
     });
-    assert.deepEqual(output1, {
+    expect(output1).to.deep.equal({
       '@media (min-width:0px)': {
         backgroundColor: 'blue',
       },
@@ -39,7 +39,7 @@ describe('style', () => {
         sm: 'red',
       },
     });
-    assert.deepEqual(output2, {
+    expect(output2).to.deep.equal({
       '@media (min-width:0px)': {
         backgroundColor: 'blue',
       },
@@ -76,7 +76,7 @@ describe('style', () => {
       boxShadow: 1,
     });
 
-    assert.deepEqual(output, {
+    expect(output).to.deep.equal({
       boxShadow: '0px 1px 3px 0px rgba(0, 0, 0, 0.2)',
     });
   });
@@ -89,7 +89,7 @@ describe('style', () => {
       boxShadow: '0px 1px 3px 0px rgba(0, 0, 0, 0.2)',
     });
 
-    assert.deepEqual(output, {
+    expect(output).to.deep.equal({
       boxShadow: '0px 1px 3px 0px rgba(0, 0, 0, 0.2)',
     });
   });
@@ -105,7 +105,7 @@ describe('style', () => {
       theme: {},
       border: 1,
     });
-    assert.deepEqual(output1, {
+    expect(output1).to.deep.equal({
       border: '1px solid',
     });
 
@@ -117,7 +117,7 @@ describe('style', () => {
       },
       border: 'small',
     });
-    assert.deepEqual(output2, {
+    expect(output2).to.deep.equal({
       border: '2px solid',
     });
 
@@ -127,7 +127,7 @@ describe('style', () => {
       },
       border: 2,
     });
-    assert.deepEqual(output3, {
+    expect(output3).to.deep.equal({
       border: '4px solid',
     });
   });

--- a/packages/material-ui-utils/src/chainPropTypes.test.js
+++ b/packages/material-ui-utils/src/chainPropTypes.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import chainPropTypes from './chainPropTypes';
@@ -19,7 +19,7 @@ describe('chainPropTypes', () => {
   });
 
   it('should have the right shape', () => {
-    assert.strictEqual(typeof chainPropTypes, 'function');
+    expect(typeof chainPropTypes).to.equal('function');
   });
 
   it('should return null for supported props', () => {
@@ -31,7 +31,7 @@ describe('chainPropTypes', () => {
       location,
       componentName,
     );
-    assert.strictEqual(consoleErrorMock.callCount(), 0);
+    expect(consoleErrorMock.callCount()).to.equal(0);
   });
 
   it('should return an error for unsupported props', () => {
@@ -43,7 +43,7 @@ describe('chainPropTypes', () => {
       location,
       componentName,
     );
-    assert.strictEqual(consoleErrorMock.callCount(), 1);
-    assert.match(consoleErrorMock.messages()[0], /something is wrong/);
+    expect(consoleErrorMock.callCount()).to.equal(1);
+    expect(consoleErrorMock.messages()[0]).to.match(/something is wrong/);
   });
 });

--- a/packages/material-ui-utils/src/elementAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementAcceptingRef.test.js
@@ -52,7 +52,10 @@ describe('elementAcceptingRef', () => {
         );
       }
 
-      expect(consoleErrorMock.callCount()).to.equal(failsOnMount ? 1 : 0);
+      expect(consoleErrorMock.callCount()).to.equal(
+        failsOnMount ? 1 : 0,
+        `but got '${consoleErrorMock.messages()[0]}'`,
+      );
     }
 
     before(() => {

--- a/packages/material-ui-utils/src/elementAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementAcceptingRef.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prefer-stateless-function */
-import { assert } from 'chai';
+import { expect } from 'chai';
 import * as PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -52,11 +52,7 @@ describe('elementAcceptingRef', () => {
         );
       }
 
-      assert.strictEqual(
-        consoleErrorMock.callCount(),
-        failsOnMount ? 1 : 0,
-        `but got '${consoleErrorMock.messages()[0]}'`,
-      );
+      expect(consoleErrorMock.callCount()).to.equal(failsOnMount ? 1 : 0);
     }
 
     before(() => {
@@ -132,9 +128,8 @@ describe('elementAcceptingRef', () => {
     function assertFail(Component, hint) {
       checkPropType(Component);
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Invalid props `children` supplied to `DummyComponent`. ' +
           `Expected an element that can hold a ref. ${hint}`,
       );
@@ -142,14 +137,14 @@ describe('elementAcceptingRef', () => {
 
     it('rejects undefined values when required', () => {
       checkPropType(undefined, true);
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.messages()[0], 'marked as required');
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include('marked as required');
     });
 
     it('rejects null values when required', () => {
       checkPropType(null, true);
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.messages()[0], 'marked as required');
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include('marked as required');
     });
 
     it('rejects function components', () => {

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable react/prefer-stateless-function */
-import { assert } from 'chai';
+import { expect } from 'chai';
 import * as PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -52,11 +52,7 @@ describe('elementTypeAcceptingRef', () => {
         );
       }
 
-      assert.strictEqual(
-        consoleErrorMock.callCount(),
-        failsOnMount ? 1 : 0,
-        `but got '${consoleErrorMock.messages()[0]}'`,
-      );
+      expect(consoleErrorMock.callCount()).to.equal(failsOnMount ? 1 : 0);
     }
 
     before(() => {
@@ -132,9 +128,8 @@ describe('elementTypeAcceptingRef', () => {
     function assertFail(Component, hint) {
       checkPropType(Component);
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Invalid props `component` supplied to `DummyComponent`. ' +
           `Expected an element type that can hold a ref. ${hint}`,
       );

--- a/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
+++ b/packages/material-ui-utils/src/elementTypeAcceptingRef.test.js
@@ -52,7 +52,10 @@ describe('elementTypeAcceptingRef', () => {
         );
       }
 
-      expect(consoleErrorMock.callCount()).to.equal(failsOnMount ? 1 : 0);
+      expect(consoleErrorMock.callCount()).to.equal(
+        failsOnMount ? 1 : 0,
+        `but got '${consoleErrorMock.messages()[0]}'`,
+      );
     }
 
     before(() => {

--- a/packages/material-ui-utils/src/exactProp.test.js
+++ b/packages/material-ui-utils/src/exactProp.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import exactProp, { specialProperty } from './exactProp';
 
 describe('exactProp()', () => {
@@ -11,8 +11,8 @@ describe('exactProp()', () => {
   });
 
   it('should have the right shape', () => {
-    assert.strictEqual(typeof exactProp, 'function');
-    assert.strictEqual(typeof exactPropTypes, 'object');
+    expect(typeof exactProp).to.equal('function');
+    expect(typeof exactPropTypes).to.equal('object');
   });
 
   describe('exactPropTypes', () => {
@@ -21,7 +21,7 @@ describe('exactProp()', () => {
         bar: false,
       };
       const result = exactPropTypes[specialProperty](props);
-      assert.strictEqual(result, null);
+      expect(result).to.equal(null);
     });
 
     it('should return an error for unsupported props', () => {
@@ -29,8 +29,7 @@ describe('exactProp()', () => {
         foo: true,
       };
       const result = exactPropTypes[specialProperty](props);
-      assert.match(
-        result.message,
+      expect(result.message).to.match(
         /The following props are not supported: `foo`. Please remove them/,
       );
     });

--- a/packages/material-ui-utils/src/getDisplayName.test.js
+++ b/packages/material-ui-utils/src/getDisplayName.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prefer-stateless-function */
 import React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import getDisplayName, { getFunctionName } from './getDisplayName';
 
 describe('utils/getDisplayName.js', () => {
@@ -48,24 +48,21 @@ describe('utils/getDisplayName.js', () => {
       const NamedMemoComponent = React.memo((props, ref) => <div {...props} ref={ref} />);
       NamedMemoComponent.displayName = 'Div';
 
-      assert.strictEqual(getDisplayName(SomeComponent), 'SomeComponent');
-      assert.strictEqual(getDisplayName(SomeOtherComponent), 'CustomDisplayName');
-      assert.strictEqual(getDisplayName(YetAnotherComponent), 'YetAnotherComponent');
-      assert.strictEqual(getDisplayName(AndAnotherComponent), 'AndAnotherComponent');
-      assert.strictEqual(
-        getDisplayName(() => <div />),
-        'Component',
-      );
-      assert.strictEqual(getDisplayName('div'), 'div');
-      assert.strictEqual(getDisplayName(AnonymousForwardRefComponent), 'ForwardRef');
-      assert.strictEqual(getDisplayName(ForwardRefComponent), 'ForwardRef(Div)');
-      assert.strictEqual(getDisplayName(NamedForwardRefComponent), 'Div');
-      assert.strictEqual(getDisplayName(AnonymousMemoComponent), 'memo');
-      assert.strictEqual(getDisplayName(MemoComponent), 'memo(Div)');
-      assert.strictEqual(getDisplayName(NamedMemoComponent), 'Div');
-      assert.strictEqual(getDisplayName(), undefined);
-      assert.strictEqual(getDisplayName({}), undefined);
-      assert.strictEqual(getDisplayName(false), undefined);
+      expect(getDisplayName(SomeComponent)).to.equal('SomeComponent');
+      expect(getDisplayName(SomeOtherComponent)).to.equal('CustomDisplayName');
+      expect(getDisplayName(YetAnotherComponent)).to.equal('YetAnotherComponent');
+      expect(getDisplayName(AndAnotherComponent)).to.equal('AndAnotherComponent');
+      expect(getDisplayName(() => <div />)).to.equal('Component');
+      expect(getDisplayName('div')).to.equal('div');
+      expect(getDisplayName(AnonymousForwardRefComponent)).to.equal('ForwardRef');
+      expect(getDisplayName(ForwardRefComponent)).to.equal('ForwardRef(Div)');
+      expect(getDisplayName(NamedForwardRefComponent)).to.equal('Div');
+      expect(getDisplayName(AnonymousMemoComponent)).to.equal('memo');
+      expect(getDisplayName(MemoComponent)).to.equal('memo(Div)');
+      expect(getDisplayName(NamedMemoComponent)).to.equal('Div');
+      expect(getDisplayName()).to.equal(undefined);
+      expect(getDisplayName({})).to.equal(undefined);
+      expect(getDisplayName(false)).to.equal(undefined);
     });
   });
 
@@ -77,8 +74,8 @@ describe('utils/getDisplayName.js', () => {
 
       const SomeOtherFunction = () => <div />;
 
-      assert.strictEqual(getFunctionName(SomeFunction), 'SomeFunction');
-      assert.strictEqual(getFunctionName(SomeOtherFunction), 'SomeOtherFunction');
+      expect(getFunctionName(SomeFunction)).to.equal('SomeFunction');
+      expect(getFunctionName(SomeOtherFunction)).to.equal('SomeOtherFunction');
     });
   });
 });

--- a/packages/material-ui/src/Backdrop/Backdrop.test.js
+++ b/packages/material-ui/src/Backdrop/Backdrop.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Backdrop from './Backdrop';
@@ -37,6 +37,6 @@ describe('<Backdrop />', () => {
         <h1>Hello World</h1>
       </Backdrop>,
     );
-    assert.strictEqual(wrapper.contains(<h1>Hello World</h1>), true);
+    expect(wrapper.contains(<h1>Hello World</h1>)).to.equal(true);
   });
 });

--- a/packages/material-ui/src/ButtonBase/Ripple.test.js
+++ b/packages/material-ui/src/ButtonBase/Ripple.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { getClasses } from '@material-ui/core/test-utils';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -116,16 +116,16 @@ describe('<Ripple />', () => {
     it('handleExit should trigger a timer', () => {
       wrapper.setProps({ in: false });
       clock.tick(549);
-      assert.strictEqual(callbackSpy.callCount, 0);
+      expect(callbackSpy.callCount).to.equal(0);
       clock.tick(1);
-      assert.strictEqual(callbackSpy.callCount, 1);
+      expect(callbackSpy.callCount).to.equal(1);
     });
 
     it('unmount should defuse the handleExit timer', () => {
       wrapper.setProps({ in: false });
       wrapper.unmount();
       clock.tick(550);
-      assert.strictEqual(callbackSpy.callCount, 0);
+      expect(callbackSpy.callCount).to.equal(0);
     });
   });
 });

--- a/packages/material-ui/src/CircularProgress/CircularProgress.test.js
+++ b/packages/material-ui/src/CircularProgress/CircularProgress.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import CircularProgress from './CircularProgress';
@@ -29,117 +29,105 @@ describe('<CircularProgress />', () => {
 
   it('should render with the primary color by default', () => {
     const wrapper = shallow(<CircularProgress />);
-    assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
+    expect(wrapper.hasClass(classes.colorPrimary)).to.equal(true);
   });
 
   it('should render with the primary color', () => {
     const wrapper = shallow(<CircularProgress color="primary" />);
-    assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
+    expect(wrapper.hasClass(classes.colorPrimary)).to.equal(true);
   });
 
   it('should render with the secondary color', () => {
     const wrapper = shallow(<CircularProgress color="secondary" />);
-    assert.strictEqual(wrapper.hasClass(classes.colorSecondary), true);
+    expect(wrapper.hasClass(classes.colorSecondary)).to.equal(true);
   });
 
   it('should contain an SVG with the svg class, and a circle with the circle class', () => {
     const wrapper = shallow(<CircularProgress />);
     const svg = wrapper.childAt(0);
-    assert.strictEqual(svg.name(), 'svg');
-    assert.strictEqual(wrapper.hasClass(classes.indeterminate), true);
-    assert.strictEqual(svg.childAt(0).name(), 'circle', 'should be a circle');
-    assert.strictEqual(
-      svg.childAt(0).hasClass(classes.circle),
-      true,
-      'should have the circle class',
-    );
+    expect(svg.name()).to.equal('svg');
+    expect(wrapper.hasClass(classes.indeterminate)).to.equal(true);
+    expect(svg.childAt(0).name()).to.equal('circle');
+    expect(svg.childAt(0).hasClass(classes.circle)).to.equal(true);
   });
 
   it('should render intermediate variant by default', () => {
     const wrapper = shallow(<CircularProgress />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
     const svg = wrapper.childAt(0);
-    assert.strictEqual(
-      svg.childAt(0).hasClass(classes.circleIndeterminate),
-      true,
-      'should have the circleIndeterminate class',
-    );
+    expect(svg.childAt(0).hasClass(classes.circleIndeterminate)).to.equal(true);
   });
 
   it('should render with a different size', () => {
     const wrapper = shallow(<CircularProgress size={60} />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.props().style.width, 60, 'should have width correctly set');
-    assert.strictEqual(wrapper.props().style.height, 60, 'should have width correctly set');
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.props().style.width).to.equal(60);
+    expect(wrapper.props().style.height).to.equal(60);
     const svg = wrapper.childAt(0);
-    assert.strictEqual(svg.name(), 'svg');
-    assert.strictEqual(svg.childAt(0).name(), 'circle');
-    assert.strictEqual(svg.childAt(0).props().cx, 44, 'should have cx correctly set');
-    assert.strictEqual(svg.childAt(0).props().cy, 44, 'should have cx correctly set');
+    expect(svg.name()).to.equal('svg');
+    expect(svg.childAt(0).name()).to.equal('circle');
+    expect(svg.childAt(0).props().cx).to.equal(44);
+    expect(svg.childAt(0).props().cy).to.equal(44);
   });
 
   describe('prop: variant="static', () => {
     it('should set strokeDasharray of circle', () => {
       const wrapper = shallow(<CircularProgress variant="static" value={70} />);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
       const svg = wrapper.childAt(0);
       const style = svg.childAt(0).props().style;
-      assert.strictEqual(style.strokeDasharray, '126.920', 'should have strokeDasharray set');
-      assert.strictEqual(style.strokeDashoffset, '38.076px', 'should have strokeDashoffset set');
-      assert.strictEqual(wrapper.props()['aria-valuenow'], 70);
+      expect(style.strokeDasharray).to.equal('126.920');
+      expect(style.strokeDashoffset).to.equal('38.076px');
+      expect(wrapper.props()['aria-valuenow']).to.equal(70);
     });
   });
 
   describe('prop: variant="determinate"', () => {
     it('should render with determinate classes', () => {
       const wrapper = shallow(<CircularProgress variant="determinate" />);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
       const svg = wrapper.childAt(0);
-      assert.strictEqual(svg.name(), 'svg');
-      assert.strictEqual(
-        svg.hasClass(classes.svgIndeterminate),
-        false,
-        'should not have the svgIndeterminate class',
-      );
+      expect(svg.name()).to.equal('svg');
+      expect(svg.hasClass(classes.svgIndeterminate)).to.equal(false);
     });
 
     it('should set strokeDasharray of circle', () => {
       const wrapper = shallow(<CircularProgress variant="determinate" value={70} />);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
       const svg = wrapper.childAt(0);
       const style = svg.childAt(0).props().style;
-      assert.strictEqual(style.strokeDasharray, '126.920');
-      assert.strictEqual(style.strokeDashoffset, '11.423px');
-      assert.strictEqual(wrapper.props()['aria-valuenow'], 70);
+      expect(style.strokeDasharray).to.equal('126.920');
+      expect(style.strokeDashoffset).to.equal('11.423px');
+      expect(wrapper.props()['aria-valuenow']).to.equal(70);
     });
   });
 
   describe('prop: disableShrink ', () => {
     it('should default to false', () => {
       const wrapper = shallow(<CircularProgress variant="indeterminate" />);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
       const svg = wrapper.childAt(0);
       const circle = svg.childAt(0);
-      assert.strictEqual(circle.name(), 'circle');
-      assert.strictEqual(circle.hasClass(classes.circleDisableShrink), false);
+      expect(circle.name()).to.equal('circle');
+      expect(circle.hasClass(classes.circleDisableShrink)).to.equal(false);
     });
 
     it('should render without disableShrink class when set to false', () => {
       const wrapper = shallow(<CircularProgress variant="indeterminate" disableShrink={false} />);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
       const svg = wrapper.childAt(0);
       const circle = svg.childAt(0);
-      assert.strictEqual(circle.name(), 'circle');
-      assert.strictEqual(circle.hasClass(classes.circleDisableShrink), false);
+      expect(circle.name()).to.equal('circle');
+      expect(circle.hasClass(classes.circleDisableShrink)).to.equal(false);
     });
 
     it('should render with disableShrink class when set to true', () => {
       const wrapper = shallow(<CircularProgress variant="indeterminate" disableShrink />);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
       const svg = wrapper.childAt(0);
       const circle = svg.childAt(0);
-      assert.strictEqual(circle.name(), 'circle');
-      assert.strictEqual(circle.hasClass(classes.circleDisableShrink), true);
+      expect(circle.name()).to.equal('circle');
+      expect(circle.hasClass(classes.circleDisableShrink)).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/Collapse/Collapse.test.js
+++ b/packages/material-ui/src/Collapse/Collapse.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
@@ -36,17 +36,17 @@ describe('<Collapse />', () => {
   it('should render a container around the wrapper', () => {
     const wrapper = mount(<Collapse {...defaultProps} classes={{ container: 'woofCollapse1' }} />);
     const child = wrapper.find('Transition').childAt(0);
-    assert.strictEqual(child.name(), 'div');
-    assert.strictEqual(child.hasClass(classes.container), true);
-    assert.strictEqual(child.hasClass('woofCollapse1'), true);
+    expect(child.name()).to.equal('div');
+    expect(child.hasClass(classes.container)).to.equal(true);
+    expect(child.hasClass('woofCollapse1')).to.equal(true);
   });
 
   it('should render a wrapper around the children', () => {
     const children = <h1>Hello</h1>;
     const wrapper = mount(<Collapse {...defaultProps}>{children}</Collapse>);
     const child = wrapper.find('Transition').childAt(0);
-    assert.strictEqual(child.childAt(0).name(), 'div');
-    assert.strictEqual(child.childAt(0).childAt(0).children().type(), 'h1');
+    expect(child.childAt(0).name()).to.equal('div');
+    expect(child.childAt(0).childAt(0).children().type()).to.equal('h1');
   });
 
   describe('transition lifecycle', () => {
@@ -107,36 +107,36 @@ describe('<Collapse />', () => {
 
       describe('handleEnter()', () => {
         it('should set element height to 0 initially', () => {
-          assert.strictEqual(nodeEnterHeightStyle, '0px');
+          expect(nodeEnterHeightStyle).to.equal('0px');
         });
 
         it('should call handleEnter', () => {
-          assert.strictEqual(handleEnter.args[0][0], container.instance());
-          assert.strictEqual(handleEnter.args[0][1], false);
+          expect(handleEnter.args[0][0]).to.equal(container.instance());
+          expect(handleEnter.args[0][1]).to.equal(false);
         });
       });
 
       describe('handleEntering()', () => {
         it('should set height to the wrapper height', () => {
-          assert.strictEqual(nodeEnteringHeightStyle, '666px');
+          expect(nodeEnteringHeightStyle).to.equal('666px');
         });
 
         it('should call handleEntering', () => {
-          assert.strictEqual(handleEntering.callCount, 1);
-          assert.strictEqual(handleEntering.args[0][0], container.instance());
-          assert.strictEqual(handleEntering.args[0][1], false);
+          expect(handleEntering.callCount).to.equal(1);
+          expect(handleEntering.args[0][0]).to.equal(container.instance());
+          expect(handleEntering.args[0][1]).to.equal(false);
         });
       });
 
       describe('handleEntered()', () => {
         it('should set height to auto', () => {
           clock.tick(1000);
-          assert.strictEqual(handleEntered.args[0][0].style.height, 'auto');
-          assert.strictEqual(handleEntered.args[0][1], false);
+          expect(handleEntered.args[0][0].style.height).to.equal('auto');
+          expect(handleEntered.args[0][1]).to.equal(false);
         });
 
         it('should have called onEntered', () => {
-          assert.strictEqual(handleEntered.callCount, 1);
+          expect(handleEntered.callCount).to.equal(1);
         });
       });
     });
@@ -149,31 +149,31 @@ describe('<Collapse />', () => {
 
       describe('handleExit()', () => {
         it('should set height to the wrapper height', () => {
-          assert.strictEqual(nodeExitHeightStyle, '666px');
+          expect(nodeExitHeightStyle).to.equal('666px');
         });
       });
 
       describe('handleExiting()', () => {
         it('should set height to the 0', () => {
-          assert.strictEqual(handleExiting.args[0][0].style.height, '0px');
+          expect(handleExiting.args[0][0].style.height).to.equal('0px');
         });
 
         it('should call onExiting', () => {
-          assert.strictEqual(handleExiting.callCount, 1);
-          assert.strictEqual(handleExiting.args[0][0], container.instance());
+          expect(handleExiting.callCount).to.equal(1);
+          expect(handleExiting.args[0][0]).to.equal(container.instance());
         });
       });
 
       describe('handleExited()', () => {
         it('should set height to the 0', () => {
           clock.tick(1000);
-          assert.strictEqual(handleExited.args[0][0].style.height, '0px');
+          expect(handleExited.args[0][0].style.height).to.equal('0px');
         });
 
         it('should call onExited', () => {
           clock.tick(1000);
-          assert.strictEqual(handleExited.callCount, 1);
-          assert.strictEqual(handleExited.args[0][0], container.instance());
+          expect(handleExited.callCount).to.equal(1);
+          expect(handleExited.args[0][0]).to.equal(container.instance());
         });
       });
     });
@@ -217,11 +217,11 @@ describe('<Collapse />', () => {
       });
 
       const autoTransitionDuration = 10;
-      assert.strictEqual(next1.callCount, 0);
+      expect(next1.callCount).to.equal(0);
       clock.tick(0);
-      assert.strictEqual(next1.callCount, 0);
+      expect(next1.callCount).to.equal(0);
       clock.tick(autoTransitionDuration);
-      assert.strictEqual(next1.callCount, 1);
+      expect(next1.callCount).to.equal(1);
 
       const next2 = spy();
       const wrapper2 = mount(
@@ -231,9 +231,9 @@ describe('<Collapse />', () => {
       );
       wrapper2.setProps({ in: true });
 
-      assert.strictEqual(next2.callCount, 0);
+      expect(next2.callCount).to.equal(0);
       clock.tick(0);
-      assert.strictEqual(next2.callCount, 1);
+      expect(next2.callCount).to.equal(1);
     });
 
     it('should use timeout as delay when timeout is number', () => {
@@ -247,11 +247,11 @@ describe('<Collapse />', () => {
 
       wrapper.setProps({ in: true });
 
-      assert.strictEqual(next.callCount, 0);
+      expect(next.callCount).to.equal(0);
       clock.tick(0);
-      assert.strictEqual(next.callCount, 0);
+      expect(next.callCount).to.equal(0);
       clock.tick(timeout);
-      assert.strictEqual(next.callCount, 1);
+      expect(next.callCount).to.equal(1);
     });
 
     it('should create proper easeOut animation onEntering', () => {
@@ -269,7 +269,7 @@ describe('<Collapse />', () => {
       );
 
       wrapper.setProps({ in: true });
-      assert.strictEqual(handleEntering.args[0][0].style.transitionDuration, '556ms');
+      expect(handleEntering.args[0][0].style.transitionDuration).to.equal('556ms');
     });
 
     it('should create proper sharp animation onExiting', () => {
@@ -288,7 +288,7 @@ describe('<Collapse />', () => {
       wrapper.setProps({
         in: false,
       });
-      assert.strictEqual(handleExiting.args[0][0].style.transitionDuration, '446ms');
+      expect(handleExiting.args[0][0].style.transitionDuration).to.equal('446ms');
     });
   });
 
@@ -298,7 +298,7 @@ describe('<Collapse />', () => {
     it('should work when closed', () => {
       const wrapper = mount(<Collapse {...defaultProps} collapsedHeight={collapsedHeight} />);
       const child = wrapper.find('Transition').childAt(0);
-      assert.strictEqual(child.props().style.minHeight, collapsedHeight);
+      expect(child.props().style.minHeight).to.equal(collapsedHeight);
     });
 
     it('should be taken into account in handleExiting', () => {
@@ -308,7 +308,7 @@ describe('<Collapse />', () => {
       );
       wrapper.setProps({ in: false });
 
-      assert.strictEqual(handleExiting.args[0][0].style.height, collapsedHeight);
+      expect(handleExiting.args[0][0].style.height).to.equal(collapsedHeight);
     });
   });
 });

--- a/packages/material-ui/src/Container/Container.test.js
+++ b/packages/material-ui/src/Container/Container.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Container from './Container';
@@ -31,9 +31,9 @@ describe('<Container />', () => {
     it('should support different maxWidth values', () => {
       let wrapper;
       wrapper = mount(<Container {...defaultProps} />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.maxWidthLg), true);
+      expect(findOutermostIntrinsic(wrapper).hasClass(classes.maxWidthLg)).to.equal(true);
       wrapper = mount(<Container {...defaultProps} maxWidth={false} />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.maxWidthLg), false);
+      expect(findOutermostIntrinsic(wrapper).hasClass(classes.maxWidthLg)).to.equal(false);
     });
   });
 });

--- a/packages/material-ui/src/CssBaseline/CssBaseline.test.js
+++ b/packages/material-ui/src/CssBaseline/CssBaseline.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount } from '@material-ui/core/test-utils';
 import CssBaseline from './CssBaseline';
 
@@ -22,6 +22,6 @@ describe('<CssBaseline />', () => {
         <div id="child" />
       </CssBaseline>,
     );
-    assert.strictEqual(wrapper.find('#child').type(), 'div');
+    expect(wrapper.find('#child').type()).to.equal('div');
   });
 });

--- a/packages/material-ui/src/DialogContent/DialogContent.test.js
+++ b/packages/material-ui/src/DialogContent/DialogContent.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import DialogContent from './DialogContent';
@@ -30,6 +30,6 @@ describe('<DialogContent />', () => {
   it('should render children', () => {
     const children = <p />;
     const wrapper = shallow(<DialogContent>{children}</DialogContent>);
-    assert.strictEqual(wrapper.children().equals(children), true);
+    expect(wrapper.children().equals(children)).to.equal(true);
   });
 });

--- a/packages/material-ui/src/DialogContentText/DialogContentText.test.js
+++ b/packages/material-ui/src/DialogContentText/DialogContentText.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '../test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import DialogContentText from './DialogContentText';
@@ -32,7 +32,7 @@ describe('<DialogContentText />', () => {
     it('should render children', () => {
       const children = <p />;
       const wrapper = shallow(<DialogContentText>{children}</DialogContentText>);
-      assert.strictEqual(wrapper.children().equals(children), true);
+      expect(wrapper.children().equals(children)).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/DialogTitle/DialogTitle.test.js
+++ b/packages/material-ui/src/DialogTitle/DialogTitle.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import DialogTitle from './DialogTitle';
@@ -30,12 +30,12 @@ describe('<DialogTitle />', () => {
   it('should render JSX children', () => {
     const children = <p className="test">Hello</p>;
     const wrapper = shallow(<DialogTitle disableTypography>{children}</DialogTitle>);
-    assert.strictEqual(wrapper.childAt(0).equals(children), true);
+    expect(wrapper.childAt(0).equals(children)).to.equal(true);
   });
 
   it('should render string children as given string', () => {
     const children = 'Hello';
     const wrapper = shallow(<DialogTitle>{children}</DialogTitle>);
-    assert.strictEqual(wrapper.childAt(0).props().children, children);
+    expect(wrapper.childAt(0).props().children).to.equal(children);
   });
 });

--- a/packages/material-ui/src/Divider/Divider.test.js
+++ b/packages/material-ui/src/Divider/Divider.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Divider from './Divider';
@@ -29,44 +29,44 @@ describe('<Divider />', () => {
 
   it('should set the absolute class', () => {
     const wrapper = shallow(<Divider absolute />);
-    assert.strictEqual(wrapper.hasClass(classes.absolute), true);
+    expect(wrapper.hasClass(classes.absolute)).to.equal(true);
   });
 
   it('should set the light class', () => {
     const wrapper = shallow(<Divider light />);
-    assert.strictEqual(wrapper.hasClass(classes.light), true);
+    expect(wrapper.hasClass(classes.light)).to.equal(true);
   });
 
   it('should set the flexItem class', () => {
     const wrapper = shallow(<Divider flexItem />);
-    assert.strictEqual(wrapper.hasClass(classes.flexItem), true);
+    expect(wrapper.hasClass(classes.flexItem)).to.equal(true);
   });
 
   describe('prop: variant', () => {
     it('should default to variant="fullWidth"', () => {
       const wrapper = shallow(<Divider />);
-      assert.strictEqual(wrapper.hasClass(classes.inset), false);
-      assert.strictEqual(wrapper.hasClass(classes.middle), false);
+      expect(wrapper.hasClass(classes.inset)).to.equal(false);
+      expect(wrapper.hasClass(classes.middle)).to.equal(false);
     });
 
     describe('prop: variant="fullWidth" ', () => {
       it('should render with the root and default class', () => {
         const wrapper = shallow(<Divider />);
-        assert.strictEqual(wrapper.hasClass(classes.root), true);
+        expect(wrapper.hasClass(classes.root)).to.equal(true);
       });
     });
 
     describe('prop: variant="inset" ', () => {
       it('should set the inset class', () => {
         const wrapper = shallow(<Divider variant="inset" />);
-        assert.strictEqual(wrapper.hasClass(classes.inset), true);
+        expect(wrapper.hasClass(classes.inset)).to.equal(true);
       });
     });
 
     describe('prop: variant="middle"', () => {
       it('should set the middle class', () => {
         const wrapper = shallow(<Divider variant="middle" />);
-        assert.strictEqual(wrapper.hasClass(classes.middle), true);
+        expect(wrapper.hasClass(classes.middle)).to.equal(true);
       });
     });
   });
@@ -74,18 +74,18 @@ describe('<Divider />', () => {
   describe('role', () => {
     it('avoids adding implicit aria semantics', () => {
       const wrapper = mount(<Divider />);
-      assert.strictEqual(wrapper.find('hr').props().role, undefined);
+      expect(wrapper.find('hr').props().role).to.equal(undefined);
     });
 
     it('adds a proper role if none is specified', () => {
       const wrapper = mount(<Divider component="div" />);
-      assert.strictEqual(wrapper.find('div').props().role, 'separator');
+      expect(wrapper.find('div').props().role).to.equal('separator');
     });
 
     it('overrides the computed role with the provided one', () => {
       // presentation is the only valid aria role
       const wrapper = mount(<Divider role="presentation" />);
-      assert.strictEqual(wrapper.find('hr').props().role, 'presentation');
+      expect(wrapper.find('hr').props().role).to.equal('presentation');
     });
   });
 });

--- a/packages/material-ui/src/Drawer/Drawer.test.js
+++ b/packages/material-ui/src/Drawer/Drawer.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import { ThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 import describeConformance from '../test-utils/describeConformance';
@@ -52,7 +52,7 @@ describe('<Drawer />', () => {
           <div />
         </Drawer>,
       );
-      assert.strictEqual(wrapper.find(Modal).exists(), true);
+      expect(wrapper.find(Modal).exists()).to.equal(true);
     });
 
     it('should render Slide > Paper inside the Modal', () => {
@@ -64,11 +64,11 @@ describe('<Drawer />', () => {
       const modal = wrapper.find(Modal);
 
       const slide = modal.find(Slide);
-      assert.strictEqual(slide.exists(), true);
+      expect(slide.exists()).to.equal(true);
 
       const paper = slide.find(Paper);
-      assert.strictEqual(paper.exists(), true);
-      assert.strictEqual(paper.hasClass(classes.paper), true);
+      expect(paper.exists()).to.equal(true);
+      expect(paper.hasClass(classes.paper)).to.equal(true);
     });
 
     describe('transitionDuration property', () => {
@@ -83,7 +83,7 @@ describe('<Drawer />', () => {
             <div />
           </Drawer>,
         );
-        assert.strictEqual(wrapper.find(Slide).props().timeout, transitionDuration);
+        expect(wrapper.find(Slide).props().timeout).to.equal(transitionDuration);
       });
 
       it("should be passed to to Modal's BackdropTransitionDuration when open=true", () => {
@@ -92,8 +92,7 @@ describe('<Drawer />', () => {
             <div />
           </Drawer>,
         );
-        assert.strictEqual(
-          wrapper.find(Modal).props().BackdropProps.transitionDuration,
+        expect(wrapper.find(Modal).props().BackdropProps.transitionDuration).to.equal(
           transitionDuration,
         );
       });
@@ -106,7 +105,7 @@ describe('<Drawer />', () => {
           <div />
         </Drawer>,
       );
-      assert.strictEqual(wrapper.find(Modal).props().BackdropTransitionDuration, testDuration);
+      expect(wrapper.find(Modal).props().BackdropTransitionDuration).to.equal(testDuration);
     });
 
     it('should set the custom className for Modal when variant is temporary', () => {
@@ -118,7 +117,7 @@ describe('<Drawer />', () => {
 
       const modal = wrapper.find(Modal);
 
-      assert.strictEqual(modal.hasClass('woofDrawer'), true);
+      expect(modal.hasClass('woofDrawer')).to.equal(true);
     });
 
     it('should set the Paper className', () => {
@@ -128,8 +127,8 @@ describe('<Drawer />', () => {
         </Drawer>,
       );
       const paper = wrapper.find(Paper);
-      assert.strictEqual(paper.hasClass(classes.paper), true);
-      assert.strictEqual(paper.hasClass('woofDrawer'), true);
+      expect(paper.hasClass(classes.paper)).to.equal(true);
+      expect(paper.hasClass('woofDrawer')).to.equal(true);
     });
 
     it('should be closed by default', () => {
@@ -141,7 +140,7 @@ describe('<Drawer />', () => {
 
       const modal = wrapper.find(Modal);
 
-      assert.strictEqual(modal.props().open, false);
+      expect(modal.props().open).to.equal(false);
     });
 
     describe('opening and closing', () => {
@@ -153,7 +152,7 @@ describe('<Drawer />', () => {
 
       it('should start closed', () => {
         const wrapper = mount(drawerElement);
-        assert.strictEqual(wrapper.find(Modal).props().open, false);
+        expect(wrapper.find(Modal).props().open).to.equal(false);
       });
 
       it('should open and close', () => {
@@ -161,11 +160,11 @@ describe('<Drawer />', () => {
 
         wrapper.setProps({ open: true });
         wrapper.update();
-        assert.strictEqual(wrapper.find(Slide).props().in, true);
+        expect(wrapper.find(Slide).props().in).to.equal(true);
 
         wrapper.setProps({ open: false });
         wrapper.update();
-        assert.strictEqual(wrapper.find(Slide).props().in, false);
+        expect(wrapper.find(Slide).props().in).to.equal(false);
       });
     });
   });
@@ -180,20 +179,20 @@ describe('<Drawer />', () => {
     it('should render a div instead of a Modal when persistent', () => {
       const wrapper = mount(drawerElement);
       const root = findOutermostIntrinsic(wrapper);
-      assert.strictEqual(root.type(), 'div');
-      assert.strictEqual(root.hasClass(classes.docked), true);
+      expect(root.type()).to.equal('div');
+      expect(root.hasClass(classes.docked)).to.equal(true);
     });
 
     it('should render Slide > Paper inside the div', () => {
       const wrapper = mount(drawerElement);
       const div = wrapper.find('div').first();
       const slide = div.childAt(0);
-      assert.strictEqual(slide.length, 1);
-      assert.strictEqual(slide.type(), Slide);
+      expect(slide.length).to.equal(1);
+      expect(slide.type()).to.equal(Slide);
 
       const paper = findOutermostIntrinsic(slide);
-      assert.strictEqual(paper.exists(), true);
-      assert.strictEqual(paper.hasClass(classes.paper), true);
+      expect(paper.exists()).to.equal(true);
+      expect(paper.hasClass(classes.paper)).to.equal(true);
     });
   });
 
@@ -207,15 +206,15 @@ describe('<Drawer />', () => {
     it('should render a div instead of a Modal when permanent', () => {
       const wrapper = mount(drawerElement);
       const root = wrapper.find(`.${classes.root}`);
-      assert.strictEqual(root.type(), 'div');
-      assert.strictEqual(root.hasClass(classes.docked), true);
+      expect(root.type()).to.equal('div');
+      expect(root.hasClass(classes.docked)).to.equal(true);
     });
 
     it('should render div > Paper inside the div', () => {
       const wrapper = mount(drawerElement);
 
       const root = wrapper.find(`div.${classes.root}`);
-      assert.strictEqual(root.exists(), true);
+      expect(root.exists()).to.equal(true);
     });
   });
 
@@ -239,16 +238,16 @@ describe('<Drawer />', () => {
       );
 
       wrapper.setProps({ anchor: 'left' });
-      assert.strictEqual(wrapper.find(Slide).props().direction, 'right');
+      expect(wrapper.find(Slide).props().direction).to.equal('right');
 
       wrapper.setProps({ anchor: 'right' });
-      assert.strictEqual(wrapper.find(Slide).props().direction, 'left');
+      expect(wrapper.find(Slide).props().direction).to.equal('left');
 
       wrapper.setProps({ anchor: 'top' });
-      assert.strictEqual(wrapper.find(Slide).props().direction, 'down');
+      expect(wrapper.find(Slide).props().direction).to.equal('down');
 
       wrapper.setProps({ anchor: 'bottom' });
-      assert.strictEqual(wrapper.find(Slide).props().direction, 'up');
+      expect(wrapper.find(Slide).props().direction).to.equal('up');
     });
   });
 
@@ -265,7 +264,7 @@ describe('<Drawer />', () => {
         </ThemeProvider>,
       );
       // slide direction for left is right, if left is switched to right, we should get left
-      assert.strictEqual(wrapper1.find(Slide).props().direction, 'left');
+      expect(wrapper1.find(Slide).props().direction).to.equal('left');
 
       const wrapper2 = mount(
         <ThemeProvider theme={theme}>
@@ -275,16 +274,16 @@ describe('<Drawer />', () => {
         </ThemeProvider>,
       );
       // slide direction for right is left, if right is switched to left, we should get right
-      assert.strictEqual(wrapper2.find(Slide).props().direction, 'right');
+      expect(wrapper2.find(Slide).props().direction).to.equal('right');
     });
   });
 
   describe('isHorizontal', () => {
     it('should recognize left and right as horizontal swiping directions', () => {
-      assert.strictEqual(isHorizontal('left'), true);
-      assert.strictEqual(isHorizontal('right'), true);
-      assert.strictEqual(isHorizontal('top'), false);
-      assert.strictEqual(isHorizontal('bottom'), false);
+      expect(isHorizontal('left')).to.equal(true);
+      expect(isHorizontal('right')).to.equal(true);
+      expect(isHorizontal('top')).to.equal(false);
+      expect(isHorizontal('bottom')).to.equal(false);
     });
   });
 
@@ -292,17 +291,17 @@ describe('<Drawer />', () => {
     it('should return the anchor', () => {
       const theme = { direction: 'ltr' };
 
-      assert.strictEqual(getAnchor(theme, 'left'), 'left');
-      assert.strictEqual(getAnchor(theme, 'right'), 'right');
-      assert.strictEqual(getAnchor(theme, 'top'), 'top');
-      assert.strictEqual(getAnchor(theme, 'bottom'), 'bottom');
+      expect(getAnchor(theme, 'left')).to.equal('left');
+      expect(getAnchor(theme, 'right')).to.equal('right');
+      expect(getAnchor(theme, 'top')).to.equal('top');
+      expect(getAnchor(theme, 'bottom')).to.equal('bottom');
     });
 
     it('should switch left/right if RTL is enabled', () => {
       const theme = { direction: 'rtl' };
 
-      assert.strictEqual(getAnchor(theme, 'left'), 'right');
-      assert.strictEqual(getAnchor(theme, 'right'), 'left');
+      expect(getAnchor(theme, 'left')).to.equal('right');
+      expect(getAnchor(theme, 'right')).to.equal('left');
     });
   });
 });

--- a/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
+++ b/packages/material-ui/src/ExpansionPanel/ExpansionPanel.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createMount, getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
@@ -36,14 +36,14 @@ describe('<ExpansionPanel />', () => {
   it('should render and not be controlled', () => {
     const wrapper = mount(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
     const root = wrapper.find(`.${classes.root}`).first();
-    assert.strictEqual(root.type(), Paper);
-    assert.strictEqual(root.props().square, false);
-    assert.strictEqual(root.hasClass(classes.expanded), false, 'uncontrolled');
+    expect(root.type()).to.equal(Paper);
+    expect(root.props().square).to.equal(false);
+    expect(root.hasClass(classes.expanded)).to.equal(false);
   });
 
   it('should handle defaultExpanded prop', () => {
     const wrapper = mount(<ExpansionPanel defaultExpanded>{minimalChildren}</ExpansionPanel>);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.expanded), true);
+    expect(findOutermostIntrinsic(wrapper).hasClass(classes.expanded)).to.equal(true);
   });
 
   it('should render the summary and collapse elements', () => {
@@ -54,16 +54,16 @@ describe('<ExpansionPanel />', () => {
       </ExpansionPanel>,
     );
 
-    assert.strictEqual(wrapper.find('[aria-expanded=false]').hostNodes().text(), 'Summary');
-    assert.strictEqual(wrapper.find(Collapse).find('div#panel-content').text(), 'Hello');
+    expect(wrapper.find('[aria-expanded=false]').hostNodes().text()).to.equal('Summary');
+    expect(wrapper.find(Collapse).find('div#panel-content').text()).to.equal('Hello');
   });
 
   it('should be controlled', () => {
     const wrapper = mount(<ExpansionPanel expanded>{minimalChildren}</ExpansionPanel>);
     const panel = wrapper.find(`.${classes.root}`).first();
-    assert.strictEqual(panel.hasClass(classes.expanded), true);
+    expect(panel.hasClass(classes.expanded)).to.equal(true);
     wrapper.setProps({ expanded: false });
-    assert.strictEqual(wrapper.hasClass(classes.expanded), false);
+    expect(wrapper.hasClass(classes.expanded)).to.equal(false);
   });
 
   it('should call onChange when clicking the summary element', () => {
@@ -72,7 +72,7 @@ describe('<ExpansionPanel />', () => {
       <ExpansionPanel onChange={handleChange}>{minimalChildren}</ExpansionPanel>,
     );
     wrapper.find(ExpansionPanelSummary).simulate('click');
-    assert.strictEqual(handleChange.callCount, 1);
+    expect(handleChange.callCount).to.equal(1);
   });
 
   it('when controlled should call the onChange', () => {
@@ -83,8 +83,8 @@ describe('<ExpansionPanel />', () => {
       </ExpansionPanel>,
     );
     wrapper.find(ExpansionPanelSummary).simulate('click');
-    assert.strictEqual(handleChange.callCount, 1);
-    assert.strictEqual(handleChange.args[0][1], false);
+    expect(handleChange.callCount).to.equal(1);
+    expect(handleChange.args[0][1]).to.equal(false);
   });
 
   it('when undefined onChange and controlled should not call the onChange', () => {
@@ -96,12 +96,12 @@ describe('<ExpansionPanel />', () => {
     );
     wrapper.setProps({ onChange: undefined });
     wrapper.find(ExpansionPanelSummary).simulate('click');
-    assert.strictEqual(handleChange.callCount, 0);
+    expect(handleChange.callCount).to.equal(0);
   });
 
   it('when disabled should have the disabled class', () => {
     const wrapper = mount(<ExpansionPanel disabled>{minimalChildren}</ExpansionPanel>);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.disabled), true);
+    expect(findOutermostIntrinsic(wrapper).hasClass(classes.disabled)).to.equal(true);
   });
 
   it('should handle the TransitionComponent prop', () => {
@@ -123,14 +123,14 @@ describe('<ExpansionPanel />', () => {
 
     // Collapse is initially shown
     const collapse = wrapper.find(NoTransitionCollapse);
-    assert.strictEqual(collapse.props().in, true);
-    assert.strictEqual(wrapper.find(CustomContent).length, 1);
+    expect(collapse.props().in).to.equal(true);
+    expect(wrapper.find(CustomContent).length).to.equal(1);
 
     // Hide the collapse
     wrapper.setProps({ expanded: false });
     const collapse2 = wrapper.find(NoTransitionCollapse);
-    assert.strictEqual(collapse2.props().in, false);
-    assert.strictEqual(wrapper.find(CustomContent).length, 0);
+    expect(collapse2.props().in).to.equal(false);
+    expect(wrapper.find(CustomContent).length).to.equal(0);
   });
 
   describe('prop: children', () => {
@@ -152,8 +152,8 @@ describe('<ExpansionPanel />', () => {
           'MockedName',
         );
 
-        assert.strictEqual(consoleErrorMock.callCount(), 1);
-        assert.include(consoleErrorMock.messages()[0], 'Material-UI: expected the first child');
+        expect(consoleErrorMock.callCount()).to.equal(1);
+        expect(consoleErrorMock.messages()[0]).to.include('Material-UI: expected the first child');
       });
 
       it('needs a valid element as the first child', () => {
@@ -164,9 +164,8 @@ describe('<ExpansionPanel />', () => {
           'MockedName',
         );
 
-        assert.strictEqual(consoleErrorMock.callCount(), 1);
-        assert.include(
-          consoleErrorMock.messages()[0],
+        expect(consoleErrorMock.callCount()).to.equal(1);
+        expect(consoleErrorMock.messages()[0]).to.include(
           "Material-UI: the ExpansionPanel doesn't accept a Fragment",
         );
       });
@@ -204,8 +203,7 @@ describe('<ExpansionPanel />', () => {
       const wrapper = mount(<ExpansionPanel>{minimalChildren}</ExpansionPanel>);
 
       wrapper.setProps({ expanded: true });
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Material-UI: a component is changing the uncontrolled expanded state of ExpansionPanel to be controlled.',
       );
     });

--- a/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.test.js
+++ b/packages/material-ui/src/ExpansionPanelDetails/ExpansionPanelDetails.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import ExpansionPanelDetails from './ExpansionPanelDetails';
@@ -34,6 +34,6 @@ describe('<ExpansionPanelDetails />', () => {
       </ExpansionPanelDetails>,
     );
     const container = wrapper.childAt(0);
-    assert.strictEqual(container.type(), 'div');
+    expect(container.type()).to.equal('div');
   });
 });

--- a/packages/material-ui/src/Fade/Fade.test.js
+++ b/packages/material-ui/src/Fade/Fade.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
@@ -75,13 +75,12 @@ describe('<Fade />', () => {
 
       describe('handleEnter()', () => {
         it('should call handleEnter()', () => {
-          assert.strictEqual(handleEnter.callCount, 1);
-          assert.strictEqual(handleEnter.args[0][0], child.instance());
+          expect(handleEnter.callCount).to.equal(1);
+          expect(handleEnter.args[0][0]).to.equal(child.instance());
         });
 
         it('should set style properties', () => {
-          assert.match(
-            handleEnter.args[0][0].style.transition,
+          expect(handleEnter.args[0][0].style.transition).to.match(
             /opacity 225ms cubic-bezier\(0.4, 0, 0.2, 1\)( 0ms)?/,
           );
         });
@@ -89,16 +88,16 @@ describe('<Fade />', () => {
 
       describe('handleEntering()', () => {
         it('should call handleEntering()', () => {
-          assert.strictEqual(handleEntering.callCount, 1);
-          assert.strictEqual(handleEntering.args[0][0], child.instance());
+          expect(handleEntering.callCount).to.equal(1);
+          expect(handleEntering.args[0][0]).to.equal(child.instance());
         });
       });
 
       describe('handleEntered()', () => {
         it('should call handleEntered()', () => {
           clock.tick(1000);
-          assert.strictEqual(handleEntered.callCount, 1);
-          assert.strictEqual(handleEntered.args[0][0], child.instance());
+          expect(handleEntered.callCount).to.equal(1);
+          expect(handleEntered.args[0][0]).to.equal(child.instance());
         });
       });
     });
@@ -111,13 +110,12 @@ describe('<Fade />', () => {
 
       describe('handleExit()', () => {
         it('should call handleExit()', () => {
-          assert.strictEqual(handleExit.callCount, 1);
-          assert.strictEqual(handleExit.args[0][0], child.instance());
+          expect(handleExit.callCount).to.equal(1);
+          expect(handleExit.args[0][0]).to.equal(child.instance());
         });
 
         it('should set style properties', () => {
-          assert.match(
-            handleExit.args[0][0].style.transition,
+          expect(handleExit.args[0][0].style.transition).to.match(
             /opacity 195ms cubic-bezier\(0.4, 0, 0.2, 1\)( 0ms)?/,
           );
         });
@@ -125,16 +123,16 @@ describe('<Fade />', () => {
 
       describe('handleExiting()', () => {
         it('should call handleExiting()', () => {
-          assert.strictEqual(handleExiting.callCount, 1);
-          assert.strictEqual(handleExiting.args[0][0], child.instance());
+          expect(handleExiting.callCount).to.equal(1);
+          expect(handleExiting.args[0][0]).to.equal(child.instance());
         });
       });
 
       describe('handleExited()', () => {
         it('should call handleExited()', () => {
           clock.tick(1000);
-          assert.strictEqual(handleExited.callCount, 1);
-          assert.strictEqual(handleExited.args[0][0], child.instance());
+          expect(handleExited.callCount).to.equal(1);
+          expect(handleExited.args[0][0]).to.equal(child.instance());
         });
       });
     });
@@ -147,7 +145,7 @@ describe('<Fade />', () => {
           <div>Foo</div>
         </Fade>,
       );
-      assert.deepEqual(wrapper.find('div').props().style, {
+      expect(wrapper.find('div').props().style).to.deep.equal({
         opacity: 0,
         visibility: 'hidden',
       });
@@ -159,7 +157,7 @@ describe('<Fade />', () => {
           <div>Foo</div>
         </Fade>,
       );
-      assert.deepEqual(wrapper.find('div').props().style, {
+      expect(wrapper.find('div').props().style).to.deep.equal({
         opacity: 0,
         visibility: 'hidden',
       });

--- a/packages/material-ui/src/FormGroup/FormGroup.test.js
+++ b/packages/material-ui/src/FormGroup/FormGroup.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import FormGroup from './FormGroup';
@@ -34,8 +34,8 @@ describe('<FormGroup />', () => {
       </FormGroup>,
     );
 
-    assert.strictEqual(wrapper.children('span').length, 0);
-    assert.strictEqual(wrapper.children('div').length, 1);
-    assert.strictEqual(wrapper.children('div').first().hasClass('woofFormGroup'), true);
+    expect(wrapper.children('span').length).to.equal(0);
+    expect(wrapper.children('div').length).to.equal(1);
+    expect(wrapper.children('div').first().hasClass('woofFormGroup')).to.equal(true);
   });
 });

--- a/packages/material-ui/src/Grid/Grid.test.js
+++ b/packages/material-ui/src/Grid/Grid.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import { createMuiTheme } from '@material-ui/core/styles';
 import describeConformance from '../test-utils/describeConformance';
@@ -31,59 +31,59 @@ describe('<Grid />', () => {
   describe('prop: container', () => {
     it('should apply the container class', () => {
       const wrapper = shallow(<Grid container />);
-      assert.strictEqual(wrapper.hasClass(classes.container), true);
+      expect(wrapper.hasClass(classes.container)).to.equal(true);
     });
   });
 
   describe('prop: item', () => {
     it('should apply the item class', () => {
       const wrapper = shallow(<Grid item />);
-      assert.strictEqual(wrapper.hasClass(classes.item), true);
+      expect(wrapper.hasClass(classes.item)).to.equal(true);
     });
   });
 
   describe('prop: xs', () => {
     it('should apply the flex-grow class', () => {
       const wrapper = shallow(<Grid item xs />);
-      assert.strictEqual(wrapper.hasClass(classes['grid-xs-true']), true);
+      expect(wrapper.hasClass(classes['grid-xs-true'])).to.equal(true);
     });
 
     it('should apply the flex size class', () => {
       const wrapper = shallow(<Grid item xs={3} />);
-      assert.strictEqual(wrapper.hasClass(classes['grid-xs-3']), true);
+      expect(wrapper.hasClass(classes['grid-xs-3'])).to.equal(true);
     });
 
     it('should apply the flex auto class', () => {
       const wrapper = shallow(<Grid item xs="auto" />);
-      assert.strictEqual(wrapper.hasClass(classes['grid-xs-auto']), true);
+      expect(wrapper.hasClass(classes['grid-xs-auto'])).to.equal(true);
     });
   });
 
   describe('prop: spacing', () => {
     it('should have a spacing', () => {
       const wrapper = shallow(<Grid container spacing={1} />);
-      assert.strictEqual(wrapper.hasClass(classes['spacing-xs-1']), true);
+      expect(wrapper.hasClass(classes['spacing-xs-1'])).to.equal(true);
     });
   });
 
   describe('prop: alignItems', () => {
     it('should apply the align-item class', () => {
       const wrapper = shallow(<Grid alignItems="center" container />);
-      assert.strictEqual(wrapper.hasClass(classes['align-items-xs-center']), true);
+      expect(wrapper.hasClass(classes['align-items-xs-center'])).to.equal(true);
     });
   });
 
   describe('prop: alignContent', () => {
     it('should apply the align-content class', () => {
       const wrapper = shallow(<Grid alignContent="center" container />);
-      assert.strictEqual(wrapper.hasClass(classes['align-content-xs-center']), true);
+      expect(wrapper.hasClass(classes['align-content-xs-center'])).to.equal(true);
     });
   });
 
   describe('prop: justify', () => {
     it('should apply the justify class', () => {
       const wrapper = shallow(<Grid justify="space-evenly" container />);
-      assert.strictEqual(wrapper.hasClass(classes['justify-xs-space-evenly']), true);
+      expect(wrapper.hasClass(classes['justify-xs-space-evenly'])).to.equal(true);
     });
   });
 
@@ -91,7 +91,7 @@ describe('<Grid />', () => {
     it('should spread the other props to the root element', () => {
       const handleClick = () => {};
       const wrapper = shallow(<Grid component="span" onClick={handleClick} />);
-      assert.strictEqual(wrapper.props().onClick, handleClick);
+      expect(wrapper.props().onClick).to.equal(handleClick);
     });
   });
 

--- a/packages/material-ui/src/GridList/GridList.test.js
+++ b/packages/material-ui/src/GridList/GridList.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import GridList from './GridList';
@@ -63,12 +63,8 @@ describe('<GridList />', () => {
       </GridList>,
     );
 
-    assert.strictEqual(wrapper.find('.grid-tile').length, 2, 'should contain the children');
-    assert.strictEqual(
-      wrapper.children().at(0).props().style.height,
-      cellHeight + 4,
-      'should have height to 254',
-    );
+    expect(wrapper.find('.grid-tile').length).to.equal(2);
+    expect(wrapper.children().at(0).props().style.height).to.equal(cellHeight + 4);
   });
 
   it('renders children by default', () => {
@@ -88,7 +84,7 @@ describe('<GridList />', () => {
       </GridList>,
     );
 
-    assert.strictEqual(wrapper.find('.grid-tile').length, 2, 'should contain the children');
+    expect(wrapper.find('.grid-tile').length).to.equal(2);
   });
 
   it('renders children and change cols', () => {
@@ -107,12 +103,8 @@ describe('<GridList />', () => {
       </GridList>,
     );
 
-    assert.strictEqual(wrapper.find('.grid-tile').length, 2, 'should contain the children');
-    assert.strictEqual(
-      wrapper.children().at(0).props().style.width,
-      '25%',
-      'should have 25% of width',
-    );
+    expect(wrapper.find('.grid-tile').length).to.equal(2);
+    expect(wrapper.children().at(0).props().style.width).to.equal('25%');
   });
 
   it('renders children and change spacing', () => {
@@ -132,12 +124,8 @@ describe('<GridList />', () => {
       </GridList>,
     );
 
-    assert.strictEqual(wrapper.find('.grid-tile').length, 2, 'should contain the children');
-    assert.strictEqual(
-      wrapper.children().at(0).props().style.padding,
-      spacing / 2,
-      'should have 5 of padding',
-    );
+    expect(wrapper.find('.grid-tile').length).to.equal(2);
+    expect(wrapper.children().at(0).props().style.padding).to.equal(spacing / 2);
   });
 
   it('should render children and overwrite style', () => {
@@ -157,8 +145,8 @@ describe('<GridList />', () => {
       </GridList>,
     );
 
-    assert.strictEqual(wrapper.find('.grid-tile').length, 2, 'should contain the children');
-    assert.strictEqual(wrapper.props().style.backgroundColor, style.backgroundColor);
+    expect(wrapper.find('.grid-tile').length).to.equal(2);
+    expect(wrapper.props().style.backgroundColor).to.equal(style.backgroundColor);
   });
 
   describe('prop: cellHeight', () => {
@@ -169,7 +157,7 @@ describe('<GridList />', () => {
         </GridList>,
       );
 
-      assert.strictEqual(wrapper.children().at(0).props().style.height, 'auto');
+      expect(wrapper.children().at(0).props().style.height).to.equal('auto');
     });
   });
 
@@ -189,9 +177,8 @@ describe('<GridList />', () => {
         </GridList>,
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         "Material-UI: the GridList component doesn't accept a Fragment as a child.",
       );
     });

--- a/packages/material-ui/src/GridListTile/GridListTile.test.js
+++ b/packages/material-ui/src/GridListTile/GridListTile.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
@@ -37,13 +37,13 @@ describe('<GridListTile />', () => {
       const children = <img src={tileData.img} alt="foo" />;
       const wrapper = mount(<GridListTile>{children}</GridListTile>);
 
-      assert.strictEqual(wrapper.containsMatchingElement(children), true);
+      expect(wrapper.containsMatchingElement(children)).to.equal(true);
     });
 
     it('should not change non image child', () => {
       const children = <div />;
       const wrapper = mount(<GridListTile>{children}</GridListTile>);
-      assert.strictEqual(wrapper.containsMatchingElement(children), true);
+      expect(wrapper.containsMatchingElement(children)).to.equal(true);
     });
   });
 
@@ -78,10 +78,10 @@ describe('<GridListTile />', () => {
         removeEventListener: () => {},
       };
       mountMockImage(imgEl);
-      assert.strictEqual(imgEl.classList.remove.callCount, 1);
-      assert.strictEqual(imgEl.classList.remove.args[0][0], classes.imgFullWidth);
-      assert.strictEqual(imgEl.classList.add.callCount, 1);
-      assert.strictEqual(imgEl.classList.add.args[0][0], classes.imgFullHeight);
+      expect(imgEl.classList.remove.callCount).to.equal(1);
+      expect(imgEl.classList.remove.args[0][0]).to.equal(classes.imgFullWidth);
+      expect(imgEl.classList.add.callCount).to.equal(1);
+      expect(imgEl.classList.add.args[0][0]).to.equal(classes.imgFullHeight);
     });
 
     it('should fit the width', () => {
@@ -94,10 +94,10 @@ describe('<GridListTile />', () => {
         removeEventListener: () => {},
       };
       mountMockImage(imgEl);
-      assert.strictEqual(imgEl.classList.remove.callCount, 1);
-      assert.strictEqual(imgEl.classList.remove.args[0][0], classes.imgFullHeight);
-      assert.strictEqual(imgEl.classList.add.callCount, 1);
-      assert.strictEqual(imgEl.classList.add.args[0][0], classes.imgFullWidth);
+      expect(imgEl.classList.remove.callCount).to.equal(1);
+      expect(imgEl.classList.remove.args[0][0]).to.equal(classes.imgFullHeight);
+      expect(imgEl.classList.add.callCount).to.equal(1);
+      expect(imgEl.classList.add.args[0][0]).to.equal(classes.imgFullWidth);
     });
   });
 
@@ -122,20 +122,20 @@ describe('<GridListTile />', () => {
         removeEventListener: () => {},
       };
       mountMockImage(imgEl);
-      assert.strictEqual(imgEl.classList.remove.callCount, 1);
-      assert.strictEqual(imgEl.classList.remove.args[0][0], classes.imgFullHeight);
-      assert.strictEqual(imgEl.classList.add.callCount, 1);
-      assert.strictEqual(imgEl.classList.add.args[0][0], classes.imgFullWidth);
+      expect(imgEl.classList.remove.callCount).to.equal(1);
+      expect(imgEl.classList.remove.args[0][0]).to.equal(classes.imgFullHeight);
+      expect(imgEl.classList.add.callCount).to.equal(1);
+      expect(imgEl.classList.add.args[0][0]).to.equal(classes.imgFullWidth);
 
       window.dispatchEvent(new window.Event('resize', {}));
-      assert.strictEqual(imgEl.classList.remove.callCount, 1);
+      expect(imgEl.classList.remove.callCount).to.equal(1);
       clock.tick(166);
 
-      assert.strictEqual(imgEl.classList.remove.callCount, 2);
-      assert.strictEqual(imgEl.classList.remove.callCount, 2);
-      assert.strictEqual(imgEl.classList.remove.args[1][0], classes.imgFullHeight);
-      assert.strictEqual(imgEl.classList.add.callCount, 2);
-      assert.strictEqual(imgEl.classList.add.args[1][0], classes.imgFullWidth);
+      expect(imgEl.classList.remove.callCount).to.equal(2);
+      expect(imgEl.classList.remove.callCount).to.equal(2);
+      expect(imgEl.classList.remove.args[1][0]).to.equal(classes.imgFullHeight);
+      expect(imgEl.classList.add.callCount).to.equal(2);
+      expect(imgEl.classList.add.args[1][0]).to.equal(classes.imgFullWidth);
     });
   });
 });

--- a/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
+++ b/packages/material-ui/src/GridListTileBar/GridListTileBar.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import GridListTileBar from './GridListTileBar';
@@ -37,11 +37,7 @@ describe('<GridListTileBar />', () => {
     it('should renders title', () => {
       const wrapper = shallow(<GridListTileBar title={tileData.title} />);
 
-      assert.strictEqual(
-        wrapper.children('div').text(),
-        tileData.title,
-        'should contain the title',
-      );
+      expect(wrapper.children('div').text()).to.equal(tileData.title);
     });
   });
 });

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -123,7 +123,10 @@ describe('<Grow />', () => {
 
         it('should set style properties', () => {
           expect(handleExit.args[0][0].style.opacity).to.equal('0');
-          expect(handleExit.args[0][0].style.transform).to.equal('scale(0.75, 0.5625)');
+          expect(handleExit.args[0][0].style.transform).to.equal(
+            'scale(0.75, 0.5625)',
+            'should have the exit scale',
+          );
         });
       });
 

--- a/packages/material-ui/src/Grow/Grow.test.js
+++ b/packages/material-ui/src/Grow/Grow.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
@@ -82,13 +82,12 @@ describe('<Grow />', () => {
 
       describe('handleEnter()', () => {
         it('should call handleEnter()', () => {
-          assert.strictEqual(handleEnter.callCount, 1);
-          assert.strictEqual(handleEnter.args[0][0], child.instance());
+          expect(handleEnter.callCount).to.equal(1);
+          expect(handleEnter.args[0][0]).to.equal(child.instance());
         });
 
         it('should set style properties', () => {
-          assert.match(
-            handleEnter.args[0][0].style.transition,
+          expect(handleEnter.args[0][0].style.transition).to.match(
             /opacity (0ms )?cubic-bezier\(0.4, 0, 0.2, 1\)( 0ms)?,( )?transform (0ms )?cubic-bezier\(0.4, 0, 0.2, 1\)( 0ms)?/,
           );
         });
@@ -96,16 +95,16 @@ describe('<Grow />', () => {
 
       describe('handleEntering()', () => {
         it('should call handleEntering()', () => {
-          assert.strictEqual(handleEntering.callCount, 1);
-          assert.strictEqual(handleEntering.args[0][0], child.instance());
+          expect(handleEntering.callCount).to.equal(1);
+          expect(handleEntering.args[0][0]).to.equal(child.instance());
         });
       });
 
       describe('handleEntered()', () => {
         it('should call handleEntered()', () => {
           clock.tick(1000);
-          assert.strictEqual(handleEntered.callCount, 1);
-          assert.strictEqual(handleEntered.args[0][0], child.instance());
+          expect(handleEntered.callCount).to.equal(1);
+          expect(handleEntered.args[0][0]).to.equal(child.instance());
         });
       });
     });
@@ -118,32 +117,28 @@ describe('<Grow />', () => {
 
       describe('handleExit()', () => {
         it('should call handleExit()', () => {
-          assert.strictEqual(handleExit.callCount, 1);
-          assert.strictEqual(handleExit.args[0][0], child.instance());
+          expect(handleExit.callCount).to.equal(1);
+          expect(handleExit.args[0][0]).to.equal(child.instance());
         });
 
         it('should set style properties', () => {
-          assert.strictEqual(handleExit.args[0][0].style.opacity, '0', 'should be transparent');
-          assert.strictEqual(
-            handleExit.args[0][0].style.transform,
-            'scale(0.75, 0.5625)',
-            'should have the exit scale',
-          );
+          expect(handleExit.args[0][0].style.opacity).to.equal('0');
+          expect(handleExit.args[0][0].style.transform).to.equal('scale(0.75, 0.5625)');
         });
       });
 
       describe('handleExiting()', () => {
         it('should call handleExiting()', () => {
-          assert.strictEqual(handleExiting.callCount, 1);
-          assert.strictEqual(handleExiting.args[0][0], child.instance());
+          expect(handleExiting.callCount).to.equal(1);
+          expect(handleExiting.args[0][0]).to.equal(child.instance());
         });
       });
 
       describe('handleExited()', () => {
         it('should call handleExited()', () => {
           clock.tick(1000);
-          assert.strictEqual(handleExited.callCount, 1);
-          assert.strictEqual(handleExited.args[0][0], child.instance());
+          expect(handleExited.callCount).to.equal(1);
+          expect(handleExited.args[0][0]).to.equal(child.instance());
         });
       });
     });
@@ -176,7 +171,7 @@ describe('<Grow />', () => {
           />,
         );
 
-        assert.match(handleEnter.args[0][0].style.transition, new RegExp(`${enterDuration}ms`));
+        expect(handleEnter.args[0][0].style.transition).to.match(new RegExp(`${enterDuration}ms`));
       });
 
       it('should delay based on height when timeout is auto', () => {
@@ -223,11 +218,11 @@ describe('<Grow />', () => {
         wrapper.setProps({
           in: true,
         });
-        assert.strictEqual(handleEntered.callCount, 0);
+        expect(handleEntered.callCount).to.equal(0);
         clock.tick(0);
-        assert.strictEqual(handleEntered.callCount, 0);
+        expect(handleEntered.callCount).to.equal(0);
         clock.tick(autoTransitionDuration);
-        assert.strictEqual(handleEntered.callCount, 1);
+        expect(handleEntered.callCount).to.equal(1);
 
         const handleEntered2 = spy();
         mount(
@@ -236,20 +231,20 @@ describe('<Grow />', () => {
           </Grow>,
         );
 
-        assert.strictEqual(handleEntered2.callCount, 0);
+        expect(handleEntered2.callCount).to.equal(0);
         clock.tick(0);
-        assert.strictEqual(handleEntered2.callCount, 1);
+        expect(handleEntered2.callCount).to.equal(1);
       });
 
       it('should use timeout as delay when timeout is number', () => {
         const timeout = 10;
         const handleEntered = spy();
         mount(<Grow {...defaultProps} timeout={timeout} onEntered={handleEntered} />);
-        assert.strictEqual(handleEntered.callCount, 0);
+        expect(handleEntered.callCount).to.equal(0);
         clock.tick(0);
-        assert.strictEqual(handleEntered.callCount, 0);
+        expect(handleEntered.callCount).to.equal(0);
         clock.tick(timeout);
-        assert.strictEqual(handleEntered.callCount, 1);
+        expect(handleEntered.callCount).to.equal(1);
       });
     });
 
@@ -268,9 +263,9 @@ describe('<Grow />', () => {
           in: false,
         });
 
-        assert.strictEqual(handleExited.callCount, 0);
+        expect(handleExited.callCount).to.equal(0);
         clock.tick(0);
-        assert.strictEqual(handleExited.callCount, 1);
+        expect(handleExited.callCount).to.equal(1);
       });
 
       it('should use timeout as delay when timeout is number', () => {
@@ -283,11 +278,11 @@ describe('<Grow />', () => {
           in: false,
         });
 
-        assert.strictEqual(handleExited.callCount, 0);
+        expect(handleExited.callCount).to.equal(0);
         clock.tick(0);
-        assert.strictEqual(handleExited.callCount, 0);
+        expect(handleExited.callCount).to.equal(0);
         clock.tick(timeout);
-        assert.strictEqual(handleExited.callCount, 1);
+        expect(handleExited.callCount).to.equal(1);
       });
 
       it('should create proper sharp animation', () => {
@@ -307,7 +302,7 @@ describe('<Grow />', () => {
           in: false,
         });
 
-        assert.match(handleExit.args[0][0].style.transition, new RegExp(`${leaveDuration}ms`));
+        expect(handleExit.args[0][0].style.transition).to.match(new RegExp(`${leaveDuration}ms`));
       });
     });
   });

--- a/packages/material-ui/src/Hidden/Hidden.test.js
+++ b/packages/material-ui/src/Hidden/Hidden.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow } from '@material-ui/core/test-utils';
 import Hidden from './Hidden';
 import HiddenJs from './HiddenJs';
@@ -15,12 +15,12 @@ describe('<Hidden />', () => {
   describe('prop: implementation', () => {
     it('should use HiddenJs by default', () => {
       const wrapper = shallow(<Hidden>Hello</Hidden>);
-      assert.strictEqual(wrapper.find(HiddenJs).length, 1);
+      expect(wrapper.find(HiddenJs).length).to.equal(1);
     });
 
     it('should change the implementation', () => {
       const wrapper = shallow(<Hidden implementation="css">Hello</Hidden>);
-      assert.strictEqual(wrapper.find(HiddenCss).length, 1);
+      expect(wrapper.find(HiddenCss).length).to.equal(1);
     });
   });
 });

--- a/packages/material-ui/src/Hidden/HiddenCss.test.js
+++ b/packages/material-ui/src/Hidden/HiddenCss.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import HiddenCss from './HiddenCss';
 import { createMuiTheme, MuiThemeProvider } from '../styles';
@@ -37,12 +37,12 @@ describe('<HiddenCss />', () => {
         </HiddenCss>,
       );
 
-      assert.strictEqual(wrapper.type(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.onlySm), true);
+      expect(wrapper.type()).to.equal('div');
+      expect(wrapper.hasClass(classes.onlySm)).to.equal(true);
 
       const div = wrapper.childAt(0);
-      assert.strictEqual(div.type(), 'div');
-      assert.strictEqual(div.props().className, 'foo');
+      expect(div.type()).to.equal('div');
+      expect(div.props().className).to.equal('foo');
     });
 
     it('should be ok with only as an array', () => {
@@ -52,9 +52,9 @@ describe('<HiddenCss />', () => {
         </HiddenCss>,
       );
 
-      assert.strictEqual(wrapper.type(), 'div');
-      assert.strictEqual(wrapper.props().className.split(' ')[0], classes.onlyXs);
-      assert.strictEqual(wrapper.props().className.split(' ')[1], classes.onlySm);
+      expect(wrapper.type()).to.equal('div');
+      expect(wrapper.props().className.split(' ')[0]).to.equal(classes.onlyXs);
+      expect(wrapper.props().className.split(' ')[1]).to.equal(classes.onlySm);
     });
 
     it('should be ok with only as an empty array', () => {
@@ -64,8 +64,8 @@ describe('<HiddenCss />', () => {
         </HiddenCss>,
       );
 
-      assert.strictEqual(wrapper.type(), 'div');
-      assert.strictEqual(wrapper.props().className, '');
+      expect(wrapper.type()).to.equal('div');
+      expect(wrapper.props().className).to.equal('');
     });
 
     it('should be ok with mdDown', () => {
@@ -74,7 +74,7 @@ describe('<HiddenCss />', () => {
           <div className="foo" />
         </HiddenCss>,
       );
-      assert.strictEqual(wrapper.hasClass(classes.mdDown), true);
+      expect(wrapper.hasClass(classes.mdDown)).to.equal(true);
     });
 
     it('should be ok with mdUp', () => {
@@ -83,7 +83,7 @@ describe('<HiddenCss />', () => {
           <div className="foo" />
         </HiddenCss>,
       );
-      assert.strictEqual(wrapper.hasClass(classes.mdUp), true);
+      expect(wrapper.hasClass(classes.mdUp)).to.equal(true);
     });
     it('should handle provided className prop', () => {
       const wrapper = shallow(
@@ -91,7 +91,7 @@ describe('<HiddenCss />', () => {
           <div className="foo" />
         </HiddenCss>,
       );
-      assert.strictEqual(wrapper.hasClass('custom'), true);
+      expect(wrapper.hasClass('custom')).to.equal(true);
     });
 
     it('allows custom breakpoints', () => {
@@ -104,16 +104,16 @@ describe('<HiddenCss />', () => {
         </MuiThemeProvider>,
       );
 
-      assert.strictEqual(wrapper.find('div.testid').hasClass('xxlUp'), true);
+      expect(wrapper.find('div.testid').hasClass('xxlUp')).to.equal(true);
     });
   });
 
   describe('prop: children', () => {
     it('should work when text Node', () => {
       const wrapper = shallow(<HiddenCss mdUp>foo</HiddenCss>);
-      assert.strictEqual(wrapper.type(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.mdUp), true);
-      assert.strictEqual(wrapper.childAt(0).text(), 'foo');
+      expect(wrapper.type()).to.equal('div');
+      expect(wrapper.hasClass(classes.mdUp)).to.equal(true);
+      expect(wrapper.childAt(0).text()).to.equal('foo');
     });
 
     it('should work when Element', () => {
@@ -122,9 +122,9 @@ describe('<HiddenCss />', () => {
           <Foo />
         </HiddenCss>,
       );
-      assert.strictEqual(wrapper.type(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.mdUp), true);
-      assert.strictEqual(wrapper.childAt(0).is(Foo), true);
+      expect(wrapper.type()).to.equal('div');
+      expect(wrapper.hasClass(classes.mdUp)).to.equal(true);
+      expect(wrapper.childAt(0).is(Foo)).to.equal(true);
     });
 
     it('should work when mixed ChildrenArray', () => {
@@ -136,11 +136,11 @@ describe('<HiddenCss />', () => {
         </HiddenCss>,
       );
 
-      assert.strictEqual(wrapper.type(), 'div');
-      assert.strictEqual(wrapper.hasClass(classes.mdUp), true);
-      assert.strictEqual(wrapper.childAt(0).is(Foo), true);
-      assert.strictEqual(wrapper.childAt(1).is(Foo), true);
-      assert.strictEqual(wrapper.childAt(2).text(), 'foo');
+      expect(wrapper.type()).to.equal('div');
+      expect(wrapper.hasClass(classes.mdUp)).to.equal(true);
+      expect(wrapper.childAt(0).is(Foo)).to.equal(true);
+      expect(wrapper.childAt(1).is(Foo)).to.equal(true);
+      expect(wrapper.childAt(2).text()).to.equal('foo');
     });
   });
 
@@ -160,9 +160,8 @@ describe('<HiddenCss />', () => {
         </HiddenCss>,
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Material-UI: unsupported props received by `<Hidden implementation="css" />`: xxlUp.',
       );
     });

--- a/packages/material-ui/src/Hidden/HiddenJs.test.js
+++ b/packages/material-ui/src/Hidden/HiddenJs.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import { createShallow } from '@material-ui/core/test-utils';
 import HiddenJs from './HiddenJs';
 
@@ -34,7 +34,7 @@ describe('<HiddenJs />', () => {
             <div>foo</div>
           </HiddenJs>,
         );
-        assert.strictEqual(wrapper.type(), null, 'should render null');
+        expect(wrapper.type()).to.equal(null);
       });
     });
   }
@@ -56,8 +56,8 @@ describe('<HiddenJs />', () => {
           </HiddenJs>,
         );
         assert.isNotNull(wrapper.type(), 'should render');
-        assert.strictEqual(wrapper.name(), 'div');
-        assert.strictEqual(wrapper.first().text(), 'foo', 'should render children');
+        expect(wrapper.name()).to.equal('div');
+        expect(wrapper.first().text()).to.equal('foo');
       });
     });
   }

--- a/packages/material-ui/src/Icon/Icon.test.js
+++ b/packages/material-ui/src/Icon/Icon.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Icon from './Icon';
@@ -29,35 +29,35 @@ describe('<Icon />', () => {
 
   it('renders children by default', () => {
     const wrapper = shallow(<Icon>account_circle</Icon>);
-    assert.strictEqual(wrapper.contains('account_circle'), true);
+    expect(wrapper.contains('account_circle')).to.equal(true);
   });
 
   describe('optional classes', () => {
     it('should render with the secondary color', () => {
       const wrapper = shallow(<Icon color="secondary">account_circle</Icon>);
-      assert.strictEqual(wrapper.hasClass(classes.colorSecondary), true);
+      expect(wrapper.hasClass(classes.colorSecondary)).to.equal(true);
     });
 
     it('should render with the action color', () => {
       const wrapper = shallow(<Icon color="action">account_circle</Icon>);
-      assert.strictEqual(wrapper.hasClass(classes.colorAction), true);
+      expect(wrapper.hasClass(classes.colorAction)).to.equal(true);
     });
 
     it('should render with the error color', () => {
       const wrapper = shallow(<Icon color="error">account_circle</Icon>);
-      assert.strictEqual(wrapper.hasClass(classes.colorError), true);
+      expect(wrapper.hasClass(classes.colorError)).to.equal(true);
     });
 
     it('should render with the primary class', () => {
       const wrapper = shallow(<Icon color="primary">account_circle</Icon>);
-      assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
+      expect(wrapper.hasClass(classes.colorPrimary)).to.equal(true);
     });
   });
 
   describe('prop: fontSize', () => {
     it('should be able to change the fontSize', () => {
       const wrapper = shallow(<Icon fontSize="inherit">account_circle</Icon>);
-      assert.strictEqual(wrapper.hasClass(classes.fontSizeInherit), true);
+      expect(wrapper.hasClass(classes.fontSizeInherit)).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/InputBase/utils.test.js
+++ b/packages/material-ui/src/InputBase/utils.test.js
@@ -1,17 +1,17 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { hasValue, isFilled } from './utils';
 
 describe('Input/utils.js', () => {
   describe('hasValue', () => {
     ['', 0].forEach((value) => {
       it(`is true for ${value}`, () => {
-        assert.strictEqual(hasValue(value), true);
+        expect(hasValue(value)).to.equal(true);
       });
     });
 
     [null, undefined].forEach((value) => {
       it(`is false for ${value}`, () => {
-        assert.strictEqual(hasValue(value), false);
+        expect(hasValue(value)).to.equal(false);
       });
     });
   });
@@ -19,20 +19,20 @@ describe('Input/utils.js', () => {
   describe('isFilled', () => {
     [' ', 0].forEach((value) => {
       it(`is true for value ${value}`, () => {
-        assert.strictEqual(isFilled({ value }), true);
+        expect(isFilled({ value })).to.equal(true);
       });
 
       it(`is true for SSR defaultValue ${value}`, () => {
-        assert.strictEqual(isFilled({ defaultValue: value }, true), true);
+        expect(isFilled({ defaultValue: value }, true)).to.equal(true);
       });
     });
     [null, undefined, ''].forEach((value) => {
       it(`is false for value ${value}`, () => {
-        assert.strictEqual(isFilled({ value }), false);
+        expect(isFilled({ value })).to.equal(false);
       });
 
       it(`is false for SSR defaultValue ${value}`, () => {
-        assert.strictEqual(isFilled({ defaultValue: value }, true), false);
+        expect(isFilled({ defaultValue: value }, true)).to.equal(false);
       });
     });
   });

--- a/packages/material-ui/src/LinearProgress/LinearProgress.test.js
+++ b/packages/material-ui/src/LinearProgress/LinearProgress.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
@@ -30,141 +30,109 @@ describe('<LinearProgress />', () => {
 
   it('should render indeterminate variant by default', () => {
     const wrapper = shallow(<LinearProgress />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.indeterminate), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Indeterminate), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.bar2Indeterminate), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.hasClass(classes.indeterminate)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.bar1Indeterminate)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.bar2Indeterminate)).to.equal(true);
   });
 
   it('should render for the primary color', () => {
     const wrapper = shallow(<LinearProgress color="primary" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorPrimary), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
   });
 
   it('should render for the secondary color', () => {
     const wrapper = shallow(<LinearProgress color="secondary" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorSecondary), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorSecondary), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.barColorSecondary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.barColorSecondary)).to.equal(true);
   });
 
   it('should render with determinate classes for the primary color by default', () => {
     const wrapper = shallow(<LinearProgress value={1} variant="determinate" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.determinate), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Determinate), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.hasClass(classes.determinate)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.bar1Determinate)).to.equal(true);
   });
 
   it('should render with determinate classes for the primary color', () => {
     const wrapper = shallow(<LinearProgress color="primary" value={1} variant="determinate" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.determinate), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Determinate), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.hasClass(classes.determinate)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.bar1Determinate)).to.equal(true);
   });
 
   it('should render with determinate classes for the secondary color', () => {
     const wrapper = shallow(<LinearProgress color="secondary" value={1} variant="determinate" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.determinate), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorSecondary), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Determinate), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.hasClass(classes.determinate)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.barColorSecondary)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.bar1Determinate)).to.equal(true);
   });
 
   it('should set width of bar1 on determinate variant', () => {
     const wrapper = shallow(<LinearProgress variant="determinate" value={77} />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.determinate), true);
-    assert.strictEqual(
-      wrapper.childAt(0).props().style.transform,
-      'translateX(-23%)',
-      'should have width set',
-    );
-    assert.strictEqual(wrapper.props()['aria-valuenow'], 77);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.hasClass(classes.determinate)).to.equal(true);
+    expect(wrapper.childAt(0).props().style.transform).to.equal('translateX(-23%)');
+    expect(wrapper.props()['aria-valuenow']).to.equal(77);
   });
 
   it('should render with buffer classes for the primary color by default', () => {
     const wrapper = shallow(<LinearProgress value={1} valueBuffer={1} variant="buffer" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.childAt(0).hasClass(classes.dashedColorPrimary),
-      true,
-      'should have the dashedColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.barColorPrimary),
-      true,
-      'should have the barColorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(1).hasClass(classes.bar1Buffer),
-      true,
-      'should have the bar1Buffer class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.colorPrimary),
-      true,
-      'should have the colorPrimary class',
-    );
-    assert.strictEqual(
-      wrapper.childAt(2).hasClass(classes.bar2Buffer),
-      true,
-      'should have the bar2Buffer class',
-    );
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.dashedColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.bar1Buffer)).to.equal(true);
+    expect(wrapper.childAt(2).hasClass(classes.colorPrimary)).to.equal(true);
+    expect(wrapper.childAt(2).hasClass(classes.bar2Buffer)).to.equal(true);
   });
 
   it('should render with buffer classes for the primary color', () => {
     const wrapper = shallow(
       <LinearProgress value={1} valueBuffer={1} color="primary" variant="buffer" />,
     );
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.dashedColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.bar1Buffer), true);
-    assert.strictEqual(wrapper.childAt(2).hasClass(classes.colorPrimary), true);
-    assert.strictEqual(wrapper.childAt(2).hasClass(classes.bar2Buffer), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.dashedColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.bar1Buffer)).to.equal(true);
+    expect(wrapper.childAt(2).hasClass(classes.colorPrimary)).to.equal(true);
+    expect(wrapper.childAt(2).hasClass(classes.bar2Buffer)).to.equal(true);
   });
 
   it('should render with buffer classes for the secondary color', () => {
     const wrapper = shallow(
       <LinearProgress value={1} valueBuffer={1} color="secondary" variant="buffer" />,
     );
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.dashedColorSecondary), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorSecondary), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.bar1Buffer), true);
-    assert.strictEqual(wrapper.childAt(2).hasClass(classes.colorSecondary), true);
-    assert.strictEqual(wrapper.childAt(2).hasClass(classes.bar2Buffer), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.dashedColorSecondary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.barColorSecondary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.bar1Buffer)).to.equal(true);
+    expect(wrapper.childAt(2).hasClass(classes.colorSecondary)).to.equal(true);
+    expect(wrapper.childAt(2).hasClass(classes.bar2Buffer)).to.equal(true);
   });
 
   it('should set width of bar1 and bar2 on buffer variant', () => {
     const wrapper = shallow(<LinearProgress variant="buffer" value={77} valueBuffer={85} />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(
-      wrapper.childAt(1).props().style.transform,
-      'translateX(-23%)',
-      'should have width set',
-    );
-    assert.strictEqual(
-      wrapper.childAt(2).props().style.transform,
-      'translateX(-15%)',
-      'should have width set',
-    );
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.childAt(1).props().style.transform).to.equal('translateX(-23%)');
+    expect(wrapper.childAt(2).props().style.transform).to.equal('translateX(-15%)');
   });
 
   it('should render with query classes', () => {
     const wrapper = shallow(<LinearProgress variant="query" />);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
-    assert.strictEqual(wrapper.hasClass(classes.query), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.barColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(0).hasClass(classes.bar1Indeterminate), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.barColorPrimary), true);
-    assert.strictEqual(wrapper.childAt(1).hasClass(classes.bar2Indeterminate), true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
+    expect(wrapper.hasClass(classes.query)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(0).hasClass(classes.bar1Indeterminate)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.barColorPrimary)).to.equal(true);
+    expect(wrapper.childAt(1).hasClass(classes.bar2Indeterminate)).to.equal(true);
   });
 
   describe('prop: value', () => {
@@ -178,13 +146,16 @@ describe('<LinearProgress />', () => {
 
     it('should warn when not used as expected', () => {
       shallow(<LinearProgress variant="determinate" value={undefined} />);
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.match(consoleErrorMock.messages()[0], /Material-UI: you need to provide a value prop/);
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.match(
+        /Material-UI: you need to provide a value prop/,
+      );
       shallow(<LinearProgress variant="buffer" value={undefined} />);
-      assert.strictEqual(consoleErrorMock.callCount(), 3);
-      assert.match(consoleErrorMock.messages()[1], /Material-UI: you need to provide a value prop/);
-      assert.match(
-        consoleErrorMock.messages()[2],
+      expect(consoleErrorMock.callCount()).to.equal(3);
+      expect(consoleErrorMock.messages()[1]).to.match(
+        /Material-UI: you need to provide a value prop/,
+      );
+      expect(consoleErrorMock.messages()[2]).to.match(
         /Material-UI: you need to provide a valueBuffer prop/,
       );
     });

--- a/packages/material-ui/src/Link/Link.test.js
+++ b/packages/material-ui/src/Link/Link.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
@@ -36,7 +36,7 @@ describe('<Link />', () => {
 
   it('should render children', () => {
     const wrapper = mount(<Link href="/">Home</Link>);
-    assert.strictEqual(wrapper.contains('Home'), true);
+    expect(wrapper.contains('Home')).to.equal(true);
   });
 
   it('should pass props to the <Typography> component', () => {
@@ -46,7 +46,7 @@ describe('<Link />', () => {
       </Link>,
     );
     const typography = wrapper.find(Typography);
-    assert.strictEqual(typography.props().color, 'primary');
+    expect(typography.props().color).to.equal('primary');
   });
 
   describe('event callbacks', () => {
@@ -67,7 +67,7 @@ describe('<Link />', () => {
       events.forEach((n) => {
         const event = n.charAt(2).toLowerCase() + n.slice(3);
         wrapper.simulate(event, { target: { tagName: 'a' } });
-        assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
+        expect(handlers[n].callCount).to.equal(1);
       });
     });
   });
@@ -77,11 +77,11 @@ describe('<Link />', () => {
       const wrapper = mount(<Link href="/">Home</Link>);
       const anchor = wrapper.find('a').instance();
 
-      assert.strictEqual(anchor.classList.contains(classes.focusVisible), false);
+      expect(anchor.classList.contains(classes.focusVisible)).to.equal(false);
       focusVisible(anchor);
-      assert.strictEqual(anchor.classList.contains(classes.focusVisible), true);
+      expect(anchor.classList.contains(classes.focusVisible)).to.equal(true);
       anchor.blur();
-      assert.strictEqual(anchor.classList.contains(classes.focusVisible), false);
+      expect(anchor.classList.contains(classes.focusVisible)).to.equal(false);
     });
   });
 });

--- a/packages/material-ui/src/List/List.test.js
+++ b/packages/material-ui/src/List/List.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import ListSubheader from '../ListSubheader';
@@ -29,35 +29,35 @@ describe('<List />', () => {
   it('should render with padding classes', () => {
     const wrapper = mount(<List className="woofList" />);
     const root = wrapper.find('ul');
-    assert.strictEqual(root.hasClass(classes.padding), true);
+    expect(root.hasClass(classes.padding)).to.equal(true);
   });
 
   it('can disable the padding', () => {
     const wrapper = mount(<List disablePadding />);
-    assert.strictEqual(wrapper.find('ul').hasClass(classes.padding), false);
+    expect(wrapper.find('ul').hasClass(classes.padding)).to.equal(false);
   });
 
   describe('prop: subheader', () => {
     it('should render with subheader class', () => {
       const wrapper = mount(<List subheader={<ListSubheader>Title</ListSubheader>} />);
-      assert.strictEqual(wrapper.find('ul').hasClass(classes.subheader), true);
+      expect(wrapper.find('ul').hasClass(classes.subheader)).to.equal(true);
     });
 
     it('should render ListSubheader', () => {
       const wrapper = mount(<List subheader={<ListSubheader>Title</ListSubheader>} />);
-      assert.strictEqual(wrapper.find(ListSubheader).length, 1);
+      expect(wrapper.find(ListSubheader).length).to.equal(1);
     });
   });
 
   describe('prop: dense', () => {
     it('is disabled by default', () => {
       const wrapper = mount(<List />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.dense), false);
+      expect(findOutermostIntrinsic(wrapper).hasClass(classes.dense)).to.equal(false);
     });
 
     it('adds a dense class', () => {
       const wrapper = mount(<List dense />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.dense), true);
+      expect(findOutermostIntrinsic(wrapper).hasClass(classes.dense)).to.equal(true);
     });
 
     it('sets dense on deep nested ListItem', () => {
@@ -75,7 +75,7 @@ describe('<List />', () => {
       );
 
       const listItemClasses = getClasses(<ListItem />);
-      assert.strictEqual(wrapper.find('li').every(`.${listItemClasses.dense}`), true);
+      expect(wrapper.find('li').every(`.${listItemClasses.dense}`)).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/ListItemText/ListItemText.test.js
+++ b/packages/material-ui/src/ListItemText/ListItemText.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { getClasses, createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Typography from '../Typography';
@@ -29,8 +29,8 @@ describe('<ListItemText />', () => {
   it('should render with inset class', () => {
     const wrapper = mount(<ListItemText inset />);
     const listItemText = findOutermostIntrinsic(wrapper);
-    assert.strictEqual(listItemText.hasClass(classes.inset), true);
-    assert.strictEqual(listItemText.hasClass(classes.root), true);
+    expect(listItemText.hasClass(classes.inset)).to.equal(true);
+    expect(listItemText.hasClass(classes.root)).to.equal(true);
   });
 
   it('should render with no children', () => {
@@ -38,7 +38,7 @@ describe('<ListItemText />', () => {
     const listItemText = findOutermostIntrinsic(wrapper);
     // wrapper.find('div > *').exists()
     // https://github.com/airbnb/enzyme/issues/1154
-    assert.strictEqual(listItemText.children().exists(), false);
+    expect(listItemText.children().exists()).to.equal(false);
   });
 
   describe('prop: primary', () => {
@@ -48,27 +48,27 @@ describe('<ListItemText />', () => {
       const wrapper = mount(<ListItemText primary="This is the primary text" ref={ref} />);
       const listItemText = findOutermostIntrinsic(wrapper);
       const typography = listItemText.find(Typography);
-      assert.strictEqual(typography.exists(), true);
-      assert.strictEqual(typography.props().variant, 'body1');
-      assert.strictEqual(text(), 'This is the primary text');
+      expect(typography.exists()).to.equal(true);
+      expect(typography.props().variant).to.equal('body1');
+      expect(text()).to.equal('This is the primary text');
     });
 
     it('should use the primary node', () => {
       const primary = <span />;
       const wrapper = mount(<ListItemText primary={primary} />);
-      assert.strictEqual(wrapper.contains(primary), true);
+      expect(wrapper.contains(primary)).to.equal(true);
     });
 
     it('should use the children prop as primary node', () => {
       const primary = <span />;
       const wrapper = mount(<ListItemText>{primary}</ListItemText>);
-      assert.strictEqual(wrapper.contains(primary), true);
+      expect(wrapper.contains(primary)).to.equal(true);
     });
 
     it('should read 0 as primary', () => {
       const wrapper = mount(<ListItemText primary={0} />);
       const listItemText = findOutermostIntrinsic(wrapper);
-      assert.strictEqual(listItemText.find(Typography).exists(), true);
+      expect(listItemText.find(Typography).exists()).to.equal(true);
     });
   });
 
@@ -77,21 +77,21 @@ describe('<ListItemText />', () => {
       const wrapper = mount(<ListItemText secondary="This is the secondary text" />);
       const listItemText = findOutermostIntrinsic(wrapper);
       const typography = listItemText.find(Typography);
-      assert.strictEqual(typography.exists(), true);
-      assert.strictEqual(typography.props().color, 'textSecondary');
-      assert.strictEqual(listItemText.text(), 'This is the secondary text');
+      expect(typography.exists()).to.equal(true);
+      expect(typography.props().color).to.equal('textSecondary');
+      expect(listItemText.text()).to.equal('This is the secondary text');
     });
 
     it('should use the secondary node', () => {
       const secondary = <span />;
       const wrapper = mount(<ListItemText secondary={secondary} />);
-      assert.strictEqual(wrapper.contains(secondary), true);
+      expect(wrapper.contains(secondary)).to.equal(true);
     });
 
     it('should read 0 as secondary', () => {
       const wrapper = mount(<ListItemText secondary={0} />);
       const listItemText = findOutermostIntrinsic(wrapper);
-      assert.strictEqual(listItemText.find(Typography).exists(), true);
+      expect(listItemText.find(Typography).exists()).to.equal(true);
     });
   });
 
@@ -103,15 +103,15 @@ describe('<ListItemText />', () => {
       const listItemText = findOutermostIntrinsic(wrapper);
 
       const texts = listItemText.find(Typography);
-      assert.strictEqual(texts.length, 2);
+      expect(texts.length).to.equal(2);
 
       const primaryText = texts.first();
-      assert.strictEqual(primaryText.props().variant, 'body1');
-      assert.strictEqual(primaryText.text(), 'This is the primary text');
+      expect(primaryText.props().variant).to.equal('body1');
+      expect(primaryText.text()).to.equal('This is the primary text');
 
       const secondaryText = texts.last();
-      assert.strictEqual(secondaryText.props().color, 'textSecondary');
-      assert.strictEqual(secondaryText.text(), 'This is the secondary text');
+      expect(secondaryText.props().color).to.equal('textSecondary');
+      expect(secondaryText.text()).to.equal('This is the secondary text');
     });
 
     it('should render JSX children', () => {
@@ -121,8 +121,8 @@ describe('<ListItemText />', () => {
         <ListItemText primary={primaryChild} secondary={secondaryChild} disableTypography />,
       );
       const texts = wrapper.find('div > p');
-      assert.strictEqual(texts.first().equals(primaryChild), true);
-      assert.strictEqual(texts.last().equals(secondaryChild), true);
+      expect(texts.first().equals(primaryChild)).to.equal(true);
+      expect(texts.last().equals(secondaryChild)).to.equal(true);
     });
   });
 
@@ -140,8 +140,8 @@ describe('<ListItemText />', () => {
     );
     const texts = wrapper.find(Typography);
 
-    assert.strictEqual(texts.first().props().className.includes('GeneralText'), true);
-    assert.strictEqual(texts.last().props().className.includes('SecondaryText'), true);
+    expect(texts.first().props().className.includes('GeneralText')).to.equal(true);
+    expect(texts.last().props().className.includes('SecondaryText')).to.equal(true);
   });
 
   it('should not re-wrap the <Typography> element', () => {
@@ -149,9 +149,9 @@ describe('<ListItemText />', () => {
     const secondary = <Typography>This is the secondary text</Typography>;
     const wrapper = mount(<ListItemText primary={primary} secondary={secondary} />);
     const texts = findOutermostIntrinsic(wrapper).find(Typography);
-    assert.strictEqual(texts.length, 2);
-    assert.strictEqual(texts.first().props().children, primary.props.children);
-    assert.strictEqual(texts.last().props().children, secondary.props.children);
+    expect(texts.length).to.equal(2);
+    expect(texts.first().props().children).to.equal(primary.props.children);
+    expect(texts.last().props().children).to.equal(secondary.props.children);
   });
 
   it('should pass primaryTypographyProps to primary Typography component', () => {
@@ -162,7 +162,7 @@ describe('<ListItemText />', () => {
       />,
     );
     const listItemText = findOutermostIntrinsic(wrapper);
-    assert.strictEqual(listItemText.find(Typography).props().color, 'inherit');
+    expect(listItemText.find(Typography).props().color).to.equal('inherit');
   });
 
   it('should pass secondaryTypographyProps to secondary Typography component', () => {
@@ -174,6 +174,6 @@ describe('<ListItemText />', () => {
       />,
     );
     const listItemText = findOutermostIntrinsic(wrapper);
-    assert.strictEqual(listItemText.find(Typography).last().props().color, 'inherit');
+    expect(listItemText.find(Typography).last().props().color).to.equal('inherit');
   });
 });

--- a/packages/material-ui/src/ListSubheader/ListSubheader.test.js
+++ b/packages/material-ui/src/ListSubheader/ListSubheader.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import ListSubheader from './ListSubheader';
@@ -28,41 +28,37 @@ describe('<ListSubheader />', () => {
 
   it('should display primary color', () => {
     const wrapper = shallow(<ListSubheader color="primary" />);
-    assert.strictEqual(
-      wrapper.hasClass(classes.colorPrimary),
-      true,
-      'should have the primary class',
-    );
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    expect(wrapper.hasClass(classes.colorPrimary)).to.equal(true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
   });
 
   it('should display inset class', () => {
     const wrapper = shallow(<ListSubheader inset />);
-    assert.strictEqual(wrapper.hasClass(classes.inset), true);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    expect(wrapper.hasClass(classes.inset)).to.equal(true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
   });
 
   describe('prop: disableSticky', () => {
     it('should display sticky class', () => {
       const wrapper = shallow(<ListSubheader />);
-      assert.strictEqual(wrapper.hasClass(classes.sticky), true);
+      expect(wrapper.hasClass(classes.sticky)).to.equal(true);
     });
 
     it('should not display sticky class', () => {
       const wrapper = shallow(<ListSubheader disableSticky />);
-      assert.strictEqual(wrapper.hasClass(classes.sticky), false);
+      expect(wrapper.hasClass(classes.sticky)).to.equal(false);
     });
   });
 
   describe('prop: disableGutters', () => {
     it('should not display gutters class', () => {
       const wrapper = shallow(<ListSubheader disableGutters />);
-      assert.strictEqual(wrapper.hasClass(classes.gutters), false);
+      expect(wrapper.hasClass(classes.gutters)).to.equal(false);
     });
 
     it('should display gutters class', () => {
       const wrapper = shallow(<ListSubheader />);
-      assert.strictEqual(wrapper.hasClass(classes.gutters), true);
+      expect(wrapper.hasClass(classes.gutters)).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/Menu/Menu.test.js
+++ b/packages/material-ui/src/Menu/Menu.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { spy } from 'sinon';
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Popover from '../Popover';
@@ -51,10 +51,10 @@ describe('<Menu />', () => {
             onEnter={handleEnter}
             onEntering={handleEntering}
             onEntered={() => {
-              assert.strictEqual(handleEnter.callCount, 1);
-              assert.strictEqual(handleEnter.args[0].length, 2);
-              assert.strictEqual(handleEntering.callCount, 1);
-              assert.strictEqual(handleEntering.args[0].length, 2);
+              expect(handleEnter.callCount).to.equal(1);
+              expect(handleEnter.args[0].length).to.equal(2);
+              expect(handleEntering.callCount).to.equal(1);
+              expect(handleEntering.args[0].length).to.equal(2);
               done();
             }}
             {...defaultProps}
@@ -77,10 +77,10 @@ describe('<Menu />', () => {
             onExit={handleExit}
             onExiting={handleExiting}
             onExited={() => {
-              assert.strictEqual(handleExit.callCount, 1);
-              assert.strictEqual(handleExit.args[0].length, 1);
-              assert.strictEqual(handleExiting.callCount, 1);
-              assert.strictEqual(handleExiting.args[0].length, 1);
+              expect(handleExit.callCount).to.equal(1);
+              expect(handleExit.args[0].length).to.equal(1);
+              expect(handleExiting.callCount).to.equal(1);
+              expect(handleExiting.args[0].length).to.equal(1);
               done();
             }}
             {...defaultProps}
@@ -97,39 +97,39 @@ describe('<Menu />', () => {
 
   it('should pass `classes.paper` to the Popover', () => {
     const wrapper = mount(<Menu {...defaultProps} />);
-    assert.strictEqual(wrapper.find(Popover).props().PaperProps.classes.root, classes.paper);
+    expect(wrapper.find(Popover).props().PaperProps.classes.root).to.equal(classes.paper);
   });
 
   describe('prop: PopoverClasses', () => {
     it('should be able to change the Popover style', () => {
       const wrapper = mount(<Menu {...defaultProps} PopoverClasses={{ paper: 'bar' }} />);
-      assert.strictEqual(wrapper.find(Popover).props().classes.paper, 'bar');
+      expect(wrapper.find(Popover).props().classes.paper).to.equal('bar');
     });
   });
 
   it('should pass the instance function `getContentAnchorEl` to Popover', () => {
     const menuRef = React.createRef();
     const wrapper = mount(<Menu ref={menuRef} {...defaultProps} />);
-    assert.strictEqual(wrapper.find(Popover).props().getContentAnchorEl != null, true);
+    expect(wrapper.find(Popover).props().getContentAnchorEl != null).to.equal(true);
   });
 
   it('should pass onClose prop to Popover', () => {
     const fn = () => {};
     const wrapper = mount(<Menu {...defaultProps} onClose={fn} />);
-    assert.strictEqual(wrapper.find(Popover).props().onClose, fn);
+    expect(wrapper.find(Popover).props().onClose).to.equal(fn);
   });
 
   it('should pass anchorEl prop to Popover', () => {
     const el = document.createElement('div');
     const wrapper = mount(<Menu {...defaultProps} anchorEl={el} />);
-    assert.strictEqual(wrapper.find(Popover).props().anchorEl, el);
+    expect(wrapper.find(Popover).props().anchorEl).to.equal(el);
   });
 
   it('should pass through the `open` prop to Popover', () => {
     const wrapper = mount(<Menu {...defaultProps} />);
-    assert.strictEqual(wrapper.find(Popover).props().open, false);
+    expect(wrapper.find(Popover).props().open).to.equal(false);
     wrapper.setProps({ open: true });
-    assert.strictEqual(wrapper.find(Popover).props().open, true);
+    expect(wrapper.find(Popover).props().open).to.equal(true);
   });
 
   describe('list node', () => {
@@ -140,7 +140,7 @@ describe('<Menu />', () => {
     });
 
     it('should render a MenuList inside the Popover', () => {
-      assert.strictEqual(wrapper.find(Popover).find(MenuList).exists(), true);
+      expect(wrapper.find(Popover).find(MenuList).exists()).to.equal(true);
     });
   });
 
@@ -153,8 +153,8 @@ describe('<Menu />', () => {
       </Menu>,
     );
     const popover = wrapper.find(Popover);
-    assert.strictEqual(popover.props().open, true);
-    assert.strictEqual(wrapper.find('[role="menuitem"]').props().autoFocus, true);
+    expect(popover.props().open).to.equal(true);
+    expect(wrapper.find('[role="menuitem"]').props().autoFocus).to.equal(true);
   });
 
   it('should not focus list if autoFocus=false', () => {
@@ -164,10 +164,10 @@ describe('<Menu />', () => {
       </Menu>,
     );
     const popover = wrapper.find(Popover);
-    assert.strictEqual(popover.props().open, true);
+    expect(popover.props().open).to.equal(true);
     const menuEl = document.querySelector('[data-mui-test="Menu"]');
-    assert.notStrictEqual(document.activeElement, menuEl);
-    assert.strictEqual(false, menuEl.contains(document.activeElement));
+    expect(document.activeElement).to.not.equal(menuEl);
+    expect(false).to.equal(menuEl.contains(document.activeElement));
   });
 
   it('should call props.onEntering with element if exists', () => {
@@ -178,8 +178,8 @@ describe('<Menu />', () => {
     const elementForHandleEnter = { clientHeight: MENU_LIST_HEIGHT };
 
     popover.props().onEntering(elementForHandleEnter);
-    assert.strictEqual(onEnteringSpy.callCount, 1);
-    assert.strictEqual(onEnteringSpy.calledWith(elementForHandleEnter), true);
+    expect(onEnteringSpy.callCount).to.equal(1);
+    expect(onEnteringSpy.calledWith(elementForHandleEnter)).to.equal(true);
   });
 
   it('should call props.onEntering, disableAutoFocusItem', () => {
@@ -192,8 +192,8 @@ describe('<Menu />', () => {
     const elementForHandleEnter = { clientHeight: MENU_LIST_HEIGHT };
 
     popover.props().onEntering(elementForHandleEnter);
-    assert.strictEqual(onEnteringSpy.callCount, 1);
-    assert.strictEqual(onEnteringSpy.calledWith(elementForHandleEnter), true);
+    expect(onEnteringSpy.callCount).to.equal(1);
+    expect(onEnteringSpy.calledWith(elementForHandleEnter)).to.equal(true);
   });
 
   it('should call onClose on tab', () => {
@@ -206,8 +206,8 @@ describe('<Menu />', () => {
     wrapper.find('span').simulate('keyDown', {
       key: 'Tab',
     });
-    assert.strictEqual(onCloseSpy.callCount, 1);
-    assert.strictEqual(onCloseSpy.args[0][1], 'tabKeyDown');
+    expect(onCloseSpy.callCount).to.equal(1);
+    expect(onCloseSpy.args[0][1]).to.equal('tabKeyDown');
   });
 
   it('ignores invalid children', () => {
@@ -241,9 +241,8 @@ describe('<Menu />', () => {
         </Menu>,
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 2);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(2);
+      expect(consoleErrorMock.messages()[0]).to.include(
         "Material-UI: the Menu component doesn't accept a Fragment as a child.",
       );
     });

--- a/packages/material-ui/src/MenuItem/MenuItem.test.js
+++ b/packages/material-ui/src/MenuItem/MenuItem.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, getClasses, createMount } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
@@ -32,29 +32,29 @@ describe('<MenuItem />', () => {
 
   it('should render a button ListItem with with ripple', () => {
     const wrapper = shallow(<MenuItem />);
-    assert.strictEqual(wrapper.type(), ListItem);
-    assert.strictEqual(wrapper.find(ListItem).props().button, true);
-    assert.strictEqual(wrapper.find(ListItem).props().disableRipple, undefined);
+    expect(wrapper.type()).to.equal(ListItem);
+    expect(wrapper.find(ListItem).props().button).to.equal(true);
+    expect(wrapper.find(ListItem).props().disableRipple).to.equal(undefined);
   });
 
   it('should render with the selected class', () => {
     const wrapper = shallow(<MenuItem selected />);
-    assert.strictEqual(wrapper.hasClass(classes.selected), true);
+    expect(wrapper.hasClass(classes.selected)).to.equal(true);
   });
 
   it('should have a default role of menuitem', () => {
     const wrapper = shallow(<MenuItem />);
-    assert.strictEqual(wrapper.props().role, 'menuitem');
+    expect(wrapper.props().role).to.equal('menuitem');
   });
 
   it('should have a role of option', () => {
     const wrapper = shallow(<MenuItem role="option" aria-selected={false} />);
-    assert.strictEqual(wrapper.props().role, 'option');
+    expect(wrapper.props().role).to.equal('option');
   });
 
   it('should have a tabIndex of -1 by default', () => {
     const wrapper = shallow(<MenuItem />);
-    assert.strictEqual(wrapper.props().tabIndex, -1);
+    expect(wrapper.props().tabIndex).to.equal(-1);
   });
 
   describe('event callbacks', () => {
@@ -82,7 +82,7 @@ describe('<MenuItem />', () => {
       events.forEach((n) => {
         const event = n.charAt(2).toLowerCase() + n.slice(3);
         wrapper.simulate(event, { persist: () => {} });
-        assert.strictEqual(handlers[n].callCount, 1, `should have called the ${n} handler`);
+        expect(handlers[n].callCount).to.equal(1);
       });
     });
   });
@@ -96,7 +96,7 @@ describe('<MenuItem />', () => {
           </ListItemSecondaryAction>
         </MenuItem>,
       );
-      assert.strictEqual(wrapper1.find('li').length, 1);
+      expect(wrapper1.find('li').length).to.equal(1);
       const wrapper2 = mount(
         <MenuItem button={false}>
           <ListItemSecondaryAction>
@@ -104,14 +104,14 @@ describe('<MenuItem />', () => {
           </ListItemSecondaryAction>
         </MenuItem>,
       );
-      assert.strictEqual(wrapper2.find('li').length, 1);
+      expect(wrapper2.find('li').length).to.equal(1);
     });
   });
 
   describe('prop: ListItemClasses', () => {
     it('should be able to change the style of ListItem', () => {
       const wrapper = mount(<MenuItem ListItemClasses={{ disabled: 'bar' }} />);
-      assert.strictEqual(wrapper.find(ListItem).props().classes.disabled, 'bar');
+      expect(wrapper.find(ListItem).props().classes.disabled).to.equal('bar');
     });
   });
 });

--- a/packages/material-ui/src/MobileStepper/MobileStepper.test.js
+++ b/packages/material-ui/src/MobileStepper/MobileStepper.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import { createMount, getClasses, findOutermostIntrinsic } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import KeyboardArrowLeft from '../internal/svg-icons/KeyboardArrowLeft';
@@ -47,17 +47,17 @@ describe('<MobileStepper />', () => {
 
   it('should render a Paper with 0 elevation', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} />);
-    assert.strictEqual(wrapper.find(Paper).props().elevation, 0);
+    expect(wrapper.find(Paper).props().elevation).to.equal(0);
   });
 
   it('should render with the bottom class if position prop is set to bottom', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} position="bottom" />);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.positionBottom), true);
+    expect(findOutermostIntrinsic(wrapper).hasClass(classes.positionBottom)).to.equal(true);
   });
 
   it('should render with the top class if position prop is set to top', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} position="top" />);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.positionTop), true);
+    expect(findOutermostIntrinsic(wrapper).hasClass(classes.positionTop)).to.equal(true);
   });
 
   it('should render two buttons', () => {
@@ -68,14 +68,14 @@ describe('<MobileStepper />', () => {
   it('should render the back button', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} />);
     const backButton = wrapper.find('button[aria-label="back"]');
-    assert.strictEqual(backButton.exists(), true);
+    expect(backButton.exists()).to.equal(true);
     assert.lengthOf(backButton.find('svg[data-mui-test="KeyboardArrowLeftIcon"]'), 1);
   });
 
   it('should render next button', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} />);
     const nextButton = wrapper.find('button[aria-label="next"]');
-    assert.strictEqual(nextButton.exists(), true);
+    expect(nextButton.exists()).to.equal(true);
     assert.lengthOf(nextButton.find('svg[data-mui-test="KeyboardArrowRightIcon"]'), 1);
   });
 
@@ -83,14 +83,14 @@ describe('<MobileStepper />', () => {
     const wrapper = mount(
       <MobileStepper {...defaultProps} variant="text" activeStep={1} steps={3} />,
     );
-    assert.strictEqual(findOutermostIntrinsic(wrapper).instance().textContent, 'Back2 / 3Next');
+    expect(findOutermostIntrinsic(wrapper).instance().textContent).to.equal('Back2 / 3Next');
   });
 
   it('should render dots when supplied with variant dots', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} variant="dots" />);
     const outermost = findOutermostIntrinsic(wrapper);
     assert.lengthOf(outermost.children(), 3);
-    assert.strictEqual(outermost.childAt(1).hasClass(classes.dots), true);
+    expect(outermost.childAt(1).hasClass(classes.dots)).to.equal(true);
   });
 
   it('should render a dot for each step when using dots variant', () => {
@@ -100,18 +100,16 @@ describe('<MobileStepper />', () => {
 
   it('should render the first dot as active if activeStep is not set', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} variant="dots" />);
-    assert.strictEqual(
+    expect(
       findOutermostIntrinsic(wrapper).childAt(1).childAt(0).hasClass(classes.dotActive),
-      true,
-    );
+    ).to.equal(true);
   });
 
   it('should honor the activeStep prop', () => {
     const wrapper = mount(<MobileStepper {...defaultProps} variant="dots" activeStep={1} />);
-    assert.strictEqual(
+    expect(
       findOutermostIntrinsic(wrapper).childAt(1).childAt(1).hasClass(classes.dotActive),
-      true,
-    );
+    ).to.equal(true);
   });
 
   it('should render a <LinearProgress /> when supplied with variant progress', () => {
@@ -122,18 +120,18 @@ describe('<MobileStepper />', () => {
   it('should calculate the <LinearProgress /> value correctly', () => {
     let wrapper = mount(<MobileStepper {...defaultProps} variant="progress" steps={3} />);
     let linearProgressProps = wrapper.find(LinearProgress).props();
-    assert.strictEqual(linearProgressProps.value, 0);
+    expect(linearProgressProps.value).to.equal(0);
 
     wrapper = mount(
       <MobileStepper {...defaultProps} variant="progress" steps={3} activeStep={1} />,
     );
     linearProgressProps = wrapper.find(LinearProgress).props();
-    assert.strictEqual(linearProgressProps.value, 50);
+    expect(linearProgressProps.value).to.equal(50);
 
     wrapper = mount(
       <MobileStepper {...defaultProps} variant="progress" steps={3} activeStep={2} />,
     );
     linearProgressProps = wrapper.find(LinearProgress).props();
-    assert.strictEqual(linearProgressProps.value, 100);
+    expect(linearProgressProps.value).to.equal(100);
   });
 });

--- a/packages/material-ui/src/Modal/ModalManager.test.js
+++ b/packages/material-ui/src/Modal/ModalManager.test.js
@@ -1,4 +1,4 @@
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import getScrollbarSize from '../utils/getScrollbarSize';
 import ModalManager from './ModalManager';
 
@@ -30,7 +30,7 @@ describe('ModalManager', () => {
     const modalManager2 = new ModalManager();
     const idx = modalManager2.add(modal, container1);
     modalManager2.mount(modal, {});
-    assert.strictEqual(modalManager2.add(modal, container1), idx);
+    expect(modalManager2.add(modal, container1)).to.equal(idx);
     modalManager2.remove(modal);
   });
 
@@ -48,58 +48,54 @@ describe('ModalManager', () => {
     it('should add modal1', () => {
       const idx = modalManager.add(modal1, container1);
       modalManager.mount(modal1, {});
-      assert.strictEqual(idx, 0, 'should be the first modal');
-      assert.strictEqual(modalManager.isTopModal(modal1), true);
+      expect(idx).to.equal(0);
+      expect(modalManager.isTopModal(modal1)).to.equal(true);
     });
 
     it('should add modal2', () => {
       const idx = modalManager.add(modal2, container1);
-      assert.strictEqual(idx, 1, 'should be the second modal');
-      assert.strictEqual(modalManager.isTopModal(modal2), true);
+      expect(idx).to.equal(1);
+      expect(modalManager.isTopModal(modal2)).to.equal(true);
     });
 
     it('should add modal3', () => {
       const idx = modalManager.add(modal3, container1);
-      assert.strictEqual(idx, 2, 'should be the third modal');
-      assert.strictEqual(modalManager.isTopModal(modal3), true);
+      expect(idx).to.equal(2);
+      expect(modalManager.isTopModal(modal3)).to.equal(true);
     });
 
     it('should remove modal2', () => {
       const idx = modalManager.remove(modal2);
-      assert.strictEqual(idx, 1, 'should be the second modal');
+      expect(idx).to.equal(1);
     });
 
     it('should add modal2 2', () => {
       const idx = modalManager.add(modal2, container1);
       modalManager.mount(modal2, {});
-      assert.strictEqual(idx, 2, 'should be the "third" modal');
-      assert.strictEqual(modalManager.isTopModal(modal2), true);
-      assert.strictEqual(
-        modalManager.isTopModal(modal3),
-        false,
-        'modal3 should not be the top modal',
-      );
+      expect(idx).to.equal(2);
+      expect(modalManager.isTopModal(modal2)).to.equal(true);
+      expect(modalManager.isTopModal(modal3)).to.equal(false);
     });
 
     it('should remove modal3', () => {
       const idx = modalManager.remove(modal3);
-      assert.strictEqual(idx, 1);
+      expect(idx).to.equal(1);
     });
 
     it('should remove modal2 2', () => {
       const idx = modalManager.remove(modal2);
-      assert.strictEqual(idx, 1);
-      assert.strictEqual(modalManager.isTopModal(modal1), true);
+      expect(idx).to.equal(1);
+      expect(modalManager.isTopModal(modal1)).to.equal(true);
     });
 
     it('should remove modal1', () => {
       const idx = modalManager.remove(modal1);
-      assert.strictEqual(idx, 0);
+      expect(idx).to.equal(0);
     });
 
     it('should not do anything', () => {
       const idx = modalManager.remove({ nonExisting: true });
-      assert.strictEqual(idx, -1);
+      expect(idx).to.equal(-1);
     });
   });
 
@@ -126,13 +122,13 @@ describe('ModalManager', () => {
       const modal = {};
       modalManager.add(modal, container1);
       modalManager.mount(modal, {});
-      assert.strictEqual(container1.style.overflow, 'hidden');
-      assert.strictEqual(container1.style.paddingRight, `${20 + getScrollbarSize()}px`);
-      assert.strictEqual(fixedNode.style.paddingRight, `${14 + getScrollbarSize()}px`);
+      expect(container1.style.overflow).to.equal('hidden');
+      expect(container1.style.paddingRight).to.equal(`${20 + getScrollbarSize()}px`);
+      expect(fixedNode.style.paddingRight).to.equal(`${14 + getScrollbarSize()}px`);
       modalManager.remove(modal);
-      assert.strictEqual(container1.style.overflow, '');
-      assert.strictEqual(container1.style.paddingRight, '20px');
-      assert.strictEqual(fixedNode.style.paddingRight, '14px');
+      expect(container1.style.overflow).to.equal('');
+      expect(container1.style.paddingRight).to.equal('20px');
+      expect(fixedNode.style.paddingRight).to.equal('14px');
     });
 
     it('should disable the scroll even when not overflowing', () => {
@@ -151,9 +147,9 @@ describe('ModalManager', () => {
       const modal = {};
       modalManager.add(modal, container2);
       modalManager.mount(modal, {});
-      assert.strictEqual(container2.style.overflow, 'hidden');
+      expect(container2.style.overflow).to.equal('hidden');
       modalManager.remove(modal);
-      assert.strictEqual(container2.style.overflow, '');
+      expect(container2.style.overflow).to.equal('');
 
       document.body.removeChild(container2);
     });
@@ -162,13 +158,13 @@ describe('ModalManager', () => {
       const modal = {};
       modalManager.add(modal, container1);
       modalManager.mount(modal, {});
-      assert.strictEqual(container1.style.overflow, 'hidden');
-      assert.strictEqual(container1.style.paddingRight, `${20 + getScrollbarSize()}px`);
-      assert.strictEqual(fixedNode.style.paddingRight, `${0 + getScrollbarSize()}px`);
+      expect(container1.style.overflow).to.equal('hidden');
+      expect(container1.style.paddingRight).to.equal(`${20 + getScrollbarSize()}px`);
+      expect(fixedNode.style.paddingRight).to.equal(`${0 + getScrollbarSize()}px`);
       modalManager.remove(modal);
-      assert.strictEqual(container1.style.overflow, '');
-      assert.strictEqual(container1.style.paddingRight, '20px');
-      assert.strictEqual(fixedNode.style.paddingRight, '');
+      expect(container1.style.overflow).to.equal('');
+      expect(container1.style.paddingRight).to.equal('20px');
+      expect(fixedNode.style.paddingRight).to.equal('');
     });
   });
 

--- a/packages/material-ui/src/NativeSelect/NativeSelect.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelect.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { getClasses, createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import Input from '../Input';
@@ -39,7 +39,7 @@ describe('<NativeSelect />', () => {
 
   it('should provide the classes to the input component', () => {
     const wrapper = mount(<NativeSelect {...defaultProps} />);
-    assert.deepEqual(wrapper.find(Input).props().inputProps.classes, classes);
+    expect(wrapper.find(Input).props().inputProps.classes).to.deep.equal(classes);
   });
 
   it('should be able to mount the component', () => {
@@ -51,6 +51,6 @@ describe('<NativeSelect />', () => {
         <option value={30}>Thirty</option>
       </NativeSelect>,
     );
-    assert.strictEqual(wrapper.find('select').props().value, 10);
+    expect(wrapper.find('select').props().value).to.equal(10);
   });
 });

--- a/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
+++ b/packages/material-ui/src/NativeSelect/NativeSelectInput.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
@@ -48,7 +48,7 @@ describe('<NativeSelectInput />', () => {
         <option value={30}>Thirty</option>
       </NativeSelectInput>,
     );
-    assert.strictEqual(wrapper.find('select').props().value, 10);
+    expect(wrapper.find('select').props().value).to.equal(10);
   });
 
   it('should respond to update event', () => {
@@ -62,8 +62,8 @@ describe('<NativeSelectInput />', () => {
     );
 
     wrapper.find('select').simulate('change', { target: { value: 20 } });
-    assert.strictEqual(handleChange.callCount, 1);
-    assert.strictEqual(handleChange.args[0][0].target.value, 20);
+    expect(handleChange.callCount).to.equal(1);
+    expect(handleChange.args[0][0].target.value).to.equal(20);
   });
 
   it('should apply outlined class', () => {
@@ -76,7 +76,7 @@ describe('<NativeSelectInput />', () => {
       />,
     );
 
-    assert.strictEqual(wrapper.find(`.${defaultProps.classes.select}`).hasClass(outlined), true);
+    expect(wrapper.find(`.${defaultProps.classes.select}`).hasClass(outlined)).to.equal(true);
   });
 
   it('should apply filled class', () => {
@@ -89,6 +89,6 @@ describe('<NativeSelectInput />', () => {
       />,
     );
 
-    assert.strictEqual(wrapper.find(`.${defaultProps.classes.select}`).hasClass(filled), true);
+    expect(wrapper.find(`.${defaultProps.classes.select}`).hasClass(filled)).to.equal(true);
   });
 });

--- a/packages/material-ui/src/NoSsr/NoSsr.test.js
+++ b/packages/material-ui/src/NoSsr/NoSsr.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount } from '@material-ui/core/test-utils';
 import createServerRender from 'test/utils/createServerRender';
 import NoSsr from './NoSsr';
@@ -23,7 +23,7 @@ describe('<NoSsr />', () => {
           <span>Hello</span>
         </NoSsr>,
       );
-      assert.strictEqual(wrapper.text(), '');
+      expect(wrapper.text()).to.equal('');
     });
   });
 
@@ -34,7 +34,7 @@ describe('<NoSsr />', () => {
           <span id="client-only" />
         </NoSsr>,
       );
-      assert.strictEqual(wrapper.find('#client-only').exists(), true);
+      expect(wrapper.find('#client-only').exists()).to.equal(true);
     });
   });
 
@@ -47,7 +47,7 @@ describe('<NoSsr />', () => {
           </NoSsr>
         </div>,
       );
-      assert.strictEqual(wrapper.text(), 'fallback');
+      expect(wrapper.text()).to.equal('fallback');
     });
   });
 
@@ -58,7 +58,7 @@ describe('<NoSsr />', () => {
           <span id="client-only">Hello</span>
         </NoSsr>,
       );
-      assert.strictEqual(wrapper.find('#client-only').exists(), true);
+      expect(wrapper.find('#client-only').exists()).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/Paper/Paper.test.js
+++ b/packages/material-ui/src/Paper/Paper.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, createShallow, getClasses } from '@material-ui/core/test-utils';
 import * as PropTypes from 'prop-types';
 import describeConformance from '../test-utils/describeConformance';
@@ -33,41 +33,29 @@ describe('<Paper />', () => {
   describe('prop: square', () => {
     it('can disable the rounded class', () => {
       const wrapper = mount(<Paper square>Hello World</Paper>);
-      assert.strictEqual(wrapper.find(`.${classes.root}`).some(`.${classes.rounded}`), false);
+      expect(wrapper.find(`.${classes.root}`).some(`.${classes.rounded}`)).to.equal(false);
     });
 
     it('adds a rounded class to the root when omitted', () => {
       const wrapper = mount(<Paper>Hello World</Paper>);
-      assert.strictEqual(wrapper.find(`.${classes.root}`).every(`.${classes.rounded}`), true);
+      expect(wrapper.find(`.${classes.root}`).every(`.${classes.rounded}`)).to.equal(true);
     });
   });
 
   describe('prop: variant', () => {
     it('adds a outlined class', () => {
       const wrapper = mount(<Paper variant="outlined">Hello World</Paper>);
-      assert.strictEqual(wrapper.find(`.${classes.root}`).some(`.${classes.outlined}`), true);
+      expect(wrapper.find(`.${classes.root}`).some(`.${classes.outlined}`)).to.equal(true);
     });
   });
 
   it('should set the elevation elevation class', () => {
     const wrapper = shallow(<Paper elevation={16}>Hello World</Paper>);
-    assert.strictEqual(
-      wrapper.hasClass(classes.elevation16),
-      true,
-      'should have the 16 elevation class',
-    );
+    expect(wrapper.hasClass(classes.elevation16)).to.equal(true);
     wrapper.setProps({ elevation: 24 });
-    assert.strictEqual(
-      wrapper.hasClass(classes.elevation24),
-      true,
-      'should have the 24 elevation class',
-    );
+    expect(wrapper.hasClass(classes.elevation24)).to.equal(true);
     wrapper.setProps({ elevation: 2 });
-    assert.strictEqual(
-      wrapper.hasClass(classes.elevation2),
-      true,
-      'should have the 2 elevation class',
-    );
+    expect(wrapper.hasClass(classes.elevation2)).to.equal(true);
   });
 
   it('allows custom elevations via theme.shadows', () => {
@@ -79,7 +67,7 @@ describe('<Paper />', () => {
       </ThemeProvider>,
     );
 
-    assert.strictEqual(wrapper.find('div[data-testid="paper"]').hasClass('custom-elevation'), true);
+    expect(wrapper.find('div[data-testid="paper"]').hasClass('custom-elevation')).to.equal(true);
   });
 
   describe('warnings', () => {
@@ -100,9 +88,8 @@ describe('<Paper />', () => {
         'MockedPaper',
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Material-UI: this elevation `25` is not implemented.',
       );
     });

--- a/packages/material-ui/src/Popover/Popover.test.js
+++ b/packages/material-ui/src/Popover/Popover.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import * as PropTypes from 'prop-types';
@@ -90,8 +90,8 @@ describe('<Popover />', () => {
         </Popover>,
       );
       const root = wrapper.find('ForwardRef(Popover) > [data-root-node]').first();
-      assert.strictEqual(root.type(), Modal);
-      assert.strictEqual(root.props().BackdropProps.invisible, true);
+      expect(root.type()).to.equal(Modal);
+      expect(root.props().BackdropProps.invisible).to.equal(true);
     });
 
     it('should pass open prop to Modal as `open`', () => {
@@ -100,11 +100,11 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(wrapper.find(Modal).props().open, false);
+      expect(wrapper.find(Modal).props().open).to.equal(false);
       wrapper.setProps({ open: true });
-      assert.strictEqual(wrapper.find(Modal).props().open, true);
+      expect(wrapper.find(Modal).props().open).to.equal(true);
       wrapper.setProps({ open: false });
-      assert.strictEqual(wrapper.find(Modal).props().open, false);
+      expect(wrapper.find(Modal).props().open).to.equal(false);
     });
 
     describe('getOffsetTop', () => {
@@ -117,25 +117,25 @@ describe('<Popover />', () => {
       it('should return vertical when vertical is a number', () => {
         const vertical = 1;
         const offsetTop = getOffsetTop('', vertical);
-        assert.strictEqual(offsetTop, vertical);
+        expect(offsetTop).to.equal(vertical);
       });
 
       it("should return half of rect.height if vertical is 'center'", () => {
         const vertical = 'center';
         const offsetTop = getOffsetTop(rect, vertical);
-        assert.strictEqual(offsetTop, rect.height / 2);
+        expect(offsetTop).to.equal(rect.height / 2);
       });
 
       it("should return rect.height if vertical is 'bottom'", () => {
         const vertical = 'bottom';
         const offsetTop = getOffsetTop(rect, vertical);
-        assert.strictEqual(offsetTop, rect.height);
+        expect(offsetTop).to.equal(rect.height);
       });
 
       it('should return zero if vertical is something else', () => {
         const vertical = undefined;
         const offsetTop = getOffsetTop(rect, vertical);
-        assert.strictEqual(offsetTop, 0);
+        expect(offsetTop).to.equal(0);
       });
     });
 
@@ -149,25 +149,25 @@ describe('<Popover />', () => {
       it('should return horizontal when horizontal is a number', () => {
         const horizontal = 1;
         const offsetLeft = getOffsetLeft('', horizontal);
-        assert.strictEqual(offsetLeft, horizontal);
+        expect(offsetLeft).to.equal(horizontal);
       });
 
       it("should return half of rect.width if horizontal is 'center'", () => {
         const horizontal = 'center';
         const offsetLeft = getOffsetLeft(rect, horizontal);
-        assert.strictEqual(offsetLeft, rect.width / 2);
+        expect(offsetLeft).to.equal(rect.width / 2);
       });
 
       it("should return rect.width if horizontal is 'right'", () => {
         const horizontal = 'right';
         const offsetLeft = getOffsetLeft(rect, horizontal);
-        assert.strictEqual(offsetLeft, rect.width);
+        expect(offsetLeft).to.equal(rect.width);
       });
 
       it('should return zero if horizontal is something else', () => {
         const horizontal = undefined;
         const offsetLeft = getOffsetLeft(rect, horizontal);
-        assert.strictEqual(offsetLeft, 0);
+        expect(offsetLeft).to.equal(0);
       });
     });
   });
@@ -192,8 +192,8 @@ describe('<Popover />', () => {
       const modal = wrapper.find('[data-mui-test="Modal"]');
       const transition = modal.find(Grow);
 
-      assert.strictEqual(transition.exists(), true);
-      assert.strictEqual(transition.props().appear, true, 'should transition on first appearance');
+      expect(transition.exists()).to.equal(true);
+      expect(transition.props().appear).to.equal(true);
     });
 
     it('should set the transition in/out based on the open prop', () => {
@@ -202,11 +202,11 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(wrapper.find(Grow).props().in, false);
+      expect(wrapper.find(Grow).props().in).to.equal(false);
       wrapper.setProps({ open: true });
-      assert.strictEqual(wrapper.find(Grow).props().in, true);
+      expect(wrapper.find(Grow).props().in).to.equal(true);
       wrapper.setProps({ open: false });
-      assert.strictEqual(wrapper.find(Grow).props().in, false);
+      expect(wrapper.find(Grow).props().in).to.equal(false);
     });
 
     it('should fire Popover transition event callbacks', () => {
@@ -229,11 +229,7 @@ describe('<Popover />', () => {
       clock.tick(0);
 
       events.forEach((eventHook) => {
-        assert.strictEqual(
-          handlers[eventHook].callCount,
-          1,
-          `should have called the ${eventHook} handler`,
-        );
+        expect(handlers[eventHook].callCount).to.equal(1);
       });
     });
   });
@@ -246,7 +242,7 @@ describe('<Popover />', () => {
         </Popover>,
       );
 
-      assert.strictEqual(wrapper.find(Grow).find(Paper).exists(), true);
+      expect(wrapper.find(Grow).find(Paper).exists()).to.equal(true);
     });
 
     it('should have the paper class and user classes', () => {
@@ -255,9 +251,9 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass('test-class'), true);
+      expect(findOutermostIntrinsic(wrapper).hasClass('test-class')).to.equal(true);
       const paper = wrapper.find(Paper);
-      assert.strictEqual(paper.hasClass(classes.paper), true);
+      expect(paper.hasClass(classes.paper)).to.equal(true);
     });
 
     it('should have a elevation prop passed down', () => {
@@ -267,14 +263,10 @@ describe('<Popover />', () => {
         </Popover>,
       );
 
-      assert.strictEqual(
-        wrapper.find(Paper).props().elevation,
-        8,
-        'should be 8 elevation by default',
-      );
+      expect(wrapper.find(Paper).props().elevation).to.equal(8);
 
       wrapper.setProps({ elevation: 16 });
-      assert.strictEqual(wrapper.find(Paper).props().elevation, 16, 'should be 16 elevation');
+      expect(wrapper.find(Paper).props().elevation).to.equal(16);
     });
   });
 
@@ -294,16 +286,8 @@ describe('<Popover />', () => {
 
         const element = handleEntering.args[0][0];
 
-        assert.strictEqual(
-          element.style.top === '16px' && element.style.left === '16px',
-          true,
-          'should offset the element from the top left of the screen by 16px',
-        );
-        assert.match(
-          element.style.transformOrigin,
-          /-16px -16px( 0px)?/,
-          'should have a transformOrigin',
-        );
+        expect(element.style.top === '16px' && element.style.left === '16px').to.equal(true);
+        expect(element.style.transformOrigin).to.match(/-16px -16px( 0px)?/);
       });
     });
   });
@@ -316,7 +300,7 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(anchorElSpy.callCount, 1);
+      expect(anchorElSpy.callCount).to.equal(1);
     });
   });
 
@@ -369,17 +353,9 @@ describe('<Popover />', () => {
       };
 
       expectPopover = (top, left) => {
-        assert.strictEqual(
-          popoverEl.style.top,
-          `${top}px`,
-          'should position at the correct top offset',
-        );
+        expect(popoverEl.style.top).to.equal(`${top}px`);
 
-        assert.strictEqual(
-          popoverEl.style.left,
-          `${left}px`,
-          'should position at the correct left offset',
-        );
+        expect(popoverEl.style.left).to.equal(`${left}px`);
         wrapper.unmount();
       };
     });
@@ -445,16 +421,12 @@ describe('<Popover />', () => {
       const container = document.createElement('div');
       const wrapper2 = mount(<Popover anchorEl={anchorEl} container={container} open={false} />);
 
-      assert.strictEqual(wrapper2.find(Modal).props().container, container);
+      expect(wrapper2.find(Modal).props().container).to.equal(container);
     });
 
     it("should use anchorEl's parent body as container if container not provided", async () => {
       await openPopover(undefined);
-      assert.strictEqual(
-        wrapper.find(Modal).props().container,
-        document.body,
-        "should use anchorEl's parent body as Modal container",
-      );
+      expect(wrapper.find(Modal).props().container).to.equal(document.body);
     });
   });
 
@@ -476,8 +448,8 @@ describe('<Popover />', () => {
         'MockedPopover',
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.messages()[0], 'It should be an Element instance');
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include('It should be an Element instance');
     });
 
     it('warns if a component for the Paper is used that cant hold a ref', () => {
@@ -488,9 +460,8 @@ describe('<Popover />', () => {
         'MockedPopover',
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Warning: Failed prop type: Invalid prop `PaperProps.component` supplied to `MockedPopover`. Expected an element type that can hold a ref.',
       );
     });
@@ -532,17 +503,9 @@ describe('<Popover />', () => {
         });
 
       expectPopover = (top, left) => {
-        assert.strictEqual(
-          popoverEl.style.top,
-          `${top}px`,
-          'should position at the correct top offset',
-        );
+        expect(popoverEl.style.top).to.equal(`${top}px`);
 
-        assert.strictEqual(
-          popoverEl.style.left,
-          `${left}px`,
-          'should position at the correct left offset',
-        );
+        expect(popoverEl.style.left).to.equal(`${left}px`);
         wrapper.unmount();
       };
     });
@@ -590,17 +553,9 @@ describe('<Popover />', () => {
         });
 
       expectPopover = (top, left) => {
-        assert.strictEqual(
-          popoverEl.style.top,
-          `${top}px`,
-          'should position at the correct top offset',
-        );
+        expect(popoverEl.style.top).to.equal(`${top}px`);
 
-        assert.strictEqual(
-          popoverEl.style.left,
-          `${left}px`,
-          'should position at the correct left offset',
-        );
+        expect(popoverEl.style.left).to.equal(`${left}px`);
         wrapper.unmount();
       };
     });
@@ -698,11 +653,7 @@ describe('<Popover />', () => {
         transformOrigin: element.style.transformOrigin,
       };
       window.innerHeight = windowInnerHeight * 2;
-      assert.strictEqual(
-        typeof popoverActions.updatePosition === 'function',
-        true,
-        'Should be a function.',
-      );
+      expect(typeof popoverActions.updatePosition === 'function').to.equal(true);
       popoverActions.updatePosition();
       clock.tick(166);
       const afterStyle = {
@@ -744,15 +695,15 @@ describe('<Popover />', () => {
         });
 
         it('should set top to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+          expect(positioningStyle.top).to.equal(`${marginThreshold}px`);
         });
 
         it('should set left to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+          expect(positioningStyle.left).to.equal(`${marginThreshold}px`);
         });
 
         it('should transformOrigin according to marginThreshold', () => {
-          assert.match(positioningStyle.transformOrigin, expectedTransformOrigin);
+          expect(positioningStyle.transformOrigin).to.match(expectedTransformOrigin);
         });
       });
 
@@ -770,15 +721,15 @@ describe('<Popover />', () => {
         });
 
         it('should set top to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+          expect(positioningStyle.top).to.equal(`${marginThreshold}px`);
         });
 
         it('should set left to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+          expect(positioningStyle.left).to.equal(`${marginThreshold}px`);
         });
 
         it('should transformOrigin according to marginThreshold', () => {
-          assert.match(positioningStyle.transformOrigin, /0px -1px( 0ms)?/);
+          expect(positioningStyle.transformOrigin).to.match(/0px -1px( 0ms)?/);
         });
       });
 
@@ -803,15 +754,15 @@ describe('<Popover />', () => {
         });
 
         it('should set top to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+          expect(positioningStyle.top).to.equal(`${marginThreshold}px`);
         });
 
         it('should set left to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+          expect(positioningStyle.left).to.equal(`${marginThreshold}px`);
         });
 
         it('should transformOrigin according to marginThreshold', () => {
-          assert.match(positioningStyle.transformOrigin, /0px 1px( 0px)?/);
+          expect(positioningStyle.transformOrigin).to.match(/0px 1px( 0px)?/);
         });
       });
 
@@ -829,15 +780,15 @@ describe('<Popover />', () => {
         });
 
         it('should set top to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+          expect(positioningStyle.top).to.equal(`${marginThreshold}px`);
         });
 
         it('should set left to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+          expect(positioningStyle.left).to.equal(`${marginThreshold}px`);
         });
 
         it('should transformOrigin according to marginThreshold', () => {
-          assert.match(positioningStyle.transformOrigin, /-1px 0px( 0px)?/);
+          expect(positioningStyle.transformOrigin).to.match(/-1px 0px( 0px)?/);
         });
       });
 
@@ -862,15 +813,15 @@ describe('<Popover />', () => {
         });
 
         it('should set top to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.top, `${marginThreshold}px`);
+          expect(positioningStyle.top).to.equal(`${marginThreshold}px`);
         });
 
         it('should set left to marginThreshold', () => {
-          assert.strictEqual(positioningStyle.left, `${marginThreshold}px`);
+          expect(positioningStyle.left).to.equal(`${marginThreshold}px`);
         });
 
         it('should transformOrigin according to marginThreshold', () => {
-          assert.match(positioningStyle.transformOrigin, /1px 0px( 0px)?/);
+          expect(positioningStyle.transformOrigin).to.match(/1px 0px( 0px)?/);
         });
       });
     });
@@ -901,9 +852,9 @@ describe('<Popover />', () => {
       );
 
       const elementStyle = handleEntering.args[0][0].style;
-      assert.match(elementStyle.transformOrigin, /0px 32px( 0px)?/);
-      assert.strictEqual(elementStyle.top, '157px');
-      assert.strictEqual(elementStyle.left, '160px');
+      expect(elementStyle.transformOrigin).to.match(/0px 32px( 0px)?/);
+      expect(elementStyle.top).to.equal('157px');
+      expect(elementStyle.left).to.equal('160px');
     });
   });
 
@@ -914,7 +865,7 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(wrapper.find(Grow).props().timeout, 'auto');
+      expect(wrapper.find(Grow).props().timeout).to.equal('auto');
     });
 
     it('should not apply the auto prop if not supported', () => {
@@ -924,7 +875,7 @@ describe('<Popover />', () => {
           <div />
         </Popover>,
       );
-      assert.strictEqual(wrapper.find(TransitionComponent).props().timeout, undefined);
+      expect(wrapper.find(TransitionComponent).props().timeout).to.equal(undefined);
     });
   });
 
@@ -944,8 +895,8 @@ describe('<Popover />', () => {
         </Popover>,
       );
 
-      assert.strictEqual(apparentHandler.callCount, 1);
-      assert.strictEqual(transitionHandler.callCount, 1);
+      expect(apparentHandler.callCount).to.equal(1);
+      expect(transitionHandler.callCount).to.equal(1);
     });
 
     it('does not chain other transition callbacks with the apparent ones', () => {
@@ -964,8 +915,8 @@ describe('<Popover />', () => {
 
       wrapper.setProps({ open: false });
 
-      assert.strictEqual(apparentHandler.callCount, 0);
-      assert.strictEqual(transitionHandler.callCount, 1);
+      expect(apparentHandler.callCount).to.equal(0);
+      expect(transitionHandler.callCount).to.equal(1);
     });
   });
 });

--- a/packages/material-ui/src/Popper/Popper.test.js
+++ b/packages/material-ui/src/Popper/Popper.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import PropTypes from 'prop-types';
 import { createMount } from '@material-ui/core/test-utils';
@@ -57,8 +57,8 @@ describe('<Popper />', () => {
           </Popper>
         </ThemeProvider>,
       );
-      assert.strictEqual(renderSpy.callCount, 2); // 2 for strict mode
-      assert.strictEqual(renderSpy.args[0][0], 'top');
+      expect(renderSpy.callCount).to.equal(2); // 2 for strict mode
+      expect(renderSpy.args[0][0]).to.equal('top');
     });
 
     [
@@ -96,8 +96,8 @@ describe('<Popper />', () => {
             ,
           </ThemeProvider>,
         );
-        assert.strictEqual(renderSpy.callCount, 2);
-        assert.strictEqual(renderSpy.args[0][0], test.out);
+        expect(renderSpy.callCount).to.equal(2);
+        expect(renderSpy.args[0][0]).to.equal(test.out);
       });
     });
 
@@ -126,19 +126,19 @@ describe('<Popper />', () => {
   describe('prop: open', () => {
     it('should open without any issue', () => {
       const wrapper = mount(<Popper {...defaultProps} open={false} />);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
       wrapper.setProps({ open: true });
       wrapper.update();
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').text(), 'Hello World');
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
+      expect(wrapper.find('[role="tooltip"]').text()).to.equal('Hello World');
     });
 
     it('should close without any issue', () => {
       const wrapper = mount(<Popper {...defaultProps} />);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').text(), 'Hello World');
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
+      expect(wrapper.find('[role="tooltip"]').text()).to.equal('Hello World');
       wrapper.setProps({ open: false });
-      assert.strictEqual(wrapper.find('[role="tooltip"]').length, 0);
+      expect(wrapper.find('[role="tooltip"]').length).to.equal(0);
     });
   });
 
@@ -192,9 +192,9 @@ describe('<Popper />', () => {
         }
 
         const wrapper = mount(<OpenClose />);
-        assert.strictEqual(wrapper.contains(children), false);
+        expect(wrapper.contains(children)).to.equal(false);
         wrapper.find('button').simulate('click');
-        assert.strictEqual(wrapper.contains(children), false);
+        expect(wrapper.contains(children)).to.equal(false);
       });
     });
   });
@@ -224,12 +224,12 @@ describe('<Popper />', () => {
           )}
         </Popper>,
       );
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').text(), 'Hello World');
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
+      expect(wrapper.find('[role="tooltip"]').text()).to.equal('Hello World');
       wrapper.setProps({ anchorEl: null, open: false });
       clock.tick(0);
       wrapper.update();
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
     });
   });
 
@@ -238,12 +238,12 @@ describe('<Popper />', () => {
       const ref1 = React.createRef();
       const ref2 = React.createRef();
       const wrapper = mount(<Popper {...defaultProps} popperRef={ref1} />);
-      assert.strictEqual(ref1.current instanceof PopperJs, true);
+      expect(ref1.current instanceof PopperJs).to.equal(true);
       wrapper.setProps({
         popperRef: ref2,
       });
-      assert.strictEqual(ref1.current, null);
-      assert.strictEqual(ref2.current instanceof PopperJs, true);
+      expect(ref1.current).to.equal(null);
+      expect(ref2.current instanceof PopperJs).to.equal(true);
     });
   });
 
@@ -252,10 +252,9 @@ describe('<Popper />', () => {
       const popperRef = React.createRef();
       const wrapper = mount(<Popper {...defaultProps} disablePortal popperRef={popperRef} />);
       // renders
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
       // correctly sets modifiers
-      assert.strictEqual(
-        popperRef.current.options.modifiers.preventOverflow.boundariesElement,
+      expect(popperRef.current.options.modifiers.preventOverflow.boundariesElement).to.equal(
         'scrollParent',
       );
     });
@@ -264,10 +263,9 @@ describe('<Popper />', () => {
       const popperRef = React.createRef();
       const wrapper = mount(<Popper {...defaultProps} popperRef={popperRef} />);
       // renders
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
       // correctly sets modifiers
-      assert.strictEqual(
-        popperRef.current.options.modifiers.preventOverflow.boundariesElement,
+      expect(popperRef.current.options.modifiers.preventOverflow.boundariesElement).to.equal(
         'window',
       );
     });
@@ -295,8 +293,8 @@ describe('<Popper />', () => {
         'MockedPopper',
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(consoleErrorMock.messages()[0], 'It should be an HTML element instance');
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include('It should be an HTML element instance');
     });
   });
 });

--- a/packages/material-ui/src/Radio/Radio.test.js
+++ b/packages/material-ui/src/Radio/Radio.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { getClasses, createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -28,23 +28,23 @@ describe('<Radio />', () => {
 
   describe('styleSheet', () => {
     it('should have the classes required for SwitchBase', () => {
-      assert.strictEqual(typeof classes.root, 'string');
-      assert.strictEqual(typeof classes.checked, 'string');
-      assert.strictEqual(typeof classes.disabled, 'string');
+      expect(typeof classes.root).to.equal('string');
+      expect(typeof classes.checked).to.equal('string');
+      expect(typeof classes.disabled).to.equal('string');
     });
   });
 
   describe('prop: unchecked', () => {
     it('should render an unchecked icon', () => {
       const wrapper = mount(<Radio />);
-      assert.strictEqual(wrapper.find('svg[data-mui-test="RadioButtonUncheckedIcon"]').length, 1);
+      expect(wrapper.find('svg[data-mui-test="RadioButtonUncheckedIcon"]').length).to.equal(1);
     });
   });
 
   describe('prop: checked', () => {
     it('should render a checked icon', () => {
       const wrapper = mount(<Radio checked />);
-      assert.strictEqual(wrapper.find('svg[data-mui-test="RadioButtonCheckedIcon"]').length, 1);
+      expect(wrapper.find('svg[data-mui-test="RadioButtonCheckedIcon"]').length).to.equal(1);
     });
   });
 

--- a/packages/material-ui/src/RadioGroup/RadioGroup.test.js
+++ b/packages/material-ui/src/RadioGroup/RadioGroup.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import * as PropTypes from 'prop-types';
 import { createMount, findOutermostIntrinsic } from '@material-ui/core/test-utils';
@@ -38,7 +38,7 @@ describe('<RadioGroup />', () => {
 
   it('the root component has the radiogroup role', () => {
     const wrapper = mount(<RadioGroup value="" />);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).props().role, 'radiogroup');
+    expect(findOutermostIntrinsic(wrapper).props().role).to.equal('radiogroup');
   });
 
   it('should fire the onBlur callback', () => {
@@ -47,8 +47,8 @@ describe('<RadioGroup />', () => {
 
     const eventMock = 'something-to-match';
     wrapper.simulate('blur', { eventMock });
-    assert.strictEqual(handleBlur.callCount, 1);
-    assert.strictEqual(handleBlur.calledWithMatch({ eventMock }), true);
+    expect(handleBlur.callCount).to.equal(1);
+    expect(handleBlur.calledWithMatch({ eventMock })).to.equal(true);
   });
 
   it('should fire the onKeyDown callback', () => {
@@ -57,8 +57,8 @@ describe('<RadioGroup />', () => {
 
     const eventMock = 'something-to-match';
     wrapper.simulate('keyDown', { eventMock });
-    assert.strictEqual(handleKeyDown.callCount, 1);
-    assert.strictEqual(handleKeyDown.calledWithMatch({ eventMock }), true);
+    expect(handleKeyDown.callCount).to.equal(1);
+    expect(handleKeyDown.calledWithMatch({ eventMock })).to.equal(true);
   });
 
   it('should support uncontrolled mode', () => {
@@ -69,7 +69,7 @@ describe('<RadioGroup />', () => {
     );
 
     findRadio(wrapper, 'one').simulate('change');
-    assert.strictEqual(findRadio(wrapper, 'one').props().checked, true);
+    expect(findRadio(wrapper, 'one').props().checked).to.equal(true);
   });
 
   it('should support default value in uncontrolled mode', () => {
@@ -80,9 +80,9 @@ describe('<RadioGroup />', () => {
       </RadioGroup>,
     );
 
-    assert.strictEqual(findRadio(wrapper, 'zero').props().checked, true);
+    expect(findRadio(wrapper, 'zero').props().checked).to.equal(true);
     findRadio(wrapper, 'one').simulate('change');
-    assert.strictEqual(findRadio(wrapper, 'one').props().checked, true);
+    expect(findRadio(wrapper, 'one').props().checked).to.equal(true);
   });
 
   it('should have a default name', () => {
@@ -93,8 +93,8 @@ describe('<RadioGroup />', () => {
       </RadioGroup>,
     );
 
-    assert.match(findRadio(wrapper, 'zero').props().name, /^mui-[0-9]+/);
-    assert.match(findRadio(wrapper, 'one').props().name, /^mui-[0-9]+/);
+    expect(findRadio(wrapper, 'zero').props().name).to.match(/^mui-[0-9]+/);
+    expect(findRadio(wrapper, 'one').props().name).to.match(/^mui-[0-9]+/);
   });
 
   describe('imperative focus()', () => {
@@ -111,7 +111,7 @@ describe('<RadioGroup />', () => {
       );
 
       actionsRef.current.focus();
-      assert.strictEqual(oneRadioOnFocus.callCount, 1);
+      expect(oneRadioOnFocus.callCount).to.equal(1);
     });
 
     it('should not focus any radios if all are disabled', () => {
@@ -130,9 +130,9 @@ describe('<RadioGroup />', () => {
 
       actionsRef.current.focus();
 
-      assert.strictEqual(zeroRadioOnFocus.callCount, 0);
-      assert.strictEqual(oneRadioOnFocus.callCount, 0);
-      assert.strictEqual(twoRadioOnFocus.callCount, 0);
+      expect(zeroRadioOnFocus.callCount).to.equal(0);
+      expect(oneRadioOnFocus.callCount).to.equal(0);
+      expect(twoRadioOnFocus.callCount).to.equal(0);
     });
 
     it('should focus the selected radio', () => {
@@ -149,7 +149,7 @@ describe('<RadioGroup />', () => {
       );
 
       actionsRef.current.focus();
-      assert.strictEqual(twoRadioOnFocus.callCount, 1);
+      expect(twoRadioOnFocus.callCount).to.equal(1);
     });
 
     it('should focus the non-disabled radio rather than the disabled selected radio', () => {
@@ -166,7 +166,7 @@ describe('<RadioGroup />', () => {
       );
 
       actionsRef.current.focus();
-      assert.strictEqual(threeRadioOnFocus.callCount, 1);
+      expect(threeRadioOnFocus.callCount).to.equal(1);
     });
 
     it('should be able to focus with no radios', () => {
@@ -198,8 +198,8 @@ describe('<RadioGroup />', () => {
 
       const eventMock = 'something-to-match';
       findRadio(wrapper, 'woofRadioGroup').simulate('change', { eventMock });
-      assert.strictEqual(handleChange.callCount, 1);
-      assert.strictEqual(handleChange.calledWithMatch({ eventMock }), true);
+      expect(handleChange.callCount).to.equal(1);
+      expect(handleChange.calledWithMatch({ eventMock })).to.equal(true);
     });
 
     it('should chain the onChange property', () => {
@@ -213,8 +213,8 @@ describe('<RadioGroup />', () => {
       );
 
       findRadio(wrapper, 'woofRadioGroup').simulate('change');
-      assert.strictEqual(handleChange1.callCount, 1);
-      assert.strictEqual(handleChange2.callCount, 1);
+      expect(handleChange1.callCount).to.equal(1);
+      expect(handleChange2.callCount).to.equal(1);
     });
 
     describe('with non-string values', () => {
@@ -253,15 +253,15 @@ describe('<RadioGroup />', () => {
 
         const wrapper = mount(<Test onChange={handleChange} value={values[1]} values={values} />);
         // on the initial mount it works because we compare to the `value` prop
-        assert.strictEqual(isNthChecked(wrapper, 0), false);
-        assert.strictEqual(isNthChecked(wrapper, 1), true);
+        expect(isNthChecked(wrapper, 0)).to.equal(false);
+        expect(isNthChecked(wrapper, 1)).to.equal(true);
 
         selectNth(wrapper, 0);
         // on updates, however, we compare against event.target.value
         // object information is lost on stringification.
-        assert.strictEqual(isNthChecked(wrapper, 0), false);
-        assert.strictEqual(isNthChecked(wrapper, 1), true);
-        assert.strictEqual(handleChange.firstCall.args[1], '[object Object]');
+        expect(isNthChecked(wrapper, 0)).to.equal(false);
+        expect(isNthChecked(wrapper, 1)).to.equal(true);
+        expect(handleChange.firstCall.args[1]).to.equal('[object Object]');
       });
     });
   });

--- a/packages/material-ui/src/RootRef/RootRef.test.js
+++ b/packages/material-ui/src/RootRef/RootRef.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import RootRef from './RootRef';
@@ -26,11 +26,11 @@ describe('<RootRef />', () => {
         <Fn />
       </RootRef>,
     );
-    assert.strictEqual(rootRef.args.length, 1);
-    assert.strictEqual(rootRef.args[0][0] instanceof window.HTMLDivElement, true);
+    expect(rootRef.args.length).to.equal(1);
+    expect(rootRef.args[0][0] instanceof window.HTMLDivElement).to.equal(true);
     wrapper.unmount();
-    assert.strictEqual(rootRef.args.length, 2);
-    assert.strictEqual(rootRef.args[1][0], null);
+    expect(rootRef.args.length).to.equal(2);
+    expect(rootRef.args[1][0]).to.equal(null);
   });
 
   it('set rootRef current field on mount and unmount', () => {
@@ -40,9 +40,9 @@ describe('<RootRef />', () => {
         <Fn />
       </RootRef>,
     );
-    assert.strictEqual(ref.current instanceof window.HTMLDivElement, true);
+    expect(ref.current instanceof window.HTMLDivElement).to.equal(true);
     wrapper.unmount();
-    assert.strictEqual(ref.current, null);
+    expect(ref.current).to.equal(null);
   });
 
   it('should support providing a new rootRef', () => {
@@ -52,17 +52,17 @@ describe('<RootRef />', () => {
         <Fn />
       </RootRef>,
     );
-    assert.strictEqual(results.length, 1);
-    assert.strictEqual(results[0] instanceof window.HTMLDivElement, true);
+    expect(results.length).to.equal(1);
+    expect(results[0] instanceof window.HTMLDivElement).to.equal(true);
     wrapper.setProps({
       rootRef: (ref) => results.push(ref),
     });
-    assert.strictEqual(results.length, 3);
-    assert.strictEqual(results[1], null);
-    assert.strictEqual(results[2] instanceof window.HTMLDivElement, true);
+    expect(results.length).to.equal(3);
+    expect(results[1]).to.equal(null);
+    expect(results[2] instanceof window.HTMLDivElement).to.equal(true);
     wrapper.unmount();
-    assert.strictEqual(results.length, 4);
-    assert.strictEqual(results[3], null);
+    expect(results.length).to.equal(4);
+    expect(results[3]).to.equal(null);
   });
 
   it('should support DOM node updates', () => {
@@ -78,8 +78,8 @@ describe('<RootRef />', () => {
 
     const wrapper = mount(<TestCase on={false} />);
     wrapper.setProps({ on: true });
-    assert.strictEqual(rootRef.callCount, 2);
-    assert.strictEqual(rootRef.args[0][0].nodeName, 'SPAN');
-    assert.strictEqual(rootRef.args[1][0].nodeName, 'DIV');
+    expect(rootRef.callCount).to.equal(2);
+    expect(rootRef.args[0][0].nodeName).to.equal('SPAN');
+    expect(rootRef.args[1][0].nodeName).to.equal('DIV');
   });
 });

--- a/packages/material-ui/src/Slide/Slide.test.js
+++ b/packages/material-ui/src/Slide/Slide.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy, stub, useFakeTimers } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
@@ -51,7 +51,7 @@ describe('<Slide />', () => {
         <div id="with-slide" style={{ color: 'blue' }} />
       </Slide>,
     );
-    assert.deepEqual(wrapper.find('#with-slide').props().style, {
+    expect(wrapper.find('#with-slide').props().style).to.deep.equal({
       backgroundColor: 'yellow',
       color: 'blue',
       visibility: undefined,
@@ -101,26 +101,26 @@ describe('<Slide />', () => {
 
       describe('handleEnter()', () => {
         it('should call handleEnter', () => {
-          assert.strictEqual(handleEntering.callCount, 1);
-          assert.strictEqual(handleEntering.args[0][0], child);
+          expect(handleEntering.callCount).to.equal(1);
+          expect(handleEntering.args[0][0]).to.equal(child);
         });
       });
 
       describe('handleEntering()', () => {
         it('should reset the translate3d', () => {
-          assert.match(handleEntering.args[0][0].style.transform, /none/);
+          expect(handleEntering.args[0][0].style.transform).to.match(/none/);
         });
 
         it('should call handleEntering', () => {
-          assert.strictEqual(handleEntering.callCount, 1);
-          assert.strictEqual(handleEntering.args[0][0], child);
+          expect(handleEntering.callCount).to.equal(1);
+          expect(handleEntering.args[0][0]).to.equal(child);
         });
       });
 
       describe('handleEntered()', () => {
         it('should have called onEntered', () => {
           clock.tick(1000);
-          assert.strictEqual(handleEntered.callCount, 1);
+          expect(handleEntered.callCount).to.equal(1);
         });
       });
     });
@@ -133,23 +133,23 @@ describe('<Slide />', () => {
 
       describe('handleExit()', () => {
         it('should call handleExit', () => {
-          assert.strictEqual(handleExiting.callCount, 1);
-          assert.strictEqual(handleExiting.args[0][0], child);
+          expect(handleExiting.callCount).to.equal(1);
+          expect(handleExiting.args[0][0]).to.equal(child);
         });
       });
 
       describe('handleExiting()', () => {
         it('should call onExiting', () => {
-          assert.strictEqual(handleExiting.callCount, 1);
-          assert.strictEqual(handleExiting.args[0][0], child);
+          expect(handleExiting.callCount).to.equal(1);
+          expect(handleExiting.args[0][0]).to.equal(child);
         });
       });
 
       describe('handleExited()', () => {
         it('should call onExited', () => {
           clock.tick(1000);
-          assert.strictEqual(handleExited.callCount, 1);
-          assert.strictEqual(handleExited.args[0][0], child);
+          expect(handleExited.callCount).to.equal(1);
+          expect(handleExited.args[0][0]).to.equal(child);
         });
       });
     });
@@ -177,16 +177,14 @@ describe('<Slide />', () => {
     });
 
     it('should create proper easeOut animation onEntering', () => {
-      assert.match(
-        handleEntering.args[0][0].style.transition,
+      expect(handleEntering.args[0][0].style.transition).to.match(
         /transform 556ms cubic-bezier\(0(.0)?, 0, 0.2, 1\)( 0ms)?/,
       );
     });
 
     it('should create proper sharp animation onExit', () => {
       wrapper.setProps({ in: false });
-      assert.match(
-        handleExit.args[0][0].style.transition,
+      expect(handleExit.args[0][0].style.transition).to.match(
         /transform 446ms cubic-bezier\(0.4, 0, 0.6, 1\)( 0ms)?/,
       );
     });
@@ -203,7 +201,7 @@ describe('<Slide />', () => {
       });
 
       const transition2 = child.style.transform;
-      assert.notStrictEqual(transition1, transition2);
+      expect(transition1).to.not.equal(transition2);
     });
   });
 
@@ -255,8 +253,7 @@ describe('<Slide />', () => {
       it('should set element transform and transition in the `left` direction', () => {
         wrapper.setProps({ direction: 'left' });
         wrapper.setProps({ in: true });
-        assert.strictEqual(
-          nodeEnterTransformStyle,
+        expect(nodeEnterTransformStyle).to.equal(
           `translateX(${global.innerWidth}px) translateX(-300px)`,
         );
       });
@@ -264,14 +261,13 @@ describe('<Slide />', () => {
       it('should set element transform and transition in the `right` direction', () => {
         wrapper.setProps({ direction: 'right' });
         wrapper.setProps({ in: true });
-        assert.strictEqual(nodeEnterTransformStyle, 'translateX(-800px)');
+        expect(nodeEnterTransformStyle).to.equal('translateX(-800px)');
       });
 
       it('should set element transform and transition in the `up` direction', () => {
         wrapper.setProps({ direction: 'up' });
         wrapper.setProps({ in: true });
-        assert.strictEqual(
-          nodeEnterTransformStyle,
+        expect(nodeEnterTransformStyle).to.equal(
           `translateY(${global.innerHeight}px) translateY(-200px)`,
         );
       });
@@ -279,14 +275,14 @@ describe('<Slide />', () => {
       it('should set element transform and transition in the `down` direction', () => {
         wrapper.setProps({ direction: 'down' });
         wrapper.setProps({ in: true });
-        assert.strictEqual(nodeEnterTransformStyle, 'translateY(-500px)');
+        expect(nodeEnterTransformStyle).to.equal('translateY(-500px)');
       });
 
       it('should reset the previous transition if needed', () => {
         child.style.transform = 'translateX(-800px)';
         wrapper.setProps({ direction: 'right' });
         wrapper.setProps({ in: true });
-        assert.strictEqual(nodeEnterTransformStyle, 'translateX(-800px)');
+        expect(nodeEnterTransformStyle).to.equal('translateX(-800px)');
       });
     });
 
@@ -306,8 +302,7 @@ describe('<Slide />', () => {
       it('should set element transform and transition in the `left` direction', () => {
         wrapper.setProps({ direction: 'left' });
         wrapper.setProps({ in: false });
-        assert.strictEqual(
-          nodeExitingTransformStyle,
+        expect(nodeExitingTransformStyle).to.equal(
           `translateX(${global.innerWidth}px) translateX(-300px)`,
         );
       });
@@ -315,14 +310,13 @@ describe('<Slide />', () => {
       it('should set element transform and transition in the `right` direction', () => {
         wrapper.setProps({ direction: 'right' });
         wrapper.setProps({ in: false });
-        assert.strictEqual(nodeExitingTransformStyle, 'translateX(-800px)');
+        expect(nodeExitingTransformStyle).to.equal('translateX(-800px)');
       });
 
       it('should set element transform and transition in the `up` direction', () => {
         wrapper.setProps({ direction: 'up' });
         wrapper.setProps({ in: false });
-        assert.strictEqual(
-          nodeExitingTransformStyle,
+        expect(nodeExitingTransformStyle).to.equal(
           `translateY(${global.innerHeight}px) translateY(-200px)`,
         );
       });
@@ -330,7 +324,7 @@ describe('<Slide />', () => {
       it('should set element transform and transition in the `down` direction', () => {
         wrapper.setProps({ direction: 'down' });
         wrapper.setProps({ in: false });
-        assert.strictEqual(nodeExitingTransformStyle, 'translateY(-500px)');
+        expect(nodeExitingTransformStyle).to.equal('translateY(-500px)');
       });
     });
   });
@@ -345,8 +339,8 @@ describe('<Slide />', () => {
       );
       const transition = childRef.current;
 
-      assert.strictEqual(transition.style.visibility, 'hidden');
-      assert.notStrictEqual(transition.style.transform, undefined);
+      expect(transition.style.visibility).to.equal('hidden');
+      expect(transition.style.transform).to.not.equal(undefined);
     });
   });
 
@@ -372,7 +366,7 @@ describe('<Slide />', () => {
       clock.tick(166);
       const child = wrapper.find('#testChild').instance();
 
-      assert.notStrictEqual(child.style.transform, undefined);
+      expect(child.style.transform).to.not.equal(undefined);
     });
 
     it('should take existing transform into account', () => {
@@ -389,8 +383,7 @@ describe('<Slide />', () => {
         style: {},
       };
       setTranslateValue('up', element);
-      assert.strictEqual(
-        element.style.transform,
+      expect(element.style.transform).to.equal(
         `translateY(${global.innerHeight}px) translateY(-780px)`,
       );
     });
@@ -409,7 +402,7 @@ describe('<Slide />', () => {
           <div id="with-slide" />
         </Slide>,
       );
-      assert.strictEqual(wrapper.find('#with-slide').props().style.visibility, 'hidden');
+      expect(wrapper.find('#with-slide').props().style.visibility).to.equal('hidden');
     });
   });
 });

--- a/packages/material-ui/src/Snackbar/Snackbar.test.js
+++ b/packages/material-ui/src/Snackbar/Snackbar.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, assert } from 'chai';
+import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -42,8 +42,8 @@ describe('<Snackbar />', () => {
       const event = new window.Event('click', { view: window, bubbles: true, cancelable: true });
       document.body.dispatchEvent(event);
 
-      assert.strictEqual(handleClose.callCount, 1);
-      assert.deepEqual(handleClose.args[0], [event, 'clickaway']);
+      expect(handleClose.callCount).to.equal(1);
+      expect(handleClose.args[0]).to.deep.equal([event, 'clickaway']);
     });
   });
 
@@ -84,21 +84,21 @@ describe('<Snackbar />', () => {
           transitionDuration={duration / 2}
         />,
       );
-      assert.strictEqual(handleCloseSpy.callCount, 0);
-      assert.strictEqual(handleExitedSpy.callCount, 0);
+      expect(handleCloseSpy.callCount).to.equal(0);
+      expect(handleExitedSpy.callCount).to.equal(0);
       wrapper.setProps({ open: true });
       clock.tick(duration);
-      assert.strictEqual(handleCloseSpy.callCount, 1);
-      assert.strictEqual(handleExitedSpy.callCount, 0);
+      expect(handleCloseSpy.callCount).to.equal(1);
+      expect(handleExitedSpy.callCount).to.equal(0);
       clock.tick(duration / 2);
-      assert.strictEqual(handleCloseSpy.callCount, 1);
-      assert.strictEqual(handleExitedSpy.callCount, 1);
+      expect(handleCloseSpy.callCount).to.equal(1);
+      expect(handleExitedSpy.callCount).to.equal(1);
       clock.tick(duration);
-      assert.strictEqual(handleCloseSpy.callCount, messageCount);
-      assert.strictEqual(handleExitedSpy.callCount, 1);
+      expect(handleCloseSpy.callCount).to.equal(messageCount);
+      expect(handleExitedSpy.callCount).to.equal(1);
       clock.tick(duration / 2);
-      assert.strictEqual(handleCloseSpy.callCount, messageCount);
-      assert.strictEqual(handleExitedSpy.callCount, messageCount);
+      expect(handleCloseSpy.callCount).to.equal(messageCount);
+      expect(handleExitedSpy.callCount).to.equal(messageCount);
     });
   });
 
@@ -126,10 +126,10 @@ describe('<Snackbar />', () => {
       );
 
       wrapper.setProps({ open: true });
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleClose.callCount, 1);
-      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
+      expect(handleClose.callCount).to.equal(1);
+      expect(handleClose.args[0]).to.deep.equal([null, 'timeout']);
     });
 
     it('calls onClose at timeout even if the prop changes', () => {
@@ -166,11 +166,11 @@ describe('<Snackbar />', () => {
       );
 
       wrapper.setProps({ open: true });
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration / 2);
       wrapper.setProps({ autoHideDuration: undefined });
       clock.tick(autoHideDuration / 2);
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
     });
 
     it('should be able to interrupt the timer', () => {
@@ -189,17 +189,17 @@ describe('<Snackbar />', () => {
         />,
       );
 
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseEnter');
-      assert.strictEqual(handleMouseEnter.callCount, 1, 'should trigger mouse enter callback');
+      expect(handleMouseEnter.callCount).to.equal(1);
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseLeave');
-      assert.strictEqual(handleMouseLeave.callCount, 1, 'should trigger mouse leave callback');
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleMouseLeave.callCount).to.equal(1);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(2e3);
-      assert.strictEqual(handleClose.callCount, 1);
-      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
+      expect(handleClose.callCount).to.equal(1);
+      expect(handleClose.args[0]).to.deep.equal([null, 'timeout']);
     });
 
     it('should not call onClose if autoHideDuration is undefined', () => {
@@ -207,9 +207,9 @@ describe('<Snackbar />', () => {
       const autoHideDuration = 2e3;
       mount(<Snackbar open onClose={handleClose} message="message" autoHideDuration={undefined} />);
 
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
     });
 
     it('should not call onClose if autoHideDuration is null', () => {
@@ -217,9 +217,9 @@ describe('<Snackbar />', () => {
       const autoHideDuration = 2e3;
       mount(<Snackbar open onClose={handleClose} message="message" autoHideDuration={null} />);
 
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
     });
 
     it('should not call onClose when closed', () => {
@@ -234,11 +234,11 @@ describe('<Snackbar />', () => {
         />,
       );
 
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration / 2);
       wrapper.setProps({ open: false });
       clock.tick(autoHideDuration / 2);
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
     });
   });
 
@@ -266,14 +266,14 @@ describe('<Snackbar />', () => {
           resumeHideDuration={resumeHideDuration}
         />,
       );
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseEnter');
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseLeave');
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(2e3);
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
     });
 
     it('should call onClose when timer done after user interaction', () => {
@@ -289,15 +289,15 @@ describe('<Snackbar />', () => {
           resumeHideDuration={resumeHideDuration}
         />,
       );
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseEnter');
       clock.tick(autoHideDuration / 2);
       wrapper.simulate('mouseLeave');
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(resumeHideDuration);
-      assert.strictEqual(handleClose.callCount, 1);
-      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
+      expect(handleClose.callCount).to.equal(1);
+      expect(handleClose.args[0]).to.deep.equal([null, 'timeout']);
     });
 
     it('should call onClose immediately after user interaction when 0', () => {
@@ -314,13 +314,13 @@ describe('<Snackbar />', () => {
         />,
       );
       wrapper.setProps({ open: true });
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       wrapper.simulate('mouseEnter');
       clock.tick(100);
       wrapper.simulate('mouseLeave');
       clock.tick(resumeHideDuration);
-      assert.strictEqual(handleClose.callCount, 1);
-      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
+      expect(handleClose.callCount).to.equal(1);
+      expect(handleClose.args[0]).to.deep.equal([null, 'timeout']);
     });
   });
 
@@ -351,17 +351,17 @@ describe('<Snackbar />', () => {
       const bEvent = new window.Event('blur', { view: window, bubbles: false, cancelable: false });
       window.dispatchEvent(bEvent);
 
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
 
       const fEvent = new window.Event('focus', { view: window, bubbles: false, cancelable: false });
       window.dispatchEvent(fEvent);
 
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleClose.callCount, 1);
-      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
+      expect(handleClose.callCount).to.equal(1);
+      expect(handleClose.args[0]).to.deep.equal([null, 'timeout']);
     });
 
     it('should not pause auto hide when disabled and window lost focus', () => {
@@ -380,24 +380,24 @@ describe('<Snackbar />', () => {
       const event = new window.Event('blur', { view: window, bubbles: false, cancelable: false });
       window.dispatchEvent(event);
 
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
       clock.tick(autoHideDuration);
-      assert.strictEqual(handleClose.callCount, 1);
-      assert.deepEqual(handleClose.args[0], [null, 'timeout']);
+      expect(handleClose.callCount).to.equal(1);
+      expect(handleClose.args[0]).to.deep.equal([null, 'timeout']);
     });
   });
 
   describe('prop: open', () => {
     it('should not render anything when closed', () => {
       const wrapper = mount(<Snackbar open={false} message="Hello, World!" />);
-      assert.strictEqual(wrapper.text(), '');
+      expect(wrapper.text()).to.equal('');
     });
 
     it('should be able show it after mounted', () => {
       const wrapper = mount(<Snackbar open={false} message="Hello, World!" />);
-      assert.strictEqual(wrapper.text(), '');
+      expect(wrapper.text()).to.equal('');
       wrapper.setProps({ open: true });
-      assert.strictEqual(wrapper.text(), 'Hello, World!');
+      expect(wrapper.text()).to.equal('Hello, World!');
     });
   });
 
@@ -405,20 +405,20 @@ describe('<Snackbar />', () => {
     it('should render the children', () => {
       const children = <div />;
       const wrapper = mount(<Snackbar open>{children}</Snackbar>);
-      assert.strictEqual(wrapper.containsMatchingElement(children), true);
+      expect(wrapper.containsMatchingElement(children)).to.equal(true);
     });
   });
 
   describe('prop: TransitionComponent', () => {
     it('should use a Grow by default', () => {
       const wrapper = mount(<Snackbar open message="message" />);
-      assert.strictEqual(wrapper.find(Grow).exists(), true);
+      expect(wrapper.find(Grow).exists()).to.equal(true);
     });
 
     it('accepts a different component that handles the transition', () => {
       const Transition = () => <div className="cloned-element-class" />;
       const wrapper = mount(<Snackbar open TransitionComponent={Transition} />);
-      assert.strictEqual(wrapper.find(Transition).exists(), true);
+      expect(wrapper.find(Transition).exists()).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/StepConnector/StepConnector.test.js
+++ b/packages/material-ui/src/StepConnector/StepConnector.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import StepConnector from './StepConnector';
@@ -30,33 +30,33 @@ describe('<StepConnector />', () => {
   describe('rendering', () => {
     it('renders a div containing a span', () => {
       const wrapper = shallow(<StepConnector orientation="horizontal" />);
-      assert.strictEqual(wrapper.type(), 'div');
-      assert.strictEqual(wrapper.find('span').length, 1);
+      expect(wrapper.type()).to.equal('div');
+      expect(wrapper.find('span').length).to.equal(1);
     });
 
     it('has the class when horizontal', () => {
       const wrapper = shallow(<StepConnector orientation="horizontal" />);
-      assert.include(wrapper.find('span').props().className, classes.lineHorizontal);
+      expect(wrapper.find('span').props().className).to.include(classes.lineHorizontal);
     });
 
     it('has the class when vertical', () => {
       const wrapper = shallow(<StepConnector orientation="vertical" />);
-      assert.include(wrapper.find('span').props().className, classes.lineVertical);
+      expect(wrapper.find('span').props().className).to.include(classes.lineVertical);
     });
 
     it('has the class when active', () => {
       const wrapper = shallow(<StepConnector active />);
-      assert.include(wrapper.props().className, classes.active);
+      expect(wrapper.props().className).to.include(classes.active);
     });
 
     it('has the class when completed', () => {
       const wrapper = shallow(<StepConnector completed />);
-      assert.include(wrapper.props().className, classes.completed);
+      expect(wrapper.props().className).to.include(classes.completed);
     });
 
     it('has the class when disabled', () => {
       const wrapper = shallow(<StepConnector disabled />);
-      assert.include(wrapper.props().className, classes.disabled);
+      expect(wrapper.props().className).to.include(classes.disabled);
     });
   });
 });

--- a/packages/material-ui/src/StepContent/StepContent.test.js
+++ b/packages/material-ui/src/StepContent/StepContent.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Collapse from '../Collapse';
@@ -42,9 +42,9 @@ describe('<StepContent />', () => {
       </StepContent>,
     );
     const props = wrapper.props();
-    assert.strictEqual(props.style.paddingRight, 200);
-    assert.strictEqual(props.style.color, 'purple');
-    assert.strictEqual(props.style.border, '1px solid tomato');
+    expect(props.style.paddingRight).to.equal(200);
+    expect(props.style.color).to.equal('purple');
+    expect(props.style.border).to.equal('1px solid tomato');
   });
 
   it('renders children inside an Collapse component', () => {
@@ -54,10 +54,10 @@ describe('<StepContent />', () => {
       </StepContent>,
     );
     const collapse = wrapper.find(Collapse);
-    assert.strictEqual(collapse.length, 1);
+    expect(collapse.length).to.equal(1);
     const content = collapse.find('.test-content');
-    assert.strictEqual(content.length, 1);
-    assert.strictEqual(content.props().children, 'This is my content!');
+    expect(content.length).to.equal(1);
+    expect(content.props().children).to.equal('This is my content!');
   });
 
   describe('prop: transitionDuration', () => {
@@ -67,7 +67,7 @@ describe('<StepContent />', () => {
           <div />
         </StepContent>,
       );
-      assert.strictEqual(wrapper.find(Collapse).props().timeout, 'auto');
+      expect(wrapper.find(Collapse).props().timeout).to.equal('auto');
     });
 
     it('should not apply the auto prop if not supported', () => {
@@ -77,7 +77,7 @@ describe('<StepContent />', () => {
           <div />
         </StepContent>,
       );
-      assert.strictEqual(wrapper.find(TransitionComponent).props().timeout, undefined);
+      expect(wrapper.find(TransitionComponent).props().timeout).to.equal(undefined);
     });
   });
 });

--- a/packages/material-ui/src/StepIcon/StepIcon.test.js
+++ b/packages/material-ui/src/StepIcon/StepIcon.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
 import StepIcon from './StepIcon';
@@ -27,27 +27,27 @@ describe('<StepIcon />', () => {
   it('renders <CheckCircle> when completed', () => {
     const wrapper = mount(<StepIcon icon={1} completed />);
     const checkCircle = wrapper.find('svg[data-mui-test="CheckCircleIcon"]');
-    assert.strictEqual(checkCircle.length, 1, 'should have an <CheckCircle />');
+    expect(checkCircle.length).to.equal(1);
   });
 
   it('renders <Warning> when error occurred', () => {
     const wrapper = mount(<StepIcon icon={1} error />);
     const warning = wrapper.find('svg[data-mui-test="WarningIcon"]');
-    assert.strictEqual(warning.length, 1, 'should have an <Warning />');
+    expect(warning.length).to.equal(1);
   });
 
   it('renders a <SvgIcon>', () => {
     const wrapper = shallow(<StepIcon icon={1} />);
-    assert.strictEqual(wrapper.find(SvgIcon).length, 1);
+    expect(wrapper.find(SvgIcon).length).to.equal(1);
   });
 
   it('contains text "3" when position is "3"', () => {
     const wrapper = shallow(<StepIcon icon={3} />);
-    assert.strictEqual(wrapper.find('text').text(), '3');
+    expect(wrapper.find('text').text()).to.equal('3');
   });
 
   it('renders the custom icon', () => {
     const wrapper = shallow(<StepIcon icon={<span className="my-icon" />} />);
-    assert.strictEqual(wrapper.find('.my-icon').length, 1, 'should have the custom icon');
+    expect(wrapper.find('.my-icon').length).to.equal(1);
   });
 });

--- a/packages/material-ui/src/StepLabel/StepLabel.test.js
+++ b/packages/material-ui/src/StepLabel/StepLabel.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Typography from '../Typography';
@@ -39,15 +39,15 @@ describe('<StepLabel />', () => {
       </StepLabel>,
     );
     const props = wrapper.props();
-    assert.strictEqual(props.style.paddingRight, 200);
-    assert.strictEqual(props.style.color, 'purple');
-    assert.strictEqual(props.style.border, '1px solid tomato');
+    expect(props.style.paddingRight).to.equal(200);
+    expect(props.style.color).to.equal('purple');
+    expect(props.style.border).to.equal('1px solid tomato');
   });
 
   describe('label content', () => {
     it('renders the label from children', () => {
       const wrapper = shallow(<StepLabel>Step One</StepLabel>);
-      assert.strictEqual(wrapper.contains('Step One'), true);
+      expect(wrapper.contains('Step One')).to.equal(true);
     });
 
     it('renders <StepIcon>', () => {
@@ -58,11 +58,11 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.length, 1, 'should have an <StepIcon />');
+      expect(stepIcon.length).to.equal(1);
       const props = stepIcon.props();
-      assert.strictEqual(props.icon, 1, 'should set icon');
-      assert.strictEqual(props.prop1, 'value1', 'should have inherited custom prop1');
-      assert.strictEqual(props.prop2, 'value2', 'should have inherited custom prop2');
+      expect(props.icon).to.equal(1);
+      expect(props.prop1).to.equal('value1');
+      expect(props.prop2).to.equal('value2');
     });
   });
 
@@ -80,15 +80,15 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.length, 0);
+      expect(stepIcon.length).to.equal(0);
 
       const customizedIcon = wrapper.find(CustomizedIcon);
-      assert.strictEqual(customizedIcon.length, 1);
+      expect(customizedIcon.length).to.equal(1);
       const props = customizedIcon.props();
-      assert.strictEqual(props.prop1, 'value1');
-      assert.strictEqual(props.prop2, 'value2');
-      assert.strictEqual(props.completed, true);
-      assert.strictEqual(props.active, true);
+      expect(props.prop1).to.equal('value1');
+      expect(props.prop2).to.equal('value2');
+      expect(props.completed).to.equal(true);
+      expect(props.active).to.equal(true);
     });
 
     it('should not render', () => {
@@ -98,7 +98,7 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.length, 0);
+      expect(stepIcon.length).to.equal(0);
     });
   });
 
@@ -106,7 +106,7 @@ describe('<StepLabel />', () => {
     it('renders <Typography> with the className active', () => {
       const wrapper = shallow(<StepLabel active>Step One</StepLabel>);
       const text = wrapper.find(Typography);
-      assert.strictEqual(text.hasClass(classes.active), true);
+      expect(text.hasClass(classes.active)).to.equal(true);
     });
 
     it('renders <StepIcon> with the prop active set to true', () => {
@@ -116,13 +116,13 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.props().active, true);
+      expect(stepIcon.props().active).to.equal(true);
     });
 
     it('renders <Typography> without the className active', () => {
       const wrapper = shallow(<StepLabel active={false}>Step One</StepLabel>);
       const text = wrapper.find(Typography);
-      assert.strictEqual(text.hasClass(classes.labelActive), false);
+      expect(text.hasClass(classes.labelActive)).to.equal(false);
     });
   });
 
@@ -130,7 +130,7 @@ describe('<StepLabel />', () => {
     it('renders <Typography> with the className completed', () => {
       const wrapper = shallow(<StepLabel completed>Step One</StepLabel>);
       const text = wrapper.find(Typography);
-      assert.strictEqual(text.hasClass(classes.completed), true);
+      expect(text.hasClass(classes.completed)).to.equal(true);
     });
 
     it('renders <StepIcon> with the prop completed set to true', () => {
@@ -140,7 +140,7 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.props().completed, true);
+      expect(stepIcon.props().completed).to.equal(true);
     });
   });
 
@@ -148,7 +148,7 @@ describe('<StepLabel />', () => {
     it('renders <Typography> with the className error', () => {
       const wrapper = shallow(<StepLabel error>Step One</StepLabel>);
       const text = wrapper.find(Typography);
-      assert.strictEqual(text.hasClass(classes.error), true);
+      expect(text.hasClass(classes.error)).to.equal(true);
     });
 
     it('renders <StepIcon> with the prop error set to true', () => {
@@ -158,7 +158,7 @@ describe('<StepLabel />', () => {
         </StepLabel>,
       );
       const stepIcon = wrapper.find(StepIcon);
-      assert.strictEqual(stepIcon.props().error, true);
+      expect(stepIcon.props().error).to.equal(true);
     });
   });
 
@@ -169,7 +169,7 @@ describe('<StepLabel />', () => {
           Step One
         </StepLabel>,
       );
-      assert.strictEqual(wrapper.hasClass(classes.disabled), true);
+      expect(wrapper.hasClass(classes.disabled)).to.equal(true);
     });
   });
 
@@ -180,7 +180,7 @@ describe('<StepLabel />', () => {
           Step One
         </StepLabel>,
       );
-      assert.strictEqual(wrapper.find(Typography).at(1).contains('Optional Text'), true);
+      expect(wrapper.find(Typography).at(1).contains('Optional Text')).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/Stepper/Stepper.test.js
+++ b/packages/material-ui/src/Stepper/Stepper.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import CheckCircle from '../internal/svg-icons/CheckCircle';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
@@ -45,7 +45,7 @@ describe('<Stepper />', () => {
         <Step />
       </Stepper>,
     );
-    assert.strictEqual(wrapper.find(Paper).props().elevation, 0, 'should have no elevation');
+    expect(wrapper.find(Paper).props().elevation).to.equal(0);
   });
 
   describe('rendering children', () => {
@@ -60,9 +60,9 @@ describe('<Stepper />', () => {
 
       const children = wrapper.children();
 
-      assert.strictEqual(children.length, 5);
-      assert.strictEqual(wrapper.childAt(1).find(StepConnector).length, 1);
-      assert.strictEqual(wrapper.childAt(3).find(StepConnector).length, 1);
+      expect(children.length).to.equal(5);
+      expect(wrapper.childAt(1).find(StepConnector).length).to.equal(1);
+      expect(wrapper.childAt(3).find(StepConnector).length).to.equal(1);
     });
   });
 
@@ -75,17 +75,17 @@ describe('<Stepper />', () => {
           <div className="child-2" />
         </Stepper>,
       );
-      assert.strictEqual(wrapper.find('.child-0').props().active, true);
-      assert.strictEqual(wrapper.find('.child-1').props().active, false);
-      assert.strictEqual(wrapper.find('.child-2').props().active, false);
-      assert.strictEqual(wrapper.find('.child-1').props().disabled, true);
-      assert.strictEqual(wrapper.find('.child-2').props().disabled, true);
+      expect(wrapper.find('.child-0').props().active).to.equal(true);
+      expect(wrapper.find('.child-1').props().active).to.equal(false);
+      expect(wrapper.find('.child-2').props().active).to.equal(false);
+      expect(wrapper.find('.child-1').props().disabled).to.equal(true);
+      expect(wrapper.find('.child-2').props().disabled).to.equal(true);
       wrapper.setProps({ activeStep: 1 });
-      assert.strictEqual(wrapper.find('.child-0').props().completed, true);
-      assert.strictEqual(wrapper.find('.child-0').props().active, false);
-      assert.strictEqual(wrapper.find('.child-1').props().active, true);
-      assert.strictEqual(wrapper.find('.child-2').props().active, false);
-      assert.strictEqual(wrapper.find('.child-2').props().disabled, true);
+      expect(wrapper.find('.child-0').props().completed).to.equal(true);
+      expect(wrapper.find('.child-0').props().active).to.equal(false);
+      expect(wrapper.find('.child-1').props().active).to.equal(true);
+      expect(wrapper.find('.child-2').props().active).to.equal(false);
+      expect(wrapper.find('.child-2').props().disabled).to.equal(true);
     });
 
     it('controls children non-linearly based on the activeStep prop', () => {
@@ -96,17 +96,17 @@ describe('<Stepper />', () => {
           <div className="child-2" />
         </Stepper>,
       );
-      assert.strictEqual(wrapper.find('.child-0').props().active, true);
-      assert.strictEqual(wrapper.find('.child-1').props().active, false);
-      assert.strictEqual(wrapper.find('.child-2').props().active, false);
+      expect(wrapper.find('.child-0').props().active).to.equal(true);
+      expect(wrapper.find('.child-1').props().active).to.equal(false);
+      expect(wrapper.find('.child-2').props().active).to.equal(false);
       wrapper.setProps({ activeStep: 1 });
-      assert.strictEqual(wrapper.find('.child-0').props().active, false);
-      assert.strictEqual(wrapper.find('.child-1').props().active, true);
-      assert.strictEqual(wrapper.find('.child-2').props().active, false);
+      expect(wrapper.find('.child-0').props().active).to.equal(false);
+      expect(wrapper.find('.child-1').props().active).to.equal(true);
+      expect(wrapper.find('.child-2').props().active).to.equal(false);
       wrapper.setProps({ activeStep: 2 });
-      assert.strictEqual(wrapper.find('.child-0').props().active, false);
-      assert.strictEqual(wrapper.find('.child-1').props().active, false);
-      assert.strictEqual(wrapper.find('.child-2').props().active, true);
+      expect(wrapper.find('.child-0').props().active).to.equal(false);
+      expect(wrapper.find('.child-1').props().active).to.equal(false);
+      expect(wrapper.find('.child-2').props().active).to.equal(true);
     });
 
     it('passes index down correctly when rendering children containing arrays', () => {
@@ -118,9 +118,9 @@ describe('<Stepper />', () => {
       );
 
       const steps = wrapper.children().find('div');
-      assert.strictEqual(steps.at(0).props().index, 0);
-      assert.strictEqual(steps.at(1).props().index, 1);
-      assert.strictEqual(steps.at(2).props().index, 2);
+      expect(steps.at(0).props().index).to.equal(0);
+      expect(steps.at(1).props().index).to.equal(1);
+      expect(steps.at(2).props().index).to.equal(2);
     });
   });
 
@@ -133,11 +133,7 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      assert.strictEqual(
-        wrapper.find(StepConnector).length,
-        1,
-        'should contain a <StepConnector /> child',
-      );
+      expect(wrapper.find(StepConnector).length).to.equal(1);
     });
 
     it('should allow the developer to specify a custom step connector', () => {
@@ -148,16 +144,8 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      assert.strictEqual(
-        wrapper.find(CheckCircle).length,
-        1,
-        'should contain a <CheckCircle /> child',
-      );
-      assert.strictEqual(
-        wrapper.find(StepConnector).length,
-        0,
-        'should not contain a <StepConnector /> child',
-      );
+      expect(wrapper.find(CheckCircle).length).to.equal(1);
+      expect(wrapper.find(StepConnector).length).to.equal(0);
     });
 
     it('should allow the step connector to be removed', () => {
@@ -168,11 +156,7 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
 
-      assert.strictEqual(
-        wrapper.find(StepConnector).length,
-        0,
-        'should not contain a <StepConnector /> child',
-      );
+      expect(wrapper.find(StepConnector).length).to.equal(0);
     });
 
     it('should pass active prop to connector when second step is active', () => {
@@ -183,7 +167,7 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
       const connectors = wrapper.find(StepConnector);
-      assert.strictEqual(connectors.first().props().active, true);
+      expect(connectors.first().props().active).to.equal(true);
     });
 
     it('should pass completed prop to connector when second step is completed', () => {
@@ -194,7 +178,7 @@ describe('<Stepper />', () => {
         </Stepper>,
       );
       const connectors = wrapper.find(StepConnector);
-      assert.strictEqual(connectors.first().props().completed, true);
+      expect(connectors.first().props().completed).to.equal(true);
     });
   });
 
@@ -205,7 +189,7 @@ describe('<Stepper />', () => {
         {null}
       </Stepper>,
     );
-    assert.strictEqual(wrapper.find(Step).length, 1);
+    expect(wrapper.find(Step).length).to.equal(1);
   });
 
   it('should be able to force a state', () => {
@@ -216,9 +200,9 @@ describe('<Stepper />', () => {
         <Step className="child-2" />
       </Stepper>,
     );
-    assert.strictEqual(wrapper.find('.child-0').props().active, true);
-    assert.strictEqual(wrapper.find('.child-1').props().active, true);
-    assert.strictEqual(wrapper.find('.child-2').props().active, false);
+    expect(wrapper.find('.child-0').props().active).to.equal(true);
+    expect(wrapper.find('.child-1').props().active).to.equal(true);
+    expect(wrapper.find('.child-2').props().active).to.equal(false);
   });
 
   it('should hide the last connector', () => {
@@ -234,7 +218,7 @@ describe('<Stepper />', () => {
         </Step>
       </Stepper>,
     );
-    assert.strictEqual(wrapper.find(StepContent).at(0).props().last, false);
-    assert.strictEqual(wrapper.find(StepContent).at(1).props().last, true);
+    expect(wrapper.find(StepContent).at(0).props().last).to.equal(false);
+    expect(wrapper.find(StepContent).at(1).props().last).to.equal(true);
   });
 });

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import SvgIcon from './SvgIcon';
@@ -46,8 +46,8 @@ describe('<SvgIcon />', () => {
 
   it('renders children by default', () => {
     const wrapper = shallow(<SvgIcon>{path}</SvgIcon>);
-    assert.strictEqual(wrapper.contains(path), true);
-    assert.strictEqual(wrapper.props()['aria-hidden'], 'true');
+    expect(wrapper.contains(path)).to.equal(true);
+    expect(wrapper.props()['aria-hidden']).to.equal('true');
   });
 
   describe('prop: titleAccess', () => {
@@ -57,43 +57,43 @@ describe('<SvgIcon />', () => {
           {path}
         </SvgIcon>,
       );
-      assert.strictEqual(wrapper.find('title').text(), 'Network');
-      assert.strictEqual(wrapper.props()['aria-hidden'], undefined);
+      expect(wrapper.find('title').text()).to.equal('Network');
+      expect(wrapper.props()['aria-hidden']).to.equal(undefined);
     });
   });
 
   describe('prop: color', () => {
     it('should render with the user and SvgIcon classes', () => {
       const wrapper = shallow(<SvgIcon className="meow">{path}</SvgIcon>);
-      assert.strictEqual(wrapper.hasClass('meow'), true);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
+      expect(wrapper.hasClass('meow')).to.equal(true);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
     });
 
     it('should render with the secondary color', () => {
       const wrapper = shallow(<SvgIcon color="secondary">{path}</SvgIcon>);
-      assert.strictEqual(wrapper.hasClass(classes.colorSecondary), true);
+      expect(wrapper.hasClass(classes.colorSecondary)).to.equal(true);
     });
 
     it('should render with the action color', () => {
       const wrapper = shallow(<SvgIcon color="action">{path}</SvgIcon>);
-      assert.strictEqual(wrapper.hasClass(classes.colorAction), true);
+      expect(wrapper.hasClass(classes.colorAction)).to.equal(true);
     });
 
     it('should render with the error color', () => {
       const wrapper = shallow(<SvgIcon color="error">{path}</SvgIcon>);
-      assert.strictEqual(wrapper.hasClass(classes.colorError), true);
+      expect(wrapper.hasClass(classes.colorError)).to.equal(true);
     });
 
     it('should render with the primary class', () => {
       const wrapper = shallow(<SvgIcon color="primary">{path}</SvgIcon>);
-      assert.strictEqual(wrapper.hasClass(classes.colorPrimary), true);
+      expect(wrapper.hasClass(classes.colorPrimary)).to.equal(true);
     });
   });
 
   describe('prop: fontSize', () => {
     it('should be able to change the fontSize', () => {
       const wrapper = shallow(<SvgIcon fontSize="inherit">{path}</SvgIcon>);
-      assert.strictEqual(wrapper.hasClass(classes.fontSizeInherit), true);
+      expect(wrapper.hasClass(classes.fontSizeInherit)).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
+++ b/packages/material-ui/src/SwipeableDrawer/SwipeableDrawer.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
@@ -113,15 +113,15 @@ describe('<SwipeableDrawer />', () => {
 
   it('should render a Drawer and a SwipeArea', () => {
     const wrapper = mount(<SwipeableDrawer onOpen={() => {}} onClose={() => {}} open={false} />);
-    assert.strictEqual(wrapper.find(Drawer).exists(), true);
-    assert.strictEqual(wrapper.find(SwipeArea).exists(), true);
+    expect(wrapper.find(Drawer).exists()).to.equal(true);
+    expect(wrapper.find(SwipeArea).exists()).to.equal(true);
   });
 
   it('should hide the SwipeArea if swipe to open is disabled', () => {
     const wrapper = mount(
       <SwipeableDrawer onOpen={() => {}} onClose={() => {}} open={false} disableSwipeToOpen />,
     );
-    assert.strictEqual(wrapper.find(SwipeArea).exists(), false);
+    expect(wrapper.find(SwipeArea).exists()).to.equal(false);
   });
 
   it('should accept user custom style', () => {
@@ -135,7 +135,7 @@ describe('<SwipeableDrawer />', () => {
       />,
     );
 
-    assert.strictEqual(wrapper.props().PaperProps, customStyle);
+    expect(wrapper.props().PaperProps).to.equal(customStyle);
   });
 
   describe('swipe to open', () => {
@@ -241,7 +241,7 @@ describe('<SwipeableDrawer />', () => {
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[2]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[2]] });
-          assert.strictEqual(handleOpen.callCount, 1, 'open');
+          expect(handleOpen.callCount).to.equal(1);
 
           const handleClose = spy();
           wrapper.setProps({ open: true, onClose: handleClose });
@@ -251,7 +251,7 @@ describe('<SwipeableDrawer />', () => {
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[2]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[2]] });
-          assert.strictEqual(handleClose.callCount, 1, 'close');
+          expect(handleClose.callCount).to.equal(1);
         });
 
         it('should stay closed when not swiping far enough', () => {
@@ -261,7 +261,7 @@ describe('<SwipeableDrawer />', () => {
           fireSwipeAreaMouseEvent(wrapper, 'touchstart', { touches: [params.openTouches[0]] });
           fireBodyMouseEvent('touchmove', { touches: [params.openTouches[1]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.openTouches[1]] });
-          assert.strictEqual(handleOpen.callCount, 0);
+          expect(handleOpen.callCount).to.equal(0);
         });
 
         it('should stay opened when not swiping far enough', () => {
@@ -274,7 +274,7 @@ describe('<SwipeableDrawer />', () => {
           });
           fireBodyMouseEvent('touchmove', { touches: [params.closeTouches[1]] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.closeTouches[1]] });
-          assert.strictEqual(handleClose.callCount, 0);
+          expect(handleClose.callCount).to.equal(0);
         });
 
         it('should ignore swiping in the wrong direction if discovery is disabled', () => {
@@ -300,7 +300,7 @@ describe('<SwipeableDrawer />', () => {
               ],
             });
           }
-          assert.strictEqual(wrapper.find('[role="presentation"]').exists(), false);
+          expect(wrapper.find('[role="presentation"]').exists()).to.equal(false);
         });
 
         it('should slide in a bit when touching near the edge', () => {
@@ -309,10 +309,10 @@ describe('<SwipeableDrawer />', () => {
           wrapper.setProps({ onOpen: handleOpen, onClose: handleClose });
           fireSwipeAreaMouseEvent(wrapper, 'touchstart', { touches: [params.edgeTouch] });
           wrapper.update();
-          assert.strictEqual(wrapper.find('[role="presentation"]').exists(), true);
+          expect(wrapper.find('[role="presentation"]').exists()).to.equal(true);
           fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
-          assert.strictEqual(handleOpen.callCount, 0);
-          assert.strictEqual(handleClose.callCount, 0);
+          expect(handleOpen.callCount).to.equal(0);
+          expect(handleClose.callCount).to.equal(0);
         });
 
         it('should makes the drawer stay hidden', () => {
@@ -325,8 +325,8 @@ describe('<SwipeableDrawer />', () => {
           });
           fireSwipeAreaMouseEvent(wrapper, 'touchstart', { touches: [params.edgeTouch] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.edgeTouch] });
-          assert.strictEqual(handleOpen.callCount, 0);
-          assert.strictEqual(handleClose.callCount, 0);
+          expect(handleOpen.callCount).to.equal(0);
+          expect(handleClose.callCount).to.equal(0);
         });
 
         it('should let user scroll the page', () => {
@@ -340,8 +340,8 @@ describe('<SwipeableDrawer />', () => {
           });
           fireSwipeAreaMouseEvent(wrapper, 'touchstart', { touches: [params.ignoreTouch] });
           fireBodyMouseEvent('touchend', { changedTouches: [params.ignoreTouch] });
-          assert.strictEqual(handleOpen.callCount, 0);
-          assert.strictEqual(handleClose.callCount, 0);
+          expect(handleOpen.callCount).to.equal(0);
+          expect(handleClose.callCount).to.equal(0);
         });
       });
     });
@@ -362,7 +362,7 @@ describe('<SwipeableDrawer />', () => {
       });
       wrapper.update();
       fireBodyMouseEvent('touchend', { changedTouches: [{ pageX: 10, clientY: 0 }] });
-      assert.strictEqual(handleClose.callCount, 0);
+      expect(handleClose.callCount).to.equal(0);
     });
 
     it('removes event listeners on unmount', () => {
@@ -376,13 +376,13 @@ describe('<SwipeableDrawer />', () => {
 
     it('toggles swipe handling when the variant is changed', () => {
       // variant is 'temporary' by default
-      assert.strictEqual(wrapper.find(SwipeArea).exists(), true);
+      expect(wrapper.find(SwipeArea).exists()).to.equal(true);
       wrapper.setProps({ variant: 'persistent' });
-      assert.strictEqual(wrapper.find(SwipeArea).exists(), false);
+      expect(wrapper.find(SwipeArea).exists()).to.equal(false);
 
       wrapper.setProps({ variant: 'temporary' });
       wrapper.update();
-      assert.strictEqual(wrapper.find(SwipeArea).exists(), true);
+      expect(wrapper.find(SwipeArea).exists()).to.equal(true);
     });
   });
 
@@ -402,12 +402,12 @@ describe('<SwipeableDrawer />', () => {
 
       // simulate open swipe
       wrapper.setProps({ disableSwipeToOpen: true });
-      assert.strictEqual(wrapper.find('[role="presentation"]').exists(), false);
+      expect(wrapper.find('[role="presentation"]').exists()).to.equal(false);
       fireBodyMouseEvent('touchstart', { touches: [{ pageX: 10, clientY: 0 }] });
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 150, clientY: 0 }] });
       fireBodyMouseEvent('touchend', { changedTouches: [{ pageX: 250, clientY: 0 }] });
-      assert.strictEqual(handleOpen.callCount, 0);
-      assert.strictEqual(wrapper.find('[role="presentation"]').exists(), false);
+      expect(handleOpen.callCount).to.equal(0);
+      expect(wrapper.find('[role="presentation"]').exists()).to.equal(false);
       wrapper.unmount();
     });
 
@@ -426,13 +426,13 @@ describe('<SwipeableDrawer />', () => {
 
       // simulate close swipe
       wrapper.setProps({ disableSwipeToOpen: true });
-      assert.strictEqual(wrapper.find('[role="presentation"]').exists(), true);
+      expect(wrapper.find('[role="presentation"]').exists()).to.equal(true);
       fireMouseEvent('touchstart', wrapper.find(FakePaper), {
         touches: [{ pageX: 250, clientY: 0 }],
       });
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 150, clientY: 0 }] });
       fireBodyMouseEvent('touchend', { changedTouches: [{ pageX: 10, clientY: 0 }] });
-      assert.strictEqual(handleClose.callCount, 1);
+      expect(handleClose.callCount).to.equal(1);
       wrapper.unmount();
     });
   });
@@ -478,7 +478,7 @@ describe('<SwipeableDrawer />', () => {
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 20, clientY: 0 }] });
       fireBodyMouseEvent('touchmove', { touches: [{ pageX: 180, clientY: 0 }] });
       fireBodyMouseEvent('touchend', { changedTouches: [{ pageX: 180, clientY: 0 }] });
-      assert.strictEqual(handleOpen.callCount, 1, 'should call onOpen once, not twice');
+      expect(handleOpen.callCount).to.equal(1);
     });
   });
 
@@ -537,9 +537,8 @@ describe('<SwipeableDrawer />', () => {
         'MockedSwipeableDrawer',
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Warning: Failed prop type: Invalid prop `PaperProps.component` supplied to `MockedSwipeableDrawer`. Expected an element type that can hold a ref.',
       );
     });
@@ -557,9 +556,8 @@ describe('<SwipeableDrawer />', () => {
         'MockedSwipeableDrawer',
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Warning: Failed prop type: Invalid prop `ModalProps.BackdropProps.component` supplied to `MockedSwipeableDrawer`. Expected an element type that can hold a ref.',
       );
     });

--- a/packages/material-ui/src/TableBody/TableBody.test.js
+++ b/packages/material-ui/src/TableBody/TableBody.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -38,7 +38,7 @@ describe('<TableBody />', () => {
   it('should render children', () => {
     const children = <tr className="test" />;
     const wrapper = mountInTable(<TableBody>{children}</TableBody>);
-    assert.strictEqual(wrapper.contains(children), true);
+    expect(wrapper.contains(children)).to.equal(true);
   });
 
   it('should define table.body in the child context', () => {
@@ -53,7 +53,7 @@ describe('<TableBody />', () => {
         </Tablelvl2Context.Consumer>
       </TableBody>,
     );
-    assert.strictEqual(context.variant, 'body');
+    expect(context.variant).to.equal('body');
   });
 
   describe('prop: component', () => {

--- a/packages/material-ui/src/TableCell/TableCell.test.js
+++ b/packages/material-ui/src/TableCell/TableCell.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import TableCell from './TableCell';
@@ -39,43 +39,43 @@ describe('<TableCell />', () => {
   describe('prop: padding', () => {
     it('doesn not have a class for padding by default', () => {
       const wrapper = mountInTable(<TableCell padding="default" />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.paddingDefault), false);
+      expect(findOutermostIntrinsic(wrapper).hasClass(classes.paddingDefault)).to.equal(false);
     });
 
     it('has a class when `none`', () => {
       const wrapper = mountInTable(<TableCell className="woofTableCell" padding="none" />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.paddingNone), true);
+      expect(findOutermostIntrinsic(wrapper).hasClass(classes.paddingNone)).to.equal(true);
     });
 
     it('has a class when `checkbox`', () => {
       const wrapper = mountInTable(<TableCell className="woofTableCell" padding="checkbox" />);
-      assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.paddingCheckbox), true);
+      expect(findOutermostIntrinsic(wrapper).hasClass(classes.paddingCheckbox)).to.equal(true);
     });
   });
 
   it('has a class when `size="small"`', () => {
     const wrapper = mountInTable(<TableCell className="woofTableCell" size="small" />);
-    assert.strictEqual(findOutermostIntrinsic(wrapper).hasClass(classes.sizeSmall), true);
+    expect(findOutermostIntrinsic(wrapper).hasClass(classes.sizeSmall)).to.equal(true);
   });
 
   it('should render children', () => {
     const children = <p className="test">Hello</p>;
     const wrapper = mountInTable(<TableCell>{children}</TableCell>);
-    assert.strictEqual(wrapper.contains(children), true);
+    expect(wrapper.contains(children)).to.equal(true);
   });
 
   it('should render aria-sort="ascending" when prop sortDirection="asc" provided', () => {
     const wrapper = mountInTable(<TableCell sortDirection="asc" />);
-    assert.strictEqual(wrapper.find('td').props()['aria-sort'], 'ascending');
+    expect(wrapper.find('td').props()['aria-sort']).to.equal('ascending');
   });
 
   it('should render aria-sort="descending" when prop sortDirection="desc" provided', () => {
     const wrapper = mountInTable(<TableCell sortDirection="desc" />);
-    assert.strictEqual(wrapper.find('td').props()['aria-sort'], 'descending');
+    expect(wrapper.find('td').props()['aria-sort']).to.equal('descending');
   });
 
   it('should center content', () => {
     const wrapper = mountInTable(<TableCell align="center" />);
-    assert.strictEqual(wrapper.find('td').hasClass(classes.alignCenter), true);
+    expect(wrapper.find('td').hasClass(classes.alignCenter)).to.equal(true);
   });
 });

--- a/packages/material-ui/src/TableFooter/TableFooter.test.js
+++ b/packages/material-ui/src/TableFooter/TableFooter.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -36,7 +36,7 @@ describe('<TableFooter />', () => {
   it('should render children', () => {
     const children = <tr className="test" />;
     const wrapper = mountInTable(<TableFooter>{children}</TableFooter>);
-    assert.strictEqual(wrapper.contains(children), true);
+    expect(wrapper.contains(children)).to.equal(true);
   });
 
   it('should define table.footer in the child context', () => {
@@ -51,7 +51,7 @@ describe('<TableFooter />', () => {
         </Tablelvl2Context.Consumer>
       </TableFooter>,
     );
-    assert.strictEqual(context.variant, 'footer');
+    expect(context.variant).to.equal('footer');
   });
 
   describe('prop: component', () => {

--- a/packages/material-ui/src/TableHead/TableHead.test.js
+++ b/packages/material-ui/src/TableHead/TableHead.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -35,7 +35,7 @@ describe('<TableHead />', () => {
   it('should render children', () => {
     const children = <tr className="test" />;
     const wrapper = mountInTable(<TableHead>{children}</TableHead>);
-    assert.strictEqual(wrapper.contains(children), true);
+    expect(wrapper.contains(children)).to.equal(true);
   });
 
   it('should define table.head in the child context', () => {
@@ -50,7 +50,7 @@ describe('<TableHead />', () => {
         </Tablelvl2Context.Consumer>
       </TableHead>,
     );
-    assert.strictEqual(context.variant, 'head');
+    expect(context.variant).to.equal('head');
   });
 
   describe('prop: component', () => {

--- a/packages/material-ui/src/TablePagination/TablePagination.test.js
+++ b/packages/material-ui/src/TablePagination/TablePagination.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, assert } from 'chai';
+import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import { fireEvent, createClientRender } from 'test/utils/createClientRender';
@@ -62,10 +62,10 @@ describe('<TablePagination />', () => {
       let labelDisplayedRowsCalled = false;
       function labelDisplayedRows({ from, to, count, page }) {
         labelDisplayedRowsCalled = true;
-        assert.strictEqual(from, 11);
-        assert.strictEqual(to, 20);
-        assert.strictEqual(count, 42);
-        assert.strictEqual(page, 1);
+        expect(from).to.equal(11);
+        expect(to).to.equal(20);
+        expect(count).to.equal(42);
+        expect(page).to.equal(1);
         return `Page ${page}`;
       }
 
@@ -85,8 +85,8 @@ describe('<TablePagination />', () => {
           </TableFooter>
         </table>,
       );
-      assert.strictEqual(labelDisplayedRowsCalled, true);
-      assert.strictEqual(wrapper.html().includes('Page 1'), true);
+      expect(labelDisplayedRowsCalled).to.equal(true);
+      expect(wrapper.html().includes('Page 1')).to.equal(true);
     });
 
     it('should use labelRowsPerPage', () => {
@@ -106,7 +106,7 @@ describe('<TablePagination />', () => {
           </TableFooter>
         </table>,
       );
-      assert.strictEqual(wrapper.html().includes('Zeilen pro Seite:'), true);
+      expect(wrapper.html().includes('Zeilen pro Seite:')).to.equal(true);
     });
 
     it('should disable the back button on the first page', () => {
@@ -128,8 +128,8 @@ describe('<TablePagination />', () => {
 
       const backButton = wrapper.find(IconButton).at(0);
       const nextButton = wrapper.find(IconButton).at(1);
-      assert.strictEqual(backButton.props().disabled, true);
-      assert.strictEqual(nextButton.props().disabled, false);
+      expect(backButton.props().disabled).to.equal(true);
+      expect(nextButton.props().disabled).to.equal(false);
     });
 
     it('should disable the next button on the last page', () => {
@@ -151,8 +151,8 @@ describe('<TablePagination />', () => {
 
       const backButton = wrapper.find(IconButton).at(0);
       const nextButton = wrapper.find(IconButton).at(1);
-      assert.strictEqual(backButton.props().disabled, false);
-      assert.strictEqual(nextButton.props().disabled, true);
+      expect(backButton.props().disabled).to.equal(false);
+      expect(nextButton.props().disabled).to.equal(true);
     });
 
     it('should handle next button clicks properly', () => {
@@ -177,7 +177,7 @@ describe('<TablePagination />', () => {
 
       const nextButton = wrapper.find(IconButton).at(1);
       nextButton.simulate('click');
-      assert.strictEqual(page, 2);
+      expect(page).to.equal(2);
     });
 
     it('should handle back button clicks properly', () => {
@@ -202,7 +202,7 @@ describe('<TablePagination />', () => {
 
       const nextButton = wrapper.find(IconButton).at(0);
       nextButton.simulate('click');
-      assert.strictEqual(page, 0);
+      expect(page).to.equal(0);
     });
 
     it('should display 0 as start number if the table is empty ', () => {
@@ -221,7 +221,7 @@ describe('<TablePagination />', () => {
           </TableFooter>
         </table>,
       );
-      assert.strictEqual(wrapper.find(Typography).at(1).text(), '0-0 of 0');
+      expect(wrapper.find(Typography).at(1).text()).to.equal('0-0 of 0');
     });
 
     it('should hide the rows per page selector if there are less than two options', () => {
@@ -242,8 +242,8 @@ describe('<TablePagination />', () => {
         </table>,
       );
 
-      assert.strictEqual(wrapper.text().indexOf('Rows per page'), -1);
-      assert.strictEqual(wrapper.find(Select).length, 0);
+      expect(wrapper.text().indexOf('Rows per page')).to.equal(-1);
+      expect(wrapper.find(Select).length).to.equal(0);
     });
   });
 
@@ -302,9 +302,8 @@ describe('<TablePagination />', () => {
         'MockedTablePagination',
       );
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.include(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.include(
         'Material-UI: the page prop of a TablePagination is out of range (0 to 1, but page is 2).',
       );
     });

--- a/packages/material-ui/src/TableRow/TableRow.test.js
+++ b/packages/material-ui/src/TableRow/TableRow.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import { createClientRender } from 'test/utils/createClientRender';
@@ -38,7 +38,7 @@ describe('<TableRow />', () => {
   it('should render children', () => {
     const children = <td className="test" />;
     const wrapper = mountInTable(<TableRow>{children}</TableRow>);
-    assert.strictEqual(wrapper.contains(children), true);
+    expect(wrapper.contains(children)).to.equal(true);
   });
 
   describe('prop: component', () => {

--- a/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
+++ b/packages/material-ui/src/TableSortLabel/TableSortLabel.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import TableSortLabel from './TableSortLabel';
@@ -32,42 +32,39 @@ describe('<TableSortLabel />', () => {
   it('should set the active class when active', () => {
     const activeFlag = true;
     const wrapper = shallow(<TableSortLabel active={activeFlag} />);
-    assert.strictEqual(wrapper.hasClass(classes.active), true);
+    expect(wrapper.hasClass(classes.active)).to.equal(true);
   });
 
   it('should not set the active class when not active', () => {
     const activeFlag = false;
     const wrapper = shallow(<TableSortLabel active={activeFlag} />);
-    assert.strictEqual(wrapper.hasClass(classes.active), false);
+    expect(wrapper.hasClass(classes.active)).to.equal(false);
   });
 
   describe('has an icon', () => {
     it('should have one child with the icon class', () => {
       const wrapper = shallow(<TableSortLabel />);
       const iconChildren = wrapper.find(`.${classes.icon}`);
-      assert.strictEqual(iconChildren.length, 1);
+      expect(iconChildren.length).to.equal(1);
     });
 
     it('when given direction desc should have desc direction class', () => {
       const wrapper = shallow(<TableSortLabel direction="desc" />);
       const icon = wrapper.find(`.${classes.icon}`).first();
-      assert.strictEqual(icon.hasClass(classes.iconDirectionAsc), false);
-      assert.strictEqual(icon.hasClass(classes.iconDirectionDesc), true);
+      expect(icon.hasClass(classes.iconDirectionAsc)).to.equal(false);
+      expect(icon.hasClass(classes.iconDirectionDesc)).to.equal(true);
     });
 
     it('when given direction asc should have asc direction class', () => {
       const wrapper = shallow(<TableSortLabel direction="asc" />);
       const icon = wrapper.find(`.${classes.icon}`).first();
-      assert.strictEqual(icon.hasClass(classes.iconDirectionAsc), true);
-      assert.strictEqual(icon.hasClass(classes.iconDirectionDesc), false);
+      expect(icon.hasClass(classes.iconDirectionAsc)).to.equal(true);
+      expect(icon.hasClass(classes.iconDirectionDesc)).to.equal(false);
     });
 
     it('should accept a custom icon for the sort icon', () => {
       const wrapper = mount(<TableSortLabel IconComponent={Sort} />);
-      assert.strictEqual(
-        wrapper.find(`svg.${classes.icon}[data-mui-test="SortIcon"]`).exists(),
-        true,
-      );
+      expect(wrapper.find(`svg.${classes.icon}[data-mui-test="SortIcon"]`).exists()).to.equal(true);
     });
   });
 
@@ -75,19 +72,19 @@ describe('<TableSortLabel />', () => {
     it('can hide icon when not active', () => {
       const wrapper = shallow(<TableSortLabel active={false} hideSortIcon />);
       const iconChildren = wrapper.find(`.${classes.icon}`).first();
-      assert.strictEqual(iconChildren.length, 0);
+      expect(iconChildren.length).to.equal(0);
     });
 
     it('does not hide icon by default when not active', () => {
       const wrapper = shallow(<TableSortLabel active={false} />);
       const iconChildren = wrapper.find(`.${classes.icon}`).first();
-      assert.strictEqual(iconChildren.length, 1);
+      expect(iconChildren.length).to.equal(1);
     });
 
     it('does not hide icon when active', () => {
       const wrapper = shallow(<TableSortLabel active hideSortIcon />);
       const iconChildren = wrapper.find(`.${classes.icon}`).first();
-      assert.strictEqual(iconChildren.length, 1);
+      expect(iconChildren.length).to.equal(1);
     });
   });
 });

--- a/packages/material-ui/src/Tabs/ScrollbarSize.test.js
+++ b/packages/material-ui/src/Tabs/ScrollbarSize.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { mount } from 'enzyme';
 import { spy, useFakeTimers, stub } from 'sinon';
 import ScrollbarSize from './ScrollbarSize';
@@ -28,14 +28,14 @@ describe('<ScrollbarSize />', () => {
     it('should not call on initial load', () => {
       const onChange = spy();
       wrapper = mount(<ScrollbarSize {...defaultProps} />);
-      assert.strictEqual(onChange.callCount, 0);
+      expect(onChange.callCount).to.equal(0);
     });
 
     it('should call on initial load', () => {
       const onChange = spy();
       wrapper = mount(<ScrollbarSize {...defaultProps} onChange={onChange} />);
-      assert.strictEqual(onChange.callCount, 1);
-      assert.strictEqual(onChange.calledWith(0), true);
+      expect(onChange.callCount).to.equal(1);
+      expect(onChange.calledWith(0)).to.equal(true);
     });
   });
 
@@ -52,18 +52,18 @@ describe('<ScrollbarSize />', () => {
     });
 
     it('should call on first resize event', () => {
-      assert.strictEqual(onChange.callCount, 1);
+      expect(onChange.callCount).to.equal(1);
       window.dispatchEvent(new window.Event('resize', {}));
       clock.tick(166);
-      assert.strictEqual(onChange.callCount, 2);
-      assert.strictEqual(onChange.calledWith(17), true);
+      expect(onChange.callCount).to.equal(2);
+      expect(onChange.calledWith(17)).to.equal(true);
     });
 
     it('should not call on second resize event', () => {
-      assert.strictEqual(onChange.callCount, 1);
+      expect(onChange.callCount).to.equal(1);
       window.dispatchEvent(new window.Event('resize', {}));
       clock.tick(166);
-      assert.strictEqual(onChange.callCount, 2);
+      expect(onChange.callCount).to.equal(2);
     });
   });
 });

--- a/packages/material-ui/src/Tabs/TabIndicator.test.js
+++ b/packages/material-ui/src/Tabs/TabIndicator.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, getClasses } from '@material-ui/core/test-utils';
 import TabIndicator from './TabIndicator';
 
@@ -20,22 +20,22 @@ describe('<TabIndicator />', () => {
 
   it('should render with the root class', () => {
     const wrapper = shallow(<TabIndicator {...defaultProps} />);
-    assert.strictEqual(wrapper.name(), 'span');
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    expect(wrapper.name()).to.equal('span');
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
   });
 
   describe('prop: style', () => {
     it('should be applied on the root element', () => {
       const wrapper = shallow(<TabIndicator {...defaultProps} style={style} />);
-      assert.strictEqual(wrapper.props().style, style, 'should apply directly the property');
+      expect(wrapper.props().style).to.equal(style);
     });
   });
 
   describe('prop: className', () => {
     it('should append the className on the root element', () => {
       const wrapper = shallow(<TabIndicator {...defaultProps} className="foo" />);
-      assert.strictEqual(wrapper.name(), 'span');
-      assert.strictEqual(wrapper.hasClass('foo'), true);
+      expect(wrapper.name()).to.equal('span');
+      expect(wrapper.hasClass('foo')).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/Tabs/Tabs.test.js
+++ b/packages/material-ui/src/Tabs/Tabs.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { expect, assert } from 'chai';
+import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
@@ -76,8 +76,7 @@ describe('<Tabs />', () => {
 
     it('should warn if the input is invalid', () => {
       render(<Tabs value={0} centered variant="scrollable" />);
-      assert.match(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.messages()[0]).to.match(
         /Material-UI: you can not use the `centered={true}` and `variant="scrollable"`/,
       );
     });

--- a/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
+++ b/packages/material-ui/src/TextareaAutosize/TextareaAutosize.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import sinon, { spy, stub, useFakeTimers } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
@@ -72,7 +72,7 @@ describe('<TextareaAutosize />', () => {
 
       it('should handle the resize event', () => {
         const wrapper = mount(<TextareaAutosize />);
-        assert.deepEqual(getStyle(wrapper), {
+        expect(getStyle(wrapper)).to.deep.equal({
           height: 0,
           overflow: 'hidden',
         });
@@ -86,7 +86,7 @@ describe('<TextareaAutosize />', () => {
         window.dispatchEvent(new window.Event('resize', {}));
         clock.tick(166);
         wrapper.update();
-        assert.deepEqual(getStyle(wrapper), {
+        expect(getStyle(wrapper)).to.deep.equal({
           height: 30,
           overflow: 'hidden',
         });
@@ -96,7 +96,7 @@ describe('<TextareaAutosize />', () => {
     it('should update when uncontrolled', () => {
       const handleChange = spy();
       const wrapper = mount(<TextareaAutosize onChange={handleChange} />);
-      assert.deepEqual(getStyle(wrapper), { height: 0, overflow: 'hidden' });
+      expect(getStyle(wrapper)).to.deep.equal({ height: 0, overflow: 'hidden' });
       setLayout(wrapper, {
         getComputedStyle: {
           'box-sizing': 'content-box',
@@ -106,14 +106,14 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.find('textarea').at(0).simulate('change');
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: 30, overflow: 'hidden' });
-      assert.strictEqual(handleChange.callCount, 1);
+      expect(getStyle(wrapper)).to.deep.equal({ height: 30, overflow: 'hidden' });
+      expect(handleChange.callCount).to.equal(1);
     });
 
     it('should take the border into account with border-box', () => {
       const border = 5;
       const wrapper = mount(<TextareaAutosize />);
-      assert.deepEqual(getStyle(wrapper), { height: 0, overflow: 'hidden' });
+      expect(getStyle(wrapper)).to.deep.equal({ height: 0, overflow: 'hidden' });
       setLayout(wrapper, {
         getComputedStyle: {
           'box-sizing': 'border-box',
@@ -124,7 +124,7 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.setProps();
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: 30 + border, overflow: 'hidden' });
+      expect(getStyle(wrapper)).to.deep.equal({ height: 30 + border, overflow: 'hidden' });
     });
 
     it('should take the padding into account with content-box', () => {
@@ -140,7 +140,7 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.setProps();
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: 30 - padding, overflow: 'hidden' });
+      expect(getStyle(wrapper)).to.deep.equal({ height: 30 - padding, overflow: 'hidden' });
     });
 
     it('should have at least height of "rows"', () => {
@@ -156,7 +156,7 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.setProps();
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: lineHeight * rows, overflow: null });
+      expect(getStyle(wrapper)).to.deep.equal({ height: lineHeight * rows, overflow: null });
     });
 
     it('should have at max "rowsMax" rows', () => {
@@ -172,7 +172,7 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.setProps();
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: lineHeight * rowsMax, overflow: null });
+      expect(getStyle(wrapper)).to.deep.equal({ height: lineHeight * rowsMax, overflow: null });
     });
 
     it('should show scrollbar when having more rows than "rowsMax"', () => {
@@ -188,7 +188,7 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.setProps();
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: lineHeight * 2, overflow: 'hidden' });
+      expect(getStyle(wrapper)).to.deep.equal({ height: lineHeight * 2, overflow: 'hidden' });
       setLayout(wrapper, {
         getComputedStyle: {
           'box-sizing': 'border-box',
@@ -198,7 +198,7 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.setProps();
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: lineHeight * 3, overflow: 'hidden' });
+      expect(getStyle(wrapper)).to.deep.equal({ height: lineHeight * 3, overflow: 'hidden' });
       setLayout(wrapper, {
         getComputedStyle: {
           'box-sizing': 'border-box',
@@ -208,7 +208,7 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.setProps();
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: lineHeight * 3, overflow: null });
+      expect(getStyle(wrapper)).to.deep.equal({ height: lineHeight * 3, overflow: null });
     });
 
     it('should update its height when the "rowsMax" prop changes', () => {
@@ -223,10 +223,10 @@ describe('<TextareaAutosize />', () => {
       });
       wrapper.setProps();
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: lineHeight * 3, overflow: null });
+      expect(getStyle(wrapper)).to.deep.equal({ height: lineHeight * 3, overflow: null });
       wrapper.setProps({ rowsMax: 2 });
       wrapper.update();
-      assert.deepEqual(getStyle(wrapper), { height: lineHeight * 2, overflow: null });
+      expect(getStyle(wrapper)).to.deep.equal({ height: lineHeight * 2, overflow: null });
     });
 
     describe('warnings', () => {
@@ -254,8 +254,8 @@ describe('<TextareaAutosize />', () => {
         wrapper.setProps();
         wrapper.update();
 
-        assert.strictEqual(consoleErrorMock.callCount(), 3);
-        assert.include(consoleErrorMock.messages()[0], 'Material-UI: too many re-renders.');
+        expect(consoleErrorMock.callCount()).to.equal(3);
+        expect(consoleErrorMock.messages()[0]).to.include('Material-UI: too many re-renders.');
       });
     });
   });

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { spy, useFakeTimers } from 'sinon';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -75,8 +75,8 @@ describe('<Tooltip />', () => {
   it('should render the correct structure', () => {
     const wrapper = mount(<Tooltip {...defaultProps} />);
     const children = wrapper.childAt(0);
-    assert.strictEqual(children.childAt(1).type(), Popper);
-    assert.strictEqual(children.childAt(1).hasClass(classes.popper), true);
+    expect(children.childAt(1).type()).to.equal(Popper);
+    expect(children.childAt(1).hasClass(classes.popper)).to.equal(true);
   });
 
   describe('prop: disableHoverListener', () => {
@@ -88,19 +88,19 @@ describe('<Tooltip />', () => {
       );
 
       const children = wrapper.find('button');
-      assert.strictEqual(children.props().title, null);
+      expect(children.props().title).to.equal(null);
     });
   });
 
   describe('prop: title', () => {
     it('should display if the title is present', () => {
       const wrapper = mount(<Tooltip {...defaultProps} open />);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
     });
 
     it('should not display if the title is an empty string', () => {
       const wrapper = mount(<Tooltip {...defaultProps} title="" open />);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
     });
 
     it('should be passed down to the child as a native title', () => {
@@ -111,27 +111,27 @@ describe('<Tooltip />', () => {
       );
 
       const children = wrapper.find('button');
-      assert.strictEqual(children.props().title, 'Hello World');
+      expect(children.props().title).to.equal('Hello World');
     });
   });
 
   describe('prop: placement', () => {
     it('should have top placement', () => {
       const wrapper = mount(<Tooltip {...defaultProps} placement="top" />);
-      assert.strictEqual(wrapper.find(Popper).props().placement, 'top');
+      expect(wrapper.find(Popper).props().placement).to.equal('top');
     });
   });
 
   it('should respond to external events', () => {
     const wrapper = mount(<Tooltip {...defaultProps} />);
     const children = wrapper.find('#testChild');
-    assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+    expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
     children.simulate('mouseOver');
-    assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+    expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
     children.simulate('mouseLeave');
     clock.tick(0);
     wrapper.update();
-    assert.strictEqual(wrapper.find(Popper).props().open, false);
+    expect(wrapper.find(Popper).props().open).to.equal(false);
   });
 
   it('should be controllable', () => {
@@ -142,15 +142,15 @@ describe('<Tooltip />', () => {
       <Tooltip {...defaultProps} open onOpen={handleRequestOpen} onClose={handleClose} />,
     );
     const children = wrapper.find('#testChild');
-    assert.strictEqual(handleRequestOpen.callCount, 0);
-    assert.strictEqual(handleClose.callCount, 0);
+    expect(handleRequestOpen.callCount).to.equal(0);
+    expect(handleClose.callCount).to.equal(0);
     children.simulate('mouseOver');
-    assert.strictEqual(handleRequestOpen.callCount, 1);
-    assert.strictEqual(handleClose.callCount, 0);
+    expect(handleRequestOpen.callCount).to.equal(1);
+    expect(handleClose.callCount).to.equal(0);
     children.simulate('mouseLeave');
     clock.tick(0);
-    assert.strictEqual(handleRequestOpen.callCount, 1);
-    assert.strictEqual(handleClose.callCount, 1);
+    expect(handleRequestOpen.callCount).to.equal(1);
+    expect(handleClose.callCount).to.equal(1);
   });
 
   describe('touch screen', () => {
@@ -159,7 +159,7 @@ describe('<Tooltip />', () => {
       const children = wrapper.find('#testChild');
       children.simulate('touchStart');
       children.simulate('touchEnd');
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
     });
 
     it('should open on long press', () => {
@@ -168,12 +168,12 @@ describe('<Tooltip />', () => {
       children.simulate('touchStart');
       clock.tick(1000);
       wrapper.update();
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
       children.simulate('touchEnd');
       children.simulate('blur');
       clock.tick(1500);
       wrapper.update();
-      assert.strictEqual(wrapper.find(Popper).props().open, false);
+      expect(wrapper.find(Popper).props().open).to.equal(false);
     });
   });
 
@@ -198,10 +198,10 @@ describe('<Tooltip />', () => {
 
       const wrapper = mount(<AutoFocus />);
       wrapper.setProps({ open: true });
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
       clock.tick(0);
       wrapper.update();
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
     });
   });
 
@@ -211,10 +211,10 @@ describe('<Tooltip />', () => {
       simulatePointerDevice();
       const children = wrapper.find('#testChild');
       focusVisibleLegacy(children);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
       clock.tick(111);
       wrapper.update();
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
     });
 
     it('should use hysteresis with the enterDelay', () => {
@@ -254,12 +254,12 @@ describe('<Tooltip />', () => {
       simulatePointerDevice();
       const children = wrapper.find('#testChild');
       focusVisibleLegacy(children);
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
       children.simulate('blur');
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
       clock.tick(111);
       wrapper.update();
-      assert.strictEqual(wrapper.find(Popper).props().open, false);
+      expect(wrapper.find(Popper).props().open).to.equal(false);
     });
   });
 
@@ -286,7 +286,7 @@ describe('<Tooltip />', () => {
         const type = name.slice(2).toLowerCase();
         children.simulate(type);
         clock.tick(0);
-        assert.strictEqual(handler.callCount, 1);
+        expect(handler.callCount).to.equal(1);
       });
     });
 
@@ -321,7 +321,7 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 0, 'should not call console.error');
+      expect(consoleErrorMock.callCount()).to.equal(0);
     });
 
     it('should raise a warning when we are uncontrolled and can not listen to events', () => {
@@ -332,9 +332,8 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 1, 'should call console.error');
-      assert.match(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.match(
         /Material-UI: you are providing a disabled `button` child to the Tooltip component/,
       );
     });
@@ -347,7 +346,7 @@ describe('<Tooltip />', () => {
           </button>
         </Tooltip>,
       );
-      assert.strictEqual(consoleErrorMock.callCount(), 0);
+      expect(consoleErrorMock.callCount()).to.equal(0);
     });
   });
 
@@ -364,13 +363,13 @@ describe('<Tooltip />', () => {
       const children = wrapper.find('#testChild');
       children.simulate('mouseOver', { type: 'mouseOver' });
       clock.tick(0);
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      expect(wrapper.find(Popper).props().open).to.equal(true);
       const popper = wrapper.find(Popper);
       children.simulate('mouseLeave', { type: 'mouseleave' });
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      expect(wrapper.find(Popper).props().open).to.equal(true);
       popper.simulate('mouseOver', { type: 'mouseover' });
       clock.tick(111);
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      expect(wrapper.find(Popper).props().open).to.equal(true);
     });
 
     it('should not animate twice', () => {
@@ -386,13 +385,13 @@ describe('<Tooltip />', () => {
       children.simulate('mouseOver', { type: 'mouseOver' });
       clock.tick(500);
       wrapper.update();
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      expect(wrapper.find(Popper).props().open).to.equal(true);
       const popper = wrapper.find(Popper);
       children.simulate('mouseLeave', { type: 'mouseleave' });
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      expect(wrapper.find(Popper).props().open).to.equal(true);
       popper.simulate('mouseOver', { type: 'mouseover' });
       clock.tick(0);
-      assert.strictEqual(wrapper.find(Popper).props().open, true);
+      expect(wrapper.find(Popper).props().open).to.equal(true);
     });
   });
 
@@ -435,7 +434,7 @@ describe('<Tooltip />', () => {
           <h1 className="bar">H1</h1>
         </Tooltip>,
       );
-      assert.strictEqual(wrapper.find('h1').props().className, 'foo bar');
+      expect(wrapper.find('h1').props().className).to.equal('foo bar');
     });
 
     it('should respect the props priority', () => {
@@ -444,7 +443,7 @@ describe('<Tooltip />', () => {
           <h1 hidden={false}>H1</h1>
         </Tooltip>,
       );
-      assert.strictEqual(wrapper.find('h1').props().hidden, false);
+      expect(wrapper.find('h1').props().hidden).to.equal(false);
     });
   });
 
@@ -463,22 +462,22 @@ describe('<Tooltip />', () => {
       const wrapper = mount(<Test />);
       simulatePointerDevice();
 
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
 
       wrapper.find('#target').simulate('focus');
 
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
     });
 
     it('opens on focus-visible', () => {
       const wrapper = mount(<Test />);
       simulatePointerDevice();
 
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), false);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(false);
 
       focusVisibleLegacy(wrapper.find('#target'));
 
-      assert.strictEqual(wrapper.find('[role="tooltip"]').exists(), true);
+      expect(wrapper.find('[role="tooltip"]').exists()).to.equal(true);
     });
 
     // https://github.com/mui-org/material-ui/issues/19883

--- a/packages/material-ui/src/Typography/Typography.test.js
+++ b/packages/material-ui/src/Typography/Typography.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow, createMount, getClasses } from '@material-ui/core/test-utils';
 import describeConformance from '../test-utils/describeConformance';
 import Typography from './Typography';
@@ -40,13 +40,13 @@ describe('<Typography />', () => {
 
   it('should render the text', () => {
     const wrapper = shallow(<Typography>Hello</Typography>);
-    assert.strictEqual(wrapper.text(), 'Hello');
+    expect(wrapper.text()).to.equal('Hello');
   });
 
   it('should render body1 root by default', () => {
     const wrapper = shallow(<Typography>Hello</Typography>);
-    assert.strictEqual(wrapper.hasClass(classes.body1), true);
-    assert.strictEqual(wrapper.hasClass(classes.root), true);
+    expect(wrapper.hasClass(classes.body1)).to.equal(true);
+    expect(wrapper.hasClass(classes.root)).to.equal(true);
   });
 
   it('should center text', () => {
@@ -55,15 +55,15 @@ describe('<Typography />', () => {
         Hello
       </Typography>,
     );
-    assert.strictEqual(wrapper.hasClass(classes.alignCenter), true);
+    expect(wrapper.hasClass(classes.alignCenter)).to.equal(true);
   });
   ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'subtitle1', 'body2', 'body1', 'caption', 'button'].forEach(
     (variant) => {
       it(`should render ${variant} text`, () => {
         // @ts-ignore literal/tuple type widening
         const wrapper = shallow(<Typography variant={variant}>Hello</Typography>);
-        assert.strictEqual(classes[variant] != null, true);
-        assert.strictEqual(wrapper.hasClass(classes[variant]), true, `should be ${variant} text`);
+        expect(classes[variant] != null).to.equal(true);
+        expect(wrapper.hasClass(classes[variant])).to.equal(true);
       });
     },
   );
@@ -78,37 +78,37 @@ describe('<Typography />', () => {
     it(`should render ${color} color`, () => {
       // @ts-ignore literal/tuple type widening
       const wrapper = shallow(<Typography color={color}>Hello</Typography>);
-      assert.strictEqual(classes[className] != null, true);
-      assert.strictEqual(wrapper.hasClass(classes[className]), true, `should be ${color} text`);
+      expect(classes[className] != null).to.equal(true);
+      expect(wrapper.hasClass(classes[className])).to.equal(true);
     });
   });
 
   describe('prop: color', () => {
     it('should inherit the color', () => {
       const wrapper = shallow(<Typography color="inherit">Hello</Typography>);
-      assert.strictEqual(wrapper.hasClass(classes.colorInherit), true);
+      expect(wrapper.hasClass(classes.colorInherit)).to.equal(true);
     });
   });
 
   describe('headline', () => {
     it('should render a span by default', () => {
       const wrapper = shallow(<Typography variant="button">Hello</Typography>);
-      assert.strictEqual(wrapper.name(), 'span');
+      expect(wrapper.name()).to.equal('span');
     });
 
     it('should render a p with a paragraph', () => {
       const wrapper = shallow(<Typography paragraph>Hello</Typography>);
-      assert.strictEqual(wrapper.name(), 'p');
+      expect(wrapper.name()).to.equal('p');
     });
 
     it('should render the mapped headline', () => {
       const wrapper = shallow(<Typography variant="h6">Hello</Typography>);
-      assert.strictEqual(wrapper.name(), 'h6');
+      expect(wrapper.name()).to.equal('h6');
     });
 
     it('should render a h1', () => {
       const wrapper = shallow(<Typography component="h1">Hello</Typography>);
-      assert.strictEqual(wrapper.name(), 'h1');
+      expect(wrapper.name()).to.equal('h1');
     });
   });
 
@@ -119,7 +119,7 @@ describe('<Typography />', () => {
           Hello
         </Typography>,
       );
-      assert.strictEqual(wrapper.type(), 'aside');
+      expect(wrapper.type()).to.equal('aside');
     });
 
     it('should work event without the full mapping', () => {
@@ -128,30 +128,30 @@ describe('<Typography />', () => {
           Hello
         </Typography>,
       );
-      assert.strictEqual(wrapper.type(), 'h6');
+      expect(wrapper.type()).to.equal('h6');
     });
   });
 
   describe('prop: display', () => {
     it('should render with displayInline class in display="inline"', () => {
       const wrapper = shallow(<Typography display="inline">Hello</Typography>);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass(classes.displayInline), true);
-      assert.strictEqual(wrapper.hasClass(classes.displayBlock), false);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
+      expect(wrapper.hasClass(classes.displayInline)).to.equal(true);
+      expect(wrapper.hasClass(classes.displayBlock)).to.equal(false);
     });
 
     it('should render with displayInline class in display="block"', () => {
       const wrapper = shallow(<Typography display="block">Hello</Typography>);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass(classes.displayBlock), true);
-      assert.strictEqual(wrapper.hasClass(classes.displayInline), false);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
+      expect(wrapper.hasClass(classes.displayBlock)).to.equal(true);
+      expect(wrapper.hasClass(classes.displayInline)).to.equal(false);
     });
 
     it('should render with no display classes if display="initial"', () => {
       const wrapper = shallow(<Typography display="initial">Hello</Typography>);
-      assert.strictEqual(wrapper.hasClass(classes.root), true);
-      assert.strictEqual(wrapper.hasClass(classes.displayBlock), false);
-      assert.strictEqual(wrapper.hasClass(classes.displayInline), false);
+      expect(wrapper.hasClass(classes.root)).to.equal(true);
+      expect(wrapper.hasClass(classes.displayBlock)).to.equal(false);
+      expect(wrapper.hasClass(classes.displayInline)).to.equal(false);
     });
   });
 });

--- a/packages/material-ui/src/Zoom/Zoom.test.js
+++ b/packages/material-ui/src/Zoom/Zoom.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { spy, useFakeTimers } from 'sinon';
 import { createMount } from '@material-ui/core/test-utils';
 import describeConformance from '@material-ui/core/test-utils/describeConformance';
@@ -75,13 +75,12 @@ describe('<Zoom />', () => {
 
       describe('handleEnter()', () => {
         it('should call handleEnter()', () => {
-          assert.strictEqual(handleEnter.callCount, 1);
-          assert.strictEqual(handleEnter.args[0][0], child.instance());
+          expect(handleEnter.callCount).to.equal(1);
+          expect(handleEnter.args[0][0]).to.equal(child.instance());
         });
 
         it('should set style properties', () => {
-          assert.match(
-            handleEnter.args[0][0].style.transition,
+          expect(handleEnter.args[0][0].style.transition).to.match(
             /transform 225ms cubic-bezier\(0.4, 0, 0.2, 1\)( 0ms)?/,
           );
         });
@@ -89,16 +88,16 @@ describe('<Zoom />', () => {
 
       describe('handleEntering()', () => {
         it('should call handleEntering()', () => {
-          assert.strictEqual(handleEntering.callCount, 1);
-          assert.strictEqual(handleEntering.args[0][0], child.instance());
+          expect(handleEntering.callCount).to.equal(1);
+          expect(handleEntering.args[0][0]).to.equal(child.instance());
         });
       });
 
       describe('handleEntered()', () => {
         it('should call handleEntered()', () => {
           clock.tick(1000);
-          assert.strictEqual(handleEntered.callCount, 1);
-          assert.strictEqual(handleEntered.args[0][0], child.instance());
+          expect(handleEntered.callCount).to.equal(1);
+          expect(handleEntered.args[0][0]).to.equal(child.instance());
         });
       });
     });
@@ -111,13 +110,12 @@ describe('<Zoom />', () => {
 
       describe('handleExit()', () => {
         it('should call handleExit()', () => {
-          assert.strictEqual(handleExit.callCount, 1);
-          assert.strictEqual(handleExit.args[0][0], child.instance());
+          expect(handleExit.callCount).to.equal(1);
+          expect(handleExit.args[0][0]).to.equal(child.instance());
         });
 
         it('should set style properties', () => {
-          assert.match(
-            handleExit.args[0][0].style.transition,
+          expect(handleExit.args[0][0].style.transition).to.match(
             /transform 195ms cubic-bezier\(0.4, 0, 0.2, 1\)( 0ms)?/,
           );
         });
@@ -125,16 +123,16 @@ describe('<Zoom />', () => {
 
       describe('handleExiting()', () => {
         it('should call handleExiting()', () => {
-          assert.strictEqual(handleExiting.callCount, 1);
-          assert.strictEqual(handleExiting.args[0][0], child.instance());
+          expect(handleExiting.callCount).to.equal(1);
+          expect(handleExiting.args[0][0]).to.equal(child.instance());
         });
       });
 
       describe('handleExited()', () => {
         it('should call handleExited()', () => {
           clock.tick(1000);
-          assert.strictEqual(handleExited.callCount, 1);
-          assert.strictEqual(handleExited.args[0][0], child.instance());
+          expect(handleExited.callCount).to.equal(1);
+          expect(handleExited.args[0][0]).to.equal(child.instance());
         });
       });
     });
@@ -147,7 +145,7 @@ describe('<Zoom />', () => {
           <div>Foo</div>
         </Zoom>,
       );
-      assert.deepEqual(wrapper.find('div').props().style, {
+      expect(wrapper.find('div').props().style).to.deep.equal({
         transform: 'scale(0)',
         visibility: 'hidden',
       });
@@ -159,7 +157,7 @@ describe('<Zoom />', () => {
           <div>Foo</div>
         </Zoom>,
       );
-      assert.deepEqual(wrapper.find('div').props().style, {
+      expect(wrapper.find('div').props().style).to.deep.equal({
         transform: 'scale(0)',
         visibility: 'hidden',
       });

--- a/packages/material-ui/src/index.test.js
+++ b/packages/material-ui/src/index.test.js
@@ -4,17 +4,17 @@
  * import the entire lib for coverage reporting
  */
 
-import { assert } from 'chai';
+import { expect } from 'chai';
 import * as MaterialUI from './index';
 
 describe('material-ui', () => {
   it('should have exports', () => {
-    assert.strictEqual(typeof MaterialUI, 'object');
+    expect(typeof MaterialUI).to.equal('object');
   });
 
   it('should not do undefined exports', () => {
     Object.keys(MaterialUI).forEach((exportKey) =>
-      assert.strictEqual(Boolean(MaterialUI[exportKey]), true),
+      expect(Boolean(MaterialUI[exportKey])).to.equal(true),
     );
   });
 });

--- a/packages/material-ui/src/internal/animate.test.js
+++ b/packages/material-ui/src/internal/animate.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import animate from './animate';
 
 describe('animate', () => {
@@ -38,30 +38,30 @@ describe('animate', () => {
 
   it('should work', (done) => {
     container.scrollLeft = 200;
-    assert.strictEqual(container.scrollLeft, 200);
+    expect(container.scrollLeft).to.equal(200);
     animate('scrollLeft', container, 300, {}, (err) => {
-      assert.strictEqual(err, null);
-      assert.strictEqual(container.scrollLeft, 300);
+      expect(err).to.equal(null);
+      expect(container.scrollLeft).to.equal(300);
       done();
     });
   });
 
   it('should work when asking for the current value', (done) => {
     container.scrollLeft = 200;
-    assert.strictEqual(container.scrollLeft, 200);
+    expect(container.scrollLeft).to.equal(200);
     animate('scrollLeft', container, 200, {}, (err) => {
-      assert.strictEqual(err.message, 'Element already at target position');
-      assert.strictEqual(container.scrollLeft, 200);
+      expect(err.message).to.equal('Element already at target position');
+      expect(container.scrollLeft).to.equal(200);
       done();
     });
   });
 
   it('should be able to cancel the animation', (done) => {
     container.scrollLeft = 200;
-    assert.strictEqual(container.scrollLeft, 200);
+    expect(container.scrollLeft).to.equal(200);
     const cancel = animate('scrollLeft', container, 300, {}, (err) => {
-      assert.strictEqual(err.message, 'Animation cancelled');
-      assert.strictEqual(container.scrollLeft, 200);
+      expect(err.message).to.equal('Animation cancelled');
+      expect(container.scrollLeft).to.equal(200);
       done();
     });
     cancel();

--- a/packages/material-ui/src/internal/svg-icons/index.test.js
+++ b/packages/material-ui/src/internal/svg-icons/index.test.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow } from '../../test-utils';
 
 describe('svg-icons', () => {
@@ -38,7 +38,7 @@ describe('svg-icons', () => {
 
         const Icon = fileLoaded.default;
         const wrapper = shallow(<Icon className="foo" />);
-        assert.strictEqual(wrapper.hasClass('foo'), true);
+        expect(wrapper.hasClass('foo')).to.equal(true);
       });
 
       done();

--- a/packages/material-ui/src/styles/colorManipulator.test.js
+++ b/packages/material-ui/src/styles/colorManipulator.test.js
@@ -104,19 +104,19 @@ describe('utils/colorManipulator', () => {
 
     it('converts an rgba color string to an object with `type` and `value` keys', () => {
       const { type, values } = decomposeColor('rgba(255, 255, 255, 0.5)');
-      expect(type).to.equal(type, 'rgba');
+      expect(type).to.equal('rgba');
       expect(values).to.deep.equal([255, 255, 255, 0.5]);
     });
 
     it('converts an hsl color string to an object with `type` and `value` keys', () => {
       const { type, values } = decomposeColor('hsl(100, 50%, 25%)');
-      expect(type).to.equal(type, 'hsl');
+      expect(type).to.equal('hsl');
       expect(values).to.deep.equal([100, 50, 25]);
     });
 
     it('converts an hsla color string to an object with `type` and `value` keys', () => {
       const { type, values } = decomposeColor('hsla(100, 50%, 25%, 0.5)');
-      expect(type).to.equal(type, 'hsla');
+      expect(type).to.equal('hsla');
       expect(values).to.deep.equal([100, 50, 25, 0.5]);
     });
 

--- a/packages/material-ui/src/styles/createBreakpoints.test.js
+++ b/packages/material-ui/src/styles/createBreakpoints.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import createBreakpoints from './createBreakpoints';
 
 describe('createBreakpoints', () => {
@@ -6,68 +6,63 @@ describe('createBreakpoints', () => {
 
   describe('up', () => {
     it('should work for xs', () => {
-      assert.strictEqual(breakpoints.up('xs'), '@media (min-width:0px)');
+      expect(breakpoints.up('xs')).to.equal('@media (min-width:0px)');
     });
 
     it('should work for md', () => {
-      assert.strictEqual(breakpoints.up('md'), '@media (min-width:960px)');
+      expect(breakpoints.up('md')).to.equal('@media (min-width:960px)');
     });
   });
 
   describe('down', () => {
     it('should work', () => {
-      assert.strictEqual(breakpoints.down('sm'), '@media (max-width:959.95px)');
+      expect(breakpoints.down('sm')).to.equal('@media (max-width:959.95px)');
     });
 
     it('should work for md', () => {
-      assert.strictEqual(breakpoints.down('md'), '@media (max-width:1279.95px)');
+      expect(breakpoints.down('md')).to.equal('@media (max-width:1279.95px)');
     });
 
     it('should accept a number', () => {
-      assert.strictEqual(breakpoints.down(600), '@media (max-width:599.95px)');
+      expect(breakpoints.down(600)).to.equal('@media (max-width:599.95px)');
     });
 
     it('should apply to all sizes for xl', () => {
-      assert.strictEqual(breakpoints.down('xl'), '@media (min-width:0px)');
+      expect(breakpoints.down('xl')).to.equal('@media (min-width:0px)');
     });
   });
 
   describe('between', () => {
     it('should work', () => {
-      assert.strictEqual(
-        breakpoints.between('sm', 'md'),
+      expect(breakpoints.between('sm', 'md')).to.equal(
         '@media (min-width:600px) and (max-width:1279.95px)',
       );
     });
 
     it('should accept numbers', () => {
-      assert.strictEqual(
-        breakpoints.between(600, 800),
+      expect(breakpoints.between(600, 800)).to.equal(
         '@media (min-width:600px) and (max-width:799.95px)',
       );
     });
 
     it('on xl should call up', () => {
-      assert.strictEqual(breakpoints.between('lg', 'xl'), '@media (min-width:1280px)');
+      expect(breakpoints.between('lg', 'xl')).to.equal('@media (min-width:1280px)');
     });
   });
 
   describe('only', () => {
     it('should work', () => {
-      assert.strictEqual(
-        breakpoints.only('md'),
-        '@media (min-width:960px) and (max-width:1279.95px)',
-      );
+      expect(breakpoints.only('md')).to.equal('@media (min-width:960px) and (max-width:1279.95px)');
     });
 
     it('on xl should call up', () => {
-      assert.strictEqual(breakpoints.only('xl'), '@media (min-width:1920px)');
+      expect(breakpoints.only('xl')).to.equal('@media (min-width:1920px)');
     });
   });
 
   describe('width', () => {
     it('should work', () => {
-      assert.strictEqual(breakpoints.width('md'), 960);
+      expect(breakpoints.width('md')).to.equal(960);
     });
   });
 });

--- a/packages/material-ui/src/styles/createMixins.test.js
+++ b/packages/material-ui/src/styles/createMixins.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import createMixins from './createMixins';
 import createMuiTheme from './createMuiTheme';
 
@@ -13,7 +13,7 @@ describe('createMixins', () => {
         paddingLeft: 1,
       },
     });
-    assert.deepEqual(mixin, {
+    expect(mixin).to.deep.equal({
       '@media (min-width:600px)': {
         paddingLeft: 1,
         paddingRight: 24,

--- a/packages/material-ui/src/styles/createMuiTheme.test.js
+++ b/packages/material-ui/src/styles/createMuiTheme.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import createMuiTheme from './createMuiTheme';
 import { deepOrange, green } from '../colors';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -6,34 +6,33 @@ import consoleErrorMock from 'test/utils/consoleErrorMock';
 describe('createMuiTheme', () => {
   it('should have a palette', () => {
     const muiTheme = createMuiTheme();
-    assert.strictEqual(typeof createMuiTheme, 'function');
-    assert.strictEqual(typeof muiTheme.palette, 'object');
+    expect(typeof createMuiTheme).to.equal('function');
+    expect(typeof muiTheme.palette).to.equal('object');
   });
 
   it('should have the custom palette', () => {
     const muiTheme = createMuiTheme({
       palette: { primary: { main: deepOrange[500] }, secondary: { main: green.A400 } },
     });
-    assert.strictEqual(muiTheme.palette.primary.main, deepOrange[500]);
-    assert.strictEqual(muiTheme.palette.secondary.main, green.A400);
+    expect(muiTheme.palette.primary.main).to.equal(deepOrange[500]);
+    expect(muiTheme.palette.secondary.main).to.equal(green.A400);
   });
 
   it('should allow providing a partial structure', () => {
     const muiTheme = createMuiTheme({ transitions: { duration: { shortest: 150 } } });
-    assert.notStrictEqual(muiTheme.transitions.duration.shorter, undefined);
+    expect(muiTheme.transitions.duration.shorter).to.not.equal(undefined);
   });
 
   it('should use the defined spacing for the gutters mixin', () => {
     const spacing = 100;
     const muiTheme = createMuiTheme({ spacing });
-    assert.strictEqual(muiTheme.mixins.gutters().paddingLeft, spacing * 2);
+    expect(muiTheme.mixins.gutters().paddingLeft).to.equal(spacing * 2);
   });
 
   describe('shadows', () => {
     it('should provide the default array', () => {
       const muiTheme = createMuiTheme();
-      assert.strictEqual(
-        muiTheme.shadows[2],
+      expect(muiTheme.shadows[2]).to.equal(
         '0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12)',
       );
     });
@@ -67,7 +66,7 @@ describe('createMuiTheme', () => {
         11,
       ];
       const muiTheme = createMuiTheme({ shadows });
-      assert.strictEqual(muiTheme.shadows, shadows);
+      expect(muiTheme.shadows).to.equal(shadows);
     });
   });
 
@@ -86,7 +85,7 @@ describe('createMuiTheme', () => {
         },
       };
       const muiTheme = createMuiTheme({ props });
-      assert.deepEqual(muiTheme.props, props);
+      expect(muiTheme.props).to.deep.equal(props);
     });
   });
 
@@ -103,15 +102,14 @@ describe('createMuiTheme', () => {
       let theme;
 
       theme = createMuiTheme({ overrides: { Button: { disabled: { color: 'blue' } } } });
-      assert.strictEqual(Object.keys(theme.overrides.Button.disabled).length, 1);
-      assert.strictEqual(consoleErrorMock.messages().length, 0);
+      expect(Object.keys(theme.overrides.Button.disabled).length).to.equal(1);
+      expect(consoleErrorMock.messages().length).to.equal(0);
       theme = createMuiTheme({ overrides: { MuiButton: { root: { color: 'blue' } } } });
-      assert.strictEqual(consoleErrorMock.messages().length, 0);
+      expect(consoleErrorMock.messages().length).to.equal(0);
       theme = createMuiTheme({ overrides: { MuiButton: { disabled: { color: 'blue' } } } });
-      assert.strictEqual(Object.keys(theme.overrides.MuiButton.disabled).length, 0);
-      assert.strictEqual(consoleErrorMock.messages().length, 1);
-      assert.match(
-        consoleErrorMock.messages()[0],
+      expect(Object.keys(theme.overrides.MuiButton.disabled).length).to.equal(0);
+      expect(consoleErrorMock.messages().length).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.match(
         /the `MuiButton` component increases the CSS specificity of the `disabled` internal state./,
       );
     });
@@ -119,8 +117,8 @@ describe('createMuiTheme', () => {
 
   it('shallow merges multiple arguments', () => {
     const muiTheme = createMuiTheme({ foo: 'I am foo' }, { bar: 'I am bar' });
-    assert.strictEqual(muiTheme.foo, 'I am foo');
-    assert.strictEqual(muiTheme.bar, 'I am bar');
+    expect(muiTheme.foo).to.equal('I am foo');
+    expect(muiTheme.bar).to.equal('I am bar');
   });
 
   it('deep merges multiple arguments', () => {
@@ -128,7 +126,7 @@ describe('createMuiTheme', () => {
       { custom: { foo: 'I am foo' } },
       { custom: { bar: 'I am bar' } },
     );
-    assert.strictEqual(muiTheme.custom.foo, 'I am foo');
-    assert.strictEqual(muiTheme.custom.bar, 'I am bar');
+    expect(muiTheme.custom.foo).to.equal('I am foo');
+    expect(muiTheme.custom.bar).to.equal('I am bar');
   });
 });

--- a/packages/material-ui/src/styles/createTypography.test.js
+++ b/packages/material-ui/src/styles/createTypography.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import createPalette from './createPalette';
 import createTypography from './createTypography';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
@@ -12,37 +12,37 @@ describe('createTypography', () => {
 
   it('should create a material design typography according to spec', () => {
     const typography = createTypography(palette, {});
-    assert.strictEqual(typography.fontSize, 14);
+    expect(typography.fontSize).to.equal(14);
   });
 
   it('should create a typography with custom fontSize', () => {
     const typography = createTypography(palette, { fontSize: 15 });
-    assert.strictEqual(typography.fontSize, 15);
+    expect(typography.fontSize).to.equal(15);
   });
 
   it('should accept a function', () => {
     const typography = createTypography(palette, (paletteCurrent) => {
-      assert.strictEqual(palette, paletteCurrent);
+      expect(palette).to.equal(paletteCurrent);
 
       return { fontSize: 15 };
     });
-    assert.strictEqual(typography.fontSize, 15);
+    expect(typography.fontSize).to.equal(15);
   });
 
   it('should accept a custom font size', () => {
     const typography = createTypography(palette, { fontSize: 16 });
-    assert.strictEqual(typography.body2.fontSize, '1rem', 'should be 16px');
+    expect(typography.body2.fontSize).to.equal('1rem');
   });
 
   it('should create a typography with a custom baseFontSize', () => {
     const typography = createTypography(palette, { htmlFontSize: 10 });
-    assert.strictEqual(typography.h2.fontSize, '6rem');
+    expect(typography.h2.fontSize).to.equal('6rem');
   });
 
   it('should create a typography with custom h1', () => {
     const customFontSize = '18px';
     const typography = createTypography(palette, { h1: { fontSize: customFontSize } });
-    assert.strictEqual(typography.h1.fontSize, customFontSize);
+    expect(typography.h1.fontSize).to.equal(customFontSize);
   });
 
   it('should apply a CSS property to all the variants', () => {
@@ -64,7 +64,7 @@ describe('createTypography', () => {
     ];
 
     allVariants.forEach((variant) => {
-      assert.strictEqual(typography[variant].marginLeft, 0);
+      expect(typography[variant].marginLeft).to.equal(0);
     });
   });
 
@@ -85,9 +85,8 @@ describe('createTypography', () => {
     it('logs an error if `fontSize` is not of type number', () => {
       createTypography({}, { fontSize: '1' });
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.match(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.match(
         /Material-UI: `fontSize` is required to be a number./,
       );
     });
@@ -95,9 +94,8 @@ describe('createTypography', () => {
     it('logs an error if `htmlFontSize` is not of type number', () => {
       createTypography({}, { htmlFontSize: '1' });
 
-      assert.strictEqual(consoleErrorMock.callCount(), 1);
-      assert.match(
-        consoleErrorMock.messages()[0],
+      expect(consoleErrorMock.callCount()).to.equal(1);
+      expect(consoleErrorMock.messages()[0]).to.match(
         /Material-UI: `htmlFontSize` is required to be a number./,
       );
     });

--- a/packages/material-ui/src/test-utils/findOutermostIntrinsic.test.js
+++ b/packages/material-ui/src/test-utils/findOutermostIntrinsic.test.js
@@ -1,20 +1,19 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import createMount from './createMount';
 import findOutermostIntrinsic from './findOutermostIntrinsic';
 
 describe('findOutermostIntrinsic', () => {
   let mount;
-  const assertIntrinsic = (node, expect) => {
+  const expectIntrinsic = (node, expected) => {
     const wrapper = mount(node);
     const outermostIntrinsic = findOutermostIntrinsic(wrapper);
 
-    if (expect === null) {
-      assert.strictEqual(outermostIntrinsic.exists(), false);
+    if (expected === null) {
+      expect(outermostIntrinsic.exists()).to.equal(false);
     } else {
-      assert.strictEqual(outermostIntrinsic.type(), expect);
-      assert.strictEqual(
-        outermostIntrinsic.type(),
+      expect(outermostIntrinsic.type()).to.equal(expected);
+      expect(outermostIntrinsic.type()).to.equal(
         outermostIntrinsic.getDOMNode().nodeName.toLowerCase(),
       );
     }
@@ -30,11 +29,11 @@ describe('findOutermostIntrinsic', () => {
   });
 
   it('returns immediate DOM nodes', () => {
-    assertIntrinsic(<div>Hello, World!</div>, 'div');
+    expectIntrinsic(<div>Hello, World!</div>, 'div');
   });
 
   it('only returns the outermost', () => {
-    assertIntrinsic(
+    expectIntrinsic(
       <span>
         <div>Hello, World!</div>
       </span>,
@@ -43,13 +42,13 @@ describe('findOutermostIntrinsic', () => {
   });
 
   it('ignores components', () => {
-    assertIntrinsic(
+    expectIntrinsic(
       <Headless>
         <div>Hello, World!</div>
       </Headless>,
       'div',
     );
-    assertIntrinsic(
+    expectIntrinsic(
       <Headless>
         <Headless>
           <div>Hello, World!</div>
@@ -57,7 +56,7 @@ describe('findOutermostIntrinsic', () => {
       </Headless>,
       'div',
     );
-    assertIntrinsic(
+    expectIntrinsic(
       <Headless>
         <Headless>
           <div>
@@ -72,6 +71,6 @@ describe('findOutermostIntrinsic', () => {
   });
 
   it('can handle that no DOM node is rendered', () => {
-    assertIntrinsic(<Headless>{false && <Headless />}</Headless>, null);
+    expectIntrinsic(<Headless>{false && <Headless />}</Headless>, null);
   });
 });

--- a/packages/material-ui/src/test-utils/until.test.js
+++ b/packages/material-ui/src/test-utils/until.test.js
@@ -1,5 +1,5 @@
-import assert from 'assert';
 import * as React from 'react';
+import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import { shallow } from 'enzyme';
 import until from './until';
@@ -11,32 +11,32 @@ describe('until', () => {
   it('shallow renders the current wrapper one level deep', () => {
     const EnhancedDiv = hoc(Div);
     const wrapper = until.call(shallow(<EnhancedDiv />), 'Div');
-    assert.strictEqual(wrapper.contains(<div />), true);
+    expect(wrapper.contains(<div />)).to.equal(true);
   });
 
   it('shallow renders the current wrapper several levels deep', () => {
     const EnhancedDiv = hoc(hoc(hoc(Div)));
     const wrapper = until.call(shallow(<EnhancedDiv />), 'Div');
-    assert.strictEqual(wrapper.contains(<div />), true);
+    expect(wrapper.contains(<div />)).to.equal(true);
   });
 
   it('stops shallow rendering when the wrapper is empty', () => {
     const nullHoc = () => () => null;
     const EnhancedDiv = nullHoc();
     const wrapper = until.call(shallow(<EnhancedDiv />), 'Div');
-    assert.strictEqual(wrapper.html(), null);
+    expect(wrapper.html()).to.equal(null);
   });
 
   it('shallow renders as much as possible when no selector is provided', () => {
     const EnhancedDiv = hoc(hoc(Div));
     const wrapper = until.call(shallow(<EnhancedDiv />));
-    assert.strictEqual(wrapper.contains(<div />), true);
+    expect(wrapper.contains(<div />)).to.equal(true);
   });
 
   it('shallow renders the current wrapper even if the selector never matches', () => {
     const EnhancedDiv = hoc(Div);
     const wrapper = until.call(shallow(<EnhancedDiv />), 'NotDiv');
-    assert.strictEqual(wrapper.contains(<div />), true);
+    expect(wrapper.contains(<div />)).to.equal(true);
   });
 
   it('stops shallow rendering when it encounters a HTML element', () => {
@@ -48,24 +48,19 @@ describe('until', () => {
       ),
       'Div',
     );
-    assert.strictEqual(
+    expect(
       wrapper.contains(
         <div>
           <Div />
         </div>,
       ),
-      true,
-    );
+    ).to.equal(true);
   });
 
   it('throws when assert.strictEqual called on an empty wrapper', () => {
-    assert.throws(
-      () => {
-        until.call(shallow(<Div />).find('Foo'), 'div');
-      },
-      Error,
-      'Method “until” is only meant to be run on a single node. 0 found instead.',
-    );
+    expect(() => {
+      until.call(shallow(<Div />).find('Foo'), 'div');
+    }).to.throw(Error);
   });
 
   it('shallow renders non-root wrappers', () => {
@@ -75,7 +70,7 @@ describe('until', () => {
       </div>
     );
     const wrapper = until.call(shallow(<Container />).find(Div));
-    assert.strictEqual(wrapper.contains(<div />), true);
+    expect(wrapper.contains(<div />)).to.equal(true);
   });
 
   // eslint-disable-next-line react/prefer-stateless-function
@@ -93,8 +88,8 @@ describe('until', () => {
     const EnhancedFoo = hoc(Foo);
     const options = { context: { quux: true } };
     const wrapper = until.call(shallow(<EnhancedFoo />, options), 'Foo', options);
-    assert.strictEqual(wrapper.context('quux'), true);
-    assert.strictEqual(wrapper.contains(<Div />), true);
+    expect(wrapper.context('quux')).to.equal(true);
+    expect(wrapper.contains(<Div />)).to.equal(true);
   });
 
   class Bar extends React.Component {
@@ -110,7 +105,7 @@ describe('until', () => {
   it('context propagation passes down context from an intermediary component', () => {
     const EnhancedBar = hoc(Bar);
     const wrapper = until.call(shallow(<EnhancedBar />), 'Foo');
-    assert.strictEqual(wrapper.context('quux'), true);
-    assert.strictEqual(wrapper.contains(<Div />), true);
+    expect(wrapper.context('quux')).to.equal(true);
+    expect(wrapper.contains(<Div />)).to.equal(true);
   });
 });

--- a/packages/material-ui/src/utils/capitalize.test.js
+++ b/packages/material-ui/src/utils/capitalize.test.js
@@ -1,14 +1,14 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import capitalize from './capitalize';
 
 describe('capitalize', () => {
   it('should work', () => {
-    assert.strictEqual(capitalize('foo'), 'Foo');
+    expect(capitalize('foo')).to.equal('Foo');
   });
 
   it('should throw when not used correctly', () => {
-    assert.throw(() => {
+    expect(() => {
       capitalize();
-    }, /expects a string argument/);
+    }).to.throw(/expects a string argument/);
   });
 });

--- a/packages/material-ui/src/utils/deprecatedPropType.test.js
+++ b/packages/material-ui/src/utils/deprecatedPropType.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import PropTypes from 'prop-types';
 import consoleErrorMock from 'test/utils/consoleErrorMock';
 import deprecatedPropType from './deprecatedPropType';
@@ -27,7 +27,7 @@ describe('deprecatedPropType', () => {
       location,
       componentName,
     );
-    assert.strictEqual(consoleErrorMock.callCount(), 0);
+    expect(consoleErrorMock.callCount()).to.equal(0);
   });
 
   it('should warn once', () => {
@@ -43,8 +43,8 @@ describe('deprecatedPropType', () => {
       location,
       componentName,
     );
-    assert.strictEqual(consoleErrorMock.callCount(), 1);
-    assert.match(consoleErrorMock.messages()[0], /give me a reason/);
+    expect(consoleErrorMock.callCount()).to.equal(1);
+    expect(consoleErrorMock.messages()[0]).to.match(/give me a reason/);
     PropTypes.checkPropTypes(
       {
         [propName]: deprecatedPropType(PropTypes.string, 'give me a reason'),
@@ -53,6 +53,6 @@ describe('deprecatedPropType', () => {
       location,
       componentName,
     );
-    assert.strictEqual(consoleErrorMock.callCount(), 1);
+    expect(consoleErrorMock.callCount()).to.equal(1);
   });
 });

--- a/packages/material-ui/src/utils/focusVisible.test.js
+++ b/packages/material-ui/src/utils/focusVisible.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { createMount } from '@material-ui/core/test-utils';
@@ -99,16 +99,16 @@ describe('focus-visible polyfill', () => {
         throw new Error('missing button');
       }
 
-      assert.strictEqual(button.classList.contains('focus-visible'), false);
+      expect(button.classList.contains('focus-visible')).to.equal(false);
 
       button.focus();
 
-      assert.strictEqual(button.classList.contains('focus-visible'), false);
+      expect(button.classList.contains('focus-visible')).to.equal(false);
 
       button.blur();
       dispatchFocusVisible(button);
 
-      assert.strictEqual(button.classList.contains('focus-visible'), true);
+      expect(button.classList.contains('focus-visible')).to.equal(true);
     });
   });
 });

--- a/packages/material-ui/src/utils/requirePropFactory.test.js
+++ b/packages/material-ui/src/utils/requirePropFactory.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect, assert } from 'chai';
 import requirePropFactory from './requirePropFactory';
 
 describe('requirePropFactory', () => {
@@ -10,8 +10,8 @@ describe('requirePropFactory', () => {
   });
 
   it('should have the right shape', () => {
-    assert.strictEqual(typeof requirePropFactory, 'function');
-    assert.strictEqual(typeof requireProp, 'function');
+    expect(typeof requirePropFactory).to.equal('function');
+    expect(typeof requireProp).to.equal('function');
   });
 
   describe('requireProp()', () => {
@@ -24,7 +24,7 @@ describe('requirePropFactory', () => {
     });
 
     it('should return a function', () => {
-      assert.strictEqual(typeof requirePropValidator, 'function');
+      expect(typeof requirePropValidator).to.equal('function');
     });
 
     describe('requirePropValidator', () => {
@@ -35,7 +35,7 @@ describe('requirePropFactory', () => {
         propName = 'propName';
         props = {};
         const result = requirePropValidator(props, propName, undefined, undefined, undefined);
-        assert.strictEqual(result, null);
+        expect(result).to.equal(null);
       });
 
       it('should return null for propName and requiredProp in props', () => {
@@ -44,7 +44,7 @@ describe('requirePropFactory', () => {
         props[propName] = true;
         props[requiredPropName] = true;
         const result = requirePropValidator(props, propName, undefined, undefined, undefined);
-        assert.strictEqual(result, null);
+        expect(result).to.equal(null);
       });
 
       describe('propName is in props and requiredProp not in props', () => {
@@ -60,11 +60,11 @@ describe('requirePropFactory', () => {
 
         it('should return Error', () => {
           assert.property(result, 'name');
-          assert.strictEqual(result.name, 'Error');
+          expect(result.name).to.equal('Error');
           assert.property(result, 'message');
-          assert.strictEqual(result.message.indexOf(propName) > -1, true);
-          assert.strictEqual(result.message.indexOf(requiredPropName) > -1, true);
-          assert.strictEqual(result.message.indexOf(componentNameInError) > -1, true);
+          expect(result.message.indexOf(propName) > -1).to.equal(true);
+          expect(result.message.indexOf(requiredPropName) > -1).to.equal(true);
+          expect(result.message.indexOf(componentNameInError) > -1).to.equal(true);
         });
 
         describe('propFullName given to validator', () => {
@@ -75,11 +75,11 @@ describe('requirePropFactory', () => {
           });
 
           it('returned error message should have propFullName', () => {
-            assert.strictEqual(result.message.indexOf(propFullName) > -1, true);
+            expect(result.message.indexOf(propFullName) > -1).to.equal(true);
           });
 
           it('returned error message should not have propName', () => {
-            assert.strictEqual(result.message.indexOf(propName), -1);
+            expect(result.message.indexOf(propName)).to.equal(-1);
           });
         });
       });

--- a/packages/material-ui/src/utils/unsupportedProp.test.js
+++ b/packages/material-ui/src/utils/unsupportedProp.test.js
@@ -1,4 +1,4 @@
-import { assert } from 'chai';
+import { expect } from 'chai';
 import unsupportedProp from './unsupportedProp';
 
 describe('unsupportedProp', () => {
@@ -10,7 +10,7 @@ describe('unsupportedProp', () => {
   it('should return null for supported props', () => {
     const props = {};
     const result = unsupportedProp(props, propName, componentName, location, propFullName);
-    assert.strictEqual(result, null);
+    expect(result).to.equal(null);
   });
 
   it('should return an error for unsupported props', () => {
@@ -18,6 +18,6 @@ describe('unsupportedProp', () => {
       children: null,
     };
     const result = unsupportedProp(props, propName, componentName, location, propFullName);
-    assert.match(result.message, /The prop `children` is not supported. Please remove it/);
+    expect(result.message).to.match(/The prop `children` is not supported. Please remove it/);
   });
 });

--- a/packages/material-ui/src/withMobileDialog/withMobileDialog.test.js
+++ b/packages/material-ui/src/withMobileDialog/withMobileDialog.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createShallow } from '@material-ui/core/test-utils';
 import Dialog from '../Dialog';
 import withMobileDialog from './withMobileDialog';
@@ -23,7 +23,7 @@ describe('withMobileDialog', () => {
             foo
           </ResponsiveDialog>,
         );
-        assert.strictEqual(wrapper.props().fullScreen, true);
+        expect(wrapper.props().fullScreen).to.equal(true);
       });
     });
   }
@@ -37,7 +37,7 @@ describe('withMobileDialog', () => {
             foo
           </ResponsiveDialog>,
         );
-        assert.strictEqual(wrapper.props().fullScreen, false);
+        expect(wrapper.props().fullScreen).to.equal(false);
       });
     });
   }

--- a/packages/material-ui/src/withWidth/withWidth.test.js
+++ b/packages/material-ui/src/withWidth/withWidth.test.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { act } from 'react-dom/test-utils';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { stub } from 'sinon';
 import { createMount, createShallow } from '@material-ui/core/test-utils';
 import mediaQuery from 'css-mediaquery';
@@ -71,60 +71,60 @@ describe('withWidth', () => {
   describe('server-side rendering', () => {
     it('should not render the children as the width is unknown', () => {
       const wrapper = shallow(<EmptyWithWidth />);
-      assert.strictEqual(wrapper.type(), null);
+      expect(wrapper.type()).to.equal(null);
     });
   });
 
   describe('prop: width', () => {
     it('should be able to override it', () => {
       const wrapper = mount(<EmptyWithWidth width="xl" />);
-      assert.strictEqual(wrapper.find(Empty).props().width, 'xl');
+      expect(wrapper.find(Empty).props().width).to.equal('xl');
     });
   });
 
   describe('browser', () => {
     it('should provide the right width to the child element', () => {
       const wrapper = mount(<EmptyWithWidth />);
-      assert.strictEqual(wrapper.find(Empty).props().width, 'md');
+      expect(wrapper.find(Empty).props().width).to.equal('md');
     });
   });
 
   describe('isWidthUp', () => {
     it('should work as default inclusive', () => {
-      assert.strictEqual(isWidthUp('md', 'lg'), true, 'should accept larger size');
-      assert.strictEqual(isWidthUp('md', 'md'), true, 'should be inclusive');
-      assert.strictEqual(isWidthUp('md', 'sm'), false, 'should reject smaller size');
+      expect(isWidthUp('md', 'lg')).to.equal(true);
+      expect(isWidthUp('md', 'md')).to.equal(true);
+      expect(isWidthUp('md', 'sm')).to.equal(false);
     });
     it('should work as exclusive', () => {
-      assert.strictEqual(isWidthUp('md', 'lg', false), true, 'should accept larger size');
-      assert.strictEqual(isWidthUp('md', 'md', false), false, 'should be exclusive');
-      assert.strictEqual(isWidthUp('md', 'sm', false), false, 'should reject smaller size');
+      expect(isWidthUp('md', 'lg', false)).to.equal(true);
+      expect(isWidthUp('md', 'md', false)).to.equal(false);
+      expect(isWidthUp('md', 'sm', false)).to.equal(false);
     });
   });
 
   describe('isWidthDown', () => {
     it('should work as default inclusive', () => {
-      assert.strictEqual(isWidthDown('md', 'lg', true), false, 'should reject larger size');
-      assert.strictEqual(isWidthDown('md', 'md', true), true, 'should be inclusive');
-      assert.strictEqual(isWidthDown('md', 'sm', true), true, 'should accept smaller size');
+      expect(isWidthDown('md', 'lg', true)).to.equal(false);
+      expect(isWidthDown('md', 'md', true)).to.equal(true);
+      expect(isWidthDown('md', 'sm', true)).to.equal(true);
     });
     it('should work as exclusive', () => {
-      assert.strictEqual(isWidthDown('md', 'lg', false), false, 'should reject larger size');
-      assert.strictEqual(isWidthDown('md', 'md', false), false, 'should be exclusive');
-      assert.strictEqual(isWidthDown('md', 'sm', false), true, 'should accept smaller size');
+      expect(isWidthDown('md', 'lg', false)).to.equal(false);
+      expect(isWidthDown('md', 'md', false)).to.equal(false);
+      expect(isWidthDown('md', 'sm', false)).to.equal(true);
     });
   });
 
   it('should observe the media queries', () => {
     const wrapper = mount(<EmptyWithWidth />);
-    assert.strictEqual(wrapper.find(Empty).props().width, 'md');
+    expect(wrapper.find(Empty).props().width).to.equal('md');
     act(() => {
       matchMediaInstances[2].instance.matches = false;
       matchMediaInstances[0].instance.matches = true;
       matchMediaInstances[0].listeners[0]();
     });
     wrapper.update();
-    assert.strictEqual(wrapper.find(Empty).props().width, 'xl');
+    expect(wrapper.find(Empty).props().width).to.equal('xl');
   });
 
   describe('prop: initialWidth', () => {
@@ -133,11 +133,11 @@ describe('withWidth', () => {
 
       // First mount on the server
       const wrapper1 = shallow(element);
-      assert.strictEqual(wrapper1.find(Empty).props().width, 'lg');
+      expect(wrapper1.find(Empty).props().width).to.equal('lg');
 
       // Second mount on the client
       const wrapper2 = mount(element);
-      assert.strictEqual(wrapper2.find(Empty).props().width, 'md');
+      expect(wrapper2.find(Empty).props().width).to.equal('md');
     });
   });
 
@@ -148,11 +148,11 @@ describe('withWidth', () => {
 
       // First mount on the server
       const wrapper1 = shallow(element);
-      assert.strictEqual(wrapper1.find(Empty).props().width, 'lg');
+      expect(wrapper1.find(Empty).props().width).to.equal('lg');
 
       // Second mount on the client
       const wrapper2 = mount(element);
-      assert.strictEqual(wrapper2.find(Empty).props().width, 'md');
+      expect(wrapper2.find(Empty).props().width).to.equal('md');
     });
   });
 
@@ -162,11 +162,11 @@ describe('withWidth', () => {
       const element = <EmptyWithWidth theme={theme} />;
       // First mount on the server
       const wrapper1 = shallow(element);
-      assert.strictEqual(wrapper1.find(Empty).props().width, 'lg');
+      expect(wrapper1.find(Empty).props().width).to.equal('lg');
 
       // Second mount on the client
       const wrapper2 = mount(element);
-      assert.strictEqual(wrapper2.find(Empty).props().width, 'md');
+      expect(wrapper2.find(Empty).props().width).to.equal('md');
     });
   });
 
@@ -174,14 +174,14 @@ describe('withWidth', () => {
     it('should inject the theme', () => {
       const EmptyWithWidth2 = withWidth({ withTheme: true })(Empty);
       const wrapper = mount(<EmptyWithWidth2 />);
-      assert.strictEqual(typeof wrapper.find(Empty).props().theme, 'object');
+      expect(typeof wrapper.find(Empty).props().theme).to.equal('object');
     });
 
     it('should forward the theme', () => {
       const EmptyWithWidth2 = withWidth({ withTheme: true })(Empty);
       const theme = createMuiTheme();
       const wrapper = mount(<EmptyWithWidth2 theme={theme} />);
-      assert.strictEqual(wrapper.find(Empty).props().theme, theme);
+      expect(wrapper.find(Empty).props().theme).to.equal(theme);
     });
   });
 
@@ -189,7 +189,7 @@ describe('withWidth', () => {
     it('should work as expected', () => {
       const EmptyWithWidth2 = withWidth({ noSSR: true })(Empty);
       const wrapper = mount(<EmptyWithWidth2 />);
-      assert.strictEqual(wrapper.find(Empty).props().width, 'md');
+      expect(wrapper.find(Empty).props().width).to.equal('md');
     });
   });
 });

--- a/packages/material-ui/test/integration/TableCell.test.js
+++ b/packages/material-ui/test/integration/TableCell.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import { createMount, findOutermostIntrinsic, getClasses } from '@material-ui/core/test-utils';
 import { createClientRender } from 'test/utils/createClientRender';
 import TableCell from '@material-ui/core/TableCell';
@@ -34,50 +34,50 @@ describe('<TableRow> integration', () => {
   it('should render a th with the head class when in the context of a table head', () => {
     const wrapper = mountInTable(<TableCell />, TableHead);
     const root = findOutermostIntrinsic(wrapper);
-    assert.strictEqual(root.type(), 'th');
-    assert.strictEqual(root.hasClass(classes.root), true);
-    assert.strictEqual(root.hasClass(classes.head), true);
-    assert.strictEqual(root.props().scope, 'col');
+    expect(root.type()).to.equal('th');
+    expect(root.hasClass(classes.root)).to.equal(true);
+    expect(root.hasClass(classes.head)).to.equal(true);
+    expect(root.props().scope).to.equal('col');
   });
 
   it('should render specified scope attribute even when in the context of a table head', () => {
     const wrapper = mountInTable(<TableCell scope="row" />, TableHead);
-    assert.strictEqual(wrapper.props().scope, 'row');
+    expect(wrapper.props().scope).to.equal('row');
   });
 
   it('should render a th with the footer class when in the context of a table footer', () => {
     const wrapper = mountInTable(<TableCell />, TableFooter);
     const root = findOutermostIntrinsic(wrapper);
-    assert.strictEqual(root.type(), 'td');
-    assert.strictEqual(root.hasClass(classes.root), true);
-    assert.strictEqual(root.hasClass(classes.footer), true);
+    expect(root.type()).to.equal('td');
+    expect(root.hasClass(classes.root)).to.equal(true);
+    expect(root.hasClass(classes.footer)).to.equal(true);
   });
 
   it('should render with the footer class when in the context of a table footer', () => {
     const wrapper = mountInTable(<TableCell />, TableFooter);
-    assert.strictEqual(wrapper.find('td').hasClass(classes.root), true);
-    assert.strictEqual(wrapper.find('td').hasClass(classes.footer), true);
+    expect(wrapper.find('td').hasClass(classes.root)).to.equal(true);
+    expect(wrapper.find('td').hasClass(classes.footer)).to.equal(true);
   });
 
   it('should render with the head class when variant is head, overriding context', () => {
     const wrapper = mountInTable(<TableCell variant="head" />, TableFooter);
-    assert.strictEqual(wrapper.find('td').hasClass(classes.head), true);
-    assert.strictEqual(wrapper.find('td').props().scope, undefined);
+    expect(wrapper.find('td').hasClass(classes.head)).to.equal(true);
+    expect(wrapper.find('td').props().scope).to.equal(undefined);
   });
 
   it('should render without head class when variant is body, overriding context', () => {
     const wrapper = mountInTable(<TableCell variant="body" />, TableFooter);
-    assert.strictEqual(wrapper.find('td').hasClass(classes.head), false);
+    expect(wrapper.find('td').hasClass(classes.head)).to.equal(false);
   });
 
   it('should render without footer class when variant is body, overriding context', () => {
     const wrapper = mountInTable(<TableCell variant="body" />, TableFooter);
-    assert.strictEqual(wrapper.find('td').hasClass(classes.footer), false);
+    expect(wrapper.find('td').hasClass(classes.footer)).to.equal(false);
   });
 
   it('should render with the footer class when variant is footer, overriding context', () => {
     const wrapper = mountInTable(<TableCell variant="footer" />, TableHead);
-    assert.strictEqual(wrapper.find('th').hasClass(classes.footer), true);
+    expect(wrapper.find('th').hasClass(classes.footer)).to.equal(true);
   });
 
   it('sets role="columnheader" when "component" prop is set and used in the context of table head', () => {

--- a/packages/material-ui/test/integration/TableRow.test.js
+++ b/packages/material-ui/test/integration/TableRow.test.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { assert } from 'chai';
+import { expect } from 'chai';
 import { createMount, getClasses } from '@material-ui/core/test-utils';
 import TableFooter from '@material-ui/core/TableFooter';
 import TableHead from '@material-ui/core/TableHead';
@@ -26,8 +26,8 @@ describe('<TableRow> integration', () => {
         </TableHead>
       </table>,
     );
-    assert.strictEqual(wrapper.find('tr').hasClass(classes.root), true);
-    assert.strictEqual(wrapper.find('tr').hasClass(classes.head), true);
+    expect(wrapper.find('tr').hasClass(classes.root)).to.equal(true);
+    expect(wrapper.find('tr').hasClass(classes.head)).to.equal(true);
   });
 
   it('should render with the footer class when in the context of a table footer', () => {
@@ -38,7 +38,7 @@ describe('<TableRow> integration', () => {
         </TableFooter>
       </table>,
     );
-    assert.strictEqual(wrapper.find('tr').hasClass(classes.root), true);
-    assert.strictEqual(wrapper.find('tr').hasClass(classes.footer), true);
+    expect(wrapper.find('tr').hasClass(classes.root)).to.equal(true);
+    expect(wrapper.find('tr').hasClass(classes.footer)).to.equal(true);
   });
 });


### PR DESCRIPTION
Follow-up on #20792. I have focused on the migrating most of the API: efficiency (not effectiveness). There are still a couple of assert in the code base, related to usage of non frequent API:

- assert.isNotNull
- assert.lengthOf
- assert.approximately
- assert.isDefined
- assert.isUndefined

IMHO, the simplest would be to update the assertion to `expect().to.equal()`, we want to have high confidence in the assertion, I still think that higher confidence outweighs the advantage of better error messages, but no strong preference. I know we went for the other way around, I don't intend to change the current tradeoff.

There are also a couple of files that jscodeshift failed to handle, some unsupported syntax error. I haven't looked at it.