### PR TITLE
[core] Batch small changes

### DIFF
--- a/docs/notifications.json
+++ b/docs/notifications.json
@@ -14,11 +14,5 @@
     "date": "2020-03-30",
     "title": "Sketch",
     "text": "<a style=\"color: inherit;\" target=\"_blank\" rel=\"noopener\" href=\"https://twitter.com/MaterialUI/status/1244519729978437633\">Introducing Material-UI for Sketch</a>. Today, we’re excited to introduce the Sketch symbols 💎 for Material-UI."
-  },
-  {
-    "id": 50,
-    "date": "2020-04-07",
-    "title": "Developer Survey",
-    "text": "Help shape the future of Material-UI.<br />🙏<a style=\"color: inherit;\" target=\"_blank\" rel=\"noopener\" href=\"https://forms.gle/TYWRdvgyZs4AhZNv8\">Please fill the survey.</a>"
   }
 ]

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -37,7 +37,7 @@ function useFirstRender() {
   return firstRenderRef.current;
 }
 
-acceptLanguage.languages(['en', 'zh']);
+acceptLanguage.languages(['en', 'zh', 'pt']);
 
 function loadCrowdin() {
   window._jipt = [];

--- a/docs/src/modules/components/MarkdownElement.js
+++ b/docs/src/modules/components/MarkdownElement.js
@@ -13,7 +13,7 @@ const styles = (theme) => ({
       position: 'absolute',
     },
     '& pre': {
-      margin: theme.spacing(3, 0),
+      margin: theme.spacing(3, 'auto'),
       padding: theme.spacing(2),
       backgroundColor: '#272c34',
       direction: 'ltr',

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -5,6 +5,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import NotificationsIcon from '@material-ui/icons/Notifications';
 import Tooltip from '@material-ui/core/Tooltip';
+import CircularProgress from '@material-ui/core/CircularProgress';
 import IconButton from '@material-ui/core/IconButton';
 import Badge from '@material-ui/core/Badge';
 import Typography from '@material-ui/core/Typography';
@@ -32,6 +33,11 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'column',
   },
+  loading: {
+    display: 'flex',
+    justifyContent: 'center',
+    margin: theme.spacing(1, 0),
+  },
   divider: {
     margin: theme.spacing(1, 0),
   },
@@ -53,34 +59,34 @@ export default function Notifications() {
   const messages = useSelector((state) => state.notifications.messages);
   const lastSeen = useSelector((state) => state.notifications.lastSeen);
 
-  const messageList = (messages || [])
-    .filter((message) => {
-      if (
-        message.userLanguage &&
-        message.userLanguage !== userLanguage &&
-        message.userLanguage !== navigator.language.substring(0, 2)
-      ) {
-        return false;
-      }
-      return true;
-    })
-    .reverse();
-
-  const unseenNotificationsCount = messageList.reduce(
-    (count, message) => (message.id > lastSeen ? count + 1 : count),
-    0,
-  );
+  const messageList = messages
+    ? messages
+        .filter((message) => {
+          if (
+            message.userLanguage &&
+            message.userLanguage !== userLanguage &&
+            message.userLanguage !== navigator.language.substring(0, 2)
+          ) {
+            return false;
+          }
+          return true;
+        })
+        .reverse()
+    : null;
 
   const handleToggle = () => {
     setOpen((prevOpen) => !prevOpen);
     setTooltipOpen(false);
-    dispatch({
-      type: ACTION_TYPES.NOTIFICATIONS_CHANGE,
-      payload: {
-        lastSeen: messageList[0].id,
-      },
-    });
-    document.cookie = `lastSeenNotification=${messageList[0].id};path=/;max-age=31536000`;
+
+    if (messageList) {
+      dispatch({
+        type: ACTION_TYPES.NOTIFICATIONS_CHANGE,
+        payload: {
+          lastSeen: messageList[0].id,
+        },
+      });
+      document.cookie = `lastSeenNotification=${messageList[0].id};path=/;max-age=31536000`;
+    }
   };
 
   React.useEffect(() => {
@@ -142,7 +148,17 @@ export default function Notifications() {
           data-ga-event-category="AppBar"
           data-ga-event-action="toggleNotifications"
         >
-          <Badge color="secondary" badgeContent={unseenNotificationsCount}>
+          <Badge
+            color="secondary"
+            badgeContent={
+              messageList
+                ? messageList.reduce(
+                    (count, message) => (message.id > lastSeen ? count + 1 : count),
+                    0,
+                  )
+                : 0
+            }
+          >
             <NotificationsIcon />
           </Badge>
         </IconButton>
@@ -165,31 +181,37 @@ export default function Notifications() {
             <Grow in={open} {...TransitionProps}>
               <Paper className={classes.paper}>
                 <List className={classes.list}>
-                  {messageList.map((message, index) => (
-                    <React.Fragment key={message.id}>
-                      <ListItem alignItems="flex-start" className={classes.listItem}>
-                        <Typography gutterBottom>{message.title}</Typography>
-                        <Typography gutterBottom variant="body2">
-                          <span
-                            id="notification-message"
-                            dangerouslySetInnerHTML={{ __html: message.text }}
-                          />
-                        </Typography>
-                        {message.date && (
-                          <Typography variant="caption" color="textSecondary">
-                            {new Date(message.date).toLocaleDateString('en-US', {
-                              year: 'numeric',
-                              month: 'long',
-                              day: 'numeric',
-                            })}
+                  {messageList ? (
+                    messageList.map((message, index) => (
+                      <React.Fragment key={message.id}>
+                        <ListItem alignItems="flex-start" className={classes.listItem}>
+                          <Typography gutterBottom>{message.title}</Typography>
+                          <Typography gutterBottom variant="body2">
+                            <span
+                              id="notification-message"
+                              dangerouslySetInnerHTML={{ __html: message.text }}
+                            />
                           </Typography>
-                        )}
-                      </ListItem>
-                      {index < messageList.length - 1 ? (
-                        <Divider className={classes.divider} />
-                      ) : null}
-                    </React.Fragment>
-                  ))}
+                          {message.date && (
+                            <Typography variant="caption" color="textSecondary">
+                              {new Date(message.date).toLocaleDateString('en-US', {
+                                year: 'numeric',
+                                month: 'long',
+                                day: 'numeric',
+                              })}
+                            </Typography>
+                          )}
+                        </ListItem>
+                        {index < messageList.length - 1 ? (
+                          <Divider className={classes.divider} />
+                        ) : null}
+                      </React.Fragment>
+                    ))
+                  ) : (
+                    <div className={classes.loading}>
+                      <CircularProgress size={32} />
+                    </div>
+                  )}
                 </List>
               </Paper>
             </Grow>

--- a/docs/src/modules/components/Notifications.js
+++ b/docs/src/modules/components/Notifications.js
@@ -43,11 +43,6 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function getLastSeenNotification() {
-  const seen = getCookie('lastSeenNotification');
-  return seen === '' ? 0 : parseInt(seen, 10);
-}
-
 export default function Notifications() {
   const classes = useStyles();
   const [open, setOpen] = React.useState(false);
@@ -78,7 +73,7 @@ export default function Notifications() {
     setOpen((prevOpen) => !prevOpen);
     setTooltipOpen(false);
 
-    if (messageList) {
+    if (messageList && messageList.length > 0) {
       dispatch({
         type: ACTION_TYPES.NOTIFICATIONS_CHANGE,
         payload: {
@@ -110,11 +105,14 @@ export default function Notifications() {
       }
 
       if (active) {
+        const seen = getCookie('lastSeenNotification');
+        const lastSeenNotification = seen === '' ? 0 : parseInt(seen, 10);
+
         dispatch({
           type: ACTION_TYPES.NOTIFICATIONS_CHANGE,
           payload: {
             messages: newMessages || [],
-            lastSeen: getLastSeenNotification(),
+            lastSeen: lastSeenNotification,
           },
         });
       }

--- a/docs/src/pages/components/autocomplete/autocomplete.md
+++ b/docs/src/pages/components/autocomplete/autocomplete.md
@@ -45,7 +45,11 @@ The component has two states that can be controlled:
 
 ## Free solo
 
-Set `freeSolo` to true so the textbox can contain any arbitrary value. The prop is designed to cover the primary use case of a **search box** with suggestions, e.g. Google search or react-autowhatever.
+Set `freeSolo` to true so the textbox can contain any arbitrary value.
+
+### Search input
+
+The prop is designed to cover the primary use case of a **search input** with suggestions, e.g. Google search or react-autowhatever.
 
 {{"demo": "pages/components/autocomplete/FreeSolo.js"}}
 

--- a/docs/src/pages/customization/typography/typography.md
+++ b/docs/src/pages/customization/typography/typography.md
@@ -106,32 +106,6 @@ The computed font size by the browser follows this mathematical equation:
 
 <!-- https://latex.codecogs.com/gif.latex?computed&space;=&space;specification&space;\frac{typography.fontSize}{14}&space;\frac{html&space;font&space;size}{typography.htmlFontSize} -->
 
-### HTML font size
-
-You might want to change the `<html>` element default font size. For instance, when using the [10px simplification](https://www.sitepoint.com/understanding-and-using-rem-units-in-css/).
-An `htmlFontSize` theme property is provided for this use case,
-which tells Material-UI what the font-size on the `<html>` element is.
-This is used to adjust the `rem` value so the calculated font-size always match the specification.
-
-```js
-const theme = createMuiTheme({
-  typography: {
-    // Tell Material-UI what's the font-size on the html element is.
-    htmlFontSize: 10,
-  },
-});
-```
-
-```css
-html {
-  font-size: 62.5%; /* 62.5% of 16px = 10px */
-}
-```
-
-_You need to apply the above CSS on the html element of this page to see the below demo rendered correctly_
-
-{{"demo": "pages/customization/typography/FontSizeTheme.js"}}
-
 ### Responsive font sizes
 
 The typography variants properties map directly to the generated CSS.
@@ -171,6 +145,35 @@ theme = responsiveFontSizes(theme);
 ### Fluid font sizes
 
 To be done: [#15251](https://github.com/mui-org/material-ui/issues/15251).
+
+### HTML font size
+
+You might want to change the `<html>` element default font size. For instance, when using the [10px simplification](https://www.sitepoint.com/understanding-and-using-rem-units-in-css/).
+
+> ⚠️ Changing the font size can harm accessibility ♿️. Most browsers agreed on the default size of 16 pixels, but the user can change it. For instance, someone with an impaired vision could have set their browser’s default font size to something larger.
+
+An `htmlFontSize` theme property is provided for this use case,
+which tells Material-UI what the font-size on the `<html>` element is.
+This is used to adjust the `rem` value so the calculated font-size always match the specification.
+
+```js
+const theme = createMuiTheme({
+  typography: {
+    // Tell Material-UI what's the font-size on the html element is.
+    htmlFontSize: 10,
+  },
+});
+```
+
+```css
+html {
+  font-size: 62.5%; /* 62.5% of 16px = 10px */
+}
+```
+
+*You need to apply the above CSS on the html element of this page to see the below demo rendered correctly*
+
+{{"demo": "pages/customization/typography/FontSizeTheme.js"}}
 
 ## Variants
 

--- a/docs/src/pages/getting-started/learn/learn.md
+++ b/docs/src/pages/getting-started/learn/learn.md
@@ -25,6 +25,8 @@ Here are some recommended resources, some of which are free.
 
 ### Free
 
+- **Introduction to Material-UI**: a series of videos covering all the important Material-UI components.
+  - 📹 [The videos](https://www.youtube.com/watch?v=pHclLuRolzE&list=PLQg6GaokU5CwiVmsZ0d_9Zsg_DnIP_xwr)
 - **Meet Material-UI — your new favorite user interface library**: a blog post that guides you in building a Todo MVC while covering some important concepts of Material-UI.
   - 📝 [The blog post](https://medium.freecodecamp.org/meet-your-material-ui-your-new-favorite-user-interface-library-6349a1c88a8c)
 - **Learn React & Material-UI**: a series of videos covering all the important Material-UI components.

--- a/docs/src/pages/guides/localization/Locales.js
+++ b/docs/src/pages/guides/localization/Locales.js
@@ -6,12 +6,10 @@ import TextField from '@material-ui/core/TextField';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme({}, zhCN);
-
 export default function Locales() {
   return (
     <div>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={(outerTheme) => createMuiTheme(outerTheme, zhCN)}>
         <TablePagination
           count={20}
           rowsPerPage={10}

--- a/docs/src/pages/guides/localization/Locales.tsx
+++ b/docs/src/pages/guides/localization/Locales.tsx
@@ -6,12 +6,10 @@ import TextField from '@material-ui/core/TextField';
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import { zhCN } from '@material-ui/core/locale';
 
-const theme = createMuiTheme({}, zhCN);
-
 export default function Locales() {
   return (
     <div>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={(outerTheme) => createMuiTheme(outerTheme, zhCN)}>
         <TablePagination
           count={20}
           rowsPerPage={10}

--- a/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
+++ b/packages/material-ui-lab/src/useAutocomplete/useAutocomplete.js
@@ -232,9 +232,12 @@ export default function useAutocomplete(props) {
     resetInputValue(null, value);
   }, [value, resetInputValue]);
 
-  const { current: isOpenControlled } = React.useRef(openProp != null);
-  const [openState, setOpenState] = React.useState(false);
-  const open = isOpenControlled ? openProp : openState;
+  const [open, setOpenState] = useControlled({
+    controlled: openProp,
+    default: false,
+    name: componentName,
+    state: 'open',
+  });
 
   const inputValueIsSelectedValue =
     !multiple && value != null && inputValue === getOptionLabel(value);
@@ -461,11 +464,10 @@ export default function useAutocomplete(props) {
       return;
     }
 
+    setOpenState(true);
+
     if (onOpen) {
       onOpen(event);
-    }
-    if (!isOpenControlled) {
-      setOpenState(true);
     }
   };
 
@@ -474,11 +476,10 @@ export default function useAutocomplete(props) {
       return;
     }
 
+    setOpenState(false);
+
     if (onClose) {
       onClose(event, reason);
-    }
-    if (!isOpenControlled) {
-      setOpenState(false);
     }
   };
 

--- a/packages/material-ui/src/SvgIcon/SvgIcon.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.js
@@ -79,7 +79,7 @@ const SvgIcon = React.forwardRef(function SvgIcon(props, ref) {
       focusable="false"
       viewBox={viewBox}
       color={htmlColor}
-      aria-hidden={titleAccess ? undefined : 'true'}
+      aria-hidden={titleAccess ? undefined : true}
       role={titleAccess ? 'img' : undefined}
       ref={ref}
       {...other}

--- a/packages/material-ui/src/SvgIcon/SvgIcon.test.js
+++ b/packages/material-ui/src/SvgIcon/SvgIcon.test.js
@@ -47,7 +47,7 @@ describe('<SvgIcon />', () => {
   it('renders children by default', () => {
     const wrapper = shallow(<SvgIcon>{path}</SvgIcon>);
     assert.strictEqual(wrapper.contains(path), true);
-    assert.strictEqual(wrapper.props()['aria-hidden'], 'true');
+    assert.strictEqual(wrapper.props()['aria-hidden'], true);
   });
 
   describe('prop: titleAccess', () => {

--- a/packages/material-ui/src/locale/index.ts
+++ b/packages/material-ui/src/locale/index.ts
@@ -571,7 +571,7 @@ export const frFR: Localization = {
       closeText: 'Fermer',
     },
     MuiPagination: {
-      'aria-label': 'pagination navigation',
+      'aria-label': 'navigation de pagination',
       getItemAriaLabel: (type, page, selected) => {
         if (type === 'page') {
           return `${selected ? '' : 'Aller à la '}page ${page}`;


### PR DESCRIPTION
- Close the developer survey 42c32dc: The survey has been running for 22 days, we had 1,450 answers, x2 more than last year. It's probably time to close it. We have to analyze the results now 😅.
- [l10n] Improve fr-FR value 16bdb64: Thanks @raduchiriac for the report in https://github.com/mui-org/material-ui/commit/9c053f85f0353cfc5ede1ce8cc0a87a618675277#r38650085.
- [docs] Automatically redirect pt to pt-BR 611a655: as discussed with @jaironalves, the `/pt/` locale is the most used one. It's also the most translated, at almost 100%. It seems safe to enable auto redirection for this locale, as we have for the Chinese one.

  ![unnamed](https://user-images.githubusercontent.com/3165635/80512165-606e9a80-897d-11ea-98d9-8b7f0451a374.png)

  *Legend*

  - `Language` => the primary configured language of the browser
  - `userLanguage` => the language of the docs
- [Autocomplete] Improve the heading structure cea1d62775a6edce94740ac104c5177098ab8ccb: freeSolo has two main use cases, make it explicit.
- [core] Most of the time, we use aria-hidden as a boolean a4ec727: a nitpick.
- [l10n] Fix dark mode support of the demo a638ef8: reported by @dtassone on

  <img width="702" alt="Capture d’écran 2020-04-28 à 18 27 38" src="https://user-images.githubusercontent.com/3165635/80512565-f86c8400-897d-11ea-9628-ffe6ba4af960.png">

  https://material-ui.com/guides/localization/#example

- [docs] Add a new introduction series of videos ee96096: New up-to-date quality content is always appreciated, thanks @AtotheY.
- [docs] Warn about the a11y implication of changing HTML font size bee571e: ♿️
- [Autocomplete] Use useControlled instead of custom logic 3f0bed0: I believe there is another case to migrate: the Rating, for another time.
- [docs] Fix centering of code on mobile 7e64043: a small display bug, it's not centered.

  <img width="433" alt="Capture d’écran 2020-04-28 à 18 32 45" src="https://user-images.githubusercontent.com/3165635/80513002-b09a2c80-897e-11ea-9675-2be9395601fc.png">

- [docs] Display a loading state for notifications 18bee68: display a loader instead of an empty state, it also throws an exception.

master:
<img width="445" alt="Capture d’écran 2020-04-28 à 18 34 14" src="https://user-images.githubusercontent.com/3165635/80513142-e6d7ac00-897e-11ea-8840-c59e586f2e99.png">
