### PR TITLE
[Tooltip] Fix disableTouchListener behavior

### DIFF
--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -432,7 +432,9 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
 
   const interactiveWrapperListeners = {};
 
-  if (!disableTouchListener) {
+  if (disableTouchListener) {
+    ignoreNonTouchEvents.current = true;
+  } else {
     childrenProps.onTouchStart = handleTouchStart;
     childrenProps.onTouchEnd = handleTouchEnd;
   }

--- a/packages/material-ui/src/Tooltip/Tooltip.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.js
@@ -367,14 +367,17 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     }, leaveDelay);
   };
 
-  const handleTouchStart = (event) => {
+  const detectTouchStart = (event) => {
     ignoreNonTouchEvents.current = true;
-    const childrenProps = children.props;
 
+    const childrenProps = children.props;
     if (childrenProps.onTouchStart) {
       childrenProps.onTouchStart(event);
     }
+  };
 
+  const handleTouchStart = (event) => {
+    detectTouchStart(event);
     clearTimeout(leaveTimer.current);
     clearTimeout(closeTimer.current);
     clearTimeout(touchTimer.current);
@@ -427,14 +430,13 @@ const Tooltip = React.forwardRef(function Tooltip(props, ref) {
     ...other,
     ...children.props,
     className: clsx(other.className, children.props.className),
+    onTouchStart: detectTouchStart,
     ref: handleRef,
   };
 
   const interactiveWrapperListeners = {};
 
-  if (disableTouchListener) {
-    ignoreNonTouchEvents.current = true;
-  } else {
+  if (!disableTouchListener) {
     childrenProps.onTouchStart = handleTouchStart;
     childrenProps.onTouchEnd = handleTouchEnd;
   }

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -175,6 +175,13 @@ describe('<Tooltip />', () => {
       wrapper.update();
       assert.strictEqual(wrapper.find(Popper).props().open, false);
     });
+
+    it('should not respond mouseOver event with disableTouchListener', () => {
+      const { baseElement } = render(<Tooltip {...defaultProps} disableTouchListener />);
+      const children = baseElement.querySelector('#testChild');
+      fireEvent.mouseOver(children);
+      expect(baseElement.querySelector('[role="tooltip"]')).to.equal(null);
+    });
   });
 
   describe('mount', () => {

--- a/packages/material-ui/src/Tooltip/Tooltip.test.js
+++ b/packages/material-ui/src/Tooltip/Tooltip.test.js
@@ -176,11 +176,12 @@ describe('<Tooltip />', () => {
       assert.strictEqual(wrapper.find(Popper).props().open, false);
     });
 
-    it('should not respond mouseOver event with disableTouchListener', () => {
-      const { baseElement } = render(<Tooltip {...defaultProps} disableTouchListener />);
-      const children = baseElement.querySelector('#testChild');
+    it('should not open if disableTouchListener', () => {
+      const { container } = render(<Tooltip {...defaultProps} disableTouchListener />);
+      const children = container.querySelector('#testChild');
+      fireEvent.touchStart(children);
       fireEvent.mouseOver(children);
-      expect(baseElement.querySelector('[role="tooltip"]')).to.equal(null);
+      expect(document.body.querySelectorAll('[role="tooltip"]').length).to.equal(0);
     });
   });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

The mouseOver event was making the tooltip visible (on a touch) with `disableTouchListener=true`

Closes #20245 