### PR TITLE
[styles] Improve component props inference of styled

### DIFF
--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -12,7 +12,7 @@ import { DefaultTheme } from '../defaultTheme';
  */
 export type ComponentCreator<Component extends React.ElementType> = <
   Theme = DefaultTheme,
-  Props extends {} = {}
+  Props extends {} = React.ComponentPropsWithoutRef<Component>
 >(
   styles:
     | CreateCSSProperties<Props>

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -1,4 +1,4 @@
-import { Omit } from '@material-ui/types';
+import { Omit, Overwrite } from '@material-ui/types';
 import {
   CreateCSSProperties,
   StyledComponentProps,
@@ -17,15 +17,14 @@ export type ComponentCreator<Component extends React.ElementType> = <
   styles:
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
-  options?: WithStylesOptions<Theme>
+  options?: WithStylesOptions<Theme>,
 ) => React.ComponentType<
   Omit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
     'classes' | 'className'
   > &
-    StyledComponentProps<'root'> & { className?: string } & (Props extends { theme: Theme }
-      ? Omit<Props, 'theme'> & { theme?: Theme }
-      : Props)
+    StyledComponentProps<'root'> &
+    Overwrite<Props, { className?: string; theme?: Theme }>
 >;
 
 export interface StyledProps {
@@ -33,5 +32,5 @@ export interface StyledProps {
 }
 
 export default function styled<Component extends React.ElementType>(
-  Component: Component
+  Component: Component,
 ): ComponentCreator<Component>;

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -17,7 +17,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
   styles:
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
-  options?: WithStylesOptions<Theme>,
+  options?: WithStylesOptions<Theme>
 ) => React.ComponentType<
   Omit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
@@ -32,5 +32,5 @@ export interface StyledProps {
 }
 
 export default function styled<Component extends React.ElementType>(
-  Component: Component,
+  Component: Component
 ): ComponentCreator<Component>;

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -84,15 +84,14 @@ function acceptanceTest() {
       fontFamily: theme.fontFamily,
     }),
   );
-  const StyledInferedPropsMyComponent = styled(MyComponent)(
-    ({ defaulted }) => ({
-      content: defaulted,
-    }),
-  );
+  const StyledInferedPropsMyComponent = styled(MyComponent)(({ defaulted }) => ({
+    content: defaulted,
+  }));
   const renderedMyComponent = (
     <React.Fragment>
       <MyComponent className="test" />
       <StyledMyComponent theme={MyThemeInstance} />
+      <StyledInferedPropsMyComponent defaulted="Hi!" />
     </React.Fragment>
   );
 }

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -91,7 +91,7 @@ function acceptanceTest() {
     <React.Fragment>
       <MyComponent className="test" />
       <StyledMyComponent theme={MyThemeInstance} />
-      <StyledInferedPropsMyComponent defaulted="Hi!" className="test" />
+      <StyledInferedPropsMyComponent defaulted="Hi!" />
     </React.Fragment>
   );
 }

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -67,7 +67,6 @@ function acceptanceTest() {
   const MyThemeInstance: MyTheme = {
     fontFamily: 'monospace',
   };
-  // tslint:disable-next-line: no-empty-interface
   interface MyComponentProps extends StyledProps {
     defaulted: string;
   }
@@ -83,6 +82,11 @@ function acceptanceTest() {
   const StyledMyComponent = styled<typeof MyComponent>(MyComponent)(
     ({ theme }: { theme: MyTheme }) => ({
       fontFamily: theme.fontFamily,
+    }),
+  );
+  const StyledInferedPropsMyComponent = styled(MyComponent)(
+    ({ defaulted }) => ({
+      content: defaulted,
     }),
   );
   const renderedMyComponent = (

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -91,7 +91,7 @@ function acceptanceTest() {
     <React.Fragment>
       <MyComponent className="test" />
       <StyledMyComponent theme={MyThemeInstance} />
-      <StyledInferedPropsMyComponent defaulted="Hi!" />
+      <StyledInferedPropsMyComponent defaulted="Hi!" className="test" />
     </React.Fragment>
   );
 }


### PR DESCRIPTION
These changes allow using props with type checking in `ComponentCreator`: 
```ts
export interface Props {
  status: 0 | 1;
}

const Component = styled(({ status }: Props) => {
  return null;
})(({ status, theme }) => ({
  ...(status === 1
    ? {
        color: theme.color.accent,
        fillOpacity: 1,
      }
    : undefined),
}));
```

Without that changes a ts error occurs: `Property 'status' does not exist on type '{ theme: DefaultTheme; }'.ts(2339)
`