### PR TITLE
[styles] Return simpler type from ComponentCreator

### DIFF
--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -7,6 +7,8 @@ import {
 import * as React from 'react';
 import { DefaultTheme } from '../defaultTheme';
 
+export type StyledComponent<P extends {}> = (props: P) => React.ReactElement<P, any> | null;
+
 /**
  * @internal
  */
@@ -17,8 +19,8 @@ export type ComponentCreator<Component extends React.ElementType> = <
   styles:
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
-  options?: WithStylesOptions<Theme>
-) => React.ForwardRefExoticComponent<
+  options?: WithStylesOptions<Theme>,
+) => StyledComponent<
   Omit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
     'classes' | 'className'

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -18,7 +18,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
   options?: WithStylesOptions<Theme>
-) => React.ComponentType<
+) => React.ForwardRefExoticComponent<
   Omit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,
     'classes' | 'className'

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -19,7 +19,7 @@ export type ComponentCreator<Component extends React.ElementType> = <
   styles:
     | CreateCSSProperties<Props>
     | ((props: { theme: Theme } & Props) => CreateCSSProperties<Props>),
-  options?: WithStylesOptions<Theme>,
+  options?: WithStylesOptions<Theme>
 ) => StyledComponent<
   Omit<
     JSX.LibraryManagedAttributes<Component, React.ComponentProps<Component>>,

