### PR TITLE
[example] Add next.js SSG clarification comment

### DIFF
--- a/examples/nextjs-with-typescript/pages/_document.tsx
+++ b/examples/nextjs-with-typescript/pages/_document.tsx
@@ -24,6 +24,8 @@ export default class MyDocument extends Document {
   }
 }
 
+// `getInitialProps` belongs to `_document` (instead of `_app`),
+// it's compatible with server-side generation (SSG).
 MyDocument.getInitialProps = async (ctx) => {
   // Resolution order
   //

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -24,6 +24,8 @@ export default class MyDocument extends Document {
   }
 }
 
+// Note that this `getInitialProps` belongs to `_document` (instead of `_app`).
+// Hence it works with next.js recommended Static Generation (SSG)
 MyDocument.getInitialProps = async (ctx) => {
   // Resolution order
   //

--- a/examples/nextjs/pages/_document.js
+++ b/examples/nextjs/pages/_document.js
@@ -24,8 +24,8 @@ export default class MyDocument extends Document {
   }
 }
 
-// Note that this `getInitialProps` belongs to `_document` (instead of `_app`).
-// Hence it works with next.js recommended Static Generation (SSG)
+// `getInitialProps` belongs to `_document` (instead of `_app`),
+// it's compatible with server-side generation (SSG).
 MyDocument.getInitialProps = async (ctx) => {
   // Resolution order
   //


### PR DESCRIPTION
**Motivation**: Since the introduction of SSG in next.js the usage of `getInitialProps` is discouraged. This has become a mantra for any next.js developer. However, sometimes is not clear that `_app` and `_document` level of `getInitialProps` is different. And adding such method to `_document` **does not alter** SSG. This 2-lines comment clarifies this to anyone looking to integrate these 2 projects.

**Related**: https://github.com/mui-org/material-ui/issues/16598#issuecomment-511367382

**Considerations**: Should we place this also in the docs? I'd say no since it's an implementation detail.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).


