### PR TITLE
[Pagination] Refactor boundaryCount

### DIFF
--- a/packages/material-ui-lab/src/Pagination/usePagination.js
+++ b/packages/material-ui-lab/src/Pagination/usePagination.js
@@ -3,7 +3,7 @@ import { useControlled } from '@material-ui/core/utils';
 export default function usePagination(props = {}) {
   // keep default values in sync with @default tags in Pagination.propTypes
   const {
-    boundaryCount: boundaryCountProp = 1,
+    boundaryCount = 1,
     componentName = 'usePagination',
     count = 1,
     defaultPage = 1,
@@ -17,9 +17,6 @@ export default function usePagination(props = {}) {
     siblingCount = 1,
     ...other
   } = props;
-
-  // TODO: Update all formulae to remove this adjustment
-  const boundaryCount = boundaryCountProp - 1;
 
   const [page, setPageState] = useControlled({
     controlled: pageProp,
@@ -43,18 +40,18 @@ export default function usePagination(props = {}) {
     return Array.from({ length }, (_, i) => start + i);
   };
 
-  const startPages = range(1, Math.min(boundaryCount + 1, count));
-  const endPages = range(Math.max(count - boundaryCount, boundaryCount + 2), count);
+  const startPages = range(1, Math.min(boundaryCount, count));
+  const endPages = range(Math.max(count - boundaryCount + 1, boundaryCount + 1), count);
 
   const siblingsStart = Math.max(
     Math.min(
       // Natural start
       page - siblingCount,
       // Lower boundary when page is high
-      count - boundaryCount - siblingCount * 2 - 2,
+      count - boundaryCount - siblingCount * 2 - 1,
     ),
     // Greater than startPages
-    boundaryCount + 3,
+    boundaryCount + 2,
   );
 
   const siblingsEnd = Math.min(
@@ -62,7 +59,7 @@ export default function usePagination(props = {}) {
       // Natural end
       page + siblingCount,
       // Upper boundary when page is low
-      boundaryCount + siblingCount * 2 + 3,
+      boundaryCount + siblingCount * 2 + 2,
     ),
     // Less than endPages
     endPages[0] - 2,
@@ -77,10 +74,10 @@ export default function usePagination(props = {}) {
 
     // Start ellipsis
     // eslint-disable-next-line no-nested-ternary
-    ...(siblingsStart > boundaryCount + 3
+    ...(siblingsStart > boundaryCount + 2
       ? ['start-ellipsis']
-      : 2 + boundaryCount < count - boundaryCount - 1
-      ? [2 + boundaryCount]
+      : boundaryCount + 1 < count - boundaryCount
+      ? [boundaryCount + 1]
       : []),
 
     // Sibling pages
@@ -88,10 +85,10 @@ export default function usePagination(props = {}) {
 
     // End ellipsis
     // eslint-disable-next-line no-nested-ternary
-    ...(siblingsEnd < count - boundaryCount - 2
+    ...(siblingsEnd < count - boundaryCount - 1
       ? ['end-ellipsis']
-      : count - boundaryCount - 1 > boundaryCount + 1
-      ? [count - boundaryCount - 1]
+      : count - boundaryCount > boundaryCount
+      ? [count - boundaryCount]
       : []),
 
     ...endPages,


### PR DESCRIPTION
During development the boundaryCount prop's name and meaning changed, along with its default value. For expedience an internal adjustment was used as a temporary stop-gap to allow code that depended on the previous default to continue to function. This PR circles back to clean that up.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
