### PR TITLE
[ButtonBase] Check before accessing rippleRef.current

### DIFF
--- a/packages/material-ui/src/ButtonBase/ButtonBase.js
+++ b/packages/material-ui/src/ButtonBase/ButtonBase.js
@@ -113,7 +113,7 @@ const ButtonBase = React.forwardRef(function ButtonBase(props, ref) {
   );
 
   React.useEffect(() => {
-    if (focusVisible && focusRipple && !disableRipple) {
+    if (focusVisible && focusRipple && !disableRipple && rippleRef.current) {
       rippleRef.current.pulsate();
     }
   }, [disableRipple, focusRipple, focusVisible]);


### PR DESCRIPTION
Caught this TypeError with Sentry. This PR adds a check before accessing `rippleRef.current`.

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