--- a/packages/material-ui-styles/src/styled/styled.d.ts
+++ b/packages/material-ui-styles/src/styled/styled.d.ts
@@ -7,6 +7,7 @@ import {
 import * as React from 'react';
 import { DefaultTheme } from '../defaultTheme';
 
+// We don't want a union type here (like React.ComponentType) in order to support mapped types.
 export type StyledComponent<P extends {}> = (props: P) => React.ReactElement<P, any> | null;
 
 /**

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -47,10 +47,6 @@ function themeTest() {
   <ComponentWithOptionalThemeStyledWithTheme value={1} theme={{ palette: { primary: '#333' } }} />; // $ExpectError
 }
 
-const StyledInferedPropsMyComponent = styled(MyComponent)(({ defaulted }) => ({
-  content: defaulted,
-}));
-
 type TweakableComponentProps<C extends React.ElementType> = Omit<
   { component?: C } & (undefined extends C ? unknown : React.ComponentProps<C>),
   never

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -47,17 +47,24 @@ function themeTest() {
   <ComponentWithOptionalThemeStyledWithTheme value={1} theme={{ palette: { primary: '#333' } }} />; // $ExpectError
 }
 
-type TweakableComponentProps<C extends React.ElementType> = Omit<
+// Infering props from another component to correct type checking.
+// Use `Omit` just for make type objectable to avoid `Rest types may only be created from object types.ts(2700)` error
+// in `ComponentWrapper`.
+// If you remove Omit or something else many things will not work with TS.
+type ComponentWrapperProps<C extends React.ElementType = any> = Omit<
   { component?: C } & (undefined extends C ? unknown : React.ComponentProps<C>),
   never
 >;
 
-function testComponentType<C extends React.ElementType = 'div'>({
-  component,
+// Component that accept another component in order to do some manipulations with that component.
+// Same technique uses in MUI AFAIK
+function ComponentWrapper<C extends React.ElementType = 'div'>({
+  component = 'div' as C,
   ...rest
-}: TweakableComponentProps<C>): C | undefined {
+}: ComponentWrapperProps<C>): JSX.Element {
   console.log(rest);
-  return component;
+  // some logic
+  return React.createElement(component);
 }
 
 function acceptanceTest() {
@@ -105,7 +112,7 @@ function acceptanceTest() {
       <MyComponent className="test" />
       <StyledMyComponent theme={MyThemeInstance} />
       <StyledInferedPropsMyComponent defaulted="Hi!" />
+      <ComponentWrapper component={StyledInferedPropsMyComponent} defaulted="def" />
     </React.Fragment>
   );
-  testComponentType({ component: StyledInferedPropsMyComponent, defaulted: 'Hi!' });
 }

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -94,4 +94,6 @@ function acceptanceTest() {
       <StyledInferedPropsMyComponent defaulted="Hi!" />
     </React.Fragment>
   );
+  // Check ExoticComponent
+  console.log(StyledInferedPropsMyComponent.$$typeof);
 }

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -47,26 +47,6 @@ function themeTest() {
   <ComponentWithOptionalThemeStyledWithTheme value={1} theme={{ palette: { primary: '#333' } }} />; // $ExpectError
 }
 
-// Infering props from another component to correct type checking.
-// Use `Omit` just for make type objectable to avoid `Rest types may only be created from object types.ts(2700)` error
-// in `ComponentWrapper`.
-// If you remove Omit or something else many things will not work with TS.
-type ComponentWrapperProps<C extends React.ElementType = any> = Omit<
-  { component?: C } & (undefined extends C ? unknown : React.ComponentProps<C>),
-  never
->;
-
-// Component that accept another component in order to do some manipulations with that component.
-// Same technique uses in MUI AFAIK
-function ComponentWrapper<C extends React.ElementType = 'div'>({
-  component = 'div' as C,
-  ...rest
-}: ComponentWrapperProps<C>): JSX.Element {
-  console.log(rest);
-  // some logic
-  return React.createElement(component);
-}
-
 function acceptanceTest() {
   const StyledButton = styled('button')({
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
@@ -112,7 +92,6 @@ function acceptanceTest() {
       <MyComponent className="test" />
       <StyledMyComponent theme={MyThemeInstance} />
       <StyledInferedPropsMyComponent defaulted="Hi!" />
-      <ComponentWrapper component={StyledInferedPropsMyComponent} defaulted="def" />
     </React.Fragment>
   );
 }

--- a/packages/material-ui-styles/src/styled/styled.spec.tsx
+++ b/packages/material-ui-styles/src/styled/styled.spec.tsx
@@ -47,6 +47,23 @@ function themeTest() {
   <ComponentWithOptionalThemeStyledWithTheme value={1} theme={{ palette: { primary: '#333' } }} />; // $ExpectError
 }
 
+const StyledInferedPropsMyComponent = styled(MyComponent)(({ defaulted }) => ({
+  content: defaulted,
+}));
+
+type TweakableComponentProps<C extends React.ElementType> = Omit<
+  { component?: C } & (undefined extends C ? unknown : React.ComponentProps<C>),
+  never
+>;
+
+function testComponentType<C extends React.ElementType = 'div'>({
+  component,
+  ...rest
+}: TweakableComponentProps<C>): C | undefined {
+  console.log(rest);
+  return component;
+}
+
 function acceptanceTest() {
   const StyledButton = styled('button')({
     background: 'linear-gradient(45deg, #FE6B8B 30%, #FF8E53 90%)',
@@ -94,6 +111,5 @@ function acceptanceTest() {
       <StyledInferedPropsMyComponent defaulted="Hi!" />
     </React.Fragment>
   );
-  // Check ExoticComponent
-  console.log(StyledInferedPropsMyComponent.$$typeof);
+  testComponentType({ component: StyledInferedPropsMyComponent, defaulted: 'Hi!' });
 }


### PR DESCRIPTION
When I use `styled` component like this:
```ts
import { Flex } from 'reflexy';
// Icon is styled component: styled((props: Props) => ...)({...});
<Flex ml component={Icon} name="copy"  />
```
I get TS error:
```
Type 'ComponentType<Pick<IconProps, "string" | "clipPath" | "color" | "cursor" | "direction" | "display" | "filter" | "fontFamily" | "fontSize" | "fontSizeAdjust" | "fontStretch" | ... 457 more ... | "zoomAndPan"> & StyledComponentProps<...> & { ...; }>' is not assignable to type 'ComponentClass<Pick<IconProps, "string" | "clipPath" | "color" | "cursor" | "direction" | "display" | "filter" | "fontFamily" | "fontSize" | "fontSizeAdjust" | "fontStretch" | ... 457 more ... | "zoomAndPan"> & StyledComponentProps<...> & { ...; }, any> | undefined'.
  Type 'FunctionComponent<Pick<IconProps, "string" | "clipPath" | "color" | "cursor" | "direction" | "display" | "filter" | "fontFamily" | "fontSize" | "fontSizeAdjust" | "fontStretch" | ... 457 more ... | "zoomAndPan"> & StyledComponentProps<...> & { ...; }>' is not assignable to type 'ComponentClass<Pick<IconProps, "string" | "clipPath" | "color" | "cursor" | "direction" | "display" | "filter" | "fontFamily" | "fontSize" | "fontSizeAdjust" | "fontStretch" | ... 457 more ... | "zoomAndPan"> & StyledComponentProps<...> & { ...; }, any>'.
    Type 'FunctionComponent<Pick<IconProps, "string" | "clipPath" | "color" | "cursor" | "direction" | "display" | "filter" | "fontFamily" | "fontSize" | "fontSizeAdjust" | "fontStretch" | ... 457 more ... | "zoomAndPan"> & StyledComponentProps<...> & { ...; }>' provides no match for the signature 'new (props: Pick<IconProps, "string" | "clipPath" | "color" | "cursor" | "direction" | "display" | "filter" | "fontFamily" | "fontSize" | "fontSizeAdjust" | "fontStretch" | "fontStyle" | ... 456 more ... | "zoomAndPan"> & StyledComponentProps<...> & { ...; }, context?: any): Component<...>'.ts(2322)
Flex.d.ts(131, 5): The expected type comes from property 'component' which is declared here on type 'IntrinsicAttributes & FlexProps & SpaceProps & OverflowProps & Pick<{ component?: ComponentClass<Pick<IconProps, "string" | ... 467 more ... | "zoomAndPan"> & StyledComponentProps<...> & { ...; }, any> | undefined; } & Pick<...> & { ...; }, "string" | ... 474 more ... | "theme"> & Styleable<...> & Transformable<...>...'
```
because TS can't assign `FunctionComponent` to `ComponentClass` and vise versa.
So in that situation we need concreate stable component type. I have look at the source of `styled` and found using `forwardRef`.