### PR TITLE
[Skeleton] Remove z-index

### DIFF
--- a/packages/material-ui-lab/src/Skeleton/Skeleton.js
+++ b/packages/material-ui-lab/src/Skeleton/Skeleton.js
@@ -57,7 +57,6 @@ export const styles = (theme) => ({
       left: 0,
       right: 0,
       top: 0,
-      zIndex: 1,
     },
   },
   '@keyframes wave': {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [ X] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
I checked the repo for other uses of zIndex, this was the only causing unexpected overlapping behavior.

Fix #20802