### PR TITLE
[TextField] Fix caret color in autofill dark theme

### DIFF
--- a/packages/material-ui/src/FilledInput/FilledInput.js
+++ b/packages/material-ui/src/FilledInput/FilledInput.js
@@ -115,6 +115,7 @@ export const styles = (theme) => {
       '&:-webkit-autofill': {
         WebkitBoxShadow: theme.palette.type === 'dark' ? '0 0 0 100px #266798 inset' : null,
         WebkitTextFillColor: theme.palette.type === 'dark' ? '#fff' : null,
+        caretColor: theme.palette.type === 'dark' ? '#fff' : null,
         borderTopLeftRadius: 'inherit',
         borderTopRightRadius: 'inherit',
       },

--- a/packages/material-ui/src/OutlinedInput/OutlinedInput.js
+++ b/packages/material-ui/src/OutlinedInput/OutlinedInput.js
@@ -75,6 +75,7 @@ export const styles = (theme) => {
       '&:-webkit-autofill': {
         WebkitBoxShadow: theme.palette.type === 'dark' ? '0 0 0 100px #266798 inset' : null,
         WebkitTextFillColor: theme.palette.type === 'dark' ? '#fff' : null,
+        caretColor: theme.palette.type === 'dark' ? '#fff' : null,
         borderRadius: 'inherit',
       },
     },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).

## Before
![Before](https://user-images.githubusercontent.com/932566/80766791-d86acb00-8b0b-11ea-8998-07d60aa55cf8.png)
## After
![After](https://user-images.githubusercontent.com/932566/80766810-e587ba00-8b0b-11ea-8a85-b3e0b745fa22.png)

