### PR TITLE
[docs] Make CSS interoperability examples easier to use

### DIFF
--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -38,7 +38,7 @@ Nothing fancy, just plain CSS.
 ```jsx
 import React from 'react';
 import Button from '@material-ui/core/Button';
-import './PlainCSSButton.css';
+import './PlainCssButton.css';
 
 export default function PlainCssButton() {
   return (

--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -39,6 +39,8 @@ Nothing fancy, just plain CSS.
 import React from 'react';
 import Button from '@material-ui/core/Button';
 
+import "./PlainCSSButton.css";
+
 export default function PlainCssButton() {
   return (
     <div>
@@ -132,6 +134,8 @@ Explicitly providing the class names to the component is too much effort?
 ```jsx
 import React from 'react';
 import Button from '@material-ui/core/Button';
+
+import './GlobalCssButton.css';
 
 export default function GlobalCssButton() {
   return <Button>Customized</Button>;

--- a/docs/src/pages/guides/interoperability/interoperability.md
+++ b/docs/src/pages/guides/interoperability/interoperability.md
@@ -38,8 +38,7 @@ Nothing fancy, just plain CSS.
 ```jsx
 import React from 'react';
 import Button from '@material-ui/core/Button';
-
-import "./PlainCSSButton.css";
+import './PlainCSSButton.css';
 
 export default function PlainCssButton() {
   return (
@@ -95,6 +94,7 @@ The following example overrides the `label` style of `Button` in addition to the
 ```jsx
 import React from 'react';
 import Button from '@material-ui/core/Button';
+import './PlainCssButtonDeep.css';
 
 export default function PlainCssButtonDeep() {
   return (
@@ -134,7 +134,6 @@ Explicitly providing the class names to the component is too much effort?
 ```jsx
 import React from 'react';
 import Button from '@material-ui/core/Button';
-
 import './GlobalCssButton.css';
 
 export default function GlobalCssButton() {


### PR DESCRIPTION
I guess the demo has to show that you still have to import the file in order for this approach to work.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

- [x] I have followed (at least) the [PR section of the contributing guide](https://github.com/mui-org/material-ui/blob/master/CONTRIBUTING.md#sending-a-pull-request).
